### PR TITLE
reducing api surface by moving date utils and some of the card utils …

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -7,8 +7,7 @@ import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 import android.text.TextUtils;
 
-import com.stripe.android.util.CardUtils;
-import com.stripe.android.util.DateUtils;
+import com.stripe.android.CardUtils;
 import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeNetworkUtils;
 import com.stripe.android.util.StripeTextUtils;
@@ -576,7 +575,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         if (!validateExpYear()) {
             return false;
         }
-        return !DateUtils.hasMonthPassed(expYear, expMonth);
+        return !ModelUtils.hasMonthPassed(expYear, expMonth);
     }
 
     /**
@@ -613,7 +612,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
      * @return {@code true} if valid, {@code false} otherwise.
      */
     public boolean validateExpYear() {
-        return expYear != null && !DateUtils.hasYearPassed(expYear);
+        return expYear != null && !ModelUtils.hasYearPassed(expYear);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/ModelUtils.java
+++ b/stripe/src/main/java/com/stripe/android/model/ModelUtils.java
@@ -1,0 +1,54 @@
+package com.stripe.android.model;
+
+import com.stripe.android.time.Clock;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+/**
+ * Utilities function class for the models package.
+ */
+class ModelUtils {
+
+    /**
+     * Determines whether the input year-month pair has passed.
+     *
+     * @param year the input year, as a two or four-digit integer
+     * @param month the input month
+     * @return {@code true} if the input time has passed, {@code false} otherwise.
+     */
+    @SuppressWarnings("WrongConstant")
+    static boolean hasMonthPassed(int year, int month) {
+        if (hasYearPassed(year)) {
+            return true;
+        }
+
+        Calendar now = Clock.getCalendarInstance();
+        // Expires at end of specified month, Calendar month starts at 0
+        return normalizeYear(year) == now.get(Calendar.YEAR)
+                && month < (now.get(Calendar.MONTH) + 1);
+    }
+
+    /**
+     * Determines whether or not the input year has already passed.
+     *
+     * @param year the input year, as a two or four-digit integer
+     * @return {@code true} if the year has passed, {@code false} otherwise.
+     */
+    static boolean hasYearPassed(int year) {
+        int normalized = normalizeYear(year);
+        Calendar now = Clock.getCalendarInstance();
+        return normalized < now.get(Calendar.YEAR);
+    }
+
+    // Convert two-digit year to full year if necessary
+    private static int normalizeYear(int year)  {
+        if (year < 100 && year >= 0) {
+            Calendar now = Clock.getCalendarInstance();
+            String currentYear = String.valueOf(now.get(Calendar.YEAR));
+            String prefix = currentYear.substring(0, currentYear.length() - 2);
+            year = Integer.parseInt(String.format(Locale.US, "%s%02d", prefix, year));
+        }
+        return year;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/util/StripeTextUtils.java
@@ -1,39 +1,16 @@
 package com.stripe.android.util;
 
 import android.support.annotation.Nullable;
-import android.view.KeyEvent;
-
-import com.stripe.android.model.BankAccount;
-import com.stripe.android.model.Card;
-import com.stripe.android.model.Token;
+import android.text.TextUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import static com.stripe.android.model.BankAccount.BankAccountType;
-import static com.stripe.android.model.Card.CardBrand;
-import static com.stripe.android.model.Card.FundingType;
-import static com.stripe.android.model.Token.TokenType;
-
 /**
  * Utility class for common text-related operations on Stripe data coming from the server.
  */
 public class StripeTextUtils {
-
-    private static int[] NON_DELETE_KEYS = {
-            KeyEvent.KEYCODE_0,
-            KeyEvent.KEYCODE_1,
-            KeyEvent.KEYCODE_2,
-            KeyEvent.KEYCODE_3,
-            KeyEvent.KEYCODE_4,
-            KeyEvent.KEYCODE_5,
-            KeyEvent.KEYCODE_6,
-            KeyEvent.KEYCODE_7,
-            KeyEvent.KEYCODE_8,
-            KeyEvent.KEYCODE_9,
-            KeyEvent.KEYCODE_SLASH
-    };
 
     /**
      * Util Array for converting bytes to a hex string.
@@ -67,19 +44,8 @@ public class StripeTextUtils {
      * @param value the input string to test
      * @return {@code true} if the input value consists entirely of integers
      */
-    public static boolean isWholePositiveNumber(String value) {
-        if (value == null) {
-            return false;
-        }
-
-        // Refraining from using android's TextUtils in order to avoid
-        // depending on another package.
-        for (int i = 0; i < value.length(); i++) {
-            if (!Character.isDigit(value.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
+    public static boolean isWholePositiveNumber(@Nullable String value) {
+        return value != null && TextUtils.isDigitsOnly(value);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -28,8 +28,6 @@ import android.widget.LinearLayout;
 
 import com.stripe.android.R;
 import com.stripe.android.model.Card;
-import com.stripe.android.util.CardUtils;
-import com.stripe.android.util.DateUtils;
 import com.stripe.android.util.LoggingUtils;
 import com.stripe.android.util.StripeTextUtils;
 
@@ -145,7 +143,7 @@ public class CardInputWidget extends LinearLayout {
         }
 
         // CVC/CVV is the only field not validated by the entry control itself, so we check here.
-        int requiredLength = mIsAmEx ? CardUtils.CVC_LENGTH_AMEX : CardUtils.CVC_LENGTH_COMMON;
+        int requiredLength = mIsAmEx ? Card.CVC_LENGTH_AMERICAN_EXPRESS : Card.CVC_LENGTH_COMMON;
         String cvcValue = mCvcNumberEditText.getText().toString();
         if (StripeTextUtils.isBlank(cvcValue) || cvcValue.length() != requiredLength) {
             return null;
@@ -188,7 +186,7 @@ public class CardInputWidget extends LinearLayout {
      */
     public void setExpiryDate(
             @IntRange(from = 1, to = 12) int month,
-            @IntRange(from = 0) int year) {
+            @IntRange(from = 0, to = 9999) int year) {
         mExpiryDateEditText.setText(DateUtils.createDateStringFromIntegerInput(month, year));
     }
 
@@ -842,11 +840,12 @@ public class CardInputWidget extends LinearLayout {
     private void updateCvc(@NonNull @Card.CardBrand String brand) {
         if (Card.AMERICAN_EXPRESS.equals(brand)) {
             mCvcNumberEditText.setFilters(
-                    new InputFilter[] {new InputFilter.LengthFilter(CardUtils.CVC_LENGTH_AMEX)});
+                    new InputFilter[] {
+                            new InputFilter.LengthFilter(Card.CVC_LENGTH_AMERICAN_EXPRESS)});
             mCvcNumberEditText.setHint(R.string.cvc_amex_hint);
         } else {
             mCvcNumberEditText.setFilters(
-                    new InputFilter[] {new InputFilter.LengthFilter(CardUtils.CVC_LENGTH_COMMON)});
+                    new InputFilter[] {new InputFilter.LengthFilter(Card.CVC_LENGTH_COMMON)});
             mCvcNumberEditText.setHint(R.string.cvc_number_hint);
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -11,7 +11,7 @@ import android.util.AttributeSet;
 import android.widget.EditText;
 
 import com.stripe.android.model.Card;
-import com.stripe.android.util.CardUtils;
+import com.stripe.android.CardUtils;
 import com.stripe.android.util.StripeTextUtils;
 
 import java.util.Arrays;
@@ -174,7 +174,7 @@ public class CardNumberEditText extends StripeEditText {
                     return;
                 }
 
-                String[] cardParts = CardUtils.separateCardNumberGroups(
+                String[] cardParts = ViewUtils.separateCardNumberGroups(
                         spacelessNumber, mCardBrand);
                 StringBuilder formattedNumberBuilder = new StringBuilder();
                 for (int i = 0; i < cardParts.length; i++) {

--- a/stripe/src/main/java/com/stripe/android/view/DateUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/DateUtils.java
@@ -1,4 +1,4 @@
-package com.stripe.android.util;
+package com.stripe.android.view;
 
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
@@ -6,45 +6,11 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.VisibleForTesting;
 
-import com.stripe.android.model.Card;
-import com.stripe.android.time.Clock;
-
 import java.util.Calendar;
-import java.util.Locale;
 
-public class DateUtils {
+class DateUtils {
 
     static final int MAX_VALID_YEAR = 9980;
-
-    /**
-     * Determines whether or not the input year has already passed.
-     *
-     * @param year the input year, as a two or four-digit integer
-     * @return {@code true} if the year has passed, {@code false} otherwise.
-     */
-    public static boolean hasYearPassed(int year) {
-        int normalized = normalizeYear(year);
-        Calendar now = Clock.getCalendarInstance();
-        return normalized < now.get(Calendar.YEAR);
-    }
-
-    /**
-     * Determines whether the input year-month pair has passed.
-     *
-     * @param year the input year, as a two or four-digit integer
-     * @param month the input month
-     * @return {@code true} if the input time has passed, {@code false} otherwise.
-     */
-    public static boolean hasMonthPassed(int year, int month) {
-        if (hasYearPassed(year)) {
-            return true;
-        }
-
-        Calendar now = Clock.getCalendarInstance();
-        // Expires at end of specified month, Calendar month starts at 0
-        return normalizeYear(year) == now.get(Calendar.YEAR)
-                && month < (now.get(Calendar.MONTH) + 1);
-    }
 
     /**
      * Checks to see if the string input represents a valid month.
@@ -53,7 +19,7 @@ public class DateUtils {
      * @return {@code true} if the string is a number between "01" and "12" inclusive,
      * {@code false} otherwise
      */
-    public static boolean isValidMonth(@Nullable String monthString) {
+    static boolean isValidMonth(@Nullable String monthString) {
         if (monthString == null) {
             return false;
         }
@@ -77,7 +43,7 @@ public class DateUtils {
      */
     @Size(2)
     @NonNull
-    public static String[] separateDateStringParts(@NonNull @Size(max = 4) String expiryInput) {
+    static String[] separateDateStringParts(@NonNull @Size(max = 4) String expiryInput) {
         String[] parts = new String[2];
         if (expiryInput.length() >= 2) {
             parts[0] = expiryInput.substring(0, 2);
@@ -103,7 +69,7 @@ public class DateUtils {
      * month and year, {@code false} otherwise. Note that some cards expire on the first of the
      * month, but we don't validate that here.
      */
-    public static boolean isExpiryDataValid(int expiryMonth, int expiryYear) {
+    static boolean isExpiryDataValid(int expiryMonth, int expiryYear) {
         return isExpiryDataValid(expiryMonth, expiryYear, Calendar.getInstance());
     }
 
@@ -141,7 +107,7 @@ public class DateUtils {
      * @param year a year number, either in two-digit form or four-digit form
      * @return a length-four string representing the date, or an empty string if input is invalid
      */
-    public static String createDateStringFromIntegerInput(
+    static String createDateStringFromIntegerInput(
             @IntRange(from = 1, to = 12) int month,
             @IntRange(from = 0, to = 9999) int year) {
         String monthString = String.valueOf(month);
@@ -175,7 +141,7 @@ public class DateUtils {
      * @return a four-digit year
      */
     @IntRange(from = 1000, to = 9999)
-    public static int convertTwoDigitYearToFour(@IntRange(from = 0, to = 99) int inputYear) {
+    static int convertTwoDigitYearToFour(@IntRange(from = 0, to = 99) int inputYear) {
         return convertTwoDigitYearToFour(inputYear, Calendar.getInstance());
     }
 
@@ -193,16 +159,5 @@ public class DateUtils {
             centuryBase--;
         }
         return centuryBase * 100 + inputYear;
-    }
-
-    // Convert two-digit year to full year if necessary
-    private static int normalizeYear(int year)  {
-        if (year < 100 && year >= 0) {
-            Calendar now = Clock.getCalendarInstance();
-            String currentYear = String.valueOf(now.get(Calendar.YEAR));
-            String prefix = currentYear.substring(0, currentYear.length() - 2);
-            year = Integer.parseInt(String.format(Locale.US, "%s%02d", prefix, year));
-        }
-        return year;
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -10,8 +10,6 @@ import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.widget.EditText;
 
-import com.stripe.android.util.DateUtils;
-
 /**
  * An {@link EditText} that handles putting numbers around a central divider character.
  */

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -1,0 +1,66 @@
+package com.stripe.android.view;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.model.Card;
+
+/**
+ * Static utility functions needed for View classes.
+ */
+class ViewUtils {
+
+    /**
+     * Separates a card number according to the brand requirements, including prefixes of card
+     * numbers, so that the groups can be easily displayed if the user is typing them in.
+     * Note that this does not verify that the card number is valid, or even that it is a number.
+     *
+     * @param spacelessCardNumber the raw card number, without spaces
+     * @param brand the {@link Card.CardBrand} to use as a separating scheme
+     * @return an array of strings with the number groups, in order. If the number is not complete,
+     * some of the array entries may be {@code null}.
+     */
+    @NonNull
+    static String[] separateCardNumberGroups(@NonNull String spacelessCardNumber,
+                                                    @NonNull @Card.CardBrand String brand) {
+        String[] numberGroups;
+        if (brand.equals(Card.AMERICAN_EXPRESS)) {
+            numberGroups = new String[3];
+
+            int length = spacelessCardNumber.length();
+            int lastUsedIndex = 0;
+            if (length > 4) {
+                numberGroups[0] = spacelessCardNumber.substring(0, 4);
+                lastUsedIndex = 4;
+            }
+
+            if (length > 10) {
+                numberGroups[1] = spacelessCardNumber.substring(4, 10);
+                lastUsedIndex = 10;
+            }
+
+            for (int i = 0; i < 3; i++) {
+                if (numberGroups[i] != null) {
+                    continue;
+                }
+                numberGroups[i] = spacelessCardNumber.substring(lastUsedIndex);
+                break;
+            }
+
+        } else {
+            numberGroups = new String[4];
+            int i = 0;
+            int previousStart = 0;
+            while((i + 1) * 4 < spacelessCardNumber.length()) {
+                String group = spacelessCardNumber.substring(previousStart, (i + 1) * 4);
+                numberGroups[i] = group;
+                previousStart = (i + 1) * 4;
+                i++;
+            }
+            // Always stuff whatever is left into the next available array entry. This handles
+            // incomplete numbers, full 16-digit numbers, and full 14-digit numbers
+            numberGroups[i] = spacelessCardNumber.substring(previousStart);
+        }
+        return numberGroups;
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
@@ -1,4 +1,4 @@
-package com.stripe.android.util;
+package com.stripe.android;
 
 import com.stripe.android.model.Card;
 
@@ -9,7 +9,6 @@ import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -194,112 +193,5 @@ public class CardUtilsTest {
         // Note: it is not the job of this function to de-space the card number, nor de-hyphen it
         assertFalse(CardUtils.isValidLuhnNumber("4242 4242 4242 4242"));
         assertFalse(CardUtils.isValidLuhnNumber("4242-4242-4242-4242"));
-    }
-
-
-    @Test
-    public void separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
-        String testCardNumber = "4000056655665556";
-        String[] groups = CardUtils.separateCardNumberGroups(testCardNumber, Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("5556", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
-        String testCardNumber = "378282246310005";
-        String[] groups =
-                CardUtils.separateCardNumberGroups(testCardNumber, Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("822463", groups[1]);
-        assertEquals("10005", groups[2]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
-        String testCardNumber = "38520000023237";
-        String[] groups =
-                CardUtils.separateCardNumberGroups(testCardNumber, Card.DINERS_CLUB);
-        assertEquals(4, groups.length);
-        assertEquals("3852", groups[0]);
-        assertEquals("0000", groups[1]);
-        assertEquals("0232", groups[2]);
-        assertEquals("37", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
-        String testCardNumber = "1234056655665556";
-        String[] groups = CardUtils.separateCardNumberGroups(testCardNumber, Card.UNKNOWN);
-        assertEquals(4, groups.length);
-        assertEquals("1234", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("5556", groups[3]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
-        String testCardNumber = "378282246310005";
-        String[] groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 2), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("37", groups[0]);
-        assertNull(groups[1]);
-        assertNull(groups[2]);
-
-        groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 5), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("8", groups[1]);
-        assertNull(groups[2]);
-
-        groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 11), Card.AMERICAN_EXPRESS);
-        assertEquals(3, groups.length);
-        assertEquals("3782", groups[0]);
-        assertEquals("822463", groups[1]);
-        assertEquals("1", groups[2]);
-    }
-
-    @Test
-    public void separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
-        String testCardNumber = "4000056655665556";
-        String[] groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 2), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("40", groups[0]);
-        assertNull(groups[1]);
-        assertNull(groups[2]);
-        assertNull(groups[3]);
-
-        groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 5), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0", groups[1]);
-        assertNull(groups[2]);
-        assertNull(groups[3]);
-
-        groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 9), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5", groups[2]);
-        assertNull(groups[3]);
-
-        groups = CardUtils.separateCardNumberGroups(
-                testCardNumber.substring(0, 15), Card.VISA);
-        assertEquals(4, groups.length);
-        assertEquals("4000", groups[0]);
-        assertEquals("0566", groups[1]);
-        assertEquals("5566", groups[2]);
-        assertEquals("555", groups[3]);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/DateUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/DateUtilsTest.java
@@ -1,4 +1,4 @@
-package com.stripe.android.util;
+package com.stripe.android.view;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
@@ -1,0 +1,125 @@
+package com.stripe.android.view;
+
+import com.stripe.android.model.Card;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test class for {@link ViewUtils}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25)
+public class ViewUtilsTest {
+
+    @Test
+    public void separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = ViewUtils.separateCardNumberGroups(testCardNumber, Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups =
+                ViewUtils.separateCardNumberGroups(testCardNumber, Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("10005", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
+        String testCardNumber = "38520000023237";
+        String[] groups =
+                ViewUtils.separateCardNumberGroups(testCardNumber, Card.DINERS_CLUB);
+        assertEquals(4, groups.length);
+        assertEquals("3852", groups[0]);
+        assertEquals("0000", groups[1]);
+        assertEquals("0232", groups[2]);
+        assertEquals("37", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
+        String testCardNumber = "1234056655665556";
+        String[] groups = ViewUtils.separateCardNumberGroups(testCardNumber, Card.UNKNOWN);
+        assertEquals(4, groups.length);
+        assertEquals("1234", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("5556", groups[3]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
+        String testCardNumber = "378282246310005";
+        String[] groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 2), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("37", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+
+        groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 5), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("8", groups[1]);
+        assertNull(groups[2]);
+
+        groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 11), Card.AMERICAN_EXPRESS);
+        assertEquals(3, groups.length);
+        assertEquals("3782", groups[0]);
+        assertEquals("822463", groups[1]);
+        assertEquals("1", groups[2]);
+    }
+
+    @Test
+    public void separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
+        String testCardNumber = "4000056655665556";
+        String[] groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 2), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("40", groups[0]);
+        assertNull(groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 5), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0", groups[1]);
+        assertNull(groups[2]);
+        assertNull(groups[3]);
+
+        groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 9), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5", groups[2]);
+        assertNull(groups[3]);
+
+        groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber.substring(0, 15), Card.VISA);
+        assertEquals(4, groups.length);
+        assertEquals("4000", groups[0]);
+        assertEquals("0566", groups[1]);
+        assertEquals("5566", groups[2]);
+        assertEquals("555", groups[3]);
+    }
+}


### PR DESCRIPTION
…functionality

r? @joeydong-stripe 
cc @bg-stripe @bdorfman-stripe 

Continuing my effort to eliminate the utils package. Moving DateUtils and other functions specific to View items into the View package (and making them package private) and moving stuff specific to models into the models package.

Note: no new tests were added, but no old tests were removed. Looks like the ModelUtils class could use a few tests, but since the goal of this series of diffs is just move + make private, I'm not including that here.

Also Note:
CardUtils was not moved entirely to one place because both the Card model and the CardNumberEditText have legit reasons to want to validate card numbers and to detect card brand from a partial card number. I'm inclined to let this one survive as public, provided we make it clear not to add public methods here. The class was moved out of utils to the main package.