### PR TITLE
bumping the verison on google play services

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     javadocDeps 'com.android.support:support-annotations:' + android_support_version
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
-    provided 'com.google.android.gms:play-services-wallet:10.2.6'
+    provided 'com.google.android.gms:play-services-wallet:11.0.1'
     provided 'com.stripe:stripe-android:4.1.3'
 
     testCompile 'junit:junit:4.12'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile project(':stripe')
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
-    compile 'com.google.android.gms:play-services-wallet:10.2.6'
+    compile 'com.google.android.gms:play-services-wallet:11.0.1'
     /* Needed for RxAndroid */
     /* Needed for Rx Bindings on views */
     compile 'io.reactivex:rxandroid:1.2.1'

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     /* To use the Stripe android pay wrapper, you need these two lines */
     compile 'com.stripe:stripe-android-pay:4.1.3'
-    compile 'com.google.android.gms:play-services-wallet:10.2.6'
+    compile 'com.google.android.gms:play-services-wallet:11.0.1'
 
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'


### PR DESCRIPTION
r? @ksun-stripe 

Just bumping the Google Play Services version to use the latest. Because the jump is from 10.2.6->11.0.1 (breaking change), this has to go in our breaking change branch.