### PR TITLE
tweaking the date input experience so that a first digit greater than 1 prepends a zero.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -83,11 +83,13 @@ public class ExpiryDateEditText extends DeleteWatchEditText {
 
                 String rawNumericInput = s.toString().replaceAll("/", "");
 
-                if(s.length() == 1 && latestChangeStart == 0 && latestInsertionSize == 1) {
-                    char first = s.charAt(0);
-                    if (first == '0' || first == '1') {
-                        // do nothing; this could be a valid two-digit number
-                    } else {
+                if(rawNumericInput.length() == 1 && latestChangeStart == 0 && latestInsertionSize == 1) {
+                    char first = rawNumericInput.charAt(0);
+                    if (!(first == '0' || first == '1')) {
+                        // If the first digit typed isn't 0 or 1, then it can't be a valid
+                        // two-digit month. Hence, we assume the user is inputting a one-digit
+                        // month. We bump it to the preferred input, so "4" becomes "04", which
+                        // later in this method goes to "04/".
                         rawNumericInput = "0" + rawNumericInput;
                         latestInsertionSize++;
                     }

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -77,11 +77,22 @@ public class ExpiryDateEditText extends DeleteWatchEditText {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if (ignoreChanges || s.length() == 0) {
+                if (ignoreChanges) {
                     return;
                 }
 
                 String rawNumericInput = s.toString().replaceAll("/", "");
+
+                if(s.length() == 1 && latestChangeStart == 0 && latestInsertionSize == 1) {
+                    char first = s.charAt(0);
+                    if (first == '0' || first == '1') {
+                        // do nothing; this could be a valid two-digit number
+                    } else {
+                        rawNumericInput = "0" + rawNumericInput;
+                        latestInsertionSize++;
+                    }
+                }
+
                 // Date input is MM/YY, so the separated parts will be {MM, YY}
                 String[] parts = DateUtils.separateDateStringParts(rawNumericInput);
 

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import android.view.KeyEvent;
+
 import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 
@@ -54,6 +56,30 @@ public class ExpiryDateEditTextTest {
 
         String text = mExpiryDateEditText.getText().toString();
         assertEquals("12/", text);
+    }
+
+    @Test
+    public void inputSingleDigit_whenDigitIsTooLargeForMonth_prependsZero() {
+        mExpiryDateEditText.append("4");
+        assertEquals("04/", mExpiryDateEditText.getText().toString());
+        assertEquals(3, mExpiryDateEditText.getSelectionStart());
+    }
+
+    @Test
+    public void inputSingleDigit_whenDigitIsZeroOrOne_doesNotPrependZero() {
+        mExpiryDateEditText.append("1");
+        assertEquals("1", mExpiryDateEditText.getText().toString());
+        assertEquals(1, mExpiryDateEditText.getSelectionStart());
+    }
+
+    @Test
+    public void inputSingleDigit_whenAtFirstCharacterButTextNotEmpty_doesNotPrependZero() {
+        mExpiryDateEditText.append("1");
+        mExpiryDateEditText.setSelection(0);
+        mExpiryDateEditText.getEditableText().replace(0, 0, "3", 0, 1);
+
+        assertEquals("31/", mExpiryDateEditText.getText().toString());
+        assertEquals(1, mExpiryDateEditText.getSelectionStart());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -83,6 +83,16 @@ public class ExpiryDateEditTextTest {
     }
 
     @Test
+    public void inputMultipleDigits_whenStartingFromEmpty_doesNotPrependZero() {
+        // This isn't a valid date, but we don't want to change complicated pastes.
+        mExpiryDateEditText.append("23");
+
+        String text = mExpiryDateEditText.getText().toString();
+        assertEquals("23/", text);
+        assertEquals(3, mExpiryDateEditText.getSelectionStart());
+    }
+
+    @Test
     public void afterInputThreeDigits_whenDeletingOne_textDoesNotContainSlash() {
         mExpiryDateEditText.append("1");
         mExpiryDateEditText.append("2");

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -1,7 +1,5 @@
 package com.stripe.android.view;
 
-import android.view.KeyEvent;
-
 import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 


### PR DESCRIPTION
r? @shale-stripe 
cc @sjayaraman-stripe @brandur-stripe 

Short diff that mimics the functionality in iOS, in which a user typing a "4" first in the ExpiryDate field has it automatically jump to "04" (because there are no two-digit months starting with 4).