### PR TITLE
allowing access to the card ID field

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -88,6 +88,7 @@ public class Card {
     private String fingerprint;
     private String country;
     private String currency;
+    private String id;
     @NonNull private List<String> loggingTokens = new ArrayList<>();
 
     /**
@@ -226,6 +227,7 @@ public class Card {
      * @param funding the funding type of the card
      * @param country ISO country code of the card itself
      * @param currency currency used by the card
+     * @param id the cardId
      */
     public Card(
             String number,
@@ -244,7 +246,8 @@ public class Card {
             String fingerprint,
             String funding,
             String country,
-            String currency) {
+            String currency,
+            String id) {
         this.number = StripeTextUtils.nullIfBlank(normalizeCardNumber(number));
         this.expMonth = expMonth;
         this.expYear = expYear;
@@ -262,6 +265,7 @@ public class Card {
         this.funding = StripeTextUtils.asFundingType(funding);
         this.country = StripeTextUtils.nullIfBlank(country);
         this.currency = StripeTextUtils.nullIfBlank(currency);
+        this.id = StripeTextUtils.nullIfBlank(id);
     }
 
     /**
@@ -310,7 +314,8 @@ public class Card {
                 null,
                 null,
                 null,
-                currency);
+                currency,
+                null);
     }
 
     /**
@@ -331,6 +336,7 @@ public class Card {
                 expMonth,
                 expYear,
                 cvc,
+                null,
                 null,
                 null,
                 null,
@@ -701,6 +707,13 @@ public class Card {
      */
     public String getCountry() {
         return country;
+    }
+
+    /**
+     * @return the {@link #id} of this card
+     */
+    public String getId() {
+        return id;
     }
 
     private Card(Builder builder) {

--- a/stripe/src/main/java/com/stripe/android/net/CardParser.java
+++ b/stripe/src/main/java/com/stripe/android/net/CardParser.java
@@ -27,6 +27,7 @@ class CardParser {
     private static final String FIELD_EXP_YEAR = "exp_year";
     private static final String FIELD_FINGERPRINT = "fingerprint";
     private static final String FIELD_FUNDING = "funding";
+    private static final String FIELD_ID = "id";
     private static final String FIELD_LAST4 = "last4";
     private static final String FIELD_NAME = "name";
 
@@ -69,6 +70,7 @@ class CardParser {
                 StripeJsonUtils.optString(objectCard, FIELD_FINGERPRINT),
                 StripeTextUtils.asFundingType(StripeJsonUtils.optString(objectCard, FIELD_FUNDING)),
                 StripeJsonUtils.optString(objectCard, FIELD_COUNTRY),
-                StripeJsonUtils.optString(objectCard, FIELD_CURRENCY));
+                StripeJsonUtils.optString(objectCard, FIELD_CURRENCY),
+                StripeJsonUtils.optString(objectCard, FIELD_ID));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -527,6 +527,7 @@ public class CardTest {
                 null,
                 null,
                 null,
+                null,
                 null
                 );
         assertEquals("1234", card.getLast4());
@@ -547,6 +548,7 @@ public class CardTest {
                 null,
                 null,
                 Card.AMERICAN_EXPRESS,
+                null,
                 null,
                 null,
                 null,

--- a/stripe/src/test/java/com/stripe/android/net/CardParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/CardParserTest.java
@@ -113,7 +113,8 @@ public class CardParserTest {
                 null,
                 Card.FUNDING_CREDIT,
                 "US",
-                null);
+                null,
+                "card_189fi32eZvKYlo2CHK8NPRME");
         try {
             Card cardFromJson = CardParser.parseCard(JSON_CARD);
             assertEquals(expectedCard.getBrand(), cardFromJson.getBrand());
@@ -124,6 +125,7 @@ public class CardParserTest {
             assertEquals(expectedCard.getExpYear(), cardFromJson.getExpYear());
             assertNull(cardFromJson.getAddressCity());
             assertNull(cardFromJson.getFingerprint());
+            assertEquals(expectedCard.getId(), cardFromJson.getId());
         } catch (JSONException jex) {
             fail();
         }


### PR DESCRIPTION
r? @bg-stripe 

Had a customer request to match Android and iOS features, allowing access to the cardID property in the token object. This is a pretty simple (and valid) customer request to accommodate.

