### PR TITLE
forcing android pay initialization with a public key

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/AndroidPayConfiguration.java
@@ -2,6 +2,7 @@ package com.stripe.wrap.pay;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.Size;
 import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 
@@ -42,27 +43,34 @@ public class AndroidPayConfiguration {
      * Initialize the AndroidPayConfiguration instance with a currency code. If the currency
      * code is invalid, this will throw an {@link IllegalArgumentException}
      *
+     * @param publicApiKey the Stripe api public key
      * @param currencyCode the code for the starting {@link Currency} for android pay configuration
      * @return the instance of the AndroidPayConfiguration singleton
      */
-    public static AndroidPayConfiguration init(@NonNull String currencyCode) {
-        return init(Currency.getInstance(currencyCode.toUpperCase()));
+    public static AndroidPayConfiguration init(
+            @NonNull @Size(min = 5) String publicApiKey,
+            @NonNull String currencyCode) {
+        return init(publicApiKey, Currency.getInstance(currencyCode.toUpperCase()));
     }
 
     /**
      * Initialize the AndroidPayConfiguration instance with a {@link Currency}.
      *
+     * @param publicApiKey the Stripe public api key
      * @param currency the starting {@link Currency} for android pay configuration
      * @return the instance of the AndroidPayConfiguration singleton
      */
-    public static AndroidPayConfiguration init(@NonNull Currency currency) {
-        mInstance = new AndroidPayConfiguration(currency);
+    public static AndroidPayConfiguration init(
+            @NonNull @Size(min = 5) String publicApiKey,
+            @NonNull Currency currency) {
+        mInstance = new AndroidPayConfiguration(publicApiKey, currency);
         return mInstance;
     }
 
     @VisibleForTesting
-    AndroidPayConfiguration(@NonNull Currency currency) {
+    AndroidPayConfiguration(@NonNull String publicApiKey, @NonNull Currency currency) {
         mCurrency = currency;
+        mPublicApiKey = publicApiKey;
     }
 
     @Nullable

--- a/android-pay/src/test/java/com/stripe/wrap/pay/AndroidPayConfigurationTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/AndroidPayConfigurationTest.java
@@ -32,19 +32,13 @@ public class AndroidPayConfigurationTest {
 
     @Before
     public void setup() {
-        AndroidPayConfiguration.init("USD");
+        AndroidPayConfiguration.init("pk_test_abc123", "USD");
         mAndroidPayConfiguration = AndroidPayConfiguration.getInstance();
         mCart = Cart.newBuilder().setTotalPrice("10.00").build();
     }
 
     @Test
-    public void getPaymentMethodTokenizationParameters_whenApiKeyIsNull_returnsNull() {
-        assertNull(mAndroidPayConfiguration.getPaymentMethodTokenizationParameters());
-    }
-
-    @Test
     public void getPaymentMethodTokenizationParameters_whenApiKeyIsNotNull_returnsExpectedObject() {
-        mAndroidPayConfiguration.setPublicApiKey("pk_test_abc123");
         PaymentMethodTokenizationParameters params =
                 mAndroidPayConfiguration.getPaymentMethodTokenizationParameters();
         assertNotNull(params);

--- a/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivityTest.java
@@ -111,8 +111,7 @@ public class StripeAndroidPayActivityTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         when(mGoogleApiClientMockBuilder.getMockGoogleApiClient()).thenReturn(mGoogleApiClient);
-        AndroidPayConfiguration.init("USD");
-        AndroidPayConfiguration.getInstance().setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+        AndroidPayConfiguration.init(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY, "USD");
 
         mCartManager = new CartManager();
         mCartManager.addLineItem("First item", 100L);

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -51,9 +51,8 @@ public class LauncherActivity extends AppCompatActivity {
     }
 
     private void createSampleCartAndLaunchAndroidPayActivity() {
-        AndroidPayConfiguration.init("USD");
+        AndroidPayConfiguration.init(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY, "USD");
         AndroidPayConfiguration androidPayConfiguration = AndroidPayConfiguration.getInstance();
-        androidPayConfiguration.setPublicApiKey(FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
         androidPayConfiguration.setShippingAddressRequired(true);
         CartManager cartManager = new CartManager("USD");
         cartManager.addLineItem("Llama Food", 5000L);


### PR DESCRIPTION
r? @bg-stripe 
cc @teich-stripe 

Realized that as long as I'm forcing you to initialize the android  pay configuration with a valid currency, I should also force you to initialize it with your public key.