### PR TITLE
moving all the deploy gradle commands into our repository

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -32,6 +32,7 @@ android {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath = configurations.compile
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     destinationDir = file("../javadoc/")
     failOnError false
 }
@@ -39,7 +40,5 @@ task javadoc(type: Javadoc) {
 task wrapper(type: Wrapper) {
     gradleVersion = '3.1'
 }
-// Apply chrisbanes' excellent gradle-mvn-push recipe,
-// which lets us publish the build artifacts to maven
-// without *writing a single line of XML.*
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+
+apply from: 'deploy.gradle'

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -29,14 +29,6 @@ android {
     }
 }
 
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath = configurations.compile
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    destinationDir = file("../javadoc/")
-    failOnError false
-}
-
 task wrapper(type: Wrapper) {
     gradleVersion = '3.1'
 }

--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -1,3 +1,14 @@
+/*
+ * Based on the example at Chris Banes's repository that allows signing
+ * without manually creating a maven file.
+ *
+ * The original can be found at
+ * https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle
+ * 
+ * Moving this into our repository to control security and to allow
+ * for finer control of javadoc and other options.
+ */
+
 apply plugin: 'maven'
 apply plugin: 'signing'
 

--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -1,0 +1,99 @@
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+afterEvaluate { project ->
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                pom.groupId = GROUP
+                pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
+
+                repository(url: getReleaseRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+
+                pom.project {
+                    name POM_NAME
+                    packaging POM_PACKAGING
+                    description POM_DESCRIPTION
+                    url POM_URL
+
+                    scm {
+                        url POM_SCM_URL
+                        connection POM_SCM_CONNECTION
+                        developerConnection POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name POM_LICENCE_NAME
+                            url POM_LICENCE_URL
+                            distribution POM_LICENCE_DIST
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id POM_DEVELOPER_ID
+                            name POM_DEVELOPER_NAME
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.archives
+    }
+
+    task androidJavadocs(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath = configurations.compile
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+        classifier = 'javadoc'
+        from androidJavadocs.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.sourceFiles
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocsJar
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @jack-stripe 

To deploy, we actually ran a script that was completely out of stripe's control. I have no reason not to trust the owner of that external script, but as it could change without us immediately knowing about it, I moved the code into our repo. This also gives us the ability to tweak it, since it was causing javadoc build problems that we had to react to without being able to adjust on our end.