### PR TITLE
fixing bug that fails validation for pasted-in credit cards

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -210,7 +210,8 @@ public class CardNumberEditText extends StripeEditText {
                         mCardNumberCompleteListener.onCardNumberComplete();
                     }
                 } else {
-                    mIsCardNumberValid = false;
+                    mIsCardNumberValid = getText() != null
+                            && CardUtils.isValidCardNumber(getText().toString());
                     // Don't show errors if we aren't full-length.
                     setShouldShowError(false);
                 }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -130,6 +130,14 @@ public class CardNumberEditTextTest {
     }
 
     @Test
+    public void setText_whenTextIsSpacelessValidNumber_changesToSpaceNumberAndValidates() {
+        mCardNumberEditText.setText(VALID_VISA_NO_SPACES);
+
+        assertTrue(mCardNumberEditText.isCardNumberValid());
+        verify(mCardNumberCompleteListener, times(1)).onCardNumberComplete();
+    }
+
+    @Test
     public void setText_whenTextIsValidAmExDinersClubLengthNumber_changesCardValidState() {
         mCardNumberEditText.setText(VALID_AMEX_WITH_SPACES);
 


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

There is a weird bug in CardNumberEditText that causes card numbers to be invalidated if you paste them in. The widget as a whole actually looks like it's working, because the card number is read as valid right before it is read as invalid.

I added a test case that fails without the source change and passes with it to check for regressions. We'll have to ship a patch update with this. Fixes issue 197: https://github.com/stripe/stripe-android/issues/197