### PR TITLE
adding stripe-account parameter to headers for Connect accounts

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -42,6 +42,7 @@ public class Stripe {
         public void create(
                 @NonNull final SourceParams sourceParams,
                 @NonNull final String publishableKey,
+                @Nullable final String stripeAccount,
                 @Nullable Executor executor,
                 @NonNull final SourceCallback sourceCallback) {
             AsyncTask<Void, Void, ResponseWrapper> task =
@@ -50,9 +51,12 @@ public class Stripe {
                         protected ResponseWrapper doInBackground(Void... params) {
                             try {
                                 Source source = StripeApiHandler.createSourceOnServer(
+                                        null,
                                         mContext,
                                         sourceParams,
-                                        publishableKey);
+                                        publishableKey,
+                                        stripeAccount,
+                                        null);
                                 return new ResponseWrapper(source);
                             } catch (StripeException stripeException) {
                                 return new ResponseWrapper(stripeException);
@@ -79,6 +83,7 @@ public class Stripe {
         public void create(
                 final Map<String, Object> tokenParams,
                 final String publishableKey,
+                final String stripeAccount,
                 final @NonNull @Token.TokenType String tokenType,
                 final Executor executor,
                 final TokenCallback callback) {
@@ -88,7 +93,10 @@ public class Stripe {
                         protected ResponseWrapper doInBackground(Void... params) {
                             try {
                                 RequestOptions requestOptions =
-                                        RequestOptions.builder(publishableKey).build();
+                                        RequestOptions.builder(
+                                                publishableKey,
+                                                stripeAccount,
+                                                RequestOptions.TYPE_QUERY).build();
                                 Token token = StripeApiHandler.createTokenOnServer(
                                         mContext,
                                         tokenParams,
@@ -114,6 +122,7 @@ public class Stripe {
     private Context mContext;
     private StripeApiHandler.LoggingResponseListener mLoggingResponseListener;
     private String mDefaultPublishableKey;
+    private String mStripeAccount;
 
     /**
      * A constructor with only context, to set the key later.
@@ -262,7 +271,10 @@ public class Stripe {
             CardException,
             APIException {
         validateKey(publishableKey);
-        RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
+        RequestOptions requestOptions = RequestOptions.builder(
+                publishableKey,
+                mStripeAccount,
+                RequestOptions.TYPE_QUERY).build();
         return StripeApiHandler.createTokenOnServer(
                 mContext,
                 hashMapFromBankAccount(mContext, bankAccount),
@@ -299,7 +311,7 @@ public class Stripe {
         if (apiKey == null) {
             return;
         }
-        mSourceCreator.create(sourceParams, apiKey, executor, callback);
+        mSourceCreator.create(sourceParams, apiKey, mStripeAccount, executor, callback);
     }
 
     /**
@@ -420,7 +432,7 @@ public class Stripe {
             return null;
         }
         return StripeApiHandler.createSourceOnServer(
-                null, mContext, params, apiKey, mLoggingResponseListener);
+                null, mContext, params, apiKey, mStripeAccount, mLoggingResponseListener);
     }
 
     /**
@@ -468,7 +480,10 @@ public class Stripe {
             APIException {
         validateKey(publishableKey);
 
-        RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
+        RequestOptions requestOptions = RequestOptions.builder(
+                publishableKey,
+                mStripeAccount,
+                RequestOptions.TYPE_QUERY).build();
         return StripeApiHandler.createTokenOnServer(
                 mContext,
                 hashMapFromCard(mContext, card),
@@ -520,7 +535,10 @@ public class Stripe {
             CardException,
             APIException {
         validateKey(publishableKey);
-        RequestOptions requestOptions = RequestOptions.builder(publishableKey).build();
+        RequestOptions requestOptions = RequestOptions.builder(
+                publishableKey,
+                mStripeAccount,
+                RequestOptions.TYPE_QUERY).build();
         return StripeApiHandler.createTokenOnServer(
                 mContext,
                 hashMapFromPersonalId(mContext, personalId),
@@ -663,7 +681,16 @@ public class Stripe {
      */
     public void setDefaultPublishableKey(@NonNull @Size(min = 1) String publishableKey) {
         validateKey(publishableKey);
-        this.mDefaultPublishableKey = publishableKey;
+        mDefaultPublishableKey = publishableKey;
+    }
+
+    /**
+     * Set the Stripe Connect account to use with this Stripe instance.
+     *
+     * @param stripeAccount the account ID to be set
+     */
+    public void setStripeAccount(@NonNull @Size(min = 1) String stripeAccount) {
+        mStripeAccount = stripeAccount;
     }
 
     @VisibleForTesting
@@ -687,6 +714,7 @@ public class Stripe {
         mTokenCreator.create(
                 tokenParams,
                 publishableKey,
+                mStripeAccount,
                 tokenType,
                 executor,
                 callback);
@@ -756,6 +784,7 @@ public class Stripe {
         void create(
                 @NonNull SourceParams params,
                 @NonNull String publishableKey,
+                @Nullable String stripeAccount,
                 @Nullable Executor executor,
                 @NonNull SourceCallback sourceCallback);
     }
@@ -764,6 +793,7 @@ public class Stripe {
     interface TokenCreator {
         void create(Map<String, Object> params,
                     String publishableKey,
+                    String stripeAccount,
                     @NonNull @Token.TokenType String tokenType,
                     Executor executor,
                     TokenCallback callback);

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -687,6 +687,8 @@ public class Stripe {
     /**
      * Set the Stripe Connect account to use with this Stripe instance.
      *
+     * @see <a href=https://stripe.com/docs/connect/authentication#authentication-via-the-stripe-account-header>
+     *     Authentication via the stripe account header</a>
      * @param stripeAccount the account ID to be set
      */
     public void setStripeAccount(@NonNull @Size(min = 1) String stripeAccount) {

--- a/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
+++ b/stripe/src/main/java/com/stripe/android/net/RequestOptions.java
@@ -25,18 +25,21 @@ public class RequestOptions {
     @Nullable private final String mIdempotencyKey;
     @Nullable private final String mPublishableApiKey;
     @NonNull @RequestType private final String mRequestType;
+    @Nullable private final String mStripeAccount;
 
     private RequestOptions(
             @NonNull String apiVersion,
             @Nullable String guid,
             @Nullable String idempotencyKey,
             @Nullable String publishableApiKey,
-            @NonNull @RequestType String requestType) {
+            @NonNull @RequestType String requestType,
+            @Nullable String stripeAccount) {
         mApiVersion = apiVersion;
         mGuid = guid;
         mIdempotencyKey = idempotencyKey;
         mPublishableApiKey = publishableApiKey;
         mRequestType = requestType;
+        mStripeAccount = stripeAccount;
     }
 
     /**
@@ -77,6 +80,11 @@ public class RequestOptions {
         return mRequestType;
     }
 
+    @Nullable
+    String getStripeAccount() {
+        return mStripeAccount;
+    }
+
     /**
      * Static accessor for the {@link RequestOptionsBuilder} class. Creates
      * a builder for a {@link #TYPE_QUERY} options item
@@ -86,6 +94,14 @@ public class RequestOptions {
      */
     public static RequestOptions.RequestOptionsBuilder builder(@Nullable String publishableApiKey) {
         return builder(publishableApiKey, TYPE_QUERY);
+    }
+
+    public static RequestOptions.RequestOptionsBuilder builder(
+            @Nullable String publishableApiKey,
+            @Nullable String stripeAccount,
+            @NonNull @RequestType String requestType) {
+        return new RequestOptionsBuilder(publishableApiKey, requestType)
+                .setStripeAccount(stripeAccount);
     }
 
     /**
@@ -113,13 +129,14 @@ public class RequestOptions {
         private String idempotencyKey;
         private String publishableApiKey;
         private @RequestType String requestType;
+        private String stripeAccount;
 
         /**
          * Builder constructor requiring an API key.
          *
          * @param publishableApiKey your publishable API key
          */
-        public RequestOptionsBuilder(
+        RequestOptionsBuilder(
                 @Nullable String publishableApiKey,
                 @NonNull @RequestType String requestType) {
             this.publishableApiKey = publishableApiKey;
@@ -133,7 +150,7 @@ public class RequestOptions {
          * @return {@code this}, for chaining purposes
          */
         @NonNull
-        public RequestOptionsBuilder setPublishableApiKey(@NonNull String publishableApiKey) {
+        RequestOptionsBuilder setPublishableApiKey(@NonNull String publishableApiKey) {
             this.publishableApiKey = publishableApiKey;
             return this;
         }
@@ -146,7 +163,7 @@ public class RequestOptions {
          * @return {@code this}, for chaining purposes
          */
         @NonNull
-        public RequestOptionsBuilder setIdempotencyKey(@Nullable String idempotencyKey) {
+        RequestOptionsBuilder setIdempotencyKey(@Nullable String idempotencyKey) {
             this.idempotencyKey = idempotencyKey;
             return this;
         }
@@ -158,7 +175,7 @@ public class RequestOptions {
          * @return {@code this}, for chaining purposes
          */
         @NonNull
-        public RequestOptionsBuilder setGuid(@Nullable String guid) {
+        RequestOptionsBuilder setGuid(@Nullable String guid) {
             this.guid = guid;
             return this;
         }
@@ -171,10 +188,16 @@ public class RequestOptions {
          * @return {@code this}, for chaining purposes
          */
         @NonNull
-        public RequestOptionsBuilder setApiVersion(@Nullable String apiVersion) {
+        RequestOptionsBuilder setApiVersion(@Nullable String apiVersion) {
             this.apiVersion = StripeTextUtils.isBlank(apiVersion)
                     ? null
                     : apiVersion;
+            return this;
+        }
+
+        @NonNull
+        RequestOptionsBuilder setStripeAccount(@Nullable String stripeAccount) {
+            this.stripeAccount = stripeAccount;
             return this;
         }
 
@@ -189,7 +212,8 @@ public class RequestOptions {
                     this.guid,
                     this.idempotencyKey,
                     this.publishableApiKey,
-                    this.requestType);
+                    this.requestType,
+                    this.stripeAccount);
         }
     }
 }


### PR DESCRIPTION
r? @bg-stripe 
cc @joeydong-stripe @bdorfman-stripe 

Adding the ability to put a stripe-account on the Stripe object, which is then added to the headers of all stripe API requests.