### PR TITLE
adding metadata to sources, plus the name field in cards

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -112,7 +112,7 @@ public class Source extends StripeJsonModel {
     private String mCurrency;
     private @SourceFlow String mFlow;
     private Boolean mLiveMode;
-    private Map<String, Object> mMetaData;
+    private Map<String, String> mMetaData;
     private SourceOwner mOwner;
     private SourceReceiver mReceiver;
     private SourceRedirect mRedirect;
@@ -130,7 +130,7 @@ public class Source extends StripeJsonModel {
             String currency,
             @SourceFlow String flow,
             Boolean liveMode,
-            Map<String, Object> metaData,
+            Map<String, String> metaData,
             SourceOwner owner,
             SourceReceiver receiver,
             SourceRedirect redirect,
@@ -190,7 +190,7 @@ public class Source extends StripeJsonModel {
         return mLiveMode;
     }
 
-    public Map<String, Object> getMetaData() {
+    public Map<String, String> getMetaData() {
         return mMetaData;
     }
 
@@ -257,7 +257,7 @@ public class Source extends StripeJsonModel {
         mLiveMode = liveMode;
     }
 
-    public void setMetaData(Map<String, Object> metaData) {
+    public void setMetaData(Map<String, String> metaData) {
         mMetaData = metaData;
     }
 
@@ -381,8 +381,8 @@ public class Source extends StripeJsonModel {
         String currency = optString(jsonObject, FIELD_CURRENCY);
         @SourceFlow String flow = asSourceFlow(optString(jsonObject, FIELD_FLOW));
         Boolean liveMode = jsonObject.optBoolean(FIELD_LIVEMODE);
-        Map<String, Object> metadata =
-                StripeJsonUtils.jsonObjectToMap(jsonObject.optJSONObject(FIELD_METADATA));
+        Map<String, String> metadata =
+                StripeJsonUtils.jsonObjectToStringMap(jsonObject.optJSONObject(FIELD_METADATA));
         SourceOwner owner = optStripeJsonModel(jsonObject, FIELD_OWNER, SourceOwner.class);
         SourceReceiver receiver = optStripeJsonModel(
                 jsonObject,

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -7,10 +7,9 @@ import android.support.annotation.Size;
 
 import com.stripe.android.util.StripeNetworkUtils;
 
+import java.security.acl.Owner;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static com.stripe.android.model.Source.SourceType;
 import static com.stripe.android.util.StripeNetworkUtils.removeNullParams;
@@ -22,6 +21,7 @@ public class SourceParams {
 
     static final String API_PARAM_AMOUNT = "amount";
     static final String API_PARAM_CURRENCY = "currency";
+    static final String API_PARAM_METADATA = "metadata";
     static final String API_PARAM_OWNER = "owner";
     static final String API_PARAM_REDIRECT = "redirect";
     static final String API_PARAM_TYPE = "type";
@@ -49,6 +49,7 @@ public class SourceParams {
     private Map<String, Object> mApiParameterMap;
     private String mCurrency;
     private Map<String, Object> mOwner;
+    private Map<String, String> mMetaData;
     private Map<String, Object> mRedirect;
     @SourceType private String mType;
 
@@ -136,8 +137,14 @@ public class SourceParams {
         removeNullParams(addressMap);
 
         // If there are any keys left...
+        Map<String, Object> ownerMap = new HashMap<>();
+        ownerMap.put(FIELD_NAME, card.getName());
         if (addressMap.keySet().size() > 0) {
-            params.setOwner(createSimpleMap(FIELD_ADDRESS, addressMap));
+            ownerMap.put(FIELD_ADDRESS, addressMap);
+        }
+        removeNullParams(ownerMap);
+        if (ownerMap.keySet().size() > 0) {
+            params.setOwner(ownerMap);
         }
 
         return params;
@@ -349,6 +356,22 @@ public class SourceParams {
     }
 
     /**
+     * @return the custom metadata set on these params
+     */
+    public Map<String, String> getMetaData() {
+        return mMetaData;
+    }
+
+    /**
+     * Set custom metadata on the parameters.
+     *
+     * @param metaData
+     */
+    public void setMetaData(@NonNull Map<String, String> metaData) {
+        mMetaData = metaData;
+    }
+
+    /**
      * Create a string-keyed map representing this object that is
      * ready to be sent over the network.
      *
@@ -357,12 +380,13 @@ public class SourceParams {
     @NonNull
     public Map<String, Object> toParamMap() {
         Map<String, Object> networkReadyMap = new HashMap<>();
-        networkReadyMap.put(API_PARAM_TYPE, getType());
-        networkReadyMap.put(getType(), getApiParameterMap());
-        networkReadyMap.put(API_PARAM_AMOUNT, getAmount());
-        networkReadyMap.put(API_PARAM_CURRENCY, getCurrency());
-        networkReadyMap.put(API_PARAM_OWNER, getOwner());
-        networkReadyMap.put(API_PARAM_REDIRECT, getRedirect());
+        networkReadyMap.put(API_PARAM_TYPE, mType);
+        networkReadyMap.put(mType, mApiParameterMap);
+        networkReadyMap.put(API_PARAM_AMOUNT, mAmount);
+        networkReadyMap.put(API_PARAM_CURRENCY, mCurrency);
+        networkReadyMap.put(API_PARAM_OWNER, mOwner);
+        networkReadyMap.put(API_PARAM_REDIRECT, mRedirect);
+        networkReadyMap.put(API_PARAM_METADATA, mMetaData);
         StripeNetworkUtils.removeNullParams(networkReadyMap);
         return networkReadyMap;
     }

--- a/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeJsonUtils.java
@@ -129,7 +129,7 @@ public class StripeJsonUtils {
         while(keyIterator.hasNext()) {
             String key = keyIterator.next();
             Object value = jsonObject.opt(key);
-            if (NULL.equals(value)) {
+            if (NULL.equals(value) || value == null) {
                 continue;
             }
 
@@ -141,6 +141,34 @@ public class StripeJsonUtils {
                 map.put(key, value);
             }
         }
+        return map;
+    }
+
+    /**
+     * Convert a {@link JSONObject} to a flat, string-keyed and string-valued map. All values
+     * are recorded as strings.
+     *
+     * @param jsonObject the input {@link JSONObject} to be converted
+     * @return a {@link Map} representing the input, or {@code null} if the input is {@code null}
+     */
+    @Nullable
+    public static Map<String, String> jsonObjectToStringMap(@Nullable JSONObject jsonObject) {
+        if (jsonObject == null) {
+            return null;
+        }
+
+        Map<String, String> map = new HashMap<>();
+        Iterator<String> keyIterator = jsonObject.keys();
+        while (keyIterator.hasNext()) {
+            String key = keyIterator.next();
+            Object value = jsonObject.opt(key);
+            if (NULL.equals(value) || value == null) {
+                continue;
+            }
+
+            map.put(key, value.toString());
+        }
+
         return map;
     }
 
@@ -190,7 +218,7 @@ public class StripeJsonUtils {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public static JSONObject mapToJsonObject(@Nullable Map<String, Object> mapObject) {
+    public static JSONObject mapToJsonObject(@Nullable Map<String, ? extends Object> mapObject) {
         if (mapObject == null) {
             return null;
         }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -13,6 +13,7 @@ import com.stripe.android.model.Token;
 import com.stripe.android.net.StripeApiHandler;
 import com.stripe.android.net.StripeResponse;
 import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.testharness.JsonTestUtils;
 import com.stripe.android.util.LoggingUtils;
 
 import org.junit.Before;
@@ -24,6 +25,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -256,6 +258,11 @@ public class StripeTest {
     public void createSourceSynchronous_withBitcoinParams_passesIntegrationTest() {
         Stripe stripe = new Stripe(mContext);
         SourceParams bitcoinParams = SourceParams.createBitcoinParams(1000L, "usd", "abc@def.com");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("site", "google");
+            put("mood", "sad");
+        }};
+        bitcoinParams.setMetaData(metamap);
         try {
             Source bitcoinSource =
                     stripe.createSourceSynchronous(bitcoinParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -268,6 +275,7 @@ public class StripeTest {
             assertNotNull(bitcoinSource.getOwner());
             assertEquals("abc@def.com", bitcoinSource.getOwner().getEmail());
             assertEquals("usd", bitcoinSource.getCurrency());
+            JsonTestUtils.assertMapEquals(metamap, bitcoinSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -278,6 +286,11 @@ public class StripeTest {
         Stripe stripe = new Stripe(mContext);
         SourceParams bancontactParams = SourceParams.createBancontactParams(
                 1000L, "John Doe", "example://path", "a statement described");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("flavor", "strawberry");
+            put("type", "sherbet");
+        }};
+        bancontactParams.setMetaData(metamap);
         try {
             Source bancontactSource =
                     stripe.createSourceSynchronous(bancontactParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -291,6 +304,7 @@ public class StripeTest {
             assertNotNull(bancontactSource.getRedirect());
             assertEquals("John Doe", bancontactSource.getOwner().getName());
             assertEquals("example://path", bancontactSource.getRedirect().getReturnUrl());
+            JsonTestUtils.assertMapEquals(metamap, bancontactSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -306,7 +320,14 @@ public class StripeTest {
         card.setAddressLine2("#456");
         card.setAddressZip("53081");
         card.setAddressState("WI");
+        card.setName("Winnie Hoop");
         SourceParams params = SourceParams.createCardParams(card);
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("addons", "cream");
+            put("type", "halfandhalf");
+        }};
+        params.setMetaData(metamap);
+
         try {
             Source cardSource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -324,6 +345,8 @@ public class StripeTest {
             assertEquals("123 Main St", cardSource.getOwner().getAddress().getLine1());
             assertEquals("#456", cardSource.getOwner().getAddress().getLine2());
             assertEquals("US", cardSource.getOwner().getAddress().getCountry());
+            assertEquals("Winnie Hoop", cardSource.getOwner().getName());
+            JsonTestUtils.assertMapEquals(metamap, cardSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -334,8 +357,6 @@ public class StripeTest {
         Stripe stripe = new Stripe(mContext);
         Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         SourceParams params = SourceParams.createCardParams(card);
-
-
         try {
             Source cardSource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -347,6 +368,12 @@ public class StripeTest {
                     "brl",
                     "example://return",
                     cardSource.getId());
+            Map<String, String> metamap = new HashMap<String, String>() {{
+                put("dimensions", "three");
+                put("type", "beach ball");
+            }};
+            threeDParams.setMetaData(metamap);
+
             Source threeDSource =
                     stripe.createSourceSynchronous(threeDParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
             assertNotNull(threeDSource);
@@ -356,6 +383,7 @@ public class StripeTest {
             assertNotNull(threeDSource.getId());
             assertEquals(Source.THREE_D_SECURE, threeDSource.getType());
             assertNotNull(threeDSource.getSourceTypeData());
+            JsonTestUtils.assertMapEquals(metamap, threeDSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -369,6 +397,11 @@ public class StripeTest {
                 "Mr. X",
                 "example://redirect",
                 "a well-described statement");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("giro", "with chicken");
+            put("type", "wrap");
+        }};
+        params.setMetaData(metamap);
         try {
             Source giropaySource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -383,6 +416,7 @@ public class StripeTest {
             assertNotNull(giropaySource.getRedirect());
             assertEquals("Mr. X", giropaySource.getOwner().getName());
             assertEquals("example://redirect", giropaySource.getRedirect().getReturnUrl());
+            JsonTestUtils.assertMapEquals(metamap, giropaySource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -399,6 +433,12 @@ public class StripeTest {
                 "Eureka",
                 "90210",
                 "EI");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("water source", "well");
+            put("type", "brackish");
+            put("value", "100000");
+        }};
+        params.setMetaData(metamap);
         try {
             Source sepaDebitSource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -415,6 +455,7 @@ public class StripeTest {
             assertEquals("123 Main St", sepaDebitSource.getOwner().getAddress().getLine1());
             assertEquals("EI", sepaDebitSource.getOwner().getAddress().getCountry());
             assertEquals("Sepa Account Holder", sepaDebitSource.getOwner().getName());
+            JsonTestUtils.assertMapEquals(metamap ,sepaDebitSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -429,6 +470,12 @@ public class StripeTest {
                 "example://return",
                 "A statement description",
                 "rabobank");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("state", "quite ideal");
+            put("picture", "17L");
+            put("arrows", "what?");
+        }};
+        params.setMetaData(metamap);
         try {
             Source idealSource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -443,6 +490,7 @@ public class StripeTest {
             assertEquals("Bond", idealSource.getOwner().getName());
             assertNotNull(idealSource.getRedirect());
             assertEquals("example://return", idealSource.getRedirect().getReturnUrl());
+            JsonTestUtils.assertMapEquals(metamap, idealSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }
@@ -456,6 +504,11 @@ public class StripeTest {
                 "example://return",
                 "NL",
                 "a description");
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("state", "soforting");
+            put("repetitions", "400");
+        }};
+        params.setMetaData(metamap);
         try {
             Source sofortSource =
                     stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
@@ -468,6 +521,7 @@ public class StripeTest {
             assertEquals(70000L, sofortSource.getAmount().longValue());
             assertNotNull(sofortSource.getRedirect());
             assertEquals("example://return", sofortSource.getRedirect().getReturnUrl());
+            JsonTestUtils.assertMapEquals(metamap, sofortSource.getMetaData());
         } catch (StripeException stripeEx) {
             fail("Unexpected error: " + stripeEx.getLocalizedMessage());
         }

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -108,6 +108,27 @@ public class SourceParamsTest {
     }
 
     @Test
+    public void createParams_thenAddMetadata_hasExpectedFieldsInMap() {
+        SourceParams params = SourceParams.createBitcoinParams(10L, "usd", "abc@def.ghi");
+        Map<String, String> metaData = new HashMap<>();
+        metaData.put("custom1", "value1");
+        metaData.put("custom2", "value2");
+        params.setMetaData(metaData);
+
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("type", "bitcoin");
+        expectedMap.put("currency", "usd");
+        expectedMap.put("amount", 10L);
+        expectedMap.put("owner", new HashMap<String, Object>() {{ put("email", "abc@def.ghi"); }});
+        expectedMap.put("metadata", new HashMap<String, Object>() {{
+            put("custom1", "value1");
+            put("custom2", "value2");
+        }});
+
+        JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
+    }
+
+    @Test
     public void createCardParams_hasBothExpectedMaps() {
         SourceParams params = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
 
@@ -119,7 +140,8 @@ public class SourceParamsTest {
         assertEquals("123", apiMap.get("cvc"));
 
         assertNotNull(params.getOwner());
-        assertEquals(1, params.getOwner().size());
+        assertEquals("Captain Cardholder", params.getOwner().get("name"));
+        assertEquals(2, params.getOwner().size());
         Map<String, Object> addressMap = getMapFromOwner(params, "address");
         assertEquals("1 ABC Street", addressMap.get("line1"));
         assertEquals("Apt. 123", addressMap.get("line2"));
@@ -151,7 +173,10 @@ public class SourceParamsTest {
         totalExpectedMap.put("type", "card");
         totalExpectedMap.put("card", expectedCardMap);
         totalExpectedMap.put("owner",
-                new HashMap<String, Object>() {{ put("address", expectedAddressMap); }});
+                new HashMap<String, Object>() {{
+                    put("address", expectedAddressMap);
+                    put("name", "Captain Cardholder");
+                }});
 
         JsonTestUtils.assertMapEquals(totalExpectedMap, params.toParamMap());
     }

--- a/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtils.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtils.java
@@ -86,7 +86,8 @@ public class JsonTestUtils {
      * @param first the first map
      * @param second the second map
      */
-    public static void assertMapEquals(Map<String, Object> first, Map<String, Object> second) {
+    public static void assertMapEquals(Map<String, ? extends Object> first,
+                                       Map<String, ? extends Object> second) {
         if (assertSameNullity(first, second)) {
             return;
         }

--- a/stripe/src/test/java/com/stripe/android/util/StripeJsonUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/StripeJsonUtilsTest.java
@@ -279,6 +279,24 @@ public class StripeJsonUtilsTest {
     }
 
     @Test
+    public void jsonObjectToStringMap_forSimpleObjects_returnsExpectedMap() {
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("akey", "avalue");
+        expectedMap.put("bkey", "bvalue");
+        expectedMap.put("boolkey", "true");
+        expectedMap.put("numkey", "123");
+
+        try {
+            JSONObject testJsonObject = new JSONObject(SIMPLE_JSON_TEST_OBJECT);
+            Map<String, String> mappedObject =
+                    StripeJsonUtils.jsonObjectToStringMap(testJsonObject);
+            JsonTestUtils.assertMapEquals(expectedMap, mappedObject);
+        } catch (JSONException jsonException) {
+            fail("Test data failure " + jsonException.getLocalizedMessage());
+        }
+    }
+
+    @Test
     public void jsonObjectToMap_forNestedObjects_returnsExpectedMap() {
         Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("top_key",
@@ -298,6 +316,24 @@ public class StripeJsonUtilsTest {
         try {
             JSONObject testJsonObject = new JSONObject(NESTED_JSON_TEST_OBJECT);
             Map<String, Object> mappedObject = StripeJsonUtils.jsonObjectToMap(testJsonObject);
+            JsonTestUtils.assertMapEquals(expectedMap, mappedObject);
+        } catch (JSONException jsonException) {
+            fail("Test data failure " + jsonException.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void jsonObjectToStringMap_forNestedObjects_returnsExpectedFlatMap() {
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("top_key", "{\"first_inner_key\":{\"innermost_key\":1000," +
+                "\"second_innermost_key\":\"second_inner_value\"}," +
+                "\"second_inner_key\":\"just a value\"}");
+        expectedMap.put("second_outer_key", "{\"another_inner_key\":false}");
+
+        try {
+            JSONObject testJsonObject = new JSONObject(NESTED_JSON_TEST_OBJECT);
+            Map<String, String> mappedObject =
+                    StripeJsonUtils.jsonObjectToStringMap(testJsonObject);
             JsonTestUtils.assertMapEquals(expectedMap, mappedObject);
         } catch (JSONException jsonException) {
             fail("Test data failure " + jsonException.getLocalizedMessage());


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Adding a string-only metadata map to source params (manually added by the user when desired). Also included an update to put a name field on card source params.

Metadata is string-string mapping only, so in order to not confuse our users, I force the map to be string-string when you input it. You can actually put any kind of object in there, but it gets stringified on the way back. By forcing strings from the beginning, at least the user knows what values to expect.