### PR TITLE
adding muid-guid logging for sources

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -50,6 +50,7 @@ public class Stripe {
                         protected ResponseWrapper doInBackground(Void... params) {
                             try {
                                 Source source = StripeApiHandler.createSourceOnServer(
+                                        mContext,
                                         sourceParams,
                                         publishableKey);
                                 return new ResponseWrapper(source);
@@ -416,7 +417,7 @@ public class Stripe {
         if (apiKey == null) {
             return null;
         }
-        return StripeApiHandler.createSourceOnServer(params, apiKey);
+        return StripeApiHandler.createSourceOnServer(mContext, params, apiKey);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeNetworkUtils.java
@@ -109,7 +109,7 @@ public class StripeNetworkUtils {
     }
 
     @SuppressWarnings("HardwareIds")
-    static void addUidParams(
+    public static void addUidParams(
             @Nullable UidProvider provider,
             @NonNull Context context,
             @NonNull Map<String, Object> params) {
@@ -166,7 +166,7 @@ public class StripeNetworkUtils {
     }
 
     @VisibleForTesting
-    interface UidProvider {
+    public interface UidProvider {
         String getUid();
         String getPackageName();
     }

--- a/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/net/StripeApiHandlerTest.java
@@ -147,8 +147,22 @@ public class StripeApiHandlerTest {
             // we are testing whether or not we log.
             TestLoggingListener testLoggingListener = new TestLoggingListener(true);
 
+            StripeNetworkUtils.UidProvider provider = new StripeNetworkUtils.UidProvider() {
+                @Override
+                public String getUid() {
+                    return "abc123";
+                }
+
+                @Override
+                public String getPackageName() {
+                    return "com.example.main";
+                }
+
+            };
             Card card = new Card("4242424242424242", 1, 2050, "123");
             Source source = StripeApiHandler.createSourceOnServer(
+                    provider,
+                    RuntimeEnvironment.application.getApplicationContext(),
                     SourceParams.createCardParams(card),
                     FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
                     testLoggingListener);
@@ -175,6 +189,8 @@ public class StripeApiHandlerTest {
 
             Card card = new Card("4242424242424242", 1, 2050, "123");
             Source source = StripeApiHandler.createSourceOnServer(
+                    null,
+                    RuntimeEnvironment.application.getApplicationContext(),
                     SourceParams.createCardParams(card),
                     FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
                     testLoggingListener);


### PR DESCRIPTION
r? @bg-stripe 
cc @teich-stripe 

Adding muid-guid logging for sources as well, with testing. Needed to pass a context through and extend visibility of a utils method. Opted to Deprecate the other create source method because it was public, and theoretically could be used by someone else, and this doesn't seem like a good enough reason to make a breaking change. I'll kill that method with the next more substantive update.