### PR TITLE
adding user-stylability to the error text color and tint color

### DIFF
--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="CardInputView">
+        <attr name="cardTint" format="color"/>
+        <attr name="cardTextErrorColor" format="color"/>
+    </declare-styleable>
+</resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -57,6 +57,12 @@ public class CardNumberEditText extends StripeEditText {
         listenForTextChanges();
     }
 
+    @NonNull
+    @Card.CardBrand
+    public String getCardBrand() {
+        return mCardBrand;
+    }
+
     /**
      * Check whether or not the card number is valid
      *

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -94,8 +94,12 @@ public class StripeEditText extends EditText {
     }
 
     @ColorInt
+    @SuppressWarnings("deprecation")
     int getDefaultErrorColorInt() {
         @ColorInt int errorColor;
+        // It's possible that we need to verify this value again
+        // in case the user programmatically changes the text color.
+        determineDefaultErrorColor();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             errorColor = getResources().getColor(mDefaultErrorColorResId, null);
         } else {

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -6,7 +6,6 @@ import android.graphics.Color;
 import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -30,7 +29,8 @@ public class StripeEditText extends EditText {
     @Nullable private DeleteEmptyListener mDeleteEmptyListener;
     @Nullable private ColorStateList mCachedColorStateList;
     private boolean mShouldShowError;
-    @ColorRes private int mColorResId;
+    @ColorRes private int mDefaultErrorColorResId;
+    @ColorInt private int mErrorColor;
 
     public StripeEditText(Context context) {
         super(context);
@@ -71,14 +71,7 @@ public class StripeEditText extends EditText {
     public void setShouldShowError(boolean shouldShowError) {
         mShouldShowError = shouldShowError;
         if (mShouldShowError) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                setTextColor(getResources().getColor(mColorResId, null));
-            } else {
-                // Resources#getColor(int) is deprecated, but the replacement only exists in
-                // SDK 23 and above.
-                setTextColor(getResources().getColor(mColorResId));
-            }
-
+            setTextColor(mErrorColor);
         } else {
             setTextColor(mCachedColorStateList);
         }
@@ -98,6 +91,24 @@ public class StripeEditText extends EditText {
      */
     public boolean getShouldShowError() {
         return mShouldShowError;
+    }
+
+    @ColorInt
+    int getDefaultErrorColorInt() {
+        @ColorInt int errorColor;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            errorColor = getResources().getColor(mDefaultErrorColorResId, null);
+        } else {
+            // Resources#getColor(int) is deprecated, but the replacement only exists in
+            // SDK 23 and above.
+            errorColor = getResources().getColor(mDefaultErrorColorResId);
+        }
+
+        return errorColor;
+    }
+
+    void setErrorColor(@ColorInt int errorColor) {
+        mErrorColor = errorColor;
     }
 
     /**
@@ -130,19 +141,19 @@ public class StripeEditText extends EditText {
 
     private void initView() {
         listenForDeleteEmpty();
-        determineErrorColor();
+        determineDefaultErrorColor();
         mCachedColorStateList = getTextColors();
     }
 
-    private void determineErrorColor() {
+    private void determineDefaultErrorColor() {
         mCachedColorStateList = getTextColors();
         int color = mCachedColorStateList.getDefaultColor();
         if (isColorDark(color)) {
             // Note: if the _text_ color is dark, then this is a
             // light theme, and vice-versa.
-            mColorResId = R.color.error_text_light_theme;
+            mDefaultErrorColorResId = R.color.error_text_light_theme;
         } else {
-            mColorResId = R.color.error_text_dark_theme;
+            mDefaultErrorColorResId = R.color.error_text_dark_theme;
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.IdRes;
 import android.view.View;
@@ -79,17 +81,17 @@ public class CardInputViewTest {
     public void onUpdateIcon_forCommonLengthBrand_callsSetImageResourceAndSetsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.
-        Drawable old = mIconView.getDrawable();
+        Bitmap oldBitmap  = ((BitmapDrawable) mIconView.getDrawable()).getBitmap();
         mCardNumberEditText.append(Card.PREFIXES_VISA[0]);
-        assertNotEquals(old, mIconView.getDrawable());
+        assertNotEquals(oldBitmap, ((BitmapDrawable) mIconView.getDrawable()).getBitmap());
         assertTrue(ViewTestUtils.hasMaxLength(mCvcEditText, 3));
     }
 
     @Test
     public void onUpdateText_forAmExPrefix_callsSetImageResourceAndSetsLengthOnCvc() {
-        Drawable old = mIconView.getDrawable();
+        Bitmap oldBitmap  = ((BitmapDrawable) mIconView.getDrawable()).getBitmap();
         mCardNumberEditText.append(Card.PREFIXES_AMERICAN_EXPRESS[0]);
-        assertNotEquals(old, mIconView.getDrawable());
+        assertNotEquals(oldBitmap, ((BitmapDrawable) mIconView.getDrawable()).getBitmap());
         assertTrue(ViewTestUtils.hasMaxLength(mCvcEditText, 4));
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -41,7 +41,7 @@ public class StripeEditTextTest {
         MockitoAnnotations.initMocks(this);
         mActivityController = Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
-        // Note that the CVC EditText is a DeleteWatchEditText
+        // Note that the CVC EditText is a StripeEditText
         mEditText =  mActivityController.get().getCvcEditText();
         mEditText.setText("");
         mEditText.setDeleteEmptyListener(mDeleteEmptyListener);

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -3,6 +3,7 @@ package com.stripe.android.view;
 import android.graphics.Color;
 import android.support.annotation.ColorInt;
 
+import com.stripe.android.R;
 import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 
@@ -13,9 +14,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
@@ -30,16 +33,16 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 public class StripeEditTextTest {
 
     @Mock StripeEditText.DeleteEmptyListener mDeleteEmptyListener;
+    private ActivityController<CardInputTestActivity> mActivityController;
     private StripeEditText mEditText;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
+        mActivityController = Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
         // Note that the CVC EditText is a DeleteWatchEditText
-        mEditText = ((CardInputTestActivity) activityController.get()).getCvcEditText();
+        mEditText =  mActivityController.get().getCvcEditText();
         mEditText.setText("");
         mEditText.setDeleteEmptyListener(mDeleteEmptyListener);
     }
@@ -110,5 +113,39 @@ public class StripeEditTextTest {
         assertTrue(StripeEditText.isColorDark(darkPurple));
         assertTrue(StripeEditText.isColorDark(darkishRed));
         assertTrue(StripeEditText.isColorDark(Color.BLACK));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getDefaultErrorColorInt_onDarkTheme_returnsDarkError() {
+        mEditText.setTextColor(
+                mActivityController.get().getResources()
+                        .getColor(android.R.color.primary_text_dark));
+        @ColorInt int colorInt = mEditText.getDefaultErrorColorInt();
+        @ColorInt int expectedErrorInt =
+                mActivityController.get().getResources().getColor(R.color.error_text_dark_theme);
+        assertEquals(expectedErrorInt, colorInt);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getDefaultErrorColorInt_onLightTheme_returnsLightError() {
+        mEditText.setTextColor(
+                mActivityController.get().getResources()
+                        .getColor(android.R.color.primary_text_light));
+        @ColorInt int colorInt = mEditText.getDefaultErrorColorInt();
+        @ColorInt int expectedErrorInt =
+                mActivityController.get().getResources().getColor(R.color.error_text_light_theme);
+        assertEquals(expectedErrorInt, colorInt);
+    }
+
+    @Test
+    public void setErrorColor_whenInError_overridesDefault() {
+        // By default, the text color in this test activity is a light theme
+        @ColorInt int blueError = 0x0000ff;
+        mEditText.setErrorColor(blueError);
+        mEditText.setShouldShowError(true);
+        int currentColorInt = mEditText.getTextColors().getDefaultColor();
+        assertEquals(blueError, currentColorInt);
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @sjayaraman-stripe @shale-stripe 

Adding custom declare-styleable attributes to the CardInputView so users can style them with two lines of xml.

Fixing the tint error in which users would be unable to persist tint after a window goes out of focus.