### PR TITLE
allowing the user to retrieve a token

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -419,6 +419,68 @@ public class Stripe {
     }
 
     /**
+     * Retrieve an existing {@link Source} on the server. This is useful for checking the status
+     * of a source requiring redirect authentication, such as 3DS cards. Note that this is a
+     * synchronous method, and cannot be called on the main thread. Doing so will cause your app
+     * to crash. This method uses the default publishable key for this {@link Stripe} instance.
+     *
+     * @param sourceId the {@link Source#mId} field of the desired Source object
+     * @param clientSecret the {@link Source#mClientSecret} field of the desired Source object
+     * @return a {@link Source} if one could be found based on the input params, or {@code null} if
+     * no such Source could be found.
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    public Source retrieveSourceSynchronous(
+            @NonNull @Size(min = 1) String sourceId,
+            @NonNull @Size(min = 1) String clientSecret)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        return retrieveSourceSynchronous(sourceId, clientSecret, null);
+    }
+
+    /**
+     * Retrieve an existing {@link Source} on the server. This is useful for checking the status
+     * of a source requiring redirect authentication, such as 3DS cards. Note that this is a
+     * synchronous method, and cannot be called on the main thread. Doing so will cause your app
+     * to crash.
+     *
+     * @param sourceId the {@link Source#mId} field of the desired Source object
+     * @param clientSecret the {@link Source#mClientSecret} field of the desired Source object
+     * @param publishableKey a publishable API key to use
+     * @return a {@link Source} if one could be found based on the input params, or {@code null} if
+     * no such Source could be found.
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    public Source retrieveSourceSynchronous(
+            @NonNull @Size(min = 1) String sourceId,
+            @NonNull @Size(min = 1) String clientSecret,
+            @Nullable String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
+        if (apiKey == null) {
+            return null;
+        }
+        return StripeApiHandler.retrieveSource(sourceId, clientSecret, apiKey);
+    }
+
+    /**
      * Set the default publishable key to use with this {@link Stripe} instance.
      *
      * @param publishableKey the key to be set

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -419,8 +419,7 @@ public class Stripe {
     }
 
     /**
-     * Retrieve an existing {@link Source} on the server. This is useful for checking the status
-     * of a source requiring redirect authentication, such as 3DS cards. Note that this is a
+     * Retrieve an existing {@link Source} from the Stripe API. Note that this is a
      * synchronous method, and cannot be called on the main thread. Doing so will cause your app
      * to crash. This method uses the default publishable key for this {@link Stripe} instance.
      *
@@ -447,8 +446,7 @@ public class Stripe {
     }
 
     /**
-     * Retrieve an existing {@link Source} on the server. This is useful for checking the status
-     * of a source requiring redirect authentication, such as 3DS cards. Note that this is a
+     * Retrieve an existing {@link Source} from the Stripe API. Note that this is a
      * synchronous method, and cannot be called on the main thread. Doing so will cause your app
      * to crash.
      *

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -26,6 +26,8 @@ public class SourceParams {
     static final String API_PARAM_REDIRECT = "redirect";
     static final String API_PARAM_TYPE = "type";
 
+    static final String API_PARAM_CLIENT_SECRET = "client_secret";
+
     static final String FIELD_ADDRESS = "address";
     static final String FIELD_BANK = "bank";
     static final String FIELD_CARD = "card";
@@ -305,6 +307,22 @@ public class SourceParams {
                 .setAmount(amount)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
         params.setApiParameterMap(createSimpleMap(FIELD_CARD, cardID));
+        return params;
+    }
+
+    /**
+     * Create parameters needed to retrieve a source.
+     *
+     * @param clientSecret the client secret for the source, needed because the Android SDK uses
+     *                     a public key
+     * @return a {@link Map} matching the parameter name to the client secret, ready to send to
+     * the server.
+     */
+    @NonNull
+    public static Map<String, Object> createRetrieveSourceParams(
+            @NonNull @Size(min = 1) String clientSecret) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(API_PARAM_CLIENT_SECRET, clientSecret);
         return params;
     }
 

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -102,6 +102,44 @@ public class StripeApiHandler {
     }
 
     /**
+     * Retrieve an existing {@link Source} object from the server.
+     *
+     * @param sourceId the {@link Source#mId} field for the Source to query
+     * @param clientSecret the {@link Source#mClientSecret} field for the Source to query
+     * @param publishableKey an API key
+     * @return a {@link Source} if one could be retrieved for the input params, or {@code null} if
+     * no such Source could be found.
+     *
+     * @throws AuthenticationException if there is a problem authenticating to the Stripe API
+     * @throws InvalidRequestException if one or more of the parameters is incorrect
+     * @throws APIConnectionException if there is a problem connecting to the Stripe API
+     * @throws APIException for unknown Stripe API errors. These should be rare.
+     */
+    public static Source retrieveSource(
+            @NonNull String sourceId,
+            @NonNull String clientSecret,
+            @NonNull String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            APIException {
+
+        Map<String, Object> paramMap = SourceParams.createRetrieveSourceParams(clientSecret);
+        RequestOptions options = RequestOptions.builder(publishableKey).build();
+        try {
+            return Source.fromString(
+                    requestData(GET, getRetrieveSourceApiUrl(sourceId), paramMap, options));
+        } catch (CardException unexpected) {
+            // This particular kind of exception should not be possible from a Source API endpoint.
+            throw new APIException(
+                    unexpected.getMessage(),
+                    unexpected.getRequestId(),
+                    unexpected.getStatusCode(),
+                    unexpected);
+        }
+    }
+
+    /**
      * Create a {@link Token} using the input card parameters.
      *
      * @param cardParams a mapped set of parameters representing the object for which this token
@@ -235,6 +273,11 @@ public class StripeApiHandler {
     @VisibleForTesting
     static String getSourcesUrl() {
         return String.format(Locale.ENGLISH, "%s/v1/%s", LIVE_API_BASE, SOURCES);
+    }
+
+    @VisibleForTesting
+    static String getRetrieveSourceApiUrl(@NonNull String sourceId) {
+        return String.format(Locale.ENGLISH, "%s/%s", getSourcesUrl(), sourceId);
     }
 
     @VisibleForTesting

--- a/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
@@ -43,6 +43,12 @@ public class StripeApiHandlerTest {
     }
 
     @Test
+    public void testGetRetrieveSourceUrl() {
+        String sourceUrlWithId = StripeApiHandler.getRetrieveSourceApiUrl("abc123");
+        assertEquals("https://api.stripe.com/v1/sources/abc123", sourceUrlWithId);
+    }
+
+    @Test
     public void testGetRequestTokenApiUrl() {
         String tokenId = "tok_sample";
         String requestApi = StripeApiHandler.getRetrieveTokenApiUrl(tokenId);


### PR DESCRIPTION
r? @bg-stripe 
cc @brandur-stripe  @sjayaraman-stripe @teich-stripe

Adding the ability to retrieve an existing token from the server. This is step 1 before adding polling functionality, which will essentially just call the retrieve function on a schedule.

Note that one break from tradition in this diff was intentional -- the only method in the Stripe class for this to retrieve a token is **synchronous**, so there is no option to do this automatically with an AsyncTask.

I can add this functionality if desired, but the intended use of this is for a client who wants to do their own polling, so they intend to call this repeatedly. Repeatedly creating asynchronous tasks as a polling method feels like the absolute worst coding pattern I could come up with, and we really, really, really should discourage so doing.