### PR TITLE
fixing two bugs: not correctly interpreting failed, and not ending on…

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -53,13 +53,15 @@ public class Source extends StripeJsonModel {
             PENDING,
             CHARGEABLE,
             CONSUMED,
-            CANCELED
+            CANCELED,
+            FAILED
     })
     public @interface SourceStatus { }
     public static final String PENDING = "pending";
     public static final String CHARGEABLE = "chargeable";
     public static final String CONSUMED = "consumed";
     public static final String CANCELED = "canceled";
+    public static final String FAILED = "failed";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -457,6 +459,8 @@ public class Source extends StripeJsonModel {
             return CONSUMED;
         } else if (CANCELED.equals(sourceStatus)) {
             return CANCELED;
+        } else if (FAILED.equals(sourceStatus)) {
+            return FAILED;
         }
         return null;
     }

--- a/stripe/src/main/java/com/stripe/android/net/PollingNetworkHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/PollingNetworkHandler.java
@@ -67,6 +67,9 @@ class PollingNetworkHandler {
                         case Source.CANCELED:
                             message = mUiHandler.obtainMessage(FAILURE, source);
                             break;
+                        case Source.FAILED:
+                            message = mUiHandler.obtainMessage(FAILURE, source);
+                            break;
                     }
                 }
             } catch (StripeException stripeEx) {
@@ -123,8 +126,10 @@ class PollingNetworkHandler {
 
                 switch (msg.what) {
                     case SUCCESS:
+                        terminated = true;
                         callback.onPollingResponse(
                                 new PollingResponse((Source) msg.obj, true, false));
+                        removeCallbacksAndMessages(null);
                         break;
                     case PENDING:
                         mRetryCount = 0;
@@ -136,11 +141,13 @@ class PollingNetworkHandler {
                         terminated = true;
                         callback.onPollingResponse(
                                 new PollingResponse((Source) msg.obj, false, false));
+                        removeCallbacksAndMessages(null);
                         break;
                     case EXPIRED:
                         terminated = true;
                         callback.onPollingResponse(
                                 new PollingResponse(mLatestRetrievedSource, false, true));
+                        removeCallbacksAndMessages(null);
                         break;
                     case ERROR:
                         mRetryCount++;
@@ -149,6 +156,7 @@ class PollingNetworkHandler {
                             callback.onPollingResponse(
                                     new PollingResponse(mLatestRetrievedSource,
                                             (StripeException) msg.obj));
+                            removeCallbacksAndMessages(null);
                         } else {
                             // We get this case for 500-errors
                             delayMs = Math.min(delayMs * POLLING_MULTIPLIER, MAX_DELAY_MS);


### PR DESCRIPTION
… success

r? @bg-stripe 
cc @sjayaraman-stripe 

There were two causes of bugs in my app implementation. The first was that I didn't include "failed" as a possible value for the status of a Source object (I thought "canceled" was the only failure state), and I didn't stop listening in my UI Handler when success came in, so the delayed call to send a "polling expired" message always landed, which would give our users a superfluous and confusing second message with every successful source polling.

Both are fixed and now tested in this PR.