### PR TITLE
Updating gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
-        classpath 'org.robolectric:robolectric-gradle-plugin:0.11.+'
+        classpath 'com.android.tools.build:gradle:+'
+        classpath 'org.robolectric:robolectric-gradle-plugin:+'
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,14 +7,14 @@ repositories {
 
 dependencies {
     compile project(':stripe')
-    compile 'com.android.support:support-v4:18.0.+'
+    compile 'com.android.support:support-v4:+'
     androidTestCompile 'junit:junit:4.+'
     androidTestCompile 'org.robolectric:robolectric:2.3+'
 }
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.0"
 
     packagingOptions {
         exclude 'LICENSE.txt'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 11 16:12:19 PDT 2014
+#Mon Dec 15 22:41:19 CST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
The project wont build with the newest version of Android studio. It requires manual changes before the project will open. This fixes those and hopefully any future issues by pulling in the newest dependency versions.