### PR TITLE
moving all possible included libraries over from 'compile' to 'provided' in gradle

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -34,12 +34,12 @@ dependencies {
     compile 'com.android.support:support-annotations:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:appcompat-v7:' + android_support_version
-    compile 'com.google.android.gms:play-services-wallet:10.2.4'
 
     javadocDeps 'com.android.support:support-annotations:' + android_support_version
     javadocDeps 'com.android.support:support-v4:' + android_support_version
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
+    provided 'com.google.android.gms:play-services-wallet:10.2.4'
     provided 'com.stripe:stripe-android:4.0.2'
 
     testCompile 'junit:junit:4.12'

--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -31,7 +31,6 @@ android {
 }
 
 dependencies {
-    compile project(':stripe')
     compile 'com.android.support:support-annotations:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:appcompat-v7:' + android_support_version
@@ -41,6 +40,7 @@ dependencies {
     javadocDeps 'com.android.support:support-v4:' + android_support_version
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
+    provided 'com.stripe:stripe-android:4.0.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
+    compile 'com.google.android.gms:play-services-wallet:10.2.4'
     /* Needed for RxAndroid */
     /* Needed for Rx Bindings on views */
     compile 'io.reactivex:rxandroid:1.2.1'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,8 +7,8 @@ repositories {
 def android_support_version = '25.3.1'
 
 dependencies {
-    compile project(':stripe')
     compile project(':android-pay')
+    compile 'com.stripe:stripe-android:4.0.2'
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
     compile 'com.android.support:design:' + android_support_version
+    // Needed to make android pay work
+    compile 'com.google.android.gms:play-services-wallet:10.2.4'
 
     /* This line is all you need for the stripe-android bindings */
     compile 'com.stripe:stripe-android:4.0.2'

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile 'com.android.support:design:' + android_support_version
 
     /* This line is all you need for the stripe-android bindings */
-    compile project(':stripe')
+    compile 'com.stripe:stripe-android:4.0.2'
     compile project(':android-pay')
 
     /* Needed for RxAndroid */


### PR DESCRIPTION
r? @bg-stripe 
cc @teich-stripe 

Making this switch forces the versions to be exact on usage when using our android bindings (so you don't have a version mismatch). This also prevents users from accidentally having two different versions of the google play libraries installed because they were using our library.