### PR TITLE
adding deprecated annotation to requestToken methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -186,7 +186,12 @@ public class Stripe {
      *
      * @param tokenId the id of the {@link Token} being requested
      * @param callback a {@link TokenCallback} to receive the result
+     *
+     * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
+     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * keys should not be included in mobile applications.
      */
+    @Deprecated
     public void requestToken(
             @NonNull final String tokenId,
             @NonNull final TokenCallback callback) {
@@ -199,6 +204,10 @@ public class Stripe {
      * @param tokenId the id of the {@link Token} being requested
      * @param publishableKey the publishable key used to create this token
      * @param callback a {@link TokenCallback} to receive the result
+     *
+     * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
+     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * keys should not be included in mobile applications.
      */
     public void requestToken(
             @NonNull final String tokenId,
@@ -213,6 +222,10 @@ public class Stripe {
      * @param tokenId the id of the {@link Token} being requested
      * @param executor an {@link Executor} on which to run this request
      * @param callback a {@link TokenCallback} to receive the result
+     *
+     * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
+     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * keys should not be included in mobile applications.
      */
     public void requestToken(
             @NonNull final String tokenId,
@@ -231,6 +244,10 @@ public class Stripe {
      * @param executor an {@link Executor} on which to run this operation, or {@code null} to run
      *                 on a default background executor
      * @param callback a {@link TokenCallback} to receive the result
+     *
+     * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
+     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * keys should not be included in mobile applications.
      */
     public void requestToken(
             @NonNull final String tokenId,

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -209,6 +209,7 @@ public class Stripe {
      * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
+    @Deprecated
     public void requestToken(
             @NonNull final String tokenId,
             @NonNull @Size(min = 1) final String publishableKey,
@@ -227,6 +228,7 @@ public class Stripe {
      * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
+    @Deprecated
     public void requestToken(
             @NonNull final String tokenId,
             @NonNull final Executor executor,
@@ -249,6 +251,7 @@ public class Stripe {
      * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
+    @Deprecated
     public void requestToken(
             @NonNull final String tokenId,
             @NonNull @Size(min = 1) final String publishableKey,

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -188,7 +188,7 @@ public class Stripe {
      * @param callback a {@link TokenCallback} to receive the result
      *
      * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
-     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
     @Deprecated
@@ -206,7 +206,7 @@ public class Stripe {
      * @param callback a {@link TokenCallback} to receive the result
      *
      * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
-     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
     public void requestToken(
@@ -224,7 +224,7 @@ public class Stripe {
      * @param callback a {@link TokenCallback} to receive the result
      *
      * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
-     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
     public void requestToken(
@@ -246,7 +246,7 @@ public class Stripe {
      * @param callback a {@link TokenCallback} to receive the result
      *
      * @deprecated the requestToken endpoint is not guaranteed to work with a public key, as that
-     * ability has been turned off for accounts using API versions later than 2014-11-07. Secret
+     * ability has been turned off for accounts using API versions later than 2014-10-07. Secret
      * keys should not be included in mobile applications.
      */
     public void requestToken(


### PR DESCRIPTION
r? @jack-stripe 
cc @brandur-stripe 

Addresses #49 

We're going to remove the requestToken method in future versions of the API, as only a small fraction of users can use it with a public key. I'm not making breaking changes yet because I'm not yet bumping to v2.0.0, so I'm just adding a notice to users so they can see the impending changes.