### PR TITLE
adding accessibility labels (and translations for said labels) to card number and expiry edit text

### DIFF
--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:orientation="horizontal"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
@@ -43,7 +44,20 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
+                    <!--The only purpose of this TextView is to be an accessibility label.-->
+                    <TextView
+                        android:id="@+id/card_number_label"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@android:color/transparent"
+                        android:textColor="@android:color/transparent"
+                        android:labelFor="@+id/et_card_number"
+                        android:clickable="false"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:text="@string/acc_label_card_number"/>
 
+                    <!-- The accessibilityTraversalBefore attribute is ignored in sdk < 22 -->
                     <com.stripe.android.view.CardNumberEditText
                         android:id="@+id/et_card_number"
                         android:layout_width="match_parent"
@@ -51,35 +65,20 @@
                         android:background="@android:color/transparent"
                         android:hint="@string/card_number_hint"
                         android:nextFocusRight="@+id/et_expiry_date"
-                        android:accessibilityTraversalAfter="@+id/et_expiry_date"
+                        tools:ignore="UnusedAttribute"
+                        android:accessibilityTraversalBefore="@+id/et_expiry_date"
                         android:inputType="number"
                         android:maxLength="19"
                         />
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="@android:color/transparent"
-                        android:textColor="@android:color/transparent"
-                        android:labelFor="@id/et_card_number"
-                        android:clickable="false"
-                        android:focusable="false"
-                        android:focusableInTouchMode="false"
-                        android:text="@string/acc_label_card_number"/>
+
                 </FrameLayout>
-                <!--<com.stripe.android.view.CardNumberEditText-->
-                    <!--android:id="@+id/et_card_number"-->
-                    <!--android:layout_width="match_parent"-->
-                    <!--android:layout_height="wrap_content"-->
-                    <!--android:background="@android:color/transparent"-->
-                    <!--android:hint="@string/card_number_hint"-->
-                    <!--android:inputType="number"-->
-                    <!--android:maxLength="19"-->
-                    <!--/>-->
 
                 <View
                     android:id="@+id/space_in_container"
                     android:layout_width="match_parent"
                     android:layout_height="10dp"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
                     />
 
             </LinearLayout>
@@ -91,12 +90,29 @@
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
             >
+
+            <!--The only purpose of this TextView is to be an accessibility label.-->
+            <TextView
+                android:id="@+id/expiry_date_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:textColor="@android:color/transparent"
+                android:labelFor="@+id/et_expiry_date"
+                android:clickable="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:text="@string/acc_label_expiry_date"/>
+
+            <!-- The accessibilityTraversalAfter attribute is ignored in sdk < 22 -->
+            <!-- The accessibilityTraversalBefore attribute is ignored in sdk < 22 -->
             <com.stripe.android.view.ExpiryDateEditText
                 android:id="@+id/et_expiry_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
                 android:hint="@string/expiry_date_hint"
+                tools:ignore="UnusedAttribute"
                 android:accessibilityTraversalAfter="@+id/et_expiry_date"
                 android:accessibilityTraversalBefore="@id/et_card_number"
                 android:nextFocusRight="@+id/et_cvc_number"
@@ -106,25 +122,16 @@
                 android:visibility="invisible"
                 />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:textColor="@android:color/transparent"
-                android:labelFor="@id/et_expiry_date"
-                android:clickable="false"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:text="@string/acc_label_expiry_date"/>
         </FrameLayout>
 
-
+        <!-- The accessibilityTraversalAfter attribute is ignored in sdk < 22 -->
         <com.stripe.android.view.StripeEditText
             android:id="@+id/et_cvc_number"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
+            tools:ignore="UnusedAttribute"
             android:accessibilityTraversalAfter="@+id/et_expiry_date"
             android:nextFocusLeft="@id/et_expiry_date"
             android:background="@android:color/transparent"

--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -39,15 +39,42 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <com.stripe.android.view.CardNumberEditText
-                    android:id="@+id/et_card_number"
+                <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@android:color/transparent"
-                    android:hint="@string/card_number_hint"
-                    android:inputType="number"
-                    android:maxLength="19"
-                    />
+                    android:layout_height="wrap_content">
+
+
+                    <com.stripe.android.view.CardNumberEditText
+                        android:id="@+id/et_card_number"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@android:color/transparent"
+                        android:hint="@string/card_number_hint"
+                        android:nextFocusRight="@+id/et_expiry_date"
+                        android:accessibilityTraversalAfter="@+id/et_expiry_date"
+                        android:inputType="number"
+                        android:maxLength="19"
+                        />
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@android:color/transparent"
+                        android:textColor="@android:color/transparent"
+                        android:labelFor="@id/et_card_number"
+                        android:clickable="false"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:text="@string/acc_label_card_number"/>
+                </FrameLayout>
+                <!--<com.stripe.android.view.CardNumberEditText-->
+                    <!--android:id="@+id/et_card_number"-->
+                    <!--android:layout_width="match_parent"-->
+                    <!--android:layout_height="wrap_content"-->
+                    <!--android:background="@android:color/transparent"-->
+                    <!--android:hint="@string/card_number_hint"-->
+                    <!--android:inputType="number"-->
+                    <!--android:maxLength="19"-->
+                    <!--/>-->
 
                 <View
                     android:id="@+id/space_in_container"
@@ -59,17 +86,38 @@
 
         </com.stripe.android.view.LockableHorizontalScrollView>
 
-        <com.stripe.android.view.ExpiryDateEditText
-            android:id="@+id/et_expiry_date"
+        <FrameLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:background="@android:color/transparent"
-            android:hint="@string/expiry_date_hint"
-            android:inputType="date"
-            android:maxLength="5"
-            android:visibility="invisible"
-            />
+            >
+            <com.stripe.android.view.ExpiryDateEditText
+                android:id="@+id/et_expiry_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:hint="@string/expiry_date_hint"
+                android:accessibilityTraversalAfter="@+id/et_expiry_date"
+                android:accessibilityTraversalBefore="@id/et_card_number"
+                android:nextFocusRight="@+id/et_cvc_number"
+                android:nextFocusLeft="@id/et_card_number"
+                android:inputType="date"
+                android:maxLength="5"
+                android:visibility="invisible"
+                />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:textColor="@android:color/transparent"
+                android:labelFor="@id/et_expiry_date"
+                android:clickable="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:text="@string/acc_label_expiry_date"/>
+        </FrameLayout>
+
 
         <com.stripe.android.view.StripeEditText
             android:id="@+id/et_cvc_number"
@@ -77,6 +125,8 @@
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
+            android:accessibilityTraversalAfter="@+id/et_expiry_date"
+            android:nextFocusLeft="@id/et_expiry_date"
             android:background="@android:color/transparent"
             android:hint="@string/cvc_number_hint"
             android:inputType="number"

--- a/stripe/res/layout/card_input_view.xml
+++ b/stripe/res/layout/card_input_view.xml
@@ -33,16 +33,21 @@
             android:layout_alignParentStart="true"
             android:fillViewport="true"
             android:fadeScrollbars="false"
+            tools:importantForAccessibility="no"
             android:scrollbars="none">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                tools:importantForAccessibility="no"
+                >
 
                 <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    tools:importantForAccessibility="no"
+                    >
 
                     <!--The only purpose of this TextView is to be an accessibility label.-->
                     <TextView
@@ -54,8 +59,10 @@
                         android:labelFor="@+id/et_card_number"
                         android:clickable="false"
                         android:focusable="false"
+                        tools:importantForAccessibility="no"
                         android:focusableInTouchMode="false"
-                        android:text="@string/acc_label_card_number"/>
+                        android:text="@string/acc_label_card_number"
+                        />
 
                     <!-- The accessibilityTraversalBefore attribute is ignored in sdk < 22 -->
                     <com.stripe.android.view.CardNumberEditText
@@ -66,6 +73,7 @@
                         android:hint="@string/card_number_hint"
                         android:nextFocusRight="@+id/et_expiry_date"
                         tools:ignore="UnusedAttribute"
+                        tools:importantForAccessibility="yes"
                         android:accessibilityTraversalBefore="@+id/et_expiry_date"
                         android:inputType="number"
                         android:maxLength="19"
@@ -79,6 +87,7 @@
                     android:layout_height="10dp"
                     android:focusable="false"
                     android:focusableInTouchMode="false"
+                    tools:importantForAccessibility="no"
                     />
 
             </LinearLayout>
@@ -89,6 +98,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
+            tools:importantForAccessibility="no"
             >
 
             <!--The only purpose of this TextView is to be an accessibility label.-->
@@ -99,10 +109,12 @@
                 android:background="@android:color/transparent"
                 android:textColor="@android:color/transparent"
                 android:labelFor="@+id/et_expiry_date"
+                tools:importantForAccessibility="no"
                 android:clickable="false"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
-                android:text="@string/acc_label_expiry_date"/>
+                android:text="@string/acc_label_expiry_date"
+                />
 
             <!-- The accessibilityTraversalAfter attribute is ignored in sdk < 22 -->
             <!-- The accessibilityTraversalBefore attribute is ignored in sdk < 22 -->
@@ -113,6 +125,7 @@
                 android:background="@android:color/transparent"
                 android:hint="@string/expiry_date_hint"
                 tools:ignore="UnusedAttribute"
+                tools:importantForAccessibility="yes"
                 android:accessibilityTraversalAfter="@+id/et_expiry_date"
                 android:accessibilityTraversalBefore="@id/et_card_number"
                 android:nextFocusRight="@+id/et_cvc_number"
@@ -132,6 +145,7 @@
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             tools:ignore="UnusedAttribute"
+            tools:importantForAccessibility="yes"
             android:accessibilityTraversalAfter="@+id/et_expiry_date"
             android:nextFocusLeft="@id/et_expiry_date"
             android:background="@android:color/transparent"

--- a/stripe/res/values-de/strings.xml
+++ b/stripe/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"Kartennummer"</string>
+    <string name="acc_label_expiry_date">"Gültig bis"</string>
+</resources>

--- a/stripe/res/values-en/strings.xml
+++ b/stripe/res/values-en/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"card number"</string>
+    <string name="acc_label_expiry_date">"expiration date"</string>
+</resources>

--- a/stripe/res/values-es/strings.xml
+++ b/stripe/res/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"número de tarjeta"</string>
+    <string name="acc_label_expiry_date">"fecha de vencimiento"</string>
+</resources>

--- a/stripe/res/values-fr/strings.xml
+++ b/stripe/res/values-fr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"numéro de carte"</string>
+    <string name="acc_label_expiry_date">"date d’expiration"</string>
+</resources>

--- a/stripe/res/values-it/strings.xml
+++ b/stripe/res/values-it/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"numero della carta"</string>
+    <string name="acc_label_expiry_date">"data di scadenza"</string>
+</resources>

--- a/stripe/res/values-ja/strings.xml
+++ b/stripe/res/values-ja/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"カード番号"</string>
+    <string name="acc_label_expiry_date">"有効期限"</string>
+</resources>

--- a/stripe/res/values-nl/strings.xml
+++ b/stripe/res/values-nl/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"kaartnummer"</string>
+    <string name="acc_label_expiry_date">"vervaldatum"</string>
+</resources>

--- a/stripe/res/values-zh/strings.xml
+++ b/stripe/res/values-zh/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="acc_label_card_number">"卡号"</string>
+    <string name="acc_label_expiry_date">"有效日期"</string>
+</resources>

--- a/stripe/res/values/donottranslate.xml
+++ b/stripe/res/values/donottranslate.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="card_number_hint">4242 4242 4242 4242</string>
+    <string name="cvc_number_hint">CVC</string>
+    <string name="cvc_amex_hint">CVV</string>
+    <string name="expiry_date_hint">MM/YY</string>
+</resources>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="card_number_hint">4242 4242 4242 4242</string>
-    <string name="cvc_number_hint">CVC</string>
-    <string name="cvc_amex_hint">CVV</string>
-    <string name="expiry_date_hint">MM/YY</string>
+    <string name="acc_label_card_number">"card number"</string>
+    <string name="acc_label_expiry_date">"expiration date"</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -108,6 +108,7 @@ public class CardInputView extends FrameLayout {
         mCvcNumberEditText = (StripeEditText) findViewById(R.id.et_cvc_number);
         mCardNumberSpace = findViewById(R.id.space_in_container);
         mCardNumberIsViewed = true;
+        mScrollView.setScrollable(false);
 
         mErrorColorInt = mCardNumberEditText.getDefaultErrorColorInt();
         mTintColorInt = mCardNumberEditText.getHintTextColors().getDefaultColor();

--- a/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
+++ b/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
@@ -1,11 +1,8 @@
 package com.stripe.android.view;
 
 import android.content.Context;
-import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
-import android.view.accessibility.AccessibilityEvent;
 import android.widget.HorizontalScrollView;
 
 /**
@@ -61,24 +58,6 @@ public class LockableHorizontalScrollView extends HorizontalScrollView {
             return;
         }
         super.scrollTo(x, y);
-    }
-
-    @Override
-    public void scrollBy(int x, int y) {
-        if (!mScrollable) {
-            return;
-        }
-        super.scrollBy(x, y);
-    }
-
-    @Override
-    public boolean onRequestSendAccessibilityEvent(View child, AccessibilityEvent event) {
-        return super.onRequestSendAccessibilityEvent(child, event);
-    }
-
-    @Override
-    protected boolean onRequestFocusInDescendants(int direction, Rect previouslyFocusedRect) {
-        return super.onRequestFocusInDescendants(direction, previouslyFocusedRect);
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
+++ b/stripe/src/main/java/com/stripe/android/view/LockableHorizontalScrollView.java
@@ -1,8 +1,11 @@
 package com.stripe.android.view;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.HorizontalScrollView;
 
 /**
@@ -58,6 +61,24 @@ public class LockableHorizontalScrollView extends HorizontalScrollView {
             return;
         }
         super.scrollTo(x, y);
+    }
+
+    @Override
+    public void scrollBy(int x, int y) {
+        if (!mScrollable) {
+            return;
+        }
+        super.scrollBy(x, y);
+    }
+
+    @Override
+    public boolean onRequestSendAccessibilityEvent(View child, AccessibilityEvent event) {
+        return super.onRequestSendAccessibilityEvent(child, event);
+    }
+
+    @Override
+    protected boolean onRequestFocusInDescendants(int direction, Rect previouslyFocusedRect) {
+        return super.onRequestFocusInDescendants(direction, previouslyFocusedRect);
     }
 
     @Override


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @brandur-stripe 

Note: the reason no similar label has been added to the CVC field is that the mobile team has no translations for that field. Will be added as found.

I'm also open to (later) encapsulating the "hidden label" feature into our StripeEditText. Whether or not doing it like this is a *best* practice is hard to tell right this moment, and I don't want to enforce a sort of overdraw here -- I'm necessarily nesting the EditText inside a FrameLayout that wouldn't otherwise be necessary, so I'm causing more layout passes by doing this.