### PR TITLE
adding bindings to create tokens from bank accounts

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -16,11 +16,13 @@ import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 import com.stripe.android.net.RequestOptions;
 import com.stripe.android.net.StripeApiHandler;
 
+import static com.stripe.android.util.StripeNetworkUtils.hashMapFromBankAccount;
 import static com.stripe.android.util.StripeNetworkUtils.hashMapFromCard;
 
 /**
@@ -175,6 +177,17 @@ public class Stripe {
             CardException,
             APIException {
         return createTokenSynchronous(card, defaultPublishableKey);
+    }
+
+    public Token createBankTokenSynchronous(final BankAccount bankAccount, String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        validateKey(publishableKey);
+        RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
+        return StripeApiHandler.createToken(hashMapFromBankAccount(bankAccount), requestOptions);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -46,7 +46,7 @@ public class Stripe {
                             try {
                                 RequestOptions requestOptions =
                                         RequestOptions.builder(publishableKey).build();
-                                Token token = StripeApiHandler.createToken(
+                                Token token = StripeApiHandler.createTokenOnServer(
                                         tokenParams,
                                         requestOptions);
                                 return new ResponseWrapper(token, null);
@@ -95,16 +95,16 @@ public class Stripe {
     }
 
     /**
-     * THe simplest way to create a {@link BankAccount} token. This runs on the default
+     * The simplest way to create a {@link BankAccount} token. This runs on the default
      * {@link Executor} and with the currently set {@link #defaultPublishableKey}.
      *
      * @param bankAccount the {@link BankAccount} used to create this token
      * @param callback a {@link TokenCallback} to receive either the token or an error
      */
-    public void createToken(
+    public void createBankAccountToken(
             @NonNull final BankAccount bankAccount,
             @NonNull final TokenCallback callback) {
-        createToken(bankAccount, defaultPublishableKey, null, callback);
+        createBankAccountToken(bankAccount, defaultPublishableKey, null, callback);
     }
 
     /**
@@ -125,7 +125,7 @@ public class Stripe {
      * Call to create a {@link Token} on a specific {@link Executor}.
      * @param card the {@link Card} to use for this token creation
      * @param executor An {@link Executor} on which to run this operation. If you don't wish to
-     *                 specify an executor, use one of the other createToken methods.
+     *                 specify an executor, use one of the other createTokenFromParams methods.
      * @param callback a {@link TokenCallback} to receive the result of this operation
      */
     public void createToken(
@@ -154,7 +154,7 @@ public class Stripe {
                     "Required Parameter: 'card' is required to create a token");
         }
 
-        createToken(hashMapFromCard(card), publishableKey, executor, callback);
+        createTokenFromParams(hashMapFromCard(card), publishableKey, executor, callback);
     }
 
     /**
@@ -167,18 +167,17 @@ public class Stripe {
      *                 default non-ui executor
      * @param callback a {@link TokenCallback} to receive the result or error message
      */
-    public void createToken(
+    public void createBankAccountToken(
             @NonNull final BankAccount bankAccount,
             @NonNull @Size(min = 1) final String publishableKey,
             @Nullable final Executor executor,
             @NonNull final TokenCallback callback) {
-
         if (bankAccount == null) {
             throw new RuntimeException(
                     "Required parameter: 'bankAccount' is requred to create a token");
         }
 
-        createToken(hashMapFromBankAccount(bankAccount), publishableKey, executor, callback);
+        createTokenFromParams(hashMapFromBankAccount(bankAccount), publishableKey, executor, callback);
     }
 
     /**
@@ -252,7 +251,7 @@ public class Stripe {
             APIException {
         validateKey(publishableKey);
         RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
-        return StripeApiHandler.createToken(hashMapFromBankAccount(bankAccount), requestOptions);
+        return StripeApiHandler.createTokenOnServer(hashMapFromBankAccount(bankAccount), requestOptions);
     }
 
     /**
@@ -270,7 +269,7 @@ public class Stripe {
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers)
      */
-    public Token createTokenSynchronous(Card card, String publishableKey)
+    public Token createTokenSynchronous(final Card card, String publishableKey)
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
@@ -279,7 +278,7 @@ public class Stripe {
         validateKey(publishableKey);
 
         RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
-        return StripeApiHandler.createToken(hashMapFromCard(card), requestOptions);
+        return StripeApiHandler.createTokenOnServer(hashMapFromCard(card), requestOptions);
     }
 
     /**
@@ -294,7 +293,7 @@ public class Stripe {
         this.defaultPublishableKey = publishableKey;
     }
 
-    private void createToken(
+    private void createTokenFromParams(
             @NonNull final Map<String, Object> tokenParams,
             @NonNull @Size(min = 1) final String publishableKey,
             @Nullable final Executor executor,
@@ -307,7 +306,6 @@ public class Stripe {
             }
 
             validateKey(publishableKey);
-
             tokenCreator.create(tokenParams, publishableKey, executor, callback);
         }
         catch (AuthenticationException e) {

--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.java
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.java
@@ -1,0 +1,135 @@
+package com.stripe.android.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+import android.support.annotation.StringDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Model class representing a bank account that can be used to create a token
+ * via the protocol outlined in
+ * <a href="https://stripe.com/docs/api/java#create_bank_account_token">the Stripe
+ * documentation.</a>
+ */
+public class BankAccount {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({TYPE_COMPANY, TYPE_INDIVIDUAL})
+    public @interface BankAccountType {}
+    public static final String TYPE_COMPANY = "company";
+    public static final String TYPE_INDIVIDUAL = "individual";
+
+    @Nullable private String mAccountHolderName;
+    @Nullable @BankAccountType private String mAccountHolderType;
+    @Nullable private String mAccountNumber;
+    @Nullable private String mBankName;
+    @Nullable @Size(2) private String mCountryCode;
+    @Nullable @Size(3) private String mCurrency;
+    @Nullable private String mFingerprint;
+    @Nullable private String mLast4;
+    @Nullable private String mRoutingNumber;
+
+    /**
+     * Constructor used to create a BankAccount object with the required parameters
+     * to send to Stripe's server.
+     *
+     * @param accountNumber the account number for this BankAccount
+     * @param countryCode the two-letter country code that this account was created in
+     * @param currency the currency of this account
+     * @param routingNumber the routing number of this account
+     */
+    public BankAccount(
+            @NonNull String accountNumber,
+            @NonNull @Size(2) String countryCode,
+            @NonNull @Size(3) String currency,
+            @NonNull String routingNumber) {
+        mAccountNumber = accountNumber;
+        mCountryCode = countryCode;
+        mCurrency = currency;
+        mRoutingNumber = routingNumber;
+    }
+
+
+    /**
+     * Constructor with no account number used internally to initialize an object
+     * from JSON returned from the server.
+     *
+     * @param accountHolderName the account holder's name
+     * @param accountHolderType the {@link BankAccountType}
+     * @param bankName the name of the bank
+     * @param countryCode the two-letter country code of the country in which the account was opened
+     * @param currency the three-letter currency code
+     * @param fingerprint the account fingerprint
+     * @param last4 the last four digits of the account number
+     * @param routingNumber the routing number of the bank
+     */
+    public BankAccount(
+            @Nullable String accountHolderName,
+            @Nullable @BankAccountType String accountHolderType,
+            @Nullable String bankName,
+            @Nullable @Size(2) String countryCode,
+            @Nullable @Size(3) String currency,
+            @Nullable String fingerprint,
+            @Nullable String last4,
+            @Nullable String routingNumber) {
+        mAccountHolderName = accountHolderName;
+        mAccountHolderType = accountHolderType;
+        mBankName = bankName;
+        mCountryCode = countryCode;
+        mCurrency = currency;
+        mFingerprint = fingerprint;
+        mLast4 = last4;
+        mRoutingNumber = routingNumber;
+    }
+
+    @Nullable
+    public String getAccountNumber() {
+        return mAccountNumber;
+    }
+
+    @Nullable
+    public String getAccountHolderName() {
+        return mAccountHolderName;
+    }
+
+    @Nullable
+    @BankAccountType
+    public String getAccountHolderType() {
+        return mAccountHolderType;
+    }
+
+    @Nullable
+    public String getBankName() {
+        return mBankName;
+    }
+
+    @Nullable
+    @Size(2)
+    public String getCountryCode() {
+        return mCountryCode;
+    }
+
+    @Nullable
+    @Size(3)
+    public String getCurrency() {
+        return mCurrency;
+    }
+
+    @Nullable
+    public String getFingerprint() {
+        return mFingerprint;
+    }
+
+    @Nullable
+    public String getLast4() {
+        return mLast4;
+    }
+
+    @Nullable
+    public String getRoutingNumber() {
+        return mRoutingNumber;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.java
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.java
@@ -52,7 +52,6 @@ public class BankAccount {
         mRoutingNumber = routingNumber;
     }
 
-
     /**
      * Constructor with no account number used internally to initialize an object
      * from JSON returned from the server.
@@ -95,10 +94,22 @@ public class BankAccount {
         return mAccountHolderName;
     }
 
+    @NonNull
+    public BankAccount setAccountHolderName(String accountHolderName) {
+        mAccountHolderName = accountHolderName;
+        return this;
+    }
+
     @Nullable
     @BankAccountType
     public String getAccountHolderType() {
         return mAccountHolderType;
+    }
+
+    @NonNull
+    public BankAccount setAccountHolderType(@BankAccountType String accountHolderType) {
+        mAccountHolderType = accountHolderType;
+        return this;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -12,15 +12,17 @@ import java.util.Date;
 public class Token {
 
     @Retention(RetentionPolicy.SOURCE)
-    @StringDef({TYPE_CARD})
+    @StringDef({TYPE_CARD, TYPE_BANK_ACCOUNT})
     public @interface TokenType {}
     public static final String TYPE_CARD = "card";
+    public static final String TYPE_BANK_ACCOUNT = "bank_account";
 
     private final String mId;
     private final String mType;
     private final Date mCreated;
     private final boolean mLivemode;
     private final boolean mUsed;
+    private final BankAccount mBankAccount;
     private final Card mCard;
 
     /**
@@ -32,14 +34,33 @@ public class Token {
             boolean livemode,
             Date created,
             Boolean used,
-            Card card,
-            @TokenType String type) {
+            Card card) {
         mId = id;
-        mType = type;
+        mType = TYPE_CARD;
         mCreated = created;
         mLivemode = livemode;
         mCard = card;
         mUsed = used;
+        mBankAccount = null;
+    }
+
+    /**
+     * Constructor that should not be invoked in your code.  This is used by Stripe to
+     * create tokens using a Stripe API response.
+     */
+    public Token(
+            String id,
+            boolean livemode,
+            Date created,
+            Boolean used,
+            BankAccount bankAccount) {
+        mId = id;
+        mType = TYPE_BANK_ACCOUNT;
+        mCreated = created;
+        mLivemode = livemode;
+        mCard = null;
+        mUsed = used;
+        mBankAccount = bankAccount;
     }
 
     /***
@@ -84,5 +105,12 @@ public class Token {
      */
     public Card getCard() {
         return mCard;
+    }
+
+    /**
+     * @return the {@link BankAccount} for this token
+     */
+    public BankAccount getBankAccount() {
+        return mBankAccount;
     }
 }

--- a/stripe/src/main/java/com/stripe/android/net/BankAccountParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/BankAccountParser.java
@@ -1,0 +1,42 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.BankAccount;
+import com.stripe.android.util.StripeJsonUtils;
+import com.stripe.android.util.StripeTextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Helper class for parsing {@link BankAccount} objects.
+ */
+class BankAccountParser {
+
+    private static final String FIELD_ACCOUNT_HOLDER_NAME = "account_holder_name";
+    private static final String FIELD_ACCOUNT_HOLDER_TYPE = "account_holder_type";
+    private static final String FIELD_BANK_NAME = "bank_name";
+    private static final String FIELD_COUNTRY = "country";
+    private static final String FIELD_CURRENCY = "currency";
+    private static final String FIELD_FINGERPRINT = "fingerprint";
+    private static final String FIELD_LAST4 = "last4";
+    private static final String FIELD_ROUTING_NUMBER = "routing_number";
+
+    static BankAccount parseBankAccount(String jsonBankAccount) throws JSONException {
+        JSONObject jsonObject = new JSONObject(jsonBankAccount);
+        return parseBankAccount(jsonObject);
+    }
+
+    static BankAccount parseBankAccount(JSONObject objectAccount) {
+        return new BankAccount(
+                StripeJsonUtils.optString(objectAccount, FIELD_ACCOUNT_HOLDER_NAME),
+                StripeTextUtils.asBankAccountType(
+                        StripeJsonUtils.optString(objectAccount, FIELD_ACCOUNT_HOLDER_TYPE)),
+                StripeJsonUtils.optString(objectAccount, FIELD_BANK_NAME),
+                StripeJsonUtils.optCountryCode(objectAccount, FIELD_COUNTRY),
+                StripeJsonUtils.optCurrency(objectAccount, FIELD_CURRENCY),
+                StripeJsonUtils.optString(objectAccount, FIELD_FINGERPRINT),
+                StripeJsonUtils.optString(objectAccount, FIELD_LAST4),
+                StripeJsonUtils.optString(objectAccount, FIELD_ROUTING_NUMBER));
+    }
+
+}

--- a/stripe/src/main/java/com/stripe/android/net/CardParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/CardParser.java
@@ -12,23 +12,23 @@ import org.json.JSONObject;
 /**
  * A helper class for parsing {@link Card} objects returned from the server.
  */
-public class CardParser {
+class CardParser {
 
-    static final String FIELD_ADDRESS_CITY = "address_city";
-    static final String FIELD_ADDRESS_COUNTRY = "address_country";
-    static final String FIELD_ADDRESS_LINE1 = "address_line1";
-    static final String FIELD_ADDRESS_LINE2 = "address_line2";
-    static final String FIELD_ADDRESS_STATE = "address_state";
-    static final String FIELD_ADDRESS_ZIP = "address_zip";
-    static final String FIELD_BRAND = "brand";
-    static final String FIELD_COUNTRY = "country";
-    static final String FIELD_CURRENCY = "currency";
-    static final String FIELD_EXP_MONTH = "exp_month";
-    static final String FIELD_EXP_YEAR = "exp_year";
-    static final String FIELD_FINGERPRINT = "fingerprint";
-    static final String FIELD_FUNDING = "funding";
-    static final String FIELD_LAST4 = "last4";
-    static final String FIELD_NAME = "name";
+    private static final String FIELD_ADDRESS_CITY = "address_city";
+    private static final String FIELD_ADDRESS_COUNTRY = "address_country";
+    private static final String FIELD_ADDRESS_LINE1 = "address_line1";
+    private static final String FIELD_ADDRESS_LINE2 = "address_line2";
+    private static final String FIELD_ADDRESS_STATE = "address_state";
+    private static final String FIELD_ADDRESS_ZIP = "address_zip";
+    private static final String FIELD_BRAND = "brand";
+    private static final String FIELD_COUNTRY = "country";
+    private static final String FIELD_CURRENCY = "currency";
+    private static final String FIELD_EXP_MONTH = "exp_month";
+    private static final String FIELD_EXP_YEAR = "exp_year";
+    private static final String FIELD_FINGERPRINT = "fingerprint";
+    private static final String FIELD_FUNDING = "funding";
+    private static final String FIELD_LAST4 = "last4";
+    private static final String FIELD_NAME = "name";
 
     /**
      * Parse the card directly from a JSON-formatted {@link String} value.
@@ -38,7 +38,7 @@ public class CardParser {
      * @throws JSONException if the String is improperly formatted or is missing required values
      */
     @NonNull
-    public static Card parseCard(String jsonCard) throws JSONException {
+    static Card parseCard(String jsonCard) throws JSONException {
         JSONObject cardObject = new JSONObject(jsonCard);
         return parseCard(cardObject);
     }
@@ -51,7 +51,7 @@ public class CardParser {
      * @throws JSONException if the input is missing a required field
      */
     @NonNull
-    public static Card parseCard(@NonNull JSONObject objectCard) throws JSONException {
+    static Card parseCard(@NonNull JSONObject objectCard) throws JSONException {
         return new Card(
                 null,
                 objectCard.getInt(FIELD_EXP_MONTH),

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -75,7 +75,7 @@ public class StripeApiHandler {
      * @throws APIException for unknown Stripe API errors. These should be rare.
      */
     @Nullable
-    public static Token createToken (
+    public static Token createTokenOnServer(
             @NonNull Map<String, Object> cardParams,
             @NonNull RequestOptions options)
             throws AuthenticationException,
@@ -98,7 +98,7 @@ public class StripeApiHandler {
      * @throws APIException for unknown Stripe API errors. These should be rare.
      */
     @Nullable
-    public static Token retrieveToken(
+    public static Token retrieveTokenFromServer(
             @NonNull RequestOptions options,
             @NonNull String tokenId)
             throws AuthenticationException,

--- a/stripe/src/main/java/com/stripe/android/net/TokenParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/TokenParser.java
@@ -16,11 +16,14 @@ import java.util.Date;
  */
 public class TokenParser {
 
-    private static final String FIELD_BANK_ACCOUNT = "bank_account";
-    private static final String FIELD_CARD = "card";
+    // The key for these object fields is identical to their retrieved values
+    // from the Type field.
+    private static final String FIELD_BANK_ACCOUNT = Token.TYPE_BANK_ACCOUNT;
+    private static final String FIELD_CARD = Token.TYPE_CARD;
     private static final String FIELD_CREATED = "created";
     private static final String FIELD_ID = "id";
     private static final String FIELD_LIVEMODE = "livemode";
+
     private static final String FIELD_TYPE = "type";
     private static final String FIELD_USED = "used";
 

--- a/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
@@ -48,6 +48,46 @@ public class StripeJsonUtils {
         return nullIfNullOrEmpty(jsonObject.optString(fieldName));
     }
 
+    /**
+     * Calls through to {@link JSONObject#optString(String)} while safely converting
+     * the raw string "null" and the empty string to {@code null}, along with any value that isn't
+     * a two-character string.
+     * @param jsonObject the object from which to retrieve the country code
+     * @param fieldName the name of the field in which the country code is stored
+     * @return a two-letter country code if one is found, or {@code null}
+     */
+    @Nullable
+    @Size(2)
+    public static String optCountryCode(
+            @NonNull JSONObject jsonObject,
+            @NonNull @Size(min = 1) String fieldName) {
+        String value = nullIfNullOrEmpty(jsonObject.optString(fieldName));
+        if (value != null && value.length() == 2) {
+            return value;
+        }
+        return null;
+    }
+
+    /**
+     * Calls through to {@link JSONObject#optString(String)} while safely converting
+     * the raw string "null" and the empty string to {@code null}, along with any value that isn't
+     * a three-character string.
+     * @param jsonObject the object from which to retrieve the currency code
+     * @param fieldName the name of the field in which the currency code is stored
+     * @return a three-letter currency code if one is found, or {@code null}
+     */
+    @Nullable
+    @Size(3)
+    public static String optCurrency(
+            @NonNull JSONObject jsonObject,
+            @NonNull @Size(min = 1) String fieldName) {
+        String value = nullIfNullOrEmpty(jsonObject.optString(fieldName));
+        if (value != null && value.length() == 3) {
+            return value;
+        }
+        return null;
+    }
+
     @Nullable
     @VisibleForTesting
     static String nullIfNullOrEmpty(@Nullable String possibleNull) {

--- a/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
@@ -41,11 +41,7 @@ public class StripeNetworkUtils {
         cardParams.put("address_country", StripeTextUtils.nullIfBlank(card.getAddressCountry()));
 
         // Remove all null values; they cause validation errors
-        for (String key : new HashSet<>(cardParams.keySet())) {
-            if (cardParams.get(key) == null) {
-                cardParams.remove(key);
-            }
-        }
+        removeNullParams(cardParams);
 
         tokenParams.put("card", cardParams);
         return tokenParams;
@@ -67,13 +63,19 @@ public class StripeNetworkUtils {
                 StripeTextUtils.nullIfBlank(bankAccount.getAccountHolderType()));
 
         // Remove all null values; they cause validation errors
-        for (String key : new HashSet<>(accountParams.keySet())) {
-            if (accountParams.get(key) == null) {
-                accountParams.remove(key);
-            }
-        }
+        removeNullParams(accountParams);
 
         tokenParams.put("bank_account", accountParams);
         return tokenParams;
     }
+
+    static void removeNullParams(Map<String, Object> mapToEdit) {
+        // Remove all null values; they cause validation errors
+        for (String key : new HashSet<>(mapToEdit.keySet())) {
+            if (mapToEdit.get(key) == null) {
+                mapToEdit.remove(key);
+            }
+        }
+    }
+
 }

--- a/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
@@ -1,5 +1,8 @@
 package com.stripe.android.util;
 
+import android.support.annotation.NonNull;
+
+import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 
 import java.util.HashMap;
@@ -19,6 +22,7 @@ public class StripeNetworkUtils {
      * @param card the {@link Card} to be read
      * @return a {@link Map} containing the appropriate values read from the card
      */
+    @NonNull
     public static Map<String, Object> hashMapFromCard(Card card) {
         Map<String, Object> tokenParams = new HashMap<>();
 
@@ -44,6 +48,32 @@ public class StripeNetworkUtils {
         }
 
         tokenParams.put("card", cardParams);
+        return tokenParams;
+    }
+
+    @NonNull
+    public static Map<String, Object> hashMapFromBankAccount(@NonNull BankAccount bankAccount) {
+        Map<String, Object> tokenParams = new HashMap<>();
+        Map<String, Object> accountParams = new HashMap<>();
+
+        accountParams.put("country", bankAccount.getCountryCode());
+        accountParams.put("currency", bankAccount.getCurrency());
+        accountParams.put("account_number", bankAccount.getAccountNumber());
+        accountParams.put("routing_number",
+                StripeTextUtils.nullIfBlank(bankAccount.getRoutingNumber()));
+        accountParams.put("account_holder_name",
+                StripeTextUtils.nullIfBlank(bankAccount.getAccountHolderName()));
+        accountParams.put("account_holder_type",
+                StripeTextUtils.nullIfBlank(bankAccount.getAccountHolderType()));
+
+        // Remove all null values; they cause validation errors
+        for (String key : new HashSet<>(accountParams.keySet())) {
+            if (accountParams.get(key) == null) {
+                accountParams.remove(key);
+            }
+        }
+
+        tokenParams.put("bank_account", accountParams);
         return tokenParams;
     }
 }

--- a/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.Token;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,7 +44,7 @@ public class StripeNetworkUtils {
         // Remove all null values; they cause validation errors
         removeNullParams(cardParams);
 
-        tokenParams.put("card", cardParams);
+        tokenParams.put(Token.TYPE_CARD, cardParams);
         return tokenParams;
     }
 
@@ -65,7 +66,7 @@ public class StripeNetworkUtils {
         // Remove all null values; they cause validation errors
         removeNullParams(accountParams);
 
-        tokenParams.put("bank_account", accountParams);
+        tokenParams.put(Token.TYPE_BANK_ACCOUNT, accountParams);
         return tokenParams;
     }
 

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -92,10 +92,6 @@ public class StripeTextUtils {
     @Nullable
     @BankAccountType
     public static String asBankAccountType(@Nullable String possibleAccountType) {
-        if (isBlank(possibleAccountType)) {
-            return null;
-        }
-
         if (BankAccount.TYPE_COMPANY.equals(possibleAccountType)) {
             return BankAccount.TYPE_COMPANY;
         } else if (BankAccount.TYPE_INDIVIDUAL.equals(possibleAccountType)) {

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -2,9 +2,11 @@ package com.stripe.android.util;
 
 import android.support.annotation.Nullable;
 
+import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 
+import static com.stripe.android.model.BankAccount.BankAccountType;
 import static com.stripe.android.model.Card.CardBrand;
 import static com.stripe.android.model.Card.FundingType;
 import static com.stripe.android.model.Token.TokenType;
@@ -81,6 +83,29 @@ public class StripeTextUtils {
     }
 
     /**
+     * Converts a String value into the appropriate {@link BankAccountType}.
+     *
+     * @param possibleAccountType a String that might match a {@link BankAccountType} or be empty.
+     * @return {@code null} if the input is blank or of unknown type, else the appropriate
+     *         {@link BankAccountType}.
+     */
+    @Nullable
+    @BankAccountType
+    public static String asBankAccountType(@Nullable String possibleAccountType) {
+        if (isBlank(possibleAccountType)) {
+            return null;
+        }
+
+        if (BankAccount.TYPE_COMPANY.equals(possibleAccountType)) {
+            return BankAccount.TYPE_COMPANY;
+        } else if (BankAccount.TYPE_INDIVIDUAL.equals(possibleAccountType)) {
+            return BankAccount.TYPE_INDIVIDUAL;
+        }
+
+        return null;
+    }
+
+    /**
      * Converts an unchecked String value to a {@link CardBrand} or {@code null}.
      *
      * @param possibleCardType a String that might match a {@link CardBrand} or be empty.
@@ -144,9 +169,16 @@ public class StripeTextUtils {
     @Nullable
     @TokenType
     public static String asTokenType(@Nullable String possibleTokenType) {
+        if (isBlank(possibleTokenType)) {
+            return null;
+        }
+
         if (Token.TYPE_CARD.equals(possibleTokenType)) {
             return Token.TYPE_CARD;
+        } else if (Token.TYPE_BANK_ACCOUNT.equals(possibleTokenType)) {
+            return Token.TYPE_BANK_ACCOUNT;
         }
+
         return null;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/net/BankAccountParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/BankAccountParserTest.java
@@ -1,0 +1,63 @@
+package com.stripe.android.net;
+
+import com.stripe.android.model.BankAccount;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for {@link BankAccountParser}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class BankAccountParserTest {
+
+    private static final String RAW_BANK_ACCOUNT = "{\n" +
+            "    \"id\": \"ba_19d8Fh2eZvKYlo2C9qw8RwpV\",\n" +
+            "    \"object\": \"bank_account\",\n" +
+            "    \"account_holder_name\": \"Jane Austen\",\n" +
+            "    \"account_holder_type\": \"individual\",\n" +
+            "    \"bank_name\": \"STRIPE TEST BANK\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"currency\": \"usd\",\n" +
+            "    \"fingerprint\": \"1JWtPxqbdX5Gamtc\",\n" +
+            "    \"last4\": \"6789\",\n" +
+            "    \"routing_number\": \"110000000\",\n" +
+            "    \"status\": \"new\"\n" +
+            "  }";
+
+    @Test
+    public void parseSampleAccount_returnsExpectedValue() {
+        BankAccount expectedAccount = new BankAccount(
+                "Jane Austen",
+                BankAccount.TYPE_INDIVIDUAL,
+                "STRIPE TEST BANK",
+                "US",
+                "usd",
+                "1JWtPxqbdX5Gamtc",
+                "6789",
+                "110000000");
+
+        try {
+            BankAccount actualAccount = BankAccountParser.parseBankAccount(RAW_BANK_ACCOUNT);
+            assertEquals(expectedAccount.getAccountHolderName(),
+                    actualAccount.getAccountHolderName());
+            assertEquals(expectedAccount.getAccountHolderType(),
+                    actualAccount.getAccountHolderType());
+            assertEquals(expectedAccount.getBankName(), actualAccount.getBankName());
+            assertEquals(expectedAccount.getCountryCode(), actualAccount.getCountryCode());
+            assertEquals(expectedAccount.getCurrency(), actualAccount.getCurrency());
+            assertEquals(expectedAccount.getFingerprint(), actualAccount.getFingerprint());
+            assertEquals(expectedAccount.getLast4(), actualAccount.getLast4());
+            assertEquals(expectedAccount.getRoutingNumber(), actualAccount.getRoutingNumber());
+        } catch (JSONException jex) {
+            fail("Json Parsing Failure");
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/net/TokenParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/TokenParserTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.net;
 
+import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 
 import org.json.JSONException;
@@ -11,7 +13,9 @@ import org.robolectric.annotation.Config;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -88,6 +92,51 @@ public class TokenParserTest {
             "  \"used\": false\n" +
             "}";
 
+    private static final String RAW_BANK_TOKEN = "{\n" +
+            "  \"id\": \"btok_9xJAbronBnS9bH\",\n" +
+            "  \"object\": \"token\",\n" +
+            "  \"bank_account\": {\n" +
+            "    \"id\": \"ba_19dOY72eZvKYlo2CVNPhmtv3\",\n" +
+            "    \"object\": \"bank_account\",\n" +
+            "    \"account_holder_name\": \"Jane Austen\",\n" +
+            "    \"account_holder_type\": \"individual\",\n" +
+            "    \"bank_name\": \"STRIPE TEST BANK\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"currency\": \"usd\",\n" +
+            "    \"fingerprint\": \"1JWtPxqbdX5Gamtc\",\n" +
+            "    \"last4\": \"6789\",\n" +
+            "    \"routing_number\": \"110000000\",\n" +
+            "    \"status\": \"new\"\n" +
+            "  },\n" +
+            "  \"client_ip\": null,\n" +
+            "  \"created\": 1484765567,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"type\": \"bank_account\",\n" +
+            "  \"used\": false\n" +
+            "}";
+
+    private static final String RAW_BANK_TOKEN_NO_TYPE = "{\n" +
+            "  \"id\": \"btok_9xJAbronBnS9bH\",\n" +
+            "  \"object\": \"token\",\n" +
+            "  \"bank_account\": {\n" +
+            "    \"id\": \"ba_19dOY72eZvKYlo2CVNPhmtv3\",\n" +
+            "    \"object\": \"bank_account\",\n" +
+            "    \"account_holder_name\": \"Jane Austen\",\n" +
+            "    \"account_holder_type\": \"individual\",\n" +
+            "    \"bank_name\": \"STRIPE TEST BANK\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"currency\": \"usd\",\n" +
+            "    \"fingerprint\": \"1JWtPxqbdX5Gamtc\",\n" +
+            "    \"last4\": \"6789\",\n" +
+            "    \"routing_number\": \"110000000\",\n" +
+            "    \"status\": \"new\"\n" +
+            "  },\n" +
+            "  \"client_ip\": null,\n" +
+            "  \"created\": 1484765567,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"used\": false\n" +
+            "}";
+
     @Test
     public void parseToken_readsObject() {
         Date createdDate = new Date(1462905355L * 1000L);
@@ -96,26 +145,56 @@ public class TokenParserTest {
                 false,
                 createdDate,
                 false,
-                null,
-                "card");
+                (Card) null);
         try {
             Token answerToken = TokenParser.parseToken(RAW_TOKEN);
             assertEquals(partialExpectedToken.getId(), answerToken.getId());
             assertEquals(partialExpectedToken.getLivemode(), answerToken.getLivemode());
             assertEquals(partialExpectedToken.getCreated(), answerToken.getCreated());
             assertEquals(partialExpectedToken.getUsed(), answerToken.getUsed());
+            assertEquals(Token.TYPE_CARD, answerToken.getType());
 
             // Note: we test the validity of the card object in CardParserTest
             assertNotNull(answerToken.getCard());
+            assertNull(answerToken.getBankAccount());
         } catch (JSONException jex) {
             fail("Json Parsing failure");
+        }
+    }
+
+    @Test
+    public void parseToken_whenBankAccount_readsObject() {
+        Date createdDate = new Date(1484765567L * 1000L);
+        Token expectedToken = new Token(
+                "btok_9xJAbronBnS9bH",
+                false,
+                createdDate,
+                false,
+                (BankAccount) null);
+        try {
+            Token answerToken = TokenParser.parseToken(RAW_BANK_TOKEN);
+            assertEquals(expectedToken.getId(), answerToken.getId());
+            assertEquals(expectedToken.getLivemode(), answerToken.getLivemode());
+            assertEquals(expectedToken.getCreated(), answerToken.getCreated());
+            assertEquals(expectedToken.getUsed(), answerToken.getUsed());
+            assertEquals(Token.TYPE_BANK_ACCOUNT, answerToken.getType());
+
+            assertNotNull(answerToken.getBankAccount());
+            assertNull(answerToken.getCard());
+        } catch (JSONException jex) {
+            fail("Json Parsing Failure");
         }
     }
 
     @Test(expected = JSONException.class)
     public void parseToken_withoutId_throwsException() throws JSONException {
         TokenParser.parseToken(RAW_TOKEN_NO_ID);
-        fail("Expected an exception.");
+        fail("Expected an exception when parsing token without ID.");
     }
 
-}
+    @Test(expected = JSONException.class)
+    public void parseToken_withoutType_throwsException() throws JSONException {
+        TokenParser.parseToken(RAW_BANK_TOKEN_NO_TYPE);
+        fail("Expected an exception when parsing token without type");
+    }
+ }

--- a/stripe/src/test/java/com/stripe/android/util/StripeNetworkUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeNetworkUtilsTest.java
@@ -2,6 +2,7 @@ package com.stripe.android.util;
 
 import android.support.annotation.NonNull;
 
+import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 
 import org.junit.Test;
@@ -33,6 +34,10 @@ public class StripeNetworkUtilsTest {
     private static final String CARD_STATE = "CA";
     private static final String CARD_ZIP = "94107";
 
+    private static final String BANK_ACCOUNT_NUMBER = "000123456789";
+    private static final String BANK_ROUTING_NUMBER = "110000000";
+    private static final String BANK_ACCOUNT_HOLDER_NAME = "Lily Thomas";
+
     @Test
     public void hashMapFromCard_mapsCorrectFields() {
         Card card = new Card.Builder(CARD_NUMBER, 8, 2019, CARD_CVC)
@@ -63,6 +68,22 @@ public class StripeNetworkUtilsTest {
     }
 
     @Test
+    public void hashMapFromBankAccount_mapsCorrectFields() {
+        BankAccount bankAccount = new BankAccount(
+                BANK_ACCOUNT_NUMBER, "US", "usd", BANK_ROUTING_NUMBER)
+                .setAccountHolderName(BANK_ACCOUNT_HOLDER_NAME)
+                .setAccountHolderType(BankAccount.TYPE_INDIVIDUAL);
+        Map<String, Object> bankAccountMap = getMapFromHashMappedBankAccount(bankAccount);
+
+        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
+        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
+        assertEquals("US", bankAccountMap.get("country"));
+        assertEquals("usd", bankAccountMap.get("currency"));
+        assertEquals(BANK_ACCOUNT_HOLDER_NAME, bankAccountMap.get("account_holder_name"));
+        assertEquals(BankAccount.TYPE_INDIVIDUAL, bankAccountMap.get("account_holder_type"));
+    }
+
+    @Test
     public void hashMapFromCard_omitsEmptyFields() {
         Card card = new Card.Builder(CARD_NUMBER, 8, 2019, CARD_CVC).build();
 
@@ -82,10 +103,31 @@ public class StripeNetworkUtilsTest {
         assertFalse(cardMap.containsKey("address_country"));
     }
 
+    @Test
+    public void hashMapFromBankAccount_omitsEmptyFields() {
+        BankAccount bankAccount = new BankAccount(
+                BANK_ACCOUNT_NUMBER, "US", "usd", BANK_ROUTING_NUMBER);
+        Map<String, Object> bankAccountMap = getMapFromHashMappedBankAccount(bankAccount);
+
+        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
+        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
+        assertEquals("US", bankAccountMap.get("country"));
+        assertEquals("usd", bankAccountMap.get("currency"));
+        assertFalse(bankAccountMap.containsKey("account_holder_name"));
+        assertFalse(bankAccountMap.containsKey("account_holder_type"));
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> getCardMapFromHashMappedCard(@NonNull Card card) {
         Map<String, Object> tokenMap = StripeNetworkUtils.hashMapFromCard(card);
         assertNotNull(tokenMap);
         return (Map<String, Object>) tokenMap.get("card");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMapFromHashMappedBankAccount(@NonNull BankAccount bankAccount) {
+        Map<String, Object> tokenMap = StripeNetworkUtils.hashMapFromBankAccount(bankAccount);
+        assertNotNull(tokenMap);
+        return (Map<String, Object>) tokenMap.get("bank_account");
     }
 }


### PR DESCRIPTION
r? @sjayaraman-stripe
cc @brandur-stripe , @shale-stripe 

Adding bindings to create tokens for Bank Accounts. **A lot of the code is tests and necessary copies of existing code, plus getters and setters.**

The testing includes a full end-to-end test of the synchronous version of the createToken methods (asynchronous methods of the type we use are a problem in JUnit).

The whole diff is basically: 
1. Create BankAccount model
2. Add functions to (manually) parse BankAccount items coming back from the server
3. Make the createToken methods overloaded to accept Card objects and BankAccount objects
4. Expand the Token model to have both Card and BankAccount types. Note: I opted to have a Card and a BankAccount field in the Token model (Rather than subclassing the Token model) because this most closely parallels what we do with the JSON server-side.
5. Add tests.
6. Add more tests. A fair amount of the lines-of-code inflation came from copying in JSON test objects.