### PR TITLE
Handling listening for the delete keypress either from a keyboard or the soft keyboard

### DIFF
--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -64,7 +64,7 @@
             android:visibility="invisible"
             />
 
-        <EditText
+        <com.stripe.android.view.DeleteWatchEditText
             android:id="@+id/et_cvc_number"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -26,7 +26,7 @@ public class CardInputView extends FrameLayout {
     private static final int END_INDEX_AMEX = 11;
 
     private CardNumberEditText mCardNumberEditText;
-    private EditText mCvcNumberEditText;
+    private DeleteWatchEditText mCvcNumberEditText;
     private ExpiryDateEditText mExpiryDateEditText;
     private LockableHorizontalScrollView mScrollView;
     private View mCardNumberSpace;
@@ -57,7 +57,7 @@ public class CardInputView extends FrameLayout {
         mScrollView = (LockableHorizontalScrollView) findViewById(R.id.root_scroll_view);
         mCardNumberEditText = (CardNumberEditText) findViewById(R.id.et_card_number);
         mExpiryDateEditText = (ExpiryDateEditText) findViewById(R.id.et_expiry_date);
-        mCvcNumberEditText = (EditText) findViewById(R.id.et_cvc_number);
+        mCvcNumberEditText = (DeleteWatchEditText) findViewById(R.id.et_cvc_number);
         mCardNumberSpace = findViewById(R.id.space_in_container);
         mCardNumberIsViewed = true;
 
@@ -88,18 +88,22 @@ public class CardInputView extends FrameLayout {
             }
         });
 
-        mExpiryDateEditText.setOnKeyListener(new OnKeyListener() {
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_DEL
-                        && event.getAction() == KeyEvent.ACTION_DOWN) {
-                    if (mExpiryDateEditText.getText().length() == 0) {
+        mExpiryDateEditText.setDeleteEmptyListener(
+                new DeleteWatchEditText.DeleteEmptyListener() {
+                    @Override
+                    public void onDeleteEmpty() {
                         mCardNumberEditText.requestFocus();
                     }
+                });
+
+        mCvcNumberEditText.setDeleteEmptyListener(
+                new DeleteWatchEditText.DeleteEmptyListener() {
+                    @Override
+                    public void onDeleteEmpty() {
+                        mExpiryDateEditText.requestFocus();
+                    }
                 }
-                return false;
-            }
-        });
+        );
 
         mCardNumberEditText.setCardNumberCompleteListener(
                 new CardNumberEditText.CardNumberCompleteListener() {

--- a/stripe/src/main/java/com/stripe/android/view/DeleteWatchEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/DeleteWatchEditText.java
@@ -1,0 +1,91 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
+import android.widget.EditText;
+
+/**
+ * Extension of {@link EditText} that listens for users pressing the delete key when there is
+ * no text present. Google has actually made this
+ * <a href="https://code.google.com/p/android/issues/detail?id=42904">somewhat difficult</a>,
+ * but we listen here for hardware key presses, older Android soft keyboard delete presses,
+ * and modern Google Keyboard delete key presses.
+ */
+public class DeleteWatchEditText extends EditText {
+
+    @Nullable private DeleteEmptyListener mDeleteEmptyListener;
+
+    public DeleteWatchEditText(Context context) {
+        super(context);
+        listenForDeleteEmpty();
+    }
+
+    public DeleteWatchEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        listenForDeleteEmpty();
+    }
+
+    public DeleteWatchEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        listenForDeleteEmpty();
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
+    }
+
+    /**
+     * Sets a listener that can react to the user attempting to delete the empty string.
+     *
+     * @param deleteEmptyListener the {@link DeleteEmptyListener} to attach to this view
+     */
+    public void setDeleteEmptyListener(DeleteEmptyListener deleteEmptyListener) {
+        mDeleteEmptyListener = deleteEmptyListener;
+    }
+
+    private void listenForDeleteEmpty() {
+        // This method works for hard keyboards and older phones.
+        setOnKeyListener(new OnKeyListener() {
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (keyCode == KeyEvent.KEYCODE_DEL
+                        && event.getAction() == KeyEvent.ACTION_DOWN
+                        && mDeleteEmptyListener != null
+                        && length() == 0) {
+                    mDeleteEmptyListener.onDeleteEmpty();
+                }
+                return false;
+            }
+        });
+    }
+
+    /**
+     * A class that can listen for when the user attempts to delete the empty string.
+     */
+    public interface DeleteEmptyListener {
+        void onDeleteEmpty();
+    }
+
+    private class SoftDeleteInputConnection extends InputConnectionWrapper {
+
+        public SoftDeleteInputConnection(InputConnection target, boolean mutable) {
+            super(target, mutable);
+        }
+
+        @Override
+        public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+            // This method works on modern versions of Android with soft keyboard delete.
+            if (getTextBeforeCursor(1, 0).length() == 0 && mDeleteEmptyListener != null) {
+                mDeleteEmptyListener.onDeleteEmpty();
+            }
+            return super.deleteSurroundingText(beforeLength, afterLength);
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -22,7 +22,7 @@ import java.util.Set;
 /**
  * An {@link EditText} that handles putting numbers around a central divider character.
  */
-public class ExpiryDateEditText extends EditText {
+public class ExpiryDateEditText extends DeleteWatchEditText {
 
     static final int INVALID_INPUT = -1;
     private static final int MAX_INPUT_LENGTH = 5;

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -7,6 +7,7 @@ import android.widget.LinearLayout;
 import com.stripe.android.R;
 import com.stripe.android.view.CardInputView;
 import com.stripe.android.view.CardNumberEditText;
+import com.stripe.android.view.DeleteWatchEditText;
 import com.stripe.android.view.ExpiryDateEditText;
 
 /**
@@ -36,6 +37,10 @@ public class CardInputTestActivity extends Activity {
 
     public ExpiryDateEditText getExpiryDateEditText() {
         return (ExpiryDateEditText) mCardInputView.findViewById(R.id.et_expiry_date);
+    }
+
+    public DeleteWatchEditText getCvcEditText() {
+        return (DeleteWatchEditText) mCardInputView.findViewById(R.id.et_cvc_number);
     }
 
     public CardInputView getCardInputView() {

--- a/stripe/src/test/java/com/stripe/android/testharness/ViewTestUtils.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/ViewTestUtils.java
@@ -1,0 +1,22 @@
+package com.stripe.android.testharness;
+
+
+import android.support.annotation.NonNull;
+import android.view.KeyEvent;
+import android.widget.EditText;
+
+/**
+ * Utility class for common actions to perform on Views under test.
+ */
+public class ViewTestUtils {
+
+    /**
+     * Send an action down call on the delete key.
+     *
+     * @param editText the {@link EditText} to which to dispatch the key press.
+     */
+    public static void sendDeleteKeyEvent(@NonNull EditText editText) {
+        editText.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL));
+        editText.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL));
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
@@ -1,16 +1,13 @@
 package com.stripe.android.view;
 
 import android.support.annotation.IdRes;
-import android.support.annotation.IntRange;
-import android.support.annotation.LayoutRes;
-import android.text.InputFilter;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.EditText;
 
 import com.stripe.android.R;
 import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,8 +20,6 @@ import org.robolectric.util.ActivityController;
 
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for {@link CardInputView}. Note that we have to test against SDK 22
@@ -66,8 +61,7 @@ public class CardInputViewTest {
     @Test
     public void onDeleteFromExpiryDate_whenEmpty_shiftsFocusToCardNumber() {
         mCardNumberEditText.setText(VALID_VISA_WITH_SPACES);
-        mExpiryEditText.dispatchKeyEvent(
-                new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL, 0));
+        ViewTestUtils.sendDeleteKeyEvent(mExpiryEditText);
         assertEquals(R.id.et_expiry_date, mOnGlobalFocusChangeListener.getOldFocusId());
         assertEquals(R.id.et_card_number, mOnGlobalFocusChangeListener.getNewFocusId());
     }

--- a/stripe/src/test/java/com/stripe/android/view/DeleteWatchEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/DeleteWatchEditTextTest.java
@@ -1,0 +1,79 @@
+package com.stripe.android.view;
+
+import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.testharness.ViewTestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ActivityController;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Test class for {@link DeleteWatchEditText}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 22)
+public class DeleteWatchEditTextTest {
+
+    @Mock DeleteWatchEditText.DeleteEmptyListener mDeleteEmptyListener;
+    private DeleteWatchEditText mEditText;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        ActivityController activityController =
+                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
+
+        // Note that the CVC EditText is a DeleteWatchEditText
+        mEditText = ((CardInputTestActivity) activityController.get()).getCvcEditText();
+        mEditText.setText("");
+        mEditText.setDeleteEmptyListener(mDeleteEmptyListener);
+    }
+
+    @Test
+    public void deleteText_whenZeroLength_callsListener() {
+        ViewTestUtils.sendDeleteKeyEvent(mEditText);
+        verify(mDeleteEmptyListener, times(1)).onDeleteEmpty();
+    }
+
+    @Test
+    public void addText_doesNotCallListener() {
+        mEditText.append("1");
+        verifyZeroInteractions(mDeleteEmptyListener);
+    }
+
+    @Test
+    public void deleteText_whenNonZeroLength_doesNotCallListener() {
+        mEditText.append("1");
+        ViewTestUtils.sendDeleteKeyEvent(mEditText);
+        verifyZeroInteractions(mDeleteEmptyListener);
+    }
+
+    @Test
+    public void deleteText_whenSelectionAtBeginningButLengthNonZero_doesNotCallListener() {
+        mEditText.append("12");
+        mEditText.setSelection(0);
+        ViewTestUtils.sendDeleteKeyEvent(mEditText);
+        verifyZeroInteractions(mDeleteEmptyListener);
+    }
+
+    @Test
+    public void deleteText_whenDeletingMultipleItems_onlyCallsListenerOneTime() {
+        mEditText.append("123");
+        // Doing this four times because we need to delete all three items, then jump back.
+        for (int i = 0; i < 4; i++) {
+            ViewTestUtils.sendDeleteKeyEvent(mEditText);
+        }
+
+        verify(mDeleteEmptyListener, times(1)).onDeleteEmpty();
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -1,11 +1,7 @@
 package com.stripe.android.view;
 
-import android.view.KeyEvent;
-
-import com.stripe.android.model.Card;
 import com.stripe.android.testharness.CardInputTestActivity;
-
-import net.bytebuddy.asm.Advice;
+import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -65,8 +61,7 @@ public class ExpiryDateEditTextTest {
         mExpiryDateEditText.append("1");
         mExpiryDateEditText.append("2");
         mExpiryDateEditText.append("3");
-        mExpiryDateEditText.dispatchKeyEvent(
-                new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL));
+        ViewTestUtils.sendDeleteKeyEvent(mExpiryDateEditText);
         String text = mExpiryDateEditText.getText().toString();
         assertEquals("12", text);
     }
@@ -97,8 +92,7 @@ public class ExpiryDateEditTextTest {
         mExpiryDateEditText.append("59");
         assertTrue(mExpiryDateEditText.isDateValid());
 
-        mExpiryDateEditText.dispatchKeyEvent(
-                new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL));
+        ViewTestUtils.sendDeleteKeyEvent(mExpiryDateEditText);
         verify(mExpiryDateEditListener, times(1)).onExpiryDateComplete();
         assertFalse(mExpiryDateEditText.isDateValid());
     }


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @brandur-stripe , @shale-stripe 

Google's method of detecting keystrokes is a little awkward, to the point where I have to listen to two different input methods in order to ensure the functionality that we want. Because this is common to two different controls (and potentially others) **and** requires attachment of irritating-to-repeat listeners, I subclassed EditText so we can do this more easily.

This allows us to "delete out" of the Expiry Date and CVC number fields in the control (which we can do in iOS)