### PR TITLE
removing reference to TextUtils

### DIFF
--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -43,6 +43,8 @@ public class StripeTextUtils {
             return false;
         }
 
+        // Refraining from using android's TextUtils in order to avoid
+        // depending on another package.
         for (int i = 0; i < value.length(); i++) {
             if (!Character.isDigit(value.charAt(i))) {
                 return false;

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -1,7 +1,6 @@
 package com.stripe.android.util;
 
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.stripe.android.model.Card;
 
@@ -44,7 +43,12 @@ public class StripeTextUtils {
             return false;
         }
 
-        return TextUtils.isDigitsOnly(value);
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -62,7 +66,7 @@ public class StripeTextUtils {
 
     /**
      * A checker for whether or not the input value is entirely whitespace. This is slightly more
-     * aggressive than {@link TextUtils#isEmpty(CharSequence)}, which only returns true for
+     * aggressive than the android TextUtils#isEmpty method, which only returns true for
      * {@code null} or {@code ""}.
      *
      * @param value a possibly blank input string value


### PR DESCRIPTION
r? @jack-stripe 
cc @brandur-stripe 

We don't strictly need Android's TextUtils class to do the check in question, so I'm omitting its use for now in response to customer request.

Fixes #100 