### PR TITLE
adding support for generic source types

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -123,7 +123,7 @@ public class Source extends StripeJsonModel {
     private SourceCodeVerification mCodeVerification;
     private Long mCreated;
     private String mCurrency;
-    private String mCustomType;
+    private String mTypeRaw;
     private @SourceFlow String mFlow;
     private Boolean mLiveMode;
     private Map<String, String> mMetaData;
@@ -153,7 +153,7 @@ public class Source extends StripeJsonModel {
             Map<String, Object> sourceTypeData,
             StripeSourceTypeModel sourceTypeModel,
             @SourceType String type,
-            String customType,
+            String rawType,
             @Usage String usage
     ) {
         mId = id;
@@ -172,7 +172,7 @@ public class Source extends StripeJsonModel {
         mSourceTypeData = sourceTypeData;
         mSourceTypeModel = sourceTypeModel;
         mType = type;
-        mCustomType = customType;
+        mTypeRaw = rawType;
         mUsage = usage;
     }
 
@@ -238,13 +238,27 @@ public class Source extends StripeJsonModel {
         return mSourceTypeModel;
     }
 
+    /**
+     * Gets the {@link SourceType} of this Source, as one of the enumerated values.
+     * If a custom source type has been created, this returns {@link #UNKNOWN}. To get
+     * the raw value of an {@link #UNKNOWN} type, use {@link #getTypeRaw()}.
+     *
+     * @return the {@link SourceType} of this Source
+     */
     @SourceType
     public String getType() {
         return mType;
     }
 
-    public String getCustomType() {
-        return mCustomType;
+    /**
+     * Gets the type of this source as a String. If it is a known type, this will return
+     * a string equal to the {@link SourceType} returned from {@link #getType()}. This
+     * method is not restricted to known types
+     *
+     * @return the type of this Source as a string
+     */
+    public String getTypeRaw() {
+        return mTypeRaw;
     }
 
     @Usage
@@ -308,8 +322,8 @@ public class Source extends StripeJsonModel {
         mSourceTypeData = sourceTypeData;
     }
 
-    public void setCustomType(@NonNull @Size(min = 1) String customType) {
-        mCustomType = customType;
+    public void setTypeRaw(@NonNull @Size(min = 1) String typeRaw) {
+        mTypeRaw = typeRaw;
         setType(UNKNOWN);
     }
 
@@ -341,7 +355,7 @@ public class Source extends StripeJsonModel {
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_RECEIVER, mReceiver);
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_REDIRECT, mRedirect);
 
-        String usableType = toUsableType(mType, mCustomType);
+        String usableType = toUsableType(mType, mTypeRaw);
         hashMap.put(usableType, mSourceTypeData);
 
         hashMap.put(FIELD_STATUS, mStatus);
@@ -373,7 +387,7 @@ public class Source extends StripeJsonModel {
 
             JSONObject sourceTypeJsonObject = mapToJsonObject(mSourceTypeData);
 
-            String usableType = toUsableType(mType, mCustomType);
+            String usableType = toUsableType(mType, mTypeRaw);
             if (sourceTypeJsonObject != null) {
                 jsonObject.put(usableType, sourceTypeJsonObject);
             }

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -355,11 +355,10 @@ public class Source extends StripeJsonModel {
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_RECEIVER, mReceiver);
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_REDIRECT, mRedirect);
 
-        String usableType = toUsableType(mType, mTypeRaw);
-        hashMap.put(usableType, mSourceTypeData);
+        hashMap.put(mTypeRaw, mSourceTypeData);
 
         hashMap.put(FIELD_STATUS, mStatus);
-        hashMap.put(FIELD_TYPE, usableType);
+        hashMap.put(FIELD_TYPE, mTypeRaw);
         hashMap.put(FIELD_USAGE, mUsage);
         removeNullParams(hashMap);
         return hashMap;
@@ -387,16 +386,15 @@ public class Source extends StripeJsonModel {
 
             JSONObject sourceTypeJsonObject = mapToJsonObject(mSourceTypeData);
 
-            String usableType = toUsableType(mType, mTypeRaw);
             if (sourceTypeJsonObject != null) {
-                jsonObject.put(usableType, sourceTypeJsonObject);
+                jsonObject.put(mTypeRaw, sourceTypeJsonObject);
             }
 
             putStripeJsonModelIfNotNull(jsonObject, FIELD_OWNER, mOwner);
             putStripeJsonModelIfNotNull(jsonObject, FIELD_RECEIVER, mReceiver);
             putStripeJsonModelIfNotNull(jsonObject, FIELD_REDIRECT, mRedirect);
             putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
-            putStringIfNotNull(jsonObject, FIELD_TYPE, usableType);
+            putStringIfNotNull(jsonObject, FIELD_TYPE, mTypeRaw);
             putStringIfNotNull(jsonObject, FIELD_USAGE, mUsage);
 
         } catch (JSONException ignored) { }
@@ -442,14 +440,14 @@ public class Source extends StripeJsonModel {
                 SourceRedirect.class);
         @SourceStatus String status = asSourceStatus(optString(jsonObject, FIELD_STATUS));
 
-        String customType = optString(jsonObject, FIELD_TYPE);
-        if (customType == null) {
+        String typeRaw = optString(jsonObject, FIELD_TYPE);
+        if (typeRaw == null) {
             // We can't allow this type to be null, as we are using it for a key
             // on the JSON object later.
-            customType = UNKNOWN;
+            typeRaw = UNKNOWN;
         }
 
-        @SourceType String type = asSourceType(customType);
+        @SourceType String type = asSourceType(typeRaw);
         if (type == null) {
             type = UNKNOWN;
         }
@@ -458,10 +456,10 @@ public class Source extends StripeJsonModel {
         // model object. The customType variable can be any field, and is not altered by
         // trying to force it to be a type that we know of.
         Map<String, Object> sourceTypeData =
-                StripeJsonUtils.jsonObjectToMap(jsonObject.optJSONObject(customType));
+                StripeJsonUtils.jsonObjectToMap(jsonObject.optJSONObject(typeRaw));
         StripeSourceTypeModel sourceTypeModel =
-                !UNKNOWN.equals(type) && MODELED_TYPES.contains(type)
-                ? optStripeJsonModel(jsonObject, type, StripeSourceTypeModel.class)
+                MODELED_TYPES.contains(typeRaw)
+                ? optStripeJsonModel(jsonObject, typeRaw, StripeSourceTypeModel.class)
                 : null;
 
         @Usage String usage = asUsage(optString(jsonObject, FIELD_USAGE));
@@ -483,7 +481,7 @@ public class Source extends StripeJsonModel {
                 sourceTypeData,
                 sourceTypeModel,
                 type,
-                customType,
+                typeRaw,
                 usage);
     }
 
@@ -562,17 +560,6 @@ public class Source extends StripeJsonModel {
         }
 
         return null;
-    }
-
-    @NonNull
-    static String toUsableType(@NonNull @SourceType String type, @Nullable String customType) {
-        if (Source.UNKNOWN.equals(type)) {
-            if (StripeTextUtils.isBlank(customType)) {
-                return Source.UNKNOWN;
-            }
-            return customType;
-        }
-        return type;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -6,6 +6,7 @@ import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
 import com.stripe.android.util.StripeJsonUtils;
+import com.stripe.android.util.StripeTextUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -38,7 +39,8 @@ public class Source extends StripeJsonModel {
             SEPA_DEBIT,
             IDEAL,
             SOFORT,
-            BANCONTACT
+            BANCONTACT,
+            UNKNOWN
     })
     public @interface SourceType { }
     public static final String BITCOIN = "bitcoin";
@@ -49,6 +51,7 @@ public class Source extends StripeJsonModel {
     public static final String IDEAL = "ideal";
     public static final String SOFORT = "sofort";
     public static final String BANCONTACT = "bancontact";
+    public static final String UNKNOWN = "unknown";
 
     public static final Set<String> MODELED_TYPES = new HashSet<>();
     static {
@@ -120,6 +123,7 @@ public class Source extends StripeJsonModel {
     private SourceCodeVerification mCodeVerification;
     private Long mCreated;
     private String mCurrency;
+    private String mCustomType;
     private @SourceFlow String mFlow;
     private Boolean mLiveMode;
     private Map<String, String> mMetaData;
@@ -149,6 +153,7 @@ public class Source extends StripeJsonModel {
             Map<String, Object> sourceTypeData,
             StripeSourceTypeModel sourceTypeModel,
             @SourceType String type,
+            String customType,
             @Usage String usage
     ) {
         mId = id;
@@ -167,6 +172,7 @@ public class Source extends StripeJsonModel {
         mSourceTypeData = sourceTypeData;
         mSourceTypeModel = sourceTypeModel;
         mType = type;
+        mCustomType = customType;
         mUsage = usage;
     }
 
@@ -237,6 +243,10 @@ public class Source extends StripeJsonModel {
         return mType;
     }
 
+    public String getCustomType() {
+        return mCustomType;
+    }
+
     @Usage
     public String getUsage() {
         return mUsage;
@@ -298,6 +308,11 @@ public class Source extends StripeJsonModel {
         mSourceTypeData = sourceTypeData;
     }
 
+    public void setCustomType(@NonNull @Size(min = 1) String customType) {
+        mCustomType = customType;
+        setType(UNKNOWN);
+    }
+
     public void setType(@SourceType String type) {
         mType = type;
     }
@@ -326,12 +341,11 @@ public class Source extends StripeJsonModel {
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_RECEIVER, mReceiver);
         putStripeJsonModelMapIfNotNull(hashMap, FIELD_REDIRECT, mRedirect);
 
-        if (mType != null) {
-            hashMap.put(mType, mSourceTypeData);
-        }
+        String usableType = toUsableType(mType, mCustomType);
+        hashMap.put(usableType, mSourceTypeData);
 
         hashMap.put(FIELD_STATUS, mStatus);
-        hashMap.put(FIELD_TYPE, mType);
+        hashMap.put(FIELD_TYPE, usableType);
         hashMap.put(FIELD_USAGE, mUsage);
         removeNullParams(hashMap);
         return hashMap;
@@ -358,14 +372,17 @@ public class Source extends StripeJsonModel {
             }
 
             JSONObject sourceTypeJsonObject = mapToJsonObject(mSourceTypeData);
-            if (mType != null && sourceTypeJsonObject != null) {
-                jsonObject.put(mType, sourceTypeJsonObject);
+
+            String usableType = toUsableType(mType, mCustomType);
+            if (sourceTypeJsonObject != null) {
+                jsonObject.put(usableType, sourceTypeJsonObject);
             }
+
             putStripeJsonModelIfNotNull(jsonObject, FIELD_OWNER, mOwner);
             putStripeJsonModelIfNotNull(jsonObject, FIELD_RECEIVER, mReceiver);
             putStripeJsonModelIfNotNull(jsonObject, FIELD_REDIRECT, mRedirect);
             putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
-            putStringIfNotNull(jsonObject, FIELD_TYPE, mType);
+            putStringIfNotNull(jsonObject, FIELD_TYPE, usableType);
             putStringIfNotNull(jsonObject, FIELD_USAGE, mUsage);
 
         } catch (JSONException ignored) { }
@@ -410,13 +427,26 @@ public class Source extends StripeJsonModel {
                 FIELD_REDIRECT,
                 SourceRedirect.class);
         @SourceStatus String status = asSourceStatus(optString(jsonObject, FIELD_STATUS));
-        @SourceType String type = asSourceType(optString(jsonObject, FIELD_TYPE));
+
+        String customType = optString(jsonObject, FIELD_TYPE);
+        if (customType == null) {
+            // We can't allow this type to be null, as we are using it for a key
+            // on the JSON object later.
+            customType = UNKNOWN;
+        }
+
+        @SourceType String type = asSourceType(customType);
+        if (type == null) {
+            type = UNKNOWN;
+        }
 
         // Until we have models for all types, keep the original hash and the
-        // model object.
+        // model object. The customType variable can be any field, and is not altered by
+        // trying to force it to be a type that we know of.
         Map<String, Object> sourceTypeData =
-                StripeJsonUtils.jsonObjectToMap(jsonObject.optJSONObject(type));
-        StripeSourceTypeModel sourceTypeModel = type != null && MODELED_TYPES.contains(type)
+                StripeJsonUtils.jsonObjectToMap(jsonObject.optJSONObject(customType));
+        StripeSourceTypeModel sourceTypeModel =
+                !UNKNOWN.equals(type) && MODELED_TYPES.contains(type)
                 ? optStripeJsonModel(jsonObject, type, StripeSourceTypeModel.class)
                 : null;
 
@@ -439,6 +469,7 @@ public class Source extends StripeJsonModel {
                 sourceTypeData,
                 sourceTypeModel,
                 type,
+                customType,
                 usage);
     }
 
@@ -512,8 +543,22 @@ public class Source extends StripeJsonModel {
             return SOFORT;
         } else if (BANCONTACT.equals(sourceType)) {
             return BANCONTACT;
+        } else if (UNKNOWN.equals(sourceType)) {
+            return UNKNOWN;
         }
+
         return null;
+    }
+
+    @NonNull
+    static String toUsableType(@NonNull @SourceType String type, @Nullable String customType) {
+        if (Source.UNKNOWN.equals(type)) {
+            if (StripeTextUtils.isBlank(customType)) {
+                return Source.UNKNOWN;
+            }
+            return customType;
+        }
+        return type;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -50,7 +50,7 @@ public class SourceParams {
     @IntRange(from = 0) private Long mAmount;
     private Map<String, Object> mApiParameterMap;
     private String mCurrency;
-    @Nullable private String mCustomType;
+    @Nullable private String mTypeRaw;
     private Map<String, Object> mOwner;
     private Map<String, String> mMetaData;
     private Map<String, Object> mRedirect;
@@ -391,8 +391,8 @@ public class SourceParams {
      * @return a custom type of this source, if one has been set
      */
     @Nullable
-    public String getCustomType() {
-        return mCustomType;
+    public String getTypeRaw() {
+        return mTypeRaw;
     }
 
     /**
@@ -459,13 +459,17 @@ public class SourceParams {
      * @return {@code this}, for chaining purposes
      */
     public SourceParams setReturnUrl(@NonNull @Size(min = 1) String returnUrl) {
-        setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
+        if (mRedirect == null) {
+            setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
+        } else {
+            mRedirect.put(FIELD_RETURN_URL, returnUrl);
+        }
         return this;
     }
 
     /**
      * Sets the {@link SourceType} for this source. If you are creating a custom type,
-     * use {@link #setCustomType(String)}.
+     * use {@link #setTypeRaw(String)}.
      *
      * @param type the {@link SourceType}
      * @return {@code this}, for chaining purposes
@@ -479,12 +483,12 @@ public class SourceParams {
      * Sets a custom type for the source, and sets the {@link #mType type} for these parameters
      * to be {@link Source#UNKNOWN}.
      *
-     * @param customType the name of the source type
+     * @param typeRaw the name of the source type
      * @return {@code this}, for chaining purposes
      */
-    public SourceParams setCustomType(@NonNull String customType) {
+    public SourceParams setTypeRaw(@NonNull String typeRaw) {
         mType = Source.UNKNOWN;
-        mCustomType = customType;
+        mTypeRaw = typeRaw;
         return this;
     }
 
@@ -508,7 +512,7 @@ public class SourceParams {
     public Map<String, Object> toParamMap() {
         Map<String, Object> networkReadyMap = new HashMap<>();
 
-        String usableType = toUsableType(mType, mCustomType);
+        String usableType = toUsableType(mType, mTypeRaw);
 
         networkReadyMap.put(API_PARAM_TYPE, usableType);
         networkReadyMap.put(usableType, mApiParameterMap);

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -443,7 +443,7 @@ public class SourceParams {
 
     /**
      * Sets a redirect property map for this source object. If you only want to
-     * set a return url, use {@link #setSimpleRedirect(String)}.
+     * set a return url, use {@link #setReturnUrl(String)}.
      *
      * @param redirect a set of redirect parameters
      * @return {@code this}, for chaining purposes
@@ -458,7 +458,7 @@ public class SourceParams {
      * @param returnUrl a redirect URL for this source.
      * @return {@code this}, for chaining purposes
      */
-    public SourceParams setSimpleRedirect(@NonNull @Size(min = 1) String returnUrl) {
+    public SourceParams setReturnUrl(@NonNull @Size(min = 1) String returnUrl) {
         setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
         return this;
     }

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.stripe.android.model.Source.SourceType;
-import static com.stripe.android.model.Source.toUsableType;
 import static com.stripe.android.util.StripeNetworkUtils.removeNullParams;
 
 /**
@@ -476,6 +475,7 @@ public class SourceParams {
      */
     public SourceParams setType(@Source.SourceType String type) {
         mType = type;
+        mTypeRaw = type;
         return this;
     }
 
@@ -487,7 +487,10 @@ public class SourceParams {
      * @return {@code this}, for chaining purposes
      */
     public SourceParams setTypeRaw(@NonNull String typeRaw) {
-        mType = Source.UNKNOWN;
+        mType = Source.asSourceType(typeRaw);
+        if (mType == null) {
+            mType = Source.UNKNOWN;
+        }
         mTypeRaw = typeRaw;
         return this;
     }
@@ -512,10 +515,8 @@ public class SourceParams {
     public Map<String, Object> toParamMap() {
         Map<String, Object> networkReadyMap = new HashMap<>();
 
-        String usableType = toUsableType(mType, mTypeRaw);
-
-        networkReadyMap.put(API_PARAM_TYPE, usableType);
-        networkReadyMap.put(usableType, mApiParameterMap);
+        networkReadyMap.put(API_PARAM_TYPE, mTypeRaw);
+        networkReadyMap.put(mTypeRaw, mApiParameterMap);
         networkReadyMap.put(API_PARAM_AMOUNT, mAmount);
         networkReadyMap.put(API_PARAM_CURRENCY, mCurrency);
         networkReadyMap.put(API_PARAM_OWNER, mOwner);

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -290,7 +290,7 @@ public class StripeTest {
         SourceParams customParams = SourceParams.createCustomParams();
         Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put("email", "abc@def.com");
-        customParams.setCustomType("bitcoin")
+        customParams.setTypeRaw("bitcoin")
                 .setAmount(1000L)
                 .setCurrency("usd")
                 .setOwner(ownerMap);

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -467,7 +467,7 @@ public class SourceParamsTest {
                 "Stripe",
                 "stripe://return",
                 "stripe descriptor");
-        params.setCustomType(DOGECOIN);
+        params.setTypeRaw(DOGECOIN);
 
         Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("type", DOGECOIN);
@@ -487,9 +487,9 @@ public class SourceParamsTest {
     @Test
     public void setCustomType_forEmptyParams_setsTypeToUnknown() {
         SourceParams params = SourceParams.createCustomParams();
-        params.setCustomType("dogecoin");
+        params.setTypeRaw("dogecoin");
         assertEquals(Source.UNKNOWN, params.getType());
-        assertEquals("dogecoin", params.getCustomType());
+        assertEquals("dogecoin", params.getTypeRaw());
     }
 
     @Test
@@ -499,9 +499,9 @@ public class SourceParamsTest {
                 "brl",
                 "stripe://returnaddress",
                 "card_id_123");
-        params.setCustomType("bar_tab");
+        params.setTypeRaw("bar_tab");
         assertEquals(Source.UNKNOWN, params.getType());
-        assertEquals("bar_tab", params.getCustomType());
+        assertEquals("bar_tab", params.getTypeRaw());
     }
 
     @SuppressWarnings("unchecked")

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -457,6 +457,53 @@ public class SourceParamsTest {
         JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
     }
 
+    @Test
+    public void createCustomParamsWithSourceTypeParameters_toParamMap_createsExpectedMap() {
+        // Using the Giropay constructor to add some free params and expected values,
+        // including a source type params
+        final String DOGECOIN = "dogecoin";
+        SourceParams params = SourceParams.createGiropayParams(
+                150L,
+                "Stripe",
+                "stripe://return",
+                "stripe descriptor");
+        params.setCustomType(DOGECOIN);
+
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("type", DOGECOIN);
+        expectedMap.put("currency", Source.EURO);
+        expectedMap.put("amount", 150L);
+        expectedMap.put("owner", new HashMap<String, Object>() {{ put("name", "Stripe"); }});
+        expectedMap.put("redirect",
+                new HashMap<String, Object>() {{ put("return_url", "stripe://return"); }});
+        expectedMap.put(DOGECOIN,
+                new HashMap<String, Object>() {{
+                    put("statement_descriptor", "stripe descriptor");
+                }});
+
+        JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
+    }
+
+    @Test
+    public void setCustomType_forEmptyParams_setsTypeToUnknown() {
+        SourceParams params = SourceParams.createCustomParams();
+        params.setCustomType("dogecoin");
+        assertEquals(Source.UNKNOWN, params.getType());
+        assertEquals("dogecoin", params.getCustomType());
+    }
+
+    @Test
+    public void setCustomType_forStandardParams_overridesStandardType() {
+        SourceParams params = SourceParams.createThreeDSecureParams(
+                99000L,
+                "brl",
+                "stripe://returnaddress",
+                "card_id_123");
+        params.setCustomType("bar_tab");
+        assertEquals(Source.UNKNOWN, params.getType());
+        assertEquals("bar_tab", params.getCustomType());
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> getMapFromOwner(
             @NonNull SourceParams params,

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -19,7 +19,9 @@ import static com.stripe.android.model.SourceRedirectTest.EXAMPLE_JSON_REDIRECT;
 
 import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -28,6 +30,8 @@ import static org.junit.Assert.fail;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 23)
 public class SourceTest {
+
+    private static final String DOGE_COIN = "dogecoin";
 
     private static final String EXAMPLE_JSON_SOURCE_WITH_NULLS = "{\n"+
             "\"id\": \"src_19t3xKBZqEXluyI4uz2dxAfQ\",\n"+
@@ -110,6 +114,39 @@ public class SourceTest {
             "}" +
             "}";
 
+    private static final String EXAMPLE_JSON_SOURCE_CUSTOM_TYPE = "{\n"+
+            "\"id\": \"src_19t3xKBZqEXluyI4uz2dxAfQ\",\n"+
+            "\"object\": \"source\",\n"+
+            "\"amount\": 1000,\n"+
+            "\"client_secret\": \"src_client_secret_of43INi1HteJwXVe3djAUosN\",\n"+
+            "\"code_verification\": " + EXAMPLE_JSON_CODE_VERIFICATION + ",\n"+
+            "\"created\": 1488499654,\n"+
+            "\"currency\": \"usd\",\n"+
+            "\"flow\": \"receiver\",\n"+
+            "\"livemode\": false,\n"+
+            "\"metadata\": {\n"+
+            "},\n"+
+            "\"owner\": " + EXAMPLE_JSON_OWNER_WITHOUT_NULLS +",\n"+
+            "\"redirect\": " + EXAMPLE_JSON_REDIRECT + ",\n"+
+            "\"receiver\": {\n"+
+            "\"address\": \"test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N\",\n"+
+            "\"amount_charged\": 0,\n"+
+            "\"amount_received\": 0,\n"+
+            "\"amount_returned\": 0\n"+
+            "},\n"+
+            "\"status\": \"pending\",\n"+
+            "\"type\": \"dogecoin\",\n"+
+            "\"usage\": \"single_use\",\n"+
+            "\"dogecoin\": {\n" +
+            "\"address\": \"test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N\",\n" +
+            "\"amount\": 2371000,\n" +
+            "\"amount_charged\": 0,\n" +
+            "\"amount_received\": 0,\n" +
+            "\"amount_returned\": 0,\n" +
+            "\"uri\": \"dogecoin:test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N?amount=0.02371000\"\n" +
+            "}" +
+            "}";
+
     private Source mSource;
 
     @Before
@@ -136,4 +173,31 @@ public class SourceTest {
         assertMapEquals(EXAMPLE_SOURCE_MAP, sourceWithNulls.toMap());
     }
 
+    @Test
+    public void fromJsonString_withCustomType_createsSourceWithCustomType() {
+        Source customSource = Source.fromString(EXAMPLE_JSON_SOURCE_CUSTOM_TYPE);
+        assertNotNull("Parsing failure", customSource);
+        assertEquals(Source.UNKNOWN, customSource.getType());
+        assertEquals(DOGE_COIN, customSource.getCustomType());
+        assertNull(customSource.getSourceTypeModel());
+        assertNotNull("Failed to find custom api params", customSource.getSourceTypeData());
+    }
+
+    @Test
+    public void toUsableSource_whenKnownSourceType_returnsSameType() {
+        String usableType = Source.toUsableType(Source.CARD, "wrong answer");
+        assertEquals(Source.CARD, usableType);
+    }
+
+    @Test
+    public void toUsableSource_whenUnknownSourceType_returnsCustomType() {
+        String usableType = Source.toUsableType(Source.UNKNOWN, DOGE_COIN);
+        assertEquals(DOGE_COIN, usableType);
+    }
+
+    @Test
+    public void toUsableSource_whenUnknownSourceTypeAndNullCustomType_returnsUnknown() {
+        String usableType = Source.toUsableType(Source.UNKNOWN, null);
+        assertEquals(Source.UNKNOWN, usableType);
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -178,7 +178,7 @@ public class SourceTest {
         Source customSource = Source.fromString(EXAMPLE_JSON_SOURCE_CUSTOM_TYPE);
         assertNotNull("Parsing failure", customSource);
         assertEquals(Source.UNKNOWN, customSource.getType());
-        assertEquals(DOGE_COIN, customSource.getCustomType());
+        assertEquals(DOGE_COIN, customSource.getTypeRaw());
         assertNull(customSource.getSourceTypeModel());
         assertNotNull("Failed to find custom api params", customSource.getSourceTypeData());
     }

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -182,22 +182,4 @@ public class SourceTest {
         assertNull(customSource.getSourceTypeModel());
         assertNotNull("Failed to find custom api params", customSource.getSourceTypeData());
     }
-
-    @Test
-    public void toUsableSource_whenKnownSourceType_returnsSameType() {
-        String usableType = Source.toUsableType(Source.CARD, "wrong answer");
-        assertEquals(Source.CARD, usableType);
-    }
-
-    @Test
-    public void toUsableSource_whenUnknownSourceType_returnsCustomType() {
-        String usableType = Source.toUsableType(Source.UNKNOWN, DOGE_COIN);
-        assertEquals(DOGE_COIN, usableType);
-    }
-
-    @Test
-    public void toUsableSource_whenUnknownSourceTypeAndNullCustomType_returnsUnknown() {
-        String usableType = Source.toUsableType(Source.UNKNOWN, null);
-        assertEquals(Source.UNKNOWN, usableType);
-    }
 }


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe @brandur-stripe @teich-stripe 

Adding support for generic source types by adding a `customType` field that can be added to any Source or SourceParams. Adding such a value immediately overrides the `type` of the Source/SourceParams to be `UNKNOWN`.

Reading in Source objects from JSON now looks to see if the `type` field is a type that we recognize. If so, we go through the usual logic. If not, we set `type` to `UNKNOWN` and then set whatever value it is in the `customType` field. The additional `SourceTypeParams` object is now keyed off of the `customType` (unless that field is `null`)