### PR TITLE
adding the ability to change the hint text on the card field

### DIFF
--- a/example/res/layout/activity_polling.xml
+++ b/example/res/layout/activity_polling.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:stripe="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -17,6 +18,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
+        stripe:cardHintText="@string/sample_card_requiring_3ds"
         />
 
     <Button

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="label_source_state">Status</string>
     <string name="label_source_id">ID Last 6</string>
 
+    <string name="sample_card_requiring_3ds">4000 0000 0000 3063</string>
+
     <string-array name="currency_array">
         <item>Currency (optional)</item>
         <item>Unspecified</item>

--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="CardInputView">
+        <attr name="cardHintText" format="string" />
         <attr name="cardTint" format="color"/>
         <attr name="cardTextErrorColor" format="color"/>
     </declare-styleable>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -9,7 +9,6 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringRes;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -9,6 +9,7 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
@@ -81,6 +82,7 @@ public class CardInputWidget extends LinearLayout {
 
     private FrameLayout mFrameLayout;
 
+    private String mCardHintText;
     private @ColorInt int mErrorColorInt;
     private @ColorInt int mTintColorInt;
 
@@ -376,11 +378,16 @@ public class CardInputWidget extends LinearLayout {
                         a.getColor(R.styleable.CardInputView_cardTextErrorColor, mErrorColorInt);
                 mTintColorInt =
                         a.getColor(R.styleable.CardInputView_cardTint, mTintColorInt);
+                mCardHintText =
+                        a.getString(R.styleable.CardInputView_cardHintText);
             } finally {
                 a.recycle();
             }
         }
 
+        if (mCardHintText != null) {
+            mCardNumberEditText.setHint(mCardHintText);
+        }
         mCardNumberEditText.setErrorColor(mErrorColorInt);
         mExpiryDateEditText.setErrorColor(mErrorColorInt);
         mCvcNumberEditText.setErrorColor(mErrorColorInt);


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Tiny diff to make it easier to set the hint text for the card entry field, in case people don't like 4242.

<img width="327" alt="screenshot 2017-03-27 12 36 52" src="https://cloud.githubusercontent.com/assets/23323692/24374388/7e675ff8-12e9-11e7-9d57-dd0b510fc50a.png">
