### PR TITLE
adjusting android-pay library to new stripe-android changes

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -38,7 +38,8 @@ dependencies {
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
     provided 'com.google.android.gms:play-services-wallet:11.0.1'
-    provided 'com.stripe:stripe-android:4.1.3'
+    // This should be changed back to a "provided" line before release
+    compile project(':stripe')
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'

--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -50,4 +50,9 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.0.1'
 }
 
-apply from: 'deploy.gradle'
+if (CONFIGURATION_STATUS == 'Release') {
+    apply from: 'deploy.gradle'
+} else {
+    print 'Current configuration status is ' + CONFIGURATION_STATUS
+}
+

--- a/android-pay/gradle.properties
+++ b/android-pay/gradle.properties
@@ -3,3 +3,4 @@ POM_DESCRIPTION=Stripe Android Pay Bindings
 POM_NAME=stripe-android-pay
 POM_ARTIFACT_ID=stripe-android-pay
 POM_PACKAGING=aar
+CONFIGURATION_STATUS=Development

--- a/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
@@ -88,9 +88,6 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
 
     static final String ANDROID_PAY_TOKEN = "AndroidPay";
 
-    static final String EVENT_TOKEN_CREATION = "token_creation";
-    static final String EVENT_SOURCE_CREATION = "source_creation";
-
     // Bool to track whether the app is already resolving an error
     private boolean mResolvingError = false;
     @NonNull private Executor mExecutor = Executors.newFixedThreadPool(3);
@@ -720,14 +717,13 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
 
     private boolean handleAsSource(@NonNull FullWallet fullWallet, @NonNull String rawSource) {
         Source source = Source.fromString(rawSource);
-
         if (source == null) {
             return false;
-        } else {
-            logApiCallOnNewThread(source);
-            onStripePaymentSourceReturned(fullWallet, source);
-            return true;
         }
+
+        logApiCallOnNewThread(source);
+        onStripePaymentSourceReturned(fullWallet, source);
+        return true;
     }
 
     private boolean handleAsToken(@NonNull FullWallet fullWallet, @NonNull String rawToken) {

--- a/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
@@ -261,7 +261,6 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
                                 if (booleanResult.getStatus().isSuccess()
                                         && booleanResult.getValue()) {
                                     onAndroidPayAvailable();
-                                    createAndAddBuyButtonWalletFragment();
                                 } else {
                                     onAndroidPayNotAvailable();
                                 }

--- a/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/AndroidPayActivity.java
@@ -110,6 +110,7 @@ public class AndroidPayActivity extends StripeAndroidPayActivity {
     @Override
     protected void onAndroidPayAvailable() {
         mFragmentContainer.setVisibility(View.VISIBLE);
+        createAndAddBuyButtonWalletFragment();
     }
 
     @Override

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.widget.Button;
 
 import com.google.android.gms.wallet.Cart;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.example.R;
 import com.stripe.wrap.pay.AndroidPayConfiguration;
 import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
@@ -28,6 +29,7 @@ public class LauncherActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_launcher);
 
+        PaymentConfiguration.init(PUBLISHABLE_KEY);
         Button tokenButton = (Button) findViewById(R.id.btn_make_card_tokens);
         tokenButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
@@ -36,13 +37,6 @@ import rx.subscriptions.CompositeSubscription;
  */
 public class RedirectActivity extends AppCompatActivity {
 
-    /*
-     * Change this to your publishable key.
-     *
-     * You can get your key here: https://dashboard.stripe.com/account/apikeys
-     */
-    private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
-            "put your key here";
     private static final String RETURN_SCHEMA = "stripe://";
     private static final String RETURN_HOST_ASYNC = "async";
     private static final String RETURN_HOST_SYNC = "sync";
@@ -145,7 +139,7 @@ public class RedirectActivity extends AppCompatActivity {
                             public Source call() throws Exception {
                                 return mStripe.createSourceSynchronous(
                                         cardSourceParams,
-                                        FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+                                        PaymentConfiguration.getInstance().getPublishableKey());
                             }
                         });
 
@@ -217,7 +211,7 @@ public class RedirectActivity extends AppCompatActivity {
                     public Source call() throws Exception {
                         return mStripe.createSourceSynchronous(
                                 threeDParams,
-                                FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+                                PaymentConfiguration.getInstance().getPublishableKey());
                     }
                 });
 

--- a/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.Button;
 
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
 import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Card;
@@ -22,7 +23,6 @@ public class AsyncTaskTokenController {
     private ErrorDialogHandler mErrorDialogHandler;
     private ListViewController mOutputListController;
     private ProgressDialogController mProgressDialogController;
-    private String mPublishableKey;
 
     public AsyncTaskTokenController(
             @NonNull Button button,
@@ -30,12 +30,10 @@ public class AsyncTaskTokenController {
             @NonNull Context context,
             @NonNull ErrorDialogHandler errorDialogHandler,
             @NonNull ListViewController outputListController,
-            @NonNull ProgressDialogController progressDialogController,
-            @NonNull String publishableKey) {
+            @NonNull ProgressDialogController progressDialogController) {
         mCardInputWidget = cardInputWidget;
         mContext = context;
         mErrorDialogHandler = errorDialogHandler;
-        mPublishableKey = publishableKey;
         mProgressDialogController = progressDialogController;
         mOutputListController = outputListController;
 
@@ -60,7 +58,7 @@ public class AsyncTaskTokenController {
         mProgressDialogController.startProgress();
         new Stripe(mContext).createToken(
                 cardToSave,
-                mPublishableKey,
+                PaymentConfiguration.getInstance().getPublishableKey(),
                 new TokenCallback() {
                     public void onSuccess(Token token) {
                         mOutputListController.addToList(token);

--- a/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
@@ -26,7 +26,6 @@ public class IntentServiceTokenController {
     private ErrorDialogHandler mErrorDialogHandler;
     private ListViewController mOutputListViewController;
     private ProgressDialogController mProgressDialogController;
-    private String mPublishableKey;
 
     private TokenBroadcastReceiver mTokenBroadcastReceiver;
 
@@ -36,15 +35,13 @@ public class IntentServiceTokenController {
             @NonNull CardInputWidget cardInputWidget,
             @NonNull ErrorDialogHandler errorDialogHandler,
             @NonNull ListViewController outputListController,
-            @NonNull ProgressDialogController progressDialogController,
-            @NonNull String publishableKey) {
+            @NonNull ProgressDialogController progressDialogController) {
 
         mActivity = appCompatActivity;
         mCardInputWidget = cardInputWidget;
         mErrorDialogHandler = errorDialogHandler;
         mOutputListViewController = outputListController;
         mProgressDialogController = progressDialogController;
-        mPublishableKey = publishableKey;
 
         button.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -86,8 +83,7 @@ public class IntentServiceTokenController {
                 cardToSave.getNumber(),
                 cardToSave.getExpMonth(),
                 cardToSave.getExpYear(),
-                cardToSave.getCVC(),
-                mPublishableKey);
+                cardToSave.getCVC());
         mProgressDialogController.startProgress();
         mActivity.startService(tokenServiceIntent);
     }

--- a/example/src/main/java/com/stripe/example/controller/RxTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/RxTokenController.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.widget.Button;
 
 import com.jakewharton.rxbinding.view.RxView;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
@@ -31,7 +32,6 @@ public class RxTokenController {
     private ErrorDialogHandler mErrorDialogHandler;
     private ListViewController mOutputListController;
     private ProgressDialogController mProgressDialogController;
-    private String mPublishableKey;
 
     public RxTokenController (
             @NonNull Button button,
@@ -39,8 +39,7 @@ public class RxTokenController {
             @NonNull Context context,
             @NonNull ErrorDialogHandler errorDialogHandler,
             @NonNull ListViewController outputListController,
-            @NonNull ProgressDialogController progressDialogController,
-            @NonNull String publishableKey) {
+            @NonNull ProgressDialogController progressDialogController) {
         mCompositeSubscription = new CompositeSubscription();
 
         mCardInputWidget = cardInputWidget;
@@ -48,7 +47,6 @@ public class RxTokenController {
         mErrorDialogHandler = errorDialogHandler;
         mOutputListController = outputListController;
         mProgressDialogController = progressDialogController;
-        mPublishableKey = publishableKey;
 
         mCompositeSubscription.add(
                 RxView.clicks(button).subscribe(new Action1<Void>() {
@@ -85,7 +83,8 @@ public class RxTokenController {
                         new Callable<Token>() {
                             @Override
                             public Token call() throws Exception {
-                                return stripe.createTokenSynchronous(cardToSave, mPublishableKey);
+                                return stripe.createTokenSynchronous(cardToSave,
+                                        PaymentConfiguration.getInstance().getPublishableKey());
                             }
                         });
 

--- a/example/src/main/java/com/stripe/example/module/DependencyHandler.java
+++ b/example/src/main/java/com/stripe/example/module/DependencyHandler.java
@@ -21,13 +21,6 @@ import com.stripe.example.controller.RxTokenController;
  */
 public class DependencyHandler {
 
-    /*
-     * Change this to your publishable key.
-     *
-     * You can get your key here: https://dashboard.stripe.com/account/apikeys
-     */
-    private static final String PUBLISHABLE_KEY = "put your key here";
-
     private AsyncTaskTokenController mAsyncTaskController;
     private CardInputWidget mCardInputWidget;
     private Context mContext;
@@ -69,8 +62,7 @@ public class DependencyHandler {
                     mContext,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController,
-                    PUBLISHABLE_KEY);
+                    mProgresDialogController);
         }
         return mAsyncTaskController;
     }
@@ -95,8 +87,7 @@ public class DependencyHandler {
                     mCardInputWidget,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController,
-                    PUBLISHABLE_KEY);
+                    mProgresDialogController);
         }
         return mIntentServiceTokenController;
     }
@@ -119,8 +110,7 @@ public class DependencyHandler {
                     mContext,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController,
-                    PUBLISHABLE_KEY);
+                    mProgresDialogController);
         }
         return mRxTokenController;
     }

--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.java
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
 
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
@@ -27,22 +28,18 @@ public class TokenIntentService extends IntentService {
     private static final String EXTRA_MONTH = "com.stripe.example.service.extra.month";
     private static final String EXTRA_YEAR = "com.stripe.example.service.extra.year";
     private static final String EXTRA_CVC = "com.stripe.example.service.extra.cvc";
-    private static final String EXTRA_PUBLISHABLE_KEY =
-            "com.stripe.example.service.extra.publishablekey";
 
     public static Intent createTokenIntent(
             @NonNull Activity launchingActivity,
             @Nullable String cardNumber,
             @Nullable Integer month,
             @Nullable Integer year,
-            @Nullable String cvc,
-            @NonNull String publishableKey) {
+            @Nullable String cvc) {
         return new Intent(launchingActivity, TokenIntentService.class)
                 .putExtra(EXTRA_CARD_NUMBER, cardNumber)
                 .putExtra(EXTRA_MONTH, month)
                 .putExtra(EXTRA_YEAR, year)
-                .putExtra(EXTRA_CVC, cvc)
-                .putExtra(EXTRA_PUBLISHABLE_KEY, publishableKey);
+                .putExtra(EXTRA_CVC, cvc);
     }
 
     public TokenIntentService() {
@@ -59,12 +56,12 @@ public class TokenIntentService extends IntentService {
             Integer year = (Integer) intent.getExtras().get(EXTRA_YEAR);
             String cvc = intent.getStringExtra(EXTRA_CVC);
 
-            String publishableKey = intent.getStringExtra(EXTRA_PUBLISHABLE_KEY);
             Card card = new Card(cardNumber, month, year, cvc);
 
             Stripe stripe = new Stripe(this);
             try {
-                token = stripe.createTokenSynchronous(card, publishableKey);
+                token = stripe.createTokenSynchronous(card,
+                        PaymentConfiguration.getInstance().getPublishableKey());
             } catch (StripeException stripeEx) {
                 errorMessage = stripeEx.getLocalizedMessage();
             }

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -165,6 +165,7 @@ public class PaymentActivity extends StripeAndroidPayActivity {
      */
     @Override
     protected void onAndroidPayAvailable() {
+        createAndAddBuyButtonWalletFragment();
         mAndroidPayGroupContainer.setVisibility(View.VISIBLE);
         mTvOr.setVisibility(View.VISIBLE);
         mTvOr.requestFocus();

--- a/stripe/src/main/java/com/stripe/android/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/LoggingUtils.java
@@ -76,10 +76,11 @@ class LoggingUtils {
 
     @NonNull
     static Map<String, Object> getSourceCreationParams(
+            @Nullable List<String> productUsageTokens,
             @NonNull String publishableApiKey,
             @NonNull @Source.SourceType String sourceType) {
         return getEventLoggingParams(
-                null,
+                productUsageTokens,
                 sourceType,
                 null,
                 publishableApiKey,

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.VisibleForTesting;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -22,6 +23,7 @@ import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.StripePaymentSource;
 import com.stripe.android.model.Token;
 
 import static com.stripe.android.StripeNetworkUtils.hashMapFromBankAccount;
@@ -543,8 +545,26 @@ public class Stripe {
                 mLoggingResponseListener);
     }
 
-    public void logEventSynchronous(@NonNull Map<String, Object> loggingMap) {
-        RequestOptions options = RequestOptions.builder(mDefaultPublishableKey).build();
+    public void logEventSynchronous(
+            @NonNull List<String> productUsageTokens,
+            @NonNull StripePaymentSource paymentSource) {
+        RequestOptions.RequestOptionsBuilder builder =
+                RequestOptions.builder(mDefaultPublishableKey);
+        if (mStripeAccount != null) {
+            builder.setStripeAccount(mStripeAccount);
+        }
+        RequestOptions options = builder.build();
+
+        Map<String, Object> loggingMap = null;
+        if (paymentSource instanceof Token) {
+            Token token = (Token) paymentSource;
+            loggingMap = LoggingUtils.getTokenCreationParams(productUsageTokens,
+                    mDefaultPublishableKey, token.getType());
+        } else {
+            Source source = (Source) paymentSource;
+            loggingMap = LoggingUtils.getSourceCreationParams(productUsageTokens,
+                    mDefaultPublishableKey, source.getType());
+        }
         StripeApiHandler.logApiCall(loggingMap, options, mLoggingResponseListener);
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -156,6 +156,7 @@ class StripeApiHandler {
 
             setTelemetryData(context, loggingResponseListener);
             Map<String, Object> loggingParams = LoggingUtils.getSourceCreationParams(
+                    null,
                     apiKey,
                     sourceParams.getType());
             RequestOptions loggingOptions = RequestOptions.builder(publishableKey).build();

--- a/stripe/src/test/java/com/stripe/android/LoggingUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/LoggingUtilsTest.java
@@ -1,7 +1,5 @@
 package com.stripe.android;
 
-import com.stripe.android.BuildConfig;
-import com.stripe.android.LoggingUtils;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.Token;
 
@@ -50,11 +48,12 @@ public class LoggingUtilsTest {
 
     @Test
     public void getSourceCreationParams_withValidInput_createsCorrectMap() {
-        // We don't use any product usage fields for sources yet, and we are also missing
-        // the TOKEN_TYPE logging field.
-        final int expectedSize = LoggingUtils.VALID_PARAM_FIELDS.size() - 2;
+        // Size is SIZE-1 because tokens don't have a token_type field
+        final int expectedSize = LoggingUtils.VALID_PARAM_FIELDS.size() - 1;
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add("CardInputView");
         Map<String, Object> loggingParams =
-                LoggingUtils.getSourceCreationParams(DUMMY_API_KEY, Source.SEPA_DEBIT);
+                LoggingUtils.getSourceCreationParams(tokenList, DUMMY_API_KEY, Source.SEPA_DEBIT);
         assertEquals(expectedSize, loggingParams.size());
         assertEquals(Source.SEPA_DEBIT, loggingParams.get(LoggingUtils.FIELD_SOURCE_TYPE));
         assertEquals(DUMMY_API_KEY, loggingParams.get(LoggingUtils.FIELD_PUBLISHABLE_KEY));


### PR DESCRIPTION
r? @ksun-stripe 
cc @bg-stripe @joeydong-stripe 

This also shifts the Example project to use the new imports, including keeping the publishable key inside the PaymentConfiguration instance