### PR TITLE
optionally specify `currency` on Card

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -83,10 +83,10 @@ public class Stripe {
 
     private void validateKey(String publishableKey) throws AuthenticationException {
         if (publishableKey == null || publishableKey.length() == 0) {
-            throw new AuthenticationException("Invalid Publishable Key: You must use a valid publishable key to create a token.  For more info, see https://stripe.com/docs/stripe.js.");
+            throw new AuthenticationException("Invalid Publishable Key: You must use a valid publishable key to create a token.  For more info, see https://stripe.com/docs/stripe.js.", null);
         }
         if (publishableKey.startsWith("sk_")) {
-            throw new AuthenticationException("Invalid Publishable Key: You are using a secret key to create a token, instead of the publishable one. For more info, see https://stripe.com/docs/stripe.js");
+            throw new AuthenticationException("Invalid Publishable Key: You are using a secret key to create a token, instead of the publishable one. For more info, see https://stripe.com/docs/stripe.js", null);
         }
     }
 
@@ -149,7 +149,7 @@ public class Stripe {
     }
 
     private Card androidCardFromStripeCard(com.stripe.model.Card stripeCard) {
-        return new Card(null, stripeCard.getExpMonth(), stripeCard.getExpYear(), null, stripeCard.getName(), stripeCard.getAddressLine1(), stripeCard.getAddressLine2(), stripeCard.getAddressCity(), stripeCard.getAddressState(), stripeCard.getAddressZip(), stripeCard.getAddressCountry(), stripeCard.getLast4(), stripeCard.getType(), stripeCard.getFingerprint(), stripeCard.getCountry());
+        return new Card(null, stripeCard.getExpMonth(), stripeCard.getExpYear(), null, stripeCard.getName(), stripeCard.getAddressLine1(), stripeCard.getAddressLine2(), stripeCard.getAddressCity(), stripeCard.getAddressState(), stripeCard.getAddressZip(), stripeCard.getAddressCountry(), stripeCard.getLast4(), stripeCard.getType(), stripeCard.getFingerprint(), stripeCard.getCountry(), stripeCard.getCurrency());
     }
 
     private Token androidTokenFromStripeToken(Card androidCard, com.stripe.model.Token stripeToken) {
@@ -187,6 +187,7 @@ public class Stripe {
         cardParams.put("address_zip", TextUtils.nullIfBlank(card.getAddressZip()));
         cardParams.put("address_state", TextUtils.nullIfBlank(card.getAddressState()));
         cardParams.put("address_country", TextUtils.nullIfBlank(card.getAddressCountry()));
+        cardParams.put("currency", TextUtils.nullIfBlank(card.getCurrency()));
 
         // Remove all null values; they cause validation errors
         for (String key : new HashSet<String>(cardParams.keySet())) {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -39,6 +39,7 @@ public class Card extends com.stripe.model.StripeObject {
     private String type;
     private String fingerprint;
     private String country;
+    private String currency;
 
     public static class Builder {
         private final String number;
@@ -56,6 +57,7 @@ public class Card extends com.stripe.model.StripeObject {
         private String type;
         private String fingerprint;
         private String country;
+        private String currency;
 
         public Builder(String number, Integer expMonth, Integer expYear, String cvc) {
             this.number = number;
@@ -119,6 +121,11 @@ public class Card extends com.stripe.model.StripeObject {
             return this;
         }
 
+        public Builder currency(String currency) {
+            this.currency = currency;
+            return this;
+        }
+
         public Card build() {
             return new Card(this);
         }
@@ -142,9 +149,10 @@ public class Card extends com.stripe.model.StripeObject {
         this.country = TextUtils.nullIfBlank(builder.country);
         this.type = getType();
         this.last4 = getLast4();
+        this.currency = TextUtils.nullIfBlank(builder.currency);
     }
 
-    public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry, String last4, String type, String fingerprint, String country) {
+    public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry, String last4, String type, String fingerprint, String country, String currency) {
         this.number = TextUtils.nullIfBlank(normalizeCardNumber(number));
         this.expMonth = expMonth;
         this.expYear = expYear;
@@ -162,14 +170,15 @@ public class Card extends com.stripe.model.StripeObject {
         this.country = TextUtils.nullIfBlank(country);
         this.type = getType();
         this.last4 = getLast4();
+        this.currency = TextUtils.nullIfBlank(currency);
     }
 
-    public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry) {
-        this(number, expMonth, expYear, cvc, name, addressLine1, addressLine2, addressCity, addressState, addressZip, addressCountry, null, null, null, null);
+    public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry, String currency) {
+        this(number, expMonth, expYear, cvc, name, addressLine1, addressLine2, addressCity, addressState, addressZip, addressCountry, null, null, null, null, currency);
     }
 
     public Card(String number, Integer expMonth, Integer expYear, String cvc) {
-        this(number, expMonth, expYear, cvc, null, null, null, null, null, null, null, null, null, null, null);
+        this(number, expMonth, expYear, cvc, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public boolean validateCard() {
@@ -400,4 +409,9 @@ public class Card extends com.stripe.model.StripeObject {
     public String getCountry() {
         return country;
     }
+
+    public String getCurrency() { return currency; }
+
+    public void setCurrency(String currency) { this.currency = currency; }
+
 }


### PR DESCRIPTION
"currency" is required on Card when using managed accounts. https://stripe.com/docs/api#create_card_token

**NOTE:** this pull request depends on an updated version of the **stripe-java** lib including this pull request: https://github.com/stripe/stripe-java/pull/192