### PR TITLE
switching from cvc icon to brand icon when cvc is complete

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     provided 'javax.annotation:jsr250-api:1.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.6.3'
-    testCompile 'org.robolectric:robolectric:3.2.1'
+    testCompile 'org.mockito:mockito-core:2.7.22'
+    testCompile 'org.robolectric:robolectric:3.3.2'
 }
 
 android {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -40,6 +40,9 @@ public class Card {
     public static final String MASTERCARD = "MasterCard";
     public static final String UNKNOWN = "Unknown";
 
+    public static final int CVC_LENGTH_AMERICAN_EXPRESS = 4;
+    public static final int CVC_LENGTH_COMMON = 3;
+
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
             FUNDING_CREDIT,

--- a/stripe/src/main/java/com/stripe/android/util/DateUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/DateUtils.java
@@ -129,6 +129,42 @@ public class DateUtils {
     }
 
     /**
+     * Creates a string value to be entered into an expiration date text field
+     * without a divider. For instance, (1, 2020) => "0120". It doesn't matter if
+     * the year is two-digit or four. (1, 20) => "0120".
+     *
+     * Note: A four-digit year will be truncated, so (1, 2720) => "0120". If the year
+     * date is 3 digits, the data will be considered invalid and the empty string will be returned.
+     * A one-digit date is valid (represents 2001, for instance).
+     *
+     * @param month a month of the year, represented as a number between 1 and 12
+     * @param year a year number, either in two-digit form or four-digit form
+     * @return a length-four string representing the date, or an empty string if input is invalid
+     */
+    public static String createDateStringFromIntegerInput(
+            @IntRange(from = 1, to = 12) int month,
+            @IntRange(from = 0, to = 9999) int year) {
+        String monthString = String.valueOf(month);
+        if (monthString.length() == 1) {
+            monthString = "0" + monthString;
+        }
+
+        String yearString = String.valueOf(year);
+        // Three-digit years are invalid.
+        if (yearString.length() == 3) {
+            return "";
+        }
+
+        if (yearString.length() > 2) {
+            yearString = yearString.substring(yearString.length() - 2);
+        } else if (yearString.length() == 1) {
+            yearString = "0" + yearString;
+        }
+
+        return monthString + yearString;
+    }
+
+    /**
      * Converts a two-digit input year to a four-digit year. As the current calendar year
      * approaches a century, we assume small values to mean the next century. For instance, if
      * the current year is 2090, and the input value is "18", the user probably means 2118,

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -467,7 +467,20 @@ public class CardInputWidget extends LinearLayout {
         mCvcNumberEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                updateIconCvc(mCardNumberEditText.getCardBrand(), hasFocus);
+                updateIconCvc(
+                        mCardNumberEditText.getCardBrand(),
+                        hasFocus,
+                        mCvcNumberEditText.getText().toString());
+            }
+        });
+
+        mCvcNumberEditText.setAfterTextChangedListener(new StripeEditText.AfterTextChangedListener() {
+            @Override
+            public void onTextChanged(String text) {
+                updateIconCvc(
+                        mCardNumberEditText.getCardBrand(),
+                        mCvcNumberEditText.hasFocus(),
+                        text);
             }
         });
 
@@ -757,17 +770,40 @@ public class CardInputWidget extends LinearLayout {
         }
     }
 
-    private void updateIconCvc(@NonNull @Card.CardBrand String brand, boolean isEntering) {
-        if (isEntering) {
-            if (Card.AMERICAN_EXPRESS.equals(brand)) {
-                mCardIconImageView.setImageResource(R.drawable.ic_cvc_amex);
-            } else {
-                mCardIconImageView.setImageResource(R.drawable.ic_cvc);
+    private void updateIconCvc(
+            @NonNull @Card.CardBrand String brand,
+            boolean hasFocus,
+            @Nullable String cvcText) {
+        if (hasFocus) {
+            int length = cvcText == null ? 0 : cvcText.length();
+            boolean isAmex = Card.AMERICAN_EXPRESS.equals(brand);
+            switch (length) {
+                case Card.CVC_LENGTH_AMERICAN_EXPRESS:
+                    updateIcon(brand);
+                    break;
+                case Card.CVC_LENGTH_COMMON:
+                    if (isAmex) {
+                        updateIconForCvcEntry(isAmex);
+                    } else {
+                        updateIcon(brand);
+                    }
+                    break;
+                default:
+                    updateIconForCvcEntry(isAmex);
+                    break;
             }
-            applyTint(true);
         } else {
             updateIcon(brand);
         }
+    }
+
+    private void updateIconForCvcEntry(boolean isAmEx) {
+        if (isAmEx) {
+            mCardIconImageView.setImageResource(R.drawable.ic_cvc_amex);
+        } else {
+            mCardIconImageView.setImageResource(R.drawable.ic_cvc);
+        }
+        applyTint(true);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IdRes;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -27,6 +28,7 @@ import android.widget.LinearLayout;
 import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.util.CardUtils;
+import com.stripe.android.util.DateUtils;
 import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeTextUtils;
 
@@ -132,6 +134,44 @@ public class CardInputWidget extends LinearLayout {
 
         return new Card(cardNumber, cardDate[0], cardDate[1], cvcValue)
                 .addLoggingToken(LoggingUtils.CARD_WIDGET_TOKEN);
+    }
+
+    /**
+     * Set the card number. Method does not change text field focus.
+     *
+     * @param cardNumber card number to be set
+     */
+    public void setCardNumber(String cardNumber) {
+        mCardNumberEditText.setText(cardNumber);
+        setCardNumberIsViewed(!mCardNumberEditText.isCardNumberValid());
+    }
+
+    /**
+     * Set the expiration date. Method invokes completion listener and changes focus
+     * to the CVC field if a valid date is entered.
+     *
+     * Note that while a four-digit and two-digit year will both work, information
+     * beyond the tens digit of a year will be truncated. Logic elsewhere in the SDK
+     * makes assumptions about what century is implied by various two-digit years, and
+     * will override any information provided here.
+     *
+     * @param month a month of the year, represented as a number between 1 and 12
+     * @param year a year number, either in two-digit form or four-digit form
+     */
+    public void setExpiryDate(
+            @IntRange(from = 1, to = 12) int month,
+            @IntRange(from = 0) int year) {
+        mExpiryDateEditText.setText(DateUtils.createDateStringFromIntegerInput(month, year));
+    }
+
+    /**
+     * Set the CVC value for the card. Note that the maximum length is assumed to
+     * be 3, unless the brand of the card has already been set (by setting the card number).
+     *
+     * @param cvcCode the CVC value to be set
+     */
+    public void setCvcCode(String cvcCode) {
+        mCvcNumberEditText.setText(cvcCode);
     }
 
     @Override
@@ -460,7 +500,7 @@ public class CardInputWidget extends LinearLayout {
     }
 
     private void scrollLeft() {
-        if (mCardNumberIsViewed) {
+        if (mCardNumberIsViewed || !mInitFlag) {
             return;
         }
 
@@ -538,7 +578,7 @@ public class CardInputWidget extends LinearLayout {
     }
 
     private void scrollRight() {
-        if (!mCardNumberIsViewed) {
+        if (!mCardNumberIsViewed || !mInitFlag) {
             return;
         }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.stripe.android.model.Card.CardBrand;
+
 /**
  * A card input widget that handles all animation on its own.
  */
@@ -681,6 +683,16 @@ public class CardInputWidget extends LinearLayout {
         }
     }
 
+    /**
+     * Determines whether or not the icon should show the card brand instead of the
+     * CVC helper icon.
+     *
+     * @param brand the {@link CardBrand} in question, used for determining max length
+     * @param cvcHasFocus {@code true} if the CVC entry field has focus, {@code false} otherwise
+     * @param cvcText the current content of {@link #mCvcNumberEditText}
+     * @return {@code true} if we should show the brand of the card, or {@code false} if we
+     * should show the CVC helper icon instead
+     */
     @VisibleForTesting
     static boolean shouldIconShowBrand(
             @NonNull @Card.CardBrand String brand,

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -681,6 +681,27 @@ public class CardInputWidget extends LinearLayout {
         }
     }
 
+    @VisibleForTesting
+    static boolean shouldIconShowBrand(
+            @NonNull @Card.CardBrand String brand,
+            boolean cvcHasFocus,
+            @Nullable String cvcText) {
+        if (!cvcHasFocus) {
+            return true;
+        }
+
+        int length = cvcText == null ? 0 : cvcText.length();
+        boolean isAmex = Card.AMERICAN_EXPRESS.equals(brand);
+        switch (length) {
+            case Card.CVC_LENGTH_AMERICAN_EXPRESS:
+                return true;
+            case Card.CVC_LENGTH_COMMON:
+                return !isAmex;
+            default:
+                return false;
+        }
+    }
+
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         super.onLayout(changed, l, t, r, b);
@@ -774,26 +795,10 @@ public class CardInputWidget extends LinearLayout {
             @NonNull @Card.CardBrand String brand,
             boolean hasFocus,
             @Nullable String cvcText) {
-        if (hasFocus) {
-            int length = cvcText == null ? 0 : cvcText.length();
-            boolean isAmex = Card.AMERICAN_EXPRESS.equals(brand);
-            switch (length) {
-                case Card.CVC_LENGTH_AMERICAN_EXPRESS:
-                    updateIcon(brand);
-                    break;
-                case Card.CVC_LENGTH_COMMON:
-                    if (isAmex) {
-                        updateIconForCvcEntry(isAmex);
-                    } else {
-                        updateIcon(brand);
-                    }
-                    break;
-                default:
-                    updateIconForCvcEntry(isAmex);
-                    break;
-            }
-        } else {
+        if (shouldIconShowBrand(brand, hasFocus, cvcText)) {
             updateIcon(brand);
+        } else {
+            updateIconForCvcEntry(Card.AMERICAN_EXPRESS.equals(brand));
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -8,6 +8,8 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatEditText;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
@@ -26,6 +28,7 @@ import com.stripe.android.R;
  */
 public class StripeEditText extends AppCompatEditText {
 
+    @Nullable private AfterTextChangedListener mAfterTextChangedListener;
     @Nullable private DeleteEmptyListener mDeleteEmptyListener;
     @Nullable private ColorStateList mCachedColorStateList;
     private boolean mShouldShowError;
@@ -50,6 +53,16 @@ public class StripeEditText extends AppCompatEditText {
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
+    }
+
+    /**
+     * Sets a listener that can react to changes in text, but only by reflecting the new
+     * text in the field.
+     *
+     * @param afterTextChangedListener the {@link AfterTextChangedListener} to attach to this view
+     */
+    public void setAfterTextChangedListener(AfterTextChangedListener afterTextChangedListener) {
+        mAfterTextChangedListener = afterTextChangedListener;
     }
 
     /**
@@ -152,6 +165,7 @@ public class StripeEditText extends AppCompatEditText {
     }
 
     private void initView() {
+        listenForTextChanges();
         listenForDeleteEmpty();
         determineDefaultErrorColor();
         mCachedColorStateList = getTextColors();
@@ -167,6 +181,27 @@ public class StripeEditText extends AppCompatEditText {
         } else {
             mDefaultErrorColorResId = R.color.error_text_dark_theme;
         }
+    }
+
+    private void listenForTextChanges() {
+        addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // purposefully not implemented.
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                // purposefully not implemented.
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (mAfterTextChangedListener != null) {
+                    mAfterTextChangedListener.onTextChanged(s.toString());
+                }
+            }
+        });
     }
 
     private void listenForDeleteEmpty() {
@@ -190,6 +225,10 @@ public class StripeEditText extends AppCompatEditText {
      */
     public interface DeleteEmptyListener {
         void onDeleteEmpty();
+    }
+
+    public interface AfterTextChangedListener {
+        void onTextChanged(String text);
     }
 
     private class SoftDeleteInputConnection extends InputConnectionWrapper {

--- a/stripe/src/test/java/com/stripe/android/util/DateUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/util/DateUtilsTest.java
@@ -60,6 +60,26 @@ public class DateUtilsTest {
     }
 
     @Test
+    public void createDateStringFromIntegerInput_whenDateHasOneDigitMonthAndYear_addsZero() {
+        assertEquals("0102", DateUtils.createDateStringFromIntegerInput(1, 2));
+    }
+
+    @Test
+    public void createDateStringFromIntegerInput_whenDateHasTwoDigitValues_returnsExpectedValue() {
+        assertEquals("1132", DateUtils.createDateStringFromIntegerInput(11, 32));
+    }
+
+    @Test
+    public void createDateStringFromIntegerInput_whenDateHasFullYear_truncatesYear() {
+        assertEquals("0132", DateUtils.createDateStringFromIntegerInput(1, 2032));
+    }
+
+    @Test
+    public void createDateStringFromIntegerInput_whenDateHasThreeDigitYear_returnsEmpty() {
+        assertEquals("", DateUtils.createDateStringFromIntegerInput(12, 101));
+    }
+
+    @Test
     public void isExpiryDataValid_whenDateIsAfterCalendarYear_returnsTrue() {
         Calendar testCalendar = Calendar.getInstance();
         testCalendar.set(Calendar.YEAR, 2018);

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -552,8 +552,6 @@ public class CardInputWidgetTest {
     }
 
     @Test
-<<<<<<< HEAD
-<<<<<<< HEAD
     public void setCardNumber_withIncompleteNumber_doesNotValidateCard() {
         mCardInputWidget.setCardNumber("123456");
         assertFalse(mCardNumberEditText.isCardNumberValid());

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -553,6 +553,7 @@ public class CardInputWidgetTest {
 
     @Test
 <<<<<<< HEAD
+<<<<<<< HEAD
     public void setCardNumber_withIncompleteNumber_doesNotValidateCard() {
         mCardInputWidget.setCardNumber("123456");
         assertFalse(mCardNumberEditText.isCardNumberValid());

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -26,6 +26,7 @@ import org.robolectric.util.ActivityController;
 
 import java.util.Calendar;
 
+import static com.stripe.android.view.CardInputWidget.shouldIconShowBrand;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_NO_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
@@ -35,7 +36,6 @@ import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WI
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -552,6 +552,7 @@ public class CardInputWidgetTest {
     }
 
     @Test
+<<<<<<< HEAD
     public void setCardNumber_withIncompleteNumber_doesNotValidateCard() {
         mCardInputWidget.setCardNumber("123456");
         assertFalse(mCardNumberEditText.isCardNumberValid());
@@ -601,6 +602,49 @@ public class CardInputWidgetTest {
         assertEquals(2079, (int) card.getExpYear());
         assertEquals("1234", card.getCVC());
         assertEquals(Card.AMERICAN_EXPRESS, card.getBrand());
+    }
+
+    @Test
+    public void shouldIconShowBrand_whenCvcNotFocused_isAlwaysTrue() {
+        assertTrue(shouldIconShowBrand(Card.AMERICAN_EXPRESS, false, "1234"));
+        assertTrue(shouldIconShowBrand(Card.AMERICAN_EXPRESS, false, ""));
+        assertTrue(shouldIconShowBrand(Card.VISA, false, "333"));
+        assertTrue(shouldIconShowBrand(Card.DINERS_CLUB, false, "12"));
+        assertTrue(shouldIconShowBrand(Card.DISCOVER, false, null));
+        assertTrue(shouldIconShowBrand(Card.JCB, false, "7"));
+    }
+
+    @Test
+    public void shouldIconShowBrand_whenAmexAndLengthNotFour_isFalse() {
+        assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, ""));
+        assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "1"));
+        assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "22"));
+        assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "333"));
+    }
+
+    @Test
+    public void shouldIconShowBrand_whenAmexAndLengthIsFour_isTrue() {
+        assertTrue(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "1234"));
+    }
+
+    @Test
+    public void shouldIconShowBrand_whenNotAmexAndLengthIsNotThree_isFalse() {
+        assertFalse(shouldIconShowBrand(Card.VISA, true, ""));
+        assertFalse(shouldIconShowBrand(Card.DISCOVER, true, "12"));
+        assertFalse(shouldIconShowBrand(Card.JCB, true, "55"));
+        assertFalse(shouldIconShowBrand(Card.MASTERCARD, true, "9"));
+        assertFalse(shouldIconShowBrand(Card.DINERS_CLUB, true, null));
+        assertFalse(shouldIconShowBrand(Card.UNKNOWN, true, "12"));
+    }
+
+    @Test
+    public void shouldIconShowBrand_whenNotAmexAndLengthIsThree_isTrue() {
+        assertTrue(shouldIconShowBrand(Card.VISA, true, "999"));
+        assertTrue(shouldIconShowBrand(Card.DISCOVER, true, "123"));
+        assertTrue(shouldIconShowBrand(Card.JCB, true, "555"));
+        assertTrue(shouldIconShowBrand(Card.MASTERCARD, true, "919"));
+        assertTrue(shouldIconShowBrand(Card.DINERS_CLUB, true, "415"));
+        assertTrue(shouldIconShowBrand(Card.UNKNOWN, true, "212"));
     }
 
     class TestFocusChangeListener implements ViewTreeObserver.OnGlobalFocusChangeListener {

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -614,7 +614,7 @@ public class CardInputWidgetTest {
     }
 
     @Test
-    public void shouldIconShowBrand_whenAmexAndLengthNotFour_isFalse() {
+    public void shouldIconShowBrand_whenAmexAndCvCStringLengthNotFour_isFalse() {
         assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, ""));
         assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "1"));
         assertFalse(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "22"));
@@ -622,12 +622,12 @@ public class CardInputWidgetTest {
     }
 
     @Test
-    public void shouldIconShowBrand_whenAmexAndLengthIsFour_isTrue() {
+    public void shouldIconShowBrand_whenAmexAndCvcStringLengthIsFour_isTrue() {
         assertTrue(shouldIconShowBrand(Card.AMERICAN_EXPRESS, true, "1234"));
     }
 
     @Test
-    public void shouldIconShowBrand_whenNotAmexAndLengthIsNotThree_isFalse() {
+    public void shouldIconShowBrand_whenNotAmexAndCvcStringLengthIsNotThree_isFalse() {
         assertFalse(shouldIconShowBrand(Card.VISA, true, ""));
         assertFalse(shouldIconShowBrand(Card.DISCOVER, true, "12"));
         assertFalse(shouldIconShowBrand(Card.JCB, true, "55"));
@@ -637,7 +637,7 @@ public class CardInputWidgetTest {
     }
 
     @Test
-    public void shouldIconShowBrand_whenNotAmexAndLengthIsThree_isTrue() {
+    public void shouldIconShowBrand_whenNotAmexAndCvcStringLengthIsThree_isTrue() {
         assertTrue(shouldIconShowBrand(Card.VISA, true, "999"));
         assertTrue(shouldIconShowBrand(Card.DISCOVER, true, "123"));
         assertTrue(shouldIconShowBrand(Card.JCB, true, "555"));


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @bg-stripe 

Adjusting CVC text entry so that when the user has finished entering a value (CVC is the right length), the icon switches back to the card brand.

Added tests to make sure the listeners are called at the right time, but the logic for setting the card is actually in a bunch of private methods that would be nearly impossible to isolate (I also can't call in test to check which icon is being shown, which would be my preferred way to hit this.)

I'm thinking of ways I can refactor it, but no obvious ones spring to mind, except maybe for pulling all the "should show brand" logic into a static method.