### PR TITLE
adding a synchronous version of polling

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -23,6 +23,7 @@ import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
+import com.stripe.android.net.PollingResponse;
 import com.stripe.android.net.PollingResponseHandler;
 import com.stripe.android.net.RequestOptions;
 import com.stripe.android.net.StripeApiHandler;
@@ -446,6 +447,35 @@ public class Stripe {
         }
 
         StripeApiHandler.pollSource(sourceId, clientSecret, apiKey, callback, timeoutMs);
+    }
+
+    /**
+     *  Starts polling the {@link Source} object with the given ID on the current thread. If called
+     *  on the main thread, this method will crash the application.
+     *
+     *  For payment methods that require additional customer action
+     *  (e.g. authorizing a payment with their bank), polling
+     *  allows you to determine if the action was successful. Polling will stop once the
+     *  Source's status is no longer {@link Source#PENDING}, or if the given timeout is reached and
+     *  the Source is still `pending`. If polling stops due to an error, the latest retrieved Source
+     *  and latest thrown {@link StripeException} will be returned in the {@link PollingResponse}.
+     *
+     * @param sourceId the {@link Source#mId} to check on
+     * @param clientSecret the {@link Source#mClientSecret} to check on
+     * @param publishableKey an API key
+     * @param timeoutMs the amount of time before the polling expires. If {@code null} is passed
+     *                  in, 10000ms will be used.
+     */
+    public PollingResponse pollSourceSynchronous(@NonNull @Size(min = 1) String sourceId,
+                                                 @NonNull @Size(min = 1) String clientSecret,
+                                                 @Nullable String publishableKey,
+                                                 @Nullable Integer timeoutMs) {
+        String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
+        if (apiKey == null) {
+            return null;
+        }
+
+        return StripeApiHandler.pollSourceSynchronous(sourceId, clientSecret, apiKey, timeoutMs);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/net/PollingParameters.java
+++ b/stripe/src/main/java/com/stripe/android/net/PollingParameters.java
@@ -34,7 +34,6 @@ class PollingParameters {
         mPollingMultiplier = pollingMultiplier;
     }
 
-
     long getDefaultTimeoutMs() {
         return mDefaultTimeoutMs;
     }

--- a/stripe/src/main/java/com/stripe/android/net/PollingParameters.java
+++ b/stripe/src/main/java/com/stripe/android/net/PollingParameters.java
@@ -1,0 +1,75 @@
+package com.stripe.android.net;
+
+/**
+ * Container class for polling parameters.
+ */
+class PollingParameters {
+
+    private static final long DEFAULT_TIMEOUT_MS = 10000L;
+    private static final long INITIAL_DELAY_MS = 1000;
+    private static final long MAX_DELAY_MS = 15000;
+    private static final int MAX_RETRY_COUNT = 5;
+    private static final long MAX_TIMEOUT_MS = 5L * 60L * 1000L; // five minutes
+    private static final int POLLING_MULTIPLIER = 2;
+
+    private final long mDefaultTimeoutMs;
+    private final long mInitialDelayMs;
+    private final long mMaxDelayMs;
+    private final int mMaxRetryCount;
+    private final long mMaxTimeoutMs;
+    private final int mPollingMultiplier;
+
+    PollingParameters(
+            long defaultTimeoutMs,
+            long initialDelayMs,
+            long maxDelayMs,
+            int maxRetryCount,
+            long maxTimeoutMs,
+            int pollingMultiplier) {
+        mDefaultTimeoutMs = defaultTimeoutMs;
+        mInitialDelayMs = initialDelayMs;
+        mMaxDelayMs = maxDelayMs;
+        mMaxRetryCount = maxRetryCount;
+        mMaxTimeoutMs = maxTimeoutMs;
+        mPollingMultiplier = pollingMultiplier;
+    }
+
+
+    long getDefaultTimeoutMs() {
+        return mDefaultTimeoutMs;
+    }
+
+    long getInitialDelayMs() {
+        return mInitialDelayMs;
+    }
+
+    int getInitialDelayMsInt() {
+        return (int) mInitialDelayMs;
+    }
+
+    long getMaxDelayMs() {
+        return mMaxDelayMs;
+    }
+
+    int getMaxRetryCount() {
+        return mMaxRetryCount;
+    }
+
+    long getMaxTimeoutMs() {
+        return mMaxTimeoutMs;
+    }
+
+    int getPollingMultiplier() {
+        return mPollingMultiplier;
+    }
+
+    static PollingParameters generateDefaultParameters() {
+        return new PollingParameters(
+                DEFAULT_TIMEOUT_MS,
+                INITIAL_DELAY_MS,
+                MAX_DELAY_MS,
+                MAX_RETRY_COUNT,
+                MAX_TIMEOUT_MS,
+                POLLING_MULTIPLIER);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/PollingSyncNetworkHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/PollingSyncNetworkHandler.java
@@ -1,0 +1,135 @@
+package com.stripe.android.net;
+
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Source;
+
+/**
+ * A synchronous polling manager that does not manage which thread
+ * it is run on.
+ */
+class PollingSyncNetworkHandler {
+
+    @NonNull private final String mSourceId;
+    @NonNull private final String mClientSecret;
+    @NonNull private final String mPublishableKey;
+    @NonNull private final PollingParameters mPollingParameters;
+    @NonNull private SourceRetriever mSourceRetriever;
+    @NonNull private TimeRetriever mTimeRetriever;
+
+    private long mTimeOutMs;
+
+    PollingSyncNetworkHandler(
+            @NonNull final String sourceId,
+            @NonNull final String clientSecret,
+            @NonNull final String publishableKey,
+            @Nullable Integer timeOutMs,
+            @Nullable SourceRetriever sourceRetriever,
+            @Nullable TimeRetriever timeRetriever,
+            @NonNull final PollingParameters pollingParameters) {
+        mSourceId = sourceId;
+        mClientSecret = clientSecret;
+        mPublishableKey = publishableKey;
+        mPollingParameters = pollingParameters;
+        mTimeOutMs = timeOutMs == null ?
+                mPollingParameters.getDefaultTimeoutMs()
+                : Math.min(timeOutMs.longValue(), mPollingParameters.getMaxTimeoutMs());
+
+        mSourceRetriever = sourceRetriever == null ? generateSourceRetriever() : sourceRetriever;
+        mTimeRetriever = timeRetriever == null ? generateTimeRetriever() : timeRetriever;
+    }
+
+    @NonNull
+    PollingResponse pollForSourceUpdate() {
+        Source source = null;
+        int errorCount = 0;
+        long delayMs = mPollingParameters.getInitialDelayMs();
+        long startTime = mTimeRetriever.getCurrentTimeInMillis();
+        do {
+            long timeWaited = mTimeRetriever.getCurrentTimeInMillis() - startTime;
+            if (timeWaited > mTimeOutMs) {
+                break;
+            }
+
+            try {
+                source = mSourceRetriever.retrieveSource(
+                        mSourceId,
+                        mClientSecret,
+                        mPublishableKey);
+                delayMs = mPollingParameters.getInitialDelayMs();
+                errorCount = 0;
+            } catch (StripeException stripeEx) {
+                if (++errorCount >= mPollingParameters.getMaxRetryCount()) {
+                    return new PollingResponse(source, stripeEx);
+                }
+                delayMs =
+                        Math.min(
+                                delayMs * mPollingParameters.getPollingMultiplier(),
+                                mPollingParameters.getMaxDelayMs());
+            }
+
+            if (source != null) {
+                switch (source.getStatus()) {
+                    case Source.CHARGEABLE:
+                        return new PollingResponse(source, true, false);
+                    case Source.CONSUMED:
+                        return new PollingResponse(source, true, false);
+                    case Source.CANCELED:
+                        return new PollingResponse(source, false, false);
+                    case Source.FAILED:
+                        return new PollingResponse(source, false, false);
+                    default:
+                        // Then the source is still PENDING
+                        break;
+                }
+            }
+
+            try {
+                synchronized (this) {
+                    wait(delayMs);
+                }
+            } catch (InterruptedException ignored) {
+                // This will decrease our wait time, but our timeout and
+                // max retries will be unaffected.
+            }
+        } while (source == null || Source.PENDING.equals(source.getStatus()));
+
+        return new PollingResponse(source, false, true);
+    }
+
+    @VisibleForTesting
+    long getTimeOutMs() {
+        return mTimeOutMs;
+    }
+
+    interface TimeRetriever {
+        long getCurrentTimeInMillis();
+    }
+
+    @NonNull
+    private static SourceRetriever generateSourceRetriever() {
+        return new SourceRetriever() {
+            @Override
+            public Source retrieveSource(
+                    @NonNull String sourceId,
+                    @NonNull String clientSecret,
+                    @NonNull String publishableKey) throws StripeException {
+                return StripeApiHandler.retrieveSource(sourceId, clientSecret, publishableKey);
+            }
+        };
+    }
+
+    @NonNull
+    private static TimeRetriever generateTimeRetriever() {
+        return new TimeRetriever() {
+            @Override
+            public long getCurrentTimeInMillis() {
+                return SystemClock.uptimeMillis();
+            }
+        };
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/net/SourceRetriever.java
+++ b/stripe/src/main/java/com/stripe/android/net/SourceRetriever.java
@@ -1,0 +1,17 @@
+package com.stripe.android.net;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Source;
+
+/**
+ * Represents something that can retrieve a source.
+ */
+interface SourceRetriever {
+    Source retrieveSource(
+            @NonNull String sourceId,
+            @NonNull String clientSecret,
+            @NonNull String publishableKey)
+            throws StripeException;
+}

--- a/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/net/StripeApiHandler.java
@@ -163,8 +163,37 @@ public class StripeApiHandler {
                         publishableKey,
                         callback,
                         timeoutMs,
-                        null);
+                        null,
+                        PollingParameters.generateDefaultParameters());
         networkHandler.start();
+    }
+
+    /**
+     * Polls for source updates synchronously. If called on the main thread,
+     * this will crash the application.
+     *
+     * @param sourceId the {@link Source#mId ID} of the Source being polled
+     * @param clientSecret the {@link Source#mClientSecret client_secret} of the Source
+     * @param publishableKey a public API key
+     * @param timeoutMs the amount of time before the polling expires. If {@code null} is passed
+     *                  in, 10000ms will be used.
+     * @return a {@link PollingResponse} that will indicate success or failure
+     */
+    public static PollingResponse pollSourceSynchronous(
+            @NonNull final String sourceId,
+            @NonNull final String clientSecret,
+            @NonNull final String publishableKey,
+            @Nullable Integer timeoutMs) {
+        PollingSyncNetworkHandler pollingSyncNetworkHandler =
+                new PollingSyncNetworkHandler(
+                        sourceId,
+                        clientSecret,
+                        publishableKey,
+                        timeoutMs,
+                        null,
+                        null,
+                        PollingParameters.generateDefaultParameters());
+        return pollingSyncNetworkHandler.pollForSourceUpdate();
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/net/PollingNetworkHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/PollingNetworkHandlerTest.java
@@ -17,7 +17,6 @@ import org.robolectric.shadows.ShadowLooper;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.stripe.android.net.PollingNetworkHandler.SourceRetriever;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -342,7 +341,8 @@ public class PollingNetworkHandlerTest {
                 DUMMY_PUBLISHABLE_KEY,
                 pollingResponseHandler,
                 timeout,
-                sourceRetriever);
+                sourceRetriever,
+                PollingParameters.generateDefaultParameters());
     }
 
     private static void advanceMainLooperBy(int millis) {

--- a/stripe/src/test/java/com/stripe/android/net/PollingSyncNetworkHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/PollingSyncNetworkHandlerTest.java
@@ -1,0 +1,315 @@
+package com.stripe.android.net;
+
+import com.stripe.android.exception.APIConnectionException;
+import com.stripe.android.exception.APIException;
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Source;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.OngoingStubbing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link PollingSyncNetworkHandler}.
+ */
+public class PollingSyncNetworkHandlerTest {
+
+    private static final String DUMMY_SOURCE_ID = "sourceId";
+    private static final String DUMMY_CLIENT_SECRET = "clientSecret";
+    private static final String DUMMY_PUBLISHABLE_KEY = "pubKey";
+
+    @Mock Source mCancelledSource;
+    @Mock Source mChargeableSource;
+    @Mock Source mConsumedSource;
+    @Mock Source mFailedSource;
+    @Mock Source mPendingSource;
+
+    @Mock SourceRetriever mSourceRetriever;
+
+    private PollingParameters mPollingParameters;
+    private PollingSyncNetworkHandler.TimeRetriever mTimeRetriever;
+    private PollingSyncNetworkHandler mPollingSyncNetworkHandler;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        mTimeRetriever = new PollingSyncNetworkHandler.TimeRetriever() {
+            @Override
+            public long getCurrentTimeInMillis() {
+                return System.currentTimeMillis();
+            }
+        };
+        when(mConsumedSource.getStatus()).thenReturn(Source.CONSUMED);
+        when(mChargeableSource.getStatus()).thenReturn(Source.CHARGEABLE);
+        when(mPendingSource.getStatus()).thenReturn(Source.PENDING);
+        when(mCancelledSource.getStatus()).thenReturn(Source.CANCELED);
+        when(mFailedSource.getStatus()).thenReturn(Source.FAILED);
+
+        mPollingParameters = new PollingParameters(
+                10000L,
+                100L,
+                1500,
+                5,
+                5L * 60L * 1000L,
+                2);
+        mPollingSyncNetworkHandler = new PollingSyncNetworkHandler(
+                DUMMY_SOURCE_ID,
+                DUMMY_CLIENT_SECRET,
+                DUMMY_PUBLISHABLE_KEY,
+                1000,
+                mSourceRetriever,
+                mTimeRetriever,
+                mPollingParameters);
+    }
+
+    @Test
+    public void createHandler_withNullTimeout_usesDefault() {
+        PollingSyncNetworkHandler handler = new PollingSyncNetworkHandler(
+                DUMMY_SOURCE_ID,
+                DUMMY_CLIENT_SECRET,
+                DUMMY_PUBLISHABLE_KEY,
+                null,
+                mSourceRetriever,
+                mTimeRetriever,
+                PollingParameters.generateDefaultParameters());
+        assertEquals(10000L, handler.getTimeOutMs());
+    }
+
+    @Test
+    public void createHandler_withNonNullTimeoutBelowMax_usesSetValue() {
+        PollingSyncNetworkHandler handler = new PollingSyncNetworkHandler(
+                DUMMY_SOURCE_ID,
+                DUMMY_CLIENT_SECRET,
+                DUMMY_PUBLISHABLE_KEY,
+                12345,
+                mSourceRetriever,
+                mTimeRetriever,
+                PollingParameters.generateDefaultParameters());
+        assertEquals(12345L, handler.getTimeOutMs());
+    }
+
+    @Test
+    public void createHandler_withTimeoutGreaterThanMax_usesMax() {
+        long fiveMinutesInMillis = 5L * 60L * 1000L;
+        Integer tenMinutesInMillis = 10 * 60 *1000;
+        PollingSyncNetworkHandler handler = new PollingSyncNetworkHandler(
+                DUMMY_SOURCE_ID,
+                DUMMY_CLIENT_SECRET,
+                DUMMY_PUBLISHABLE_KEY,
+                tenMinutesInMillis,
+                mSourceRetriever,
+                mTimeRetriever,
+                PollingParameters.generateDefaultParameters());
+        assertEquals(fiveMinutesInMillis, handler.getTimeOutMs());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenChargeable_returnsSuccess() {
+        setSourceResponses(mSourceRetriever, mChargeableSource);
+
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        assertNotNull(response.getSource());
+        assertEquals(Source.CHARGEABLE, response.getSource().getStatus());
+        assertTrue(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenConsumed_returnsSuccess() {
+        setSourceResponses(mSourceRetriever, mConsumedSource);
+
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        assertNotNull(response.getSource());
+        assertEquals(Source.CONSUMED, response.getSource().getStatus());
+        assertTrue(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenChangesToChargeable_returnsSuccess() {
+        setSourceResponses(mSourceRetriever, mPendingSource, mChargeableSource);
+
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        verifyRetrieveCallCount(mSourceRetriever, 2);
+
+        assertNotNull(response.getSource());
+        assertEquals(Source.CHARGEABLE, response.getSource().getStatus());
+        assertTrue(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenChangesToFailed_returnsFailure() {
+        setSourceResponses(mSourceRetriever, mPendingSource, mPendingSource, mFailedSource);
+
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        verifyRetrieveCallCount(mSourceRetriever, 3);
+
+        assertNotNull(response.getSource());
+        assertEquals(Source.FAILED, response.getSource().getStatus());
+        assertFalse(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenChangesToCanceled_returnsFailure() {
+        setSourceResponses(mSourceRetriever, mPendingSource, mPendingSource, mCancelledSource);
+
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        verifyRetrieveCallCount(mSourceRetriever, 3);
+
+        assertNotNull(response.getSource());
+        assertEquals(Source.CANCELED, response.getSource().getStatus());
+        assertFalse(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenAlwaysPending_expires() {
+        setSourceResponses(mSourceRetriever, mPendingSource);
+        long startTime = System.currentTimeMillis();
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        long endTime = System.currentTimeMillis();
+
+        assertTrue(endTime - startTime > 1000L);
+        // Default timeout is 10 seconds (set to 1 for test),
+        // and we poll ten times per second (in test), so we should be slightly
+        // over the timeout limit after 10 tries.
+        verifyRetrieveCallCount(mSourceRetriever, 10);
+        assertNotNull(response.getSource());
+        assertEquals(Source.PENDING, response.getSource().getStatus());
+        assertFalse(response.isSuccess());
+        assertTrue(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenSingleExceptionThenChargeable_returnsSuccess() {
+        setSourceResponses(mSourceRetriever, mPendingSource, mPendingSource, mCancelledSource);
+
+        try {
+            when(mSourceRetriever.retrieveSource(
+                    DUMMY_SOURCE_ID,
+                    DUMMY_CLIENT_SECRET,
+                    DUMMY_PUBLISHABLE_KEY))
+                    .thenReturn(mPendingSource)
+                    .thenThrow(new APIConnectionException("Stripe is down"))
+                    .thenThrow(new APIConnectionException("Still down"))
+                    .thenReturn(mChargeableSource);
+        } catch (StripeException stripeEx) {
+            fail("Unexpected exception: " + stripeEx.getLocalizedMessage());
+        }
+
+        long startTime = System.currentTimeMillis();
+        PollingResponse response = mPollingSyncNetworkHandler.pollForSourceUpdate();
+        long endTime = System.currentTimeMillis();
+
+        // If the exception instances were just pending responses, this would only take
+        // approximately 4000ms
+        assertTrue("Exponential backing off should delay calls", endTime - startTime >= 700L);
+        verifyRetrieveCallCount(mSourceRetriever, 4);
+
+        assertNotNull(response.getSource());
+        assertEquals(Source.CHARGEABLE, response.getSource().getStatus());
+        assertTrue(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    @Test
+    public void pollForSourceUpdate_whenFiveExceptions_returnsFailureWithLastException() {
+
+        PollingSyncNetworkHandler pollingSyncNetworkHandler
+                = new PollingSyncNetworkHandler(
+                        DUMMY_SOURCE_ID,
+                        DUMMY_CLIENT_SECRET,
+                        DUMMY_PUBLISHABLE_KEY,
+                        5000, // need a longer timeout because of the exponential backoff
+                        mSourceRetriever,
+                        mTimeRetriever,
+                        mPollingParameters);
+        APIConnectionException connectEx = new APIConnectionException("Can't reach server");
+        APIException apiException = new APIException("Something different", "abc", 123, null);
+        setSourceExceptions(mSourceRetriever,
+                connectEx,
+                connectEx,
+                connectEx,
+                connectEx,
+                apiException);
+
+        long startTime = System.currentTimeMillis();
+        PollingResponse response = pollingSyncNetworkHandler.pollForSourceUpdate();
+        long endTime = System.currentTimeMillis();
+
+        // Delays are 100 + 200 + 400 + 800 = 1500
+        assertTrue("Exponential backing off should delay calls", endTime - startTime >= 1500L);
+        verifyRetrieveCallCount(mSourceRetriever, 5);
+
+        assertNull(response.getSource());
+        assertNotNull(response.getStripeException());
+        assertTrue(response.getStripeException() instanceof APIException);
+        assertFalse(response.isSuccess());
+        assertFalse(response.isExpired());
+    }
+
+    private static void verifyRetrieveCallCount(SourceRetriever sourceRetriever, int count) {
+        try {
+            verify(sourceRetriever, times(count)).retrieveSource(
+                    DUMMY_SOURCE_ID,
+                    DUMMY_CLIENT_SECRET,
+                    DUMMY_PUBLISHABLE_KEY);
+        } catch (StripeException stripeEx) {
+            fail("Unexpected exception: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
+    private static void setSourceResponses(SourceRetriever sourceRetriever, Source... sources) {
+        try {
+            OngoingStubbing<Source> stubbing = null;
+            for(Source source : sources) {
+                if (stubbing == null) {
+                    stubbing = when(sourceRetriever.retrieveSource(
+                            DUMMY_SOURCE_ID,
+                            DUMMY_CLIENT_SECRET,
+                            DUMMY_PUBLISHABLE_KEY)).thenReturn(source);
+                } else {
+                    stubbing = stubbing.thenReturn(source);
+                }
+            }
+
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
+    private static void setSourceExceptions(SourceRetriever sourceRetriever,
+                                            StripeException... exes) {
+        try {
+            OngoingStubbing<Source> stubbing = null;
+
+            for (StripeException ex : exes) {
+                if (stubbing == null) {
+                    stubbing = when(sourceRetriever.retrieveSource(
+                            DUMMY_SOURCE_ID,
+                            DUMMY_CLIENT_SECRET,
+                            DUMMY_PUBLISHABLE_KEY)).thenThrow(ex);
+                } else {
+                    stubbing = stubbing.thenThrow(ex);
+                }
+            }
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+}


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Adding a synchronous version of polling, so users can schedule the thread themselves. This is considerably simpler, code-wise than the async version. I refactored some of the constants for testing's sake, and allowed for customization of the selected timer object because Robolectric doesn't like using SystemClock.uptimeMillis(), which developers.android says is the appropriate timing tool for our situation.

I purposefully avoided adding example app changes to this diff in order to keep the size down (and because all further diffs on polling will involve sample app changes)