### PR TITLE
adding an example application that makes test android pay purchases

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
@@ -225,6 +225,13 @@ public class CartManager {
         return PaymentUtils.getTotalPrice(mLineItemsShipping.values(), mCurrency);
     }
 
+    public Long calculateTax() {
+        if (mLineItemTax == null) {
+            return null;
+        }
+        return PaymentUtils.getPriceLong(mLineItemTax.getTotalPrice(), mCurrency);
+    }
+
     /**
      * Adds a {@link LineItem.Role#TAX} item to the cart with a description
      * and total price value. Currency matches the currency of the {@link CartManager}.

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
@@ -225,10 +225,22 @@ public class CartManager {
         return PaymentUtils.getTotalPrice(mLineItemsShipping.values(), mCurrency);
     }
 
+    /**
+     * Gets the price of the {@link LineItem.Role#TAX} item, if it exists and
+     * has the same currency as the cart.
+     *
+     * @return the value of the tax item, zero if it doesn't exist, or {@code null} if
+     * the value is in the wrong currency or is not given
+     */
     public Long calculateTax() {
         if (mLineItemTax == null) {
+            return 0L;
+        }
+
+        if (!mCurrency.getCurrencyCode().equals(mLineItemTax.getCurrencyCode())) {
             return null;
         }
+
         return PaymentUtils.getPriceLong(mLineItemTax.getTotalPrice(), mCurrency);
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -293,7 +293,10 @@ public class PaymentUtils {
      * @return a String that can be used as an Android Pay price string
      */
     @NonNull
-    public static String getPriceString(long price, @NonNull Currency currency) {
+    public static String getPriceString(Long price, @NonNull Currency currency) {
+        if (price == null) {
+            return "";
+        }
 
         int fractionDigits = currency.getDefaultFractionDigits();
         int totalLength = String.valueOf(price).length();

--- a/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/testharness/TestAndroidPayActivity.java
@@ -15,8 +15,7 @@ import com.google.android.gms.wallet.MaskedWallet;
 import com.google.android.gms.wallet.fragment.SupportWalletFragment;
 
 import com.google.android.gms.wallet.fragment.WalletFragmentOptions;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.Token;
+import com.stripe.android.model.StripePaymentSource;
 import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
 
 public class TestAndroidPayActivity extends StripeAndroidPayActivity {
@@ -143,8 +142,8 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
     }
 
     @Override
-    protected void onConfirmedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
-        super.onConfirmedMaskedWalletRetrieved(maskedWallet);
+    protected void onChangedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
+        super.onChangedMaskedWalletRetrieved(maskedWallet);
         if (mListener != null) {
             mListener.onConfirmedMaskedWalletRetrieved(maskedWallet);
         }
@@ -158,18 +157,10 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
     }
 
     @Override
-    protected void onTokenReturned(FullWallet wallet, Token token) {
-        super.onTokenReturned(wallet, token);
+    protected void onStripePaymentSourceReturned(
+            FullWallet wallet, StripePaymentSource paymentSource) {
         if (mListener != null) {
-            mListener.onTokenReturned(wallet, token);
-        }
-    }
-
-    @Override
-    protected void onSourceReturned(FullWallet wallet, Source source) {
-        super.onSourceReturned(wallet, source);
-        if (mListener != null) {
-            mListener.onSourceReturned(wallet, source);
+            mListener.onStripePaymentSourceReturned(wallet, paymentSource);
         }
     }
 
@@ -235,8 +226,7 @@ public class TestAndroidPayActivity extends StripeAndroidPayActivity {
         void onConnectionFailed(@NonNull ConnectionResult connectionResult);
         void onConnectionSuspended(int i);
         void onMaskedWalletRetrieved(MaskedWallet maskedWallet);
-        void onTokenReturned(FullWallet fullWallet, Token token);
-        void onSourceReturned(FullWallet fullWallet, Source source);
+        void onStripePaymentSourceReturned(FullWallet fullWallet, StripePaymentSource paySource);
         void verifyAndPrepareAndroidPayControls(@NonNull IsReadyToPayRequest payRequest);
     }
 

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -191,6 +191,45 @@ public class CartManagerTest {
     }
 
     @Test
+    public void calculateTax_whenItemHasCorrectFormat_returnsValue() {
+        CartManager manager = new CartManager("USD");
+        manager.setTaxLineItem("Tax", 1000L);
+
+        assertEquals(Long.valueOf(1000L), manager.calculateTax());
+    }
+
+    @Test
+    public void calculateTax_whenItemNotPresent_returnsZero() {
+        CartManager manager = new CartManager("KRW");
+        assertEquals(Long.valueOf(0L), manager.calculateTax());
+    }
+
+    @Test
+    public void calculateTax_whenItemHasWrongCurrency_returnsNull() {
+        CartManager manager = new CartManager("USD");
+        LineItem taxItem = new LineItemBuilder("AUD")
+                .setTotalPrice(5000L)
+                .setDescription("Australian Taxes")
+                .setRole(LineItem.Role.TAX)
+                .build();
+        manager.setTaxLineItem(taxItem);
+
+        assertNull(manager.calculateTax());
+    }
+
+    @Test
+    public void calculateTax_whenItemHasNoPrice_returnsNull() {
+        CartManager manager = new CartManager("JPY");
+        LineItem taxItem = new LineItemBuilder("JPY")
+                .setDescription("Tax")
+                .setRole(LineItem.Role.TAX)
+                .build();
+        manager.setTaxLineItem(taxItem);
+
+        assertNull(manager.calculateTax());
+    }
+
+    @Test
     public void createCartManager_fromExistingCart_copiesRegularLineItemsAndCurrencyCode() {
         Cart oldCart = generateCartWithAllItems("USD");
 

--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -10,6 +10,10 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/appName">
 
+        <meta-data
+            android:name="com.google.android.gms.wallet.api.enabled"
+            android:value="true" />
+
         <activity
             android:name=".activity.PaymentActivity"
             android:theme="@style/SampleTheme">
@@ -26,7 +30,6 @@
             android:name=".activity.PollingActivity"
             android:launchMode="singleTask"
             android:theme="@style/SampleTheme">
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -37,7 +40,6 @@
                     android:host="async"
                     android:scheme="stripe"/>
             </intent-filter>
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -49,12 +51,22 @@
                     android:scheme="stripe"/>
             </intent-filter>
         </activity>
-        <activity android:name=".activity.LauncherActivity"
+
+        <activity
+            android:name=".activity.LauncherActivity"
             android:launchMode="singleTask"
             android:theme="@style/SampleTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+
+        <activity android:name=".activity.AndroidPayActivity"
+            android:theme="@style/SampleTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
     </application>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }
 
 android {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,6 +8,7 @@ def android_support_version = '25.3.1'
 
 dependencies {
     compile project(':stripe')
+    compile project(':android-pay')
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
@@ -16,6 +17,7 @@ dependencies {
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }
 
 android {

--- a/example/res/layout/activity_android_pay.xml
+++ b/example/res/layout/activity_android_pay.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.stripe.example.activity.AndroidPayActivity">
+    tools:context="com.stripe.example.activity.AndroidPayActivity"
+    >
 
     <TextView
         android:id="@+id/tv_item_total"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/android_pay_button_separation"
+        android:layout_marginLeft="@dimen/android_pay_button_separation"
+        android:layout_marginStart="@dimen/android_pay_button_separation"
         android:textAppearance="@android:style/TextAppearance.Medium"
         />
 
@@ -19,6 +22,8 @@
         android:id="@+id/tv_shipping_total"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/android_pay_button_separation"
+        android:layout_marginStart="@dimen/android_pay_button_separation"
         android:textAppearance="@android:style/TextAppearance.Medium"
         />
 
@@ -26,6 +31,8 @@
         android:id="@+id/tv_tax_total"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/android_pay_button_separation"
+        android:layout_marginStart="@dimen/android_pay_button_separation"
         android:textAppearance="@android:style/TextAppearance.Medium"
         />
 
@@ -34,20 +41,25 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textStyle="bold"
+        android:layout_marginLeft="@dimen/android_pay_button_separation"
+        android:layout_marginStart="@dimen/android_pay_button_separation"
         android:textAppearance="@android:style/TextAppearance.Medium"
         />
 
     <FrameLayout
-        android:id="@+id/container_android_pay"
+        android:id="@+id/container_android_pay_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/android_pay_button_layout_margin"/>
+        android:layout_margin="@dimen/android_pay_button_layout_margin"
+        />
 
     <LinearLayout
         android:id="@+id/proceed_container"
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/android_pay_button_layout_margin"
+        >
 
         <TextView
             android:id="@+id/tv_card_info"
@@ -55,7 +67,8 @@
             android:layout_height="wrap_content"
             android:textAppearance="@android:style/TextAppearance.Medium"
             android:maxLines="1"
-            android:ellipsize="end"/>
+            android:ellipsize="end"
+            />
 
         <TextView
             android:id="@+id/tv_shipping_info"
@@ -63,11 +76,12 @@
             android:layout_height="wrap_content"
             android:textAppearance="@android:style/TextAppearance.Medium"
             android:maxLines="1"
-            android:ellipsize="end"/>
+            android:ellipsize="end"
+            />
 
         <Button
-            android:id="@+id/btn_proceed"
-            android:text="@string/confirmPayment"
+            android:id="@+id/btn_change"
+            android:text="@string/changeDetails"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/android_pay_button_layout_margin"
@@ -75,8 +89,8 @@
             />
 
         <Button
-            android:id="@+id/btn_change"
-            android:text="@string/changeDetails"
+            android:id="@+id/btn_proceed"
+            android:text="@string/confirmPayment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/android_pay_button_separation"
@@ -93,17 +107,19 @@
         android:layout_height="wrap_content">
 
         <Button
-            android:id="@+id/button_confirm"
+            android:id="@+id/btn_okay"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@android:string/ok"
-            android:layout_margin="@dimen/android_pay_button_layout_margin"/>
+            android:layout_margin="@dimen/android_pay_button_layout_margin"
+            />
 
         <FrameLayout
             android:id="@+id/container_fragment_confirmation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/android_pay_confirmation_margin"/>
+            android:layout_margin="@dimen/android_pay_confirmation_margin"
+            />
 
     </LinearLayout>
 
@@ -112,5 +128,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_margin="@dimen/android_pay_confirmation_margin"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
+
 </LinearLayout>

--- a/example/res/layout/activity_android_pay.xml
+++ b/example/res/layout/activity_android_pay.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.stripe.example.activity.AndroidPayActivity">
+
+    <TextView
+        android:id="@+id/tv_item_total"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        />
+
+    <TextView
+        android:id="@+id/tv_shipping_total"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        />
+
+    <TextView
+        android:id="@+id/tv_tax_total"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        />
+
+    <TextView
+        android:id="@+id/tv_payment_total"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        />
+
+    <FrameLayout
+        android:id="@+id/container_android_pay"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/android_pay_button_layout_margin"/>
+
+    <LinearLayout
+        android:id="@+id/proceed_container"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_card_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@android:style/TextAppearance.Medium"
+            android:maxLines="1"
+            android:ellipsize="end"/>
+
+        <TextView
+            android:id="@+id/tv_shipping_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@android:style/TextAppearance.Medium"
+            android:maxLines="1"
+            android:ellipsize="end"/>
+
+        <Button
+            android:id="@+id/btn_proceed"
+            android:text="@string/confirmPayment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/android_pay_button_layout_margin"
+            android:layout_marginRight="@dimen/android_pay_button_layout_margin"
+            />
+
+        <Button
+            android:id="@+id/btn_change"
+            android:text="@string/changeDetails"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/android_pay_button_separation"
+            android:layout_marginLeft="@dimen/android_pay_button_layout_margin"
+            android:layout_marginRight="@dimen/android_pay_button_layout_margin"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/confirmation_total_container"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <Button
+            android:id="@+id/button_confirm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@android:string/ok"
+            android:layout_margin="@dimen/android_pay_button_layout_margin"/>
+
+        <FrameLayout
+            android:id="@+id/container_fragment_confirmation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/android_pay_confirmation_margin"/>
+
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/android_pay_listview"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="@dimen/android_pay_confirmation_margin"
+        android:layout_weight="1"/>
+</LinearLayout>

--- a/example/res/layout/activity_launcher.xml
+++ b/example/res/layout/activity_launcher.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
@@ -31,7 +30,8 @@
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         android:layout_gravity="center"
-        android:text="@string/createThreeDSecure"/>
+        android:text="@string/createThreeDSecure"
+        />
 
     <Button
         android:id="@+id/btn_android_pay_launch"
@@ -39,5 +39,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         android:layout_gravity="center"
-        android:text="@string/createAndroidPayTokens"/>
+        android:text="@string/createAndroidPayTokens"
+        />
+
 </LinearLayout>

--- a/example/res/layout/activity_launcher.xml
+++ b/example/res/layout/activity_launcher.xml
@@ -32,4 +32,12 @@
         android:layout_margin="10dp"
         android:layout_gravity="center"
         android:text="@string/createThreeDSecure"/>
+
+    <Button
+        android:id="@+id/btn_android_pay_launch"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:layout_gravity="center"
+        android:text="@string/createAndroidPayTokens"/>
 </LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -11,10 +11,13 @@
     <string name="progressMessage">Creating Token&#8230;</string>
     <string name="validationErrors">Validation Errors</string>
 
+    <string name="createAndroidPayTokens">Create Android Pay Tokens</string>
     <string name="createCardTokens">Create Card Tokens</string>
     <string name="createThreeDSecure">Create 3DS Sources</string>
     <string name="cardNumber">Card Number</string>
     <string name="createSource">Creating source&#8230;</string>
+    <string name="confirmPayment">Confirm payment details</string>
+    <string name="changeDetails">Change payment details</string>
     <string name="pollingSource">Polling for source changes&#8230;</string>
     <string name="save">Save</string>
     <string name="saverx">Save Rx</string>

--- a/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentTransaction;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -39,7 +38,6 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
     private static final Locale LOC = Locale.US;
     private static final Currency DOLLARS = Currency.getInstance("USD");
 
-    private CartManager mCartManager;
     private ViewGroup mChangeDetailsContainer;
     private ViewGroup mConfirmDetailsContainer;
     private ViewGroup mFragmentContainer;
@@ -55,22 +53,18 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
     private TextView mSelectedCardDisplay;
     private TextView mSelectedShippingAddressDisplay;
 
-    private Button mConfirmDetailsButton;
-    private Button mConfirmDialogButton;
-    private Button mChangeDetailsButton;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_android_pay);
-        mFragmentContainer = (ViewGroup) findViewById(R.id.container_android_pay);
+        mFragmentContainer = (ViewGroup) findViewById(R.id.container_android_pay_button);
         mChangeDetailsContainer = (ViewGroup) findViewById(R.id.confirmation_total_container);
         mConfirmDetailsContainer = (ViewGroup) findViewById(R.id.proceed_container);
         ListView tokenListView = (ListView) findViewById(R.id.android_pay_listview);
         mListViewController = new ListViewController(tokenListView);
         mProgressDialogController = new ProgressDialogController(getSupportFragmentManager());
 
-        Button confirmButton = (Button) findViewById(R.id.button_confirm);
+        Button confirmButton = (Button) findViewById(R.id.btn_okay);
         confirmButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -125,7 +119,7 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
     @Override
     protected void addBuyButtonWalletFragment(@NonNull SupportWalletFragment walletFragment) {
         FragmentTransaction buttonTransaction = getSupportFragmentManager().beginTransaction();
-        buttonTransaction.add(R.id.container_android_pay, walletFragment).commit();
+        buttonTransaction.add(R.id.container_android_pay_button, walletFragment).commit();
     }
 
     @Override
@@ -151,13 +145,8 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
     protected void onChangedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
         super.onChangedMaskedWalletRetrieved(maskedWallet);
         if (maskedWallet == null) {
-            Log.i(TAG, "Confirmed masked wallet was null");
             return;
-        } else {
-            Log.i(TAG, "Confirmed masked wallet was not null");
         }
-
-        Log.i(TAG, "Proceeding with changed wallet");
         mPossibleConfirmedMaskedWallet = maskedWallet;
         mChangeDetailsContainer.setVisibility(View.GONE);
         mConfirmDetailsContainer.setVisibility(View.VISIBLE);
@@ -166,7 +155,6 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
 
     @Override
     protected void onMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
-        mCartManager = new CartManager(mCart);
         if (maskedWallet != null) {
             mPossibleConfirmedMaskedWallet = maskedWallet;
 
@@ -242,7 +230,7 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
 
         CartManager copyCart = new CartManager(mCart);
         long shippingUpdate = calculateShipping(maskedWallet.getBuyerShippingAddress());
-        long taxUpdate = calculateShipping(maskedWallet.getBuyerBillingAddress());
+        long taxUpdate = calculateTaxes(maskedWallet.getBuyerBillingAddress());
         copyCart.addShippingLineItem("Shipping", shippingUpdate);
         copyCart.setTaxLineItem("Tax", taxUpdate);
 

--- a/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
@@ -1,0 +1,324 @@
+package com.stripe.example.activity;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentTransaction;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.google.android.gms.identity.intents.model.UserAddress;
+import com.google.android.gms.wallet.FullWallet;
+import com.google.android.gms.wallet.FullWalletRequest;
+import com.google.android.gms.wallet.InstrumentInfo;
+import com.google.android.gms.wallet.MaskedWallet;
+import com.google.android.gms.wallet.fragment.SupportWalletFragment;
+import com.google.android.gms.wallet.fragment.WalletFragmentStyle;
+import com.stripe.android.model.StripePaymentSource;
+import com.stripe.example.R;
+import com.stripe.example.controller.ListViewController;
+import com.stripe.example.controller.ProgressDialogController;
+import com.stripe.wrap.pay.AndroidPayConfiguration;
+import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
+import com.stripe.wrap.pay.utils.CartContentException;
+import com.stripe.wrap.pay.utils.CartManager;
+
+import java.util.Currency;
+import java.util.Locale;
+
+import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceString;
+
+public class AndroidPayActivity extends StripeAndroidPayActivity {
+
+    private static final String TAG = "chewie";
+    private static final Locale LOC = Locale.US;
+    private static final Currency DOLLARS = Currency.getInstance("USD");
+
+    private CartManager mCartManager;
+    private ViewGroup mChangeDetailsContainer;
+    private ViewGroup mConfirmDetailsContainer;
+    private ViewGroup mFragmentContainer;
+    private ListViewController mListViewController;
+    private ProgressDialogController mProgressDialogController;
+
+    private MaskedWallet mPossibleConfirmedMaskedWallet;
+
+    private TextView mItemsPriceDisplay;
+    private TextView mShippingDisplay;
+    private TextView mTaxesDisplay;
+    private TextView mTotalPaymentDisplay;
+    private TextView mSelectedCardDisplay;
+    private TextView mSelectedShippingAddressDisplay;
+
+    private Button mConfirmDetailsButton;
+    private Button mConfirmDialogButton;
+    private Button mChangeDetailsButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_android_pay);
+        mFragmentContainer = (ViewGroup) findViewById(R.id.container_android_pay);
+        mChangeDetailsContainer = (ViewGroup) findViewById(R.id.confirmation_total_container);
+        mConfirmDetailsContainer = (ViewGroup) findViewById(R.id.proceed_container);
+        ListView tokenListView = (ListView) findViewById(R.id.android_pay_listview);
+        mListViewController = new ListViewController(tokenListView);
+        mProgressDialogController = new ProgressDialogController(getSupportFragmentManager());
+
+        Button confirmButton = (Button) findViewById(R.id.button_confirm);
+        confirmButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                confirmPayment();
+            }
+        });
+
+        Button changeDetailsButton = (Button) findViewById(R.id.btn_change);
+        changeDetailsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mPossibleConfirmedMaskedWallet != null) {
+                    mConfirmDetailsContainer.setVisibility(View.GONE);
+                    createAndAddConfirmationWalletFragment(mPossibleConfirmedMaskedWallet);
+                }
+            }
+        });
+
+        Button finishButton = (Button) findViewById(R.id.btn_proceed);
+        finishButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mPossibleConfirmedMaskedWallet != null) {
+                    proceedWithWallet(mPossibleConfirmedMaskedWallet);
+                }
+            }
+        });
+        mChangeDetailsContainer.setVisibility(View.GONE);
+        mConfirmDetailsContainer.setVisibility(View.GONE);
+
+        mItemsPriceDisplay = (TextView) findViewById(R.id.tv_item_total);
+        mShippingDisplay = (TextView) findViewById(R.id.tv_shipping_total);
+        mTaxesDisplay = (TextView) findViewById(R.id.tv_tax_total);
+        mTotalPaymentDisplay = (TextView) findViewById(R.id.tv_payment_total);
+        mSelectedCardDisplay = (TextView) findViewById(R.id.tv_card_info);
+        mSelectedShippingAddressDisplay = (TextView) findViewById(R.id.tv_shipping_info);
+
+        updateCartTotals(new CartManager(mCart, true, true));
+    }
+
+    @Override
+    protected void onAndroidPayAvailable() {
+        mFragmentContainer.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    protected void onAndroidPayNotAvailable() {
+        mFragmentContainer.setVisibility(View.GONE);
+        mChangeDetailsContainer.setVisibility(View.GONE);
+    }
+
+    @Override
+    protected void addBuyButtonWalletFragment(@NonNull SupportWalletFragment walletFragment) {
+        FragmentTransaction buttonTransaction = getSupportFragmentManager().beginTransaction();
+        buttonTransaction.add(R.id.container_android_pay, walletFragment).commit();
+    }
+
+    @Override
+    protected void addConfirmationWalletFragment(@NonNull SupportWalletFragment walletFragment) {
+        mChangeDetailsContainer.setVisibility(View.VISIBLE);
+        FragmentTransaction confirmationTransaction =
+                getSupportFragmentManager().beginTransaction();
+        confirmationTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
+        confirmationTransaction.replace(R.id.container_fragment_confirmation, walletFragment).commit();
+    }
+
+    @NonNull
+    @Override
+    protected WalletFragmentStyle getWalletFragmentConfirmationStyle() {
+        return new WalletFragmentStyle()
+                .setMaskedWalletDetailsLogoImageType(WalletFragmentStyle.LogoImageType.ANDROID_PAY)
+                .setStyleResourceId(R.style.SampleTheme)
+                .setMaskedWalletDetailsTextAppearance(android.R.style.TextAppearance_DeviceDefault_Medium)
+                .setMaskedWalletDetailsHeaderTextAppearance(android.R.style.TextAppearance_DeviceDefault_Large);
+    }
+
+    @Override
+    protected void onChangedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
+        super.onChangedMaskedWalletRetrieved(maskedWallet);
+        if (maskedWallet == null) {
+            Log.i(TAG, "Confirmed masked wallet was null");
+            return;
+        } else {
+            Log.i(TAG, "Confirmed masked wallet was not null");
+        }
+
+        Log.i(TAG, "Proceeding with changed wallet");
+        mPossibleConfirmedMaskedWallet = maskedWallet;
+        mChangeDetailsContainer.setVisibility(View.GONE);
+        mConfirmDetailsContainer.setVisibility(View.VISIBLE);
+        updatePaymentInformation(mPossibleConfirmedMaskedWallet);
+    }
+
+    @Override
+    protected void onMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
+        mCartManager = new CartManager(mCart);
+        if (maskedWallet != null) {
+            mPossibleConfirmedMaskedWallet = maskedWallet;
+
+            updatePaymentInformation(mPossibleConfirmedMaskedWallet);
+
+            mChangeDetailsContainer.setVisibility(View.GONE);
+            mConfirmDetailsContainer.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Override
+    protected void onStripePaymentSourceReturned(
+            FullWallet wallet,
+            StripePaymentSource paymentSource) {
+        super.onStripePaymentSourceReturned(wallet, paymentSource);
+        mProgressDialogController.finishProgress();
+
+        String cardDetails = null;
+        if (wallet.getInstrumentInfos() != null && wallet.getInstrumentInfos().length > 0) {
+            InstrumentInfo info = wallet.getInstrumentInfos()[0];
+            cardDetails = info.getInstrumentDetails();
+        }
+
+        String id = paymentSource.getId();
+
+        if (cardDetails == null) {
+            cardDetails = "UNKN";
+        }
+        mListViewController.addToList(cardDetails, id);
+    }
+
+    private void confirmPayment() {
+        mChangeDetailsContainer.setVisibility(View.GONE);
+        mConfirmDetailsContainer.setVisibility(View.VISIBLE);
+    }
+
+    private void proceedWithWallet(@NonNull MaskedWallet maskedWallet) {
+        mChangeDetailsContainer.setVisibility(View.GONE);
+
+        FullWalletRequest walletRequest =
+                AndroidPayConfiguration.generateFullWalletRequest(
+                        maskedWallet.getGoogleTransactionId(),
+                        mCart);
+        mProgressDialogController.startProgress();
+        loadFullWallet(walletRequest);
+    }
+
+    private void updateCartTotals(@NonNull CartManager cartManager) {
+        Long itemTotal = cartManager.calculateRegularItemTotal();
+        Long shippingTotal = cartManager.calculateShippingItemTotal();
+        Long tax = cartManager.calculateTax();
+        mItemsPriceDisplay.setText(
+                String.format(LOC,
+                        "Item Total: %s",
+                        getPriceString(itemTotal, DOLLARS)));
+        mShippingDisplay.setText(
+                String.format(LOC,
+                        "Shipping: %s",
+                        getPriceString(shippingTotal, DOLLARS)));
+        mTaxesDisplay.setText(String.format(LOC, "Tax: %s", getPriceString(tax, DOLLARS)));
+        mTotalPaymentDisplay.setText(String.format(
+                LOC,
+                "Total: %s",
+                getPriceString(addIfNotNull(itemTotal, shippingTotal, tax), DOLLARS)));
+    }
+
+    private void updatePaymentInformation(@NonNull MaskedWallet maskedWallet) {
+        if (maskedWallet.getPaymentDescriptions() != null
+                && maskedWallet.getPaymentDescriptions().length > 0) {
+            String cardText = String.format(LOC, "Card: %s", maskedWallet.getPaymentDescriptions()[0]);
+            mSelectedCardDisplay.setText(cardText);
+        }
+
+        CartManager copyCart = new CartManager(mCart);
+        long shippingUpdate = calculateShipping(maskedWallet.getBuyerShippingAddress());
+        long taxUpdate = calculateShipping(maskedWallet.getBuyerBillingAddress());
+        copyCart.addShippingLineItem("Shipping", shippingUpdate);
+        copyCart.setTaxLineItem("Tax", taxUpdate);
+
+        if (maskedWallet.getBuyerShippingAddress() != null) {
+            mSelectedShippingAddressDisplay.setText(maskedWallet.getBuyerShippingAddress().getAddress1());
+        }
+
+        try {
+            mCart = copyCart.buildCart();
+            updateCartTotals(copyCart);
+        } catch (CartContentException unexpected) {
+            // ignore for now
+        }
+    }
+
+    private long calculateShipping(UserAddress userAddress) {
+        if (userAddress == null) {
+            // It's hard to ship to literally nowhere!
+            return 30000L;
+        }
+
+        long runningTotal = 0L;
+        if (!TextUtils.isEmpty(userAddress.getAddress1())) {
+            runningTotal += 10 * userAddress.getAddress1().length();
+        }
+
+        if (!TextUtils.isEmpty(userAddress.getAdministrativeArea())) {
+            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaAray) {
+                runningTotal += 5L * (long) c;
+            }
+        }
+
+        if (!TextUtils.isEmpty(userAddress.getCountryCode())) {
+            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaAray) {
+                runningTotal += 8L * (long) c;
+            }
+        }
+        return runningTotal;
+    }
+
+    private long calculateTaxes(UserAddress userAddress) {
+        if (userAddress == null) {
+            // Taxes are cheap in a null zone.
+            return 3L;
+        }
+
+        long runningTotal = 0L;
+        if (!TextUtils.isEmpty(userAddress.getAddress1())) {
+            runningTotal += 2 * userAddress.getAddress1().length();
+        }
+
+        if (!TextUtils.isEmpty(userAddress.getAdministrativeArea())) {
+            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaAray) {
+                runningTotal += 99L * (long) c;
+            }
+        }
+
+        if (!TextUtils.isEmpty(userAddress.getCountryCode())) {
+            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaAray) {
+                runningTotal += 199L * (long) c;
+            }
+        }
+        return runningTotal;
+    }
+
+    private long addIfNotNull(Long... args) {
+        long total = 0;
+        for (Long l : args) {
+            if (l != null) {
+                total += l;
+            }
+        }
+        return total;
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
@@ -34,7 +34,6 @@ import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceString;
 
 public class AndroidPayActivity extends StripeAndroidPayActivity {
 
-    private static final String TAG = "chewie";
     private static final Locale LOC = Locale.US;
     private static final Currency DOLLARS = Currency.getInstance("USD");
 
@@ -258,15 +257,15 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
         }
 
         if (!TextUtils.isEmpty(userAddress.getAdministrativeArea())) {
-            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
-            for (char c : adminAreaAray) {
+            char[] adminAreaArray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaArray) {
                 runningTotal += 5L * (long) c;
             }
         }
 
         if (!TextUtils.isEmpty(userAddress.getCountryCode())) {
-            char[] adminAreaAray = userAddress.getAdministrativeArea().toCharArray();
-            for (char c : adminAreaAray) {
+            char[] adminAreaArray = userAddress.getAdministrativeArea().toCharArray();
+            for (char c : adminAreaArray) {
                 runningTotal += 8L * (long) c;
             }
         }

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -6,9 +6,17 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
+import com.google.android.gms.wallet.Cart;
 import com.stripe.example.R;
+import com.stripe.wrap.pay.AndroidPayConfiguration;
+import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
+import com.stripe.wrap.pay.utils.CartContentException;
+import com.stripe.wrap.pay.utils.CartManager;
 
 public class LauncherActivity extends AppCompatActivity {
+
+    private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
+            "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,5 +40,32 @@ public class LauncherActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
+
+        Button androidPayButton = (Button) findViewById(R.id.btn_android_pay_launch);
+        androidPayButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                createSampleCartAndLaunchAndroidPayActivity();
+            }
+        });
+    }
+
+    private void createSampleCartAndLaunchAndroidPayActivity() {
+        AndroidPayConfiguration androidPayConfiguration = AndroidPayConfiguration.getInstance();
+        androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+        androidPayConfiguration.setShippingAddressRequired(true);
+        CartManager cartManager = new CartManager("USD");
+        cartManager.addLineItem("Llama Food", 5000L);
+        cartManager.addLineItem("Llama Shoes", 4, 2000L);
+        cartManager.addShippingLineItem("Domestic shipping estimate", 1000L);
+
+        try {
+            Cart cart = cartManager.buildCart();
+            Intent intent = new Intent(this, AndroidPayActivity.class)
+                    .putExtra(StripeAndroidPayActivity.EXTRA_CART, cart);
+            startActivity(intent);
+        } catch (CartContentException unexpected) {
+            // Ignore for now.
+        }
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/ListViewController.java
+++ b/example/src/main/java/com/stripe/example/controller/ListViewController.java
@@ -37,7 +37,7 @@ public class ListViewController {
         addToList(token.getCard().getLast4(), token.getId());
     }
 
-    void addToList(@NonNull String last4, @NonNull String tokenId) {
+    public void addToList(@NonNull String last4, @NonNull String tokenId) {
         String endingIn = mContext.getString(R.string.endingIn);
         Map<String, String> map = new HashMap<>();
         map.put("last4", endingIn + " " + last4);

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -6,5 +6,5 @@
     <dimen name="card_cvc_initial_margin">1000dp</dimen>
     <dimen name="android_pay_button_layout_margin">24dp</dimen>
     <dimen name="android_pay_confirmation_margin">8dp</dimen>
-    <dimen name="android_pay_button_separation">4dp</dimen>
+    <dimen name="android_pay_button_separation">8dp</dimen>
 </resources>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -4,4 +4,7 @@
     <dimen name="card_widget_min_width">320dp</dimen>
     <dimen name="card_expiry_initial_margin">200dp</dimen>
     <dimen name="card_cvc_initial_margin">1000dp</dimen>
+    <dimen name="android_pay_button_layout_margin">24dp</dimen>
+    <dimen name="android_pay_confirmation_margin">8dp</dimen>
+    <dimen name="android_pay_button_separation">4dp</dimen>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -28,7 +28,7 @@ import static com.stripe.android.util.StripeNetworkUtils.removeNullParams;
  * A model class representing a source in the Android SDK. More detailed information
  * and interaction can be seen at {@url https://stripe.com/docs/api/java#source_object}.
  */
-public class Source extends StripeJsonModel {
+public class Source extends StripeJsonModel implements StripePaymentSource {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -176,6 +176,7 @@ public class Source extends StripeJsonModel {
         mUsage = usage;
     }
 
+    @Override
     public String getId() {
         return mId;
     }

--- a/stripe/src/main/java/com/stripe/android/model/StripePaymentSource.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripePaymentSource.java
@@ -1,0 +1,8 @@
+package com.stripe.android.model;
+
+/**
+ * Represents an object that has an ID field that can be used to create payments with Stripe.
+ */
+public interface StripePaymentSource {
+    String getId();
+}

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -9,7 +9,7 @@ import java.util.Date;
 /**
  * The model of a Stripe card token.
  */
-public class Token {
+public class Token implements StripePaymentSource {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({TYPE_CARD, TYPE_BANK_ACCOUNT})
@@ -73,6 +73,7 @@ public class Token {
     /**
      * @return the {@link #mId} of this token
      */
+    @Override
     public String getId() {
         return mId;
     }


### PR DESCRIPTION
r? @bg-stripe 
cc @teich-stripe 

Adding an example application that makes test purchases (and shows how you can update shipping and taxes based on user address) in the Example application. This version is intentionally somewhat barebones, just to show you how to plug it in. It doesn't, for instance, handle what to do if the user doesn't have Android Pay enabled. That will be for the emoji store, where you're going through the full loop of making fake purchases.

This diff also includes an interface to extend Token and Source as "id-carying-payment-things" to future-proof the library, as per @bg-stripe's suggestion.