### PR TITLE
bumping the android pay library to 4.1.3

### DIFF
--- a/android-pay/AndroidManifest.xml
+++ b/android-pay/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.stripe.wrap.pay"
-          android:versionCode="6"
-          android:versionName="4.1.2">
+          android:versionCode="7"
+          android:versionName="4.1.3">
 </manifest>

--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
     provided 'com.google.android.gms:play-services-wallet:10.2.6'
-    provided 'com.stripe:stripe-android:4.1.2'
+    provided 'com.stripe:stripe-android:4.1.3'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'

--- a/android-pay/gradle.properties
+++ b/android-pay/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.1.2
+VERSION_NAME=4.1.3
 POM_DESCRIPTION=Stripe Android Pay Bindings
 POM_NAME=stripe-android-pay
 POM_ARTIFACT_ID=stripe-android-pay


### PR DESCRIPTION
r? @bdorfman-stripe 
cc @ksun-stripe 

Bumping the android pay library to match the stripe library. No other changes.