### PR TITLE
removing the try catch needed around constructor for Stripe object

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -124,7 +124,6 @@ public class Stripe {
      *
      * @param context {@link Context} for resolving resources
      * @param publishableKey the client's publishable key
-     * @throws AuthenticationException if the key is invalid
      */
     public Stripe(@NonNull Context context, String publishableKey) throws AuthenticationException {
         mContext = context;
@@ -542,10 +541,8 @@ public class Stripe {
      * Set the default publishable key to use with this {@link Stripe} instance.
      *
      * @param publishableKey the key to be set
-     * @throws AuthenticationException if the key is null, empty, or a secret key
      */
-    public void setDefaultPublishableKey(@NonNull @Size(min = 1) String publishableKey)
-            throws AuthenticationException {
+    public void setDefaultPublishableKey(@NonNull @Size(min = 1) String publishableKey) {
         validateKey(publishableKey);
         this.mDefaultPublishableKey = publishableKey;
     }
@@ -560,34 +557,28 @@ public class Stripe {
             @NonNull @Size(min = 1) final String publishableKey,
             @Nullable final Executor executor,
             @NonNull final TokenCallback callback) {
-        try {
-            if (callback == null) {
-                throw new RuntimeException(
-                        "Required Parameter: 'callback' is required to use the created " +
-                                "token and handle errors");
-            }
+        if (callback == null) {
+            throw new RuntimeException(
+                    "Required Parameter: 'callback' is required to use the created " +
+                            "token and handle errors");
+        }
 
-            validateKey(publishableKey);
-            mTokenCreator.create(tokenParams, publishableKey, executor, callback);
-        }
-        catch (AuthenticationException e) {
-            callback.onError(e);
-        }
+        validateKey(publishableKey);
+        mTokenCreator.create(tokenParams, publishableKey, executor, callback);
     }
 
-    private void validateKey(@NonNull @Size(min = 1) String publishableKey)
-            throws AuthenticationException {
+    private void validateKey(@NonNull @Size(min = 1) String publishableKey) {
         if (publishableKey == null || publishableKey.length() == 0) {
-            throw new AuthenticationException("Invalid Publishable Key: " +
+            throw new IllegalArgumentException("Invalid Publishable Key: " +
                     "You must use a valid publishable key to create a token.  " +
-                    "For more info, see https://stripe.com/docs/stripe.js.", null, 0);
+                    "For more info, see https://stripe.com/docs/stripe.js.");
         }
 
         if (publishableKey.startsWith("sk_")) {
-            throw new AuthenticationException("Invalid Publishable Key: " +
+            throw new IllegalArgumentException("Invalid Publishable Key: " +
                     "You are using a secret key to create a token, " +
                     "instead of the publishable one. For more info, " +
-                    "see https://stripe.com/docs/stripe.js", null, 0);
+                    "see https://stripe.com/docs/stripe.js");
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.fail;
 @Config(constants = BuildConfig.class, sdk = 22)
 public class StripeTest {
 
-
     private static final String DEFAULT_PUBLISHABLE_KEY = "pk_default";
     private static final String DEFAULT_SECRET_KEY = "sk_default";
     private static final Card DEFAULT_CARD = new Card(null, null, null, null);
@@ -86,34 +85,34 @@ public class StripeTest {
                 TEST_BANK_ROUTING_NUMBER);
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void constructorShouldFailWithNullPublishableKey() throws AuthenticationException {
         new Stripe(mContext, null);
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void constructorShouldFailWithEmptyPublishableKey() throws AuthenticationException {
         new Stripe(mContext, "");
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void constructorShouldFailWithSecretKey() throws AuthenticationException {
         new Stripe(mContext, DEFAULT_SECRET_KEY);
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void setDefaultPublishableKeyShouldFailWhenNull() throws AuthenticationException {
         Stripe stripe = new Stripe(mContext);
         stripe.setDefaultPublishableKey(null);
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void setDefaultPublishableKeyShouldFailWhenEmpty() throws AuthenticationException {
         Stripe stripe = new Stripe(mContext);
         stripe.setDefaultPublishableKey("");
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void setDefaultPublishableKeyShouldFailWithSecretKey() throws AuthenticationException {
         Stripe stripe = new Stripe(mContext);
         stripe.setDefaultPublishableKey(DEFAULT_SECRET_KEY);
@@ -132,15 +131,25 @@ public class StripeTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void createTokenShouldFailWithNullTokencallback() {
+    public void createTokenShouldFailWithNullTokenCallback() {
         Stripe stripe = new Stripe(mContext);
         stripe.createToken(DEFAULT_CARD, null);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void createTokenShouldFailWithNullPublishableKey() {
         Stripe stripe = new Stripe(mContext);
-        stripe.createToken(DEFAULT_CARD, new ErrorTokenCallback(AuthenticationException.class));
+        stripe.createToken(DEFAULT_CARD, new TokenCallback() {
+            @Override
+            public void onError(Exception error) {
+                fail("Should not call method");
+            }
+
+            @Override
+            public void onSuccess(Token token) {
+                fail("Should not call method");
+            }
+        });
     }
 
     @Test
@@ -639,7 +648,7 @@ public class StripeTest {
         try {
             stripe.createTokenSynchronous(mCard);
             fail("We shouldn't be able to make a token without a key.");
-        } catch (StripeException exception) {
+        } catch (Exception exception) {
             // Note: we're not testing the type of exception in this test.
             assertNull(listener.mStripeResponse);
             assertNull(listener.mStripeException);
@@ -693,24 +702,6 @@ public class StripeTest {
         @Override
         public void onStripeException(StripeException exception) {
             mStripeException = exception;
-        }
-    }
-
-    private static class ErrorTokenCallback implements TokenCallback {
-        final Class<?> expectedError;
-
-        public ErrorTokenCallback(Class<?> expectedError) {
-            this.expectedError = expectedError;
-        }
-
-        @Override
-        public void onError(Exception error) {
-            assertEquals(expectedError, error.getClass());
-        }
-
-        @Override
-        public void onSuccess(Token token) {
-            fail("onSuccess should not be called");
         }
     }
 }


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Just doing a solid for our users. While we do want to throw an exception if you try to give us a bad publishable key (or try to give us a secret key), it's super annoying to have to try/catch every single constructor. By switching to IllegalArgumentException, you can still find out that you've done it wrong when you test your app, but you don't have to have 10 extra lines of annoying code wrapping a simple constructor.