### PR TITLE
deleting the last item in the previous text field when going back

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -281,6 +281,14 @@ public class CardInputView extends FrameLayout {
         }
     }
 
+    /**
+     * Class used to encapsulate the functionality of "backing up" via the delete/backspace key
+     * from one text field to the previous. We use this to simulate multiple fields being all part
+     * of the same EditText, so a delete key entry from field N+1 deletes the last character in
+     * field N. Each BackUpFieldDeleteListener is attached to the N+1 field, from which it gets
+     * its {@link #onDeleteEmpty()} call, and given a reference to the N field, upon which
+     * it will be acting.
+     */
     private class BackUpFieldDeleteListener implements StripeEditText.DeleteEmptyListener {
 
         private StripeEditText backUpTarget;

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -130,21 +130,10 @@ public class CardInputView extends FrameLayout {
         });
 
         mExpiryDateEditText.setDeleteEmptyListener(
-                new StripeEditText.DeleteEmptyListener() {
-                    @Override
-                    public void onDeleteEmpty() {
-                        mCardNumberEditText.requestFocus();
-                    }
-                });
+                new BackUpFieldDeleteListener(mCardNumberEditText));
 
         mCvcNumberEditText.setDeleteEmptyListener(
-                new StripeEditText.DeleteEmptyListener() {
-                    @Override
-                    public void onDeleteEmpty() {
-                        mExpiryDateEditText.requestFocus();
-                    }
-                }
-        );
+                new BackUpFieldDeleteListener(mExpiryDateEditText));
 
         mCvcNumberEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
             @Override
@@ -289,6 +278,26 @@ public class CardInputView extends FrameLayout {
             }
         } else {
             mScrollToPostion = mScrollViewWidth;
+        }
+    }
+
+    private class BackUpFieldDeleteListener implements StripeEditText.DeleteEmptyListener {
+
+        private StripeEditText backUpTarget;
+
+        BackUpFieldDeleteListener(StripeEditText backUpTarget) {
+            this.backUpTarget = backUpTarget;
+        }
+
+        @Override
+        public void onDeleteEmpty() {
+            String fieldText = backUpTarget.getText().toString();
+            if (fieldText.length() > 1) {
+                backUpTarget.setText(
+                        fieldText.substring(0, fieldText.length() - 1));
+            }
+            backUpTarget.requestFocus();
+            backUpTarget.setSelection(backUpTarget.length());
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
@@ -25,6 +25,7 @@ import org.robolectric.util.ActivityController;
 import java.util.Calendar;
 
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
+import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -130,6 +131,18 @@ public class CardInputViewTest {
 
         assertTrue(mCvcEditText.hasFocus());
         assertEquals("12/79", mExpiryEditText.getText().toString());
+    }
+
+    @Test
+    public void onDeleteFromCvcDate_whenEmptyAndExpiryDateIsEmpty_shiftsFocusOnly() {
+        mCardNumberEditText.setText(VALID_DINERS_CLUB_WITH_SPACES);
+
+        // Simulates user tapping into this text field without filling out the date first.
+        mCvcEditText.requestFocus();
+
+        ViewTestUtils.sendDeleteKeyEvent(mCvcEditText);
+        assertEquals(R.id.et_cvc_number, mOnGlobalFocusChangeListener.getOldFocusId());
+        assertEquals(R.id.et_expiry_date, mOnGlobalFocusChangeListener.getNewFocusId());
     }
 
     @Test


### PR DESCRIPTION
r? @brandur-stripe 
cc @sjayaraman-stripe @shale-stripe 

As requested in design review, deleting the last character of the previous text field when going back via the delete-on-empty action. (With tests!)