### PR TITLE
adding the base classes and util functions for the credit card input view

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,10 +4,12 @@ repositories {
     mavenCentral()
 }
 
+def android_support_version = '25.1.0'
+
 dependencies {
     compile project(':stripe')
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:appcompat-v7:' + android_support_version
+    compile 'com.android.support:support-v4:' + android_support_version
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,8 +6,8 @@ repositories {
 
 dependencies {
     compile project(':stripe')
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:support-v4:25.1.0'
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,8 +6,8 @@ repositories {
 
 dependencies {
     compile project(':stripe')
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:support-v4:25.0.1'
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'

--- a/example/res/layout/payment_activity.xml
+++ b/example/res/layout/payment_activity.xml
@@ -14,10 +14,6 @@
               android:text="@string/addPayment"
               style="@style/Header" />
 
-    <com.stripe.android.view.CardInputView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
     <EditText
         android:id="@+id/number"
         android:layout_width="match_parent"

--- a/example/res/layout/payment_activity.xml
+++ b/example/res/layout/payment_activity.xml
@@ -14,6 +14,10 @@
               android:text="@string/addPayment"
               style="@style/Header" />
 
+    <com.stripe.android.view.CardInputView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
     <EditText
         android:id="@+id/number"
         android:layout_width="match_parent"

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     provided 'javax.annotation:jsr250-api:1.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile "org.robolectric:robolectric:3.1.4"
+    testCompile "org.robolectric:robolectric:3.2.1"
 }
 
 android {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.library'
 
+def android_support_version = '25.1.0'
+
 configurations {
     javadocDeps
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:support-annotations:' + android_support_version
+    compile 'com.android.support:support-v4:' + android_support_version
 
-    javadocDeps 'com.android.support:support-annotations:25.1.0'
+    javadocDeps 'com.android.support:support-annotations:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
 
     testCompile 'junit:junit:4.12'

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -6,6 +6,7 @@ configurations {
 
 dependencies {
     compile 'com.android.support:support-annotations:25.1.0'
+    compile 'com.android.support:support-v4:25.1.0'
 
     javadocDeps 'com.android.support:support-annotations:25.1.0'
     provided 'javax.annotation:jsr250-api:1.0'

--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="horizontal"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <com.stripe.android.view.LockableHorizontalScrollView
+        android:id="@+id/root_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:fillViewport="true"
+        android:fadeScrollbars="false"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <com.stripe.android.view.CardNumberEditText
+                android:id="@+id/et_card_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:hint="1234 5678 9012 3456"
+                android:inputType="number"
+                android:maxLength="19"
+                />
+
+            <android.support.v4.widget.Space
+                android:id="@+id/space_in_container"
+                android:layout_width="1dp"
+                android:layout_height="wrap_content"/>
+        </LinearLayout>
+    </com.stripe.android.view.LockableHorizontalScrollView>
+
+    <EditText
+        android:id="@+id/et_expiry_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:hint="MM/YY"
+        android:inputType="date"
+        android:maxLength="5"
+        android:visibility="gone"
+        />
+
+    <EditText
+        android:id="@+id/et_cvc_number"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:hint="123"
+        android:inputType="number"
+        android:maxLength="4"
+        android:visibility="gone"/>
+
+</LinearLayout>

--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -23,7 +23,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
-                android:hint="1234 5678 9012 3456"
+                android:hint="@string/card_number_hint"
                 android:inputType="number"
                 android:maxLength="19"
                 />
@@ -40,7 +40,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
-        android:hint="MM/YY"
+        android:hint="@string/expiry_date_hint"
         android:inputType="date"
         android:maxLength="5"
         android:visibility="gone"
@@ -51,7 +51,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
-        android:hint="123"
+        android:hint="@string/cvc_number_hint"
         android:inputType="number"
         android:maxLength="4"
         android:visibility="gone"/>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="card_number_hint">1234 5678 9012 3456</string>
+    <string name="card_number_hint">4242 4242 4242 4242</string>
     <string name="cvc_number_hint">123</string>
     <string name="expiry_date_hint">MM/YY</string>
 </resources>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -1,2 +1,5 @@
 <resources>
+    <string name="card_number_hint">1234 5678 9012 3456</string>
+    <string name="cvc_number_hint">123</string>
+    <string name="expiry_date_hint">MM/YY</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -1,5 +1,6 @@
 package com.stripe.android.util;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.model.Card;
@@ -78,6 +79,107 @@ public class StripeTextUtils {
      */
     public static boolean isBlank(String value) {
         return value == null || value.trim().length() == 0;
+    }
+
+    /**
+     * Returns a {@link CardBrand} corresponding to a partial card number, or {@link Card#UNKNOWN}
+     * if the card brand can't be determined from the input value.
+     *
+     * @param cardNumber a credit card number or partial card number
+     * @return the {@link CardBrand} corresponding to that number, or {@link Card#UNKNOWN} if it
+     * can't be determined
+     */
+    @NonNull
+    @CardBrand
+    public static String getPossibleCardType(@Nullable String cardNumber) {
+        if (isBlank(cardNumber)) {
+            return Card.UNKNOWN;
+        }
+
+        String spacelessCardNumber = convertToSpacelessNumber(cardNumber);
+
+        if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_AMERICAN_EXPRESS)) {
+            return Card.AMERICAN_EXPRESS;
+        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DISCOVER)) {
+            return Card.DISCOVER;
+        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_JCB)) {
+            return Card.JCB;
+        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DINERS_CLUB)) {
+            return Card.DINERS_CLUB;
+        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_VISA)) {
+            return Card.VISA;
+        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_MASTERCARD)) {
+            return Card.MASTERCARD;
+        } else {
+            return Card.UNKNOWN;
+        }
+    }
+
+    /**
+     * Converts a card number that may have spaces between the numbers into one without any spaces.
+     * @param cardNumberWithSpaces a card number, for instance "4242 4242 4242 4242"
+     * @return the input number minus any spaces, for instance "4242424242424242".
+     * Returns {@code null} if the input was {@code null} or all spaces.
+     */
+    @Nullable
+    public static String convertToSpacelessNumber(@Nullable String cardNumberWithSpaces) {
+        if (isBlank(cardNumberWithSpaces)) {
+            return null;
+        }
+        return cardNumberWithSpaces.replaceAll("\\s", "");
+    }
+
+    /**
+     * Separates a card number according to the brand requirements, including prefixes of card
+     * numbers, so that the groups can be easily displayed if the user is typing them in.
+     *
+     * @param spacelessCardNumber the raw card number, without spaces
+     * @param brand the {@link CardBrand} to use as a separating scheme
+     * @return an array of strings with the number groups, in order. If the number is not complete,
+     * some of the array entries may be {@code null}.
+     */
+    @NonNull
+    public static String[] separateCardNumberGroups(@NonNull String spacelessCardNumber,
+                                                    @NonNull @CardBrand String brand) {
+        String[] numberGroups;
+        if (brand.equals(Card.AMERICAN_EXPRESS)) {
+            numberGroups = new String[3];
+
+            int length = spacelessCardNumber.length();
+            int lastUsedIndex = 0;
+            if (length > 4) {
+                numberGroups[0] = spacelessCardNumber.substring(0, 4);
+                lastUsedIndex = 4;
+            }
+
+            if (length > 10) {
+                numberGroups[1] = spacelessCardNumber.substring(4, 10);
+                lastUsedIndex = 10;
+            }
+
+            for (int i = 0; i < 3; i++) {
+                if (numberGroups[i] != null) {
+                    continue;
+                }
+                numberGroups[i] = spacelessCardNumber.substring(lastUsedIndex);
+                break;
+            }
+
+        } else {
+            numberGroups = new String[4];
+            int i = 0;
+            int previousStart = 0;
+            while((i + 1) * 4 < spacelessCardNumber.length()) {
+                String group = spacelessCardNumber.substring(previousStart, (i + 1) * 4);
+                numberGroups[i] = group;
+                previousStart = (i + 1) * 4;
+                i++;
+            }
+            // Always stuff whatever is left into the next available array entry. This handles
+            // incomplete numbers, full 16-digit numbers, and full 14-digit numbers
+            numberGroups[i] = spacelessCardNumber.substring(previousStart);
+        }
+        return numberGroups;
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -96,7 +96,7 @@ public class StripeTextUtils {
             return Card.UNKNOWN;
         }
 
-        String spacelessCardNumber = convertToSpacelessNumber(cardNumber);
+        String spacelessCardNumber = removeSpaces(cardNumber);
 
         if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_AMERICAN_EXPRESS)) {
             return Card.AMERICAN_EXPRESS;
@@ -117,12 +117,14 @@ public class StripeTextUtils {
 
     /**
      * Converts a card number that may have spaces between the numbers into one without any spaces.
+     * Note: method does not check that all characters are digits or spaces.
+     *
      * @param cardNumberWithSpaces a card number, for instance "4242 4242 4242 4242"
      * @return the input number minus any spaces, for instance "4242424242424242".
      * Returns {@code null} if the input was {@code null} or all spaces.
      */
     @Nullable
-    public static String convertToSpacelessNumber(@Nullable String cardNumberWithSpaces) {
+    public static String removeSpaces(@Nullable String cardNumberWithSpaces) {
         if (isBlank(cardNumberWithSpaces)) {
             return null;
         }
@@ -132,6 +134,7 @@ public class StripeTextUtils {
     /**
      * Separates a card number according to the brand requirements, including prefixes of card
      * numbers, so that the groups can be easily displayed if the user is typing them in.
+     * Note that this does not verify that the card number is valid, or even that it is a number.
      *
      * @param spacelessCardNumber the raw card number, without spaces
      * @param brand the {@link CardBrand} to use as a separating scheme

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -1,0 +1,48 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.support.v4.widget.Space;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+
+import com.stripe.android.R;
+
+/**
+ * Custom view to accept credit card numbers information.
+ */
+public class CardInputView extends FrameLayout {
+
+    private EditText mCardNumberEditText;
+    private EditText mCvcNumberEditText;
+    private EditText mExpiryDateEditText;
+    private LockableHorizontalScrollView mScrollView;
+    private Space mCardNumberSpace;
+
+    public CardInputView(Context context) {
+        super(context);
+        initView();
+    }
+
+    public CardInputView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initView();
+    }
+
+    public CardInputView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initView();
+    }
+
+    private void initView() {
+        inflate(getContext(), R.layout.card_input_view, this);
+
+        mScrollView = (LockableHorizontalScrollView) findViewById(R.id.root_scroll_view);
+        mCardNumberEditText = (EditText) findViewById(R.id.et_card_number);
+        mExpiryDateEditText = (EditText) findViewById(R.id.et_expiry_date);
+        mCvcNumberEditText = (EditText) findViewById(R.id.et_cvc_number);
+        mCardNumberSpace = (Space) findViewById(R.id.space_in_container);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -110,7 +110,7 @@ public class CardNumberEditText extends EditText {
                     return;
                 }
 
-                String spacelessNumber = StripeTextUtils.convertToSpacelessNumber(s.toString());
+                String spacelessNumber = StripeTextUtils.removeSpaces(s.toString());
                 if (spacelessNumber == null) {
                     return;
                 }

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -1,0 +1,167 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.widget.EditText;
+
+import com.stripe.android.model.Card;
+import com.stripe.android.util.StripeTextUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An {@link EditText} that handles spacing out the digits of a credit card.
+ */
+public class CardNumberEditText extends EditText {
+
+    private static final int MAX_LENGTH_COMMON = 19;
+    // Note that AmEx and Diners Club have the same length
+    // because Diners Club has one more space, but one less digit.
+    private static final int MAX_LENGTH_AMEX_DINERS = 17;
+
+    private static final Integer[] SPACES_ARRAY_COMMON = {4, 9, 14};
+    private static final Set<Integer> SPACE_SET_COMMON =
+            new HashSet<>(Arrays.asList(SPACES_ARRAY_COMMON));
+
+    private static final Integer[] SPACES_ARRAY_AMEX = {4, 11};
+    private static final Set<Integer> SPACE_SET_AMEX =
+            new HashSet<>(Arrays.asList(SPACES_ARRAY_AMEX));
+
+    @Card.CardBrand private String mCardBrand = Card.UNKNOWN;
+    private int mLengthMax = 19;
+
+    public CardNumberEditText(Context context) {
+        super(context);
+        listenForTextChanges();
+    }
+
+    public CardNumberEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        listenForTextChanges();
+    }
+
+    public CardNumberEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        listenForTextChanges();
+    }
+
+    private void listenForTextChanges() {
+        addTextChangedListener(new TextWatcher() {
+            boolean ignoreChanges = false;
+            int beforeStringLength = 0;
+            int beforeSelectionIndex = 0;
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                if (!ignoreChanges) {
+                    beforeStringLength = getText().toString().length();
+                    beforeSelectionIndex = getSelectionEnd();
+                }
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (ignoreChanges) {
+                    return;
+                }
+
+                if (start < 4) {
+                    updateCardBrand(s.toString());
+                    // update the card icon here
+                }
+
+                if (beforeSelectionIndex > 16) {
+                    // no need to do formatting if we're past all of the spaces.
+                    return;
+                }
+
+                String spacelessNumber = StripeTextUtils.convertToSpacelessNumber(s.toString());
+                if (spacelessNumber == null) {
+                    return;
+                }
+
+                String[] cardParts = StripeTextUtils.separateCardNumberGroups(
+                        spacelessNumber, mCardBrand);
+                StringBuilder formattedNumberBuilder = new StringBuilder();
+                for (int i = 0; i < cardParts.length; i++) {
+                    if (cardParts[i] == null) {
+                        break;
+                    }
+
+                    if (i != 0) {
+                        formattedNumberBuilder.append(' ');
+                    }
+                    formattedNumberBuilder.append(cardParts[i]);
+                }
+
+                String formattedNumber = formattedNumberBuilder.toString();
+                int cursorPosition = updateSelectionIndex(
+                        beforeSelectionIndex,
+                        beforeStringLength,
+                        formattedNumber.length());
+
+                ignoreChanges = true;
+                setText(formattedNumber);
+                setSelection(cursorPosition);
+                ignoreChanges = false;
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
+    }
+
+    private int updateSelectionIndex(int oldPosition,
+                                     int oldLength,
+                                     int newLength) {
+
+        int increment, newPosition;
+        Set<Integer> spaceSet = Card.AMERICAN_EXPRESS.equals(mCardBrand)
+                ? SPACE_SET_AMEX
+                : SPACE_SET_COMMON;
+
+        boolean growing = newLength > oldLength;
+
+        if (growing) {
+            increment = spaceSet.contains(oldPosition) ? 2 : 1;
+            newPosition = oldPosition + increment;
+            return newPosition <= newLength ? newPosition : newLength;
+        } else {
+            increment = spaceSet.contains(oldPosition - 2) ? 2 : 1;
+            newPosition = oldPosition - increment;
+            return newPosition > 0 ? newPosition : 0;
+        }
+    }
+
+    private void updateCardBrand(String partialNumber) {
+        @Card.CardBrand String oldBrand = mCardBrand;
+        mCardBrand = StripeTextUtils.getPossibleCardType(partialNumber);
+        if (mCardBrand.equals(oldBrand)) {
+            return;
+        }
+
+        int oldLength = mLengthMax;
+        mLengthMax = getLengthForBrand(mCardBrand);
+        if (oldLength == mLengthMax) {
+            return;
+        }
+
+        setFilters(new InputFilter[] {new InputFilter.LengthFilter(mLengthMax)});
+    }
+
+    private static int getLengthForBrand(@Card.CardBrand String cardBrand) {
+        if (Card.AMERICAN_EXPRESS.equals(cardBrand) || Card.DINERS_CLUB.equals(cardBrand)) {
+            return MAX_LENGTH_AMEX_DINERS;
+        } else {
+            return MAX_LENGTH_COMMON;
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -51,6 +51,15 @@ public class CardNumberEditText extends EditText {
         listenForTextChanges();
     }
 
+    /**
+     * Updates the selection index based on the current (pre-edit) index, and
+     * the size change of the number being input.
+     *
+     * @param oldPosition the original position of the cursor
+     * @param oldLength the pre-edit length of the string
+     * @param newLength the post-edit length of the string
+     * @return an index within the string at which to put the cursor
+     */
     @VisibleForTesting
     int updateSelectionIndex(int oldPosition, int oldLength, int newLength) {
         int increment, newPosition;

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -1,6 +1,7 @@
 package com.stripe.android.view;
 
 import android.content.Context;
+import android.support.annotation.VisibleForTesting;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
@@ -32,7 +33,7 @@ public class CardNumberEditText extends EditText {
     private static final Set<Integer> SPACE_SET_AMEX =
             new HashSet<>(Arrays.asList(SPACES_ARRAY_AMEX));
 
-    @Card.CardBrand private String mCardBrand = Card.UNKNOWN;
+    @VisibleForTesting @Card.CardBrand String mCardBrand = Card.UNKNOWN;
     private int mLengthMax = 19;
 
     public CardNumberEditText(Context context) {
@@ -48,6 +49,26 @@ public class CardNumberEditText extends EditText {
     public CardNumberEditText(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         listenForTextChanges();
+    }
+
+    @VisibleForTesting
+    int updateSelectionIndex(int oldPosition, int oldLength, int newLength) {
+        int increment, newPosition;
+        Set<Integer> spaceSet = Card.AMERICAN_EXPRESS.equals(mCardBrand)
+                ? SPACE_SET_AMEX
+                : SPACE_SET_COMMON;
+
+        boolean growing = newLength > oldLength;
+
+        if (growing) {
+            increment = spaceSet.contains(oldPosition) ? 2 : 1;
+            newPosition = oldPosition + increment;
+            return newPosition <= newLength ? newPosition : newLength;
+        } else {
+            increment = spaceSet.contains(oldPosition - 2) ? 2 : 1;
+            newPosition = oldPosition - increment;
+            return newPosition > 0 ? newPosition : 0;
+        }
     }
 
     private void listenForTextChanges() {
@@ -117,28 +138,6 @@ public class CardNumberEditText extends EditText {
 
             }
         });
-    }
-
-    private int updateSelectionIndex(int oldPosition,
-                                     int oldLength,
-                                     int newLength) {
-
-        int increment, newPosition;
-        Set<Integer> spaceSet = Card.AMERICAN_EXPRESS.equals(mCardBrand)
-                ? SPACE_SET_AMEX
-                : SPACE_SET_COMMON;
-
-        boolean growing = newLength > oldLength;
-
-        if (growing) {
-            increment = spaceSet.contains(oldPosition) ? 2 : 1;
-            newPosition = oldPosition + increment;
-            return newPosition <= newLength ? newPosition : newLength;
-        } else {
-            increment = spaceSet.contains(oldPosition - 2) ? 2 : 1;
-            newPosition = oldPosition - increment;
-            return newPosition > 0 ? newPosition : 0;
-        }
     }
 
     private void updateCardBrand(String partialNumber) {

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -1,8 +1,26 @@
 package com.stripe.android.testharness;
 
-/**
- * Created by mrmcduff on 1/9/17.
- */
+import android.app.Activity;
+import android.os.Bundle;
 
-public class CardInputTestActivity {
+import com.stripe.android.R;
+import com.stripe.android.view.CardNumberEditText;
+
+/**
+ * Activity used to test UI components.
+ */
+public class CardInputTestActivity extends Activity {
+
+    private CardNumberEditText mCardNumberEditText;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.card_input_view);
+        mCardNumberEditText = (CardNumberEditText) findViewById(R.id.et_card_number);
+    }
+
+    public CardNumberEditText getCardNumberEditText() {
+        return mCardNumberEditText;
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -1,0 +1,8 @@
+package com.stripe.android.testharness;
+
+/**
+ * Created by mrmcduff on 1/9/17.
+ */
+
+public class CardInputTestActivity {
+}

--- a/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
@@ -339,4 +339,88 @@ public class StripeTextUtilsTest {
         assertEquals("5566", groups[2]);
         assertEquals("555", groups[3]);
     }
+
+    @Test
+    public void convertToSpacelessNumber_withSpacesInInterior_returnsSpacelessNumber() {
+        String testCardNumber = "4242 4242 4242 4242";
+        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+    }
+
+    @Test
+    public void convertToSpacelessNumber_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
+        String testCardNumber = "4  242                  4 242 4  242 42 4   2";
+        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+    }
+
+    @Test
+    public void convertToSpacelessNumber_withSpacesOnExterior_returnsSpacelessNumber() {
+        String testCardNumber = "      42424242 4242 4242";
+        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+    }
+
+    @Test
+    public void convertToSpacelessNumber_whenEmpty_returnsNull () {
+        assertNull(StripeTextUtils.convertToSpacelessNumber("        "));
+    }
+
+    @Test
+    public void convertToSpacelessNumber_whenNull_returnsNull() {
+        assertNull(StripeTextUtils.convertToSpacelessNumber(null));
+    }
+
+    @Test
+    public void getPossibleCardType_withEmptyCard_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("   "));
+    }
+
+    @Test
+    public void getPossibleCardType_withNullCardNumber_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType(null));
+    }
+
+    @Test
+    public void getPossibleCardType_withVisaPrefix_returnsVisa() {
+        assertEquals(Card.VISA, StripeTextUtils.getPossibleCardType("4899 99"));
+        assertEquals(Card.VISA, StripeTextUtils.getPossibleCardType("4"));
+    }
+
+    @Test
+    public void getPossibleCardType_withAmexPrefix_returnsAmex() {
+        assertEquals(Card.AMERICAN_EXPRESS, StripeTextUtils.getPossibleCardType("345"));
+        assertEquals(Card.AMERICAN_EXPRESS, StripeTextUtils.getPossibleCardType("37999999999"));
+    }
+
+    @Test
+    public void getPossibleCardType_withJCBPrefix_returnsJCB() {
+        assertEquals(Card.JCB, StripeTextUtils.getPossibleCardType("3535 3535"));
+    }
+
+    @Test
+    public void getPossibleCardType_withMasterCardPrefix_returnsMasterCard() {
+        assertEquals(Card.MASTERCARD, StripeTextUtils.getPossibleCardType("2222 452"));
+        assertEquals(Card.MASTERCARD, StripeTextUtils.getPossibleCardType("5050"));
+    }
+
+    @Test
+    public void getPossibleCardType_withDinersClubPrefix_returnsDinersClub() {
+        assertEquals(Card.DINERS_CLUB, StripeTextUtils.getPossibleCardType("303922 2234"));
+        assertEquals(Card.DINERS_CLUB, StripeTextUtils.getPossibleCardType("36778 9098"));
+    }
+
+    @Test
+    public void getPossibleCardType_withDiscoverPrefix_returnsDiscover() {
+        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("60355"));
+        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("62"));
+        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("6433 8 90923"));
+        // This one has too many numbers on purpose. Checking for length is not part of the
+        // function under test.
+        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("6523452309209340293423"));
+    }
+
+    @Test
+    public void getPossibleCardType_withNonsenseNumber_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("1234567890123456"));
+        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("9999 9999 9999 9999"));
+        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("3"));
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
@@ -1,6 +1,5 @@
 package com.stripe.android.util;
 
-import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 
 import org.junit.Test;
@@ -244,5 +243,100 @@ public class StripeTextUtilsTest {
     @Test
     public void asFundingType_whenGobbledegook_returnsUnkown() {
         assertEquals(Card.FUNDING_UNKNOWN, StripeTextUtils.asFundingType("personal iou"));
+    }
+
+    @Test
+    public void separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups =
+                StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("10005", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
+        String testCardNumber = "38520000023237";
+        String[] groups =
+                StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.DINERS_CLUB);
+        assertEquals(4, groups.length);
+        assertEquals("3852", groups[0]);
+        assertEquals("0000", groups[1]);
+        assertEquals("0232", groups[2]);
+        assertEquals("37", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups = StripeTextUtils.separateCardNumberGroups(
+                        testCardNumber.substring(0, 2), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("37", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+
+        groups = StripeTextUtils.separateCardNumberGroups(
+                        testCardNumber.substring(0, 5), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("8", groups[1]);
+        assertNull(groups[2]);
+
+        groups = StripeTextUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 11), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("1", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = StripeTextUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 2), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("40", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = StripeTextUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 5), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0", groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = StripeTextUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 9), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5", groups[2]);
+        assertNull(groups[3]);
+
+        groups = StripeTextUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 15), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("555", groups[3]);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
@@ -352,31 +352,31 @@ public class StripeTextUtilsTest {
     }
 
     @Test
-    public void convertToSpacelessNumber_withSpacesInInterior_returnsSpacelessNumber() {
+    public void removeSpaces_withSpacesInInterior_returnsSpacelessNumber() {
         String testCardNumber = "4242 4242 4242 4242";
-        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
     }
 
     @Test
-    public void convertToSpacelessNumber_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
+    public void removeSpaces_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
         String testCardNumber = "4  242                  4 242 4  242 42 4   2";
-        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
     }
 
     @Test
-    public void convertToSpacelessNumber_withSpacesOnExterior_returnsSpacelessNumber() {
+    public void removeSpaces_withSpacesOnExterior_returnsSpacelessNumber() {
         String testCardNumber = "      42424242 4242 4242    ";
-        assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
     }
 
     @Test
-    public void convertToSpacelessNumber_whenEmpty_returnsNull () {
-        assertNull(StripeTextUtils.convertToSpacelessNumber("        "));
+    public void removeSpaces_whenEmpty_returnsNull () {
+        assertNull(StripeTextUtils.removeSpaces("        "));
     }
 
     @Test
-    public void convertToSpacelessNumber_whenNull_returnsNull() {
-        assertNull(StripeTextUtils.convertToSpacelessNumber(null));
+    public void removeSpaces_whenNull_returnsNull() {
+        assertNull(StripeTextUtils.removeSpaces(null));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
@@ -280,6 +280,17 @@ public class StripeTextUtilsTest {
     }
 
     @Test
+    public void separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
+        String testCardNumber = "1234056655665556";
+        String[] groups = StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.UNKNOWN);
+        assertEquals(4, groups.length);
+        assertEquals("1234", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
     public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
         String testCardNumber = "378282246310005";
         String[] groups = StripeTextUtils.separateCardNumberGroups(
@@ -354,7 +365,7 @@ public class StripeTextUtilsTest {
 
     @Test
     public void convertToSpacelessNumber_withSpacesOnExterior_returnsSpacelessNumber() {
-        String testCardNumber = "      42424242 4242 4242";
+        String testCardNumber = "      42424242 4242 4242    ";
         assertEquals("4242424242424242", StripeTextUtils.convertToSpacelessNumber(testCardNumber));
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,0 +1,8 @@
+package com.stripe.android.view;
+
+/**
+ * Created by mrmcduff on 1/9/17.
+ */
+
+public class CardNumberEditText {
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,8 +1,68 @@
 package com.stripe.android.view;
 
-/**
- * Created by mrmcduff on 1/9/17.
- */
+import android.app.Activity;
 
-public class CardNumberEditText {
+import com.stripe.android.model.Card;
+import com.stripe.android.testharness.CardInputTestActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for {@link CardNumberEditText}. Note that we have to test against SDK 22
+ * because of a <a href="https://github.com/robolectric/robolectric/issues/1932">known issue</a> in
+ * Robolectric.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 22)
+public class CardNumberEditTextTest {
+
+    private CardNumberEditText mCardNumberEditText;
+
+    @Before
+    public void setup() {
+        ActivityController activityController =
+                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
+
+        mCardNumberEditText =
+                ((CardInputTestActivity) activityController.get()).getCardNumberEditText();
+    }
+
+    @Test
+    public void updateSelectionIndex_whenVisa_increasesIndexWhenGoingPastTheSpaces() {
+        // Directly setting card brand as a testing hack (annotated in source)
+        mCardNumberEditText.mCardBrand = Card.VISA;
+        assertEquals(6, mCardNumberEditText.updateSelectionIndex(4, 4, 6));
+        assertEquals(11, mCardNumberEditText.updateSelectionIndex(9, 9, 11));
+        assertEquals(16, mCardNumberEditText.updateSelectionIndex(14, 14, 16));
+    }
+
+    @Test
+    public void updateSelectionIndex_whenAmEx_increasesIndexWhenGoingPastTheSpaces() {
+        mCardNumberEditText.mCardBrand = Card.AMERICAN_EXPRESS;
+        assertEquals(6, mCardNumberEditText.updateSelectionIndex(4, 4, 6));
+        assertEquals(13, mCardNumberEditText.updateSelectionIndex(11, 11, 13));
+    }
+
+    @Test
+    public void updateSelectionIndex_whenDinersClub_decreasesIndexWhenDeletingPastTheSpaces() {
+        mCardNumberEditText.mCardBrand = Card.DINERS_CLUB;
+        assertEquals(4, mCardNumberEditText.updateSelectionIndex(6, 6, 4));
+        assertEquals(9, mCardNumberEditText.updateSelectionIndex(11, 11, 9));
+        assertEquals(14, mCardNumberEditText.updateSelectionIndex(16, 16, 14));
+    }
+
+    @Test
+    public void updateSelectionIndex_whenAmEx_decreasesIndexWhenDeletingPastTheSpaces() {
+        mCardNumberEditText.mCardBrand = Card.AMERICAN_EXPRESS;
+        assertEquals(4, mCardNumberEditText.updateSelectionIndex(6, 6, 4));
+        assertEquals(11, mCardNumberEditText.updateSelectionIndex(13, 13, 11));
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -65,4 +65,16 @@ public class CardNumberEditTextTest {
         assertEquals(4, mCardNumberEditText.updateSelectionIndex(6, 6, 4));
         assertEquals(11, mCardNumberEditText.updateSelectionIndex(13, 13, 11));
     }
+
+    @Test
+    public void updateSelectionIndex_whenSelectionInTheMiddle_increasesIndexOverASpace() {
+        mCardNumberEditText.mCardBrand = Card.VISA;
+        assertEquals(6, mCardNumberEditText.updateSelectionIndex(4, 8, 9));
+    }
+
+    @Test
+    public void updateSelectionIndex_whenSelectionInTheMiddle_skipsBackDownOverASpace() {
+        mCardNumberEditText.mCardBrand = Card.AMERICAN_EXPRESS;
+        assertEquals(4, mCardNumberEditText.updateSelectionIndex(6, 8, 7));
+    }
 }


### PR DESCRIPTION
r? @shale-stripe 
cc @brandur-stripe 

This diff adds the CardInputView and handles the tricky business whereby a user typing in a credit card number sees it magically add spaces in the appropriate places for Visa, AmEx, and other types of cards.

What this diff does address:
- dynamically determining the type of credit card being input as soon as it is possible to do so
- having the cursor "hop" over the spaces in a credit card number (of any brand)
- having the maximum length of input change depending on the updated card brand

What this diff does NOT address:
- copy-pasting in CC numbers, which will currently not function well with the updateSelectionIndex function (plan to address in a subsequent diff for clarity)
- Reporting the discovered brand outside the CardNumberEditText (so that it can be shown in the currently-unused imageview in the greater control)

What this diff leaves in as a framework:
- Currently unused fields in the CardInputView, just as a sketch for where this is going