### PR TITLE
adding a LineItemBuilder that makes sense for users

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
@@ -1,0 +1,198 @@
+package com.stripe.wrap.pay.utils;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.google.android.gms.wallet.LineItem;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Currency;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A wrapper for {@link LineItem.Builder} that allows you to use price as a {@link Long} and
+ * to easily set default currency values.
+ */
+public class LineItemBuilder {
+
+    public static final Set<Integer> VALID_ROLES = new HashSet<Integer>(){{
+        add(LineItem.Role.TAX);
+        add(LineItem.Role.REGULAR);
+        add(LineItem.Role.SHIPPING);
+    }};
+
+    static final String TAG = "Stripe:LineItemBuilder";
+
+    private static final double CONSISTENCY_THRESHOLD = 0.01;
+    private static final int CONSISTENCY_SCALE = 3;
+
+    private Currency mCurrency;
+    private Long mUnitPrice;
+    private Long mTotalPrice;
+    private BigDecimal mQuantity;
+    private String mDescription;
+    private int mRole;
+
+    LineItemBuilder() {
+        mCurrency = Currency.getInstance(Locale.getDefault());
+        mRole = LineItem.Role.REGULAR;
+    }
+
+    LineItemBuilder(int role, String currencyCode) {
+        setCurrencyCode(currencyCode);
+        mRole = role;
+    }
+
+    /**
+     * Sets the ISO 4217 currency code of the line item. If the input currency is invalid,
+     * currency is set to the default for the phone's locale.
+     *
+     * @param currencyCode the currency code to set
+     * @return {@code this}, for chaining purposes
+     */
+    public LineItemBuilder setCurrencyCode(String currencyCode) {
+        try {
+            mCurrency = Currency.getInstance(currencyCode.toUpperCase());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            Log.w(TAG, String.format(Locale.ENGLISH,
+                    "Could not create currency with code %s", currencyCode));
+            mCurrency = Currency.getInstance(Locale.getDefault());
+        }
+        return this;
+    }
+
+    public LineItemBuilder setUnitPrice(long unitPrice) {
+        mUnitPrice = unitPrice;
+        return this;
+    }
+
+    public LineItemBuilder setTotalPrice(long totalPrice) {
+        mTotalPrice = totalPrice;
+        return this;
+    }
+
+    /**
+     * Sets the quantity for this line item. Note: the quantity may have at most one number
+     * after the decimal place. Further precision will be rounded away.
+     *
+     * @param quantity the quantity of this line item
+     * @return {@code this}, for chaining purposes
+     */
+    public LineItemBuilder setQuantity(double quantity) {
+        BigDecimal fullQuantity = BigDecimal.valueOf(quantity);
+        mQuantity = BigDecimal.valueOf(quantity).setScale(1, BigDecimal.ROUND_HALF_EVEN);
+        if (fullQuantity.scale() > 1) {
+            Log.w(TAG, String.format(
+                    Locale.ENGLISH,
+                    "Tried to create quantity %.2f, but Android Pay quantity" +
+                            " may only have one digit after decimal. Value was rounded to %s",
+                    quantity,
+                    mQuantity.toString()));
+        }
+        return this;
+    }
+
+    public LineItemBuilder setDescription(String description) {
+        mDescription = description;
+        return this;
+    }
+
+    /**
+     * Sets the {@link LineItem.Role} of this line item, if the input is a member of
+     * {@link #VALID_ROLES}.
+     *
+     * @param role the {@link LineItem.Role} of this item
+     * @return {@code this}, for chaining purposes
+     */
+    public LineItemBuilder setRole(int role) {
+        if (VALID_ROLES.contains(role)) {
+            mRole = role;
+        }
+        return this;
+    }
+
+    public LineItem build() {
+        LineItem.Builder androidPayBuilder = LineItem.newBuilder();
+        androidPayBuilder.setCurrencyCode(mCurrency.getCurrencyCode()).setRole(mRole);
+
+        if (mTotalPrice != null) {
+            androidPayBuilder.setTotalPrice(PaymentUtils.getPriceString(mTotalPrice, mCurrency));
+        }
+
+        if (mUnitPrice != null) {
+            androidPayBuilder.setUnitPrice(PaymentUtils.getPriceString(mUnitPrice, mCurrency));
+        }
+
+        if (mQuantity != null) {
+            if (isWholeNumber(mQuantity)) {
+                androidPayBuilder.setQuantity(mQuantity.toBigInteger().toString());
+            } else {
+                androidPayBuilder.setQuantity(mQuantity.toString());
+            }
+        }
+
+        if (mTotalPrice == null && mQuantity != null && mUnitPrice != null) {
+            mTotalPrice = mQuantity.multiply(
+                    BigDecimal.valueOf(mUnitPrice),
+                    MathContext.DECIMAL64).longValue();
+            androidPayBuilder.setTotalPrice(PaymentUtils.getPriceString(mTotalPrice, mCurrency));
+        } else {
+            if (!isPriceBreakdownConsistent(mUnitPrice, mQuantity, mTotalPrice)) {
+                Log.w(TAG, String.format(Locale.ENGLISH,
+                        "Price breakdown of %d * %.1f = %d is off by more than 1 percent",
+                        mUnitPrice, mQuantity.floatValue(), mTotalPrice));
+            }
+        }
+
+        if (mRole != LineItem.Role.REGULAR) {
+            androidPayBuilder.setRole(mRole);
+        }
+
+        if (!TextUtils.isEmpty(mDescription)) {
+            androidPayBuilder.setDescription(mDescription);
+        }
+
+        return androidPayBuilder.build();
+    }
+
+    static boolean isWholeNumber(BigDecimal number) {
+        return number.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0;
+    }
+
+    /**
+     * Checks to see if the unit * quantity expected price is within 1% of the
+     * listed totalPrice. Returns {@code true} if any value is null.
+     *
+     * @param unitPrice the listed price per unit of the line item
+     * @param quantity the listed quantity of the line item
+     * @param totalPrice the listed total price of the line item
+     * @return {@code true} if the quantity or unit price is zero, or if any item is null.
+     * Otherwise, {@code true} if and only if totalPrice / (unitPrice * quantity) is between
+     * 0.99 and 1.01.
+     */
+    static boolean isPriceBreakdownConsistent(
+            Long unitPrice,
+            BigDecimal quantity,
+            Long totalPrice) {
+        if (unitPrice == null || quantity == null || totalPrice == null) {
+            return true;
+        }
+
+        BigDecimal expectedPrice = quantity.multiply(BigDecimal.valueOf(unitPrice));
+        BigDecimal actualPrice = BigDecimal.valueOf(totalPrice);
+
+        if (expectedPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return totalPrice == 0;
+        }
+
+        double ratio = actualPrice.divide(
+                expectedPrice,
+                CONSISTENCY_SCALE,
+                BigDecimal.ROUND_HALF_EVEN).doubleValue();
+
+        return Math.abs(ratio - 1.0) < CONSISTENCY_THRESHOLD;
+    }
+}

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
@@ -117,7 +117,7 @@ public class LineItemBuilderTest {
     }
 
     @Test
-    public void isWholeNumber_whenBigDecimalDoubleWithoutDecimalPart_returnsFalse() {
+    public void isWholeNumber_whenBigDecimalDoubleWithoutDecimalPart_returnsTrue() {
         assertTrue(LineItemBuilder.isWholeNumber(BigDecimal.valueOf(1.0000)));
     }
 

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
@@ -1,0 +1,172 @@
+package com.stripe.wrap.pay.utils;
+
+import android.util.Log;
+
+import com.google.android.gms.wallet.LineItem;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.List;
+import java.util.Locale;
+
+import static com.stripe.wrap.pay.utils.LineItemBuilder.isPriceBreakdownConsistent;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for {@link LineItemBuilder}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23)
+public class LineItemBuilderTest {
+
+    @Test
+    public void emptyLineItemBuilder_createsEmptyLineItemWithDefaults() {
+        Locale.setDefault(Locale.US);
+
+        LineItemBuilder lineItemBuilder = new LineItemBuilder();
+        LineItem item = lineItemBuilder.build();
+        assertEquals(LineItem.Role.REGULAR, item.getRole());
+        assertEquals(Currency.getInstance(Locale.US).getCurrencyCode(), item.getCurrencyCode());
+    }
+
+    @Test
+    public void setAllAttributes_thenBuild_createsExpectedLineItem() {
+        final String currencyCode = "EUR";
+        final String description = "a test item";
+
+        LineItemBuilder lineItemBuilder = new LineItemBuilder(LineItem.Role.REGULAR, currencyCode);
+        LineItem lineItem = lineItemBuilder.setDescription(description)
+                .setUnitPrice(100)
+                .setQuantity(2)
+                .setTotalPrice(200)
+                .build();
+        assertEquals(LineItem.Role.REGULAR, lineItem.getRole());
+        assertEquals(currencyCode, lineItem.getCurrencyCode());
+        assertEquals(description, lineItem.getDescription());
+        assertEquals("2", lineItem.getQuantity());
+        assertEquals("1.00", lineItem.getUnitPrice());
+        assertEquals("2.00", lineItem.getTotalPrice());
+    }
+
+    @Test
+    public void setCurrency_withLowerCaseString_stillSetsCurrency() {
+        // If you try to create a Currency object with a lower-case code, it throws
+        // an IllegalArgumentException.
+        LineItemBuilder builder = new LineItemBuilder(LineItem.Role.TAX, "eur");
+        LineItem item = builder.build();
+        assertEquals("EUR", item.getCurrencyCode());
+    }
+
+    @Test
+    public void setQuantityAndUnitPrice_whenNoTotalPriceSet_createsTotalPrice() {
+        LineItemBuilder builder = new LineItemBuilder(LineItem.Role.REGULAR, "usd");
+        LineItem item = builder.setQuantity(1.5)
+                .setUnitPrice(399)
+                .build();
+
+        assertEquals("1.5", item.getQuantity());
+        assertEquals("3.99", item.getUnitPrice());
+        assertEquals("5.98", item.getTotalPrice());
+    }
+
+    @Test
+    public void setQuantity_whenMoreThanOneDigitAfterDecimal_getsRoundedAndLogsWarning() {
+        ShadowLog.stream = System.out;
+        Locale.setDefault(Locale.US);
+        LineItem item = new LineItemBuilder().setQuantity(1.71).build();
+
+        String expectedWarning = String.format(
+                Locale.ENGLISH,
+                "Tried to create quantity %.2f, but Android Pay quantity" +
+                        " may only have one digit after decimal. Value was rounded to 1.7",
+                1.71);
+        List<ShadowLog.LogItem> logItems = ShadowLog.getLogsForTag(LineItemBuilder.TAG);
+        assertFalse(logItems.isEmpty());
+        assertEquals(1, logItems.size());
+        assertEquals(expectedWarning, logItems.get(0).msg);
+        assertEquals(Log.WARN, logItems.get(0).type);
+        assertEquals("1.7", item.getQuantity());
+    }
+
+    @Test
+    public void setCurrencyCode_whenInvalid_setsToLocaleDefaultAndLogsWarning() {
+        ShadowLog.stream = System.out;
+        Locale.setDefault(Locale.JAPAN);
+
+        LineItem item = new LineItemBuilder(LineItem.Role.REGULAR, "notacurrency").build();
+        String expectedWarning = "Could not create currency with code notacurrency";
+        List<ShadowLog.LogItem> logItems = ShadowLog.getLogsForTag(LineItemBuilder.TAG);
+        assertEquals("JPY", item.getCurrencyCode());
+        assertEquals(1, logItems.size());
+        assertEquals(Log.WARN, logItems.get(0).type);
+        assertEquals(expectedWarning, logItems.get(0).msg);
+    }
+
+    @Test
+    public void isWholeNumber_whenBigDecimalFromInteger_returnsTrue() {
+        assertTrue(LineItemBuilder.isWholeNumber(BigDecimal.ZERO));
+        assertTrue(LineItemBuilder.isWholeNumber(BigDecimal.valueOf(555)));
+    }
+
+    @Test
+    public void isWholeNumber_whenBigDecimalDoubleWithoutDecimalPart_returnsFalse() {
+        assertTrue(LineItemBuilder.isWholeNumber(BigDecimal.valueOf(1.0000)));
+    }
+
+    @Test
+    public void isWholeNumber_whenBigDecimalDoubleWithDecimalPart_returnsFalse() {
+        assertFalse(LineItemBuilder.isWholeNumber(BigDecimal.valueOf(1.5)));
+        assertFalse(LineItemBuilder.isWholeNumber(BigDecimal.valueOf(2.07)));
+    }
+
+    @Test
+    public void isPriceBreakdownConsistent_whenItemsMultiplyClosely_returnsTrue() {
+        assertTrue(isPriceBreakdownConsistent(1000L, BigDecimal.TEN, 10000L));
+    }
+
+    @Test
+    public void isPriceBreakdownConsistent_whenAnyItemIsNull_returnsTrue() {
+        assertTrue(isPriceBreakdownConsistent(null, BigDecimal.TEN, 1234L));
+        assertTrue(isPriceBreakdownConsistent(55L, null, 8888L));
+        assertTrue(isPriceBreakdownConsistent(33L, BigDecimal.ONE, null));
+    }
+
+    @Test
+    public void isPriceBreakdownConsistent_whenItemsAreOffByALot_returnsFalse() {
+        assertFalse(isPriceBreakdownConsistent(55L, BigDecimal.ONE, 56L));
+    }
+
+    @Test
+    public void isPriceBreakdownConsistent_whenItemsAreOffByOnlyALittle_returnsTrue() {
+        assertTrue(isPriceBreakdownConsistent(199L, BigDecimal.ONE, 200L));
+    }
+
+    @Test
+    public void build_whenPriceBreakdownIsNotConsistent_logsWarning() {
+        ShadowLog.stream = System.out;
+        Locale.setDefault(Locale.JAPAN);
+
+        LineItem item = new LineItemBuilder(LineItem.Role.REGULAR, "USD")
+                .setQuantity(1.0)
+                .setUnitPrice(1500L)
+                .setTotalPrice(2000L).build();
+
+
+        String expectedWarning = "Price breakdown of 1500 * 1.0 = 2000 is off by more than 1 percent";
+        List<ShadowLog.LogItem> logItems = ShadowLog.getLogsForTag(LineItemBuilder.TAG);
+        assertEquals("15.00", item.getUnitPrice());
+        assertEquals("20.00", item.getTotalPrice());
+        assertEquals("1", item.getQuantity());
+        assertEquals(1, logItems.size());
+        assertEquals(Log.WARN, logItems.get(0).type);
+        assertEquals(expectedWarning, logItems.get(0).msg);
+    }
+}


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Adding a LineItemBuilder that wraps Google's LineItem.Builder and allows creation of line items using more standard parts.
In particular, prices are handled (in my builder) as `long` numeric types in the smallest subunit of currency, instead of String objects with a required regex. Also, we do regex-checking on the string client side so you don't have to wait for a server trip to find out about irregularities. Any oddities are logged, rather than thrown, because Google doesn't explicitly forbid you from making these seeming errors.

For instance, if your line item indicates that you bought 3 boxes of Llama Food at $10.00 each, and your total price for that line item is $100.00, I log a warning. Google doesn't prevent this, and I have a method that explicitly says something is probably wrong here, but I don't stop you. Only the total price really matters for each item.