### PR TITLE
Change a few test names to make them more accurate

### DIFF
--- a/example/src/test/java/com/stripe/android/StripeTest.java
+++ b/example/src/test/java/com/stripe/android/StripeTest.java
@@ -48,19 +48,19 @@ public class StripeTest {
     }
 
     @Test(expected = AuthenticationException.class)
-    public void setPublishableKeyShouldFailWhenNull() throws AuthenticationException {
+    public void setDefaultPublishableKeyShouldFailWhenNull() throws AuthenticationException {
         Stripe stripe = new Stripe();
         stripe.setDefaultPublishableKey(null);
     }
 
     @Test(expected = AuthenticationException.class)
-    public void setPublishableKeyShouldFailWhenEmpty() throws AuthenticationException {
+    public void setDefaultPublishableKeyShouldFailWhenEmpty() throws AuthenticationException {
         Stripe stripe = new Stripe();
         stripe.setDefaultPublishableKey("");
     }
 
     @Test(expected = AuthenticationException.class)
-    public void setPublishableKeyShouldFailWithSecretKey() throws AuthenticationException {
+    public void setDefaultPublishableKeyShouldFailWithSecretKey() throws AuthenticationException {
         Stripe stripe = new Stripe();
         stripe.setDefaultPublishableKey(DEFAULT_SECRET_KEY);
     }


### PR DESCRIPTION
As described in #30 it looks like `setPublishableKey` was renamed at
some point to `setDefaultPublishableKey`, but some documents and other
miscellaneous odd ends weren't updated. This patch renames a few tests
to make them more accurate for today's naming.