### PR TITLE
bumping sample store to the new libraries

### DIFF
--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -32,15 +32,14 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:' + android_support_version
-    compile 'com.android.support:support-v4:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
     compile 'com.android.support:design:' + android_support_version
 
     /* This line is all you need for the stripe-android bindings */
-    compile 'com.stripe:stripe-android:4.1.1'
+    compile 'com.stripe:stripe-android:4.1.2'
 
     /* To use the Stripe android pay wrapper, you need these two lines */
-    compile 'com.stripe:stripe-android-pay:4.1.1'
+    compile 'com.stripe:stripe-android-pay:4.1.2'
     compile 'com.google.android.gms:play-services-wallet:10.2.6'
 
     /* Needed for RxAndroid */


### PR DESCRIPTION
r? @bg-stripe 

Just bumping the sample store to 4.1.2 now that we're live.