### PR TITLE
removing unneeded values-en file since american english is our default

### DIFF
--- a/stripe/res/values-en/strings.xml
+++ b/stripe/res/values-en/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="acc_label_card_number">"card number"</string>
-    <string name="acc_label_expiry_date">"expiration date"</string>
-    <string name="expiry_date_hint">MM/YY</string>
-</resources>


### PR DESCRIPTION
cc @bg-stripe 

Removing unnecessary file.
Fixes https://github.com/stripe/stripe-android/issues/217