### PR TITLE
moving card validation logic into a utils class, adding tests, making CardNumberEditText validate card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.3 2017-01-09
+    Updated OS version logging to be relevant for Android
+
 2.0.2 2016-12-22
     Made the StripeApiHandler.VERSION constant public
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These Stripe Android bindings can be used to generate tokens in your Android app
 
 No need to clone the repository or download any files -- just add this line to your app's `build.gradle` inside the `dependencies` section:
 
-    compile 'com.stripe:stripe-android:2.0.2'
+    compile 'com.stripe:stripe-android:2.0.3'
 
 Note: We recommend that you don't use `compile 'com.stripe:stripe-android:+`, as future versions of the SDK may not maintain full backwards compatibility. When such a change occurs, a major version number change will accompany it.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.2
+VERSION_NAME=2.0.3
 GROUP=com.stripe
 
 POM_DESCRIPTION=Stripe Android Bindings

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
+import com.stripe.android.util.CardUtils;
 import com.stripe.android.util.DateUtils;
 import com.stripe.android.util.StripeTextUtils;
 
@@ -360,25 +361,7 @@ public class Card {
      * @return {@code true} if valid, {@code false} otherwise.
      */
     public boolean validateNumber() {
-        if (StripeTextUtils.isBlank(number)) {
-            return false;
-        }
-
-        String rawNumber = number.trim().replaceAll("\\s+|-", "");
-        if (StripeTextUtils.isBlank(rawNumber)
-                || !StripeTextUtils.isWholePositiveNumber(rawNumber)
-                || !isValidLuhnNumber(rawNumber)) {
-            return false;
-        }
-
-        String updatedType = getBrand();
-        if (AMERICAN_EXPRESS.equals(updatedType)) {
-            return rawNumber.length() == MAX_LENGTH_AMERICAN_EXPRESS;
-        } else if (DINERS_CLUB.equals(updatedType)) {
-            return rawNumber.length() == MAX_LENGTH_DINERS_CLUB;
-        } else {
-            return rawNumber.length() == MAX_LENGTH_STANDARD;
-        }
+        return CardUtils.isValidCardNumber(number);
     }
 
     /**
@@ -726,32 +709,6 @@ public class Card {
         this.funding = StripeTextUtils.asFundingType(builder.funding);
         this.country = StripeTextUtils.nullIfBlank(builder.country);
         this.currency = StripeTextUtils.nullIfBlank(builder.currency);
-    }
-
-    private boolean isValidLuhnNumber(String number) {
-        boolean isOdd = true;
-        int sum = 0;
-
-        for (int index = number.length() - 1; index >= 0; index--) {
-            char c = number.charAt(index);
-            if (!Character.isDigit(c)) {
-                return false;
-            }
-            int digitInteger = Integer.parseInt("" + c);
-            isOdd = !isOdd;
-
-            if (isOdd) {
-                digitInteger *= 2;
-            }
-
-            if (digitInteger > 9) {
-                digitInteger -= 9;
-            }
-
-            sum += digitInteger;
-        }
-
-        return sum % 10 == 0;
     }
 
     private String normalizeCardNumber(String number) {

--- a/stripe/src/main/java/com/stripe/android/util/CardUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/CardUtils.java
@@ -1,0 +1,201 @@
+package com.stripe.android.util;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.model.Card;
+
+import static com.stripe.android.model.Card.CardBrand;
+
+/**
+ * Utility class for functions to do with cards.
+ */
+public class CardUtils {
+
+    public static final int LENGTH_COMMON_CARD = 16;
+    public static final int LENGTH_AMERICAN_EXPRESS = 15;
+    public static final int LENGTH_DINERS_CLUB = 14;
+
+    public static boolean isValidCardNumber(@Nullable String cardNumber) {
+        String normalizedNumber = StripeTextUtils.removeSpacesAndHyphens(cardNumber);
+        return isValidLuhnNumber(normalizedNumber) && isValidCardLength(normalizedNumber);
+    }
+
+    /**
+     * Checks the input string to see whether or not it is a valid Luhn number.
+     *
+     * @param cardNumber a String that may or may not represent a valid Luhn number
+     * @return {@code true} if and only if the input value is a valid Luhn number
+     */
+    public static boolean isValidLuhnNumber(@Nullable String cardNumber) {
+        if (cardNumber == null) {
+            return false;
+        }
+
+        boolean isOdd = true;
+        int sum = 0;
+
+        for (int index = cardNumber.length() - 1; index >= 0; index--) {
+            char c = cardNumber.charAt(index);
+            if (!Character.isDigit(c)) {
+                return false;
+            }
+
+            int digitInteger = Character.getNumericValue(c);
+            isOdd = !isOdd;
+
+            if (isOdd) {
+                digitInteger *= 2;
+            }
+
+            if (digitInteger > 9) {
+                digitInteger -= 9;
+            }
+
+            sum += digitInteger;
+        }
+
+        return sum % 10 == 0;
+    }
+
+    /**
+     * Checks to see whether the input number is of the correct length, after determining its brand.
+     * This function does not perform a Luhn check.
+     *
+     * @param cardNumber the card number with no spaces or dashes
+     * @return {@code true} if the card number is of known type and the correct length
+     */
+    public static boolean isValidCardLength(@Nullable String cardNumber) {
+        if (cardNumber == null) {
+            return false;
+        }
+
+        return isValidCardLength(cardNumber, getPossibleCardType(cardNumber, false));
+    }
+
+    /**
+     * Checks to see whether the input number is of the correct length, given the assumed brand of
+     * the card. This function does not perform a Luhn check.
+     *
+     * @param cardNumber the card number with no spaces or dashes
+     * @param cardBrand a {@link CardBrand} used to get the correct size
+     * @return {@code true} if the card number is the correct length for the assumed brand
+     */
+    public static boolean isValidCardLength(
+            @Nullable String cardNumber,
+            @NonNull @CardBrand String cardBrand) {
+        if(cardNumber == null || Card.UNKNOWN.equals(cardBrand)) {
+            return false;
+        }
+
+        int length = cardNumber.length();
+        switch (cardBrand) {
+            case Card.AMERICAN_EXPRESS:
+                return length == LENGTH_AMERICAN_EXPRESS;
+            case Card.DINERS_CLUB:
+                return length == LENGTH_DINERS_CLUB;
+            default:
+                return length == LENGTH_COMMON_CARD;
+        }
+    }
+
+    /**
+     * Returns a {@link CardBrand} corresponding to a partial card number,
+     * or {@link Card#UNKNOWN} if the card brand can't be determined from the input value.
+     *
+     * @param cardNumber a credit card number or partial card number
+     * @return the {@link CardBrand} corresponding to that number,
+     * or {@link Card#UNKNOWN} if it can't be determined
+     */
+    @NonNull
+    @CardBrand
+    public static String getPossibleCardType(@Nullable String cardNumber) {
+        return getPossibleCardType(cardNumber, true);
+    }
+
+    @NonNull
+    @CardBrand
+    private static String getPossibleCardType(@Nullable String cardNumber,
+                                              boolean shouldNormalize) {
+        if (StripeTextUtils.isBlank(cardNumber)) {
+            return Card.UNKNOWN;
+        }
+
+        String spacelessCardNumber = cardNumber;
+        if (shouldNormalize) {
+            spacelessCardNumber = StripeTextUtils.removeSpacesAndHyphens(cardNumber);
+        }
+
+        if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_AMERICAN_EXPRESS)) {
+            return Card.AMERICAN_EXPRESS;
+        } else if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DISCOVER)) {
+            return Card.DISCOVER;
+        } else if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_JCB)) {
+            return Card.JCB;
+        } else if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DINERS_CLUB)) {
+            return Card.DINERS_CLUB;
+        } else if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_VISA)) {
+            return Card.VISA;
+        } else if (StripeTextUtils.hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_MASTERCARD)) {
+            return Card.MASTERCARD;
+        } else {
+            return Card.UNKNOWN;
+        }
+    }
+
+
+    /**
+     * Separates a card number according to the brand requirements, including prefixes of card
+     * numbers, so that the groups can be easily displayed if the user is typing them in.
+     * Note that this does not verify that the card number is valid, or even that it is a number.
+     *
+     * @param spacelessCardNumber the raw card number, without spaces
+     * @param brand the {@link CardBrand} to use as a separating scheme
+     * @return an array of strings with the number groups, in order. If the number is not complete,
+     * some of the array entries may be {@code null}.
+     */
+    @NonNull
+    public static String[] separateCardNumberGroups(@NonNull String spacelessCardNumber,
+                                                    @NonNull @CardBrand String brand) {
+        String[] numberGroups;
+        if (brand.equals(Card.AMERICAN_EXPRESS)) {
+            numberGroups = new String[3];
+
+            int length = spacelessCardNumber.length();
+            int lastUsedIndex = 0;
+            if (length > 4) {
+                numberGroups[0] = spacelessCardNumber.substring(0, 4);
+                lastUsedIndex = 4;
+            }
+
+            if (length > 10) {
+                numberGroups[1] = spacelessCardNumber.substring(4, 10);
+                lastUsedIndex = 10;
+            }
+
+            for (int i = 0; i < 3; i++) {
+                if (numberGroups[i] != null) {
+                    continue;
+                }
+                numberGroups[i] = spacelessCardNumber.substring(lastUsedIndex);
+                break;
+            }
+
+        } else {
+            numberGroups = new String[4];
+            int i = 0;
+            int previousStart = 0;
+            while((i + 1) * 4 < spacelessCardNumber.length()) {
+                String group = spacelessCardNumber.substring(previousStart, (i + 1) * 4);
+                numberGroups[i] = group;
+                previousStart = (i + 1) * 4;
+                i++;
+            }
+            // Always stuff whatever is left into the next available array entry. This handles
+            // incomplete numbers, full 16-digit numbers, and full 14-digit numbers
+            numberGroups[i] = spacelessCardNumber.substring(previousStart);
+        }
+        return numberGroups;
+    }
+
+}

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -82,40 +82,6 @@ public class StripeTextUtils {
     }
 
     /**
-     * Returns a {@link CardBrand} corresponding to a partial card number, or {@link Card#UNKNOWN}
-     * if the card brand can't be determined from the input value.
-     *
-     * @param cardNumber a credit card number or partial card number
-     * @return the {@link CardBrand} corresponding to that number, or {@link Card#UNKNOWN} if it
-     * can't be determined
-     */
-    @NonNull
-    @CardBrand
-    public static String getPossibleCardType(@Nullable String cardNumber) {
-        if (isBlank(cardNumber)) {
-            return Card.UNKNOWN;
-        }
-
-        String spacelessCardNumber = removeSpaces(cardNumber);
-
-        if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_AMERICAN_EXPRESS)) {
-            return Card.AMERICAN_EXPRESS;
-        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DISCOVER)) {
-            return Card.DISCOVER;
-        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_JCB)) {
-            return Card.JCB;
-        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_DINERS_CLUB)) {
-            return Card.DINERS_CLUB;
-        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_VISA)) {
-            return Card.VISA;
-        } else if (hasAnyPrefix(spacelessCardNumber, Card.PREFIXES_MASTERCARD)) {
-            return Card.MASTERCARD;
-        } else {
-            return Card.UNKNOWN;
-        }
-    }
-
-    /**
      * Converts a card number that may have spaces between the numbers into one without any spaces.
      * Note: method does not check that all characters are digits or spaces.
      *
@@ -124,65 +90,11 @@ public class StripeTextUtils {
      * Returns {@code null} if the input was {@code null} or all spaces.
      */
     @Nullable
-    public static String removeSpaces(@Nullable String cardNumberWithSpaces) {
+    public static String removeSpacesAndHyphens(@Nullable String cardNumberWithSpaces) {
         if (isBlank(cardNumberWithSpaces)) {
             return null;
         }
-        return cardNumberWithSpaces.replaceAll("\\s", "");
-    }
-
-    /**
-     * Separates a card number according to the brand requirements, including prefixes of card
-     * numbers, so that the groups can be easily displayed if the user is typing them in.
-     * Note that this does not verify that the card number is valid, or even that it is a number.
-     *
-     * @param spacelessCardNumber the raw card number, without spaces
-     * @param brand the {@link CardBrand} to use as a separating scheme
-     * @return an array of strings with the number groups, in order. If the number is not complete,
-     * some of the array entries may be {@code null}.
-     */
-    @NonNull
-    public static String[] separateCardNumberGroups(@NonNull String spacelessCardNumber,
-                                                    @NonNull @CardBrand String brand) {
-        String[] numberGroups;
-        if (brand.equals(Card.AMERICAN_EXPRESS)) {
-            numberGroups = new String[3];
-
-            int length = spacelessCardNumber.length();
-            int lastUsedIndex = 0;
-            if (length > 4) {
-                numberGroups[0] = spacelessCardNumber.substring(0, 4);
-                lastUsedIndex = 4;
-            }
-
-            if (length > 10) {
-                numberGroups[1] = spacelessCardNumber.substring(4, 10);
-                lastUsedIndex = 10;
-            }
-
-            for (int i = 0; i < 3; i++) {
-                if (numberGroups[i] != null) {
-                    continue;
-                }
-                numberGroups[i] = spacelessCardNumber.substring(lastUsedIndex);
-                break;
-            }
-
-        } else {
-            numberGroups = new String[4];
-            int i = 0;
-            int previousStart = 0;
-            while((i + 1) * 4 < spacelessCardNumber.length()) {
-                String group = spacelessCardNumber.substring(previousStart, (i + 1) * 4);
-                numberGroups[i] = group;
-                previousStart = (i + 1) * 4;
-                i++;
-            }
-            // Always stuff whatever is left into the next available array entry. This handles
-            // incomplete numbers, full 16-digit numbers, and full 14-digit numbers
-            numberGroups[i] = spacelessCardNumber.substring(previousStart);
-        }
-        return numberGroups;
+        return cardNumberWithSpaces.replaceAll("\\s|-", "");
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/util/CardUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/CardUtilsTest.java
@@ -1,0 +1,305 @@
+package com.stripe.android.util;
+
+import com.stripe.android.model.Card;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for {@link CardUtils}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class CardUtilsTest {
+
+    @Test
+    public void getPossibleCardType_withEmptyCard_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, CardUtils.getPossibleCardType("   "));
+    }
+
+    @Test
+    public void getPossibleCardType_withNullCardNumber_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, CardUtils.getPossibleCardType(null));
+    }
+
+    @Test
+    public void getPossibleCardType_withVisaPrefix_returnsVisa() {
+        assertEquals(Card.VISA, CardUtils.getPossibleCardType("4899 99"));
+        assertEquals(Card.VISA, CardUtils.getPossibleCardType("4"));
+    }
+
+    @Test
+    public void getPossibleCardType_withAmexPrefix_returnsAmex() {
+        assertEquals(Card.AMERICAN_EXPRESS, CardUtils.getPossibleCardType("345"));
+        assertEquals(Card.AMERICAN_EXPRESS, CardUtils.getPossibleCardType("37999999999"));
+    }
+
+    @Test
+    public void getPossibleCardType_withJCBPrefix_returnsJCB() {
+        assertEquals(Card.JCB, CardUtils.getPossibleCardType("3535 3535"));
+    }
+
+    @Test
+    public void getPossibleCardType_withMasterCardPrefix_returnsMasterCard() {
+        assertEquals(Card.MASTERCARD, CardUtils.getPossibleCardType("2222 452"));
+        assertEquals(Card.MASTERCARD, CardUtils.getPossibleCardType("5050"));
+    }
+
+    @Test
+    public void getPossibleCardType_withDinersClubPrefix_returnsDinersClub() {
+        assertEquals(Card.DINERS_CLUB, CardUtils.getPossibleCardType("303922 2234"));
+        assertEquals(Card.DINERS_CLUB, CardUtils.getPossibleCardType("36778 9098"));
+    }
+
+    @Test
+    public void getPossibleCardType_withDiscoverPrefix_returnsDiscover() {
+        assertEquals(Card.DISCOVER, CardUtils.getPossibleCardType("60355"));
+        assertEquals(Card.DISCOVER, CardUtils.getPossibleCardType("62"));
+        assertEquals(Card.DISCOVER, CardUtils.getPossibleCardType("6433 8 90923"));
+        // This one has too many numbers on purpose. Checking for length is not part of the
+        // function under test.
+        assertEquals(Card.DISCOVER, CardUtils.getPossibleCardType("6523452309209340293423"));
+    }
+
+    @Test
+    public void getPossibleCardType_withNonsenseNumber_returnsUnknown() {
+        assertEquals(Card.UNKNOWN, CardUtils.getPossibleCardType("1234567890123456"));
+        assertEquals(Card.UNKNOWN, CardUtils.getPossibleCardType("9999 9999 9999 9999"));
+        assertEquals(Card.UNKNOWN, CardUtils.getPossibleCardType("3"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidVisaNumber_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("4242424242424242"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidJCBNumber_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("3530111333300000"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidDiscover_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("6011000990139424"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidDinersClub_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("30569309025904"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidMasterCard_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("5555555555554444"));
+    }
+
+    @Test
+    public void isValidCardLength_whenValidAmEx_returnsTrue() {
+        assertTrue(CardUtils.isValidCardLength("378282246310005"));
+    }
+
+    @Test
+    public void isValidCardLength_whenNull_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength(null));
+    }
+
+    @Test
+    public void isValidCardLength_whenVisaStyleNumberButDinersClubLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("42424242424242"));
+    }
+
+    @Test
+    public void isValidCardLength_whenVisaStyleNumberButAmExLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("424242424242424"));
+    }
+
+    @Test
+    public void isValidCardLength_whenAmExStyleNumberButVisaLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("3782822463100050"));
+    }
+
+    @Test
+    public void isValidCardLength_whenAmExStyleNumberButDinersClubLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("37828224631000"));
+    }
+
+    @Test
+    public void isValidCardLength_whenDinersClubStyleNumberButVisaLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("3056930902590400"));
+    }
+
+    @Test
+    public void isValidCardLength_whenDinersClubStyleNumberStyleNumberButAmexLength_returnsFalse() {
+        assertFalse(CardUtils.isValidCardLength("305693090259040"));
+    }
+
+    @Test
+    public void isValidCardLengthWithBrand_whenBrandUnknown_alwaysReturnsFalse() {
+        String validVisa = "4242424242424242";
+        // Adding this check to ensure the input number is correct
+        assertTrue(CardUtils.isValidCardLength(validVisa));
+        assertFalse(CardUtils.isValidCardLength(validVisa, Card.UNKNOWN));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidVisaNumber_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("4242424242424242"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidJCBNumber_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("3530111333300000"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidDiscover_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("6011000990139424"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidDinersClub_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("30569309025904"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidMasterCard_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("5555555555554444"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenValidAmEx_returnsTrue() {
+        assertTrue(CardUtils.isValidLuhnNumber("378282246310005"));
+    }
+
+    @Test
+    public void isValidLunhNumber_whenNumberIsInvalid_returnsFalse() {
+        assertFalse(CardUtils.isValidLuhnNumber("4242424242424243"));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenInputIsNull_returnsFalse() {
+        assertFalse(CardUtils.isValidLuhnNumber(null));
+    }
+
+    @Test
+    public void isValidLuhnNumber_whenInputIsNotNumeric_returnsFalse() {
+        assertFalse(CardUtils.isValidLuhnNumber("abcdefg"));
+        // Note: it is not the job of this function to de-space the card number, nor de-hyphen it
+        assertFalse(CardUtils.isValidLuhnNumber("4242 4242 4242 4242"));
+        assertFalse(CardUtils.isValidLuhnNumber("4242-4242-4242-4242"));
+    }
+
+
+    @Test
+    public void separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = CardUtils.separateCardNumberGroups(testCardNumber, Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups =
+                CardUtils.separateCardNumberGroups(testCardNumber, Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("10005", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
+        String testCardNumber = "38520000023237";
+        String[] groups =
+                CardUtils.separateCardNumberGroups(testCardNumber, Card.DINERS_CLUB);
+        assertEquals(4, groups.length);
+        assertEquals("3852", groups[0]);
+        assertEquals("0000", groups[1]);
+        assertEquals("0232", groups[2]);
+        assertEquals("37", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
+        String testCardNumber = "1234056655665556";
+        String[] groups = CardUtils.separateCardNumberGroups(testCardNumber, Card.UNKNOWN);
+        assertEquals(4, groups.length);
+        assertEquals("1234", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 2), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("37", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+
+        groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 5), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("8", groups[1]);
+        assertNull(groups[2]);
+
+        groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 11), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("1", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 2), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("40", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 5), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0", groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 9), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5", groups[2]);
+        assertNull(groups[3]);
+
+        groups = CardUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 15), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("555", groups[3]);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeTextUtilsTest.java
@@ -246,192 +246,42 @@ public class StripeTextUtilsTest {
     }
 
     @Test
-    public void separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
-        String testCardNumber = "4000056655665556";
-        String[] groups = StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("5556", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
-        String testCardNumber = "378282246310005";
-        String[] groups =
-                StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("822463", groups[1]);
-        assertEquals("10005", groups[2]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
-        String testCardNumber = "38520000023237";
-        String[] groups =
-                StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.DINERS_CLUB);
-        assertEquals(4, groups.length);
-        assertEquals("3852", groups[0]);
-        assertEquals("0000", groups[1]);
-        assertEquals("0232", groups[2]);
-        assertEquals("37", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
-        String testCardNumber = "1234056655665556";
-        String[] groups = StripeTextUtils.separateCardNumberGroups(testCardNumber, Card.UNKNOWN);
-        assertEquals(4, groups.length);
-        assertEquals("1234", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("5556", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
-        String testCardNumber = "378282246310005";
-        String[] groups = StripeTextUtils.separateCardNumberGroups(
-                        testCardNumber.substring(0, 2), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("37", groups[0]);
-        assertNull(groups[1]);
-        assertNull(groups[2]);
-
-        groups = StripeTextUtils.separateCardNumberGroups(
-                        testCardNumber.substring(0, 5), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("8", groups[1]);
-        assertNull(groups[2]);
-
-        groups = StripeTextUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 11), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("822463", groups[1]);
-        assertEquals("1", groups[2]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
-        String testCardNumber = "4000056655665556";
-        String[] groups = StripeTextUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 2), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("40", groups[0]);
-        assertNull(groups[1]);
-        assertNull(groups[2]);
-        assertNull(groups[3]);
-
-        groups = StripeTextUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 5), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0", groups[1]);
-        assertNull(groups[2]);
-        assertNull(groups[3]);
-
-        groups = StripeTextUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 9), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5", groups[2]);
-        assertNull(groups[3]);
-
-        groups = StripeTextUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 15), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("555", groups[3]);
-    }
-
-    @Test
-    public void removeSpaces_withSpacesInInterior_returnsSpacelessNumber() {
+    public void removeSpacesAndHyphens_withSpacesInInterior_returnsSpacelessNumber() {
         String testCardNumber = "4242 4242 4242 4242";
-        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber));
     }
 
     @Test
-    public void removeSpaces_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
+    public void removeSpacesAndHyphens_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
         String testCardNumber = "4  242                  4 242 4  242 42 4   2";
-        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber));
     }
 
     @Test
-    public void removeSpaces_withSpacesOnExterior_returnsSpacelessNumber() {
+    public void removeSpacesAndHyphens_withSpacesOnExterior_returnsSpacelessNumber() {
         String testCardNumber = "      42424242 4242 4242    ";
-        assertEquals("4242424242424242", StripeTextUtils.removeSpaces(testCardNumber));
+        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber));
     }
 
     @Test
-    public void removeSpaces_whenEmpty_returnsNull () {
-        assertNull(StripeTextUtils.removeSpaces("        "));
+    public void removeSpacesAndHyphens_whenEmpty_returnsNull () {
+        assertNull(StripeTextUtils.removeSpacesAndHyphens("        "));
     }
 
     @Test
-    public void removeSpaces_whenNull_returnsNull() {
-        assertNull(StripeTextUtils.removeSpaces(null));
+    public void removeSpacesAndHyphens_whenNull_returnsNull() {
+        assertNull(StripeTextUtils.removeSpacesAndHyphens(null));
     }
 
     @Test
-    public void getPossibleCardType_withEmptyCard_returnsUnknown() {
-        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("   "));
+    public void removeSpacesAndHyphens_withHyphenatedCardNumber_returnsCardNumber() {
+        assertEquals("4242424242424242",
+                StripeTextUtils.removeSpacesAndHyphens("4242-4242-4242-4242"));
     }
 
     @Test
-    public void getPossibleCardType_withNullCardNumber_returnsUnknown() {
-        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType(null));
-    }
-
-    @Test
-    public void getPossibleCardType_withVisaPrefix_returnsVisa() {
-        assertEquals(Card.VISA, StripeTextUtils.getPossibleCardType("4899 99"));
-        assertEquals(Card.VISA, StripeTextUtils.getPossibleCardType("4"));
-    }
-
-    @Test
-    public void getPossibleCardType_withAmexPrefix_returnsAmex() {
-        assertEquals(Card.AMERICAN_EXPRESS, StripeTextUtils.getPossibleCardType("345"));
-        assertEquals(Card.AMERICAN_EXPRESS, StripeTextUtils.getPossibleCardType("37999999999"));
-    }
-
-    @Test
-    public void getPossibleCardType_withJCBPrefix_returnsJCB() {
-        assertEquals(Card.JCB, StripeTextUtils.getPossibleCardType("3535 3535"));
-    }
-
-    @Test
-    public void getPossibleCardType_withMasterCardPrefix_returnsMasterCard() {
-        assertEquals(Card.MASTERCARD, StripeTextUtils.getPossibleCardType("2222 452"));
-        assertEquals(Card.MASTERCARD, StripeTextUtils.getPossibleCardType("5050"));
-    }
-
-    @Test
-    public void getPossibleCardType_withDinersClubPrefix_returnsDinersClub() {
-        assertEquals(Card.DINERS_CLUB, StripeTextUtils.getPossibleCardType("303922 2234"));
-        assertEquals(Card.DINERS_CLUB, StripeTextUtils.getPossibleCardType("36778 9098"));
-    }
-
-    @Test
-    public void getPossibleCardType_withDiscoverPrefix_returnsDiscover() {
-        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("60355"));
-        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("62"));
-        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("6433 8 90923"));
-        // This one has too many numbers on purpose. Checking for length is not part of the
-        // function under test.
-        assertEquals(Card.DISCOVER, StripeTextUtils.getPossibleCardType("6523452309209340293423"));
-    }
-
-    @Test
-    public void getPossibleCardType_withNonsenseNumber_returnsUnknown() {
-        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("1234567890123456"));
-        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("9999 9999 9999 9999"));
-        assertEquals(Card.UNKNOWN, StripeTextUtils.getPossibleCardType("3"));
+    public void removeSpacesAndHyphens_removesMultipleSpacesAndHyphens() {
+        assertEquals("123",
+                StripeTextUtils.removeSpacesAndHyphens(" -    1-  --- 2   3- - - -------- "));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,7 +1,5 @@
 package com.stripe.android.view;
 
-import android.annotation.SuppressLint;
-
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.CardInputTestActivity;
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import android.annotation.SuppressLint;
+
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.CardInputTestActivity;
 
@@ -12,6 +14,8 @@ import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for {@link CardNumberEditText}. Note that we have to test against SDK 22
@@ -22,6 +26,8 @@ import static org.junit.Assert.assertEquals;
 @Config(sdk = 22)
 public class CardNumberEditTextTest {
 
+    private static final String VALID_VISA_WITH_SPACES = "4242 4242 4242 4242";
+    private static final String VALID_AMEX_WITH_SPACES = "3782 822463 10005";
     private CardNumberEditText mCardNumberEditText;
 
     @Before
@@ -31,6 +37,7 @@ public class CardNumberEditTextTest {
 
         mCardNumberEditText =
                 ((CardInputTestActivity) activityController.get()).getCardNumberEditText();
+        mCardNumberEditText.setText("");
     }
 
     @Test
@@ -96,5 +103,29 @@ public class CardNumberEditTextTest {
         mCardNumberEditText.mCardBrand = Card.VISA;
         // This case could happen when you paste over 5 digits with only 2
         assertEquals(3, mCardNumberEditText.updateSelectionIndex(3, 3, 2));
+    }
+
+    @Test
+    public void setText_whenTextIsValidCommonLengthNumber_changesCardValidState() {
+        mCardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+
+        assertTrue(mCardNumberEditText.isCardNumberValid());
+    }
+
+    @Test
+    public void setText_whenTextIsValidAmExDinersClubLengthNumber_changesCardValidState() {
+        mCardNumberEditText.setText(VALID_AMEX_WITH_SPACES);
+
+        assertTrue(mCardNumberEditText.isCardNumberValid());
+    }
+
+    @Test
+    public void setText_whenTextChangesFromValidToInvalid_changesCardValidState() {
+        mCardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        String mutable = mCardNumberEditText.getText().toString();
+        // Removing a single character should make this invalid
+        mutable = mutable.substring(0, 18);
+        mCardNumberEditText.setText(mutable);
+        assertFalse(mCardNumberEditText.isCardNumberValid());
     }
 }


### PR DESCRIPTION
r? @shale-stripe 
cc @brandur-stripe 

Note: this diff is deceptively large. Because StripeTextUtils was getting enormous, I moved the explicitly card-related functions (including new ones) to CardUtils. This also meant I moved tests from StripeTextUtilsTest to CardUtilsTest. This accounts for approximately 300 of the 500ish lines of the diff.

Other than reorganization, the main point of this diff was to add validation functionality to the CardNumberEditText, so that if we ever have a case where the text inside it goes from an invalid number to a valid number (or vice versa), we reflect that change in a readable boolean value. In the future, we'll update the color of the text or show an error message in certain situations.

Care was taken to ensure that we don't check the validity unnecessarily (on each keystroke, for instance), since each check involves small-but-poorly-scaling operations (string length checking and prefix checking).