### PR TITLE
removing incorrect deprecations

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -454,6 +454,7 @@ public class Card {
      *
      * @param number the new {@link #number}
      */
+    @Deprecated
     public void setNumber(String number) {
         this.number = number;
         this.brand = null;
@@ -470,6 +471,7 @@ public class Card {
     /**
      * @param cvc the new {@link #cvc} code for this card
      */
+    @Deprecated
     public void setCVC(String cvc) {
         this.cvc = cvc;
     }
@@ -486,6 +488,7 @@ public class Card {
     /**
      * @param expMonth sets the {@link #expMonth} for this card
      */
+    @Deprecated
     public void setExpMonth(@Nullable @IntRange(from = 1, to = 12) Integer expMonth) {
         this.expMonth = expMonth;
     }
@@ -500,6 +503,7 @@ public class Card {
     /**
      * @param expYear sets the {@link #expYear} for this card
      */
+    @Deprecated
     public void setExpYear(Integer expYear) {
         this.expYear = expYear;
     }

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -16,7 +16,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 
-
 /**
  * A model object representing a Card in the Android SDK.
  */
@@ -455,7 +454,6 @@ public class Card {
      *
      * @param number the new {@link #number}
      */
-    @Deprecated
     public void setNumber(String number) {
         this.number = number;
         this.brand = null;
@@ -472,7 +470,6 @@ public class Card {
     /**
      * @param cvc the new {@link #cvc} code for this card
      */
-    @Deprecated
     public void setCVC(String cvc) {
         this.cvc = cvc;
     }
@@ -489,7 +486,6 @@ public class Card {
     /**
      * @param expMonth sets the {@link #expMonth} for this card
      */
-    @Deprecated
     public void setExpMonth(@Nullable @IntRange(from = 1, to = 12) Integer expMonth) {
         this.expMonth = expMonth;
     }
@@ -504,7 +500,6 @@ public class Card {
     /**
      * @param expYear sets the {@link #expYear} for this card
      */
-    @Deprecated
     public void setExpYear(Integer expYear) {
         this.expYear = expYear;
     }
@@ -519,7 +514,6 @@ public class Card {
     /**
      * @param name sets the cardholder {@link #name} for this card
      */
-    @Deprecated
     public void setName(String name) {
         this.name = name;
     }
@@ -534,7 +528,6 @@ public class Card {
     /**
      * @param addressLine1 sets the {@link #addressLine1} for this card
      */
-    @Deprecated
     public void setAddressLine1(String addressLine1) {
         this.addressLine1 = addressLine1;
     }
@@ -549,7 +542,6 @@ public class Card {
     /**
      * @param addressLine2 sets the {@link #addressLine2} for this card
      */
-    @Deprecated
     public void setAddressLine2(String addressLine2) {
         this.addressLine2 = addressLine2;
     }
@@ -564,7 +556,6 @@ public class Card {
     /**
      * @param addressCity sets the {@link #addressCity} for this card
      */
-    @Deprecated
     public void setAddressCity(String addressCity) {
         this.addressCity = addressCity;
     }
@@ -579,7 +570,6 @@ public class Card {
     /**
      * @param addressZip sets the {@link #addressZip} for this card
      */
-    @Deprecated
     public void setAddressZip(String addressZip) {
         this.addressZip = addressZip;
     }
@@ -594,7 +584,6 @@ public class Card {
     /**
      * @param addressState sets the {@link #addressState} for this card
      */
-    @Deprecated
     public void setAddressState(String addressState) {
         this.addressState = addressState;
     }
@@ -609,7 +598,6 @@ public class Card {
     /**
      * @param addressCountry sets the {@link #addressCountry} for this card
      */
-    @Deprecated
     public void setAddressCountry(String addressCountry) {
         this.addressCountry = addressCountry;
     }
@@ -624,7 +612,6 @@ public class Card {
     /**
      * @param currency sets the {@link #currency} of this card. Only supported for Managed accounts.
      */
-    @Deprecated
     public void setCurrency(String currency) {
         this.currency = currency;
     }


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @brandur-stripe 

Long ago, I deprecated the setter methods on the Card object, encouraging users to create a Builder object. It's a little bit neater way of doing things and discourages card details from being altered. (Ideally, they'd be set-once values). I didn't consider that the (at the time nonexistent) card input widget would only take Number/Expiry/CVC, and if you wanted to put any other details on the card, you should call the setters. So those shouldn't be deprecated.

This diff just removes the @Deprecated tags on the setters that are perfectly valid to use now.