### PR TITLE
fixing a bug in which DecimalFormat picks out a comma separator based…

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -3,9 +3,9 @@ package com.stripe.wrap.pay.utils;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Currency;
@@ -311,7 +311,10 @@ public class PaymentUtils {
         double modBreak = Math.pow(10, fractionDigits);
         double decimalPrice = price / modBreak;
 
-        DecimalFormat decimalFormat = new DecimalFormat(builder.toString());
+        // No matter the Locale, Android Pay requires a dot for the decimal separator.
+        DecimalFormatSymbols symbolOverride = new DecimalFormatSymbols();
+        symbolOverride.setDecimalSeparator('.');
+        DecimalFormat decimalFormat = new DecimalFormat(builder.toString(), symbolOverride);
         decimalFormat.setCurrency(currency);
 
         return decimalFormat.format(decimalPrice);

--- a/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/utils/PaymentUtils.java
@@ -292,6 +292,7 @@ public class PaymentUtils {
             }
             DecimalFormat noDecimalCurrencyFormat = new DecimalFormat(builder.toString());
             noDecimalCurrencyFormat.setCurrency(currency);
+            noDecimalCurrencyFormat.setGroupingUsed(false);
             return noDecimalCurrencyFormat.format(price);
         }
 
@@ -316,6 +317,7 @@ public class PaymentUtils {
         symbolOverride.setDecimalSeparator('.');
         DecimalFormat decimalFormat = new DecimalFormat(builder.toString(), symbolOverride);
         decimalFormat.setCurrency(currency);
+        decimalFormat.setGroupingUsed(false);
 
         return decimalFormat.format(decimalPrice);
     }

--- a/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
+++ b/android-pay/src/test/java/com/stripe/wrap/pay/utils/PaymentUtilsTest.java
@@ -312,6 +312,22 @@ public class PaymentUtilsTest {
     }
 
     @Test
+    public void getPriceString_whenLocaleWithCommas_returnsExpectedValue() {
+        Locale.setDefault(Locale.FRENCH);
+        String priceString = getPriceString(100L, Currency.getInstance("USD"));
+        assertEquals("1.00", priceString);
+        assertTrue(matchesCurrencyPatternOrEmpty(priceString));
+
+        String littlePrice = getPriceString(8L, Currency.getInstance("EUR"));
+        assertEquals("0.08", littlePrice);
+        assertTrue(matchesCurrencyPatternOrEmpty(littlePrice));
+
+        String bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"));
+        assertEquals("200000.00", bigPrice);
+        assertTrue(matchesCurrencyPatternOrEmpty(bigPrice));
+    }
+
+    @Test
     public void getPriceString_whenCurrencyWithoutDecimals_returnsExpectedValue() {
         String priceString = getPriceString(250L, Currency.getInstance("JPY"));
         assertEquals("250", priceString);


### PR DESCRIPTION
… on locale, not currency

r? @anelder-stripe 
cc @ksun-stripe 

Added a unit test that fails without the added code as well.