### PR TITLE
adding a full polling and 3ds path in the sample application

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.stripe.example"
-    android:versionCode="1"
-    android:versionName="1.0">
+          package="com.stripe.example"
+          android:versionCode="1"
+          android:versionName="1.0">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:icon="@drawable/ic_launcher"
@@ -13,15 +13,19 @@
             android:name=".activity.PaymentActivity"
             android:theme="@style/Theme.AppCompat">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
 
         <service
             android:name=".service.TokenIntentService"
             android:exported="false"/>
+
+        <activity android:name=".activity.PollingActivity"
+            android:theme="@style/Theme.AppCompat.Light">
+        </activity>
     </application>
 
 </manifest>

--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -24,7 +24,15 @@
             android:exported="false"/>
 
         <activity android:name=".activity.PollingActivity"
-            android:theme="@style/Theme.AppCompat.Light">
+            android:theme="@style/Theme.AppCompat.Light"
+            android:launchMode="singleTask">
+            <intent-filter >
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="stripe"
+                      android:host="example" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -10,11 +10,13 @@ dependencies {
     compile project(':stripe')
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
+    compile 'com.android.support:recyclerview-v7:' + android_support_version
     /* Needed for RxAndroid */
+    /* Needed for Rx Bindings on views */
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
-    /* Needed for Rx Bindings on views */
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta3'
 }
 
 android {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -12,11 +12,10 @@ dependencies {
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
     /* Needed for RxAndroid */
-    /* Needed for Rx Bindings on views */
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
+    /* Needed for Rx Bindings on views */
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta3'
 }
 
 android {

--- a/example/res/drawable/dialog_link.xml
+++ b/example/res/drawable/dialog_link.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:top="2dp" android:right="2dp" android:left="2dp" android:bottom="2dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent"/>
+
+            <stroke android:width="2dp"
+                    android:color="@color/underline"/>
+        </shape>
+    </item>
+</layer-list>

--- a/example/res/drawable/header_light.xml
+++ b/example/res/drawable/header_light.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:top="-2dp" android:right="-2dp" android:left="-2dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent"/>
+
+            <stroke android:width="2dp"
+                    android:color="@color/underline"/>
+        </shape>
+    </item>
+</layer-list>

--- a/example/res/layout/activity_polling.xml
+++ b/example/res/layout/activity_polling.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.stripe.example.activity.PollingActivity">
+
+    <TextView android:id="@+id/payment_form_title"
+              android:text="@string/addThreeDSecureCard"
+              style="@style/Header.Light" />
+
+    <com.stripe.android.view.CardInputWidget
+        android:id="@+id/card_input_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        />
+
+    <Button
+        android:id="@+id/btn_three_d_secure"
+        android:layout_width="160dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/addThreeDSecureCard"/>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+</LinearLayout>

--- a/example/res/layout/activity_polling.xml
+++ b/example/res/layout/activity_polling.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
@@ -13,10 +12,10 @@
               style="@style/Header.Light" />
 
     <com.stripe.android.view.CardInputWidget
-        android:id="@+id/card_input_widget"
+        android:id="@+id/card_widget_three_d"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="4dp"
+        android:layout_margin="8dp"
         />
 
     <Button
@@ -26,9 +25,14 @@
         android:layout_gravity="center"
         android:text="@string/addThreeDSecureCard"/>
 
+    <TextView android:text="@string/updatedSources"
+              style="@style/Header.Light" />
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:layout_margin="8dp"/>
+
 </LinearLayout>

--- a/example/res/layout/payment_activity.xml
+++ b/example/res/layout/payment_activity.xml
@@ -41,6 +41,15 @@
         android:text="@string/saveService"
         style="@style/Save"/>
 
+    <Button
+        android:id="@+id/three_d_secure"
+        android:layout_height="wrap_content"
+        android:layout_width="160dp"
+        android:text="@string/tryThreeDSecure"
+        style="@style/Save"
+        >
+
+    </Button>
     <TextView android:id="@+id/token_list_title"
               android:text="@string/paymentMethods"
               android:layout_marginTop="12dp"

--- a/example/res/layout/polling_dialog.xml
+++ b/example/res/layout/polling_dialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="wrap_content"
+              android:layout_height="400dp">
+
+    <TextView
+        android:id="@+id/tv_link_redirect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:gravity="center"
+        android:layout_gravity="center"
+        android:background="@drawable/dialog_link"
+        android:textColor="@color/underline"
+        android:textAppearance="@android:style/TextAppearance.Large"
+        style="@style/Header.Light"/>
+
+</LinearLayout>

--- a/example/res/layout/polling_list_item.xml
+++ b/example/res/layout/polling_list_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="horizontal"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="4dp">
+
+    <TextView
+        android:id="@+id/tv_poll_count"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:gravity="start"/>
+
+    <TextView
+        android:id="@+id/tv_ending_status"
+        android:layout_width="0dp"
+        android:layout_weight="2"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:textAllCaps="true"
+        android:gravity="center"/>
+
+    <TextView
+        android:id="@+id/tv_source_id"
+        android:layout_width="0dp"
+        android:layout_weight="2"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:gravity="end"/>
+
+</LinearLayout>

--- a/example/res/values/colors.xml
+++ b/example/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="editText">#AAAAAA</color>
     <color name="buttonText">#EEEEEE</color>
     <color name="headerText">#EEEEEE</color>
+    <color name="underline">#5458DF</color>
 </resources>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -11,10 +11,15 @@
     <string name="validationErrors">Validation Errors</string>
 
     <string name="cardNumber">Card Number</string>
+    <string name="createSource">Creating source&#8230;</string>
+    <string name="pollingSource">Polling for source changes&#8230;</string>
     <string name="save">Save</string>
     <string name="saverx">Save Rx</string>
     <string name="saveService">Save with Service</string>
+    <string name="startPolling">Start polling</string>
     <string name="tryThreeDSecure">Try 3DS</string>
+    <string name="verify">Verify</string>
+    <string name="updatedSources">Source results</string>
     <string name="cvc">CVC</string>
 
     <string name="ok">OK</string>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="appName">Stripe Payments Example</string>
 
     <string name="addPayment">Add Payment Method</string>
+    <string name="addThreeDSecureCard">Add 3DS Card</string>
     <string name="paymentMethods">Payment Methods</string>
 
     <string name="endingIn">Card ending in </string>
@@ -13,6 +14,7 @@
     <string name="save">Save</string>
     <string name="saverx">Save Rx</string>
     <string name="saveService">Save with Service</string>
+    <string name="tryThreeDSecure">Try 3DS</string>
     <string name="cvc">CVC</string>
 
     <string name="ok">OK</string>

--- a/example/res/values/styles.xml
+++ b/example/res/values/styles.xml
@@ -25,4 +25,15 @@
         <item name="android:textColor">@color/headerText</item>
     </style>
 
+    <style name="Header.Light" parent="@android:style/Widget.TextView">
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:background">@drawable/header_light</item>
+        <item name="android:layout_marginBottom">5dp</item>
+        <item name="android:paddingBottom">4dp</item>
+        <item name="android:paddingLeft">3dp</item>
+        <item name="android:paddingTop">10dp</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">@android:color/primary_text_light</item>
+    </style>
 </resources>

--- a/example/src/main/java/com/stripe/example/activity/PaymentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentActivity.java
@@ -1,13 +1,17 @@
 package com.stripe.example.activity;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Button;
 import android.widget.ListView;
 
+import com.jakewharton.rxbinding.view.RxView;
 import com.stripe.android.view.CardInputWidget;
 import com.stripe.example.R;
 import com.stripe.example.module.DependencyHandler;
+
+import rx.functions.Action1;
 
 public class PaymentActivity extends AppCompatActivity {
 
@@ -31,6 +35,14 @@ public class PaymentActivity extends AppCompatActivity {
 
         Button saveIntentServiceButton = (Button) findViewById(R.id.saveWithService);
         mDependencyHandler.attachIntentServiceTokenController(this, saveIntentServiceButton);
+
+        RxView.clicks(findViewById(R.id.three_d_secure)).subscribe(new Action1<Void>() {
+            @Override
+            public void call(Void aVoid) {
+                Intent intent = new Intent(PaymentActivity.this, PollingActivity.class);
+                startActivity(intent);
+            }
+        });
     }
 
     @Override

--- a/example/src/main/java/com/stripe/example/activity/PollingActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PollingActivity.java
@@ -1,0 +1,164 @@
+package com.stripe.example.activity;
+
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.Button;
+
+import com.stripe.android.Stripe;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.view.CardInputWidget;
+import com.stripe.example.R;
+import com.stripe.example.adapter.PollingAdapter;
+import com.stripe.example.controller.ErrorDialogHandler;
+import com.stripe.example.controller.ProgressDialogController;
+
+import java.util.concurrent.Callable;
+
+import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.functions.Func1;
+import rx.schedulers.Schedulers;
+import rx.subscriptions.CompositeSubscription;
+
+public class PollingActivity extends AppCompatActivity {
+
+    private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
+            "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
+
+    private CardInputWidget mCardInputWidget;
+    private CompositeSubscription mCompositeSubscription;
+    private PollingAdapter mPollingAdapter;
+    private ErrorDialogHandler mErrorDialogHandler;
+    private ProgressDialogController mProgressDialogController;
+    private Stripe mStripe;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_polling);
+
+        mCompositeSubscription = new CompositeSubscription();
+        mCardInputWidget = (CardInputWidget) findViewById(R.id.card_input_widget);
+        mErrorDialogHandler = new ErrorDialogHandler(this.getSupportFragmentManager());
+        mProgressDialogController = new ProgressDialogController(this.getSupportFragmentManager());
+        mStripe = new Stripe(this);
+
+        Button threeDSecureButton = (Button) findViewById(R.id.btn_three_d_secure);
+        threeDSecureButton.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        beginSequence();
+                    }
+                });
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+
+        RecyclerView.LayoutManager linearLayoutManager = new LinearLayoutManager(this);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(linearLayoutManager);
+        mPollingAdapter = new PollingAdapter();
+        recyclerView.setAdapter(mPollingAdapter);
+
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mCompositeSubscription.unsubscribe();
+    }
+
+    void beginSequence() {
+        Card displayCard = mCardInputWidget.getCard();
+        if (displayCard == null) {
+            return;
+        }
+        createCardSource(displayCard);
+    }
+
+    void createCardSource(@NonNull Card card) {
+        final SourceParams cardSourceParams = SourceParams.createCardParams(card);
+        if (cardSourceParams == null) {
+            return;
+        }
+
+        final Observable<Source> cardSourceObservable =
+                Observable.fromCallable(
+                        new Callable<Source>() {
+                            @Override
+                            public Source call() throws Exception {
+                                return mStripe.createSourceSynchronous(
+                                        cardSourceParams,
+                                        FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+                            }
+                        });
+        mCompositeSubscription.add(cardSourceObservable
+                .subscribeOn(Schedulers.io())
+                .doOnSubscribe(
+                        new Action0() {
+                            @Override
+                            public void call() {
+                                mProgressDialogController.startProgress();
+                            }
+                })
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        mProgressDialogController.finishProgress();
+                    }
+                })
+                .flatMap(
+                        new Func1<Source, Observable<Source>>() {
+                            @Override
+                            public Observable<Source> call(Source source) {
+                                if (source == null || !Source.CARD.equals(source.getType())) {
+                                    return null;
+                                }
+
+                                final SourceParams threeDParams = SourceParams.createThreeDSecureParams(
+                                        1000L,
+                                        "EUR",
+                                        "example://return",
+                                        source.getId());
+
+                                return Observable.fromCallable(
+                                        new Callable<Source>() {
+                                            @Override
+                                            public Source call() throws Exception {
+                                                return mStripe.createSourceSynchronous(
+                                                        threeDParams,
+                                                        FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+                                            }
+                                        });
+                            }
+                        })
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        new Action1<Source>() {
+                            @Override
+                            public void call(Source source) {
+                                addNewSource(source);
+                            }
+                        },
+                        new Action1<Throwable>() {
+                            @Override
+                            public void call(Throwable throwable) {
+                                mErrorDialogHandler.showError(throwable.getMessage());
+                            }
+                        }
+
+                ));
+    }
+
+    void addNewSource(Source source) {
+        mPollingAdapter.addItem(source.getType(), source.getStatus(), source.getRedirect().getUrl());
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/PollingActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PollingActivity.java
@@ -1,5 +1,6 @@
 package com.stripe.example.activity;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -9,15 +10,20 @@ import android.view.View;
 import android.widget.Button;
 
 import com.stripe.android.Stripe;
+import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
+import com.stripe.android.net.PollingResponse;
+import com.stripe.android.net.PollingResponseHandler;
 import com.stripe.android.view.CardInputWidget;
 import com.stripe.example.R;
 import com.stripe.example.adapter.PollingAdapter;
 import com.stripe.example.controller.ErrorDialogHandler;
+import com.stripe.example.controller.PollingDialogController;
 import com.stripe.example.controller.ProgressDialogController;
 
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 import rx.Observable;
@@ -28,18 +34,25 @@ import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
+/**
+ * Activity that lets you poll for a 3DS source update.
+ */
 public class PollingActivity extends AppCompatActivity {
 
     private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
             "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
+    private static final String RETURN_URL = "stripe://example";
+
+    private static final String QUERY_CLIENT_SECRET = "client_secret";
+    private static final String QUERY_SOURCE_ID = "source";
 
     private CardInputWidget mCardInputWidget;
     private CompositeSubscription mCompositeSubscription;
     private PollingAdapter mPollingAdapter;
     private ErrorDialogHandler mErrorDialogHandler;
+    private PollingDialogController mPollingDialogController;
     private ProgressDialogController mProgressDialogController;
     private Stripe mStripe;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,9 +60,10 @@ public class PollingActivity extends AppCompatActivity {
         setContentView(R.layout.activity_polling);
 
         mCompositeSubscription = new CompositeSubscription();
-        mCardInputWidget = (CardInputWidget) findViewById(R.id.card_input_widget);
+        mCardInputWidget = (CardInputWidget) findViewById(R.id.card_widget_three_d);
         mErrorDialogHandler = new ErrorDialogHandler(this.getSupportFragmentManager());
         mProgressDialogController = new ProgressDialogController(this.getSupportFragmentManager());
+        mPollingDialogController = new PollingDialogController(this);
         mStripe = new Stripe(this);
 
         Button threeDSecureButton = (Button) findViewById(R.id.btn_three_d_secure);
@@ -68,6 +82,19 @@ public class PollingActivity extends AppCompatActivity {
         mPollingAdapter = new PollingAdapter();
         recyclerView.setAdapter(mPollingAdapter);
 
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        if (intent.getData() != null && intent.getData().getQuery() != null) {
+            String clientSecret = intent.getData().getQueryParameter(QUERY_CLIENT_SECRET);
+            String sourceId = intent.getData().getQueryParameter(QUERY_SOURCE_ID);
+            if (clientSecret != null && sourceId != null) {
+                addNewSource(sourceId, clientSecret);
+            }
+            mPollingDialogController.dismissDialog();
+        }
     }
 
     @Override
@@ -100,14 +127,15 @@ public class PollingActivity extends AppCompatActivity {
                                         FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
                             }
                         });
+
         mCompositeSubscription.add(cardSourceObservable
                 .subscribeOn(Schedulers.io())
-                .doOnSubscribe(
-                        new Action0() {
-                            @Override
-                            public void call() {
-                                mProgressDialogController.startProgress();
-                            }
+                .doOnSubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        mProgressDialogController.setMessageResource(R.string.createSource);
+                        mProgressDialogController.startProgress();
+                    }
                 })
                 .doOnUnsubscribe(new Action0() {
                     @Override
@@ -117,16 +145,18 @@ public class PollingActivity extends AppCompatActivity {
                 })
                 .flatMap(
                         new Func1<Source, Observable<Source>>() {
+                            // This mapping converts the card source into a 3DS source
                             @Override
                             public Observable<Source> call(Source source) {
                                 if (source == null || !Source.CARD.equals(source.getType())) {
                                     return null;
                                 }
 
+                                // This represents a request for a 3DS purchase of 10.00 euro.
                                 final SourceParams threeDParams = SourceParams.createThreeDSecureParams(
                                         1000L,
                                         "EUR",
-                                        "example://return",
+                                        RETURN_URL,
                                         source.getId());
 
                                 return Observable.fromCallable(
@@ -142,10 +172,12 @@ public class PollingActivity extends AppCompatActivity {
                         })
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
+                        // Because we've made the mapping above, we're now subscribing
+                        // to the result of creating a 3DS Source
                         new Action1<Source>() {
                             @Override
                             public void call(Source source) {
-                                addNewSource(source);
+                                showDialog(source);
                             }
                         },
                         new Action1<Throwable>() {
@@ -154,11 +186,67 @@ public class PollingActivity extends AppCompatActivity {
                                 mErrorDialogHandler.showError(throwable.getMessage());
                             }
                         }
-
                 ));
     }
 
-    void addNewSource(Source source) {
-        mPollingAdapter.addItem(source.getType(), source.getStatus(), source.getRedirect().getUrl());
+    void showDialog(final Source source) {
+        mPollingDialogController.showDialog(source.getRedirect().getUrl());
+    }
+
+    void addNewSource(String sourceId, String clientSecret) {
+        mProgressDialogController.setMessageResource(R.string.pollingSource);
+        mProgressDialogController.startProgress();
+        mStripe.pollSource(
+                sourceId,
+                clientSecret,
+                FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
+                new PollingResponseHandler() {
+                    int count = 0;
+                    @Override
+                    public void onPollingResponse(PollingResponse pollingResponse) {
+                        count++;
+                        mProgressDialogController.finishProgress();
+                        if (pollingResponse.isSuccess()) {
+                            Source source = pollingResponse.getSource();
+                            if (source == null) {
+                                return;
+                            }
+                            mPollingAdapter.addItem(
+                                    getCountString(count),
+                                    source.getStatus(),
+                                    source.getId());
+                        } else if (pollingResponse.isExpired()){
+                            Source source = pollingResponse.getSource();
+                            mPollingAdapter.addItem(
+                                    getCountString(count),
+                                    source.getStatus(),
+                                    "Polling Expired");
+                        } else {
+                            StripeException stripeEx = pollingResponse.getStripeException();
+                            Source source = pollingResponse.getSource();
+                            if (stripeEx != null) {
+                                mPollingAdapter.addItem(
+                                        getCountString(count),
+                                        "error",
+                                        stripeEx.getMessage());
+                            } else {
+                                mPollingAdapter.addItem(
+                                        getCountString(count),
+                                        source.getStatus(),
+                                        source.getId());
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onRetry(int millis) {
+                        count++;
+                    }
+                },
+                null);
+    }
+
+    private static String getCountString(int count) {
+        return String.format(Locale.ENGLISH, "API Queries: %d", count);
     }
 }

--- a/example/src/main/java/com/stripe/example/adapter/PollingAdapter.java
+++ b/example/src/main/java/com/stripe/example/adapter/PollingAdapter.java
@@ -1,0 +1,100 @@
+package com.stripe.example.adapter;
+
+import android.support.v4.text.TextUtilsCompat;
+import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.stripe.example.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A simple {@link RecyclerView} implementation to hold our data.
+ */
+public class PollingAdapter extends RecyclerView.Adapter<PollingAdapter.ViewHolder> {
+    private List<ViewModel> mDataset = new ArrayList<>();
+
+    // Provide a reference to the views for each data item
+    // Complex data items may need more than one view per item, and
+    // you provide access to all the views for a data item in a view holder
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        // each data item is just a string in this case
+        private TextView mPollingCountView;
+        private TextView mFinalStatusView;
+        private TextView mSourceIdView;
+        ViewHolder(LinearLayout pollingLayout) {
+            super(pollingLayout);
+            mPollingCountView = (TextView) pollingLayout.findViewById(R.id.tv_poll_count);
+            mFinalStatusView = (TextView) pollingLayout.findViewById(R.id.tv_ending_status);
+            mSourceIdView = (TextView) pollingLayout.findViewById(R.id.tv_source_id);
+        }
+
+        public void setPollingCount(String pollingCount) {
+            mPollingCountView.setText(pollingCount);
+        }
+
+        public void setFinalStatus(String finalStatus) {
+            mFinalStatusView.setText(finalStatus);
+        }
+
+        public void setSourceId(String sourceId) {
+            mSourceIdView.setText(sourceId);
+        }
+    }
+
+    public static class ViewModel {
+        public final String mPollingCount;
+        public final String mFinalStatus;
+        public final String mSourceId;
+
+        public ViewModel(String pollingCount, String finalStatus, String sourceId) {
+            mPollingCount = pollingCount;
+            mFinalStatus = finalStatus;
+            mSourceId = sourceId;
+        }
+    }
+
+    // Provide a suitable constructor (depends on the kind of dataset)
+    public PollingAdapter() {}
+
+    // Create new views (invoked by the layout manager)
+    @Override
+    public PollingAdapter.ViewHolder onCreateViewHolder(ViewGroup parent,
+                                                   int viewType) {
+        // create a new view
+
+        LinearLayout pollingView = (LinearLayout) LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.polling_list_item, parent, false);
+
+        //
+        ViewHolder vh = new ViewHolder(pollingView);
+        return vh;
+    }
+
+    // Replace the contents of a view (invoked by the layout manager)
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        // - get element from your dataset at this position
+        // - replace the contents of the view with that element
+        ViewModel model = mDataset.get(position);
+        holder.setPollingCount(model.mPollingCount);
+        holder.setFinalStatus(model.mFinalStatus);
+        holder.setSourceId(model.mSourceId);
+    }
+
+    // Return the size of your dataset (invoked by the layout manager)
+    @Override
+    public int getItemCount() {
+        return mDataset.size();
+    }
+
+    public void addItem(String pollingCount, String finalStatus, String sourceId) {
+        mDataset.add(new ViewModel(pollingCount, finalStatus, sourceId));
+        notifyDataSetChanged();
+    }
+}

--- a/example/src/main/java/com/stripe/example/controller/PollingDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/PollingDialogController.java
@@ -1,0 +1,50 @@
+package com.stripe.example.controller;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import com.stripe.example.R;
+
+/**
+ * Controller for the polling dialog used to direct users out of the application.
+ */
+public class PollingDialogController {
+
+    AppCompatActivity mActivity;
+    AlertDialog mAlertDialog;
+
+    public PollingDialogController(AppCompatActivity appCompatActivity) {
+        mActivity = appCompatActivity;
+    }
+
+    public void showDialog(final String url) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
+        View dialogView = LayoutInflater.from(mActivity).inflate(R.layout.polling_dialog, null);
+
+        TextView linkView = (TextView) dialogView.findViewById(R.id.tv_link_redirect);
+        linkView.setText(R.string.verify);
+        linkView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                mActivity.startActivity(browserIntent);
+            }
+        });
+        builder.setView(dialogView);
+
+        mAlertDialog = builder.create();
+        mAlertDialog.show();
+    }
+
+    public void dismissDialog() {
+        if (mAlertDialog != null) {
+            mAlertDialog.dismiss();
+            mAlertDialog = null;
+        }
+    }
+}

--- a/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
@@ -19,11 +19,11 @@ public class ProgressDialogController {
         mProgressFragment = ProgressDialogFragment.newInstance(R.string.progressMessage);
     }
 
-    void startProgress() {
+    public void startProgress() {
         mProgressFragment.show(mFragmentManager, "progress");
     }
 
-    void finishProgress() {
+    public void finishProgress() {
         mProgressFragment.dismiss();
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
@@ -1,6 +1,7 @@
 package com.stripe.example.controller;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.support.v4.app.FragmentManager;
 
 import com.stripe.example.R;
@@ -17,6 +18,14 @@ public class ProgressDialogController {
     public ProgressDialogController(@NonNull FragmentManager fragmentManager) {
         mFragmentManager = fragmentManager;
         mProgressFragment = ProgressDialogFragment.newInstance(R.string.progressMessage);
+    }
+
+    public void setMessageResource(@StringRes int resId) {
+        if (mProgressFragment.isVisible()) {
+            mProgressFragment.dismiss();
+            mProgressFragment = null;
+        }
+        mProgressFragment = ProgressDialogFragment.newInstance(resId);
     }
 
     public void startProgress() {

--- a/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.java
+++ b/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.java
@@ -15,7 +15,7 @@ public class ProgressDialogFragment extends DialogFragment {
         fragment.setArguments(args);
 
         return fragment;
-   }
+    }
 
     public ProgressDialogFragment() {
         // Empty constructor required for DialogFragment

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -428,9 +428,6 @@ public class Stripe {
      *  `pending`. If polling stops due to an error, the callback will be fired with the latest
      *  retrieved source and the error.
      *
-     *  Note that if a poll is already running for a source, subsequent calls to `pollSource`
-     *  with the same source ID will do nothing.
-     *
      * @param sourceId the {@link Source#mId} to check on
      * @param clientSecret the {@link Source#mClientSecret} to check on
      * @param publishableKey an API key


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @bg-stripe 

Adding full polling integration in the PollingActivity that allows you to make a 3ds call, complete with linking out to a web site and getting redirected back to our application.

Note: this has *not* yet completed a proper redesign for the sample application, which would include a better routing system (we just tap the "Try 3DS" button from the first activity to get to the PollingActivity).

<img width="272" alt="screenshot 2017-03-17 12 33 33" src="https://cloud.githubusercontent.com/assets/23323692/24059764/837bd8f4-0b0d-11e7-8020-501682c5696d.png">

<img width="272" alt="screenshot 2017-03-17 12 34 22" src="https://cloud.githubusercontent.com/assets/23323692/24059777/884be8c4-0b0d-11e7-921e-ca412cc8b637.png">

<img width="272" alt="screenshot 2017-03-17 12 34 38" src="https://cloud.githubusercontent.com/assets/23323692/24059791/902df848-0b0d-11e7-8262-898c874f3171.png">

<img width="274" alt="screenshot 2017-03-17 12 34 46" src="https://cloud.githubusercontent.com/assets/23323692/24059797/94c7e49a-0b0d-11e7-9d8e-25d0653542f2.png">

