### PR TITLE
Switching the cart manager to build using an exception-throwing error style

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartContentException.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartContentException.java
@@ -1,0 +1,71 @@
+package com.stripe.wrap.pay.utils;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+
+import com.google.android.gms.wallet.LineItem;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Class representing an error that will prevent a {@link com.google.android.gms.wallet.Cart} from
+ * being used.
+ */
+public class CartContentException extends Exception {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            CART_CURRENCY,
+            DUPLICATE_TAX,
+            INVALID_PRICE,
+            INVALID_CHARACTERS,
+            LINE_ITEM_CURRENCY,
+            LINE_ITEM_PRICE,
+            LINE_ITEM_QUANTITY
+    })
+    @interface CartErrorType { }
+    public static final String CART_CURRENCY = "cart_currency";
+    public static final String DUPLICATE_TAX = "duplicate_tax";
+    public static final String INVALID_PRICE = "invalid_price";
+    public static final String INVALID_CHARACTERS = "invalid_characters";
+    public static final String LINE_ITEM_CURRENCY = "line_item_currency";
+    public static final String LINE_ITEM_PRICE = "line_item_price";
+    public static final String LINE_ITEM_QUANTITY = "line_item_quantity";
+
+    @NonNull private final String mErrorMessage;
+    @NonNull private final @CartErrorType String mErrorType;
+    @Nullable private final LineItem mLineItem;
+
+    public CartContentException(
+            @NonNull @CartErrorType String errorType,
+            @NonNull String errorMessage) {
+        this(errorType, errorMessage, null);
+    }
+
+    public CartContentException(
+            @NonNull @CartErrorType String errorType,
+            @NonNull String errorMessage,
+            @Nullable LineItem errorLineItem) {
+        mErrorType = errorType;
+        mErrorMessage = errorMessage;
+        mLineItem = errorLineItem;
+    }
+
+    @Override
+    public String getMessage() {
+        return mErrorMessage;
+    }
+
+    @NonNull
+    @CartErrorType
+    public String getErrorType() {
+        return mErrorType;
+    }
+
+    @Nullable
+    public LineItem getLineItem() {
+        return mLineItem;
+    }
+}

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartContentException.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartContentException.java
@@ -1,13 +1,9 @@
 package com.stripe.wrap.pay.utils;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
+import android.support.annotation.Size;
 
-import com.google.android.gms.wallet.LineItem;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import java.util.List;
 
 /**
  * Class representing an error that will prevent a {@link com.google.android.gms.wallet.Cart} from
@@ -15,57 +11,25 @@ import java.lang.annotation.RetentionPolicy;
  */
 public class CartContentException extends Exception {
 
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({
-            CART_CURRENCY,
-            DUPLICATE_TAX,
-            INVALID_PRICE,
-            INVALID_CHARACTERS,
-            LINE_ITEM_CURRENCY,
-            LINE_ITEM_PRICE,
-            LINE_ITEM_QUANTITY
-    })
-    @interface CartErrorType { }
-    public static final String CART_CURRENCY = "cart_currency";
-    public static final String DUPLICATE_TAX = "duplicate_tax";
-    public static final String INVALID_PRICE = "invalid_price";
-    public static final String INVALID_CHARACTERS = "invalid_characters";
-    public static final String LINE_ITEM_CURRENCY = "line_item_currency";
-    public static final String LINE_ITEM_PRICE = "line_item_price";
-    public static final String LINE_ITEM_QUANTITY = "line_item_quantity";
+    static final String CART_ERROR_MESSAGE_START = "Cart Content Error Found:\n";
 
-    @NonNull private final String mErrorMessage;
-    @NonNull private final @CartErrorType String mErrorType;
-    @Nullable private final LineItem mLineItem;
+    @NonNull private final List<CartError> mCartErrors;
 
-    public CartContentException(
-            @NonNull @CartErrorType String errorType,
-            @NonNull String errorMessage) {
-        this(errorType, errorMessage, null);
-    }
-
-    public CartContentException(
-            @NonNull @CartErrorType String errorType,
-            @NonNull String errorMessage,
-            @Nullable LineItem errorLineItem) {
-        mErrorType = errorType;
-        mErrorMessage = errorMessage;
-        mLineItem = errorLineItem;
+    CartContentException(@NonNull @Size(min = 1) List<CartError> cartErrors) {
+        mCartErrors = cartErrors;
     }
 
     @Override
     public String getMessage() {
-        return mErrorMessage;
+        StringBuilder builder = new StringBuilder();
+        builder.append(CART_ERROR_MESSAGE_START);
+        for (CartError error : mCartErrors) {
+            builder.append(error.getMessage()).append('\n');
+        }
+        return builder.toString();
     }
 
-    @NonNull
-    @CartErrorType
-    public String getErrorType() {
-        return mErrorType;
-    }
-
-    @Nullable
-    public LineItem getLineItem() {
-        return mLineItem;
+    public List<CartError> getCartErrors() {
+        return mCartErrors;
     }
 }

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartError.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartError.java
@@ -1,0 +1,65 @@
+package com.stripe.wrap.pay.utils;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+
+import com.google.android.gms.wallet.LineItem;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Class representing a single cart error, either with a line item or
+ * the cart as a whole.
+ */
+public class CartError {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            CART_CURRENCY,
+            DUPLICATE_TAX,
+            LINE_ITEM_CURRENCY,
+            LINE_ITEM_PRICE,
+            LINE_ITEM_QUANTITY
+    })
+    @interface CartErrorType { }
+    public static final String CART_CURRENCY = "cart_currency";
+    public static final String DUPLICATE_TAX = "duplicate_tax";
+    public static final String LINE_ITEM_CURRENCY = "line_item_currency";
+    public static final String LINE_ITEM_PRICE = "line_item_price";
+    public static final String LINE_ITEM_QUANTITY = "line_item_quantity";
+
+    @NonNull private final String mErrorMessage;
+    @NonNull private final @CartErrorType String mErrorType;
+    @Nullable private final LineItem mLineItem;
+
+    public CartError(@CartErrorType String errorType,
+            @NonNull String errorMessage) {
+        this(errorType, errorMessage, null);
+    }
+
+    public CartError(
+            @NonNull @CartErrorType String errorType,
+            @NonNull String errorMessage,
+            @Nullable LineItem errorLineItem) {
+        mErrorType = errorType;
+        mErrorMessage = errorMessage;
+        mLineItem = errorLineItem;
+    }
+
+    public String getMessage() {
+        return mErrorMessage;
+    }
+
+    @NonNull
+    @CartErrorType
+    public String getErrorType() {
+        return mErrorType;
+    }
+
+    @Nullable
+    public LineItem getLineItem() {
+        return mLineItem;
+    }
+}

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
@@ -41,9 +41,9 @@ public class LineItemBuilder {
         mRole = LineItem.Role.REGULAR;
     }
 
-    LineItemBuilder(int role, String currencyCode) {
+    LineItemBuilder(String currencyCode) {
         setCurrencyCode(currencyCode);
-        mRole = role;
+        mRole = LineItem.Role.REGULAR;
     }
 
     /**

--- a/android-pay/src/test/java/com/stripe/wrap/pay/testutils/AssertUtils.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/testutils/AssertUtils.java
@@ -1,0 +1,23 @@
+package com.stripe.wrap.pay.testutils;
+
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Utility functions for tests.
+ */
+public class AssertUtils {
+
+    public static void assertEmpty(List list) {
+        assertNotNull(list);
+        assertTrue(list.isEmpty());
+    }
+
+    public static void assertEmpty(Map map) {
+        assertNotNull(map);
+        assertTrue(map.isEmpty());
+    }
+}

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -2,6 +2,7 @@ package com.stripe.wrap.pay.utils;
 
 import android.util.Log;
 
+import com.google.android.gms.wallet.Cart;
 import com.google.android.gms.wallet.LineItem;
 
 import org.junit.Test;
@@ -14,11 +15,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.stripe.wrap.pay.testutils.AssertUtils.assertEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link CartManager}.
@@ -53,7 +56,7 @@ public class CartManagerTest {
         LineItem taxItem = cartManager.getLineItemTax();
 
         assertEquals(1, shippingItems.size());
-        assertTrue(regularItems.isEmpty());
+        assertEmpty(regularItems);
         assertNull(taxItem);
     }
 
@@ -83,10 +86,10 @@ public class CartManagerTest {
 
         CartManager cartManager = new CartManager();
 
-        LineItem firstTaxItem = new LineItemBuilder(LineItem.Role.TAX, "USD")
-                .setTotalPrice(100L).build();
-        LineItem secondTaxItem = new LineItemBuilder(LineItem.Role.TAX, "USD")
-                .setTotalPrice(200L).build();
+        LineItem firstTaxItem = new LineItemBuilder("USD")
+                .setTotalPrice(100L).setRole(LineItem.Role.TAX).build();
+        LineItem secondTaxItem = new LineItemBuilder("USD")
+                .setTotalPrice(200L).setRole(LineItem.Role.TAX).build();
 
         cartManager.addLineItem(firstTaxItem);
         cartManager.addLineItem(secondTaxItem);
@@ -101,5 +104,125 @@ public class CartManagerTest {
 
         assertNotNull(cartTaxItem);
         assertEquals(PaymentUtils.getPriceString(200L), cartTaxItem.getTotalPrice());
+    }
+
+    @Test
+    public void generateUuidForRole_beginsWithAppropriatePrefix() {
+        String regularUuid = CartManager.generateUuidForRole(LineItem.Role.REGULAR);
+        String shippingUuid = CartManager.generateUuidForRole(LineItem.Role.SHIPPING);
+
+        assertTrue(regularUuid.startsWith(CartManager.REGULAR_ID));
+        assertTrue(shippingUuid.startsWith(CartManager.SHIPPING_ID));
+    }
+
+    @Test
+    public void addItem_thenRemoveItem_leavesNoItems() {
+        CartManager manager = new CartManager("USD");
+        String id = manager.addLineItem("llama food", 10000L);
+
+        LineItem item = manager.removeItem(id);
+
+        assertNotNull(item);
+        assertEquals(LineItem.Role.REGULAR, item.getRole());
+        assertEquals("llama food", item.getDescription());
+        assertEquals("100.00", item.getTotalPrice());
+
+        assertEmpty(manager.getLineItemsRegular());
+        assertEmpty(manager.getLineItemsShipping());
+    }
+
+    @Test
+    public void addShippingItem_thenRemoveItem_leavesNoShippingItems() {
+        CartManager manager = new CartManager("KRW");
+        String id = manager.addShippingLineItem("2 Day Guaranteed", 2099);
+
+        LineItem item = manager.removeItem(id);
+
+        assertNotNull(item);
+        assertEquals(LineItem.Role.SHIPPING, item.getRole());
+        assertEquals("2 Day Guaranteed", item.getDescription());
+        assertEquals("2099", item.getTotalPrice());
+
+        assertEmpty(manager.getLineItemsRegular());
+        assertEmpty(manager.getLineItemsShipping());
+    }
+
+    @Test
+    public void buildCart_withValidCart_createsExpectedCart() {
+        CartManager manager = new CartManager("USD");
+        manager.addLineItem("llama food", 10000L);
+        manager.addLineItem("llama scarf", 2000L);
+        manager.addShippingLineItem("Overnight", 50000L);
+        manager.setTaxLineItem("Tax", 1278L);
+
+        try {
+            Cart cart = manager.buildCart();
+            assertNotNull(cart);
+            assertEquals("USD", cart.getCurrencyCode());
+            assertEquals(4, cart.getLineItems().size());
+            assertEquals("632.78", cart.getTotalPrice());
+        } catch (CartContentException cartEx) {
+            fail("Unexpected error: " + cartEx.getMessage());
+        }
+    }
+
+    @Test
+    public void buildCart_whenLineItemsEmpty_returnsNull() {
+        CartManager manager = new CartManager("USD");
+
+        try {
+            assertNull(manager.buildCart());
+        } catch (CartContentException cartEx) {
+            fail("Unexpected error: " + cartEx.getMessage());
+        }
+    }
+
+    @Test
+    public void buildCart_whenHasErrors_throwsExpectedException() {
+        Locale.setDefault(Locale.JAPAN);
+        CartManager manager = new CartManager();
+
+        LineItem dollarItem = new LineItemBuilder("USD").setTotalPrice(100L).build();
+        LineItem wonItem = new LineItemBuilder("KRW").setTotalPrice(5000L).build();
+        LineItem taxItem = new LineItemBuilder()
+                .setTotalPrice(20L)
+                .setRole(LineItem.Role.TAX)
+                .build();
+        LineItem badPriceStringItem = LineItem.newBuilder()
+                .setCurrencyCode("JPY")
+                .setTotalPrice("$70.00").build();
+        LineItem badQuantityStringItem = LineItem.newBuilder()
+                .setQuantity("1.75")
+                .setUnitPrice("300")
+                .setTotalPrice("8000000")
+                .setCurrencyCode("JPY")
+                .build();
+        manager.addLineItem(dollarItem);
+        manager.addLineItem(wonItem);
+        manager.addLineItem(taxItem);
+        manager.addLineItem(badPriceStringItem);
+        manager.addLineItem(badQuantityStringItem);
+
+        try {
+            manager.buildCart();
+            fail("Should not be able to build a cart with bad line items.");
+        } catch (CartContentException cartEx) {
+            String message = cartEx.getMessage();
+            List<CartError> errors = cartEx.getCartErrors();
+            assertEquals(4, errors.size());
+            assertTrue(message.startsWith(CartContentException.CART_ERROR_MESSAGE_START));
+
+            assertEquals(CartError.LINE_ITEM_CURRENCY, errors.get(0).getErrorType());
+            assertEquals(CartError.LINE_ITEM_CURRENCY, errors.get(1).getErrorType());
+            assertEquals(CartError.LINE_ITEM_PRICE, errors.get(2).getErrorType());
+            assertEquals(CartError.LINE_ITEM_QUANTITY, errors.get(3).getErrorType());
+
+            String[] messageLines = message.split("\n");
+            assertEquals(5, messageLines.length);
+            assertTrue(messageLines[1].contains("USD"));
+            assertTrue(messageLines[2].contains("KRW"));
+            assertTrue(messageLines[3].contains("$70.00"));
+            assertTrue(messageLines[4].contains("1.75"));
+        }
     }
 }

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -213,9 +213,13 @@ public class CartManagerTest {
             assertTrue(message.startsWith(CartContentException.CART_ERROR_MESSAGE_START));
 
             assertEquals(CartError.LINE_ITEM_CURRENCY, errors.get(0).getErrorType());
+            assertEquals(dollarItem, errors.get(0).getLineItem());
             assertEquals(CartError.LINE_ITEM_CURRENCY, errors.get(1).getErrorType());
+            assertEquals(wonItem, errors.get(1).getLineItem());
             assertEquals(CartError.LINE_ITEM_PRICE, errors.get(2).getErrorType());
+            assertEquals(badPriceStringItem, errors.get(2).getLineItem());
             assertEquals(CartError.LINE_ITEM_QUANTITY, errors.get(3).getErrorType());
+            assertEquals(badQuantityStringItem, errors.get(3).getLineItem());
 
             String[] messageLines = message.split("\n");
             assertEquals(5, messageLines.length);

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -12,6 +12,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -32,8 +33,8 @@ public class CartManagerTest {
         LineItem regularItem = LineItem.newBuilder().setRole(LineItem.Role.REGULAR).build();
         cartManager.addLineItem(regularItem);
 
-        List<LineItem> regularItems = cartManager.getLineItemsRegular();
-        List<LineItem> shippingItems = cartManager.getLineItemsShipping();
+        Map<String, LineItem> regularItems = cartManager.getLineItemsRegular();
+        Map<String, LineItem> shippingItems = cartManager.getLineItemsShipping();
         LineItem taxItem = cartManager.getLineItemTax();
 
         assertEquals(1, regularItems.size());
@@ -47,8 +48,8 @@ public class CartManagerTest {
         LineItem shippingItem = LineItem.newBuilder().setRole(LineItem.Role.SHIPPING).build();
         cartManager.addLineItem(shippingItem);
 
-        List<LineItem> regularItems = cartManager.getLineItemsRegular();
-        List<LineItem> shippingItems = cartManager.getLineItemsShipping();
+        Map<String, LineItem> regularItems = cartManager.getLineItemsRegular();
+        Map<String, LineItem> shippingItems = cartManager.getLineItemsShipping();
         LineItem taxItem = cartManager.getLineItemTax();
 
         assertEquals(1, shippingItems.size());
@@ -62,8 +63,8 @@ public class CartManagerTest {
         LineItem taxItem = LineItem.newBuilder().setRole(LineItem.Role.TAX).build();
         cartManager.addLineItem(taxItem);
 
-        List<LineItem> regularItems = cartManager.getLineItemsRegular();
-        List<LineItem> shippingItems = cartManager.getLineItemsShipping();
+        Map<String, LineItem> regularItems = cartManager.getLineItemsRegular();
+        Map<String, LineItem> shippingItems = cartManager.getLineItemsShipping();
         LineItem cartTaxItem = cartManager.getLineItemTax();
 
         assertTrue(regularItems.isEmpty());

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
@@ -42,7 +42,7 @@ public class LineItemBuilderTest {
         final String currencyCode = "EUR";
         final String description = "a test item";
 
-        LineItemBuilder lineItemBuilder = new LineItemBuilder(LineItem.Role.REGULAR, currencyCode);
+        LineItemBuilder lineItemBuilder = new LineItemBuilder(currencyCode);
         LineItem lineItem = lineItemBuilder.setDescription(description)
                 .setUnitPrice(100)
                 .setQuantity(2)
@@ -58,7 +58,7 @@ public class LineItemBuilderTest {
 
     @Test
     public void setHighPrice_thenBuild_createsExpectedLineItem() {
-        LineItemBuilder lineItemBuilder = new LineItemBuilder(LineItem.Role.REGULAR, "USD");
+        LineItemBuilder lineItemBuilder = new LineItemBuilder("USD");
         LineItem lineItem = lineItemBuilder
                 .setUnitPrice(1000000L)
                 .setQuantity(2)
@@ -77,14 +77,14 @@ public class LineItemBuilderTest {
     public void setCurrency_withLowerCaseString_stillSetsCurrency() {
         // If you try to create a Currency object with a lower-case code, it throws
         // an IllegalArgumentException.
-        LineItemBuilder builder = new LineItemBuilder(LineItem.Role.TAX, "eur");
+        LineItemBuilder builder = new LineItemBuilder("eur");
         LineItem item = builder.build();
         assertEquals("EUR", item.getCurrencyCode());
     }
 
     @Test
     public void setQuantityAndUnitPrice_whenNoTotalPriceSet_createsTotalPrice() {
-        LineItemBuilder builder = new LineItemBuilder(LineItem.Role.REGULAR, "usd");
+        LineItemBuilder builder = new LineItemBuilder("usd");
         LineItem item = builder.setQuantity(1.5)
                 .setUnitPrice(399)
                 .build();
@@ -118,7 +118,7 @@ public class LineItemBuilderTest {
         ShadowLog.stream = System.out;
         Locale.setDefault(Locale.JAPAN);
 
-        LineItem item = new LineItemBuilder(LineItem.Role.REGULAR, "notacurrency").build();
+        LineItem item = new LineItemBuilder("notacurrency").build();
         String expectedWarning = "Could not create currency with code \"notacurrency\". Using " +
                 "currency JPY by default.";
         List<ShadowLog.LogItem> logItems = ShadowLog.getLogsForTag(PaymentUtils.TAG);
@@ -172,7 +172,7 @@ public class LineItemBuilderTest {
         ShadowLog.stream = System.out;
         Locale.setDefault(Locale.JAPAN);
 
-        LineItem item = new LineItemBuilder(LineItem.Role.REGULAR, "USD")
+        LineItem item = new LineItemBuilder("USD")
                 .setQuantity(1.0)
                 .setUnitPrice(1500L)
                 .setTotalPrice(2000L).build();


### PR DESCRIPTION
r? @sjayaraman-stripe 
cc @bg-stripe 

Added support for throwing a CartContentException if the CartManager has bad items in it when you try to build a Cart object.
Other functionality:
Keeping line items in a map, so that you can call cartManager.remove(itemId) if you want to remove an item from your cart. Like you can in every cart implementation everywhere other than on Android Pay.