### PR TITLE
adding ability to create a source token, with full integration tests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/SourceCallback.java
+++ b/stripe/src/main/java/com/stripe/android/SourceCallback.java
@@ -1,12 +1,12 @@
 package com.stripe.android;
 
-import com.stripe.android.model.Token;
+import com.stripe.android.model.Source;
 
 /**
  * An interface representing a callback to be notified about the results of
- * {@link Token} creation or requests
+ * {@link Source} creation.
  */
-public interface TokenCallback {
+public interface SourceCallback {
 
     /**
      * Error callback method.
@@ -16,7 +16,7 @@ public interface TokenCallback {
 
     /**
      * Success callback method.
-     * @param token the {@link Token} that was found or created.
+     * @param source the {@link Source} that was found or created.
      */
-    void onSuccess(Token token);
+    void onSuccess(Source source);
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -349,7 +349,6 @@ public class Stripe {
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
      * @throws InvalidRequestException your request has invalid parameters
      * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws CardException the card cannot be charged for some reason
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers
      */
@@ -359,13 +358,12 @@ public class Stripe {
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
-            CardException,
             APIException {
         String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
         if (apiKey == null) {
             return null;
         }
-        return StripeApiHandler.createSourceOnServer(params, publishableKey);
+        return StripeApiHandler.createSourceOnServer(params, apiKey);
     }
 
     /**
@@ -402,7 +400,6 @@ public class Stripe {
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
      * @throws InvalidRequestException your request has invalid parameters
      * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws CardException the card cannot be charged for some reason
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers)
      */
@@ -472,10 +469,6 @@ public class Stripe {
                     "instead of the publishable one. For more info, " +
                     "see https://stripe.com/docs/stripe.js", null, 0);
         }
-    }
-
-    private void sourceTaskPostExecution(ResponseWrapper result, SourceCallback callback) {
-
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -20,6 +20,8 @@ import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 import com.stripe.android.net.RequestOptions;
 import com.stripe.android.net.StripeApiHandler;
@@ -31,6 +33,41 @@ import static com.stripe.android.util.StripeNetworkUtils.hashMapFromCard;
  * Class that handles {@link Token} creation from charges and {@link Card} models.
  */
 public class Stripe {
+
+    SourceCreator mSourceCreator = new SourceCreator() {
+        @Override
+        public void create(
+                @NonNull final SourceParams sourceParams,
+                @NonNull final String publishableKey,
+                @Nullable Executor executor,
+                @NonNull final SourceCallback sourceCallback) {
+            AsyncTask<Void, Void, ResponseWrapper> task =
+                    new AsyncTask<Void, Void, ResponseWrapper>() {
+                        @Override
+                        protected ResponseWrapper doInBackground(Void... params) {
+                            try {
+                                Source source = StripeApiHandler.createSourceOnServer(
+                                        sourceParams,
+                                        publishableKey);
+                                return new ResponseWrapper(source);
+                            } catch (StripeException stripeException) {
+                                return new ResponseWrapper(stripeException);
+                            }
+                        }
+
+                        @Override
+                        protected void onPostExecute(ResponseWrapper responseWrapper) {
+                            if (responseWrapper.source != null) {
+                                sourceCallback.onSuccess(responseWrapper.source);
+                            } else if (responseWrapper.error != null) {
+                                sourceCallback.onError(responseWrapper.error);
+                            }
+                        }
+                    };
+
+            executeTask(executor, task);
+        }
+    };
 
     @VisibleForTesting
     TokenCreator mTokenCreator = new TokenCreator() {
@@ -51,9 +88,9 @@ public class Stripe {
                                         tokenParams,
                                         requestOptions,
                                         mLoggingResponseListener);
-                                return new ResponseWrapper(token, null);
+                                return new ResponseWrapper(token);
                             } catch (StripeException e) {
-                                return new ResponseWrapper(null, e);
+                                return new ResponseWrapper(e);
                             }
                         }
 
@@ -63,7 +100,7 @@ public class Stripe {
                         }
             };
 
-            executeTokenTask(executor, task);
+            executeTask(executor, task);
         }
     };
 
@@ -184,6 +221,37 @@ public class Stripe {
     }
 
     /**
+     * Create a {@link Source} using an {@link AsyncTask} on the default {@link Executor} with a
+     * publishable api key that has already been set on this {@link Stripe} instance.
+     *
+     * @param sourceParams the {@link SourceParams} to be used
+     * @param callback a {@link SourceCallback} to receive a result or an error message
+     */
+    public void createSource(@NonNull SourceParams sourceParams, @NonNull SourceCallback callback) {
+        createSource(sourceParams, callback, null, null);
+    }
+
+    /**
+     * Create a {@link Source} using an {@link AsyncTask}.
+     *
+     * @param sourceParams the {@link SourceParams} to be used
+     * @param callback a {@link SourceCallback} to receive a result or an error message
+     * @param publishableKey the publishable api key to be used
+     * @param executor an {@link Executor} on which to execute the task, or {@link null} for default
+     */
+    public void createSource(
+            @NonNull SourceParams sourceParams,
+            @NonNull SourceCallback callback,
+            @Nullable String publishableKey,
+            @Nullable Executor executor) {
+        String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
+        if (apiKey == null) {
+            return;
+        }
+        mSourceCreator.create(sourceParams, apiKey, executor, callback);
+    }
+
+    /**
      * The simplest way to create a token, using a {@link Card} and {@link TokenCallback}. This
      * runs on the default {@link Executor} and with the
      * currently set {@link #mDefaultPublishableKey}.
@@ -243,6 +311,61 @@ public class Stripe {
         }
 
         createTokenFromParams(hashMapFromCard(mContext, card), publishableKey, executor, callback);
+    }
+
+    /**
+     * Blocking method to create a {@link Source} object using this object's
+     * {@link Stripe#mDefaultPublishableKey key}.
+     *
+     * Do not call this on the UI thread or your app will crash.
+     *
+     * @param params a set of {@link SourceParams} with which to create the source
+     * @return a {@link Source}, or {@code null} if a problem occurred
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws CardException the card cannot be charged for some reason
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers
+     */
+    @Nullable
+    public Source createSourceSynchronous(@NonNull SourceParams params)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        return createSourceSynchronous(params, null);
+    }
+
+    /**
+     * Blocking method to create a {@link Source} object.
+     * Do not call this on the UI thread or your app will crash.
+     *
+     * @param params a set of {@link SourceParams} with which to create the source
+     * @param publishableKey a publishable API key to use
+     * @return a {@link Source}, or {@code null} if a problem occurred
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws CardException the card cannot be charged for some reason
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers
+     */
+    public Source createSourceSynchronous(
+            @NonNull SourceParams params,
+            @Nullable String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
+        if (apiKey == null) {
+            return null;
+        }
+        return StripeApiHandler.createSourceOnServer(params, publishableKey);
     }
 
     /**
@@ -351,6 +474,10 @@ public class Stripe {
         }
     }
 
+    private void sourceTaskPostExecution(ResponseWrapper result, SourceCallback callback) {
+
+    }
+
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {
         if (result.token != null) {
             callback.onSuccess(result.token);
@@ -364,7 +491,7 @@ public class Stripe {
         }
     }
 
-    private void executeTokenTask(Executor executor, AsyncTask<Void, Void, ResponseWrapper> task) {
+    private void executeTask(Executor executor, AsyncTask<Void, Void, ResponseWrapper> task) {
         if (executor != null && Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB) {
             task.executeOnExecutor(executor);
         } else {
@@ -373,13 +500,35 @@ public class Stripe {
     }
 
     private class ResponseWrapper {
+        final Source source;
         final Token token;
         final Exception error;
 
-        private ResponseWrapper(Token token, Exception error) {
-            this.error = error;
+        private ResponseWrapper(Token token) {
             this.token = token;
+            this.source = null;
+            this.error = null;
         }
+
+        private ResponseWrapper(Source source) {
+            this.source = source;
+            this.error = null;
+            this.token = null;
+        }
+
+        private ResponseWrapper(Exception error) {
+            this.error = error;
+            this.source = null;
+            this.token = null;
+        }
+    }
+
+    interface SourceCreator {
+        void create(
+                @NonNull SourceParams params,
+                @NonNull String publishableKey,
+                @Nullable Executor executor,
+                @NonNull SourceCallback sourceCallback);
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
@@ -59,64 +59,64 @@ public class SourceOwner extends StripeJsonModel {
         mVerifiedPhone = verifiedPhone;
     }
 
-    SourceAddress getAddress() {
+    public SourceAddress getAddress() {
         return mAddress;
+    }
+
+    public String getEmail() {
+        return mEmail;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public String getPhone() {
+        return mPhone;
+    }
+
+    public SourceAddress getVerifiedAddress() {
+        return mVerifiedAddress;
+    }
+
+    public String getVerifiedEmail() {
+        return mVerifiedEmail;
+    }
+
+    public String getVerifiedName() {
+        return mVerifiedName;
+    }
+
+    public String getVerifiedPhone() {
+        return mVerifiedPhone;
     }
 
     void setAddress(SourceAddress address) {
         mAddress = address;
     }
 
-    String getEmail() {
-        return mEmail;
-    }
-
     void setEmail(String email) {
         mEmail = email;
-    }
-
-    String getName() {
-        return mName;
     }
 
     void setName(String name) {
         mName = name;
     }
 
-    String getPhone() {
-        return mPhone;
-    }
-
     void setPhone(String phone) {
         mPhone = phone;
-    }
-
-    SourceAddress getVerifiedAddress() {
-        return mVerifiedAddress;
     }
 
     void setVerifiedAddress(SourceAddress verifiedAddress) {
         mVerifiedAddress = verifiedAddress;
     }
 
-    String getVerifiedEmail() {
-        return mVerifiedEmail;
-    }
-
     void setVerifiedEmail(String verifiedEmail) {
         mVerifiedEmail = verifiedEmail;
     }
 
-    String getVerifiedName() {
-        return mVerifiedName;
-    }
-
     void setVerifiedName(String verifiedName) {
         mVerifiedName = verifiedName;
-    }
-
-    String getVerifiedPhone() {
-        return mVerifiedPhone;
     }
 
     void setVerifiedPhone(String verifiedPhone) {

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -76,7 +76,6 @@ public class StripeApiHandler {
      * @throws AuthenticationException if there is a problem authenticating to the Stripe API
      * @throws InvalidRequestException if one or more of the parameters is incorrect
      * @throws APIConnectionException if there is a problem connecting to the Stripe API
-     * @throws CardException if there is a problem with the card information
      * @throws APIException for unknown Stripe API errors. These should be rare.
      */
     @Nullable
@@ -86,12 +85,20 @@ public class StripeApiHandler {
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
-            CardException,
             APIException {
         Map<String, Object> paramMap = sourceParams.toParamMap();
         RequestOptions options = RequestOptions.builder(publishableKey).build();
 
-        return Source.fromString(requestData(POST, getSourcesUrl(), paramMap, options));
+        try {
+            return Source.fromString(requestData(POST, getSourcesUrl(), paramMap, options));
+        } catch (CardException unexpected) {
+            // This particular kind of exception should not be possible from a Source API endpoint.
+            throw new APIException(
+                    unexpected.getMessage(),
+                    unexpected.getRequestId(),
+                    unexpected.getStatusCode(),
+                    unexpected);
+        }
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -350,6 +350,8 @@ public class StripeTest {
             Source threeDSource =
                     stripe.createSourceSynchronous(threeDParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
             assertNotNull(threeDSource);
+            assertEquals(50L, threeDSource.getAmount().longValue());
+            assertEquals("brl", threeDSource.getCurrency());
             assertNotNull(threeDSource.getClientSecret());
             assertNotNull(threeDSource.getId());
             assertEquals(Source.THREE_D_SECURE, threeDSource.getType());
@@ -373,6 +375,8 @@ public class StripeTest {
             assertNotNull(giropaySource);
             assertNotNull(giropaySource.getClientSecret());
             assertNotNull(giropaySource.getId());
+            assertEquals("eur", giropaySource.getCurrency());
+            assertEquals(2000L, giropaySource.getAmount().longValue());
             assertEquals(Source.GIROPAY, giropaySource.getType());
             assertNotNull(giropaySource.getSourceTypeData());
             assertNotNull(giropaySource.getOwner());
@@ -405,6 +409,7 @@ public class StripeTest {
             assertNotNull(sepaDebitSource.getSourceTypeData());
             assertNotNull(sepaDebitSource.getOwner());
             assertNotNull(sepaDebitSource.getOwner().getAddress());
+            assertEquals("eur", sepaDebitSource.getCurrency());
             assertEquals("Eureka", sepaDebitSource.getOwner().getAddress().getCity());
             assertEquals("90210", sepaDebitSource.getOwner().getAddress().getPostalCode());
             assertEquals("123 Main St", sepaDebitSource.getOwner().getAddress().getLine1());
@@ -430,7 +435,9 @@ public class StripeTest {
             assertNotNull(idealSource);
             assertNotNull(idealSource.getClientSecret());
             assertNotNull(idealSource.getId());
+            assertEquals(5500L, idealSource.getAmount().longValue());
             assertEquals(Source.IDEAL, idealSource.getType());
+            assertEquals("eur", idealSource.getCurrency());
             assertNotNull(idealSource.getSourceTypeData());
             assertNotNull(idealSource.getOwner());
             assertEquals("Bond", idealSource.getOwner().getName());

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -267,6 +267,7 @@ public class StripeTest {
             assertNotNull(bitcoinSource.getSourceTypeData());
             assertNotNull(bitcoinSource.getOwner());
             assertEquals("abc@def.com", bitcoinSource.getOwner().getEmail());
+            assertEquals("usd", bitcoinSource.getCurrency());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -300,6 +300,12 @@ public class StripeTest {
     public void createSourceSynchronous_withCardParams_passesIntegrationTest() {
         Stripe stripe = new Stripe(mContext);
         Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
+        card.setAddressCity("Sheboygan");
+        card.setAddressCountry("US");
+        card.setAddressLine1("123 Main St");
+        card.setAddressLine2("#456");
+        card.setAddressZip("53081");
+        card.setAddressState("WI");
         SourceParams params = SourceParams.createCardParams(card);
         try {
             Source cardSource =
@@ -309,6 +315,15 @@ public class StripeTest {
             assertNotNull(cardSource.getId());
             assertEquals(Source.CARD, cardSource.getType());
             assertNotNull(cardSource.getSourceTypeData());
+
+            assertNotNull(cardSource.getOwner());
+            assertNotNull(cardSource.getOwner().getAddress());
+            assertEquals("Sheboygan", cardSource.getOwner().getAddress().getCity());
+            assertEquals("WI", cardSource.getOwner().getAddress().getState());
+            assertEquals("53081", cardSource.getOwner().getAddress().getPostalCode());
+            assertEquals("123 Main St", cardSource.getOwner().getAddress().getLine1());
+            assertEquals("#456", cardSource.getOwner().getAddress().getLine2());
+            assertEquals("US", cardSource.getOwner().getAddress().getCountry());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Adding the ability to create a source on our server, along with full integration tests for so doing. #itsalive 

* Unfortunately this includes support for the batteries-included old-fashioned version that calls to an asynchronous task, which added more code than the synchronous method by a long shot.