### PR TITLE
breaks the dependency on GSON and stripe-java

### DIFF
--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.java
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.java
@@ -10,7 +10,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
-import com.stripe.exception.StripeException;
+import com.stripe.android.exception.StripeException;
 
 /**
  * An {@link IntentService} subclass for handling the creation of a {@link Token} from

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -6,8 +6,6 @@ configurations {
 
 dependencies {
     compile 'com.android.support:support-annotations:25.0.1'
-    compile 'com.stripe:stripe-java:3.2.0'
-    compile 'com.google.code.gson:gson:2.2.4'
 
     javadocDeps 'com.android.support:support-annotations:25.0.1'
     provided 'javax.annotation:jsr250-api:1.0'

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -8,7 +8,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.VisibleForTesting;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -384,34 +383,6 @@ public class Stripe {
         this.defaultPublishableKey = publishableKey;
     }
 
-    /**
-     * Converts a stripe-java card model into a {@link Card} model.
-     *
-     * @param stripeCard the server-returned {@link com.stripe.model.Card}.
-     * @return an equivalent {@link Card}.
-     */
-    @VisibleForTesting
-    Card androidCardFromStripeCard(com.stripe.model.Card stripeCard) {
-        return new Card(
-                null,
-                stripeCard.getExpMonth(),
-                stripeCard.getExpYear(),
-                null,
-                stripeCard.getName(),
-                stripeCard.getAddressLine1(),
-                stripeCard.getAddressLine2(),
-                stripeCard.getAddressCity(),
-                stripeCard.getAddressState(),
-                stripeCard.getAddressZip(),
-                stripeCard.getAddressCountry(),
-                stripeCard.getBrand(),
-                stripeCard.getLast4(),
-                stripeCard.getFingerprint(),
-                stripeCard.getFunding(),
-                stripeCard.getCountry(),
-                stripeCard.getCurrency());
-    }
-
     private void validateKey(@NonNull @Size(min = 1) String publishableKey)
             throws AuthenticationException {
         if (publishableKey == null || publishableKey.length() == 0) {
@@ -426,18 +397,6 @@ public class Stripe {
                     "instead of the publishable one. For more info, " +
                     "see https://stripe.com/docs/stripe.js", null, 0);
         }
-    }
-
-    private Token androidTokenFromStripeToken(
-            Card androidCard,
-            com.stripe.model.Token stripeToken) {
-        return new Token(
-                stripeToken.getId(),
-                stripeToken.getLivemode(),
-                new Date(stripeToken.getCreated() * 1000),
-                stripeToken.getUsed(),
-                androidCard,
-                Token.TYPE_CARD);
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -13,10 +13,9 @@ import java.lang.annotation.RetentionPolicy;
 
 
 /**
- * A model object representing a Card in the Android SDK. Note that this is slightly different
- * from the Card model in stripe-java.
+ * A model object representing a Card in the Android SDK.
  */
-public class Card extends com.stripe.model.StripeObject {
+public class Card {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -1,6 +1,5 @@
 package com.stripe.android.model;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.StringDef;
 
 import java.lang.annotation.Retention;

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -10,7 +10,7 @@ import java.util.Date;
 /**
  * The model of a Stripe card token.
  */
-public class Token extends com.stripe.model.StripeObject {
+public class Token {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({TYPE_CARD})
@@ -27,8 +27,6 @@ public class Token extends com.stripe.model.StripeObject {
     /**
      * Constructor that should not be invoked in your code.  This is used by Stripe to
      * create tokens using a Stripe API response.
-     *
-     *
      */
     public Token(
             String id,

--- a/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
@@ -1,0 +1,60 @@
+package com.stripe.android.net;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.util.StripeJsonUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * A helper class for parsing errors coming from Stripe servers.
+ */
+class ErrorParser {
+
+    private static final String FIELD_CHARGE = "charge";
+    private static final String FIELD_CODE = "code";
+    private static final String FIELD_DECLINE_CODE = "decline_code";
+    private static final String FIELD_ERROR = "error";
+    private static final String FIELD_MESSAGE = "message";
+    private static final String FIELD_PARAM = "param";
+    private static final String FIELD_TYPE = "type";
+
+    private static final String MALFORMED_RESPONSE_MESSAGE =
+            "An improperly formatted error response was found.";
+
+    @NonNull
+    static Error parseError(String rawError) {
+        Error error = new Error();
+        try {
+            JSONObject jsonError = new JSONObject(rawError);
+            JSONObject errorObject = jsonError.getJSONObject(FIELD_ERROR);
+            error.charge = StripeJsonUtils.optString(errorObject, FIELD_CHARGE);
+            error.code = StripeJsonUtils.optString(errorObject, FIELD_CODE);
+            error.decline_code = StripeJsonUtils.optString(errorObject, FIELD_DECLINE_CODE);
+            error.message = StripeJsonUtils.optString(errorObject, FIELD_MESSAGE);
+            error.param = StripeJsonUtils.optString(errorObject, FIELD_PARAM);
+            error.type = StripeJsonUtils.optString(errorObject, FIELD_TYPE);
+        } catch (JSONException jsonException) {
+            error.message = MALFORMED_RESPONSE_MESSAGE;
+        }
+        return error;
+    }
+
+    /**
+     * A model for error objects sent from the server.
+     */
+    static class Error {
+        public String type;
+
+        public String message;
+
+        public String code;
+
+        public String param;
+
+        public String decline_code;
+
+        public String charge;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
@@ -26,27 +26,27 @@ class ErrorParser {
     private static final String FIELD_TYPE = "type";
 
     @NonNull
-    static Error parseError(String rawError) {
-        Error error = new Error();
+    static StripeError parseError(String rawError) {
+        StripeError stripeError = new StripeError();
         try {
             JSONObject jsonError = new JSONObject(rawError);
             JSONObject errorObject = jsonError.getJSONObject(FIELD_ERROR);
-            error.charge = StripeJsonUtils.optString(errorObject, FIELD_CHARGE);
-            error.code = StripeJsonUtils.optString(errorObject, FIELD_CODE);
-            error.decline_code = StripeJsonUtils.optString(errorObject, FIELD_DECLINE_CODE);
-            error.message = StripeJsonUtils.optString(errorObject, FIELD_MESSAGE);
-            error.param = StripeJsonUtils.optString(errorObject, FIELD_PARAM);
-            error.type = StripeJsonUtils.optString(errorObject, FIELD_TYPE);
+            stripeError.charge = StripeJsonUtils.optString(errorObject, FIELD_CHARGE);
+            stripeError.code = StripeJsonUtils.optString(errorObject, FIELD_CODE);
+            stripeError.decline_code = StripeJsonUtils.optString(errorObject, FIELD_DECLINE_CODE);
+            stripeError.message = StripeJsonUtils.optString(errorObject, FIELD_MESSAGE);
+            stripeError.param = StripeJsonUtils.optString(errorObject, FIELD_PARAM);
+            stripeError.type = StripeJsonUtils.optString(errorObject, FIELD_TYPE);
         } catch (JSONException jsonException) {
-            error.message = MALFORMED_RESPONSE_MESSAGE;
+            stripeError.message = MALFORMED_RESPONSE_MESSAGE;
         }
-        return error;
+        return stripeError;
     }
 
     /**
      * A model for error objects sent from the server.
      */
-    static class Error {
+    static class StripeError {
         public String type;
 
         public String message;

--- a/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/ErrorParser.java
@@ -1,6 +1,7 @@
 package com.stripe.android.net;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.util.StripeJsonUtils;
 
@@ -12,6 +13,10 @@ import org.json.JSONObject;
  */
 class ErrorParser {
 
+    @VisibleForTesting
+    static final String MALFORMED_RESPONSE_MESSAGE =
+            "An improperly formatted error response was found.";
+
     private static final String FIELD_CHARGE = "charge";
     private static final String FIELD_CODE = "code";
     private static final String FIELD_DECLINE_CODE = "decline_code";
@@ -19,9 +24,6 @@ class ErrorParser {
     private static final String FIELD_MESSAGE = "message";
     private static final String FIELD_PARAM = "param";
     private static final String FIELD_TYPE = "type";
-
-    private static final String MALFORMED_RESPONSE_MESSAGE =
-            "An improperly formatted error response was found.";
 
     @NonNull
     static Error parseError(String rawError) {

--- a/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
+++ b/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
@@ -50,6 +50,16 @@ public class RequestOptions {
     }
 
     /**
+     * Static accessor for the {@link RequestOptionsBuilder} class.
+     *
+     * @param publishableApiKey your publishable API key
+     * @return a {@link RequestOptionsBuilder} instance
+     */
+    public static RequestOptions.RequestOptionsBuilder builder(@NonNull String publishableApiKey) {
+        return new RequestOptions.RequestOptionsBuilder(publishableApiKey);
+    }
+
+    /**
      * Builder class for a set of {@link RequestOptions}.
      */
     public static final class RequestOptionsBuilder {

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -1,0 +1,494 @@
+package com.stripe.android.net;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+
+import com.stripe.android.exception.APIConnectionException;
+import com.stripe.android.exception.APIException;
+import com.stripe.android.exception.AuthenticationException;
+import com.stripe.android.exception.CardException;
+import com.stripe.android.exception.InvalidRequestException;
+import com.stripe.android.exception.PermissionException;
+import com.stripe.android.exception.RateLimitException;
+import com.stripe.android.model.Token;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+
+/**
+ * Handler for calls to the Stripe API.
+ */
+public class StripeApiHandler {
+
+    public static final String LIVE_API_BASE = "https://api.stripe.com";
+    public static final String CHARSET = "UTF-8";
+    public static final String TOKENS = "tokens";
+    public static final String VERSION = "3.5.0";
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            GET,
+            POST
+    })
+    @interface RestMethod { }
+    static final String GET = "GET";
+    static final String POST = "POST";
+
+    private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
+    private static final SSLSocketFactory SSL_SOCKET_FACTORY = new StripeSSLSocketFactory();
+
+    /**
+     * Create a {@link Token} using the input card parameters.
+     *
+     * @param cardParams
+     * @param options
+     * @return
+     * @throws AuthenticationException if there is a problem authenticating to the stripe api
+     * @throws InvalidRequestException if one or more of the parameters is incorrect
+     * @throws APIConnectionException if there is a problem connecting to the stripe api
+     * @throws CardException if there is a problem with the card information
+     * @throws APIException for unknown Stripe API errors. These should be rare.
+     */
+    @Nullable
+    public static Token createToken (
+            @NonNull Map<String, Object> cardParams,
+            @NonNull RequestOptions options)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        return requestToken(POST, getApiUrl(), cardParams, options);
+    }
+
+    private static String getApiUrl() {
+        return String.format("%s/v1/%s", LIVE_API_BASE, TOKENS);
+    }
+
+    private static String formatURL(String url, String query) {
+        if (query == null || query.isEmpty()) {
+            return url;
+        } else {
+            // In some cases, URL can already contain a question mark (eg, upcoming invoice lines)
+            String separator = url.contains("?") ? "&" : "?";
+            return String.format("%s%s%s", url, separator, query);
+        }
+    }
+
+    private static java.net.HttpURLConnection createGetConnection(
+            String url, String query, RequestOptions options) throws IOException {
+        String getURL = formatURL(url, query);
+        java.net.HttpURLConnection conn = createStripeConnection(getURL, options);
+        conn.setRequestMethod(GET);
+
+        return conn;
+    }
+
+    private static java.net.HttpURLConnection createPostConnection(
+            String url, String query, RequestOptions options) throws IOException {
+        java.net.HttpURLConnection conn = createStripeConnection(url, options);
+
+        conn.setDoOutput(true);
+        conn.setRequestMethod(POST);
+        conn.setRequestProperty("Content-Type", String.format(
+                "application/x-www-form-urlencoded;charset=%s", CHARSET));
+
+        OutputStream output = null;
+        try {
+            output = conn.getOutputStream();
+            output.write(query.getBytes(CHARSET));
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+        return conn;
+    }
+
+    static Map<String, String> getHeaders(RequestOptions options) {
+        Map<String, String> headers = new HashMap<>();
+        String apiVersion = options.getApiVersion();
+        headers.put("Accept-Charset", CHARSET);
+        headers.put("Accept", "application/json");
+        headers.put("User-Agent",
+                String.format("Stripe/v1 JavaBindings/%s", VERSION));
+
+        headers.put("Authorization", String.format("Bearer %s", options.getPublishableApiKey()));
+
+        // debug headers
+        String[] propertyNames = { "os.name", "os.version", "os.arch",
+                "java.version", "java.vendor", "java.vm.version",
+                "java.vm.vendor" };
+
+        Map<String, String> propertyMap = new HashMap<>();
+        for (String propertyName : propertyNames) {
+            propertyMap.put(propertyName, System.getProperty(propertyName));
+        }
+        propertyMap.put("bindings.version", VERSION);
+        propertyMap.put("lang", "Java");
+        propertyMap.put("publisher", "Stripe");
+        JSONObject headerMappingObject = new JSONObject(propertyMap);
+        headers.put("X-Stripe-Client-User-Agent", headerMappingObject.toString());
+
+        if (apiVersion != null) {
+            headers.put("Stripe-Version", apiVersion);
+        }
+
+        if (options.getIdempotencyKey() != null) {
+            headers.put("Idempotency-Key", options.getIdempotencyKey());
+        }
+
+        return headers;
+    }
+
+    private static java.net.HttpURLConnection createStripeConnection(
+            String url,
+            RequestOptions options)
+            throws IOException {
+        URL stripeURL;
+
+        stripeURL = new URL(url);
+        HttpURLConnection conn  = (HttpURLConnection) stripeURL.openConnection();
+        conn.setConnectTimeout(30 * 1000);
+        conn.setReadTimeout(80 * 1000);
+        conn.setUseCaches(false);
+        for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {
+            conn.setRequestProperty(header.getKey(), header.getValue());
+        }
+
+        if (conn instanceof HttpsURLConnection) {
+            ((HttpsURLConnection) conn).setSSLSocketFactory(SSL_SOCKET_FACTORY);
+        }
+
+        return conn;
+    }
+
+    private static Token requestToken(
+            @RestMethod String method,
+            String url,
+            Map<String, Object> params,
+            RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        if (options == null) {
+            return null;
+        }
+        String originalDNSCacheTTL = null;
+        Boolean allowedToSetTTL = true;
+
+        try {
+            originalDNSCacheTTL = java.security.Security
+                    .getProperty(DNS_CACHE_TTL_PROPERTY_NAME);
+            // disable DNS cache
+            java.security.Security
+                    .setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "0");
+        } catch (SecurityException se) {
+            allowedToSetTTL = false;
+        }
+
+        String apiKey = options.getPublishableApiKey();
+        if (apiKey.trim().isEmpty()) {
+            throw new AuthenticationException(
+                    "No API key provided. (HINT: set your API key using 'Stripe.apiKey = <API-KEY>'. "
+                            + "You can generate API keys from the Stripe web interface. "
+                            + "See https://stripe.com/api for details or email support@stripe.com if you have questions.",
+                    null, 0);
+        }
+
+        try {
+            StripeResponse response = getStripeResponse(method, url, params, options);
+
+            int rCode = response.getResponseCode();
+            String rBody = response.getResponseBody();
+
+            String requestId = null;
+            Map<String, List<String>> headers = response.getResponseHeaders();
+            List<String> requestIdList = headers == null ? null : headers.get("Request-Id");
+            if (requestIdList != null && requestIdList.size() > 0) {
+                requestId = requestIdList.get(0);
+            }
+
+            if (rCode < 200 || rCode >= 300) {
+                handleAPIError(rBody, rCode, requestId);
+            }
+
+            // Note that the 'finally' block runs immediately prior to this return statement.
+            return TokenParser.parseToken(rBody);
+        } catch(JSONException jsonException) {
+            return null;
+        } finally {
+            if (allowedToSetTTL) {
+                if (originalDNSCacheTTL == null) {
+                    // value unspecified by implementation
+                    // DNS_CACHE_TTL_PROPERTY_NAME of -1 = cache forever
+                    java.security.Security.setProperty(
+                            DNS_CACHE_TTL_PROPERTY_NAME, "-1");
+                } else {
+                    java.security.Security.setProperty(
+                            DNS_CACHE_TTL_PROPERTY_NAME, originalDNSCacheTTL);
+                }
+            }
+        }
+    }
+
+    private static StripeResponse getStripeResponse(
+            @RestMethod String method,
+            String url,
+            Map<String, Object> params,
+            RequestOptions options)
+            throws InvalidRequestException, APIConnectionException, APIException {
+        String query;
+        try {
+            query = createQuery(params);
+        } catch (UnsupportedEncodingException e) {
+            throw new InvalidRequestException("Unable to encode parameters to "
+                    + CHARSET
+                    + ". Please contact support@stripe.com for assistance.",
+                    null, null, 0, e);
+        }
+
+        // HTTPSURLConnection verifies SSL cert by default
+        return makeURLConnectionRequest(method, url, query, options);
+    }
+
+    private static String createQuery(Map<String, Object> params)
+            throws UnsupportedEncodingException, InvalidRequestException {
+        StringBuilder queryStringBuffer = new StringBuilder();
+        List<Parameter> flatParams = flattenParams(params);
+        Iterator<Parameter> it = flatParams.iterator();
+
+        while (it.hasNext()) {
+            if (queryStringBuffer.length() > 0) {
+                queryStringBuffer.append("&");
+            }
+            Parameter param = it.next();
+            queryStringBuffer.append(urlEncodePair(param.key, param.value));
+        }
+
+        return queryStringBuffer.toString();
+    }
+
+    private static List<Parameter> flattenParams(Map<String, Object> params)
+            throws InvalidRequestException {
+        return flattenParamsMap(params, null);
+    }
+
+    private static List<Parameter> flattenParamsList(List<Object> params, String keyPrefix)
+            throws InvalidRequestException {
+        List<Parameter> flatParams = new LinkedList<Parameter>();
+        Iterator<?> it = ((List<?>)params).iterator();
+        String newPrefix = String.format("%s[]", keyPrefix);
+
+        // Because application/x-www-form-urlencoded cannot represent an empty
+        // list, convention is to take the list parameter and just set it to an
+        // empty string. (e.g. A regular list might look like `a[]=1&b[]=2`.
+        // Emptying it would look like `a=`.)
+        if (params.isEmpty()) {
+            flatParams.add(new Parameter(keyPrefix, ""));
+        } else {
+            while (it.hasNext()) {
+                flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
+            }
+        }
+
+        return flatParams;
+    }
+
+    private static List<Parameter> flattenParamsMap(Map<String, Object> params, String keyPrefix)
+            throws InvalidRequestException {
+        List<Parameter> flatParams = new LinkedList<Parameter>();
+        if (params == null) {
+            return flatParams;
+        }
+
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            String newPrefix = key;
+            if (keyPrefix != null) {
+                newPrefix = String.format("%s[%s]", keyPrefix, key);
+            }
+
+            flatParams.addAll(flattenParamsValue(value, newPrefix));
+        }
+
+        return flatParams;
+    }
+
+    private static List<Parameter> flattenParamsValue(Object value, String keyPrefix)
+            throws InvalidRequestException {
+        List<Parameter> flatParams;
+
+        if (value instanceof Map<?, ?>) {
+            flatParams = flattenParamsMap((Map<String, Object>) value, keyPrefix);
+        } else if (value instanceof List<?>) {
+            flatParams = flattenParamsList((List<Object>) value, keyPrefix);
+        } else if ("".equals(value)) {
+            throw new InvalidRequestException("You cannot set '"+keyPrefix+"' to an empty string. "+
+                    "We interpret empty strings as null in requests. "+
+                    "You may set '"+keyPrefix+"' to null to delete the property.",
+                    keyPrefix, null, 0, null);
+        } else if (value == null) {
+            flatParams = new LinkedList<>();
+            flatParams.add(new Parameter(keyPrefix, ""));
+        } else {
+            flatParams = new LinkedList<>();
+            flatParams.add(new Parameter(keyPrefix, value.toString()));
+        }
+
+        return flatParams;
+    }
+
+    private static void handleAPIError(String rBody, int rCode, String requestId)
+            throws InvalidRequestException, AuthenticationException,
+            CardException, APIException {
+
+        ErrorParser.Error error = ErrorParser.parseError(rBody);
+        switch (rCode) {
+            case 400:
+                throw new InvalidRequestException(
+                        error.message,
+                        error.param,
+                        requestId,
+                        rCode,
+                        null);
+            case 404:
+                throw new InvalidRequestException(
+                        error.message,
+                        error.param,
+                        requestId,
+                        rCode,
+                        null);
+            case 401:
+                throw new AuthenticationException(error.message, requestId, rCode);
+            case 402:
+                throw new CardException(
+                        error.message,
+                        requestId,
+                        error.code,
+                        error.param,
+                        error.decline_code,
+                        error.charge,
+                        rCode,
+                        null);
+            case 403:
+                throw new PermissionException(error.message, requestId, rCode);
+            case 429:
+                throw new RateLimitException(error.message, error.param, requestId, rCode, null);
+            default:
+                throw new APIException(error.message, requestId, rCode, null);
+        }
+    }
+
+    private static String urlEncodePair(String k, String v)
+            throws UnsupportedEncodingException {
+        return String.format("%s=%s", urlEncode(k), urlEncode(v));
+    }
+
+    private static String urlEncode(String str) throws UnsupportedEncodingException {
+        // Preserve original behavior that passing null for an object id will lead
+        // to us actually making a request to /v1/foo/null
+        if (str == null) {
+            return null;
+        }
+        else {
+            return URLEncoder.encode(str, CHARSET);
+        }
+    }
+
+    private static StripeResponse makeURLConnectionRequest(
+            @RestMethod String method,
+            String url,
+            String query,
+            RequestOptions options)
+            throws APIConnectionException {
+        java.net.HttpURLConnection conn = null;
+        try {
+            switch (method) {
+                case GET:
+                    conn = createGetConnection(url, query, options);
+                    break;
+                case POST:
+                    conn = createPostConnection(url, query, options);
+                    break;
+                default:
+                    throw new APIConnectionException(
+                            String.format(
+                                    "Unrecognized HTTP method %s. "
+                                            + "This indicates a bug in the Stripe bindings. "
+                                            + "Please contact support@stripe.com for assistance.",
+                                    method));
+            }
+            // trigger the request
+            int rCode = conn.getResponseCode();
+            String rBody;
+            Map<String, List<String>> headers;
+
+            if (rCode >= 200 && rCode < 300) {
+                rBody = getResponseBody(conn.getInputStream());
+            } else {
+                rBody = getResponseBody(conn.getErrorStream());
+            }
+            headers = conn.getHeaderFields();
+            return new StripeResponse(rCode, rBody, headers);
+
+        } catch (IOException e) {
+            throw new APIConnectionException(
+                    String.format(
+                            "IOException during API request to Stripe (%s): %s "
+                                    + "Please check your internet connection and try again. "
+                                    + "If this problem persists, you should check Stripe's "
+                                    + "service status at https://twitter.com/stripestatus, "
+                                    + "or let us know at support@stripe.com.",
+                            getApiUrl(), e.getMessage()), e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static String getResponseBody(InputStream responseStream)
+            throws IOException {
+        //\A is the beginning of
+        // the stream boundary
+        String rBody = new Scanner(responseStream, CHARSET)
+                .useDelimiter("\\A")
+                .next(); //
+
+        responseStream.close();
+        return rBody;
+    }
+
+    private static final class Parameter {
+        public final String key;
+        public final String value;
+
+        public Parameter(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -402,40 +402,40 @@ public class StripeApiHandler {
             throws InvalidRequestException, AuthenticationException,
             CardException, APIException {
 
-        ErrorParser.Error error = ErrorParser.parseError(rBody);
+        ErrorParser.StripeError stripeError = ErrorParser.parseError(rBody);
         switch (rCode) {
             case 400:
                 throw new InvalidRequestException(
-                        error.message,
-                        error.param,
+                        stripeError.message,
+                        stripeError.param,
                         requestId,
                         rCode,
                         null);
             case 404:
                 throw new InvalidRequestException(
-                        error.message,
-                        error.param,
+                        stripeError.message,
+                        stripeError.param,
                         requestId,
                         rCode,
                         null);
             case 401:
-                throw new AuthenticationException(error.message, requestId, rCode);
+                throw new AuthenticationException(stripeError.message, requestId, rCode);
             case 402:
                 throw new CardException(
-                        error.message,
+                        stripeError.message,
                         requestId,
-                        error.code,
-                        error.param,
-                        error.decline_code,
-                        error.charge,
+                        stripeError.code,
+                        stripeError.param,
+                        stripeError.decline_code,
+                        stripeError.charge,
                         rCode,
                         null);
             case 403:
-                throw new PermissionException(error.message, requestId, rCode);
+                throw new PermissionException(stripeError.message, requestId, rCode);
             case 429:
-                throw new RateLimitException(error.message, error.param, requestId, rCode, null);
+                throw new RateLimitException(stripeError.message, stripeError.param, requestId, rCode, null);
             default:
-                throw new APIException(error.message, requestId, rCode, null);
+                throw new APIException(stripeError.message, requestId, rCode, null);
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1,8 +1,8 @@
 package com.stripe.android;
 
+import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
-import com.stripe.exception.AuthenticationException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -250,64 +250,6 @@ public class StripeTest {
         } catch (AuthenticationException e) {
             fail("Unexpected error: " + e.getMessage());
         }
-    }
-
-    @Test
-    public void androidCardFromStripeCard_properlyConvertsStandardFields() {
-        Stripe stripe;
-        try {
-            stripe = new Stripe(DEFAULT_PUBLISHABLE_KEY);
-        } catch (AuthenticationException e) {
-            fail("Unexpected error: " + e.getMessage());
-            return;
-        }
-
-        com.stripe.model.Card stripeCard = new com.stripe.model.Card();
-        final Integer EXP_MONTH = 3;
-        final Integer EXP_YEAR = 2020;
-        final String NAME = "Anita Cardholder";
-        final String ADDR_FIRST_LINE = "123 Burns Street";
-        final String ADDR_SECOND_LINE = "Apartment 456";
-        final String ADDR_STATE = "CA";
-        final String ADDR_CITY = "Eureka";
-        final String ADDR_ZIP = "95501";
-        final String CARD_BRAND = "Visa";
-        final String LAST_FOUR = "6789";
-        final String FINGERPRINT = "abc123";
-        final String FUNDING = "credit";
-        final String COUNTRY = "us";
-        final String CURRENCY = "usd";
-        stripeCard.setExpMonth(EXP_MONTH);
-        stripeCard.setExpYear(EXP_YEAR);
-        stripeCard.setName(NAME);
-        stripeCard.setAddressLine1(ADDR_FIRST_LINE);
-        stripeCard.setAddressLine2(ADDR_SECOND_LINE);
-        stripeCard.setAddressCity(ADDR_CITY);
-        stripeCard.setAddressState(ADDR_STATE);
-        stripeCard.setAddressZip(ADDR_ZIP);
-        stripeCard.setAddressCountry(COUNTRY);
-        stripeCard.setBrand(CARD_BRAND);
-        stripeCard.setLast4(LAST_FOUR);
-        stripeCard.setFingerprint(FINGERPRINT);
-        stripeCard.setFunding(FUNDING);
-        stripeCard.setCurrency(CURRENCY);
-        stripeCard.setCountry(COUNTRY);
-
-        Card androidCard = stripe.androidCardFromStripeCard(stripeCard);
-        assertEquals(EXP_MONTH, androidCard.getExpMonth());
-        assertEquals(EXP_YEAR, androidCard.getExpYear());
-        assertEquals(ADDR_FIRST_LINE, androidCard.getAddressLine1());
-        assertEquals(ADDR_SECOND_LINE, androidCard.getAddressLine2());
-        assertEquals(ADDR_CITY, androidCard.getAddressCity());
-        assertEquals(COUNTRY, androidCard.getCountry());
-        assertEquals(COUNTRY, androidCard.getCountry());
-        assertEquals(ADDR_ZIP, androidCard.getAddressZip());
-        assertEquals(ADDR_STATE, androidCard.getAddressState());
-        assertEquals(CARD_BRAND, androidCard.getBrand());
-        assertEquals(LAST_FOUR, androidCard.getLast4());
-        assertEquals(FINGERPRINT, androidCard.getFingerprint());
-        assertEquals(FUNDING, androidCard.getFunding());
-        assertEquals(CURRENCY, androidCard.getCurrency());
     }
 
     private static class ErrorTokenCallback implements TokenCallback {

--- a/stripe/src/test/java/com/stripe/android/net/ErrorParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/ErrorParserTest.java
@@ -1,7 +1,5 @@
 package com.stripe.android.net;
 
-import com.stripe.android.model.Token;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -35,18 +33,18 @@ public class ErrorParserTest {
 
     @Test
     public void parseError_withInvalidRequestError_createsCorrectObject() {
-        ErrorParser.Error parsedError = ErrorParser.parseError(RAW_INVALID_REQUEST_ERROR);
+        ErrorParser.StripeError parsedStripeError = ErrorParser.parseError(RAW_INVALID_REQUEST_ERROR);
         String errorMessage = "The Stripe API is only accessible over HTTPS.  " +
                 "Please see <https://stripe.com/docs> for more information.";
-        assertEquals(errorMessage, parsedError.message);
-        assertEquals("invalid_request_error", parsedError.type);
-        assertNull(parsedError.param);
+        assertEquals(errorMessage, parsedStripeError.message);
+        assertEquals("invalid_request_error", parsedStripeError.type);
+        assertNull(parsedStripeError.param);
     }
 
     @Test
     public void parseError_withNoErrorMessage_addsInvalidResponseMessage() {
-        ErrorParser.Error badError = ErrorParser.parseError(RAW_INCORRECT_FORMAT_ERROR);
-        assertEquals(ErrorParser.MALFORMED_RESPONSE_MESSAGE, badError.message);
-        assertNull(badError.type);
+        ErrorParser.StripeError badStripeError = ErrorParser.parseError(RAW_INCORRECT_FORMAT_ERROR);
+        assertEquals(ErrorParser.MALFORMED_RESPONSE_MESSAGE, badStripeError.message);
+        assertNull(badStripeError.type);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/net/ErrorParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/ErrorParserTest.java
@@ -1,0 +1,52 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.Token;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test class for {@link ErrorParser}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class ErrorParserTest {
+
+    private static final String RAW_INVALID_REQUEST_ERROR =
+            "{\n" +
+                    "  \"error\": {\n" +
+                    "    \"message\" : \"The Stripe API is only accessible over HTTPS.  " +
+                    "Please see <https://stripe.com/docs> for more information.\",\n" +
+                    "    \"type\": \"invalid_request_error\"\n" +
+                    "  }\n" +
+                    "}";
+
+    private static final String RAW_INCORRECT_FORMAT_ERROR =
+            "{\n" +
+                    "    \"message\" : \"The Stripe API is only accessible over HTTPS.  " +
+                    "Please see <https://stripe.com/docs> for more information.\",\n" +
+                    "    \"type\": \"invalid_request_error\"\n" +
+                    "}";
+
+    @Test
+    public void parseError_withInvalidRequestError_createsCorrectObject() {
+        ErrorParser.Error parsedError = ErrorParser.parseError(RAW_INVALID_REQUEST_ERROR);
+        String errorMessage = "The Stripe API is only accessible over HTTPS.  " +
+                "Please see <https://stripe.com/docs> for more information.";
+        assertEquals(errorMessage, parsedError.message);
+        assertEquals("invalid_request_error", parsedError.type);
+        assertNull(parsedError.param);
+    }
+
+    @Test
+    public void parseError_withNoErrorMessage_addsInvalidResponseMessage() {
+        ErrorParser.Error badError = ErrorParser.parseError(RAW_INCORRECT_FORMAT_ERROR);
+        assertEquals(ErrorParser.MALFORMED_RESPONSE_MESSAGE, badError.message);
+        assertNull(badError.type);
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @shale-stripe @jack-stripe 

This PR is currently under-tested. The reason I have not yet implemented live functional testing of the `createToken` and `requestToken` methods, along with individual method tests in the `StripeApiHandler` class, is that this PR is to merge into the `networking` branch, and the diff is already very large. I prefer not to go over 700 lines, which this has already broken. Other than doing the ErrorParser by itself (which wouldn't pull out very many lines), the diff is also somewhat irreducible. As is, you can test the new functionality with the sample application to see that we do indeed successfully hit the tokens endpoint.

MOAR TESTING is definitely needed. I don't think the resulting branch should be allowed to merge to master until we have done a separate diff with extensive testing on the networking classes.

I intend to add a significant amount of tests in a separate diff, which will be easier to review on its own.