### PR TITLE
adding logging appropriate for android

### DIFF
--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -1,5 +1,6 @@
 package com.stripe.android.net;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
@@ -144,15 +145,12 @@ public class StripeApiHandler {
         headers.put("Authorization", String.format("Bearer %s", options.getPublishableApiKey()));
 
         // debug headers
-        String[] propertyNames = { "os.name", "os.version", "os.arch",
-                "java.version", "java.vendor", "java.vm.version",
-                "java.vm.vendor" };
-
         Map<String, String> propertyMap = new HashMap<>();
-        for (String propertyName : propertyNames) {
-            propertyMap.put(propertyName, System.getProperty(propertyName));
-        }
 
+        final String systemPropertyName = "java.version";
+        propertyMap.put(systemPropertyName, System.getProperty(systemPropertyName));
+        propertyMap.put("os.name", "android");
+        propertyMap.put("os.version", String.valueOf(Build.VERSION.SDK_INT));
         propertyMap.put("bindings.version", VERSION);
         propertyMap.put("lang", "Java");
         propertyMap.put("publisher", "Stripe");

--- a/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
@@ -80,6 +80,8 @@ public class StripeApiHandlerTest {
             assertEquals("3.5.0", mapObject.getString("bindings.version"));
             assertEquals("Java", mapObject.getString("lang"));
             assertEquals("Stripe", mapObject.getString("publisher"));
+            assertEquals("android", mapObject.getString("os.name"));
+            assertTrue(mapObject.has("java.version"));
         } catch (JSONException jsonException) {
             fail("Failed to get a parsable JsonObject for the user agent.");
         }


### PR DESCRIPTION
r? @kjc-stripe 
cc @brandur-stripe @shale-stripe 

Adding some logging that is appropriate for android -- including `os.name = "android"`, so it's super easy to find, `os.version` set to the SDK number of android, which will give us fantastic information about the level of android expected (and what versions we need to support), and still including the java.version value in case we find that useful (that value is pretty consistent across android devices).

There's a test to make sure the values are correctly added to the header.