### PR TITLE
adding a very simple customer session

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
 
+    testCompile 'org.json:json:20140107'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'org.robolectric:robolectric:3.3.2'
@@ -40,6 +41,9 @@ android {
     }
     productFlavors {
     }
+//    testOptions {
+//        unitTests.returnDefaultValues = true
+//    }
 }
 
 task wrapper(type: Wrapper) {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
 
-    testCompile 'org.json:json:20140107'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'org.robolectric:robolectric:3.3.2'
@@ -41,9 +40,6 @@ android {
     }
     productFlavors {
     }
-//    testOptions {
-//        unitTests.returnDefaultValues = true
-//    }
 }
 
 task wrapper(type: Wrapper) {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -129,13 +129,6 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         }
     }
 
-    /**
-     * Get the currently cached {@link Customer}. Note that this may be an empty
-     * customer value (equivalent to {@link Customer#getEmptyCustomer()} if there is no
-     * valid current customer.
-     *
-     * @return the current {@link Customer} object
-     */
     @Nullable
     @VisibleForTesting
     Customer getCustomer() {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -1,19 +1,55 @@
 package com.stripe.android;
 
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
+import com.stripe.android.exception.APIConnectionException;
+import com.stripe.android.exception.APIException;
+import com.stripe.android.exception.InvalidRequestException;
+import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Customer;
+
+import java.lang.ref.WeakReference;
+import java.util.Calendar;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Represents a logged-in session of a single Customer.
  */
 public class CustomerSession implements Parcelable {
 
-    private @Nullable EphemeralKey mEphemeralKey;
+    private @NonNull Customer mCustomer;
+    private @NonNull EphemeralKey mEphemeralKey;
     private @NonNull EphemeralKeyProvider mKeyProvider;
+
+    private @NonNull Handler mUiThreadHandler;
+
+    private @Nullable Calendar mProxyNowCalendar;
+    private @Nullable StripeApiProxy mStripeApiProxy;
+
+    // A queue of Runnables for doing customer updates
+    private final BlockingQueue<Runnable> mNetworkQueue = new LinkedBlockingQueue<>();
+
+    private @NonNull ThreadPoolExecutor mThreadPoolExecutor;
+
+    private static final int CUSTOMER_RETRIEVED = 7;
+
+    // The maximum number of active threads we support
+    private static final int THREAD_POOL_SIZE = 3;
+    // Sets the amount of time an idle thread waits before terminating
+    private static final int KEEP_ALIVE_TIME = 2;
+    // Sets the Time Unit to seconds
+    private static final TimeUnit KEEP_ALIVE_TIME_UNIT = TimeUnit.SECONDS;
 
     private CustomerSession(Parcel in) {
         ClassLoader keyProviderLoader =
@@ -22,13 +58,45 @@ public class CustomerSession implements Parcelable {
             throw new IllegalStateException("Cannot create CustomerSession objects without " +
                     "a KeyProvider with proper ClassLoader");
         }
+
+        // Initialize Threads and Handlers
+        initializeMainThreadHandler();
+        initializeThreadPoolExecutor();
+
         mKeyProvider = in.readParcelable(keyProviderLoader);
+
+        // The Ephemeral Key class is part of this package, so we use this classloader.
+        mEphemeralKey = in.readParcelable(getClass().getClassLoader());
+
+        Customer customer = Customer.fromString(in.readString());
+        mCustomer = customer == null ? Customer.getEmptyCustomer() : customer;
     }
 
+    /**
+     * Create a CustomerSession with the provided {@link EphemeralKeyProvider}.
+     *
+     * @param keyProvider an {@link EphemeralKeyProvider} used to get
+     * {@link EphemeralKey EphemeralKeys} as needed
+     */
     public CustomerSession(@NonNull EphemeralKeyProvider keyProvider) {
+        this(keyProvider, null, null);
+    }
+
+    @VisibleForTesting
+    CustomerSession(
+            @NonNull EphemeralKeyProvider keyProvider,
+            @Nullable StripeApiProxy stripeApiProxy,
+            @Nullable Calendar proxyNowCalendar) {
         mKeyProvider = keyProvider;
+        mEphemeralKey = EphemeralKey.getEmptyKey();
+        mCustomer = Customer.getEmptyCustomer();
+        mStripeApiProxy = stripeApiProxy;
+        mProxyNowCalendar = proxyNowCalendar;
         PaymentConfiguration.getInstance().setEphemeralKeyProviderClassLoader(
                 keyProvider.getClassLoader());
+        initializeThreadPoolExecutor();
+        initializeMainThreadHandler();
+        updateKeyIfNecessary(mEphemeralKey, mProxyNowCalendar);
     }
 
     @Override
@@ -39,6 +107,149 @@ public class CustomerSession implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeParcelable(mKeyProvider, i);
+        parcel.writeParcelable(mEphemeralKey, i);
+        // Using JSON serialization of the Customer
+        parcel.writeString(mCustomer.toString());
+    }
+
+    /**
+     * Get the currently cached {@link Customer}. Note that this may be an empty
+     * customer value (equivalent to {@link Customer#getEmptyCustomer()} if there is no
+     * valid current customer.
+     *
+     * @return the current {@link Customer} object
+     */
+    @NonNull
+    public Customer getCustomer() {
+        return mCustomer;
+    }
+
+    @NonNull
+    @VisibleForTesting
+    EphemeralKey getEphemeralKey() {
+        return mEphemeralKey;
+    }
+
+    void updateCustomerIfNecessary(
+            @NonNull final EphemeralKey key,
+            @Nullable final Calendar nowCalendar) {
+        if (key.getCustomerId().equals(mCustomer.getId())) {
+            return;
+        }
+
+        Runnable fetchCustomerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                Customer customer = retrieveCustomerWithKey(key, mStripeApiProxy, nowCalendar);
+                Message message = mUiThreadHandler.obtainMessage(CUSTOMER_RETRIEVED, customer);
+                mUiThreadHandler.sendMessage(message);
+            }
+        };
+
+        executeRunnable(fetchCustomerRunnable);
+    }
+
+    void updateKeyIfNecessary(@NonNull final EphemeralKey key, @Nullable Calendar nowCalendar) {
+        if (!isTimeInPast(key.getExpires(), nowCalendar)) {
+            return;
+        }
+
+        mKeyProvider.fetchEphemeralKey(
+                StripeApiHandler.API_VERSION,
+                new CustomerKeyUpdateListener(this));
+    }
+
+    void executeRunnable(@NonNull Runnable runnable) {
+
+        // In automation, run on the main thread.
+        if (mStripeApiProxy != null) {
+            runnable.run();
+            return;
+        }
+
+        mThreadPoolExecutor.execute(runnable);
+    }
+
+    void onKeyUpdated(String rawKey) {
+        EphemeralKey key = EphemeralKey.fromString(rawKey);
+        mEphemeralKey = key == null ? EphemeralKey.getEmptyKey() : key;
+        updateCustomerIfNecessary(mEphemeralKey, mProxyNowCalendar);
+    }
+
+    void onKeyError(int code, @Nullable String errorMessage) {
+        // Not yet handling this case
+    }
+
+    private void initializeMainThreadHandler() {
+        mUiThreadHandler = new Handler(Looper.getMainLooper()) {
+            @Override
+            public void handleMessage(Message msg) {
+                super.handleMessage(msg);
+
+                Object messageObject = msg.obj;
+
+                switch (msg.what) {
+                    case CUSTOMER_RETRIEVED:
+                        if (messageObject instanceof Customer) {
+                            mCustomer = (Customer) messageObject;
+                        }
+                        break;
+                }
+            }
+        };
+    }
+
+    private void initializeThreadPoolExecutor() {
+        mThreadPoolExecutor = new ThreadPoolExecutor(
+                THREAD_POOL_SIZE,
+                THREAD_POOL_SIZE,
+                KEEP_ALIVE_TIME,
+                KEEP_ALIVE_TIME_UNIT,
+                mNetworkQueue);
+    }
+
+    /**
+     * Calls the Stripe API (or a test proxy) to fetch a customer. If the provided key is expired,
+     * this method <b>does not</b> update the key.
+     * Use {@link #updateCustomerIfNecessary(EphemeralKey, Calendar)} to validate the key
+     * before refreshing the customer.
+     *
+     * @param key the {@link EphemeralKey} used for this access
+     * @param proxy a {@link StripeApiProxy} to intercept calls to the real servers
+     * @return a {@link Customer} if one can be found with this key, or {@code null} if one cannot.
+     */
+    @Nullable
+    static Customer retrieveCustomerWithKey(
+            @NonNull EphemeralKey key,
+            @Nullable StripeApiProxy proxy,
+            @Nullable Calendar nowCalendar) {
+        Customer customer = null;
+        if (isTimeInPast(key.getExpires(), nowCalendar)) {
+            return null;
+        }
+
+        try {
+            if (proxy != null) {
+                return proxy.retrieveCustomerWithKey(key.getCustomerId(), key.getSecret());
+            }
+            customer = StripeApiHandler.retrieveCustomerWithKey(
+                    key.getCustomerId(),
+                    key.getSecret());
+        } catch (InvalidRequestException invalidException) {
+            // Then the key is invalid
+        } catch (StripeException stripeException) {
+            Log.e(CustomerSession.class.getName(), stripeException.getMessage());
+        }
+        return customer;
+    }
+
+    static boolean isTimeInPast(long milliSeconds, @Nullable Calendar nowCalendar) {
+        if (milliSeconds == 0L) {
+            return true;
+        }
+
+        Calendar now = nowCalendar == null ? Calendar.getInstance() : nowCalendar;
+        return now.getTimeInMillis() > milliSeconds;
     }
 
     static final Parcelable.Creator<CustomerSession> CREATOR
@@ -55,15 +266,34 @@ public class CustomerSession implements Parcelable {
         }
     };
 
-    public static class KeyUpdateCallback {
+    private static class CustomerKeyUpdateListener implements EphemeralKeyUpdateListener {
 
-        public void onKeyUpdate(String updatedRawKey) {
-            EphemeralKey key = EphemeralKey.fromString(updatedRawKey);
+        private @NonNull WeakReference<CustomerSession> mCustomerSessionReference;
+
+        CustomerKeyUpdateListener(@NonNull CustomerSession session) {
+            mCustomerSessionReference = new WeakReference<>(session);
         }
 
-        public void onKeyUpdateError(String errorMessage) {
-
+        @Override
+        public void onKeyUpdate(@NonNull String rawKey) {
+            final CustomerSession session = mCustomerSessionReference.get();
+            if (session != null) {
+                session.onKeyUpdated(rawKey);
+            }
         }
+
+        @Override
+        public void onKeyUpdateFailure(int responseCode, @Nullable String message) {
+            final CustomerSession session = mCustomerSessionReference.get();
+            if (session != null) {
+                session.onKeyError(responseCode, message);
+            }
+        }
+    }
+
+    interface StripeApiProxy {
+        Customer retrieveCustomerWithKey(@NonNull String customerId, @NonNull String secret)
+                throws InvalidRequestException, APIConnectionException, APIException;
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -246,7 +246,7 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
             if (proxy != null) {
                 return proxy.retrieveCustomerWithKey(key.getCustomerId(), key.getSecret());
             }
-            customer = StripeApiHandler.retrieveCustomerWithKey(
+            customer = StripeApiHandler.retrieveCustomer(
                     key.getCustomerId(),
                     key.getSecret());
         } catch (InvalidRequestException invalidException) {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -1,0 +1,69 @@
+package com.stripe.android;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.model.Customer;
+
+/**
+ * Represents a logged-in session of a single Customer.
+ */
+public class CustomerSession implements Parcelable {
+
+    private @Nullable EphemeralKey mEphemeralKey;
+    private @NonNull EphemeralKeyProvider mKeyProvider;
+
+    private CustomerSession(Parcel in) {
+        ClassLoader keyProviderLoader =
+                PaymentConfiguration.getInstance().getEphemeralKeyProviderClassLoader();
+        if (keyProviderLoader == null) {
+            throw new IllegalStateException("Cannot create CustomerSession objects without " +
+                    "a KeyProvider with proper ClassLoader");
+        }
+        mKeyProvider = in.readParcelable(keyProviderLoader);
+    }
+
+    public CustomerSession(@NonNull EphemeralKeyProvider keyProvider) {
+        mKeyProvider = keyProvider;
+        PaymentConfiguration.getInstance().setEphemeralKeyProviderClassLoader(
+                keyProvider.getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeParcelable(mKeyProvider, i);
+    }
+
+    static final Parcelable.Creator<CustomerSession> CREATOR
+            = new Parcelable.Creator<CustomerSession>() {
+
+        @Override
+        public CustomerSession createFromParcel(Parcel in) {
+            return new CustomerSession(in);
+        }
+
+        @Override
+        public CustomerSession[] newArray(int size) {
+            return new CustomerSession[size];
+        }
+    };
+
+    public static class KeyUpdateCallback {
+
+        public void onKeyUpdate(String updatedRawKey) {
+            EphemeralKey key = EphemeralKey.fromString(updatedRawKey);
+        }
+
+        public void onKeyUpdateError(String errorMessage) {
+
+        }
+    }
+
+}

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -249,7 +249,7 @@ public class CustomerSession implements Parcelable {
         }
 
         Calendar now = nowCalendar == null ? Calendar.getInstance() : nowCalendar;
-        return now.getTimeInMillis() > milliSeconds;
+        return TimeUnit.MILLISECONDS.toSeconds(now.getTimeInMillis()) > milliSeconds;
     }
 
     static final Parcelable.Creator<CustomerSession> CREATOR

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.java
@@ -214,10 +214,6 @@ class EphemeralKey extends StripeJsonModel implements Parcelable {
         }
     };
 
-    static EphemeralKey getEmptyKey() {
-        return new EphemeralKey(0, NULL, 0, NULL, false, NULL, NULL, NULL);
-    }
-
     @Nullable
     static EphemeralKey fromString(@Nullable String rawJson) {
         if (rawJson == null) {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.java
@@ -4,7 +4,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.model.StripeJsonModel;
 
@@ -31,7 +31,7 @@ class EphemeralKey extends StripeJsonModel implements Parcelable {
     static final String FIELD_ASSOCIATED_OBJECTS = "associated_objects";
     static final String FIELD_TYPE = "type";
 
-    private static final String NULL = "null";
+    static final String NULL = "null";
 
     private long mCreated;
     private @NonNull String mCustomerId;
@@ -171,6 +171,11 @@ class EphemeralKey extends StripeJsonModel implements Parcelable {
         return mExpires;
     }
 
+    @VisibleForTesting
+    void setExpires(long value) {
+        mExpires = value;
+    }
+
     @NonNull
     String getId() {
         return mId;
@@ -209,6 +214,10 @@ class EphemeralKey extends StripeJsonModel implements Parcelable {
         }
     };
 
+    static EphemeralKey getEmptyKey() {
+        return new EphemeralKey(0, NULL, 0, NULL, false, NULL, NULL, NULL);
+    }
+
     @Nullable
     static EphemeralKey fromString(@Nullable String rawJson) {
         if (rawJson == null) {
@@ -216,7 +225,8 @@ class EphemeralKey extends StripeJsonModel implements Parcelable {
         }
 
         try {
-            return fromJson(new JSONObject(rawJson));
+            JSONObject object = new JSONObject(rawJson);
+            return fromJson(object);
         } catch (JSONException ignored) {
             return null;
         }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -48,12 +48,12 @@ class EphemeralKeyManager {
         return mEphemeralKey;
     }
 
-    private void updateSessionKey(@NonNull String key) {
+    private void updateKey(@NonNull String key) {
         mEphemeralKey = EphemeralKey.fromString(key);
         mListener.onKeyUpdate(mEphemeralKey);
     }
 
-    private void updateSessionKeyError(int errorCode, @Nullable String errorMessage) {
+    private void updateKeyError(int errorCode, @Nullable String errorMessage) {
         mEphemeralKey = null;
         mListener.onKeyError(errorCode, errorMessage);
     }
@@ -91,7 +91,7 @@ class EphemeralKeyManager {
         public void onKeyUpdate(@NonNull String rawKey) {
             final EphemeralKeyManager keyManager = mEphemeralKeyManagerWeakReference.get();
             if (keyManager != null) {
-                keyManager.updateSessionKey(rawKey);
+                keyManager.updateKey(rawKey);
             }
         }
 
@@ -99,7 +99,7 @@ class EphemeralKeyManager {
         public void onKeyUpdateFailure(int responseCode, @Nullable String message) {
             final EphemeralKeyManager keyManager = mEphemeralKeyManagerWeakReference.get();
             if (keyManager != null) {
-                keyManager.updateSessionKeyError(responseCode, message);
+                keyManager.updateKeyError(responseCode, message);
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -1,0 +1,105 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+class EphemeralKeyManager {
+
+    private @Nullable EphemeralKey mEphemeralKey;
+    private @NonNull EphemeralKeyProvider mEphemeralKeyProvider;
+    private @Nullable Calendar mOverrideCalendar;
+    private @NonNull KeyManagerListener mListener;
+    private final long mTimeBufferInSeconds;
+
+    EphemeralKeyManager(
+            @NonNull EphemeralKeyProvider ephemeralKeyProvider,
+            @NonNull KeyManagerListener keyManagerListener,
+            long timeBufferInSeconds,
+            @Nullable Calendar overrideCalendar) {
+
+        mEphemeralKeyProvider = ephemeralKeyProvider;
+        mListener = keyManagerListener;
+        mTimeBufferInSeconds = timeBufferInSeconds;
+        mOverrideCalendar = overrideCalendar;
+        updateKeyIfNecessary();
+    }
+
+    @Nullable
+    EphemeralKey getEphemeralKey() {
+        return mEphemeralKey;
+    }
+
+    void updateKeyIfNecessary() {
+        if (mEphemeralKey != null &&
+                !shouldRefreshKey(
+                    mEphemeralKey,
+                    mTimeBufferInSeconds,
+                    mOverrideCalendar)) {
+            return;
+        }
+
+        mEphemeralKeyProvider.createEphemeralKey(
+                StripeApiHandler.API_VERSION,
+                new ClientKeyUpdateListener(this));
+    }
+
+    private void updateSessionKey(@NonNull String key) {
+        mEphemeralKey = EphemeralKey.fromString(key);
+        mListener.onKeyUpdate(mEphemeralKey);
+    }
+
+    private void updateSessionKeyError(int errorCode, @Nullable String errorMessage) {
+        mEphemeralKey = null;
+        mListener.onKeyError(errorCode, errorMessage);
+    }
+
+    static boolean shouldRefreshKey(
+            @Nullable EphemeralKey key,
+            long bufferInSeconds,
+            @Nullable Calendar proxyCalendar) {
+
+        if (key == null) {
+            return true;
+        }
+
+        Calendar now = proxyCalendar == null ? Calendar.getInstance() : proxyCalendar;
+        long nowInSeconds = TimeUnit.MILLISECONDS.toSeconds(now.getTimeInMillis());
+        long nowPlusBuffer = nowInSeconds + bufferInSeconds;
+        return key.getExpires() < nowPlusBuffer;
+    }
+
+    interface KeyManagerListener {
+        void onKeyUpdate(@Nullable EphemeralKey ephemeralKey);
+        void onKeyError(int errorCode, @Nullable String errorMessage);
+    }
+
+    private static class ClientKeyUpdateListener implements EphemeralKeyUpdateListener {
+
+        private @NonNull
+        WeakReference<EphemeralKeyManager> mEphemeralKeyManagerWeakReference;
+
+        ClientKeyUpdateListener(@NonNull EphemeralKeyManager keyManager) {
+            mEphemeralKeyManagerWeakReference = new WeakReference<>(keyManager);
+        }
+
+        @Override
+        public void onKeyUpdate(@NonNull String rawKey) {
+            final EphemeralKeyManager keyManager = mEphemeralKeyManagerWeakReference.get();
+            if (keyManager != null) {
+                keyManager.updateSessionKey(rawKey);
+            }
+        }
+
+        @Override
+        public void onKeyUpdateFailure(int responseCode, @Nullable String message) {
+            final EphemeralKeyManager keyManager = mEphemeralKeyManagerWeakReference.get();
+            if (keyManager != null) {
+                keyManager.updateSessionKeyError(responseCode, message);
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -2,6 +2,7 @@ package com.stripe.android;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import java.lang.ref.WeakReference;
 import java.util.Calendar;
@@ -25,26 +26,28 @@ class EphemeralKeyManager {
         mListener = keyManagerListener;
         mTimeBufferInSeconds = timeBufferInSeconds;
         mOverrideCalendar = overrideCalendar;
-        updateKeyIfNecessary();
+        retrieveEphemeralKey();
     }
 
-    @Nullable
-    EphemeralKey getEphemeralKey() {
-        return mEphemeralKey;
-    }
-
-    void updateKeyIfNecessary() {
+    void retrieveEphemeralKey() {
         if (mEphemeralKey != null &&
                 !shouldRefreshKey(
-                    mEphemeralKey,
-                    mTimeBufferInSeconds,
-                    mOverrideCalendar)) {
+                        mEphemeralKey,
+                        mTimeBufferInSeconds,
+                        mOverrideCalendar)) {
+            mListener.onKeyUpdate(mEphemeralKey);
             return;
         }
 
         mEphemeralKeyProvider.createEphemeralKey(
                 StripeApiHandler.API_VERSION,
                 new ClientKeyUpdateListener(this));
+    }
+
+    @Nullable
+    @VisibleForTesting
+    EphemeralKey getEphemeralKey() {
+        return mEphemeralKey;
     }
 
     private void updateSessionKey(@NonNull String key) {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -30,18 +30,16 @@ class EphemeralKeyManager {
     }
 
     void retrieveEphemeralKey() {
-        if (mEphemeralKey != null &&
-                !shouldRefreshKey(
-                        mEphemeralKey,
-                        mTimeBufferInSeconds,
-                        mOverrideCalendar)) {
+        if (shouldRefreshKey(
+                mEphemeralKey,
+                mTimeBufferInSeconds,
+                mOverrideCalendar)) {
+            mEphemeralKeyProvider.createEphemeralKey(
+                    StripeApiHandler.API_VERSION,
+                    new ClientKeyUpdateListener(this));
+        } else {
             mListener.onKeyUpdate(mEphemeralKey);
-            return;
         }
-
-        mEphemeralKeyProvider.createEphemeralKey(
-                StripeApiHandler.API_VERSION,
-                new ClientKeyUpdateListener(this));
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
@@ -1,14 +1,21 @@
 package com.stripe.android;
 
-import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Size;
 
-public interface EphemeralKeyProvider extends Parcelable {
+/**
+ * Represents an object that can call to a server and create {@link EphemeralKey EphemeralKeys}.
+ */
+public interface EphemeralKeyProvider {
 
-    void fetchEphemeralKey(
+    /**
+     * When called, talks to a client server that then communicates with Stripe's servers to
+     * create an {@link EphemeralKey}.
+     *
+     * @param apiVersion the Stripe API Version being used
+     * @param keyUpdateListener a callback object to notify about results
+     */
+    void createEphemeralKey(
             @NonNull @Size(min = 4) String apiVersion,
             @NonNull final EphemeralKeyUpdateListener keyUpdateListener);
-
-    @NonNull ClassLoader getClassLoader();
 }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
@@ -2,10 +2,13 @@ package com.stripe.android;
 
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Size;
 
 public interface EphemeralKeyProvider extends Parcelable {
 
-    void fetchEphemeralKey(String apiVersion);
+    void fetchEphemeralKey(
+            @NonNull @Size(min = 4) String apiVersion,
+            @NonNull final EphemeralKeyUpdateListener keyUpdateListener);
 
     @NonNull ClassLoader getClassLoader();
 }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
@@ -1,0 +1,11 @@
+package com.stripe.android;
+
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+public interface EphemeralKeyProvider extends Parcelable {
+
+    void fetchEphemeralKey(String apiVersion);
+
+    @NonNull ClassLoader getClassLoader();
+}

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
@@ -1,0 +1,26 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * Represents a listener for Ephemeral Key Update events.
+ */
+public interface EphemeralKeyUpdateListener {
+
+    /**
+     * Called when a key update request from your server comes back successfully.
+     *
+     * @param rawKey the raw String returned from Stripe's servers
+     */
+    void onKeyUpdate(@NonNull String rawKey);
+
+    /**
+     * Called when a key update request from your server comes back with an error.
+     *
+     * @param responseCode the error code returned from Stripe's servers
+     * @param message the error message returned from Stripe's servers
+     */
+    void onKeyUpdateFailure(int responseCode, @Nullable String message);
+
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -23,7 +23,7 @@ public class PaymentConfiguration {
     @NonNull
     public static PaymentConfiguration getInstance() {
         if (mInstance == null) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Attempted to get instance of PaymentConfiguration without initialization.");
         }
         return mInstance;

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -62,15 +62,6 @@ public class PaymentConfiguration {
         return this;
     }
 
-    void setEphemeralKeyProviderClassLoader(@NonNull ClassLoader classLoader) {
-        mEphemeralKeyProviderClassLoader = classLoader;
-    }
-
-    @Nullable
-    ClassLoader getEphemeralKeyProviderClassLoader() {
-        return mEphemeralKeyProviderClassLoader;
-    }
-
     @VisibleForTesting
     static void setInstance(@Nullable PaymentConfiguration paymentConfiguration) {
         mInstance = paymentConfiguration;

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -10,6 +10,7 @@ public class PaymentConfiguration {
 
     private static PaymentConfiguration mInstance;
 
+    private @Nullable ClassLoader mEphemeralKeyProviderClassLoader;
     private @NonNull String mPublishableKey;
     private @Address.RequiredBillingAddressFields
     int mRequiredBillingAddressFields;
@@ -59,6 +60,15 @@ public class PaymentConfiguration {
     public PaymentConfiguration setShouldUseSourcesForCards(boolean shouldUseSourcesForCards) {
         mShouldUseSourcesForCards = shouldUseSourcesForCards;
         return this;
+    }
+
+    void setEphemeralKeyProviderClassLoader(@NonNull ClassLoader classLoader) {
+        mEphemeralKeyProviderClassLoader = classLoader;
+    }
+
+    @Nullable
+    ClassLoader getEphemeralKeyProviderClassLoader() {
+        return mEphemeralKeyProviderClassLoader;
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -70,7 +70,7 @@ class StripeApiHandler {
     private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
     private static final SSLSocketFactory SSL_SOCKET_FACTORY = new StripeSSLSocketFactory();
 
-    static final String API_VERSION = "2015-10-12";
+    static final String API_VERSION = "2017-06-05";
 
     static void logApiCall(
             @NonNull Map<String, Object> loggingMap,

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -16,6 +16,7 @@ import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.PermissionException;
 import com.stripe.android.exception.RateLimitException;
 import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Customer;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
@@ -63,10 +64,13 @@ class StripeApiHandler {
     private static final String LOGGING_ENDPOINT = "https://m.stripe.com/4";
 
     private static final String CHARSET = "UTF-8";
+    private static final String CUSTOMERS = "customers";
     private static final String TOKENS = "tokens";
     private static final String SOURCES = "sources";
     private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
     private static final SSLSocketFactory SSL_SOCKET_FACTORY = new StripeSSLSocketFactory();
+
+    static final String API_VERSION = "2015-10-12";
 
     static void logApiCall(
             @NonNull Map<String, Object> loggingMap,
@@ -301,6 +305,17 @@ class StripeApiHandler {
         }
     }
 
+    @Nullable
+    static Customer retrieveCustomerWithKey(@NonNull String customerId, @NonNull String secret)
+            throws InvalidRequestException, APIConnectionException, APIException {
+        StripeResponse response = getStripeResponse(
+                GET,
+                getRetrieveCustomerUrl(customerId),
+                null,
+                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+        return Customer.fromString(response.getResponseBody());
+    }
+
     static String createQuery(Map<String, Object> params)
             throws UnsupportedEncodingException, InvalidRequestException {
         StringBuilder queryStringBuffer = new StringBuilder();
@@ -366,6 +381,16 @@ class StripeApiHandler {
     @VisibleForTesting
     static String getSourcesUrl() {
         return String.format(Locale.ENGLISH, "%s/v1/%s", LIVE_API_BASE, SOURCES);
+    }
+
+    @VisibleForTesting
+    static String getCustomersUrl() {
+        return String.format(Locale.ENGLISH, "%s/v1/%s", LIVE_API_BASE, CUSTOMERS);
+    }
+
+    @VisibleForTesting
+    static String getRetrieveCustomerUrl(@NonNull String customerId) {
+        return String.format(Locale.ENGLISH, "%s/%s", getCustomersUrl(), customerId);
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -306,7 +306,7 @@ class StripeApiHandler {
     }
 
     @Nullable
-    static Customer retrieveCustomerWithKey(@NonNull String customerId, @NonNull String secret)
+    static Customer retrieveCustomer(@NonNull String customerId, @NonNull String secret)
             throws InvalidRequestException, APIConnectionException, APIException {
         StripeResponse response = getStripeResponse(
                 GET,

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -103,11 +103,6 @@ public class Customer extends StripeJsonModel {
     }
 
     @NonNull
-    public static Customer getEmptyCustomer() {
-        return new Customer();
-    }
-
-    @NonNull
     @Override
     public Map<String, Object> toMap() {
         Map<String, Object> mapObject = new HashMap<>();

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -103,6 +103,11 @@ public class Customer extends StripeJsonModel {
     }
 
     @NonNull
+    public static Customer getEmptyCustomer() {
+        return new Customer();
+    }
+
+    @NonNull
     @Override
     public Map<String, Object> toMap() {
         Map<String, Object> mapObject = new HashMap<>();
@@ -135,8 +140,7 @@ public class Customer extends StripeJsonModel {
     @Nullable
     public static Customer fromString(String jsonString) {
         try {
-            JSONObject jsonObject = new JSONObject(jsonString);
-            return fromJson(jsonObject);
+            return fromJson(new JSONObject(jsonString));
         } catch (JSONException ignored) {
             return null;
         }

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -12,13 +12,10 @@ import com.stripe.android.model.Customer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
 
 import java.util.Calendar;
 
@@ -28,13 +25,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-//import static org.mockito.Mockito.when;
 
 /**
  * Test class for {@link CustomerSession}.

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -1,0 +1,283 @@
+package com.stripe.android;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Customer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+//import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link CustomerSession}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25)
+public class CustomerSessionTest {
+
+    private static final String FIRST_SAMPLE_KEY_RAW = "{\n" +
+            "  \"id\": \"ephkey_123\",\n" +
+            "  \"object\": \"ephemeral_key\",\n" +
+            "  \"secret\": \"ek_test_123\",\n" +
+            "  \"created\": 1501188006223,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"expires\": 1501188016223,\n" +
+            "  \"associated_objects\": [{\n" +
+            "            \"type\": \"customer\",\n" +
+            "            \"id\": \"cus_AQsHpvKfKwJDrF\"\n" +
+            "            }]\n" +
+            "}";
+
+    private static final String SECOND_SAMPLE_KEY_RAW = "{\n" +
+            "  \"id\": \"ephkey_ABC\",\n" +
+            "  \"object\": \"ephemeral_key\",\n" +
+            "  \"secret\": \"ek_test_456\",\n" +
+            "  \"created\": 1483575790,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"expires\": 1483579790,\n" +
+            "  \"associated_objects\": [{\n" +
+            "            \"type\": \"customer\",\n" +
+            "            \"id\": \"cus_abc123\"\n" +
+            "            }]\n" +
+            "}";
+
+    private static final String FIRST_TEST_CUSTOMER_OBJECT =
+            "{\n" +
+                    "  \"id\": \"cus_AQsHpvKfKwJDrF\",\n" +
+                    "  \"object\": \"customer\",\n" +
+                    "  \"default_source\": \"abc123\",\n" +
+                    "  \"sources\": {\n" +
+                    "    \"object\": \"list\",\n" +
+                    "    \"data\": [\n" +
+                    "\n" +
+                    "    ],\n" +
+                    "    \"has_more\": false,\n" +
+                    "    \"total_count\": 0,\n" +
+                    "    \"url\": \"/v1/customers/cus_AQsHpvKfKwJDrF/sources\"\n" +
+                    "  }\n" +
+                    "}";
+
+    private static final String SECOND_TEST_CUSTOMER_OBJECT =
+            "{\n" +
+                    "  \"id\": \"cus_ABC123\",\n" +
+                    "  \"object\": \"customer\",\n" +
+                    "  \"default_source\": \"def456\",\n" +
+                    "  \"sources\": {\n" +
+                    "    \"object\": \"list\",\n" +
+                    "    \"data\": [\n" +
+                    "\n" +
+                    "    ],\n" +
+                    "    \"has_more\": false,\n" +
+                    "    \"total_count\": 0,\n" +
+                    "    \"url\": \"/v1/customers/cus_ABC123/sources\"\n" +
+                    "  }\n" +
+                    "}";
+
+    @Mock CustomerSession.StripeApiProxy mStripeApiProxy;
+    private CustomerSession mCustomerSession;
+    private TestEphemeralKeyProvider mEphemeralKeyProvider;
+
+    private Customer mFirstCustomer;
+    private Customer mSecondCustomer;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        PaymentConfiguration.init("pk_test_abc123");
+
+        mFirstCustomer = Customer.fromString(FIRST_TEST_CUSTOMER_OBJECT);
+        assertNotNull(mFirstCustomer);
+        mSecondCustomer = Customer.fromString(SECOND_TEST_CUSTOMER_OBJECT);
+        assertNotNull(mSecondCustomer);
+
+        mEphemeralKeyProvider = new TestEphemeralKeyProvider();
+
+        try {
+            when(mStripeApiProxy.retrieveCustomerWithKey(anyString(), anyString()))
+                    .thenReturn(mFirstCustomer, mSecondCustomer);
+        } catch (StripeException exception) {
+            fail("Exception when accessing mock api proxy: " + exception.getMessage());
+        }
+    }
+
+    @Test
+    public void create_withoutInvokingFunctions_fetchesKeyAndCustomer() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        // Note: the test ephemeral key expiration is set to July 27, 2017
+        Calendar fixedCalendar = Calendar.getInstance();
+        fixedCalendar.set(2017, 1, 1);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession session = new CustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                fixedCalendar);
+
+        assertEquals(firstKey.getId(), session.getEphemeralKey().getId());
+
+        try {
+            verify(mStripeApiProxy, times(1)).retrieveCustomerWithKey(
+                    firstKey.getCustomerId(), firstKey.getSecret());
+            assertEquals(mFirstCustomer.getId(), session.getCustomer().getId());
+        } catch (StripeException unexpected) {
+            fail(unexpected.getMessage());
+        }
+    }
+
+    @Test
+    public void updateKeyIfNecessary_whenKeyIsValid_doesNotUpdateKey() {
+        // This test will always be run after January 01, 2000.
+        Calendar pastCalendar = Calendar.getInstance();
+        pastCalendar.set(2000, 1, 1);
+        Calendar now = Calendar.getInstance();
+
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+        EphemeralKey secondKey = EphemeralKey.fromString(SECOND_SAMPLE_KEY_RAW);
+        assertNotNull(secondKey);
+        assertNotEquals("Test keys should not have same ID", secondKey.getId(), firstKey.getId());
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        mEphemeralKeyProvider.setEphemeralKeyExpiration(now.getTimeInMillis());
+
+        CustomerSession session = new CustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                pastCalendar);
+
+        // We'll fetch a new key if the first one is expired.
+        mEphemeralKeyProvider.setNextRawEphemeralKey(SECOND_SAMPLE_KEY_RAW);
+
+        session.updateKeyIfNecessary(session.getEphemeralKey(), pastCalendar);
+        assertEquals(firstKey.getId(), session.getEphemeralKey().getId());
+    }
+
+    @Test
+    public void isTimeInPast_forTimeInPast_returnsTrue() {
+        // This test will always be run after January 01, 2000.
+        Calendar pastCalendar = Calendar.getInstance();
+        pastCalendar.set(2000, 1, 1);
+
+        assertTrue(CustomerSession.isTimeInPast(pastCalendar.getTimeInMillis(), null));
+    }
+
+    @Test
+    public void isTimeInPast_forPresentOrFuture_returnsFalse() {
+        // This test will always be run after January 01, 2000.
+        Calendar pastCalendar = Calendar.getInstance();
+        pastCalendar.set(2000, 1, 1);
+
+        Calendar nowCalendar = Calendar.getInstance();
+        assertFalse(CustomerSession.isTimeInPast(nowCalendar.getTimeInMillis(), pastCalendar));
+    }
+
+    @Test
+    public void isTimeInPast_forZeroTime_returnsTrue() {
+        assertTrue(CustomerSession.isTimeInPast(0L, null));
+    }
+
+    static class TestEphemeralKeyProvider implements EphemeralKeyProvider {
+
+        private static final int INVALID_ERROR_CODE = -1;
+        private @Nullable String mRawEphemeralKey;
+        private int mErrorCode = INVALID_ERROR_CODE;
+        private @Nullable String mErrorMessage;
+
+        private EphemeralKey mEphemeralKey;
+
+        private TestEphemeralKeyProvider(Parcel in) {}
+
+        TestEphemeralKeyProvider() {}
+
+        @Override
+        public void fetchEphemeralKey(
+                @NonNull @Size(min = 4) String apiVersion,
+                @NonNull final EphemeralKeyUpdateListener keyUpdateListener) {
+            if (mRawEphemeralKey != null) {
+                keyUpdateListener.onKeyUpdate(mRawEphemeralKey);
+            } else if (mErrorCode != INVALID_ERROR_CODE) {
+                keyUpdateListener.onKeyUpdateFailure(mErrorCode, mErrorMessage);
+            }
+        }
+
+        @NonNull
+        @Override
+        public ClassLoader getClassLoader() {
+            return getClass().getClassLoader();
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel parcel, int i) {
+
+        }
+
+        void setNextRawEphemeralKey(@NonNull String rawEphemeralKey) {
+            mRawEphemeralKey = rawEphemeralKey;
+            mEphemeralKey = EphemeralKey.fromString(mRawEphemeralKey);
+            mErrorCode = INVALID_ERROR_CODE;
+            mErrorMessage = null;
+        }
+
+        void setEphemeralKeyExpiration(long expiration) {
+            if (mEphemeralKey != null) {
+                mEphemeralKey.setExpires(expiration);
+                mRawEphemeralKey = mEphemeralKey.toString();
+            }
+        }
+
+        void setNextError(int errorCode, @NonNull String errorMessage) {
+            mRawEphemeralKey = null;
+            mErrorCode = errorCode;
+            mErrorMessage = errorMessage;
+        }
+
+        static final Parcelable.Creator<TestEphemeralKeyProvider> CREATOR
+                = new Parcelable.Creator<TestEphemeralKeyProvider>() {
+
+            @Override
+            public TestEphemeralKeyProvider createFromParcel(Parcel in) {
+                return new TestEphemeralKeyProvider(in);
+            }
+
+            @Override
+            public TestEphemeralKeyProvider[] newArray(int size) {
+                return new TestEphemeralKeyProvider[size];
+            }
+        };
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -18,6 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,9 +42,9 @@ public class CustomerSessionTest {
             "  \"id\": \"ephkey_123\",\n" +
             "  \"object\": \"ephemeral_key\",\n" +
             "  \"secret\": \"ek_test_123\",\n" +
-            "  \"created\": 1501188006223,\n" +
+            "  \"created\": 1501199335,\n" +
             "  \"livemode\": false,\n" +
-            "  \"expires\": 1501188016223,\n" +
+            "  \"expires\": 1501199335,\n" +
             "  \"associated_objects\": [{\n" +
             "            \"type\": \"customer\",\n" +
             "            \"id\": \"cus_AQsHpvKfKwJDrF\"\n" +
@@ -96,7 +97,6 @@ public class CustomerSessionTest {
                     "}";
 
     @Mock CustomerSession.StripeApiProxy mStripeApiProxy;
-    private CustomerSession mCustomerSession;
     private TestEphemeralKeyProvider mEphemeralKeyProvider;
 
     private Customer mFirstCustomer;
@@ -182,7 +182,8 @@ public class CustomerSessionTest {
         Calendar pastCalendar = Calendar.getInstance();
         pastCalendar.set(2000, 1, 1);
 
-        assertTrue(CustomerSession.isTimeInPast(pastCalendar.getTimeInMillis(), null));
+        long timeInSeconds = TimeUnit.MILLISECONDS.toSeconds(pastCalendar.getTimeInMillis());
+        assertTrue(CustomerSession.isTimeInPast(timeInSeconds, null));
     }
 
     @Test
@@ -192,7 +193,9 @@ public class CustomerSessionTest {
         pastCalendar.set(2000, 1, 1);
 
         Calendar nowCalendar = Calendar.getInstance();
-        assertFalse(CustomerSession.isTimeInPast(nowCalendar.getTimeInMillis(), pastCalendar));
+        long timeInSeconds = TimeUnit.MILLISECONDS.toSeconds(nowCalendar.getTimeInMillis());
+
+        assertFalse(CustomerSession.isTimeInPast(timeInSeconds, pastCalendar));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -175,8 +175,8 @@ public class EphemeralKeyManagerTest {
         final String errorMessage = "This is an error";
         mTestEphemeralKeyProvider.setNextError(404, errorMessage);
 
-        // It should be necessary because the key is expired.
-        keyManager.updateKeyIfNecessary();
+        // It should be necessary to update because the key is expired.
+        keyManager.retrieveEphemeralKey();
 
         verify(mKeyManagerListener, times(1)).onKeyError(404, errorMessage);
         verifyNoMoreInteractions(mKeyManagerListener);

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -1,0 +1,185 @@
+package com.stripe.android;
+
+import com.stripe.android.testharness.TestEphemeralKeyProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Test class for {@link EphemeralKeyManager}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25)
+public class EphemeralKeyManagerTest {
+
+    private static final String FIRST_SAMPLE_KEY_RAW = "{\n" +
+            "  \"id\": \"ephkey_123\",\n" +
+            "  \"object\": \"ephemeral_key\",\n" +
+            "  \"secret\": \"ek_test_123\",\n" +
+            "  \"created\": 1501199335,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"expires\": 1501199335,\n" +
+            "  \"associated_objects\": [{\n" +
+            "            \"type\": \"customer\",\n" +
+            "            \"id\": \"cus_AQsHpvKfKwJDrF\"\n" +
+            "            }]\n" +
+            "}";
+
+    private static final long TEST_SECONDS_BUFFER = 10L;
+
+    @Mock EphemeralKeyManager.KeyManagerListener mKeyManagerListener;
+
+    private Calendar mProxyCalendar;
+    private TestEphemeralKeyProvider mTestEphemeralKeyProvider;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        mProxyCalendar = Calendar.getInstance();
+        mTestEphemeralKeyProvider = new TestEphemeralKeyProvider();
+    }
+
+    @Test
+    public void shouldRefreshKey_whenKeyIsNullAndTimeIsInFuture_returnsTrue() {
+        Calendar futureCalendar = Calendar.getInstance();
+        futureCalendar.add(Calendar.YEAR, 1);
+        // If you don't call getTime or getTimeInMillis on a Calendar, none of the updates happen.
+        futureCalendar.getTimeInMillis();
+        assertTrue(EphemeralKeyManager.shouldRefreshKey(null,
+                TEST_SECONDS_BUFFER,
+                futureCalendar));
+    }
+
+    @Test
+    public void shouldRefreshKey_whenKeyIsNullAndTimeIsInPast_returnsTrue() {
+        Calendar pastCalendar = Calendar.getInstance();
+        pastCalendar.add(Calendar.YEAR, -1);
+        // If you don't call getTime or getTimeInMillis on a Calendar, none of the updates happen.
+        pastCalendar.getTimeInMillis();
+        assertTrue(EphemeralKeyManager.shouldRefreshKey(null,
+                TEST_SECONDS_BUFFER,
+                pastCalendar));
+    }
+
+    @Test
+    public void shouldRefreshKey_whenKeyExpiryIsAfterBufferFromPresent_returnsFalse() {
+        Calendar fixedCalendar = Calendar.getInstance();
+        EphemeralKey key = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(key);
+
+        long expiryTimeInSeconds = key.getExpires();
+        long sufficientBufferTime = 2*TEST_SECONDS_BUFFER;
+        key.setExpires(expiryTimeInSeconds + sufficientBufferTime);
+
+        long expiryTimeInMilliseconds = TimeUnit.SECONDS.toMillis(expiryTimeInSeconds);
+        fixedCalendar.setTimeInMillis(expiryTimeInMilliseconds);
+        // If you don't call getTime or getTimeInMillis on a Calendar, none of the updates happen.
+        assertEquals(expiryTimeInMilliseconds, fixedCalendar.getTimeInMillis());
+        assertFalse(EphemeralKeyManager.shouldRefreshKey(key,
+                TEST_SECONDS_BUFFER,
+                fixedCalendar));
+    }
+
+    @Test
+    public void shouldRefreshKey_whenKeyExpiryIsInThePast_returnsTrue() {
+        Calendar fixedCalendar = Calendar.getInstance();
+        EphemeralKey key = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(key);
+
+        long currentTimeInMillis = fixedCalendar.getTimeInMillis();
+        long timeAgoInMillis = currentTimeInMillis - 100L;
+
+        key.setExpires(TimeUnit.MILLISECONDS.toSeconds(timeAgoInMillis));
+        assertTrue(EphemeralKeyManager.shouldRefreshKey(key,
+                TEST_SECONDS_BUFFER,
+                fixedCalendar));
+    }
+
+    @Test
+    public void shouldRefreshKey_whenKeyExpiryIsInFutureButWithinBuffer_returnsTrue() {
+        Calendar fixedCalendar = Calendar.getInstance();
+        EphemeralKey key = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(key);
+
+        long parsedExpiryTimeInMillis = TimeUnit.SECONDS.toMillis(key.getExpires());
+        long bufferTimeInMillis = TimeUnit.SECONDS.toMillis(TEST_SECONDS_BUFFER);
+
+        long notFarEnoughInTheFuture = parsedExpiryTimeInMillis + bufferTimeInMillis / 2;
+        fixedCalendar.setTimeInMillis(notFarEnoughInTheFuture);
+        assertEquals(notFarEnoughInTheFuture, fixedCalendar.getTimeInMillis());
+
+        assertTrue(EphemeralKeyManager.shouldRefreshKey(key,
+                TEST_SECONDS_BUFFER,
+                fixedCalendar));
+    }
+
+    @Test
+    public void createKeyManager_updatesEphemeralKey_notifiesListener() {
+        EphemeralKey testKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(testKey);
+
+        mTestEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        EphemeralKeyManager keyManager = new EphemeralKeyManager(
+                mTestEphemeralKeyProvider,
+                mKeyManagerListener,
+                TEST_SECONDS_BUFFER,
+                null);
+
+        verify(mKeyManagerListener, times(1)).onKeyUpdate(any(EphemeralKey.class));
+        assertNotNull(keyManager.getEphemeralKey());
+        assertEquals(testKey.getId(), keyManager.getEphemeralKey().getId());
+    }
+
+    @Test
+    public void updateKeyIfNecessary_whenReturnsError_setsExistingKeyToNull() {
+        EphemeralKey testKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(testKey);
+
+        Calendar proxyCalendar = Calendar.getInstance();
+        long expiryTimeInMillis = TimeUnit.SECONDS.toMillis(testKey.getExpires());
+        // The time is one millisecond past the expiration date for this test.
+        proxyCalendar.setTimeInMillis(expiryTimeInMillis + 1L);
+        // Testing this just to invoke getTime
+        assertEquals(expiryTimeInMillis + 1L, proxyCalendar.getTimeInMillis());
+
+        mTestEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        EphemeralKeyManager keyManager = new EphemeralKeyManager(
+                mTestEphemeralKeyProvider,
+                mKeyManagerListener,
+                TEST_SECONDS_BUFFER,
+                proxyCalendar);
+
+        // Make sure we're in a good state
+        verify(mKeyManagerListener, times(1)).onKeyUpdate(any(EphemeralKey.class));
+        assertNotNull(keyManager.getEphemeralKey());
+
+        // Set up the error
+        final String errorMessage = "This is an error";
+        mTestEphemeralKeyProvider.setNextError(404, errorMessage);
+
+        // It should be necessary because the key is expired.
+        keyManager.updateKeyIfNecessary();
+
+        verify(mKeyManagerListener, times(1)).onKeyError(404, errorMessage);
+        verifyNoMoreInteractions(mKeyManagerListener);
+        assertNull(keyManager.getEphemeralKey());
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
@@ -26,7 +26,7 @@ public class PaymentConfigurationTest {
         PaymentConfiguration.setInstance(null);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalStateException.class)
     public void getInstance_beforeInit_throwsRuntimeException() {
         PaymentConfiguration.getInstance();
         fail("Should not be able to get a payment configuration before it has been initialized.");

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -4,6 +4,7 @@ import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.Customer;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 

--- a/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.java
@@ -1,0 +1,44 @@
+package com.stripe.android.testharness;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+
+import com.stripe.android.EphemeralKeyProvider;
+import com.stripe.android.EphemeralKeyUpdateListener;
+
+/**
+ * An {@link EphemeralKeyProvider} to be used in tests that automatically returns test values.
+ */
+public class TestEphemeralKeyProvider implements EphemeralKeyProvider {
+
+    private static final int INVALID_ERROR_CODE = -1;
+    private int mErrorCode = INVALID_ERROR_CODE;
+    private @Nullable String mErrorMessage;
+    private @Nullable String mRawEphemeralKey;
+
+    public TestEphemeralKeyProvider() {}
+
+    @Override
+    public void createEphemeralKey(
+            @NonNull @Size(min = 4) String apiVersion,
+            @NonNull final EphemeralKeyUpdateListener keyUpdateListener) {
+        if (mRawEphemeralKey != null) {
+            keyUpdateListener.onKeyUpdate(mRawEphemeralKey);
+        } else if (mErrorCode != INVALID_ERROR_CODE) {
+            keyUpdateListener.onKeyUpdateFailure(mErrorCode, mErrorMessage);
+        }
+    }
+
+    public void setNextRawEphemeralKey(@NonNull String rawEphemeralKey) {
+        mRawEphemeralKey = rawEphemeralKey;
+        mErrorCode = INVALID_ERROR_CODE;
+        mErrorMessage = null;
+    }
+
+    public void setNextError(int errorCode, @NonNull String errorMessage) {
+        mRawEphemeralKey = null;
+        mErrorCode = errorCode;
+        mErrorMessage = errorMessage;
+    }
+}


### PR DESCRIPTION
r? @bg-stripe 
cc @ksun-stripe @joeydong-stripe 

This adds a CustomerSession class, along with EphemeralKeyProvider and EphemeralKeyUpdateListener (a callback interface).

Intentionally omitted functions/classes to be added in the future:
1 - an example activity that uses these (I have tested with one)
2 - a KeyManager class that updates the EphemeralKey on a schedule
3 - Checking to see if the EphemeralKey is "close enough" to expired. Right now, if there is only one millisecond left before the key expires, I call it valid.
4 - refreshing the customer object after a given period
5 - handling API errors

Note that testing multithreaded operations is not currently supported in our repo, so if a StripeApiProxy is added, all "networking" (it does not hit the network) is done on the main thread.