### PR TITLE
Added proguard rules for gson dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ If you're planning on optimizing your app with ProGuard, make sure that you excl
 
     -keep class com.stripe.** { *; }
 
+    # Gson uses generic type information stored in a class file when working with fields. Proguard
+    # removes such information by default, so configure it to keep all of it.
+    -keepattributes Signature
+
+    # For using GSON @Expose annotation
+    -keepattributes *Annotation*
+
+    # Gson specific classes
+    -keep class sun.misc.Unsafe { *; }
+
 ## Usage
 
 ### setDefaultPublishableKey


### PR DESCRIPTION
Release builds of my app were crashing when attempting to create a token. I've added the following to my proguard and it looks like it's fixed it. More info in [my SO question here](http://stackoverflow.com/questions/36969790/stripe-for-android-exceptionininitializererror/36971092#36971092). I don't know much about proguard, but it looks to me like there's some unexpected behavior where the library was crashing when it tried to call `registerTypeAdapter` for some classes below, that I'm assuming were removed by proguard:
```
public static final Gson GSON = new GsonBuilder()
			.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
			.registerTypeAdapter(EventData.class, new EventDataDeserializer())
			.registerTypeAdapter(ChargeRefundCollection.class, new ChargeRefundCollectionDeserializer())
			.registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
			.registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
			.registerTypeAdapter(Dispute.class, new DisputeDataDeserializer())
			.registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
			.create();
```