### PR TITLE
Fixing an issue where the "type" of the card was incorrectly set to null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk: oraclejdk8
 android:
   components:
     - tools
-    - build-tools-25.0.0
-    - android-25
+    - build-tools-24.0.1
+    - android-24
     - extra-google-m2repository
     - extra-android-m2repository
   licenses:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ jdk: oraclejdk8
 android:
   components:
     - tools
-    - build-tools-24.0.1
-    - android-24
+    - build-tools-25.0.0
+    - android-25
     - extra-google-m2repository
     - extra-android-m2repository
-  licenses:
-    - 'android-sdk-license-.+'
 
 script:
   - ./gradlew clean test

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -155,11 +155,31 @@ public class Stripe {
     }
 
     private Card androidCardFromStripeCard(com.stripe.model.Card stripeCard) {
-        return new Card(null, stripeCard.getExpMonth(), stripeCard.getExpYear(), null, stripeCard.getName(), stripeCard.getAddressLine1(), stripeCard.getAddressLine2(), stripeCard.getAddressCity(), stripeCard.getAddressState(), stripeCard.getAddressZip(), stripeCard.getAddressCountry(), stripeCard.getLast4(), stripeCard.getType(), stripeCard.getFingerprint(), stripeCard.getCountry());
+        return new Card(
+                null,
+                stripeCard.getExpMonth(),
+                stripeCard.getExpYear(),
+                null,
+                stripeCard.getName(),
+                stripeCard.getAddressLine1(),
+                stripeCard.getAddressLine2(),
+                stripeCard.getAddressCity(),
+                stripeCard.getAddressState(),
+                stripeCard.getAddressZip(),
+                stripeCard.getAddressCountry(),
+                stripeCard.getLast4(),
+                stripeCard.getBrand(),
+                stripeCard.getFingerprint(),
+                stripeCard.getCountry());
     }
 
     private Token androidTokenFromStripeToken(Card androidCard, com.stripe.model.Token stripeToken) {
-        return new Token(stripeToken.getId(), stripeToken.getLivemode(), new Date(stripeToken.getCreated() * 1000), stripeToken.getUsed(), androidCard);
+        return new Token(
+                stripeToken.getId(),
+                stripeToken.getLivemode(),
+                new Date(stripeToken.getCreated() * 1000),
+                stripeToken.getUsed(),
+                androidCard);
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -13,42 +13,47 @@ import com.stripe.android.util.TextUtils;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.net.RequestOptions;
 
+/**
+ * Class that handles {@link Token} creation from charges and {@link Card} models.
+ */
 public class Stripe {
-    private String defaultPublishableKey;
 
-    public TokenCreator tokenCreator = new TokenCreator() {
+    TokenCreator tokenCreator = new TokenCreator() {
         @Override
         public void create(
                 final Card card,
                 final String publishableKey,
                 final Executor executor,
                 final TokenCallback callback) {
-            AsyncTask<Void, Void, ResponseWrapper> task = new AsyncTask<Void, Void, ResponseWrapper>() {
-                protected ResponseWrapper doInBackground(Void... params) {
-                    try {
-                        RequestOptions requestOptions = RequestOptions.builder()
-                                .setApiKey(publishableKey).build();
-                        com.stripe.model.Token stripeToken = com.stripe.model.Token.create(
-                                hashMapFromCard(card), requestOptions);
-                        com.stripe.model.Card stripeCard = stripeToken.getCard();
-                        Card card = androidCardFromStripeCard(stripeCard);
-                        Token token = androidTokenFromStripeToken(card, stripeToken);
-                        return new ResponseWrapper(token, null);
-                    } catch (Exception e) {
-                        return new ResponseWrapper(null, e);
-                    }
-                }
+            AsyncTask<Void, Void, ResponseWrapper> task =
+                    new AsyncTask<Void, Void, ResponseWrapper>() {
+                        @Override
+                        protected ResponseWrapper doInBackground(Void... params) {
+                            try {
+                                RequestOptions requestOptions = RequestOptions.builder()
+                                        .setApiKey(publishableKey).build();
+                                com.stripe.model.Token stripeToken = com.stripe.model.Token.create(
+                                        hashMapFromCard(card), requestOptions);
+                                com.stripe.model.Card stripeCard = stripeToken.getCard();
+                                Card card = androidCardFromStripeCard(stripeCard);
+                                Token token = androidTokenFromStripeToken(card, stripeToken);
+                                return new ResponseWrapper(token, null);
+                            } catch (Exception e) {
+                                return new ResponseWrapper(null, e);
+                            }
+                        }
 
-                protected void onPostExecute(ResponseWrapper result) {
-                    tokenTaskPostExecution(result, callback);
-               }
+                        @Override
+                        protected void onPostExecute(ResponseWrapper result) {
+                            tokenTaskPostExecution(result, callback);
+                        }
             };
 
             executeTokenTask(executor, task);
         }
     };
 
-    public TokenRequester tokenRequester = new TokenRequester() {
+    TokenRequester tokenRequester = new TokenRequester() {
           @Override
           public void request(final String tokenId, final String publishableKey,
                   final Executor executor, final TokenCallback callback) {
@@ -75,40 +80,81 @@ public class Stripe {
           }
     };
 
-    public Stripe() {
-    }
+    private String defaultPublishableKey;
 
+    /**
+     * A blank constructor to set the key later.
+     */
+    public Stripe() { }
+
+    /**
+     * Constructor with publishable key.
+     *
+     * @param publishableKey the client's publishable key
+     * @throws AuthenticationException if the key is invalid
+     */
     public Stripe(String publishableKey) throws AuthenticationException {
         setDefaultPublishableKey(publishableKey);
     }
 
-    public void setDefaultPublishableKey(String publishableKey) throws AuthenticationException {
+    /**
+     * Call to create a {@link Token}.
+     *
+     * @param card the {@link Card} used for this transaction
+     * @param publishableKey the public key used for this transaction
+     * @param callback a {@link TokenCallback} to receive the result of this operation
+     */
+    public void createToken(
+            final Card card,
+            final String publishableKey,
+            final TokenCallback callback) {
+        createToken(card, publishableKey, null, callback);
+    }
+
+    void setDefaultPublishableKey(String publishableKey) throws AuthenticationException {
         validateKey(publishableKey);
         this.defaultPublishableKey = publishableKey;
     }
 
     private void validateKey(String publishableKey) throws AuthenticationException {
         if (publishableKey == null || publishableKey.length() == 0) {
-            throw new AuthenticationException("Invalid Publishable Key: You must use a valid publishable key to create a token.  For more info, see https://stripe.com/docs/stripe.js.", null, 0);
+            throw new AuthenticationException("Invalid Publishable Key: " +
+                    "You must use a valid publishable key to create a token.  " +
+                    "For more info, see https://stripe.com/docs/stripe.js.", null, 0);
         }
         if (publishableKey.startsWith("sk_")) {
-            throw new AuthenticationException("Invalid Publishable Key: You are using a secret key to create a token, instead of the publishable one. For more info, see https://stripe.com/docs/stripe.js", null, 0);
+            throw new AuthenticationException("Invalid Publishable Key: " +
+                    "You are using a secret key to create a token, " +
+                    "instead of the publishable one. For more info, " +
+                    "see https://stripe.com/docs/stripe.js", null, 0);
         }
     }
 
-    public void requestToken(final String tokenId, final Executor executor, final TokenCallback callback) {
+    void requestToken(final String tokenId, final Executor executor, final TokenCallback callback) {
         requestToken(tokenId, defaultPublishableKey, executor, callback);
     }
 
-    public void requestToken(final String tokenId, final String publishableKey, final TokenCallback callback) {
+    void requestToken(final String tokenId, final String publishableKey, final TokenCallback callback) {
         requestToken(tokenId, publishableKey, null, callback);
     }
 
-    public void requestToken(final String tokenId, final TokenCallback callback) {
+    void requestToken(final String tokenId, final TokenCallback callback) {
         requestToken(tokenId, defaultPublishableKey, callback);
     }
 
-    public void requestToken(final String tokenId, final String publishableKey, final Executor executor, final TokenCallback callback) {
+    void createToken(final Card card, final Executor executor, final TokenCallback callback) {
+        createToken(card, defaultPublishableKey, executor, callback);
+    }
+
+    void createToken(final Card card, final TokenCallback callback) {
+        createToken(card, defaultPublishableKey, callback);
+    }
+
+    private void requestToken(
+            final String tokenId,
+            final String publishableKey,
+            final Executor executor,
+            final TokenCallback callback) {
         try {
             if (tokenId == null)
                 throw new RuntimeException("Required Parameter: 'tokenId' is required to request a token");
@@ -125,25 +171,22 @@ public class Stripe {
         }
     }
 
-    public void createToken(final Card card, final Executor executor, final TokenCallback callback) {
-        createToken(card, defaultPublishableKey, executor, callback);
-    }
-
-    public void createToken(final Card card, final String publishableKey, final TokenCallback callback) {
-        createToken(card, publishableKey, null, callback);
-    }
-
-    public void createToken(final Card card, final TokenCallback callback) {
-        createToken(card, defaultPublishableKey, callback);
-    }
-
-    public void createToken(final Card card, final String publishableKey, final Executor executor, final TokenCallback callback) {
+    private void createToken(
+            final Card card,
+            final String publishableKey,
+            final Executor executor,
+            final TokenCallback callback) {
         try {
-            if (card == null)
-                throw new RuntimeException("Required Parameter: 'card' is required to create a token");
+            if (card == null) {
+                throw new RuntimeException(
+                        "Required Parameter: 'card' is required to create a token");
+            }
 
-            if (callback == null)
-                throw new RuntimeException("Required Parameter: 'callback' is required to use the created token and handle errors");
+            if (callback == null) {
+                throw new RuntimeException(
+                        "Required Parameter: 'callback' is required to use the created " +
+                                "token and handle errors");
+            }
 
             validateKey(publishableKey);
 
@@ -173,7 +216,9 @@ public class Stripe {
                 stripeCard.getCountry());
     }
 
-    private Token androidTokenFromStripeToken(Card androidCard, com.stripe.model.Token stripeToken) {
+    private Token androidTokenFromStripeToken(
+            Card androidCard,
+            com.stripe.model.Token stripeToken) {
         return new Token(
                 stripeToken.getId(),
                 stripeToken.getLivemode(),
@@ -183,12 +228,16 @@ public class Stripe {
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {
-        if (result.token != null)
+        if (result.token != null) {
             callback.onSuccess(result.token);
-        else if (result.error != null)
+        }
+        else if (result.error != null) {
             callback.onError(result.error);
-        else
-            callback.onError(new RuntimeException("Somehow got neither a token response or an error response"));
+        }
+        else {
+            callback.onError(new RuntimeException(
+                    "Somehow got neither a token response or an error response"));
+        }
     }
 
     private void executeTokenTask(Executor executor, AsyncTask<Void, Void, ResponseWrapper> task) {
@@ -199,9 +248,9 @@ public class Stripe {
     }
 
     private Map<String, Object> hashMapFromCard(Card card) {
-        Map<String, Object> tokenParams = new HashMap<String, Object>();
+        Map<String, Object> tokenParams = new HashMap<>();
 
-        Map<String, Object> cardParams = new HashMap<String, Object>();
+        Map<String, Object> cardParams = new HashMap<>();
         cardParams.put("number", TextUtils.nullIfBlank(card.getNumber()));
         cardParams.put("cvc", TextUtils.nullIfBlank(card.getCVC()));
         cardParams.put("exp_month", card.getExpMonth());
@@ -216,7 +265,7 @@ public class Stripe {
         cardParams.put("address_country", TextUtils.nullIfBlank(card.getAddressCountry()));
 
         // Remove all null values; they cause validation errors
-        for (String key : new HashSet<String>(cardParams.keySet())) {
+        for (String key : new HashSet<>(cardParams.keySet())) {
             if (cardParams.get(key) == null) {
                 cardParams.remove(key);
             }
@@ -227,8 +276,8 @@ public class Stripe {
     }
 
     private class ResponseWrapper {
-        public final Token token;
-        public final Exception error;
+        final Token token;
+        final Exception error;
 
         private ResponseWrapper(Token token, Exception error) {
             this.error = error;
@@ -237,10 +286,10 @@ public class Stripe {
     }
 
     interface TokenCreator {
-        public void create(Card card, String publishableKey, Executor executor, TokenCallback callback);
+        void create(Card card, String publishableKey, Executor executor, TokenCallback callback);
     }
 
     interface TokenRequester {
-        public void request(String tokenId, String publishableKey, Executor executor, TokenCallback callback);
+        void request(String tokenId, String publishableKey, Executor executor, TokenCallback callback);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -18,7 +18,7 @@ import com.stripe.net.RequestOptions;
  */
 public class Stripe {
 
-    TokenCreator tokenCreator = new TokenCreator() {
+    public TokenCreator tokenCreator = new TokenCreator() {
         @Override
         public void create(
                 final Card card,
@@ -53,7 +53,7 @@ public class Stripe {
         }
     };
 
-    TokenRequester tokenRequester = new TokenRequester() {
+    public TokenRequester tokenRequester = new TokenRequester() {
           @Override
           public void request(final String tokenId, final String publishableKey,
                   final Executor executor, final TokenCallback callback) {
@@ -111,7 +111,7 @@ public class Stripe {
         createToken(card, publishableKey, null, callback);
     }
 
-    void setDefaultPublishableKey(String publishableKey) throws AuthenticationException {
+    public void setDefaultPublishableKey(String publishableKey) throws AuthenticationException {
         validateKey(publishableKey);
         this.defaultPublishableKey = publishableKey;
     }
@@ -130,27 +130,27 @@ public class Stripe {
         }
     }
 
-    void requestToken(final String tokenId, final Executor executor, final TokenCallback callback) {
+    public void requestToken(final String tokenId, final Executor executor, final TokenCallback callback) {
         requestToken(tokenId, defaultPublishableKey, executor, callback);
     }
 
-    void requestToken(final String tokenId, final String publishableKey, final TokenCallback callback) {
+    public void requestToken(final String tokenId, final String publishableKey, final TokenCallback callback) {
         requestToken(tokenId, publishableKey, null, callback);
     }
 
-    void requestToken(final String tokenId, final TokenCallback callback) {
+    public void requestToken(final String tokenId, final TokenCallback callback) {
         requestToken(tokenId, defaultPublishableKey, callback);
     }
 
-    void createToken(final Card card, final Executor executor, final TokenCallback callback) {
+    public void createToken(final Card card, final Executor executor, final TokenCallback callback) {
         createToken(card, defaultPublishableKey, executor, callback);
     }
 
-    void createToken(final Card card, final TokenCallback callback) {
+    public void createToken(final Card card, final TokenCallback callback) {
         createToken(card, defaultPublishableKey, callback);
     }
 
-    private void requestToken(
+    public void requestToken(
             final String tokenId,
             final String publishableKey,
             final Executor executor,
@@ -171,7 +171,7 @@ public class Stripe {
         }
     }
 
-    private void createToken(
+    public void createToken(
             final Card card,
             final String publishableKey,
             final Executor executor,
@@ -276,8 +276,8 @@ public class Stripe {
     }
 
     private class ResponseWrapper {
-        final Token token;
-        final Exception error;
+        public final Token token;
+        public final Exception error;
 
         private ResponseWrapper(Token token, Exception error) {
             this.error = error;

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -3,6 +3,10 @@ package com.stripe.android.model;
 import com.stripe.android.util.DateUtils;
 import com.stripe.android.util.TextUtils;
 
+/**
+ * A model object representing a Card in the Android SDK. Note that this is slightly different
+ * from the Card model in stripe-java.
+ */
 public class Card extends com.stripe.model.StripeObject {
     public static final String AMERICAN_EXPRESS = "American Express";
     public static final String DISCOVER = "Discover";
@@ -182,14 +186,65 @@ public class Card extends com.stripe.model.StripeObject {
         this.currency = TextUtils.nullIfBlank(currency);
     }
 
-    public Card(String number, Integer expMonth, Integer expYear, String cvc, String name, String addressLine1, String addressLine2, String addressCity, String addressState, String addressZip, String addressCountry, String currency) {
-        this(number, expMonth, expYear, cvc, name, addressLine1, addressLine2, addressCity, addressState, addressZip, addressCountry, null, null, null, null);
+    public Card(
+            String number,
+            Integer expMonth,
+            Integer expYear,
+            String cvc,
+            String name,
+            String addressLine1,
+            String addressLine2,
+            String addressCity,
+            String addressState,
+            String addressZip,
+            String addressCountry,
+            String currency) {
+        this(
+                number,
+                expMonth,
+                expYear,
+                cvc,
+                name,
+                addressLine1,
+                addressLine2,
+                addressCity,
+                addressState,
+                addressZip,
+                addressCountry,
+                null,
+                null,
+                null,
+                null);
     }
 
-    public Card(String number, Integer expMonth, Integer expYear, String cvc) {
-        this(number, expMonth, expYear, cvc, null, null, null, null, null, null, null, null, null, null, null);
+    public Card(
+            String number,
+            Integer expMonth,
+            Integer expYear,
+            String cvc) {
+        this(
+                number,
+                expMonth,
+                expYear,
+                cvc,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
+    /**
+     * Checks whether {@code this} represents a valid card.
+     *
+     * @return {@code true} if valid, {@code false} otherwise.
+     */
     public boolean validateCard() {
         if (cvc == null) {
             return validateNumber() && validateExpiryDate();
@@ -198,6 +253,11 @@ public class Card extends com.stripe.model.StripeObject {
         }
     }
 
+    /**
+     * Checks whether or not the {@link #number} field is valid.
+     *
+     * @return {@code true} if valid, {@code false} otherwise.
+     */
     public boolean validateNumber() {
         if (TextUtils.isBlank(number)) {
             return false;
@@ -219,30 +279,27 @@ public class Card extends com.stripe.model.StripeObject {
         }
     }
 
+    /**
+     * Checks whether or not the {@link #expMonth} and {@link #expYear} fields represent a valid
+     * expiry date.
+     *
+     * @return {@code true} if valid, {@code false} otherwise
+     */
     public boolean validateExpiryDate() {
-    	if (!validateExpMonth()) {
-    		return false;
-    	}
-    	if (!validateExpYear()) {
-    		return false;
-    	}
-    	return !DateUtils.hasMonthPassed(expYear, expMonth);
+        if (!validateExpMonth()) {
+            return false;
+        }
+        if (!validateExpYear()) {
+            return false;
+        }
+        return !DateUtils.hasMonthPassed(expYear, expMonth);
     }
 
-    public boolean validateExpMonth() {
-    	if (expMonth == null) {
-    		return false;
-    	}
-    	return (expMonth >= 1 && expMonth <= 12);
-    }
-
-    public boolean validateExpYear() {
-    	if (expYear == null) {
-    		return false;
-    	}
-    	return !DateUtils.hasYearPassed(expYear);
-    }
-
+    /**
+     * Checks whether or not the {@link #cvc} field is valid.
+     *
+     * @return {@code true} if valid, {@code false} otherwise
+     */
     public boolean validateCVC() {
         if (TextUtils.isBlank(cvc)) {
             return false;
@@ -253,10 +310,25 @@ public class Card extends com.stripe.model.StripeObject {
                 (AMERICAN_EXPRESS.equals(type) && cvcValue.length() == 4) ||
                 (!AMERICAN_EXPRESS.equals(type) && cvcValue.length() == 3));
 
-        if (!TextUtils.isWholePositiveNumber(cvcValue) || !validLength) {
-            return false;
-        }
-        return true;
+        return TextUtils.isWholePositiveNumber(cvcValue) && validLength;
+    }
+
+    /**
+     * Checks whether or not the {@link #expMonth} field is valid.
+     *
+     * @return {@code true} if valid, {@code false} otherwise.
+     */
+    boolean validateExpMonth() {
+        return expMonth != null && expMonth >= 1 && expMonth <= 12;
+    }
+
+    /**
+     * Checks whether or not the {@link #expYear} field is valid.
+     *
+     * @return {@code true} if valid, {@code false} otherwise.
+     */
+    boolean validateExpYear() {
+        return expYear != null && !DateUtils.hasYearPassed(expYear);
     }
 
     private boolean isValidLuhnNumber(String number) {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -320,7 +320,7 @@ public class Card extends com.stripe.model.StripeObject {
      *
      * @return {@code true} if valid, {@code false} otherwise.
      */
-    boolean validateExpMonth() {
+    public boolean validateExpMonth() {
         return expMonth != null && expMonth >= 1 && expMonth <= 12;
     }
 
@@ -329,7 +329,7 @@ public class Card extends com.stripe.model.StripeObject {
      *
      * @return {@code true} if valid, {@code false} otherwise.
      */
-    boolean validateExpYear() {
+    public boolean validateExpYear() {
         return expYear != null && !DateUtils.hasYearPassed(expYear);
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -270,9 +270,10 @@ public class Card extends com.stripe.model.StripeObject {
             return false;
         }
 
-        if (AMERICAN_EXPRESS.equals(type)) {
+        String updatedType = getType();
+        if (AMERICAN_EXPRESS.equals(updatedType)) {
             return rawNumber.length() == MAX_LENGTH_AMERICAN_EXPRESS;
-        } else if (DINERS_CLUB.equals(type)) {
+        } else if (DINERS_CLUB.equals(updatedType)) {
             return rawNumber.length() == MAX_LENGTH_DINERS_CLUB;
         } else {
             return rawNumber.length() == MAX_LENGTH_STANDARD;
@@ -306,9 +307,10 @@ public class Card extends com.stripe.model.StripeObject {
         }
         String cvcValue = cvc.trim();
 
-        boolean validLength = ((type == null && cvcValue.length() >= 3 && cvcValue.length() <= 4) ||
-                (AMERICAN_EXPRESS.equals(type) && cvcValue.length() == 4) ||
-                (!AMERICAN_EXPRESS.equals(type) && cvcValue.length() == 3));
+        String updatedType = getType();
+        boolean validLength = ((updatedType == null && cvcValue.length() >= 3 && cvcValue.length() <= 4) ||
+                (AMERICAN_EXPRESS.equals(updatedType) && cvcValue.length() == 4) ||
+                (!AMERICAN_EXPRESS.equals(updatedType) && cvcValue.length() == 3));
 
         return TextUtils.isWholePositiveNumber(cvcValue) && validLength;
     }

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -46,37 +46,37 @@ public class CardTest {
     @Test
     public void testTypeReturnsCorrectlyForAmexCard() {
         Card card = new Card("3412123412341234", null, null, null);
-        assertEquals("American Express", card.getType());
+        assertEquals(Card.AMERICAN_EXPRESS, card.getType());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForDiscoverCard() {
         Card card = new Card("6452123412341234", null, null, null);
-        assertEquals("Discover", card.getType());
+        assertEquals(Card.DISCOVER, card.getType());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForJCBCard() {
         Card card = new Card("3512123412341234", null, null, null);
-        assertEquals("JCB", card.getType());
+        assertEquals(Card.JCB, card.getType());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForDinersClubCard() {
         Card card = new Card("3612123412341234", null, null, null);
-        assertEquals("Diners Club", card.getType());
+        assertEquals(Card.DINERS_CLUB, card.getType());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForVisaCard() {
         Card card = new Card("4112123412341234", null, null, null);
-        assertEquals("Visa", card.getType());
+        assertEquals(Card.VISA, card.getType());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForMasterCard() {
         Card card = new Card("5112123412341234", null, null, null);
-        assertEquals("MasterCard", card.getType());
+        assertEquals(Card.MASTERCARD, card.getType());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class CardTest {
     @Test
     public void shouldPassValidateNumberIfLuhnNumberAmex() {
         Card card = new Card("378282246310005", null, null, null);
-        assertEquals("American Express", card.getType());
+        assertEquals(Card.AMERICAN_EXPRESS, card.getType());
         assertTrue(card.validateNumber());
     }
 
@@ -131,7 +131,7 @@ public class CardTest {
     @Test
     public void shouldFailValidateNumberIfTooLong() {
         Card card = new Card("4242 4242 4242 4242 6", null, null, null);
-        assertEquals("Visa", card.getType());
+        assertEquals(Card.VISA, card.getType());
         assertFalse(card.validateNumber());
     }
 


### PR DESCRIPTION
r? @brandur-stripe
cc @jack-stripe @jenan-stripe 

Two changes:
1 - when getting a com.stripe.model.Card and converting it to a com.stripe.mode.android.Card object, I'm using the "brand" field and putting that into the "type" field of the android model (pursuant to a change that was made on the api a while back).
2 - Using an updated call to getType in the validateNumber() method of the (android) card object which was causing problems validating the numbers of AMEX cards when type was not already stored.