### PR TITLE
turning on error displays for the CardNumberEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -172,11 +172,14 @@ public class CardNumberEditText extends StripeEditText {
                 if (s.length() == mLengthMax) {
                     boolean before = mIsCardNumberValid;
                     mIsCardNumberValid = CardUtils.isValidCardNumber(s.toString());
+                    setShouldShowError(!mIsCardNumberValid);
                     if (!before && mIsCardNumberValid && mCardNumberCompleteListener != null) {
                         mCardNumberCompleteListener.onCardNumberComplete();
                     }
                 } else {
                     mIsCardNumberValid = false;
+                    // Don't show errors if we aren't full-length.
+                    setShouldShowError(false);
                 }
             }
         });

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -17,8 +17,8 @@ import com.stripe.android.view.ExpiryDateEditText;
 public class CardInputTestActivity extends Activity {
 
     public static final String VALID_AMEX_WITH_SPACES = "3782 822463 10005";
-    public static final String VALID_VISA_WITH_SPACES = "4242 4242 4242 4242";
     public static final String VALID_DINERS_CLUB_WITH_SPACES = "3056 9309 0259 04";
+    public static final String VALID_VISA_WITH_SPACES = "4242 4242 4242 4242";
 
     private CardInputView mCardInputView;
 

--- a/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/CardInputTestActivity.java
@@ -18,6 +18,7 @@ public class CardInputTestActivity extends Activity {
 
     public static final String VALID_AMEX_WITH_SPACES = "3782 822463 10005";
     public static final String VALID_VISA_WITH_SPACES = "4242 4242 4242 4242";
+    public static final String VALID_DINERS_CLUB_WITH_SPACES = "3056 9309 0259 04";
 
     private CardInputView mCardInputView;
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -2,6 +2,7 @@ package com.stripe.android.view;
 
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +15,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
+import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -149,5 +151,72 @@ public class CardNumberEditTextTest {
         mCardNumberEditText.setText(almostValid);
         assertFalse(mCardNumberEditText.isCardNumberValid());
         verifyZeroInteractions(mCardNumberCompleteListener);
+    }
+
+    @Test
+    public void whenNotFinishedTyping_doesNotSetErrorValue() {
+        // We definitely shouldn't start out in an error state.
+        assertFalse(mCardNumberEditText.getShouldShowError());
+
+        mCardNumberEditText.append("123");
+        assertFalse(mCardNumberEditText.getShouldShowError());
+    }
+
+    @Test
+    public void finishTypingCommonLengthCardNumber_whenValidCard_doesNotSetErrorValue() {
+        String almostThere = VALID_VISA_WITH_SPACES.substring(0, 18);
+        mCardNumberEditText.setText(almostThere);
+        assertFalse(mCardNumberEditText.getShouldShowError());
+        // We now have the valid 4242 Visa
+        mCardNumberEditText.append("2");
+        assertFalse(mCardNumberEditText.getShouldShowError());
+    }
+
+    @Test
+    public void finishTypingCommonLengthCardNumber_whenInvalidCard_setsErrorValue() {
+        String almostThere = VALID_VISA_WITH_SPACES.substring(0, 18);
+        mCardNumberEditText.setText(almostThere);
+        // This makes the number officially invalid
+        mCardNumberEditText.append("3");
+        assertTrue(mCardNumberEditText.getShouldShowError());
+    }
+
+    @Test
+    public void finishTypingInvalidCardNumber_whenFollowedByDelete_setsErrorBackToFalse() {
+        String notQuiteValid = VALID_VISA_WITH_SPACES.substring(0, 18) + "3";
+        mCardNumberEditText.setText(notQuiteValid);
+        assertTrue(mCardNumberEditText.getShouldShowError());
+
+        // Now that we're in an error state, back up by one
+        ViewTestUtils.sendDeleteKeyEvent(mCardNumberEditText);
+        assertFalse(mCardNumberEditText.getShouldShowError());
+    }
+
+    @Test
+    public void finishTypingDinersClub_whenInvalid_setsErrorValueAndRemovesItAppropriately() {
+        String notQuiteValid = VALID_DINERS_CLUB_WITH_SPACES.substring(0, 16) + "3";
+        mCardNumberEditText.setText(notQuiteValid);
+        assertTrue(mCardNumberEditText.getShouldShowError());
+
+        // Now that we're in an error state, back up by one
+        ViewTestUtils.sendDeleteKeyEvent(mCardNumberEditText);
+        assertFalse(mCardNumberEditText.getShouldShowError());
+
+        mCardNumberEditText.append("4");
+        assertFalse(mCardNumberEditText.getShouldShowError());
+    }
+
+    @Test
+    public void finishTypingAmEx_whenInvalid_setsErrorValueAndRemovesItAppropriately() {
+        String notQuiteValid = VALID_AMEX_WITH_SPACES.substring(0, 16) + "3";
+        mCardNumberEditText.setText(notQuiteValid);
+        assertTrue(mCardNumberEditText.getShouldShowError());
+
+        // Now that we're in an error state, back up by one
+        ViewTestUtils.sendDeleteKeyEvent(mCardNumberEditText);
+        assertFalse(mCardNumberEditText.getShouldShowError());
+
+        mCardNumberEditText.append("5");
+        assertFalse(mCardNumberEditText.getShouldShowError());
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @sjayaraman-stripe @shale-stripe 

When you type an invalid card number, the text turns red. If you delete a digit, the text turns back to its normal color. To be invalid, the number must be full-length for the type of card (this is detected by the CardNumberEditText and tested for in this diff and elsewhere).

Tests added for Visa-length cards, Amex-length cards, and Diners Club-length cards.