### PR TITLE
adding defaults that work better in design mode

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -94,6 +94,8 @@
             android:visibility="visible"
             android:focusable="true"
             android:focusableInTouchMode="true"
+            android:layout_marginLeft="@dimen/card_expiry_initial_margin"
+            android:layout_marginStart="@dimen/card_expiry_initial_margin"
             android:layout_gravity="left"
             />
 
@@ -110,6 +112,8 @@
             android:hint="@string/cvc_number_hint"
             android:inputType="number"
             android:maxLength="4"
+            android:layout_marginLeft="@dimen/card_cvc_initial_margin"
+            android:layout_marginStart="@dimen/card_cvc_initial_margin"
             android:layout_gravity="left"
             />
 

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -2,4 +2,6 @@
 <resources>
     <dimen name="card_icon_padding">12dp</dimen>
     <dimen name="card_widget_min_width">320dp</dimen>
+    <dimen name="card_expiry_initial_margin">200dp</dimen>
+    <dimen name="card_cvc_initial_margin">1000dp</dimen>
 </resources>


### PR DESCRIPTION
r? @bg-stripe 
cc @anelder-stripe

The current display widget shows fine when you run the application, but in the design preview, the layout isn't yet spaced, so you get a bit of a jumble:
<img width="260" alt="screenshot 2017-04-04 10 13 22" src="https://cloud.githubusercontent.com/assets/23323692/24671002/feb18512-1924-11e7-9e35-51963fd59376.png">

I added defaults (that are immediately overwritten at runtime)
<img width="262" alt="screenshot 2017-04-04 10 15 29" src="https://cloud.githubusercontent.com/assets/23323692/24671017/0a7bb23c-1925-11e7-831b-c162a2de19ea.png">
