### PR TITLE
correcting the scroll locking functionality so that accessibility mode won't break the control

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
 import android.text.Layout;
@@ -44,16 +45,17 @@ public class CardInputView extends FrameLayout {
 
     private ImageView mCardIconImageView;
     private CardNumberEditText mCardNumberEditText;
+    private CustomWidthSetter mCustomWidthSetter;
     private StripeEditText mCvcNumberEditText;
     private ExpiryDateEditText mExpiryDateEditText;
     private LockableHorizontalScrollView mScrollView;
     private View mCardNumberSpace;
     private boolean mCardNumberIsViewed;
     private @ColorInt int mErrorColorInt;
-    private boolean mIsAmex;
+    private boolean mIsAmEx;
     private boolean mInitializedFlag;
     private int mScrollViewWidth;
-    private int mScrollToPostion;
+    private int mScrollToPosition;
     private @ColorInt int mTintColorInt;
 
     public CardInputView(Context context) {
@@ -87,7 +89,7 @@ public class CardInputView extends FrameLayout {
         }
 
         // CVC/CVV is the only field not validated by the entry control itself, so we check here.
-        int requiredLength = mIsAmex ? CardUtils.CVC_LENGTH_AMEX : CardUtils.CVC_LENGTH_COMMON;
+        int requiredLength = mIsAmEx ? CardUtils.CVC_LENGTH_AMEX : CardUtils.CVC_LENGTH_COMMON;
         String cvcValue = mCvcNumberEditText.getText().toString();
         if (StripeTextUtils.isBlank(cvcValue) || cvcValue.length() != requiredLength) {
             return null;
@@ -181,7 +183,7 @@ public class CardInputView extends FrameLayout {
                 new CardNumberEditText.CardBrandChangeListener() {
                     @Override
                     public void onCardBrandChanged(@NonNull @Card.CardBrand String brand) {
-                        mIsAmex = Card.AMERICAN_EXPRESS.equals(brand);
+                        mIsAmEx = Card.AMERICAN_EXPRESS.equals(brand);
                         updateIcon(brand);
                         updateCvc(brand);
                     }
@@ -205,6 +207,16 @@ public class CardInputView extends FrameLayout {
         }
     }
 
+    @VisibleForTesting
+    void setScrollToPosition(int scrollToPosition) {
+        mScrollToPosition = scrollToPosition;
+    }
+
+    @VisibleForTesting
+    void setCustomWidthSetter(CustomWidthSetter customWidthSetter) {
+        mCustomWidthSetter = customWidthSetter;
+    }
+
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -219,7 +231,7 @@ public class CardInputView extends FrameLayout {
         if (!mInitializedFlag) {
             mInitializedFlag = true;
             mScrollViewWidth = mScrollView.getMeasuredWidth();
-            mScrollToPostion = mScrollViewWidth;
+            mScrollToPosition = mScrollViewWidth;
             ViewGroup.LayoutParams widthParams = mCardNumberSpace.getLayoutParams();
             widthParams.width = mScrollViewWidth;
             mCardNumberSpace.setLayoutParams(widthParams);
@@ -239,25 +251,30 @@ public class CardInputView extends FrameLayout {
         if (!mCardNumberIsViewed) {
             return;
         }
+        mScrollView.setScrollable(true);
         mCardNumberIsViewed = false;
         updateScrollToPosition();
-        mScrollView.smoothScrollBy(mScrollToPostion, 0);
+        mScrollView.wrappedSmoothScrollBy(mScrollToPosition, 0);
         mExpiryDateEditText.setVisibility(View.VISIBLE);
         mCvcNumberEditText.setVisibility(View.VISIBLE);
         mExpiryDateEditText.requestFocus();
+        mScrollView.setScrollable(false);
     }
 
     private void scrollLeft() {
         if (mCardNumberIsViewed) {
             return;
         }
+        mScrollView.setScrollable(true);
         mCardNumberIsViewed = true;
         updateScrollToPosition();
         mCardNumberEditText.setSelection(mCardNumberEditText.getText().length());
-        mScrollView.smoothScrollBy(-1*mScrollToPostion, 0);
+        mScrollView.wrappedSmoothScrollBy(-1* mScrollToPosition, 0);
         mExpiryDateEditText.setVisibility(View.INVISIBLE);
         mCvcNumberEditText.setVisibility(View.INVISIBLE);
+
         mCardNumberEditText.requestFocus();
+        mScrollView.setScrollable(false);
     }
 
     private void updateIcon(@NonNull @Card.CardBrand String brand) {
@@ -296,16 +313,24 @@ public class CardInputView extends FrameLayout {
 
     private void updateScrollToPosition() {
         if (!mCardNumberIsViewed) {
-            int endScrollIndex = mIsAmex ? END_INDEX_AMEX : END_INDEX_COMMON;
+            int endScrollIndex = mIsAmEx ? END_INDEX_AMEX : END_INDEX_COMMON;
             String cardString = mCardNumberEditText.getText().toString();
             if (cardString.length() >= endScrollIndex) {
                 String hiddenString = cardString.substring(0, endScrollIndex);
-                mScrollToPostion =
-                        (int) Layout.getDesiredWidth(hiddenString, mCardNumberEditText.getPaint());
+                mScrollToPosition = mCustomWidthSetter == null
+                        ? (int) Layout.getDesiredWidth(hiddenString, mCardNumberEditText.getPaint())
+                        : mCustomWidthSetter.getDesiredScrollRight(hiddenString);
             }
         } else {
-            mScrollToPostion = mScrollViewWidth;
+            mScrollToPosition = mCustomWidthSetter == null
+                    ? mScrollViewWidth
+                    : mCustomWidthSetter.getDesiredScrollLeft();
         }
+    }
+
+    interface CustomWidthSetter {
+        int getDesiredScrollRight(String hiddenString);
+        int getDesiredScrollLeft();
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -323,6 +323,10 @@ public class CardInputView extends FrameLayout {
         }
     }
 
+    /**
+     * Test harness assistant - this helps us verify when we scroll.
+     */
+    @VisibleForTesting
     interface CustomWidthSetter {
         int getDesiredScrollRight(String hiddenString);
         int getDesiredScrollLeft();

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -208,11 +208,6 @@ public class CardInputView extends FrameLayout {
     }
 
     @VisibleForTesting
-    void setScrollToPosition(int scrollToPosition) {
-        mScrollToPosition = scrollToPosition;
-    }
-
-    @VisibleForTesting
     void setCustomWidthSetter(CustomWidthSetter customWidthSetter) {
         mCustomWidthSetter = customWidthSetter;
     }

--- a/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
+++ b/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
@@ -2,9 +2,7 @@ package com.stripe.android.view;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.MotionEvent;
-import android.view.View;
 import android.widget.HorizontalScrollView;
 
 /**
@@ -93,7 +91,18 @@ public class LockableHorizontalScrollView extends HorizontalScrollView {
         }
     }
 
-    public interface LockableScrollChangedListener {
+    /**
+     * Allows you to listen to {@link HorizontalScrollView#smoothScrollBy(int, int)}
+     * commands being sent to a {@link LockableHorizontalScrollView}. Useful for testing.
+     */
+    interface LockableScrollChangedListener {
+
+        /**
+         * Reacts to smoothScroll commands.
+         *
+         * @param dx the number of pixels to scroll by on the X axis
+         * @param dy the number of pixels to scroll by on the Y axis
+         */
         void onSmoothScrollBy(int dx, int dy);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
+++ b/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
@@ -45,6 +45,13 @@ public class LockableHorizontalScrollView extends HorizontalScrollView {
         setSmoothScrollingEnabled(scrollable);
     }
 
+    /**
+     * Without this override, keyboard and accessibility scrolling can still cause the "locked"
+     * {@link HorizontalScrollView} to scroll.
+     *
+     * @param x the x position to scroll to
+     * @param y the y position to scroll to
+     */
     @Override
     public void scrollTo(int x, int y) {
         if (!mScrollable) {


### PR DESCRIPTION
r? @brandur-stripe 
cc @sjayaraman-stripe 

The LockableScrollView wasn't quite locking correctly -- it worked fine by touch, but by keyboard you could make the view scroll away too far and fail to turn on the newly visible controls. I originally didn't think this was a big deal, but it turns out that's how accessibility scrolling works; you need to stop more than just the onTouch events.

I also added some just-for-test code because I was sick of CardInputView barely being tested and this was some rather hard-to-hit stuff.