### PR TITLE
adding an abstract StripeAndroidPayActivity for doing simple Android Pay actions

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'com.android.support:support-annotations:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:appcompat-v7:' + android_support_version
-    compile 'com.google.android.gms:play-services-wallet:10.2.1'
+    compile 'com.google.android.gms:play-services-wallet:10.2.4'
 
     javadocDeps 'com.android.support:support-annotations:' + android_support_version
     javadocDeps 'com.android.support:support-v4:' + android_support_version

--- a/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
@@ -1,0 +1,456 @@
+package com.stripe.wrap.pay.activity;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.BooleanResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.wallet.Cart;
+import com.google.android.gms.wallet.FullWallet;
+import com.google.android.gms.wallet.FullWalletRequest;
+import com.google.android.gms.wallet.IsReadyToPayRequest;
+import com.google.android.gms.wallet.MaskedWallet;
+import com.google.android.gms.wallet.MaskedWalletRequest;
+import com.google.android.gms.wallet.Wallet;
+import com.google.android.gms.wallet.WalletConstants;
+import com.google.android.gms.wallet.fragment.SupportWalletFragment;
+import com.google.android.gms.wallet.fragment.WalletFragmentInitParams;
+import com.google.android.gms.wallet.fragment.WalletFragmentMode;
+import com.google.android.gms.wallet.fragment.WalletFragmentOptions;
+import com.google.android.gms.wallet.fragment.WalletFragmentStyle;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.Token;
+import com.stripe.android.net.TokenParser;
+import com.stripe.wrap.pay.AndroidPayConfiguration;
+import com.stripe.wrap.pay.utils.PaymentUtils;
+
+import org.json.JSONException;
+
+import java.util.Locale;
+
+public abstract class StripeAndroidPayActivity extends AppCompatActivity
+        implements GoogleApiClient.ConnectionCallbacks,
+        GoogleApiClient.OnConnectionFailedListener {
+
+    public static final String TAG = StripeAndroidPayActivity.class.getName();
+
+    public static final String EXTRA_ACCOUNT_NAME = "extra_account_name";
+    public static final String EXTRA_CART = "extra_cart";
+
+    // Request code to use when requesting the Masked Wallet.
+    public static final int REQUEST_CODE_MASKED_WALLET = 2002;
+
+    // Request code to use when requesting the Full Wallet.
+    public static final int REQUEST_CODE_RESOLVE_LOAD_FULL_WALLET = 3003;
+
+    // Request code to use when launching the resolution activity
+    private static final int REQUEST_RESOLVE_ERROR = 1001;
+    // Unique tag for the error dialog fragment
+    private static final String DIALOG_ERROR = "dialog_error";
+    private static final String STATE_RESOLVING_ERROR = "resolving_error";
+    // Bool to track whether the app is already resolving an error
+    private boolean mResolvingError = false;
+
+    protected String mAccountName;
+    protected AndroidPayConfiguration mAndroidPayConfiguration;
+    protected Cart mCart;
+    protected GoogleApiClient mGoogleApiClient;
+    protected String mGoogleTransactionId;
+    protected SupportWalletFragment mSupportWalletFragment;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mResolvingError = savedInstanceState != null
+                && savedInstanceState.getBoolean(STATE_RESOLVING_ERROR, false);
+
+        if (getIntent().hasExtra(EXTRA_CART)) {
+            mCart = getIntent().getParcelableExtra(EXTRA_CART);
+        }
+
+        if (getIntent().hasExtra(EXTRA_ACCOUNT_NAME)) {
+            mAccountName = getIntent().getStringExtra(EXTRA_ACCOUNT_NAME);
+        }
+
+        mAndroidPayConfiguration = AndroidPayConfiguration.getInstance();
+        mGoogleApiClient = buildGoogleApiClient();
+
+        onBeforeAndroidPayAvailable();
+        verifyAndPrepareAndroidPayControls(mGoogleApiClient,
+                PaymentUtils.getStripeIsReadyToPayRequest());
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mGoogleApiClient.connect();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mGoogleApiClient.disconnect();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // retrieve the error code, if available
+        int errorCode = -1;
+        if (data != null) {
+            errorCode = data.getIntExtra(WalletConstants.EXTRA_ERROR_CODE, -1);
+        }
+        switch (requestCode) {
+            case REQUEST_RESOLVE_ERROR:
+                mResolvingError = false;
+                if (resultCode != RESULT_OK) {
+                    return;
+                }
+                // Make sure the app is not already connected or attempting to connect
+                if (!mGoogleApiClient.isConnecting() && !mGoogleApiClient.isConnected()) {
+                    mGoogleApiClient.connect();
+                }
+                break;
+            case REQUEST_CODE_MASKED_WALLET:
+                switch (resultCode) {
+                    case RESULT_OK:
+                        if (data != null) {
+                            MaskedWallet maskedWallet =
+                                    data.getParcelableExtra(WalletConstants.EXTRA_MASKED_WALLET);
+                            if (maskedWallet != null) {
+                                mGoogleTransactionId = maskedWallet.getGoogleTransactionId();
+                            }
+                            onMaskedWalletRetrieved(maskedWallet);
+                        }
+                        break;
+                    case RESULT_CANCELED:
+                        break;
+                    default:
+                        handleError(errorCode);
+                        break;
+                }
+                break;
+            case REQUEST_CODE_RESOLVE_LOAD_FULL_WALLET:
+                switch (resultCode) {
+                    case RESULT_OK:
+                        if (data != null && data.hasExtra(WalletConstants.EXTRA_FULL_WALLET)) {
+                            FullWallet fullWallet =
+                                    data.getParcelableExtra(WalletConstants.EXTRA_FULL_WALLET);
+                            // the full wallet can now be used to process the customer's payment
+                            // send the wallet info up to server to process, and to get the result
+                            // for sending a transaction status
+                            onFullWalletRetrieved(fullWallet);
+                        }
+                        break;
+                    case RESULT_CANCELED:
+                        break;
+                    default:
+                        handleError(errorCode);
+                        break;
+                }
+            case WalletConstants.RESULT_ERROR:
+                handleError(errorCode);
+                break;
+            default:
+                super.onActivityResult(requestCode, resultCode, data);
+                break;
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(STATE_RESOLVING_ERROR, mResolvingError);
+    }
+
+    protected void verifyAndPrepareAndroidPayControls(
+            @NonNull GoogleApiClient googleApiClient,
+            @NonNull IsReadyToPayRequest isReadyToPayRequest) {
+        Wallet.Payments.isReadyToPay(googleApiClient, isReadyToPayRequest)
+                .setResultCallback(
+                        new ResultCallback<BooleanResult>() {
+                            @Override
+                            public void onResult(@NonNull BooleanResult booleanResult) {
+                                onAfterAndroidPayCheckComplete();
+                                if (booleanResult.getStatus().isSuccess() && booleanResult.getValue()) {
+                                    createAndAddWalletFragment();
+                                } else {
+                                    onAndroidPayNotAvailable();
+                                }
+                            }
+                        });
+    }
+
+    protected void makeFullWalletRequest(@NonNull FullWalletRequest fullWalletRequest) {
+        Wallet.Payments.loadFullWallet(
+                mGoogleApiClient,
+                fullWalletRequest,
+                REQUEST_CODE_RESOLVE_LOAD_FULL_WALLET);
+    }
+
+    /**
+     * Builds the {@link GoogleApiClient} used in this Activity. Override
+     * if you'd like to change the default GoogleApiClient.
+     *
+     * @return a {@link GoogleApiClient} used to interact with the Wallet API
+     */
+    @NonNull
+    protected GoogleApiClient buildGoogleApiClient() {
+        return new GoogleApiClient.Builder(this)
+                .addApi(Wallet.API, new Wallet.WalletOptions.Builder()
+                        .setEnvironment(getWalletEnvironment())
+                        .setTheme(getWalletTheme())
+                        .build())
+                .addConnectionCallbacks(this)
+                .addOnConnectionFailedListener(this)
+                .build();
+    }
+
+    /**
+     * Creates the {@link WalletFragmentStyle} for this Activity. Override to change
+     * the appearance of the Wallet Fragment itself. The results of this method
+     * are used to build the {@link WalletFragmentOptions}.
+     *
+     * @return a {@link WalletFragmentStyle} used to display Android Pay options to the user
+     */
+    @NonNull
+    protected WalletFragmentStyle getWalletFragmentStyle() {
+        return new WalletFragmentStyle()
+                .setBuyButtonText(WalletFragmentStyle.BuyButtonText.BUY_WITH)
+                .setBuyButtonAppearance(WalletFragmentStyle.BuyButtonAppearance.ANDROID_PAY_DARK)
+                .setBuyButtonWidth(WalletFragmentStyle.Dimension.MATCH_PARENT);
+    }
+
+    @NonNull
+    protected WalletFragmentOptions getWalletFragmentOptions() {
+        return WalletFragmentOptions.newBuilder()
+                .setEnvironment(getWalletEnvironment())
+                .setFragmentStyle(getWalletFragmentStyle())
+                .setTheme(getWalletTheme())
+                .setMode(WalletFragmentMode.BUY_BUTTON)
+                .build();
+    }
+
+    protected void createAndAddWalletFragment() {
+        mSupportWalletFragment = SupportWalletFragment.newInstance(getWalletFragmentOptions());
+
+        MaskedWalletRequest maskedWalletRequest =
+                mAndroidPayConfiguration.generateMaskedWalletRequest(mCart);
+        WalletFragmentInitParams.Builder startParamsBuilder =
+                WalletFragmentInitParams.newBuilder()
+                        .setMaskedWalletRequest(maskedWalletRequest)
+                        .setMaskedWalletRequestCode(REQUEST_CODE_MASKED_WALLET);
+
+        if (!TextUtils.isEmpty(mAccountName)) {
+            startParamsBuilder.setAccountName(mAccountName);
+        }
+
+        mSupportWalletFragment.initialize(startParamsBuilder.build());
+        addWalletFragment(mSupportWalletFragment);
+    }
+
+    protected void onFullWalletRetrieved(FullWallet fullWallet) {
+        if (fullWallet == null || fullWallet.getPaymentMethodToken() == null) {
+            return;
+        }
+
+        String rawPurchaseToken = fullWallet.getPaymentMethodToken().getToken();
+        if (rawPurchaseToken == null) {
+            Log.w(TAG, "Null token returned with full wallet");
+        }
+
+        try {
+            Token token = TokenParser.parseToken(rawPurchaseToken);
+            onTokenReturned(fullWallet, token);
+        } catch (JSONException jsonException) {
+            Log.w(TAG,
+                    String.format(Locale.ENGLISH,
+                            "Could not parse object as Stripe token. Trying as Source.\n%s",
+                            rawPurchaseToken),
+                    jsonException);
+            Source source = Source.fromString(rawPurchaseToken);
+
+            if (source == null) {
+                Log.w(TAG,
+                        String.format(Locale.ENGLISH,
+                                "Could not parse object as Stripe Source\n%s",
+                                rawPurchaseToken),
+                        jsonException);
+                return;
+            }
+            onSourceReturned(fullWallet, source);
+        }
+    }
+
+    /*------ Begin GoogleApiClient.ConnectionCallbacks ------*/
+
+    @Override
+    public void onConnected(@Nullable Bundle bundle) {
+        onAndroidPayAvailable();
+    }
+
+    @Override
+    public void onConnectionSuspended(int i) {
+        onAndroidPayNotAvailable();
+    }
+
+    /*------ End GoogleApiClient.ConnectionCallbacks ------*/
+
+    /*------ Begin GoogleApiClient.OnConnectionFailedListener ------*/
+
+    /**
+     * Handles the error conditions for connection issues with the {@link GoogleApiClient}.
+     * Deliberately mimics the behavior of enableAutoManage.
+     *
+     * @param connectionResult a {@link ConnectionResult} failure in the {@link GoogleApiClient}
+     */
+    @Override
+    public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+        if (mResolvingError) {
+            // Already attempting to resolve an error.
+            return;
+        } else if (connectionResult.hasResolution()) {
+            try {
+                mResolvingError = true;
+                connectionResult.startResolutionForResult(this, REQUEST_RESOLVE_ERROR);
+            } catch (IntentSender.SendIntentException e) {
+                // There was an error with the resolution intent. Try again.
+                mGoogleApiClient.connect();
+            }
+        } else {
+            // Show dialog using GoogleApiAvailability.getErrorDialog()
+            showErrorDialog(connectionResult.getErrorCode());
+            mResolvingError = true;
+        }
+    }
+
+    /*------ End GoogleApiClient.OnConnectionFailedListener ------*/
+
+    /* Creates a dialog for an error message */
+    private void showErrorDialog(int errorCode) {
+        // Create a fragment for the error dialog
+        ErrorDialogFragment dialogFragment = new ErrorDialogFragment();
+        // Pass the error that should be displayed
+        Bundle args = new Bundle();
+        args.putInt(DIALOG_ERROR, errorCode);
+        dialogFragment.setArguments(args);
+        dialogFragment.show(getSupportFragmentManager(), "errordialog");
+    }
+
+    /* Called from ErrorDialogFragment when the dialog is dismissed. */
+    public void onDialogDismissed() {
+        mResolvingError = false;
+    }
+
+    /*------ Required Overrides ------*/
+
+    protected abstract void onAndroidPayAvailable();
+    protected abstract void onAndroidPayNotAvailable();
+
+    /*------ Optional Overrides ------*/
+
+    protected void onBeforeAndroidPayAvailable() {
+        // This is a good place to display a spinner if you anticipate network delays
+        // initializing the Google API client.
+    }
+
+    protected void onAfterAndroidPayCheckComplete() {
+        // If a spinner was showing, remove it in this method.
+    }
+
+    /**
+     * Override to handle Google errors in custom ways.
+     *
+     * @param errorCode the error code returned from the {@link GoogleApiClient}
+     */
+    protected void handleError(int errorCode) { }
+
+    /**
+     * Override this method to display the Android Pay fragment (a clickable button). Place
+     * it in a container of your choice using a {@link android.support.v4.app.FragmentTransaction}.
+     *
+     * @param walletFragment a {@link SupportWalletFragment} created using the
+     */
+    protected void addWalletFragment(@NonNull SupportWalletFragment walletFragment) { }
+
+    /**
+     * Override this method to react to a {@link MaskedWallet} being returned from
+     * the Google API. The masked wallet will have the user's shipping information (if
+     * it was required), which you can use to update the final shipping price. You can also
+     * use the card information as a confirmation for the user.
+     *
+     * @param maskedWallet the {@link MaskedWallet} returned from the {@link GoogleApiClient}
+     */
+    protected void onMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) { }
+
+    /**
+     * Override this function to move to {@link WalletConstants#ENVIRONMENT_PRODUCTION}
+     *
+     * @return the current wallet environment
+     */
+    protected int getWalletEnvironment() {
+        return WalletConstants.ENVIRONMENT_TEST;
+    }
+
+    /**
+     * Override this function to change the theme of Wallet display items
+     *
+     * @return the current wallet theme
+     */
+    protected int getWalletTheme() {
+        return WalletConstants.THEME_LIGHT;
+    }
+
+    /**
+     * Called when a Stripe {@link Source} is returned from Google's servers.
+     * Send the token in this method to your server to make a charge.
+     *
+     * Note: this feature is not yet implemented, but to be future-proof, a returned
+     * {@link Source} should still be handled.
+     *
+     * @param wallet the final {@link FullWallet} object
+     * @param source a Stripe {@link Source} that can be used to make a charge
+     */
+    protected void onSourceReturned(FullWallet wallet, Source source) { }
+
+    /**
+     * Called when a Stripe {@link Token} is returned from Google's servers.
+     * Send the token in this method to your server to make a charge.
+     *
+     * @param wallet the final {@link FullWallet} object
+     * @param token a Stripe {@link Token} that can be used to make a charge
+     */
+    protected void onTokenReturned(FullWallet wallet, Token token) { }
+
+    /*------ End Overrides ------*/
+
+    /* A fragment to display an error dialog */
+    public static class ErrorDialogFragment extends DialogFragment {
+        public ErrorDialogFragment() { }
+
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            // Get the error code and retrieve the appropriate dialog
+            int errorCode = this.getArguments().getInt(DIALOG_ERROR);
+            return GoogleApiAvailability.getInstance().getErrorDialog(
+                    this.getActivity(), errorCode, REQUEST_RESOLVE_ERROR);
+        }
+
+        @Override
+        public void onDismiss(DialogInterface dialog) {
+            ((StripeAndroidPayActivity) getActivity()).onDialogDismissed();
+        }
+    }
+}

--- a/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
@@ -1,0 +1,113 @@
+package com.stripe.wrap.pay.activity;
+
+import android.content.Intent;
+
+import com.google.android.gms.common.api.BooleanResult;
+import com.google.android.gms.common.api.CommonStatusCodes;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.wallet.Cart;
+import com.google.android.gms.wallet.MaskedWallet;
+import com.google.android.gms.wallet.WalletConstants;
+import com.google.android.gms.wallet.fragment.SupportWalletFragment;
+import com.stripe.wrap.pay.AndroidPayConfiguration;
+import com.stripe.wrap.pay.BuildConfig;
+import com.stripe.wrap.pay.testharness.TestAndroidPayActivity;
+import com.stripe.wrap.pay.utils.CartContentException;
+import com.stripe.wrap.pay.utils.CartManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import static android.app.Activity.RESULT_OK;
+import static junit.framework.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link StripeAndroidPayActivity}. Note that we have to test against SDK 22
+ * because of a <a href="https://github.com/robolectric/robolectric/issues/1932">known issue</a> in
+ * Robolectric.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 22)
+public class StripeAndroidPayActivityTest {
+
+    private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
+            "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
+
+    @Mock TestAndroidPayActivity.AndroidPayAvailabilityChooser mAndroidPayAvailabilityChooser;
+    @Mock GoogleApiClient mGoogleApiClient;
+    @Mock TestAndroidPayActivity.GoogleApiClientMockBuilder mGoogleApiClientMockBuilder;
+    @Mock TestAndroidPayActivity.StripeAndroidPayActivityListener mListener;
+
+    private ActivityController<TestAndroidPayActivity> mActivityController;
+    private CartManager mCartManager;
+    private Cart mCart;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(mGoogleApiClientMockBuilder.getMockGoogleApiClient()).thenReturn(mGoogleApiClient);
+        mCartManager = new CartManager();
+        mCartManager.addLineItem("First item", 100L);
+        mCartManager.addLineItem("Second item", 200L);
+
+        AndroidPayConfiguration androidPayConfiguration = AndroidPayConfiguration.getInstance();
+        androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+        when(mAndroidPayAvailabilityChooser.doesAndroidPayCheckSucceed()).thenReturn(
+                new BooleanResult(new Status(CommonStatusCodes.SUCCESS), true));
+
+        try {
+            mCart = mCartManager.buildCart();
+            Intent intent = new Intent(RuntimeEnvironment.application, TestAndroidPayActivity.class)
+                    .putExtra(StripeAndroidPayActivity.EXTRA_CART, mCart);
+            mActivityController = Robolectric.buildActivity(TestAndroidPayActivity.class, intent);
+            mActivityController.get().setStripeAppCompatActivityListener(mListener);
+            mActivityController.get().setGoogleApiClientMockBuilder(mGoogleApiClientMockBuilder);
+            mActivityController.get()
+                    .setAndroidPayAvailabilityChooser(mAndroidPayAvailabilityChooser);
+        } catch (CartContentException unexpected) {
+            fail("Error setting up tests");
+        }
+    }
+
+    @Test
+    public void onCreate_listenerHitsExpectedMethods() {
+        mActivityController.create().start();
+        verify(mListener).onBeforeAndroidPayAvailable();
+        verify(mListener).onAfterAndroidPayCheckComplete();
+        verify(mListener).getWalletEnvironment(WalletConstants.ENVIRONMENT_TEST);
+        verify(mListener).getWalletTheme(WalletConstants.THEME_LIGHT);
+        verify(mListener).addBuyButtonWalletFragment(any(SupportWalletFragment.class));
+
+        verify(mGoogleApiClient).connect();
+    }
+
+    @Test
+    public void onAndroidPayAvailable_listenerHitsExpectedMethods() {
+        mActivityController.create().start();
+        // Actions prior to this point are tested elsewhere
+        reset(mListener);
+
+//        MaskedWallet wallet = new MaskedWallet.Builder()
+//        Intent dataIntent = new Intent().putExtra(
+//                WalletConstants.EXTRA_MASKED_WALLET,
+//                MaskedWallet.Builder)
+//        mActivityController.get().onActivityResult(
+//                StripeAndroidPayActivity.REQUEST_CODE_MASKED_WALLET,
+//                RESULT_OK,
+//                );
+
+    }
+}

--- a/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
@@ -1,6 +1,7 @@
 package com.stripe.wrap.pay.testharness;
 
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -76,6 +77,10 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
             mListener.getWalletFragmentOptions(options);
         }
         return options;
+    }
+
+    public WalletFragmentOptions accessWalletFragmentOptions(int walletFragmentMode) {
+        return getWalletFragmentOptions(walletFragmentMode);
     }
 
     @Override
@@ -194,6 +199,14 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
     }
 
     @Override
+    public void onConnected(@Nullable Bundle bundle) {
+        super.onConnected(bundle);
+        if (mListener != null) {
+            mListener.onConnected(bundle);
+        }
+    }
+
+    @Override
     public void onConnectionSuspended(int i) {
         super.onConnectionSuspended(i);
         if (mListener != null) {
@@ -218,6 +231,7 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
         void onAndroidPayNotAvailable();
         void onBeforeAndroidPayAvailable();
         void onConfirmedMaskedWalletRetrieved(MaskedWallet maskedWallet);
+        void onConnected(Bundle bundle);
         void onConnectionFailed(@NonNull ConnectionResult connectionResult);
         void onConnectionSuspended(int i);
         void onMaskedWalletRetrieved(MaskedWallet maskedWallet);

--- a/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
@@ -1,0 +1,236 @@
+package com.stripe.wrap.pay.testharness;
+
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.BooleanResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.wallet.FullWallet;
+import com.google.android.gms.wallet.FullWalletRequest;
+import com.google.android.gms.wallet.IsReadyToPayRequest;
+import com.google.android.gms.wallet.MaskedWallet;
+import com.google.android.gms.wallet.fragment.SupportWalletFragment;
+
+import com.google.android.gms.wallet.fragment.WalletFragmentOptions;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.Token;
+import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
+
+public class TestAndroidPayActivity extends StripeAndroidPayActivity {
+
+    AndroidPayAvailabilityChooser mAndroidPayAvailabilityChooser;
+    GoogleApiClientMockBuilder mGoogleApiClientMockBuilder;
+    StripeAndroidPayActivityListener mListener;
+
+    public void setStripeAppCompatActivityListener(StripeAndroidPayActivityListener listener) {
+        mListener = listener;
+    }
+
+    public void setGoogleApiClientMockBuilder(GoogleApiClientMockBuilder builder) {
+        mGoogleApiClientMockBuilder = builder;
+    }
+
+    public void setAndroidPayAvailabilityChooser(AndroidPayAvailabilityChooser chooser) {
+        mAndroidPayAvailabilityChooser = chooser;
+    }
+
+    @NonNull
+    @Override
+    protected GoogleApiClient buildGoogleApiClient() {
+        return mGoogleApiClientMockBuilder.getMockGoogleApiClient();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (mListener != null) {
+            mListener.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
+    protected int getWalletEnvironment() {
+        int walletEnvironment = super.getWalletEnvironment();
+        if (mListener != null) {
+            mListener.getWalletEnvironment(walletEnvironment);
+        }
+        return walletEnvironment;
+    }
+
+    @Override
+    protected int getWalletTheme() {
+        int walletTheme = super.getWalletTheme();
+        if (mListener  != null) {
+            mListener.getWalletTheme(walletTheme);
+        }
+        return walletTheme;
+    }
+
+    @NonNull
+    @Override
+    protected WalletFragmentOptions getWalletFragmentOptions(int walletFragmentMode) {
+        WalletFragmentOptions options = super.getWalletFragmentOptions(walletFragmentMode);
+        if (mListener != null) {
+            mListener.getWalletFragmentOptions(options);
+        }
+        return options;
+    }
+
+    @Override
+    protected void addBuyButtonWalletFragment(@NonNull SupportWalletFragment walletFragment) {
+        if (mListener != null) {
+            mListener.addBuyButtonWalletFragment(walletFragment);
+        }
+    }
+
+    @Override
+    protected void addConfirmationWalletFragment(@NonNull SupportWalletFragment walletFragment) {
+        if (mListener != null) {
+            mListener.addConfirmationWalletFragment(walletFragment);
+        }
+    }
+
+    @Override
+    protected void onBeforeAndroidPayAvailable() {
+        super.onBeforeAndroidPayAvailable();
+        if (mListener != null) {
+            mListener.onBeforeAndroidPayAvailable();
+        }
+    }
+
+    @Override
+    protected void onAfterAndroidPayCheckComplete() {
+        super.onAfterAndroidPayCheckComplete();
+        if (mListener != null) {
+            mListener.onAfterAndroidPayCheckComplete();
+        }
+    }
+
+    @Override
+    protected void onAndroidPayAvailable() {
+        if (mListener != null) {
+            mListener.onAndroidPayAvailable();
+        }
+    }
+
+    @Override
+    protected void onAndroidPayNotAvailable() {
+        if (mListener != null) {
+            mListener.onAndroidPayNotAvailable();
+        }
+    }
+
+    @Override
+    protected void handleError(int errorCode) {
+        if (mListener != null) {
+            mListener.handleError(errorCode);
+        }
+    }
+
+    @Override
+    protected void loadFullWallet(@NonNull FullWalletRequest fullWalletRequest) {
+        super.loadFullWallet(fullWalletRequest);
+        if (mListener != null) {
+            mListener.loadFullWallet(fullWalletRequest);
+        }
+    }
+
+    @Override
+    protected void onConfirmedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
+        super.onConfirmedMaskedWalletRetrieved(maskedWallet);
+        if (mListener != null) {
+            mListener.onConfirmedMaskedWalletRetrieved(maskedWallet);
+        }
+    }
+
+    @Override
+    protected void onMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
+        if (mListener != null) {
+            mListener.onMaskedWalletRetrieved(maskedWallet);
+        }
+    }
+
+    @Override
+    protected void onTokenReturned(FullWallet wallet, Token token) {
+        super.onTokenReturned(wallet, token);
+        if (mListener != null) {
+            mListener.onTokenReturned(wallet, token);
+        }
+    }
+
+    @Override
+    protected void onSourceReturned(FullWallet wallet, Source source) {
+        super.onSourceReturned(wallet, source);
+        if (mListener != null) {
+            mListener.onSourceReturned(wallet, source);
+        }
+    }
+
+    @Override
+    protected void verifyAndPrepareAndroidPayControls(
+            @NonNull GoogleApiClient googleApiClient,
+            @NonNull IsReadyToPayRequest isReadyToPayRequest) {
+        if (mListener != null && mAndroidPayAvailabilityChooser != null) {
+            mListener.verifyAndPrepareAndroidPayControls(isReadyToPayRequest);
+            // Simulate the check completing
+            onAfterAndroidPayCheckComplete();
+            BooleanResult result = mAndroidPayAvailabilityChooser.doesAndroidPayCheckSucceed();
+            if (result.getStatus().isSuccess() && result.getValue()) {
+                createAndAddBuyButtonWalletFragment();
+            } else {
+                onAndroidPayNotAvailable();
+            }
+        }
+    }
+
+    @Override
+    public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+        super.onConnectionFailed(connectionResult);
+        if (mListener != null) {
+            mListener.onConnectionFailed(connectionResult);
+        }
+    }
+
+    @Override
+    public void onConnectionSuspended(int i) {
+        super.onConnectionSuspended(i);
+        if (mListener != null) {
+            mListener.onConnectionSuspended(i);
+        }
+    }
+
+    /**
+     * Listener that acts as a shadow of this Activity
+     */
+    public interface StripeAndroidPayActivityListener {
+        void addBuyButtonWalletFragment(SupportWalletFragment walletFragment);
+        void addConfirmationWalletFragment(SupportWalletFragment walletFragment);
+        void getWalletEnvironment(int walletEnvironment);
+        void getWalletFragmentOptions(WalletFragmentOptions options);
+        void getWalletTheme(int walletTheme);
+        void handleError(int errorCode);
+        void loadFullWallet(FullWalletRequest fullWalletRequest);
+        void onActivityResult(int requestCode, int resultCode, Intent data);
+        void onAfterAndroidPayCheckComplete();
+        void onAndroidPayAvailable();
+        void onAndroidPayNotAvailable();
+        void onBeforeAndroidPayAvailable();
+        void onConfirmedMaskedWalletRetrieved(MaskedWallet maskedWallet);
+        void onConnectionFailed(@NonNull ConnectionResult connectionResult);
+        void onConnectionSuspended(int i);
+        void onMaskedWalletRetrieved(MaskedWallet maskedWallet);
+        void onTokenReturned(FullWallet fullWallet, Token token);
+        void onSourceReturned(FullWallet fullWallet, Source source);
+        void verifyAndPrepareAndroidPayControls(@NonNull IsReadyToPayRequest payRequest);
+    }
+
+    public interface GoogleApiClientMockBuilder {
+        GoogleApiClient getMockGoogleApiClient();
+    }
+
+    public interface AndroidPayAvailabilityChooser {
+        BooleanResult doesAndroidPayCheckSucceed();
+    }
+}


### PR DESCRIPTION
r? @bg-stripe 
cc @sjayaraman-stripe 

Adding a StripeAndroidPayActivity for handling the rather large amount of boilerplate needed just to get an android pay purchase up and running. This includes handling the connection to the Google Play Services API and routing the various activity callbacks.

Unfortunately, the robolectric test runner and Power Mock test runner don't coexist in a useable form, so running automation and passing in test MaskedWallets (or anything that requires a non-mocked call to the google api client), FullWallets, ConnectionResult, et. al., are not (at this moment) feasible.