### PR TITLE
removing option of using default currency in carts and line items

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
@@ -19,6 +19,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceString;
+import static com.stripe.wrap.pay.utils.PaymentUtils.getTotalPrice;
+
 /**
  * A wrapper for {@link Cart.Builder} that aids in the generation of new {@link LineItem}
  * objects.
@@ -201,6 +204,16 @@ public class CartManager {
                 .build());
     }
 
+    @Nullable
+    public Long calculateRegularItemTotal() {
+        return PaymentUtils.getTotalPrice(mLineItemsRegular.values(), mCurrency);
+    }
+
+    @Nullable
+    public Long calculateShippingItemTotal() {
+        return PaymentUtils.getTotalPrice(mLineItemsShipping.values(), mCurrency);
+    }
+
     /**
      * Adds a {@link LineItem.Role#TAX} item to the cart with a description
      * and total price value. Currency matches the currency of the {@link CartManager}.
@@ -222,9 +235,9 @@ public class CartManager {
      * from the sum of the prices of the items within the cart.
      *
      * @param totalPrice a number representing the price, in the lowest possible denomination
-     *                   of the cart's currency, or {@code null} to clear the manually set price
+     *                   of the cart's currency
      */
-    public void setTotalPrice(@Nullable Long totalPrice) {
+    public void setTotalPrice(@NonNull Long totalPrice) {
         mManualTotalPrice = totalPrice;
     }
 
@@ -330,9 +343,11 @@ public class CartManager {
                 totalLineItems,
                 mCurrency.getCurrencyCode());
 
-        String totalPriceString = mManualTotalPrice == null
-                ? PaymentUtils.getTotalPriceString(totalLineItems, mCurrency)
-                : PaymentUtils.getPriceString(mManualTotalPrice, mCurrency);
+        Long totalPrice = mManualTotalPrice == null
+                ? getTotalPrice(totalLineItems, mCurrency)
+                : mManualTotalPrice;
+
+        String totalPriceString = totalPrice == null ? null : getPriceString(totalPrice, mCurrency);
 
         if (!TextUtils.isEmpty(totalPriceString)) {
             // If a manual value has been set for the total price string, then we don't need

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
@@ -31,8 +31,6 @@ public class CartManager {
 
     private final Currency mCurrency;
 
-    private boolean mHasMixedCurrencies = false;
-
     @NonNull private LinkedHashMap<String, LineItem> mLineItemsRegular = new LinkedHashMap<>();
     @NonNull private LinkedHashMap<String, LineItem> mLineItemsShipping = new LinkedHashMap<>();
 
@@ -384,14 +382,13 @@ public class CartManager {
 
     @VisibleForTesting
     void updateRunningPrice(@Nullable LineItem itemAdded, @Nullable LineItem itemRemoved) {
-        if (mHasMixedCurrencies) {
+        if (mRunningTotalPrice == null) {
             return;
         }
 
         if (itemAdded != null && !mCurrency.getCurrencyCode().equals(itemAdded.getCurrencyCode())) {
             // Note: if we add a different currency item to our cart, this puts the cart in a
             // permanent error state with regards to calculating the running total.
-            mHasMixedCurrencies = true;
             mRunningTotalPrice = null;
             return;
         }

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
@@ -36,11 +36,6 @@ public class LineItemBuilder {
     private String mDescription;
     private int mRole;
 
-    LineItemBuilder() {
-        mCurrency = Currency.getInstance(Locale.getDefault());
-        mRole = LineItem.Role.REGULAR;
-    }
-
     LineItemBuilder(String currencyCode) {
         setCurrencyCode(currencyCode);
         mRole = LineItem.Role.REGULAR;
@@ -65,6 +60,28 @@ public class LineItemBuilder {
 
     public LineItemBuilder setTotalPrice(long totalPrice) {
         mTotalPrice = totalPrice;
+        return this;
+    }
+
+    /**
+     * Sets the quantity for this line item. Note: the quantity may have at most one number
+     * after the decimal place. Further precision will be rounded away.
+     *
+     * @param quantity the quantity of this line item
+     * @return {@code this}, for chaining purposes
+     */
+    public LineItemBuilder setQuantity(BigDecimal quantity) {
+        if (quantity.scale() > 1) {
+            mQuantity = quantity.setScale(1, BigDecimal.ROUND_HALF_EVEN);
+            Log.w(TAG, String.format(
+                    Locale.ENGLISH,
+                    "Tried to create quantity %.2f, but Android Pay quantity" +
+                            " may only have one digit after decimal. Value was rounded to %s",
+                    quantity,
+                    mQuantity.toString()));
+        } else {
+            mQuantity = quantity;
+        }
         return this;
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
@@ -26,7 +27,7 @@ public class PaymentUtils {
     static final String QUANTITY_REGEX = "\"[0-9]+(\\.[0-9])?\"";
 
     @Nullable
-    static String getTotalPriceString(@NonNull List<LineItem> lineItems,
+    static Long getTotalPrice(@NonNull Collection<LineItem> lineItems,
                                       @NonNull Currency currency) {
         Long totalPrice = null;
         for (LineItem lineItem : lineItems) {
@@ -44,11 +45,12 @@ public class PaymentUtils {
             }
         }
 
+        // In this case, the values were simply all empty, not invalid. The total price is zero.
         if (totalPrice == null) {
-            return "";
-        } else {
-            return getPriceString(totalPrice, currency);
+            return 0L;
         }
+
+        return totalPrice;
     }
 
     @NonNull

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -25,10 +25,15 @@ public class PaymentUtils {
     static final String CURRENCY_REGEX = "\"^-?[0-9]+(\\.[0-9][0-9])?\"";
     static final String QUANTITY_REGEX = "\"[0-9]+(\\.[0-9])?\"";
 
+    @Nullable
     static String getTotalPriceString(@NonNull List<LineItem> lineItems,
                                       @NonNull Currency currency) {
         Long totalPrice = null;
         for (LineItem lineItem : lineItems) {
+            if (!currency.getCurrencyCode().equals(lineItem.getCurrencyCode())) {
+                return null;
+            }
+
             Long itemPrice = getPriceLong(lineItem.getTotalPrice(), currency);
             if (itemPrice != null) {
                 if (totalPrice == null) {
@@ -255,6 +260,27 @@ public class PaymentUtils {
     @NonNull
     public static String getPriceString(long price) {
         return getPriceString(price, Currency.getInstance(Locale.getDefault()));
+    }
+
+    /**
+     * Filter a list of {@link CartError} objects to remove all of a given type.
+     *
+     * @param errors the original list of {@link CartError CartErrors}
+     * @param errorType the {@link CartError.CartErrorType} to remove from the list
+     * @return the original list, minus any of the errors that were of the filtered type
+     */
+    @NonNull
+    public static List<CartError> removeErrorType(
+            @NonNull List<CartError> errors,
+            @NonNull @CartError.CartErrorType String errorType) {
+        List<CartError> filteredErrors = new ArrayList<>();
+        for (CartError error : errors) {
+            if (errorType.equals(error.getErrorType())) {
+                continue;
+            }
+            filteredErrors.add(error);
+        }
+        return filteredErrors;
     }
 
     /**

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -35,7 +35,7 @@ public class CartManagerTest {
 
     @Test
     public void addItem_whenRegularItem_addsOnlyRegularItem() {
-        CartManager cartManager = new CartManager();
+        CartManager cartManager = new CartManager("USD");
         LineItem regularItem = LineItem.newBuilder().setRole(LineItem.Role.REGULAR).build();
         cartManager.addLineItem(regularItem);
 
@@ -50,7 +50,7 @@ public class CartManagerTest {
 
     @Test
     public void addItem_whenShippingItem_addsOnlyShippingItem() {
-        CartManager cartManager = new CartManager();
+        CartManager cartManager = new CartManager("USD");
         LineItem shippingItem = LineItem.newBuilder().setRole(LineItem.Role.SHIPPING).build();
         cartManager.addLineItem(shippingItem);
 
@@ -65,7 +65,7 @@ public class CartManagerTest {
 
     @Test
     public void addItem_whenTaxItem_addsOnlyTaxItem() {
-        CartManager cartManager = new CartManager();
+        CartManager cartManager = new CartManager("JPY");
         LineItem taxItem = LineItem.newBuilder().setRole(LineItem.Role.TAX).build();
         cartManager.addLineItem(taxItem);
 
@@ -87,7 +87,7 @@ public class CartManagerTest {
                 "already exists. Old tax of 1.00 is being overwritten " +
                 "to maintain a valid cart.";
 
-        CartManager cartManager = new CartManager();
+        CartManager cartManager = new CartManager("USD");
 
         LineItem firstTaxItem = new LineItemBuilder("USD")
                 .setTotalPrice(100L).setRole(LineItem.Role.TAX).build();
@@ -106,6 +106,7 @@ public class CartManagerTest {
         LineItem cartTaxItem = cartManager.getLineItemTax();
 
         assertNotNull(cartTaxItem);
+        assertEquals(Long.valueOf(200L), cartManager.getRunningTotalPrice());
         assertEquals(PaymentUtils.getPriceString(200L), cartTaxItem.getTotalPrice());
     }
 
@@ -130,6 +131,7 @@ public class CartManagerTest {
         assertEquals("llama food", item.getDescription());
         assertEquals("100.00", item.getTotalPrice());
 
+        assertEquals(Long.valueOf(0L), manager.getRunningTotalPrice());
         assertEmpty(manager.getLineItemsRegular());
         assertEmpty(manager.getLineItemsShipping());
     }
@@ -138,6 +140,7 @@ public class CartManagerTest {
     public void addShippingItem_thenRemoveItem_leavesNoShippingItems() {
         CartManager manager = new CartManager("KRW");
         String id = manager.addShippingLineItem("2 Day Guaranteed", 2099);
+        assertNotNull(id);
 
         LineItem item = manager.removeItem(id);
 
@@ -146,8 +149,46 @@ public class CartManagerTest {
         assertEquals("2 Day Guaranteed", item.getDescription());
         assertEquals("2099", item.getTotalPrice());
 
+        assertEquals(Long.valueOf(0L), manager.getRunningTotalPrice());
         assertEmpty(manager.getLineItemsRegular());
         assertEmpty(manager.getLineItemsShipping());
+    }
+
+    @Test
+    public void addTaxLineItem_whenTaxItemExists_updatesRunningTotalProperly() {
+        CartManager manager = new CartManager("JPY");
+        manager.addLineItem("Regular Item", 100L);
+        manager.addLineItem("Another Regular Thing", 100L);
+        manager.addLineItem("Shipping Item", 50L, LineItem.Role.SHIPPING);
+        manager.addLineItem("Tax", 50L, LineItem.Role.TAX);
+
+        assertEquals(Long.valueOf(300L), manager.getRunningTotalPrice());
+
+        manager.addLineItem("Alternate Tax", 100L, LineItem.Role.TAX);
+
+        assertEquals(Long.valueOf(350L), manager.getRunningTotalPrice());
+    }
+
+    @Test
+    public void addLineItem_whenDifferentCurrencyFromCart_changesRunningTotalPriceToNull() {
+        CartManager manager = new CartManager("JPY");
+        manager.addLineItem("Regular Item", 100L);
+        manager.addLineItem("Another Regular Thing", 100L);
+
+        assertEquals(Long.valueOf(200L), manager.getRunningTotalPrice());
+
+        LineItem wonItem = new LineItemBuilder("KRW")
+                .setDescription("Imported Item")
+                .setTotalPrice(500L)
+                .build();
+        manager.addLineItem(wonItem);
+
+        // We can't add prices in different currencies
+        assertNull(manager.getRunningTotalPrice());
+
+        manager.addLineItem("A Yen Item", 100L);
+        // Once we've gone null, we shouldn't go back
+        assertNull(manager.getRunningTotalPrice());
     }
 
     @Test
@@ -167,6 +208,7 @@ public class CartManagerTest {
         List<LineItem> copiedLineItems = new ArrayList<>();
         copiedLineItems.addAll(copyCartManager.getLineItemsRegular().values());
 
+        assertEquals(Long.valueOf(7000L), copyCartManager.getRunningTotalPrice());
         verifyLineItemsHaveExpectedValues(expectedItemMap, copiedLineItems);
     }
 
@@ -229,12 +271,11 @@ public class CartManagerTest {
 
     @Test
     public void buildCart_whenHasErrors_throwsExpectedException() {
-        Locale.setDefault(Locale.JAPAN);
-        CartManager manager = new CartManager();
+        CartManager manager = new CartManager("JPY");
 
         LineItem dollarItem = new LineItemBuilder("USD").setTotalPrice(100L).build();
         LineItem wonItem = new LineItemBuilder("KRW").setTotalPrice(5000L).build();
-        LineItem taxItem = new LineItemBuilder()
+        LineItem taxItem = new LineItemBuilder("JPY")
                 .setTotalPrice(20L)
                 .setRole(LineItem.Role.TAX)
                 .build();
@@ -277,6 +318,81 @@ public class CartManagerTest {
             assertTrue(messageLines[2].contains("KRW"));
             assertTrue(messageLines[3].contains("$70.00"));
             assertTrue(messageLines[4].contains("1.75"));
+        }
+    }
+
+    @Test
+    public void buildCart_withManyErrorsButTotalValueSet_doesRemovesLineItemCurrencyErrors() {
+        CartManager manager = new CartManager("JPY");
+
+        LineItem dollarItem = new LineItemBuilder("USD").setTotalPrice(100L).build();
+        LineItem wonItem = new LineItemBuilder("KRW").setTotalPrice(5000L).build();
+        LineItem taxItem = new LineItemBuilder("JPY")
+                .setTotalPrice(20L)
+                .setRole(LineItem.Role.TAX)
+                .build();
+        LineItem badPriceStringItem = LineItem.newBuilder()
+                .setCurrencyCode("JPY")
+                .setTotalPrice("$70.00").build();
+        LineItem badQuantityStringItem = LineItem.newBuilder()
+                .setQuantity("1.75")
+                .setUnitPrice("300")
+                .setTotalPrice("8000000")
+                .setCurrencyCode("JPY")
+                .build();
+        manager.addLineItem(dollarItem);
+        manager.addLineItem(wonItem);
+        manager.addLineItem(taxItem);
+        manager.addLineItem(badPriceStringItem);
+        manager.addLineItem(badQuantityStringItem);
+
+        manager.setTotalPrice(5000L);
+
+        try {
+            manager.buildCart();
+            fail("Should not be able to build a cart with bad line items.");
+        } catch (CartContentException cartEx) {
+            String message = cartEx.getMessage();
+            List<CartError> errors = cartEx.getCartErrors();
+            assertEquals(2, errors.size());
+            assertTrue(message.startsWith(CartContentException.CART_ERROR_MESSAGE_START));
+
+            assertEquals(CartError.LINE_ITEM_PRICE, errors.get(0).getErrorType());
+            assertEquals(badPriceStringItem, errors.get(0).getLineItem());
+            assertEquals(CartError.LINE_ITEM_QUANTITY, errors.get(1).getErrorType());
+            assertEquals(badQuantityStringItem, errors.get(1).getLineItem());
+
+            String[] messageLines = message.split("\n");
+            assertEquals(3, messageLines.length);
+            assertTrue(messageLines[1].contains("$70.00"));
+            assertTrue(messageLines[2].contains("1.75"));
+        }
+
+    }
+
+        @Test
+    public void buildCart_withItemCurrencyErrorsButTotalValueIsManuallySet_doesNotThrowErrors() {
+        CartManager cartManager = new CartManager("CAD");
+        LineItem dollarItem = new LineItemBuilder("USD").setTotalPrice(100L).build();
+        LineItem wonItem = new LineItemBuilder("KRW").setTotalPrice(5000L).build();
+        LineItem yenItem = new LineItemBuilder("JPY")
+                .setTotalPrice(20L)
+                .setRole(LineItem.Role.TAX)
+                .build();
+        cartManager.addLineItem(dollarItem);
+        cartManager.addLineItem(wonItem);
+        cartManager.addLineItem(yenItem);
+
+        // Note that the total price doesn't have to be related to the other item prices.
+        cartManager.setTotalPrice(500000L);
+
+        Cart cart;
+        try {
+            cart = cartManager.buildCart();
+            assertNotNull(cart);
+            assertEquals("5000.00", cart.getTotalPrice());
+        } catch (CartContentException unexpected) {
+            fail("Should not have found any cart content exceptions.");
         }
     }
 

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -107,7 +108,8 @@ public class CartManagerTest {
 
         assertNotNull(cartTaxItem);
         assertEquals(Long.valueOf(200L), cartManager.getRunningTotalPrice());
-        assertEquals(PaymentUtils.getPriceString(200L), cartTaxItem.getTotalPrice());
+        assertEquals(PaymentUtils.getPriceString(200L, Currency.getInstance("USD")),
+                cartTaxItem.getTotalPrice());
     }
 
     @Test
@@ -370,7 +372,7 @@ public class CartManagerTest {
 
     }
 
-        @Test
+    @Test
     public void buildCart_withItemCurrencyErrorsButTotalValueIsManuallySet_doesNotThrowErrors() {
         CartManager cartManager = new CartManager("CAD");
         LineItem dollarItem = new LineItemBuilder("USD").setTotalPrice(100L).build();

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
@@ -28,16 +28,6 @@ import static org.junit.Assert.assertTrue;
 public class LineItemBuilderTest {
 
     @Test
-    public void emptyLineItemBuilder_createsEmptyLineItemWithDefaults() {
-        Locale.setDefault(Locale.US);
-
-        LineItemBuilder lineItemBuilder = new LineItemBuilder();
-        LineItem item = lineItemBuilder.build();
-        assertEquals(LineItem.Role.REGULAR, item.getRole());
-        assertEquals(Currency.getInstance(Locale.US).getCurrencyCode(), item.getCurrencyCode());
-    }
-
-    @Test
     public void setAllAttributes_thenBuild_createsExpectedLineItem() {
         final String currencyCode = "EUR";
         final String description = "a test item";
@@ -98,7 +88,7 @@ public class LineItemBuilderTest {
     public void setQuantity_whenMoreThanOneDigitAfterDecimal_getsRoundedAndLogsWarning() {
         ShadowLog.stream = System.out;
         Locale.setDefault(Locale.US);
-        LineItem item = new LineItemBuilder().setQuantity(1.71).build();
+        LineItem item = new LineItemBuilder("USD").setQuantity(1.71).build();
 
         String expectedWarning = String.format(
                 Locale.ENGLISH,

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
@@ -23,7 +23,7 @@ import static com.stripe.wrap.pay.utils.PaymentUtils.getCurrencyByCodeOrDefault;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceLong;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceString;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getStripeIsReadyToPayRequest;
-import static com.stripe.wrap.pay.utils.PaymentUtils.getTotalPriceString;
+import static com.stripe.wrap.pay.utils.PaymentUtils.getTotalPrice;
 import static com.stripe.wrap.pay.utils.PaymentUtils.validateLineItemList;
 import static com.stripe.wrap.pay.utils.PaymentUtils.searchLineItemForErrors;
 import static com.stripe.wrap.pay.utils.PaymentUtils.matchesCurrencyPatternOrEmpty;
@@ -328,21 +328,6 @@ public class PaymentUtilsTest {
     }
 
     @Test
-    public void getPriceString_whenNoCurrencyProvided_usesDefault() {
-        Locale.setDefault(Locale.US);
-
-        String dollarString = getPriceString(499L);
-        assertEquals("4.99", dollarString);
-        assertTrue(matchesCurrencyPatternOrEmpty(dollarString));
-
-        Locale.setDefault(Locale.JAPAN);
-
-        String yenString = getPriceString(499L);
-        assertEquals("499", yenString);
-        assertTrue(matchesCurrencyPatternOrEmpty(yenString));
-    }
-
-    @Test
     public void getPriceLong_whenDecimalValueGiven_correctlyParsesResult() {
         assertEquals(Long.valueOf(1000L), getPriceLong("10.00", Currency.getInstance("USD")));
         assertEquals(Long.valueOf(55555555L),
@@ -401,7 +386,7 @@ public class PaymentUtilsTest {
     }
 
     @Test
-    public void getTotalPriceString_forGroupOfStandardLineItemsInUsd_returnsExpectedValue() {
+    public void getTotalPrice_forGroupOfStandardLineItemsInUsd_returnsExpectedValue() {
         Locale.setDefault(Locale.US);
         LineItem item1 = new LineItemBuilder("USD").setTotalPrice(1000L).build();
         LineItem item2 = new LineItemBuilder("USD").setTotalPrice(2000L).build();
@@ -411,11 +396,11 @@ public class PaymentUtilsTest {
         items.add(item2);
         items.add(item3);
 
-        assertEquals("60.00", getTotalPriceString(items, Currency.getInstance("USD")));
+        assertEquals(Long.valueOf(6000L), getTotalPrice(items, Currency.getInstance("USD")));
     }
 
     @Test
-    public void getTotalPriceString_forGroupOfStandardLineItemsInKrw_returnsExpectedValue() {
+    public void getTotalPrice_forGroupOfStandardLineItemsInKrw_returnsExpectedValue() {
         Locale.setDefault(Locale.KOREA);
         LineItem item1 = new LineItemBuilder("KRW").setTotalPrice(1000L).build();
         LineItem item2 = new LineItemBuilder("KRW").setTotalPrice(2000L).build();
@@ -425,7 +410,7 @@ public class PaymentUtilsTest {
         items.add(item2);
         items.add(item3);
 
-        assertEquals("6000", getTotalPriceString(items, Currency.getInstance("KRW")));
+        assertEquals(Long.valueOf(6000L), getTotalPrice(items, Currency.getInstance("KRW")));
     }
 
     @Test
@@ -439,11 +424,11 @@ public class PaymentUtilsTest {
         items.add(item2);
         items.add(item3);
 
-        assertEquals("40.00", getTotalPriceString(items, Currency.getInstance("USD")));
+        assertEquals(Long.valueOf(4000L), getTotalPrice(items, Currency.getInstance("USD")));
     }
 
     @Test
-    public void getTotalPriceString_whenNoItemHasPrice_returnsEmptyString() {
+    public void getTotalPrice_whenNoItemHasPrice_returnsZero() {
         Locale.setDefault(Locale.CANADA);
         LineItem item1 = new LineItemBuilder("CAD").build();
         LineItem item2 = new LineItemBuilder("CAD").build();
@@ -451,12 +436,12 @@ public class PaymentUtilsTest {
         items.add(item1);
         items.add(item2);
 
-        assertEquals("", getTotalPriceString(items, Currency.getInstance("CAD")));
+        assertEquals(Long.valueOf(0L), getTotalPrice(items, Currency.getInstance("CAD")));
     }
 
     @Test
-    public void getTotalPriceString_whenEmptyList_returnsEmptyString() {
-        assertEquals("", getTotalPriceString(
+    public void getTotalPriceString_whenEmptyList_returnsZero() {
+        assertEquals(Long.valueOf(0L), getTotalPrice(
                 new ArrayList<LineItem>(), Currency.getInstance("OMR")));
     }
 

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
@@ -414,7 +414,7 @@ public class PaymentUtilsTest {
     }
 
     @Test
-    public void getTotalPriceString_whenOneItemHasNoPrice_returnsExpectedValue() {
+    public void getTotalPrice_whenOneItemHasNoPrice_returnsExpectedValue() {
         Locale.setDefault(Locale.US);
         LineItem item1 = new LineItemBuilder("USD").setTotalPrice(1000L).build();
         LineItem item2 = new LineItemBuilder("USD").build();
@@ -440,7 +440,18 @@ public class PaymentUtilsTest {
     }
 
     @Test
-    public void getTotalPriceString_whenEmptyList_returnsZero() {
+    public void getTotalPrice_whenOneItemHasInvalidCurrency_returnsNull() {
+        LineItem item1 = new LineItemBuilder("USD").setTotalPrice(100L).build();
+        LineItem item2 = new LineItemBuilder("CAD").setTotalPrice(100L).build();
+        List<LineItem> items = new ArrayList<>();
+        items.add(item1);
+        items.add(item2);
+
+        assertNull(getTotalPrice(items, Currency.getInstance("USD")));
+    }
+
+    @Test
+    public void getTotalPrice_whenEmptyList_returnsZero() {
         assertEquals(Long.valueOf(0L), getTotalPrice(
                 new ArrayList<LineItem>(), Currency.getInstance("OMR")));
     }


### PR DESCRIPTION
r? @teich-stripe 
cc @bg-stripe 

Removed the ability to have default currency in CartManager and LineItemBuilder, and added the ability to have multi-currency carts. This required some adjustment to when the cart is considered invalid. I also added convenience methods to add items to the cart with different roles, as well as the ability to keep a running total in a Cart Manager (this was a natural offshoot of needing to abandon making our own sums if the currencies get mixed up)