### PR TITLE
adding the request options classes and socket enhancers

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -20,7 +20,7 @@ android {
     compileSdkVersion 25
     buildToolsVersion '25.0.0'
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 9
         targetSdkVersion 25
     }
     sourceSets {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -399,7 +399,8 @@ public class Stripe {
                 stripeToken.getLivemode(),
                 new Date(stripeToken.getCreated() * 1000),
                 stripeToken.getUsed(),
-                androidCard);
+                androidCard,
+                Token.TYPE_CARD);
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -761,5 +761,4 @@ public class Card extends com.stripe.model.StripeObject {
         }
         return number.trim().replaceAll("\\s+|-", "");
     }
-
 }

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -1,41 +1,62 @@
 package com.stripe.android.model;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.StringDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Date;
 
 /**
  * The model of a Stripe card token.
  */
 public class Token extends com.stripe.model.StripeObject {
-    private final String id;
-    private final Date created;
-    private final boolean livemode;
-    private final boolean used;
-    private final Card card;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({TYPE_CARD})
+    public @interface TokenType {}
+    public static final String TYPE_CARD = "card";
+
+    private final String mId;
+    private final String mType;
+    private final Date mCreated;
+    private final boolean mLivemode;
+    private final boolean mUsed;
+    private final Card mCard;
 
     /**
-     * This method should not be invoked in your code.  This is used by Stripe to
-     * create tokens using a Stripe API response
+     * Constructor that should not be invoked in your code.  This is used by Stripe to
+     * create tokens using a Stripe API response.
+     *
+     *
      */
-    public Token(String id, boolean livemode, Date created, Boolean used, Card card) {
-        this.id = id;
-        this.livemode = livemode;
-        this.card = card;
-        this.created = created;
-        this.used = used;
+    public Token(
+            String id,
+            boolean livemode,
+            Date created,
+            Boolean used,
+            Card card,
+            @TokenType String type) {
+        mId = id;
+        mType = type;
+        mCreated = created;
+        mLivemode = livemode;
+        mCard = card;
+        mUsed = used;
     }
 
     /***
      * @return the {@link Date} this token was created
      */
     public Date getCreated() {
-        return created;
+        return mCreated;
     }
 
     /**
-     * @return the {@link #id} of this token
+     * @return the {@link #mId} of this token
      */
     public String getId() {
-        return id;
+        return mId;
     }
 
     /**
@@ -43,20 +64,28 @@ public class Token extends com.stripe.model.StripeObject {
      * it is only usable for testing
      */
     public boolean getLivemode() {
-        return livemode;
+        return mLivemode;
     }
 
     /**
      * @return {@code true} if this token has been used, {@code false} otherwise
      */
     public boolean getUsed() {
-        return used;
+        return mUsed;
+    }
+
+    /**
+     * @return Get the {@link TokenType} of this token.
+     */
+    @TokenType
+    public String getType() {
+        return mType;
     }
 
     /**
      * @return the {@link Card} for this token
      */
     public Card getCard() {
-        return card;
+        return mCard;
     }
 }

--- a/stripe/src/main/java/com/stripe/android/net/CardParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/CardParser.java
@@ -1,0 +1,74 @@
+package com.stripe.android.net;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.model.Card;
+import com.stripe.android.util.StripeJsonUtils;
+import com.stripe.android.util.StripeTextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * A helper class for parsing {@link Card} objects returned from the server.
+ */
+public class CardParser {
+
+    static final String FIELD_ADDRESS_CITY = "address_city";
+    static final String FIELD_ADDRESS_COUNTRY = "address_country";
+    static final String FIELD_ADDRESS_LINE1 = "address_line1";
+    static final String FIELD_ADDRESS_LINE2 = "address_line2";
+    static final String FIELD_ADDRESS_STATE = "address_state";
+    static final String FIELD_ADDRESS_ZIP = "address_zip";
+    static final String FIELD_BRAND = "brand";
+    static final String FIELD_COUNTRY = "country";
+    static final String FIELD_CURRENCY = "currency";
+    static final String FIELD_EXP_MONTH = "exp_month";
+    static final String FIELD_EXP_YEAR = "exp_year";
+    static final String FIELD_FINGERPRINT = "fingerprint";
+    static final String FIELD_FUNDING = "funding";
+    static final String FIELD_LAST4 = "last4";
+    static final String FIELD_NAME = "name";
+
+    /**
+     * Parse the card directly from a JSON-formatted {@link String} value.
+     *
+     * @param jsonCard the raw JSON
+     * @return a {@link Card} object represented by the JSON
+     * @throws JSONException if the String is improperly formatted or is missing required values
+     */
+    @NonNull
+    static Card parseCard(String jsonCard) throws JSONException {
+        JSONObject cardObject = new JSONObject(jsonCard);
+        return parseCard(cardObject);
+    }
+
+    /**
+     * Convert a {@link JSONObject} into a {@link Card} object.
+     *
+     * @param objectCard a {@link JSONObject} that represents a {@link Card}
+     * @return a {@link Card} with fields determined by the input
+     * @throws JSONException if the input is missing a required field
+     */
+    @NonNull
+    static Card parseCard(@NonNull JSONObject objectCard) throws JSONException {
+        return new Card(
+                null,
+                objectCard.getInt(FIELD_EXP_MONTH),
+                objectCard.getInt(FIELD_EXP_YEAR),
+                null,
+                StripeJsonUtils.optString(objectCard, FIELD_NAME),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_LINE1),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_LINE2),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_CITY),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_STATE),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_ZIP),
+                StripeJsonUtils.optString(objectCard, FIELD_ADDRESS_COUNTRY),
+                StripeTextUtils.asCardBrand(StripeJsonUtils.optString(objectCard, FIELD_BRAND)),
+                StripeJsonUtils.optString(objectCard, FIELD_LAST4),
+                StripeJsonUtils.optString(objectCard, FIELD_FINGERPRINT),
+                StripeTextUtils.asFundingType(StripeJsonUtils.optString(objectCard, FIELD_FUNDING)),
+                StripeJsonUtils.optString(objectCard, FIELD_COUNTRY),
+                StripeJsonUtils.optString(objectCard, FIELD_CURRENCY));
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
+++ b/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
@@ -1,0 +1,117 @@
+package com.stripe.android.net;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.util.StripeTextUtils;
+
+/**
+ * Data class representing options for a Stripe API request.
+ */
+public class RequestOptions {
+
+    public static final String DEFAULT_API_VERSION = "2016-07-06";
+
+    @NonNull private final String mApiVersion;
+    @Nullable private final String mIdempotencyKey;
+    @NonNull private final String mPublishableApiKey;
+
+    private RequestOptions(
+            @NonNull String apiVersion,
+            @Nullable String idempotencyKey,
+            @NonNull String publishableApiKey) {
+        mApiVersion = apiVersion;
+        mIdempotencyKey = idempotencyKey;
+        mPublishableApiKey = publishableApiKey;
+    }
+
+    /**
+     * @return the API version for this request
+     */
+    @NonNull
+    public String getApiVersion() {
+        return mApiVersion;
+    }
+
+    /**
+     * @return the idempotency key for this request
+     */
+    @Nullable
+    public String getIdempotencyKey() {
+        return mIdempotencyKey;
+    }
+
+    /**
+     * @return the publishable API key for this request
+     */
+    @NonNull
+    public String getPublishableApiKey() {
+        return mPublishableApiKey;
+    }
+
+    /**
+     * Builder class for a set of {@link RequestOptions}.
+     */
+    public static final class RequestOptionsBuilder {
+
+        private String publishableApiKey;
+        private String idempotencyKey;
+        private String apiVersion;
+
+        /**
+         * Builder constructor requiring an API key.
+         *
+         * @param publishableApiKey your publishable API key
+         */
+        public RequestOptionsBuilder(@NonNull String publishableApiKey) {
+            this.publishableApiKey = publishableApiKey;
+            this.apiVersion = DEFAULT_API_VERSION;
+        }
+
+        /**
+         * A way to set your publishable key outside of the constructor.
+         *
+         * @param publishableApiKey your publishable API key
+         * @return {@code this}, for chaining purposes
+         */
+        public RequestOptionsBuilder setPublishableApiKey(@NonNull String publishableApiKey) {
+            this.publishableApiKey = publishableApiKey;
+            return this;
+        }
+
+        /**
+         * Setter for the optional idempotency value of the {@link RequestOptions}. This can
+         * be any value you want.
+         *
+         * @param idempotencyKey the idempotency key
+         * @return {@code this}, for chaining purposes
+         */
+        public RequestOptionsBuilder setIdempotencyKey(@Nullable String idempotencyKey) {
+            this.idempotencyKey = idempotencyKey;
+            return this;
+        }
+
+        /**
+         * Setter for the API version for this set of {@link RequestOptions}. If not set,
+         * {@link RequestOptions#DEFAULT_API_VERSION} is used.
+         *
+         * @param apiVersion the API version to use
+         * @return {@code this}, for chaining purposes
+         */
+        public RequestOptionsBuilder setApiVersion(@Nullable String apiVersion) {
+            this.apiVersion = StripeTextUtils.isBlank(apiVersion)
+                    ? DEFAULT_API_VERSION
+                    : apiVersion;
+            return this;
+        }
+
+        /**
+         * Construct the {@link RequestOptions} object.
+         *
+         * @return the new {@link RequestOptions} object
+         */
+        public RequestOptions build() {
+            return new RequestOptions(this.apiVersion, this.idempotencyKey, this.publishableApiKey);
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/StripeResponse.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeResponse.java
@@ -1,0 +1,54 @@
+package com.stripe.android.net;
+
+import android.support.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a response from the Stripe servers.
+ */
+public class StripeResponse {
+
+    private String mResponseBody;
+    private int mResponseCode;
+    private Map<String, List<String>> mResponseHeaders;
+
+    /**
+     * Object constructor.
+     *
+     * @param responseCode the response code (i.e. 404)
+     * @param responseBody the body of the response
+     * @param responseHeaders any headers associated with the response
+     */
+    public StripeResponse(
+            int responseCode,
+            String responseBody,
+            @Nullable Map<String, List<String>> responseHeaders) {
+        mResponseCode = responseCode;
+        mResponseBody = responseBody;
+        mResponseHeaders = responseHeaders;
+    }
+
+    /**
+     * @return the {@link #mResponseCode response code}.
+     */
+    public int getResponseCode() {
+        return mResponseCode;
+    }
+
+    /**
+     * @return the {@link #mResponseBody response body}.
+     */
+    public String getResponseBody() {
+        return mResponseBody;
+    }
+
+    /**
+     * @return the {@link #mResponseHeaders response headers}.
+     */
+    @Nullable
+    public Map<String, List<String>> getResponseHeaders() {
+        return mResponseHeaders;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/StripeSSLSocketFactory.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeSSLSocketFactory.java
@@ -1,0 +1,120 @@
+package com.stripe.android.net;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Wraps a SSLSocketFactory and enables more TLS versions on older versions of Android.
+ * Most of the code is taken from stripe-java.
+ */
+public class StripeSSLSocketFactory extends SSLSocketFactory {
+
+    private final SSLSocketFactory under;
+    private final boolean tlsv11Supported, tlsv12Supported;
+
+    private static final String TLSv11Proto = "TLSv1.1", TLSv12Proto = "TLSv1.2";
+
+    /**
+     * Constructor for a socket factory instance.
+     */
+    public StripeSSLSocketFactory() {
+        this.under = HttpsURLConnection.getDefaultSSLSocketFactory();
+
+        // For Android prior to 4.1, TLSv1.1 and TLSv1.2 might not be supported
+        boolean tlsv11Supported = false, tlsv12Supported = false;
+
+        String[] supportedProtocols;
+        try {
+            supportedProtocols = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
+        } catch (NoSuchAlgorithmException e) {
+            supportedProtocols = new String[0];
+        }
+
+        for (String proto : supportedProtocols) {
+            if (proto.equals(TLSv11Proto)) {
+                tlsv11Supported = true;
+            } else if (proto.equals(TLSv12Proto)) {
+                tlsv12Supported = true;
+            }
+        }
+
+        this.tlsv11Supported = tlsv11Supported;
+        this.tlsv12Supported = tlsv12Supported;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return this.under.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return this.under.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(
+            Socket s,
+            String host,
+            int port,
+            boolean autoClose) throws IOException {
+        return fixupSocket(this.under.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return fixupSocket(this.under.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(
+            String host,
+            int port,
+            InetAddress localHost,
+            int localPort) throws IOException {
+        return fixupSocket(this.under.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return fixupSocket(this.under.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(
+            InetAddress address,
+            int port,
+            InetAddress localAddress,
+            int localPort) throws IOException {
+        return fixupSocket(
+                this.under.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket fixupSocket(Socket sock) {
+        if (!(sock instanceof SSLSocket)) {
+            return sock;
+        }
+
+        SSLSocket sslSock = (SSLSocket) sock;
+
+        Set<String> protos = new HashSet<>(Arrays.asList(sslSock.getEnabledProtocols()));
+        if (tlsv11Supported) {
+            protos.add(TLSv11Proto);
+        }
+        if (tlsv12Supported) {
+            protos.add(TLSv12Proto);
+        }
+
+        sslSock.setEnabledProtocols(protos.toArray(new String[0]));
+        return sslSock;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/TokenParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/TokenParser.java
@@ -1,0 +1,41 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Token;
+import com.stripe.android.util.StripeJsonUtils;
+import com.stripe.android.util.StripeTextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Date;
+
+/**
+ * A class that handles parsing the JSON of a {@link com.stripe.android.model.Token} object.
+ */
+public class TokenParser {
+
+    private static final String FIELD_CARD = "card";
+    private static final String FIELD_CREATED = "created";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_LIVEMODE = "livemode";
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_USED = "used";
+
+    static Token parseToken(String jsonToken) throws JSONException {
+        JSONObject jsonObject = new JSONObject(jsonToken);
+        String tokenId = StripeJsonUtils.getString(jsonObject, FIELD_ID);
+        Long createdTimeStamp = jsonObject.getLong(FIELD_CREATED);
+        Boolean liveMode = jsonObject.getBoolean(FIELD_LIVEMODE);
+        @Token.TokenType String tokenType =
+                StripeTextUtils.asTokenType(StripeJsonUtils.getString(jsonObject, FIELD_TYPE));
+        Boolean used = jsonObject.getBoolean(FIELD_USED);
+
+        JSONObject cardObject = jsonObject.getJSONObject(FIELD_CARD);
+        Card card = CardParser.parseCard(cardObject);
+
+        Date date = new Date(createdTimeStamp * 1000);
+
+        return new Token(tokenId, liveMode, date, used, card, tokenType);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
@@ -1,0 +1,58 @@
+package com.stripe.android.util;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+import android.support.annotation.VisibleForTesting;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * A set of JSON parsing utility functions.
+ */
+public class StripeJsonUtils {
+
+    static final String EMPTY = "";
+    static final String NULL = "null";
+
+    /**
+     * Calls through to {@link JSONObject#getString(String)} while safely
+     * converting the raw string "null" and the empty string to {@code null}.
+     *
+     * @param jsonObject the input object
+     * @param fieldName the required field name
+     * @return the value stored in the requested field
+     * @throws JSONException if the field does not exist
+     */
+    @Nullable
+    public static String getString(
+            @NonNull JSONObject jsonObject,
+            @NonNull @Size(min = 1) String fieldName) throws JSONException {
+        return nullIfNullOrEmpty(jsonObject.getString(fieldName));
+    }
+
+    /**
+     * Calls through to {@link JSONObject#optString(String)} while safely
+     * converting the raw string "null" and the empty string to {@code null}. Will not throw
+     * an exception if the field isn't found.
+     *
+     * @param jsonObject the input object
+     * @param fieldName the optional field name
+     * @return the value stored in the field, or {@code null} if the field isn't present
+     */
+    @Nullable
+    public static String optString(
+            @NonNull JSONObject jsonObject,
+            @NonNull @Size(min = 1) String fieldName) {
+        return nullIfNullOrEmpty(jsonObject.optString(fieldName));
+    }
+
+    @Nullable
+    @VisibleForTesting
+    static String nullIfNullOrEmpty(@Nullable String possibleNull) {
+        return NULL.equals(possibleNull) || EMPTY.equals(possibleNull)
+                ? null
+                : possibleNull;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -3,9 +3,11 @@ package com.stripe.android.util;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.model.Card;
+import com.stripe.android.model.Token;
 
 import static com.stripe.android.model.Card.CardBrand;
 import static com.stripe.android.model.Card.FundingType;
+import static com.stripe.android.model.Token.TokenType;
 
 /**
  * Utility class for common text-related operations on Stripe data coming from the server.
@@ -130,5 +132,21 @@ public class StripeTextUtils {
         } else {
             return Card.FUNDING_UNKNOWN;
         }
+    }
+
+    /**
+     * Converts an unchecked String value to a {@link TokenType} or {@code null}.
+     *
+     * @param possibleTokenType a String that might match a {@link TokenType} or be empty
+     * @return {@code null} if the input is blank or otherwise does not match a {@link TokenType},
+     * else the appropriate {@link TokenType}.
+     */
+    @Nullable
+    @TokenType
+    public static String asTokenType(@Nullable String possibleTokenType) {
+        if (Token.TYPE_CARD.equals(possibleTokenType)) {
+            return Token.TYPE_CARD;
+        }
+        return null;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/net/CardParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/CardParserTest.java
@@ -1,0 +1,149 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.Card;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for {@link CardParser}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class CardParserTest {
+
+    private static final String JSON_CARD = "{\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": null,\n" +
+            "    \"address_country\": null,\n" +
+            "    \"address_line1\": null,\n" +
+            "    \"address_line1_check\": null,\n" +
+            "    \"address_line2\": null,\n" +
+            "    \"address_state\": null,\n" +
+            "    \"address_zip\": null,\n" +
+            "    \"address_zip_check\": null,\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"cvc_check\": null,\n" +
+            "    \"dynamic_last4\": null,\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"metadata\": {\n" +
+            "    },\n" +
+            "    \"name\": null,\n" +
+            "    \"tokenization_method\": null\n" +
+            "  }";
+
+    private static final String JSON_NO_EXP_MONTH = "{\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": null,\n" +
+            "    \"address_country\": null,\n" +
+            "    \"address_line1\": null,\n" +
+            "    \"address_line1_check\": null,\n" +
+            "    \"address_line2\": null,\n" +
+            "    \"address_state\": null,\n" +
+            "    \"address_zip\": null,\n" +
+            "    \"address_zip_check\": null,\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"cvc_check\": null,\n" +
+            "    \"dynamic_last4\": null,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"metadata\": {\n" +
+            "    },\n" +
+            "    \"name\": null,\n" +
+            "    \"tokenization_method\": null\n" +
+            "  }";
+
+    private static final String JSON_NO_EXP_YEAR = "{\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": null,\n" +
+            "    \"address_country\": null,\n" +
+            "    \"address_line1\": null,\n" +
+            "    \"address_line1_check\": null,\n" +
+            "    \"address_line2\": null,\n" +
+            "    \"address_state\": null,\n" +
+            "    \"address_zip\": null,\n" +
+            "    \"address_zip_check\": null,\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"cvc_check\": null,\n" +
+            "    \"dynamic_last4\": null,\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"metadata\": {\n" +
+            "    },\n" +
+            "    \"name\": null,\n" +
+            "    \"tokenization_method\": null\n" +
+            "  }";
+
+    private static final String BAD_JSON = "{ \"id\": ";
+
+    @Test
+    public void parseSampleCard_returnsExpectedValue() {
+        Card expectedCard = new Card(
+                null,
+                8,
+                2017,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Card.VISA,
+                "4242",
+                null,
+                Card.FUNDING_CREDIT,
+                "US",
+                null);
+        try {
+            Card cardFromJson = CardParser.parseCard(JSON_CARD);
+            assertEquals(expectedCard.getBrand(), cardFromJson.getBrand());
+            assertEquals(expectedCard.getFunding(), cardFromJson.getFunding());
+            assertEquals(expectedCard.getCountry(), cardFromJson.getCountry());
+            assertEquals(expectedCard.getLast4(), cardFromJson.getLast4());
+            assertEquals(expectedCard.getExpMonth(), cardFromJson.getExpMonth());
+            assertEquals(expectedCard.getExpYear(), cardFromJson.getExpYear());
+            assertNull(cardFromJson.getAddressCity());
+            assertNull(cardFromJson.getFingerprint());
+        } catch (JSONException jex) {
+            fail();
+        }
+    }
+
+    @Test(expected = JSONException.class)
+    public void parseCard_withBadJson_throwsJsonException() throws JSONException {
+        CardParser.parseCard(BAD_JSON);
+        fail("Expected an exception.");
+    }
+
+    @Test(expected = JSONException.class)
+    public void parseCard_withNoExpirationMonth_throwsJsonException() throws JSONException {
+        CardParser.parseCard(JSON_NO_EXP_MONTH);
+        fail("Expected an exception.");
+    }
+
+    @Test(expected = JSONException.class)
+    public void parseCard_withNoExpirationYear_throwsJsonException() throws JSONException {
+        CardParser.parseCard(JSON_NO_EXP_YEAR);
+        fail("Expected an exception.");
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/net/TokenParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/TokenParserTest.java
@@ -1,0 +1,121 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.Token;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for {@link TokenParser}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class TokenParserTest {
+
+    private static final String RAW_TOKEN = "{\n" +
+            "  \"id\": \"tok_189fi32eZvKYlo2Ct0KZvU5Y\",\n" +
+            "  \"object\": \"token\",\n" +
+            "  \"card\": {\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": null,\n" +
+            "    \"address_country\": null,\n" +
+            "    \"address_line1\": null,\n" +
+            "    \"address_line1_check\": null,\n" +
+            "    \"address_line2\": null,\n" +
+            "    \"address_state\": null,\n" +
+            "    \"address_zip\": null,\n" +
+            "    \"address_zip_check\": null,\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"cvc_check\": null,\n" +
+            "    \"dynamic_last4\": null,\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"metadata\": {\n" +
+            "    },\n" +
+            "    \"name\": null,\n" +
+            "    \"tokenization_method\": null\n" +
+            "  },\n" +
+            "  \"client_ip\": null,\n" +
+            "  \"created\": 1462905355,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"type\": \"card\",\n" +
+            "  \"used\": false\n" +
+            "}";
+
+    private static final String RAW_TOKEN_NO_ID = "{\n" +
+            "  \"object\": \"token\",\n" +
+            "  \"card\": {\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": null,\n" +
+            "    \"address_country\": null,\n" +
+            "    \"address_line1\": null,\n" +
+            "    \"address_line1_check\": null,\n" +
+            "    \"address_line2\": null,\n" +
+            "    \"address_state\": null,\n" +
+            "    \"address_zip\": null,\n" +
+            "    \"address_zip_check\": null,\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"cvc_check\": null,\n" +
+            "    \"dynamic_last4\": null,\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"metadata\": {\n" +
+            "    },\n" +
+            "    \"name\": null,\n" +
+            "    \"tokenization_method\": null\n" +
+            "  },\n" +
+            "  \"client_ip\": null,\n" +
+            "  \"created\": 1462905355,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"type\": \"card\",\n" +
+            "  \"used\": false\n" +
+            "}";
+
+    @Test
+    public void parseToken_readsObject() {
+        Date createdDate = new Date(1462905355L * 1000L);
+        Token partialExpectedToken = new Token(
+                "tok_189fi32eZvKYlo2Ct0KZvU5Y",
+                false,
+                createdDate,
+                false,
+                null,
+                "card");
+        try {
+            Token answerToken = TokenParser.parseToken(RAW_TOKEN);
+            assertEquals(partialExpectedToken.getId(), answerToken.getId());
+            assertEquals(partialExpectedToken.getLivemode(), answerToken.getLivemode());
+            assertEquals(partialExpectedToken.getCreated(), answerToken.getCreated());
+            assertEquals(partialExpectedToken.getUsed(), answerToken.getUsed());
+
+            // Note: we test the validity of the card object in CardParserTest
+            assertNotNull(answerToken.getCard());
+        } catch (JSONException jex) {
+            fail("Json Parsing failure");
+        }
+    }
+
+    @Test(expected = JSONException.class)
+    public void parseToken_withoutId_throwsException() throws JSONException {
+        TokenParser.parseToken(RAW_TOKEN_NO_ID);
+        fail("Expected an exception.");
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/util/StripeJsonUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeJsonUtilsTest.java
@@ -1,0 +1,101 @@
+package com.stripe.android.util;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for {@link StripeJsonUtils}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class StripeJsonUtilsTest {
+
+    @Test
+    public void nullIfNullOrEmpty_returnsNullForNull() {
+        assertNull(StripeJsonUtils.nullIfNullOrEmpty("null"));
+    }
+
+    @Test
+    public void nullIfNullOrEmpty_returnsNullForEmpty() {
+        assertNull(StripeJsonUtils.nullIfNullOrEmpty(""));
+    }
+
+    @Test
+    public void nullIfNullOrEmpty_returnsInputIfNotNull() {
+        final String notANull = "notANull";
+        assertEquals(notANull, StripeJsonUtils.nullIfNullOrEmpty(notANull));
+    }
+
+    @Test
+    public void getString_whenFieldPresent_findsAndReturnsField() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("key", "value");
+            assertEquals("value", StripeJsonUtils.getString(jsonObject, "key"));
+        } catch (JSONException jex) {
+            fail("No exception expected");
+        }
+    }
+
+    @Test
+    public void getString_whenFieldContainsRawNull_returnsNull() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("key", "null");
+            assertNull(StripeJsonUtils.getString(jsonObject, "key"));
+        } catch (JSONException jex) {
+            fail("No exception expected");
+        }
+    }
+
+    @Test(expected = JSONException.class)
+    public void getString_whenFieldNotPresent_throwsJsonException() throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key", "value");
+
+        StripeJsonUtils.getString(jsonObject, "differentKey");
+        fail("Expected an exception.");
+    }
+
+    @Test
+    public void optString_whenFieldPresent_findsAndReturnsField() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("key", "value");
+            assertEquals("value", StripeJsonUtils.optString(jsonObject, "key"));
+        } catch (JSONException jex) {
+            fail("No exception expected");
+        }
+    }
+
+    @Test
+    public void optString_whenFieldContainsRawNull_returnsNull() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("key", "null");
+            assertNull(StripeJsonUtils.optString(jsonObject, "key"));
+        } catch (JSONException jex) {
+            fail("No exception expected");
+        }
+    }
+
+    @Test
+    public void optString_whenFieldNotPresent_returnsNull() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("key", "value");
+            Object ob  = StripeJsonUtils.optString(jsonObject, "nokeyshere");
+            assertNull(ob);
+        } catch (JSONException jex) {
+            fail("No exception expected");
+        }
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @shale-stripe 

Adding the RequestOptions, StripeResponse, and StripeSSLSocketFactory, all of which are ported and paired down from stripe-java. The StripeSSLSocketFactory turns out to actually matter on Android for versions older than JellyBean, which fall well within our support.

I had to bump the android min SDK version up to 9 (still within plans and excluding less than 0.01% of global android users) in order to use the StripeSSLSocketFactory methods.