### PR TITLE
Fix createToken() snippet to compile correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here's a sample implementation of the token callback:
             }
             public void onError(Exception error) {
                 Toast.makeText(getContext(),
-                    error.getLocalizedString(getContext()),
+                    error.getLocalizedMessage(),
                     Toast.LENGTH_LONG).show();
             }
         }


### PR DESCRIPTION
Not sure where error.getLocalizedString(context) came from?
Replace this with getLocalizedMessage()