### PR TITLE
setting text to a red error color based on the input text color

### DIFF
--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -64,7 +64,7 @@
             android:visibility="invisible"
             />
 
-        <com.stripe.android.view.DeleteWatchEditText
+        <com.stripe.android.view.StripeEditText
             android:id="@+id/et_cvc_number"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/stripe/res/values/colors.xml
+++ b/stripe/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="error_text">#ffd00000</color>
+    <color name="error_text_dark">#ffee0000</color>
+</resources>

--- a/stripe/res/values/colors.xml
+++ b/stripe/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="error_text">#ffd00000</color>
-    <color name="error_text_dark">#ffee0000</color>
+    <color name="error_text_light_theme">#ffd00000</color>
+    <color name="error_text_dark_theme">#ffee0000</color>
 </resources>

--- a/stripe/res/values/colors.xml
+++ b/stripe/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="error_text_light_theme">#ffd00000</color>
-    <color name="error_text_dark_theme">#ffee0000</color>
+    <color name="error_text_light_theme">#ff9e2416</color>
+    <color name="error_text_dark_theme">#ffc23d4b</color>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -1,18 +1,10 @@
 package com.stripe.android.view;
 
 import android.content.Context;
-import android.support.v4.widget.DrawerLayout;
-import android.support.v4.widget.Space;
-import android.text.Editable;
 import android.text.Layout;
-import android.text.TextWatcher;
-import android.text.method.KeyListener;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 import android.widget.FrameLayout;
 
 import com.stripe.android.R;
@@ -26,7 +18,7 @@ public class CardInputView extends FrameLayout {
     private static final int END_INDEX_AMEX = 11;
 
     private CardNumberEditText mCardNumberEditText;
-    private DeleteWatchEditText mCvcNumberEditText;
+    private StripeEditText mCvcNumberEditText;
     private ExpiryDateEditText mExpiryDateEditText;
     private LockableHorizontalScrollView mScrollView;
     private View mCardNumberSpace;
@@ -57,7 +49,7 @@ public class CardInputView extends FrameLayout {
         mScrollView = (LockableHorizontalScrollView) findViewById(R.id.root_scroll_view);
         mCardNumberEditText = (CardNumberEditText) findViewById(R.id.et_card_number);
         mExpiryDateEditText = (ExpiryDateEditText) findViewById(R.id.et_expiry_date);
-        mCvcNumberEditText = (DeleteWatchEditText) findViewById(R.id.et_cvc_number);
+        mCvcNumberEditText = (StripeEditText) findViewById(R.id.et_cvc_number);
         mCardNumberSpace = findViewById(R.id.space_in_container);
         mCardNumberIsViewed = true;
 
@@ -89,7 +81,7 @@ public class CardInputView extends FrameLayout {
         });
 
         mExpiryDateEditText.setDeleteEmptyListener(
-                new DeleteWatchEditText.DeleteEmptyListener() {
+                new StripeEditText.DeleteEmptyListener() {
                     @Override
                     public void onDeleteEmpty() {
                         mCardNumberEditText.requestFocus();
@@ -97,7 +89,7 @@ public class CardInputView extends FrameLayout {
                 });
 
         mCvcNumberEditText.setDeleteEmptyListener(
-                new DeleteWatchEditText.DeleteEmptyListener() {
+                new StripeEditText.DeleteEmptyListener() {
                     @Override
                     public void onDeleteEmpty() {
                         mExpiryDateEditText.requestFocus();

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -169,14 +169,6 @@ public class CardNumberEditText extends StripeEditText {
 
             @Override
             public void afterTextChanged(Editable s) {
-                if (s.length() == 0) {
-                    setShouldShowError(false);
-                } else if (s.length() % 2 == 0) {
-                    setShouldShowError(true);
-                } else {
-                    setShouldShowError(false);
-                }
-
                 if (s.length() == mLengthMax) {
                     boolean before = mIsCardNumberValid;
                     mIsCardNumberValid = CardUtils.isValidCardNumber(s.toString());

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -20,7 +20,7 @@ import java.util.Set;
 /**
  * An {@link EditText} that handles spacing out the digits of a credit card.
  */
-public class CardNumberEditText extends EditText {
+public class CardNumberEditText extends StripeEditText {
 
     private static final int MAX_LENGTH_COMMON = 19;
     // Note that AmEx and Diners Club have the same length
@@ -169,6 +169,14 @@ public class CardNumberEditText extends EditText {
 
             @Override
             public void afterTextChanged(Editable s) {
+                if (s.length() == 0) {
+                    setShouldShowError(false);
+                } else if (s.length() % 2 == 0) {
+                    setShouldShowError(true);
+                } else {
+                    setShouldShowError(false);
+                }
+
                 if (s.length() == mLengthMax) {
                     boolean before = mIsCardNumberValid;
                     mIsCardNumberValid = CardUtils.isValidCardNumber(s.toString());

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -7,22 +7,14 @@ import android.support.annotation.VisibleForTesting;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.KeyEvent;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputConnection;
-import android.view.inputmethod.InputConnectionWrapper;
 import android.widget.EditText;
 
-import com.stripe.android.model.Card;
 import com.stripe.android.util.DateUtils;
-
-import java.util.Set;
 
 /**
  * An {@link EditText} that handles putting numbers around a central divider character.
  */
-public class ExpiryDateEditText extends DeleteWatchEditText {
+public class ExpiryDateEditText extends StripeEditText {
 
     static final int INVALID_INPUT = -1;
     private static final int MAX_INPUT_LENGTH = 5;

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -68,7 +68,8 @@ public class StripeEditText extends EditText {
      */
     @SuppressWarnings("deprecation")
     public void setShouldShowError(boolean shouldShowError) {
-        if (!mShouldShowError && shouldShowError) {
+        mShouldShowError = shouldShowError;
+        if (mShouldShowError) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 setTextColor(getResources().getColor(mColorResId, null));
             } else {
@@ -77,12 +78,20 @@ public class StripeEditText extends EditText {
                 setTextColor(getResources().getColor(mColorResId));
             }
 
-        } else if (mShouldShowError && !shouldShowError){
+        } else {
             setTextColor(mCachedColorStateList);
         }
 
-        mShouldShowError = shouldShowError;
         refreshDrawableState();
+    }
+
+    /**
+     * Gets whether or not the text should be displayed in error mode.
+     *
+     * @return the value of {@link #mShouldShowError}
+     */
+    public boolean getShouldShowError() {
+        return mShouldShowError;
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -1,6 +1,9 @@
 package com.stripe.android.view;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -9,6 +12,8 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputConnectionWrapper;
 import android.widget.EditText;
+
+import com.stripe.android.R;
 
 /**
  * Extension of {@link EditText} that listens for users pressing the delete key when there is
@@ -20,20 +25,26 @@ import android.widget.EditText;
 public class StripeEditText extends EditText {
 
     @Nullable private DeleteEmptyListener mDeleteEmptyListener;
+    @Nullable private ColorStateList mCachedColorStateList;
+    private boolean mShouldShowError;
+    @ColorRes private int mColorResId;
 
     public StripeEditText(Context context) {
         super(context);
         listenForDeleteEmpty();
+        determineErrorColor();
     }
 
     public StripeEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
         listenForDeleteEmpty();
+        determineErrorColor();
     }
 
     public StripeEditText(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         listenForDeleteEmpty();
+        determineErrorColor();
     }
 
     @Override
@@ -48,6 +59,38 @@ public class StripeEditText extends EditText {
      */
     public void setDeleteEmptyListener(DeleteEmptyListener deleteEmptyListener) {
         mDeleteEmptyListener = deleteEmptyListener;
+    }
+
+    public void setShouldShowError(boolean shouldShowError) {
+        if (!mShouldShowError && shouldShowError) {
+            mCachedColorStateList = getTextColors();
+            setTextColor(getResources().getColor(mColorResId));
+
+        } else if (mShouldShowError && !shouldShowError){
+            setTextColor(mCachedColorStateList);
+        }
+
+        mShouldShowError = shouldShowError;
+        refreshDrawableState();
+    }
+
+    public boolean isColorDark(int color){
+        double darkness = 1-(0.299*Color.red(color) + 0.587*Color.green(color) + 0.114* Color.blue(color))/255;
+        if(darkness>0.5){
+            return false; // It's a light color
+        }else{
+            return true; // It's a dark color
+        }
+    }
+
+    private void determineErrorColor() {
+        mCachedColorStateList = getTextColors();
+        int color = mCachedColorStateList.getDefaultColor();
+        if (isColorDark(color)) {
+            mColorResId = R.color.error_text_dark;
+        } else {
+            mColorResId = R.color.error_text;
+        }
     }
 
     private void listenForDeleteEmpty() {

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -17,21 +17,21 @@ import android.widget.EditText;
  * but we listen here for hardware key presses, older Android soft keyboard delete presses,
  * and modern Google Keyboard delete key presses.
  */
-public class DeleteWatchEditText extends EditText {
+public class StripeEditText extends EditText {
 
     @Nullable private DeleteEmptyListener mDeleteEmptyListener;
 
-    public DeleteWatchEditText(Context context) {
+    public StripeEditText(Context context) {
         super(context);
         listenForDeleteEmpty();
     }
 
-    public DeleteWatchEditText(Context context, AttributeSet attrs) {
+    public StripeEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
         listenForDeleteEmpty();
     }
 
-    public DeleteWatchEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+    public StripeEditText(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         listenForDeleteEmpty();
     }

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -7,7 +7,7 @@ import android.widget.LinearLayout;
 import com.stripe.android.R;
 import com.stripe.android.view.CardInputView;
 import com.stripe.android.view.CardNumberEditText;
-import com.stripe.android.view.DeleteWatchEditText;
+import com.stripe.android.view.StripeEditText;
 import com.stripe.android.view.ExpiryDateEditText;
 
 /**
@@ -39,8 +39,8 @@ public class CardInputTestActivity extends Activity {
         return (ExpiryDateEditText) mCardInputView.findViewById(R.id.et_expiry_date);
     }
 
-    public DeleteWatchEditText getCvcEditText() {
-        return (DeleteWatchEditText) mCardInputView.findViewById(R.id.et_cvc_number);
+    public StripeEditText getCvcEditText() {
+        return (StripeEditText) mCardInputView.findViewById(R.id.et_cvc_number);
     }
 
     public CardInputView getCardInputView() {

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -18,14 +18,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
- * Test class for {@link DeleteWatchEditText}.
+ * Test class for {@link StripeEditText}.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 22)
-public class DeleteWatchEditTextTest {
+public class StripeEditTextTest {
 
-    @Mock DeleteWatchEditText.DeleteEmptyListener mDeleteEmptyListener;
-    private DeleteWatchEditText mEditText;
+    @Mock StripeEditText.DeleteEmptyListener mDeleteEmptyListener;
+    private StripeEditText mEditText;
 
     @Before
     public void setup() {

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -1,5 +1,8 @@
 package com.stripe.android.view;
 
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+
 import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 
@@ -13,6 +16,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -75,5 +80,35 @@ public class StripeEditTextTest {
         }
 
         verify(mDeleteEmptyListener, times(1)).onDeleteEmpty();
+    }
+
+    @Test
+    public void isColorDark_forExampleLightColors_returnsFalse() {
+        @ColorInt int middleGray = 0x888888;
+        @ColorInt int offWhite = 0xfaebd7;
+        @ColorInt int lightCyan = 0x8feffb;
+        @ColorInt int lightYellow = 0xfcf4b2;
+        @ColorInt int lightBlue = 0x9cdbff;
+
+        assertFalse(StripeEditText.isColorDark(middleGray));
+        assertFalse(StripeEditText.isColorDark(offWhite));
+        assertFalse(StripeEditText.isColorDark(lightCyan));
+        assertFalse(StripeEditText.isColorDark(lightYellow));
+        assertFalse(StripeEditText.isColorDark(lightBlue));
+        assertFalse(StripeEditText.isColorDark(Color.WHITE));
+    }
+
+    @Test
+    public void isColorDark_forExampleDarkColors_returnsTrue() {
+        @ColorInt int logoBlue = 0x6772e5;
+        @ColorInt int slate = 0x525f7f;
+        @ColorInt int darkPurple = 0x6b3791;
+        @ColorInt int darkishRed = 0x9e2146;
+
+        assertTrue(StripeEditText.isColorDark(logoBlue));
+        assertTrue(StripeEditText.isColorDark(slate));
+        assertTrue(StripeEditText.isColorDark(darkPurple));
+        assertTrue(StripeEditText.isColorDark(darkishRed));
+        assertTrue(StripeEditText.isColorDark(Color.BLACK));
     }
 }


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @brandur-stripe @shale-stripe 

Changing the name of DeleteWatchEditText to StripeEditText and adding the "setErrorState" functionality that turns the text red. We determine which shade of red by looking at the current text color -- if it's light, we use a lighter shade of red (named error_red_dark_theme, because light text usually goes with a dark theme), and if it's dark, we use a dark color.

In the future, I'd like to allow users to set this with a declare-stylable, but that is unfortunately difficult to get working, and in the meantime this will work for most people.