### PR TITLE
making sepa line 1 optional

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -232,7 +232,7 @@ public class SourceParams {
     public static SourceParams createSepaDebitParams(
             @NonNull String name,
             @NonNull String iban,
-            @NonNull String addressLine1,
+            @Nullable String addressLine1,
             @NonNull String city,
             @NonNull String postalCode,
             @NonNull @Size(2) String country) {

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -470,6 +470,40 @@ public class StripeTest {
     }
 
     @Test
+    public void createSepaDebitSource_withNoAddress_passesIntegrationTest() {
+        Stripe stripe = new Stripe(mContext);
+        String validIban = "DE89370400440532013000";
+        SourceParams params = SourceParams.createSepaDebitParams(
+                "Sepa Account Holder",
+                validIban,
+                null,
+                "Eureka",
+                "90210",
+                "EI");
+
+        try {
+            Source sepaDebitSource =
+                    stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+            assertNotNull(sepaDebitSource);
+            assertNotNull(sepaDebitSource.getClientSecret());
+            assertNotNull(sepaDebitSource.getId());
+            assertEquals(Source.SEPA_DEBIT, sepaDebitSource.getType());
+            assertNotNull(sepaDebitSource.getSourceTypeData());
+            assertNotNull(sepaDebitSource.getOwner());
+            assertNotNull(sepaDebitSource.getOwner().getAddress());
+            assertNotNull(sepaDebitSource.getSourceTypeModel());
+            assertTrue(sepaDebitSource.getSourceTypeModel() instanceof SourceSepaDebitData);
+            assertEquals("eur", sepaDebitSource.getCurrency());
+            assertEquals("Eureka", sepaDebitSource.getOwner().getAddress().getCity());
+            assertEquals("90210", sepaDebitSource.getOwner().getAddress().getPostalCode());
+            assertEquals("EI", sepaDebitSource.getOwner().getAddress().getCountry());
+            assertEquals("Sepa Account Holder", sepaDebitSource.getOwner().getName());
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
+        @Test
     public void createSourceSynchronous_withIDealParams_passesIntegrationTest() {
         Stripe stripe = new Stripe(mContext);
         SourceParams params = SourceParams.createIdealParams(


### PR DESCRIPTION
r? @bg-stripe 
cc @bdorfman-stripe 

As per APM team request, the SEPA Debit params creator's line 1 is now optional. Threw in a test to make sure creating that on the back end doesn't barf.