### PR TITLE
forcing users to access android pay configuration with a valid currency

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
@@ -32,15 +32,33 @@ public class AndroidPayConfiguration {
     @NonNull
     public static AndroidPayConfiguration getInstance() {
         if (mInstance == null) {
-            mInstance = new AndroidPayConfiguration();
+            throw new RuntimeException(
+                    "Attempted to get instance of AndroidPayConfiguration " +
+                            "without specified currency");
+        }
+        return mInstance;
+    }
+
+    @NonNull
+    public static AndroidPayConfiguration getInstance(@NonNull String currencyCode) {
+        Currency currency = Currency.getInstance(currencyCode.toUpperCase());
+        return getInstance(currency);
+    }
+
+    @NonNull
+    public static AndroidPayConfiguration getInstance(@NonNull Currency currency) {
+        if (mInstance == null) {
+            mInstance = new AndroidPayConfiguration(currency);
+        } else {
+            mInstance.setCurrency(currency);
         }
         return mInstance;
     }
 
     @VisibleForTesting
-    AndroidPayConfiguration() {
+    AndroidPayConfiguration(@NonNull Currency currency) {
         // Default is set to dollars until otherwise specified.
-        mCurrency = Currency.getInstance(Locale.US);
+        mCurrency = currency;
     }
 
     @Nullable
@@ -120,7 +138,7 @@ public class AndroidPayConfiguration {
 
     @NonNull
     public AndroidPayConfiguration setCurrencyCode(String currencyCode) {
-        mCurrency = PaymentUtils.getCurrencyByCodeOrDefault(currencyCode);
+        mCurrency = Currency.getInstance(currencyCode.toUpperCase());
         return this;
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
@@ -57,7 +57,6 @@ public class AndroidPayConfiguration {
 
     @VisibleForTesting
     AndroidPayConfiguration(@NonNull Currency currency) {
-        // Default is set to dollars until otherwise specified.
         mCurrency = currency;
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
@@ -548,11 +548,9 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
     @CallSuper
     protected void onChangedMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
         if (maskedWallet == null) {
+            // A null value for the changed masked wallet means that nothing changed, not that
+            // there is no wallet.
             return;
-        }
-
-        if (mBuyButtonFragment != null) {
-            mBuyButtonFragment.updateMaskedWallet(maskedWallet);
         }
         mMaskedWallet = maskedWallet;
     }
@@ -567,9 +565,6 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
      */
     @CallSuper
     protected void onMaskedWalletRetrieved(@Nullable MaskedWallet maskedWallet) {
-        if (mBuyButtonFragment != null) {
-            mBuyButtonFragment.updateMaskedWallet(maskedWallet);
-        }
         mMaskedWallet = maskedWallet;
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/CartManager.java
@@ -40,6 +40,8 @@ public class CartManager {
 
     /**
      * Create a new CartManager. Currency will be set to {@link AndroidPayConfiguration#mCurrency}.
+     * Note that this will throw a {@link RuntimeException} if a currency has not been set on
+     * the {@link AndroidPayConfiguration}.
      */
     public CartManager() {
         mCurrency = AndroidPayConfiguration.getInstance().getCurrency();
@@ -53,7 +55,7 @@ public class CartManager {
      * @param currencyCode a currency code used for this cart, and the rest of the application
      */
     public CartManager(String currencyCode) {
-        mCurrency = PaymentUtils.getCurrencyByCodeOrDefault(currencyCode);
+        mCurrency = Currency.getInstance(currencyCode.toUpperCase());
         synchronizeCartCurrencyWithConfiguration(mCurrency);
     }
 
@@ -85,7 +87,7 @@ public class CartManager {
      *                      and only the last one will be kept
      */
     public CartManager(@NonNull Cart oldCart, boolean shouldKeepShipping, boolean shouldKeepTax) {
-        mCurrency = PaymentUtils.getCurrencyByCodeOrDefault(oldCart.getCurrencyCode());
+        mCurrency = Currency.getInstance(oldCart.getCurrencyCode());
         synchronizeCartCurrencyWithConfiguration(mCurrency);
 
         for (LineItem item : oldCart.getLineItems()) {

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/LineItemBuilder.java
@@ -64,7 +64,7 @@ public class LineItemBuilder {
      * @return {@code this}, for chaining purposes
      */
     public LineItemBuilder setCurrencyCode(String currencyCode) {
-        mCurrency = PaymentUtils.getCurrencyByCodeOrDefault(currencyCode);
+        mCurrency = Currency.getInstance(currencyCode.toUpperCase());
         return this;
     }
 

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -54,23 +54,6 @@ public class PaymentUtils {
         return totalPrice;
     }
 
-    @NonNull
-    public static Currency getCurrencyByCodeOrDefault(@Nullable String currencyCode) {
-        Currency defaultCurrency = Currency.getInstance(Locale.US);
-        if (currencyCode == null) {
-            return defaultCurrency;
-        }
-        try {
-            return Currency.getInstance(currencyCode.toUpperCase());
-        } catch (IllegalArgumentException illegalArgumentException) {
-            Log.w(TAG, String.format(Locale.ENGLISH,
-                    "Could not create currency with code \"%s\". " +
-                            "Using currency %s by default.",
-                    currencyCode, defaultCurrency.getCurrencyCode()));
-            return defaultCurrency;
-        }
-    }
-
     /**
      * Utility function to convert the already-valid price String obtained from a {@link LineItem}
      * into a {@link Long} value that can be used for calculations.

--- a/android-pay/src/test/java/com/stripe/wrap/pay/AndroidPayConfigurationTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/AndroidPayConfigurationTest.java
@@ -14,8 +14,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Locale;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -34,15 +32,8 @@ public class AndroidPayConfigurationTest {
 
     @Before
     public void setup() {
-        mAndroidPayConfiguration = AndroidPayConfiguration.getInstance();
+        mAndroidPayConfiguration = AndroidPayConfiguration.getInstance("USD");
         mCart = Cart.newBuilder().setTotalPrice("10.00").build();
-    }
-
-    @Test
-    public void instantiate_andDoNothingElse_setsCurrencyToDefaultCurrency() {
-        Locale.setDefault(Locale.JAPAN);
-        AndroidPayConfiguration testConfig = new AndroidPayConfiguration();
-        assertEquals("USD", testConfig.getCurrencyCode());
     }
 
     @Test
@@ -136,19 +127,5 @@ public class AndroidPayConfigurationTest {
     public void generateMaskedWalletRequest_whenCartHasNoTotalPrice_returnsNull() {
         Cart noPriceCart = Cart.newBuilder().build();
         assertNull(mAndroidPayConfiguration.generateMaskedWalletRequest(noPriceCart));
-    }
-
-    @Test
-    public void generateMaskedWalletRequest_whenApiKeyIsSetButNotCurrency_usesUsd() {
-        // Need to instantiate a new Android Pay Configuration to avoid conflicts with other
-        // tests.
-        AndroidPayConfiguration testPayConfiguration = new AndroidPayConfiguration();
-        testPayConfiguration.setPublicApiKey("pk_test_abc123");
-
-        // In this case, we haven't set a currency yet.
-        MaskedWalletRequest maskedWalletRequest =
-                testPayConfiguration.generateMaskedWalletRequest(mCart);
-        assertNotNull(maskedWalletRequest);
-        assertEquals("USD", maskedWalletRequest.getCurrencyCode());
     }
 }

--- a/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
@@ -111,12 +111,14 @@ public class StripeAndroidPayActivityTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         when(mGoogleApiClientMockBuilder.getMockGoogleApiClient()).thenReturn(mGoogleApiClient);
+        AndroidPayConfiguration androidPayConfiguration =
+                AndroidPayConfiguration.getInstance("USD");
+        androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+
         mCartManager = new CartManager("USD");
         mCartManager.addLineItem("First item", 100L);
         mCartManager.addLineItem("Second item", 200L);
 
-        AndroidPayConfiguration androidPayConfiguration = AndroidPayConfiguration.getInstance();
-        androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
         when(mAndroidPayAvailabilityChooser.doesAndroidPayCheckSucceed()).thenReturn(
                 new BooleanResult(new Status(CommonStatusCodes.SUCCESS), true));
 

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/CartManagerTest.java
@@ -36,6 +36,12 @@ import static org.junit.Assert.fail;
 @Config(sdk = 23)
 public class CartManagerTest {
 
+    @Test(expected = RuntimeException.class)
+    public void createCartManager_withBadCurrencyString_throwsRuntimeException() {
+        new CartManager("cookies");
+        fail("Should not be able to build cart manager with an invalid currency.");
+    }
+
     @Test
     public void createCartManager_withoutCurrencyArgument_usesAndroidPayConfiguration() {
         AndroidPayConfiguration.getInstance().setCurrencyCode("JPY");

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/LineItemBuilderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link LineItemBuilder}.
@@ -145,19 +146,10 @@ public class LineItemBuilderTest {
         assertEquals("2.5", item.getQuantity());
     }
 
-    @Test
-    public void setCurrencyCode_whenInvalid_setsToLocaleDefaultAndLogsWarning() {
-        ShadowLog.stream = System.out;
-        Locale.setDefault(Locale.JAPAN);
-
-        LineItem item = new LineItemBuilder("notacurrency").build();
-        String expectedWarning = "Could not create currency with code \"notacurrency\". Using " +
-                "currency USD by default.";
-        List<ShadowLog.LogItem> logItems = ShadowLog.getLogsForTag(PaymentUtils.TAG);
-        assertEquals("USD", item.getCurrencyCode());
-        assertEquals(1, logItems.size());
-        assertEquals(Log.WARN, logItems.get(0).type);
-        assertEquals(expectedWarning, logItems.get(0).msg);
+    @Test(expected = RuntimeException.class)
+    public void setCurrencyCode_whenInvalid_throwsRuntimeException() {
+        new LineItemBuilder("notacurrency").build();
+        fail("Can't create a LineItemBuilder with an illegal currency.");
     }
 
     @Test

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import static com.stripe.wrap.pay.testutils.AssertUtils.assertEmpty;
-import static com.stripe.wrap.pay.utils.PaymentUtils.getCurrencyByCodeOrDefault;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceLong;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getPriceString;
 import static com.stripe.wrap.pay.utils.PaymentUtils.getStripeIsReadyToPayRequest;
@@ -454,37 +453,6 @@ public class PaymentUtilsTest {
     public void getTotalPrice_whenEmptyList_returnsZero() {
         assertEquals(Long.valueOf(0L), getTotalPrice(
                 new ArrayList<LineItem>(), Currency.getInstance("OMR")));
-    }
-
-    @Test
-    public void getCurrencyByCodeOrDefault_forValidCurrencyCode_returnsCorrectCurrency() {
-        Currency foundCurrency = getCurrencyByCodeOrDefault("CAD");
-        assertEquals(Currency.getInstance(Locale.CANADA), foundCurrency);
-    }
-
-    @Test
-    public void getCurrencyByCodeOrDefault_forNull_returnsDefaultUsd() {
-        assertEquals(Currency.getInstance(Locale.US),
-                getCurrencyByCodeOrDefault(null));
-    }
-
-    @Test
-    public void getCurrencyByCodeOrDefault_forNullWhenLocaleIsNotUs_returnsDefaultUsd() {
-        Locale.setDefault(Locale.JAPAN);
-        assertEquals(Currency.getInstance(Locale.US),
-                getCurrencyByCodeOrDefault(null));
-    }
-
-    @Test
-    public void getCurrencyByCodeOrDefault_forInvalid_returnsDefaultUsd() {
-        assertEquals(Currency.getInstance(Locale.US),
-                getCurrencyByCodeOrDefault("tea and crumpets"));
-    }
-
-    @Test
-    public void getCurrencyByCodeOrDefault_forLowercase_stillReturnsCorrectCurrency() {
-        assertEquals(Currency.getInstance(Locale.US),
-                getCurrencyByCodeOrDefault("usd"));
     }
 
     @Test

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -51,7 +51,8 @@ public class LauncherActivity extends AppCompatActivity {
     }
 
     private void createSampleCartAndLaunchAndroidPayActivity() {
-        AndroidPayConfiguration androidPayConfiguration = AndroidPayConfiguration.getInstance();
+        AndroidPayConfiguration androidPayConfiguration =
+                AndroidPayConfiguration.getInstance("USD");
         androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
         androidPayConfiguration.setShippingAddressRequired(true);
         CartManager cartManager = new CartManager("USD");


### PR DESCRIPTION
r? @teich-stripe 
cc @bg-stripe 

Throwing a runtime exception if you don't specify currency with your first call to the AndroidPayConfiguration.