### PR TITLE
fixing MM/AA cutoff

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -82,7 +82,7 @@ public class CardInputWidget extends LinearLayout {
     private static final String HIDDEN_TEXT_COMMON = "4242 4242 4242 ";
 
     private static final String FULL_SIZING_CARD_TEXT = "4242 4242 4242 4242";
-    private static final String FULL_SIZING_DATE_TEXT = "MM/YY";
+    private static final String FULL_SIZING_DATE_TEXT = "MM/MM";
 
     private static final String EXTRA_CARD_VIEWED = "extra_card_viewed";
     private static final String EXTRA_SUPER_STATE = "extra_super_state";


### PR DESCRIPTION
r? @ksun-stripe 
cc @bg-stripe 
As per https://github.com/stripe/stripe-android/issues/303, the expiry date can get its hint cut off in certain locales and with certain fonts. The cause was that I was using "MM/YY" to calculate the width of the text view -- I should have been using "MM/MM". This is a screen-size / pixel length issue, so it's pretty hard to add an automated test for. The best way to see that it works is to change the English hint text for the expiry date to MM/AA and verify that it isn't cut off (and that it was before the diff).

We measure this value dynamically, so by changing the measurement text to the widest possible letter, we should avoid this for all fonts.