### PR TITLE
Always update card type for all card constructors

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -162,6 +162,7 @@ public class Card extends com.stripe.model.StripeObject {
         this.type = TextUtils.nullIfBlank(type);
         this.fingerprint = TextUtils.nullIfBlank(fingerprint);
         this.country = TextUtils.nullIfBlank(country);
+        this.type = getType();
     }
 
     public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry) {
@@ -170,7 +171,6 @@ public class Card extends com.stripe.model.StripeObject {
 
     public Card(String number, Integer expMonth, Integer expYear, String cvc) {
         this(number, expMonth, expYear, cvc, null, null, null, null, null, null, null, null, null, null, null);
-        this.type = getType();
     }
 
     public boolean validateCard() {


### PR DESCRIPTION
This will fix Amex number validation when using card constructors with address/zip. Otherwise, validateNumber() always returns false for Amex.
