### PR TITLE
adding migration documentation and fixing throws statement in Stripe …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+4.0.0 2017-04-10
+    Fixed issue #179, where certain pasted in credit cards would be incorrectly read as invalid
+    *breaking* Removed the try/catch required around Stripe instance creation.
+
 3.1.1 2017-04-04
     Fixed design tab display bug on card input widget
     Upgraded to Gradle version 3.4.1

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,23 @@
+## Migration Guides
+
+### Migrating from versions < 4.0.0
+
+- Instantiation of a Stripe object can no longer throw an `AuthenticationException`.
+    - Any time you were instantiating a Stripe object in a try/catch block will be simplified.
+    ```java
+    Stripe stripe;
+    try {
+       stripe = new Stripe(mContext, MY_PUBLISHABLE_KEY);
+    } catch (AuthenticationException authEx) {
+       // This never happens because you check your key.
+    }
+    ```
+    now becomes
+    ```java
+    Stripe stripe = new Stripe(mContext, MY_PUBLISHABLE_KEY);
+    ```
+- `Stripe#setDefaultPublishableKey(String key)` has similarly been changed, and no longer needs to be wrapped.
+- Both methods can still throw an `IllegalArgumentException` if an invalid key is used, but as a
+runtime exception, that does not need to be wrapped.
+- `AuthenticationException` will now only be thrown if you attempt to create a `Token` or `Source`
+with an invalid key.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These Stripe Android bindings can be used to generate tokens in your Android app
 
 No need to clone the repository or download any files -- just add this line to your app's `build.gradle` inside the `dependencies` section:
 
-    compile 'com.stripe:stripe-android:3.1.1'
+    compile 'com.stripe:stripe-android:4.0.0'
 
 Note: We recommend that you don't use `compile 'com.stripe:stripe-android:+`, as future versions of the SDK may not maintain full backwards compatibility. When such a change occurs, a major version number change will accompany it.
 
@@ -293,3 +293,7 @@ The example application ships with a sample publishable key, but if you want to 
 
 Three different ways of creating tokens are shown, with all the Stripe-specific logic needed for each separated into the three controllers,
 [AsyncTaskTokenController](example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java), [RxTokenController](example/src/main/java/com/stripe/example/controller/RxTokenController.java), and [IntentServiceTokenController](example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java).
+
+## Migrating from older versions
+
+See `MIGRATING.md`

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -125,7 +125,7 @@ public class Stripe {
      * @param context {@link Context} for resolving resources
      * @param publishableKey the client's publishable key
      */
-    public Stripe(@NonNull Context context, String publishableKey) throws AuthenticationException {
+    public Stripe(@NonNull Context context, String publishableKey) {
         mContext = context;
         setDefaultPublishableKey(publishableKey);
     }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -155,20 +155,16 @@ public class StripeTest {
     @Test
     public void createTokenShouldCallTokenCreator() {
         final boolean[] tokenCreatorCalled = { false };
-        try {
-            Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
-            stripe.mTokenCreator = new Stripe.TokenCreator() {
-                @Override
-                public void create(Map<String, Object> tokenParams, String publishableKey,
-                                   Executor executor, TokenCallback callback) {
-                    tokenCreatorCalled[0] = true;
-                }
-            };
-            stripe.createToken(DEFAULT_CARD, DEFAULT_TOKEN_CALLBACK);
-            assertTrue(tokenCreatorCalled[0]);
-        } catch (AuthenticationException e) {
-            fail("Unexpected error: " + e.getMessage());
-        }
+        Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        stripe.mTokenCreator = new Stripe.TokenCreator() {
+            @Override
+            public void create(Map<String, Object> tokenParams, String publishableKey,
+                               Executor executor, TokenCallback callback) {
+                tokenCreatorCalled[0] = true;
+            }
+        };
+        stripe.createToken(DEFAULT_CARD, DEFAULT_TOKEN_CALLBACK);
+        assertTrue(tokenCreatorCalled[0]);
     }
 
     @Test
@@ -178,42 +174,33 @@ public class StripeTest {
             public void execute(Runnable command) {
             }
         };
-
-        try {
-            Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
-            stripe.mTokenCreator = new Stripe.TokenCreator() {
-                @Override
-                public void create(Map<String, Object> tokenParams, String publishableKey,
-                                   Executor executor, TokenCallback callback) {
-                    assertEquals(expectedExecutor, executor);
-                    assertEquals(DEFAULT_PUBLISHABLE_KEY, publishableKey);
-                    assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
-                }
-            };
-            stripe.createToken(DEFAULT_CARD, expectedExecutor, DEFAULT_TOKEN_CALLBACK);
-        } catch (AuthenticationException e) {
-            fail("Unexpected error: " + e.getMessage());
-        }
+        Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        stripe.mTokenCreator = new Stripe.TokenCreator() {
+            @Override
+            public void create(Map<String, Object> tokenParams, String publishableKey,
+                               Executor executor, TokenCallback callback) {
+                assertEquals(expectedExecutor, executor);
+                assertEquals(DEFAULT_PUBLISHABLE_KEY, publishableKey);
+                assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
+            }
+        };
+        stripe.createToken(DEFAULT_CARD, expectedExecutor, DEFAULT_TOKEN_CALLBACK);
     }
 
     @Test
     public void createTokenShouldUseProvidedKey() {
         final String expectedPublishableKey = "pk_this_one";
-        try {
-            Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
-            stripe.mTokenCreator = new Stripe.TokenCreator() {
-                @Override
-                public void create(Map<String, Object> tokenParams, String publishableKey,
-                                   Executor executor, TokenCallback callback) {
-                    assertEquals(expectedPublishableKey, publishableKey);
-                    assertNull(executor);
-                    assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
-                }
-            };
-            stripe.createToken(DEFAULT_CARD, expectedPublishableKey, DEFAULT_TOKEN_CALLBACK);
-        } catch (AuthenticationException e) {
-            fail("Unexpected error: " + e.getMessage());
-        }
+        Stripe stripe = new Stripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        stripe.mTokenCreator = new Stripe.TokenCreator() {
+            @Override
+            public void create(Map<String, Object> tokenParams, String publishableKey,
+                               Executor executor, TokenCallback callback) {
+                assertEquals(expectedPublishableKey, publishableKey);
+                assertNull(executor);
+                assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
+            }
+        };
+        stripe.createToken(DEFAULT_CARD, expectedPublishableKey, DEFAULT_TOKEN_CALLBACK);
     }
 
     @Test


### PR DESCRIPTION
…instance

r? @bg-stripe 

Fixing the try/catch completely empty call around Stripe instantiation and adding  migration documentation.