### PR TITLE
Add a method to enable or disable card widget text fields

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -217,6 +217,17 @@ public class CardInputWidget extends LinearLayout {
         mCardNumberEditText.setText("");
     }
 
+    /**
+     * Enable or disable text fields
+     *
+     * @param isEnabled boolean indicating whether fields should be enabled
+     */
+    public void setEnabled(boolean isEnabled) {
+        mCardNumberEditText.setEnabled(isEnabled);
+        mExpiryDateEditText.setEnabled(isEnabled);
+        mCvcNumberEditText.setEnabled(isEnabled);
+    }
+
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         if (ev.getAction() != MotionEvent.ACTION_DOWN) {

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -611,6 +611,22 @@ public class CardInputWidgetTest {
     }
 
     @Test
+    public void setEnabled_isTrue() {
+        mCardInputWidget.setEnabled(true);
+        assertTrue(mCardNumberEditText.isEnabled());
+        assertTrue(mExpiryEditText.isEnabled());
+        assertTrue(mCvcEditText.isEnabled());
+    }
+
+    @Test
+    public void setEnabled_isFalse() {
+        mCardInputWidget.setEnabled(false);
+        assertFalse(mCardNumberEditText.isEnabled());
+        assertFalse(mExpiryEditText.isEnabled());
+        assertFalse(mCvcEditText.isEnabled());
+    }
+
+    @Test
     public void setAllCardFields_whenValidValues_allowsGetCardWithExpectedValues() {
         if (Calendar.getInstance().get(Calendar.YEAR) > 2079) {
             fail("Update the code with a date that is still valid. Also, hello from the past.");


### PR DESCRIPTION
For instance, when I make an HTTP request when showing the form, I add a loading indicator in the screen. I think these fields should be disabled.