### PR TITLE
logging all token creation calls! (But not token requests, because we don't really do that)

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -1,16 +1,20 @@
 package com.stripe.android.model;
 
 import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
 import com.stripe.android.util.CardUtils;
 import com.stripe.android.util.DateUtils;
+import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeTextUtils;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -85,6 +89,7 @@ public class Card {
     private String fingerprint;
     private String country;
     private String currency;
+    @NonNull private List<String> loggingTokens = new ArrayList<>();
 
     /**
      * Builder class for a {@link Card} model.
@@ -422,6 +427,23 @@ public class Card {
      */
     public String getNumber() {
         return number;
+    }
+
+    /**
+     * @return the {@link List} of logging tokens associated with this {@link Card} object
+     */
+    @NonNull
+    public List<String> getLoggingTokens() {
+        return loggingTokens;
+    }
+
+    /**
+     * Add a logging token to this {@link Card} object.
+     *
+     * @param loggingToken a token to be logged with this card
+     */
+    public void addLoggingToken(@NonNull @LoggingUtils.LoggingToken String loggingToken) {
+        loggingTokens.add(loggingToken);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -441,9 +441,12 @@ public class Card {
      * Add a logging token to this {@link Card} object.
      *
      * @param loggingToken a token to be logged with this card
+     * @return {@code this}, for chaining purposes
      */
-    public void addLoggingToken(@NonNull @LoggingUtils.LoggingToken String loggingToken) {
+    @NonNull
+    public Card addLoggingToken(@NonNull @LoggingUtils.LoggingToken String loggingToken) {
         loggingTokens.add(loggingToken);
+        return this;
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -13,7 +13,9 @@ import com.stripe.android.exception.CardException;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.PermissionException;
 import com.stripe.android.exception.RateLimitException;
+import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Token;
+import com.stripe.android.util.LoggingUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -44,6 +46,7 @@ import javax.net.ssl.SSLSocketFactory;
 public class StripeApiHandler {
 
     public static final String LIVE_API_BASE = "https://api.stripe.com";
+    public static final String LIVE_LOGGING_BASE = "https://q.stripe.com";
     public static final String CHARSET = "UTF-8";
     public static final String TOKENS = "tokens";
     public static final String VERSION = "3.5.0";
@@ -67,6 +70,8 @@ public class StripeApiHandler {
      *                   is being created
      * @param options a {@link RequestOptions} object that contains connection data like the api
      *                key, api version, etc
+     * @param listener a {@link LoggingResponseListener} useful for testing logging calls
+     *
      * @return a {@link Token} that can be used to perform other operations with this card
      * @throws AuthenticationException if there is a problem authenticating to the Stripe API
      * @throws InvalidRequestException if one or more of the parameters is incorrect
@@ -75,14 +80,30 @@ public class StripeApiHandler {
      * @throws APIException for unknown Stripe API errors. These should be rare.
      */
     @Nullable
+    @SuppressWarnings("unchecked")
     public static Token createTokenOnServer(
             @NonNull Map<String, Object> cardParams,
-            @NonNull RequestOptions options)
+            @NonNull RequestOptions options,
+            @Nullable LoggingResponseListener listener)
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
             CardException,
             APIException {
+
+        // Only fires if the card params contain logging information.
+        if (cardParams.containsKey(LoggingUtils.FIELD_PRODUCT_USAGE)) {
+            try {
+                List<String> loggingTokens =
+                        (List<String>) cardParams.get(LoggingUtils.FIELD_PRODUCT_USAGE);
+                cardParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
+                logTokenRequest(loggingTokens, options, listener);
+            } catch (ClassCastException classCastEx) {
+                // This can only happen if someone puts a weird object in the map.
+                cardParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
+            }
+        }
+
         return requestToken(POST, getApiUrl(), cardParams, options);
     }
 
@@ -238,6 +259,63 @@ public class StripeApiHandler {
         }
 
         return conn;
+    }
+
+    private static void logTokenRequest(
+            @NonNull List<String> loggingTokens,
+            @Nullable RequestOptions options,
+            @Nullable LoggingResponseListener listener) {
+        if (options == null) {
+            return;
+        }
+
+        String apiKey = options.getPublishableApiKey();
+        if (apiKey.trim().isEmpty()) {
+            // if there is no apiKey associated with the request, we don't need to react here.
+            return;
+        }
+
+        String originalDNSCacheTTL = null;
+        Boolean allowedToSetTTL = true;
+
+        try {
+            originalDNSCacheTTL = java.security.Security
+                    .getProperty(DNS_CACHE_TTL_PROPERTY_NAME);
+            // disable DNS cache
+            java.security.Security
+                    .setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "0");
+        } catch (SecurityException se) {
+            allowedToSetTTL = false;
+        }
+
+        try {
+            StripeResponse response = getStripeResponse(
+                    GET,
+                    LIVE_LOGGING_BASE,
+                    LoggingUtils.getTokenCreationParams(loggingTokens, apiKey),
+                    options);
+
+            if (listener != null) {
+                listener.onLoggingResponse(response);
+            }
+        } catch(StripeException stripeException) {
+            if (listener != null) {
+                listener.onStripeException(stripeException);
+            }
+            // We're just logging. No need to crash here or attempt to re-log things.
+        } finally {
+            if (allowedToSetTTL) {
+                if (originalDNSCacheTTL == null) {
+                    // value unspecified by implementation
+                    // DNS_CACHE_TTL_PROPERTY_NAME of -1 = cache forever
+                    java.security.Security.setProperty(
+                            DNS_CACHE_TTL_PROPERTY_NAME, "-1");
+                } else {
+                    java.security.Security.setProperty(
+                            DNS_CACHE_TTL_PROPERTY_NAME, originalDNSCacheTTL);
+                }
+            }
+        }
     }
 
     private static Token requestToken(
@@ -519,6 +597,11 @@ public class StripeApiHandler {
 
         responseStream.close();
         return rBody;
+    }
+
+    public interface LoggingResponseListener {
+        void onLoggingResponse(StripeResponse response);
+        void onStripeException(StripeException exception);
     }
 
     private static final class Parameter {

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 import android.support.annotation.VisibleForTesting;
 
+import com.stripe.android.BuildConfig;
 import com.stripe.android.exception.APIConnectionException;
 import com.stripe.android.exception.APIException;
 import com.stripe.android.exception.AuthenticationException;
@@ -49,7 +50,6 @@ public class StripeApiHandler {
     public static final String LIVE_LOGGING_BASE = "https://q.stripe.com";
     public static final String CHARSET = "UTF-8";
     public static final String TOKENS = "tokens";
-    public static final String VERSION = "3.5.0";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -161,7 +161,7 @@ public class StripeApiHandler {
         headers.put("Accept-Charset", CHARSET);
         headers.put("Accept", "application/json");
         headers.put("User-Agent",
-                String.format("Stripe/v1 JavaBindings/%s", VERSION));
+                String.format("Stripe/v1 AndroidBindings/%s", BuildConfig.VERSION_NAME));
 
         headers.put("Authorization", String.format("Bearer %s", options.getPublishableApiKey()));
 
@@ -172,7 +172,7 @@ public class StripeApiHandler {
         propertyMap.put(systemPropertyName, System.getProperty(systemPropertyName));
         propertyMap.put("os.name", "android");
         propertyMap.put("os.version", String.valueOf(Build.VERSION.SDK_INT));
-        propertyMap.put("bindings.version", VERSION);
+        propertyMap.put("bindings.version", BuildConfig.VERSION_NAME);
         propertyMap.put("lang", "Java");
         propertyMap.put("publisher", "Stripe");
         JSONObject headerMappingObject = new JSONObject(propertyMap);

--- a/stripe/src/main/java/com/stripe/android/util/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/LoggingUtils.java
@@ -2,16 +2,12 @@ package com.stripe.android.util;
 
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RawRes;
 import android.support.annotation.StringDef;
 
 import com.stripe.android.BuildConfig;
-import com.stripe.android.net.StripeApiHandler;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,7 +22,7 @@ public class LoggingUtils {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
-            CARD_WIDGET_TOKEN
+            CARD_WIDGET_TOKEN,
     })
     public @interface LoggingToken { }
     public static final String CARD_WIDGET_TOKEN = "CardInputView";
@@ -43,16 +39,26 @@ public class LoggingUtils {
     public static final String EVENT_TOKEN_CREATION = "token_creation";
     public static final String FIELD_PRODUCT_USAGE = "product_usage";
 
+    static final String FIELD_ANALYTICS_UA = "analytics_ua";
+    static final String FIELD_BINDINGS_VERSION = "bindings_version";
+    static final String FIELD_DEVICE_TYPE = "device_type";
+    static final String FIELD_EVENT = "event";
+    static final String FIELD_OS_VERSION = "os_version";
+    static final String FIELD_PUBLISHABLE_KEY = "publishable_key";
+    static final Set<String> VALID_PARAM_FIELDS = new HashSet<>();
+    static {
+        VALID_PARAM_FIELDS.add(FIELD_ANALYTICS_UA);
+        VALID_PARAM_FIELDS.add(FIELD_BINDINGS_VERSION);
+        VALID_PARAM_FIELDS.add(FIELD_DEVICE_TYPE);
+        VALID_PARAM_FIELDS.add(FIELD_EVENT);
+        VALID_PARAM_FIELDS.add(FIELD_OS_VERSION);
+        VALID_PARAM_FIELDS.add(FIELD_PRODUCT_USAGE);
+        VALID_PARAM_FIELDS.add(FIELD_PUBLISHABLE_KEY);
+    }
+
     private static final String ANALYTICS_PREFIX = "analytics";
     private static final String ANALYTICS_NAME = "stripe_android";
     private static final String ANALYTICS_VERSION = "1.0";
-    private static final String FIELD_ANALYTICS_UA = "analytics_ua";
-    private static final String FIELD_EVENT = "event";
-    private static final String FIELD_BINDINGS_VERSION = "bindings_version";
-    private static final String FIELD_DEVICE_TYPE = "device_type";
-    private static final String FIELD_OS_VERSION = "os_version";
-    private static final String FIELD_PUBLISHABLE_KEY = "publishable_key";
-    private static final String FIELD_JAVA_BINDINGS_VERSION = "java_bindings";
 
     @NonNull
     public static Map<String, Object> getTokenCreationParams(
@@ -60,12 +66,11 @@ public class LoggingUtils {
             @NonNull String publishableApiKey) {
         Map<String, Object> paramsObject = new HashMap<>();
         paramsObject.put(FIELD_ANALYTICS_UA, getAnalyticsUa());
-        paramsObject.put(FIELD_EVENT, getEventName(EVENT_TOKEN_CREATION));
+        paramsObject.put(FIELD_EVENT, getEventParamName(EVENT_TOKEN_CREATION));
         paramsObject.put(FIELD_PUBLISHABLE_KEY, publishableApiKey);
         paramsObject.put(FIELD_OS_VERSION, Build.VERSION.SDK_INT);
         paramsObject.put(FIELD_DEVICE_TYPE, getDeviceLoggingString());
         paramsObject.put(FIELD_BINDINGS_VERSION, BuildConfig.VERSION_NAME);
-        paramsObject.put(FIELD_JAVA_BINDINGS_VERSION, StripeApiHandler.VERSION);
         paramsObject.put(FIELD_PRODUCT_USAGE, productUsageTokens);
         return paramsObject;
     }
@@ -85,7 +90,7 @@ public class LoggingUtils {
     }
 
     @NonNull
-    static String getEventName(@NonNull @LoggingEventName String eventName) {
+    static String getEventParamName(@NonNull @LoggingEventName String eventName) {
         return ANALYTICS_NAME + '.' + eventName;
     }
 }

--- a/stripe/src/main/java/com/stripe/android/util/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/LoggingUtils.java
@@ -1,0 +1,91 @@
+package com.stripe.android.util;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
+import android.support.annotation.StringDef;
+
+import com.stripe.android.BuildConfig;
+import com.stripe.android.net.StripeApiHandler;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Util class to create logging items, which are fed as {@link java.util.Map Map} objects in
+ * query parameters to our server.
+ */
+public class LoggingUtils {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            CARD_WIDGET_TOKEN
+    })
+    public @interface LoggingToken { }
+    public static final String CARD_WIDGET_TOKEN = "CardInputView";
+    public static final Set<String> VALID_LOGGING_TOKENS = new HashSet<>();
+    static {
+        VALID_LOGGING_TOKENS.add(CARD_WIDGET_TOKEN);
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            EVENT_TOKEN_CREATION
+    })
+    public @interface LoggingEventName { }
+    public static final String EVENT_TOKEN_CREATION = "token_creation";
+    public static final String FIELD_PRODUCT_USAGE = "product_usage";
+
+    private static final String ANALYTICS_PREFIX = "analytics";
+    private static final String ANALYTICS_NAME = "stripe_android";
+    private static final String ANALYTICS_VERSION = "1.0";
+    private static final String FIELD_ANALYTICS_UA = "analytics_ua";
+    private static final String FIELD_EVENT = "event";
+    private static final String FIELD_BINDINGS_VERSION = "bindings_version";
+    private static final String FIELD_DEVICE_TYPE = "device_type";
+    private static final String FIELD_OS_VERSION = "os_version";
+    private static final String FIELD_PUBLISHABLE_KEY = "publishable_key";
+    private static final String FIELD_JAVA_BINDINGS_VERSION = "java_bindings";
+
+    @NonNull
+    public static Map<String, Object> getTokenCreationParams(
+            @NonNull List<String> productUsageTokens,
+            @NonNull String publishableApiKey) {
+        Map<String, Object> paramsObject = new HashMap<>();
+        paramsObject.put(FIELD_ANALYTICS_UA, getAnalyticsUa());
+        paramsObject.put(FIELD_EVENT, getEventName(EVENT_TOKEN_CREATION));
+        paramsObject.put(FIELD_PUBLISHABLE_KEY, publishableApiKey);
+        paramsObject.put(FIELD_OS_VERSION, Build.VERSION.SDK_INT);
+        paramsObject.put(FIELD_DEVICE_TYPE, getDeviceLoggingString());
+        paramsObject.put(FIELD_BINDINGS_VERSION, BuildConfig.VERSION_NAME);
+        paramsObject.put(FIELD_JAVA_BINDINGS_VERSION, StripeApiHandler.VERSION);
+        paramsObject.put(FIELD_PRODUCT_USAGE, productUsageTokens);
+        return paramsObject;
+    }
+
+    @NonNull
+    static String getDeviceLoggingString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(Build.MANUFACTURER).append('_')
+                .append(Build.BRAND).append('_')
+                .append(Build.MODEL);
+        return builder.toString();
+    }
+
+    @NonNull
+    static String getAnalyticsUa() {
+        return ANALYTICS_PREFIX + "." + ANALYTICS_NAME + "-" + ANALYTICS_VERSION;
+    }
+
+    @NonNull
+    static String getEventName(@NonNull @LoggingEventName String eventName) {
+        return ANALYTICS_NAME + '.' + eventName;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
@@ -44,6 +44,10 @@ public class StripeNetworkUtils {
         // Remove all null values; they cause validation errors
         removeNullParams(cardParams);
 
+        // We store the logging items in this field, which is extracted from the parameters
+        // sent to the API.
+        tokenParams.put(LoggingUtils.FIELD_PRODUCT_USAGE, card.getLoggingTokens());
+
         tokenParams.put(Token.TYPE_CARD, cardParams);
         return tokenParams;
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardInputView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputView.java
@@ -19,6 +19,7 @@ import android.widget.ImageView;
 import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.util.CardUtils;
+import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeTextUtils;
 
 import java.util.HashMap;
@@ -95,7 +96,8 @@ public class CardInputView extends FrameLayout {
             return null;
         }
 
-        return new Card(cardNumber, cardDate[0], cardDate[1], cvcValue);
+        return new Card(cardNumber, cardDate[0], cardDate[1], cvcValue)
+                .addLoggingToken(LoggingUtils.CARD_WIDGET_TOKEN);
     }
 
     private void initView(AttributeSet attrs) {

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -8,6 +8,7 @@ import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 import com.stripe.android.net.StripeApiHandler;
 import com.stripe.android.net.StripeResponse;
+import com.stripe.android.util.LoggingUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static org.junit.Assert.fail;
  * Test class for {@link Stripe}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 23)
 public class StripeTest {
 
 
@@ -274,6 +275,9 @@ public class StripeTest {
             Stripe stripe = new Stripe(FUNCTIONAL_PUBLISHABLE_KEY);
             TestLoggingListener testLoggingListener = new TestLoggingListener();
             stripe.setLoggingResponseListener(testLoggingListener);
+
+            // Pretend that this one was created by the CardInputView
+            mCard.addLoggingToken(LoggingUtils.CARD_WIDGET_TOKEN);
 
             Token token = stripe.createTokenSynchronous(mCard);
             // Check that we get a token back; we don't care about its fields for this test.

--- a/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
@@ -1,5 +1,6 @@
 package com.stripe.android.net;
 
+import com.stripe.android.BuildConfig;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.model.Card;
 import com.stripe.android.util.LoggingUtils;
@@ -25,7 +26,7 @@ import static org.junit.Assert.fail;
  * Test class for {@link StripeApiHandler}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(constants = BuildConfig.class, sdk = 23)
 public class StripeApiHandlerTest {
 
     @Test
@@ -78,7 +79,7 @@ public class StripeApiHandlerTest {
         String userAgentRawString = headerMap.get("X-Stripe-Client-User-Agent");
         try {
             JSONObject mapObject = new JSONObject(userAgentRawString);
-            assertEquals("3.5.0", mapObject.getString("bindings.version"));
+            assertEquals(BuildConfig.VERSION_NAME, mapObject.getString("bindings.version"));
             assertEquals("Java", mapObject.getString("lang"));
             assertEquals("Stripe", mapObject.getString("publisher"));
             assertEquals("android", mapObject.getString("os.name"));
@@ -94,7 +95,9 @@ public class StripeApiHandlerTest {
         Map<String, String> headerMap = StripeApiHandler.getHeaders(requestOptions);
         assertNotNull(headerMap);
 
-        assertEquals("Stripe/v1 JavaBindings/3.5.0", headerMap.get("User-Agent"));
+        final String expectedUserAgent =
+                String.format("Stripe/v1 AndroidBindings/%s", BuildConfig.VERSION_NAME);
+        assertEquals(expectedUserAgent, headerMap.get("User-Agent"));
         assertEquals("application/json", headerMap.get("Accept"));
         assertEquals("UTF-8", headerMap.get("Accept-Charset"));
     }

--- a/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
@@ -2,6 +2,7 @@ package com.stripe.android.net;
 
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.model.Card;
+import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeNetworkUtils;
 
 import org.json.JSONException;
@@ -102,8 +103,8 @@ public class StripeApiHandlerTest {
     public void createQuery_withCardData_createsProperQueryString() {
         Card card = new Card.Builder("4242424242424242", 8, 2019, "123").build();
         Map<String, Object> cardMap = StripeNetworkUtils.hashMapFromCard(card);
-        String expectedValue = "card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123&card%5" +
-                "Bexp_month%5D=8&card%5Bexp_year%5D=2019";
+        String expectedValue = "product_usage=&card%5Bnumber%5D=4242424242424242&card%5B" +
+                "cvc%5D=123&card%5Bexp_month%5D=8&card%5Bexp_year%5D=2019";
         try {
             String query = StripeApiHandler.createQuery(cardMap);
             assertEquals(expectedValue, query);

--- a/stripe/src/test/java/com/stripe/android/util/LoggingUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/LoggingUtilsTest.java
@@ -1,0 +1,73 @@
+package com.stripe.android.util;
+
+import android.util.Log;
+
+import com.stripe.android.BuildConfig;
+import com.stripe.android.model.Card;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for {@link LoggingUtils}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 23)
+public class LoggingUtilsTest {
+
+    private static final String DUMMY_API_KEY = "pk_abc123";
+    private static final List<String> EXPECTED_SINGLE_TOKEN_LIST = new ArrayList<>();
+    static {
+        EXPECTED_SINGLE_TOKEN_LIST.add(LoggingUtils.CARD_WIDGET_TOKEN);
+    }
+
+    @Test
+    public void getTokenCreationParams_withValidInput_createsCorrectMap() {
+        List<String> tokensList = new ArrayList<>();
+        tokensList.add(LoggingUtils.CARD_WIDGET_TOKEN);
+        // Correctness of these methods will be tested elsewhere. Assume validity for this test.
+        final String expectedTokenName =
+                LoggingUtils.getEventParamName(LoggingUtils.EVENT_TOKEN_CREATION);
+        final String expectedUaName = LoggingUtils.getAnalyticsUa();
+
+        Map<String, Object> params = LoggingUtils.getTokenCreationParams(tokensList, DUMMY_API_KEY);
+        assertEquals(LoggingUtils.VALID_PARAM_FIELDS.size(), params.size());
+        assertEquals(DUMMY_API_KEY, params.get(LoggingUtils.FIELD_PUBLISHABLE_KEY));
+        assertEquals(EXPECTED_SINGLE_TOKEN_LIST, params.get(LoggingUtils.FIELD_PRODUCT_USAGE));
+        // Expected value is 23 because that's the number in the @Config for this test class.
+        assertEquals(23, params.get(LoggingUtils.FIELD_OS_VERSION));
+
+        // The @Config constants param means BuildConfig constants are the same in prod as in test.
+        assertEquals(BuildConfig.VERSION_NAME, params.get(LoggingUtils.FIELD_BINDINGS_VERSION));
+        assertEquals(expectedTokenName, params.get(LoggingUtils.FIELD_EVENT));
+        assertEquals(expectedUaName, params.get(LoggingUtils.FIELD_ANALYTICS_UA));
+
+        // Not yet PowerMocking android.os.Build -- just check that this is logged.
+        assertNotNull(params.get(LoggingUtils.FIELD_DEVICE_TYPE));
+    }
+
+    @Test
+    public void getEventParamName_withTokenCreation_createsExpectedParameter() {
+        final String expectedEventParam = "stripe_android.token_creation";
+        assertEquals(expectedEventParam,
+                LoggingUtils.getEventParamName(LoggingUtils.EVENT_TOKEN_CREATION));
+    }
+
+    @Test
+    public void getAnalyticsUa_returnsExpectedValue() {
+        final String androidAnalyticsUserAgent = "analytics.stripe_android-1.0";
+        assertEquals(androidAnalyticsUserAgent, LoggingUtils.getAnalyticsUa());
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputViewTest.java
@@ -11,6 +11,7 @@ import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
+import com.stripe.android.util.LoggingUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
 import java.util.Calendar;
+import java.util.List;
 
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_NO_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
@@ -33,6 +35,7 @@ import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_NO_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -57,6 +60,8 @@ public class CardInputViewTest {
 
     @Mock LockableHorizontalScrollView.LockableScrollChangedListener mLockableScrollChangedListener;
 
+    // Every Card made by the CardInputView should have the card widget token.
+    private static final String[] EXPECTED_LOGGING_ARRAY = { LoggingUtils.CARD_WIDGET_TOKEN };
     private CardInputView mCardInputView;
     private CardNumberEditText mCardNumberEditText;
     private CardInputView.CustomWidthSetter mCustomWidthSetter;
@@ -102,7 +107,7 @@ public class CardInputViewTest {
     }
 
     @Test
-    public void getCard_whenInputIsValidVisa_returnsCardObject() {
+    public void getCard_whenInputIsValidVisa_returnsCardObjectWithLoggingToken() {
         // The input date here will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
 
@@ -120,10 +125,11 @@ public class CardInputViewTest {
         assertEquals(2050, card.getExpYear().intValue());
         assertEquals("123", card.getCVC());
         assertTrue(card.validateCard());
+        assertArrayEquals(EXPECTED_LOGGING_ARRAY, card.getLoggingTokens().toArray());
     }
 
     @Test
-    public void getCard_whenInputIsValidAmEx_returnsCardObject() {
+    public void getCard_whenInputIsValidAmEx_returnsCardObjectWithLoggingToken() {
         // The input date here will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
 
@@ -141,10 +147,11 @@ public class CardInputViewTest {
         assertEquals(2050, card.getExpYear().intValue());
         assertEquals("1234", card.getCVC());
         assertTrue(card.validateCard());
+        assertArrayEquals(EXPECTED_LOGGING_ARRAY, card.getLoggingTokens().toArray());
     }
 
     @Test
-    public void getCard_whenInputIsValidDinersClub_returnsCardObject() {
+    public void getCard_whenInputIsValidDinersClub_returnsCardObjectWithLoggingToken() {
         // The input date here will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
 
@@ -162,6 +169,7 @@ public class CardInputViewTest {
         assertEquals(2050, card.getExpYear().intValue());
         assertEquals("123", card.getCVC());
         assertTrue(card.validateCard());
+        assertArrayEquals(EXPECTED_LOGGING_ARRAY, card.getLoggingTokens().toArray());
     }
 
     @Test


### PR DESCRIPTION
r? @brandur-stripe 
cc @sjayaraman-stripe 

Adding a logging call before the calls to create a token on the server. Logging fields equivalent to the iOS logging:
```javascript
{
    "analytics_ua" = "analytics.stripe_android-1.0";
    "event" = "stripe_android.token_creation";
    "bindings_version" = "2.1.0";
    "device_type" = MANUFACTURER_BRAND_MODEL; // samsung_galaxy_s7
    "os_version" = "25"; // android sdk number
    "publishable_key" = "pk_test_1";
    "product_usage" = ["CardInputView"] // either CardInputView or nothing for now, but will expand in future
}
```