### PR TITLE
adding the CardMultilineWidget and associated tests

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'
-    testCompile 'org.robolectric:robolectric:3.3.2'
+    testCompile 'org.robolectric:robolectric:3.4'
 }
 
 android {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -11,9 +11,11 @@ configurations {
 dependencies {
     compile 'com.android.support:support-annotations:' + android_support_version
     compile 'com.android.support:appcompat-v7:' + android_support_version
+    compile 'com.android.support:design:' + android_support_version
 
     javadocDeps 'com.android.support:support-annotations:' + android_support_version
     javadocDeps 'com.android.support:appcompat-v7:' + android_support_version
+    javadocDeps 'com.android.support:design:' + android_support_version
     provided 'javax.annotation:jsr250-api:1.0'
 
     testCompile 'junit:junit:4.12'

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content">
+
+    <com.stripe.android.view.IconTextInputLayout
+        android:id="@+id/tl_add_source_card_number_ml"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/add_card_element_vertical_margin"
+        >
+
+        <com.stripe.android.view.CardNumberEditText
+            android:id="@+id/et_add_source_card_number_ml"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/acc_label_card_number"
+            android:inputType="number"
+            android:drawableLeft="@drawable/ic_unknown"
+            android:drawableStart="@drawable/ic_unknown"
+            android:drawablePadding="@dimen/card_icon_padding"
+            android:nextFocusDown="@+id/et_add_source_expiry_ml"
+            android:nextFocusForward="@+id/et_add_source_expiry_ml"
+            />
+
+    </com.stripe.android.view.IconTextInputLayout>
+
+    <LinearLayout
+        android:id="@+id/second_row_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false"
+        android:layout_marginTop="@dimen/add_card_element_vertical_margin"
+        >
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/tl_add_source_expiry_ml"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
+            android:layout_marginEnd="@dimen/add_card_expiry_middle_margin"
+            >
+            <com.stripe.android.view.ExpiryDateEditText
+                android:id="@+id/et_add_source_expiry_ml"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/acc_label_expiry_date"
+                android:inputType="date"
+                android:nextFocusDown="@+id/et_add_source_cvc_ml"
+                android:nextFocusForward="@+id/et_add_source_cvc_ml"
+                />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/tl_add_source_cvc_ml"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
+            android:layout_marginEnd="@dimen/add_card_expiry_middle_margin"
+            >
+
+            <com.stripe.android.view.StripeEditText
+                android:id="@+id/et_add_source_cvc_ml"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:nextFocusDown="@+id/et_add_source_zip_ml"
+                android:nextFocusForward="@+id/et_add_source_zip_ml"
+
+                />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/tl_add_source_zip_ml"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            >
+
+            <com.stripe.android.view.StripeEditText
+                android:id="@+id/et_add_source_zip_ml"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/acc_label_zip"
+                android:inputType="number"
+                android:maxLength="5"
+                />
+
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+</merge>

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -14,6 +14,7 @@
             android:id="@+id/et_add_source_card_number_ml"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:digits="@string/valid_digits"
             android:drawableLeft="@drawable/ic_unknown"
             android:drawablePadding="@dimen/card_icon_padding"
             android:drawableStart="@drawable/ic_unknown"
@@ -69,24 +70,28 @@
                 android:id="@+id/et_add_source_cvc_ml"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:digits="@string/valid_digits"
                 android:inputType="number"
-                android:nextFocusDown="@+id/et_add_source_zip_ml"
-                android:nextFocusForward="@+id/et_add_source_zip_ml"
+                android:nextFocusDown="@+id/et_add_source_postal_ml"
+                android:nextFocusForward="@+id/et_add_source_postal_ml"
                 />
 
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
-            android:id="@+id/tl_add_source_zip_ml"
+            android:id="@+id/tl_add_source_postal_ml"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             >
 
+            <!--In future releases we will remove the android:digits restriction
+            to support international postal codes.-->
             <com.stripe.android.view.StripeEditText
-                android:id="@+id/et_add_source_zip_ml"
+                android:id="@+id/et_add_source_postal_ml"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:digits="@string/valid_digits"
                 android:hint="@string/acc_label_zip"
                 android:inputType="number"
                 android:maxLength="5"

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -14,11 +14,11 @@
             android:id="@+id/et_add_source_card_number_ml"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:drawableLeft="@drawable/ic_unknown"
+            android:drawablePadding="@dimen/card_icon_padding"
+            android:drawableStart="@drawable/ic_unknown"
             android:hint="@string/acc_label_card_number"
             android:inputType="number"
-            android:drawableLeft="@drawable/ic_unknown"
-            android:drawableStart="@drawable/ic_unknown"
-            android:drawablePadding="@dimen/card_icon_padding"
             android:nextFocusDown="@+id/et_add_source_expiry_ml"
             android:nextFocusForward="@+id/et_add_source_expiry_ml"
             />
@@ -29,28 +29,29 @@
         android:id="@+id/second_row_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:baselineAligned="false"
         android:layout_marginTop="@dimen/add_card_element_vertical_margin"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
         >
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tl_add_source_expiry_ml"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
             android:layout_marginEnd="@dimen/add_card_expiry_middle_margin"
+            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
+            android:layout_weight="1"
             >
+
             <com.stripe.android.view.ExpiryDateEditText
                 android:id="@+id/et_add_source_expiry_ml"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/acc_label_expiry_date"
                 android:inputType="date"
+                android:maxLength="@integer/date_length"
                 android:nextFocusDown="@+id/et_add_source_cvc_ml"
                 android:nextFocusForward="@+id/et_add_source_cvc_ml"
-                android:maxLength="@integer/date_length"
                 />
 
         </android.support.design.widget.TextInputLayout>
@@ -59,9 +60,9 @@
             android:id="@+id/tl_add_source_cvc_ml"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
             android:layout_marginEnd="@dimen/add_card_expiry_middle_margin"
+            android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
+            android:layout_weight="1"
             >
 
             <com.stripe.android.view.StripeEditText
@@ -71,7 +72,6 @@
                 android:inputType="number"
                 android:nextFocusDown="@+id/et_add_source_zip_ml"
                 android:nextFocusForward="@+id/et_add_source_zip_ml"
-
                 />
 
         </android.support.design.widget.TextInputLayout>

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -50,6 +50,7 @@
                 android:inputType="date"
                 android:nextFocusDown="@+id/et_add_source_cvc_ml"
                 android:nextFocusForward="@+id/et_add_source_cvc_ml"
+                android:maxLength="@integer/date_length"
                 />
 
         </android.support.design.widget.TextInputLayout>

--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -5,4 +5,8 @@
         <attr name="cardTint" format="color"/>
         <attr name="cardTextErrorColor" format="color"/>
     </declare-styleable>
+
+    <declare-styleable name="CardMultilineWidget">
+        <attr name="shouldShowPostalCode" format="boolean" />
+    </declare-styleable>
 </resources>

--- a/stripe/res/values/constants.xml
+++ b/stripe/res/values/constants.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="date_length">5</integer>
+</resources>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="add_card_element_vertical_margin">12dp</dimen>
+    <dimen name="add_card_expiry_middle_margin">8dp</dimen>
     <dimen name="card_icon_padding">12dp</dimen>
     <dimen name="card_widget_min_width">320dp</dimen>
     <dimen name="card_expiry_initial_margin">200dp</dimen>
@@ -7,4 +9,5 @@
     <dimen name="android_pay_button_layout_margin">24dp</dimen>
     <dimen name="android_pay_confirmation_margin">8dp</dimen>
     <dimen name="android_pay_button_separation">8dp</dimen>
+    <dimen name="card_icon_multiline_width">24dp</dimen>
 </resources>

--- a/stripe/res/values/donottranslate.xml
+++ b/stripe/res/values/donottranslate.xml
@@ -5,5 +5,6 @@
     <string name="cvc_amex_hint">CVV</string>
     <string name="cvc_multiline_helper">123</string>
     <string name="cvc_multiline_helper_amex">1234</string>
+    <string name="valid_digits">0123456789</string>
     <string name="zip_helper">12345</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -8,6 +8,7 @@ import android.support.annotation.StringDef;
 import android.text.TextUtils;
 
 import com.stripe.android.CardUtils;
+import com.stripe.android.R;
 import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.StripeTextUtils;
 
@@ -67,6 +68,17 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     public static final String FUNDING_DEBIT = "debit";
     public static final String FUNDING_PREPAID = "prepaid";
     public static final String FUNDING_UNKNOWN = "unknown";
+
+    public static final Map<String , Integer> BRAND_RESOURCE_MAP =
+            new HashMap<String , Integer>() {{
+                put(Card.AMERICAN_EXPRESS, R.drawable.ic_amex);
+                put(Card.DINERS_CLUB, R.drawable.ic_diners);
+                put(Card.DISCOVER, R.drawable.ic_discover);
+                put(Card.JCB, R.drawable.ic_jcb);
+                put(Card.MASTERCARD, R.drawable.ic_mastercard);
+                put(Card.VISA, R.drawable.ic_visa);
+                put(Card.UNKNOWN, R.drawable.ic_unknown);
+            }};
 
     // Based on http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29
     public static final String[] PREFIXES_AMERICAN_EXPRESS = {"34", "37"};
@@ -988,7 +1000,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         }
         return !ModelUtils.hasMonthPassed(expYear, expMonth, now);
     }
-    
+
     private Card(Builder builder) {
         this.number = StripeTextUtils.nullIfBlank(normalizeCardNumber(builder.number));
         this.expMonth = builder.expMonth;

--- a/stripe/src/main/java/com/stripe/android/view/BackUpFieldDeleteListener.java
+++ b/stripe/src/main/java/com/stripe/android/view/BackUpFieldDeleteListener.java
@@ -1,0 +1,29 @@
+package com.stripe.android.view;
+
+/**
+ * Class used to encapsulate the functionality of "backing up" via the delete/backspace key
+ * from one text field to the previous. We use this to simulate multiple fields being all part
+ * of the same EditText, so a delete key entry from field N+1 deletes the last character in
+ * field N. Each BackUpFieldDeleteListener is attached to the N+1 field, from which it gets
+ * its {@link #onDeleteEmpty()} call, and given a reference to the N field, upon which
+ * it will be acting.
+ */
+class BackUpFieldDeleteListener implements StripeEditText.DeleteEmptyListener {
+
+    private StripeEditText backUpTarget;
+
+    BackUpFieldDeleteListener(StripeEditText backUpTarget) {
+        this.backUpTarget = backUpTarget;
+    }
+
+    @Override
+    public void onDeleteEmpty() {
+        String fieldText = backUpTarget.getText().toString();
+        if (fieldText.length() > 1) {
+            backUpTarget.setText(
+                    fieldText.substring(0, fieldText.length() - 1));
+        }
+        backUpTarget.requestFocus();
+        backUpTarget.setSelection(backUpTarget.length());
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardInputListener.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputListener.java
@@ -1,0 +1,61 @@
+package com.stripe.android.view;
+
+import android.support.annotation.StringDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Represents a listener for card input events. Note that events are
+ * not one-time events. For instance, a user can "complete" the CVC many times
+ * by deleting and re-entering the value.
+ */
+public interface CardInputListener {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({
+            FocusField.FOCUS_CARD,
+            FocusField.FOCUS_EXPIRY,
+            FocusField.FOCUS_CVC,
+            FocusField.FOCUS_POSTAL
+    })
+    @interface FocusField {
+        String FOCUS_CARD = "focus_card";
+        String FOCUS_EXPIRY = "focus_expiry";
+        String FOCUS_CVC = "focus_cvc";
+        String FOCUS_POSTAL = "focus_postal";
+    }
+
+    /**
+     * Called whenever the field of focus within the widget changes.
+     *
+     * @param focusField a {@link FocusField} to which the focus has just changed.
+     */
+    void onFocusChange(@FocusField String focusField);
+
+    /**
+     * Called when a potentially valid card number has been completed in the
+     * {@link CardNumberEditText}. May be called multiple times if the user edits
+     * the field.
+     */
+    void onCardComplete();
+
+    /**
+     * Called when a expiration date (one that has not yet passed) has been entered.
+     * May be called multiple times, if the user edits the date.
+     */
+    void onExpirationComplete();
+
+    /**
+     * Called when a potentially valid CVC has been entered. The only verification performed
+     * on the number is that it is the correct length. May be called multiple times, if
+     * the user edits the CVC.
+     */
+    void onCvcComplete();
+
+    /**
+     * Called when a potentially valid postal code or zip code has been entered.
+     * May be called multiple times.
+     */
+    void onPostalCodeComplete();
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -486,10 +486,10 @@ public class CardInputWidget extends LinearLayout {
         });
 
         mExpiryDateEditText.setDeleteEmptyListener(
-                new CardInputWidget.BackUpFieldDeleteListener(mCardNumberEditText));
+                new BackUpFieldDeleteListener(mCardNumberEditText));
 
         mCvcNumberEditText.setDeleteEmptyListener(
-                new CardInputWidget.BackUpFieldDeleteListener(mExpiryDateEditText));
+                new BackUpFieldDeleteListener(mExpiryDateEditText));
 
         mCvcNumberEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
             @Override
@@ -511,7 +511,7 @@ public class CardInputWidget extends LinearLayout {
             @Override
             public void onTextChanged(String text) {
                 if (mCardInputListener != null
-                        && isCvcMaximalLength(mCardNumberEditText.getCardBrand(), text)) {
+                        && ViewUtils.isCvcMaximalLength(mCardNumberEditText.getCardBrand(), text)) {
                     mCardInputListener.onCvcComplete();
                 }
                 updateIconCvc(
@@ -742,7 +742,7 @@ public class CardInputWidget extends LinearLayout {
         if (!cvcHasFocus) {
             return true;
         }
-        return isCvcMaximalLength(brand, cvcText);
+        return ViewUtils.isCvcMaximalLength(brand, cvcText);
     }
 
     @Override
@@ -771,20 +771,6 @@ public class CardInputWidget extends LinearLayout {
                     + mPlacementParameters.dateWidth
                     + mPlacementParameters.dateCvcSeparation;
             setLayoutValues(mPlacementParameters.cvcWidth, cvcMargin, mCvcNumberEditText);
-        }
-    }
-
-    private static boolean isCvcMaximalLength(
-            @NonNull @CardBrand String cardBrand,
-            @Nullable String cvcText) {
-        if (cvcText == null) {
-            return false;
-        }
-
-        if (Card.AMERICAN_EXPRESS.equals(cardBrand)) {
-            return cvcText.length() == CVC_LENGTH_AMERICAN_EXPRESS;
-        } else {
-            return cvcText.length() == CVC_LENGTH_COMMON;
         }
     }
 
@@ -879,37 +865,9 @@ public class CardInputWidget extends LinearLayout {
     }
 
     /**
-     * Class used to encapsulate the functionality of "backing up" via the delete/backspace key
-     * from one text field to the previous. We use this to simulate multiple fields being all part
-     * of the same EditText, so a delete key entry from field N+1 deletes the last character in
-     * field N. Each BackUpFieldDeleteListener is attached to the N+1 field, from which it gets
-     * its {@link #onDeleteEmpty()} call, and given a reference to the N field, upon which
-     * it will be acting.
-     */
-    private class BackUpFieldDeleteListener implements StripeEditText.DeleteEmptyListener {
-
-        private StripeEditText backUpTarget;
-
-        BackUpFieldDeleteListener(StripeEditText backUpTarget) {
-            this.backUpTarget = backUpTarget;
-        }
-
-        @Override
-        public void onDeleteEmpty() {
-            String fieldText = backUpTarget.getText().toString();
-            if (fieldText.length() > 1) {
-                backUpTarget.setText(
-                        fieldText.substring(0, fieldText.length() - 1));
-            }
-            backUpTarget.requestFocus();
-            backUpTarget.setSelection(backUpTarget.length());
-        }
-    }
-
-    /**
      * A data-dump class.
      */
-    class PlacementParameters {
+    static class PlacementParameters {
         int cardWidth;
         int hiddenCardWidth;
         int peekCardWidth;

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -10,7 +10,6 @@ import android.support.annotation.IdRes;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
@@ -30,42 +29,20 @@ import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.StripeTextUtils;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
+import static com.stripe.android.model.Card.BRAND_RESOURCE_MAP;
 import static com.stripe.android.model.Card.CVC_LENGTH_AMERICAN_EXPRESS;
 import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
 import static com.stripe.android.model.Card.CardBrand;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_EXPIRY;
 
 /**
  * A card input widget that handles all animation on its own.
  */
 public class CardInputWidget extends LinearLayout {
-
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({
-            FOCUS_CARD,
-            FOCUS_EXPIRY,
-            FOCUS_CVC
-    })
-    @interface FocusField { }
-    static final String FOCUS_CARD = "focus_card";
-    static final String FOCUS_EXPIRY = "focus_expiry";
-    static final String FOCUS_CVC = "focus_cvc";
-
-    public static final Map<String , Integer> BRAND_RESOURCE_MAP =
-            new HashMap<String , Integer>() {{
-                put(Card.AMERICAN_EXPRESS, R.drawable.ic_amex);
-                put(Card.DINERS_CLUB, R.drawable.ic_diners);
-                put(Card.DISCOVER, R.drawable.ic_discover);
-                put(Card.JCB, R.drawable.ic_jcb);
-                put(Card.MASTERCARD, R.drawable.ic_mastercard);
-                put(Card.VISA, R.drawable.ic_visa);
-                put(Card.UNKNOWN, R.drawable.ic_unknown);
-            }};
 
     static final String LOGGING_TOKEN = "CardInputView";
 
@@ -409,8 +386,8 @@ public class CardInputWidget extends LinearLayout {
                     + mPlacementParameters.cardDateSeparation;
             mPlacementParameters.dateRightTouchBufferLimit =
                     mPlacementParameters.dateStartPosition
-                    + mPlacementParameters.dateWidth
-                    + mPlacementParameters.dateCvcSeparation / 2;
+                            + mPlacementParameters.dateWidth
+                            + mPlacementParameters.dateCvcSeparation / 2;
             mPlacementParameters.cvcStartPosition = mPlacementParameters.dateStartPosition
                     + mPlacementParameters.dateWidth
                     + mPlacementParameters.dateCvcSeparation;
@@ -449,14 +426,14 @@ public class CardInputWidget extends LinearLayout {
         setOrientation(LinearLayout.HORIZONTAL);
         setMinimumWidth(getResources().getDimensionPixelSize(R.dimen.card_widget_min_width));
         mPlacementParameters = new PlacementParameters();
-        mCardIconImageView = (ImageView) findViewById(R.id.iv_card_icon);
-        mCardNumberEditText = (CardNumberEditText) findViewById(R.id.et_card_number);
-        mExpiryDateEditText = (ExpiryDateEditText) findViewById(R.id.et_expiry_date);
-        mCvcNumberEditText = (StripeEditText) findViewById(R.id.et_cvc_number);
+        mCardIconImageView = findViewById(R.id.iv_card_icon);
+        mCardNumberEditText = findViewById(R.id.et_card_number);
+        mExpiryDateEditText = findViewById(R.id.et_expiry_date);
+        mCvcNumberEditText = findViewById(R.id.et_cvc_number);
 
         mCardNumberIsViewed = true;
 
-        mFrameLayout = (FrameLayout) findViewById(R.id.frame_container);
+        mFrameLayout = findViewById(R.id.frame_container);
         mErrorColorInt = mCardNumberEditText.getDefaultErrorColorInt();
         mTintColorInt = mCardNumberEditText.getHintTextColors().getDefaultColor();
         if (attrs != null) {
@@ -680,7 +657,7 @@ public class CardInputWidget extends LinearLayout {
 
         final int dateDestination =
                 mPlacementParameters.peekCardWidth
-                + mPlacementParameters.cardDateSeparation;
+                        + mPlacementParameters.cardDateSeparation;
 
         Animation slideDateRightAnimation = new Animation() {
             @Override
@@ -698,9 +675,9 @@ public class CardInputWidget extends LinearLayout {
 
         final int cvcDestination =
                 mPlacementParameters.peekCardWidth
-                + mPlacementParameters.cardDateSeparation
-                + mPlacementParameters.dateWidth
-                + mPlacementParameters.dateCvcSeparation;
+                        + mPlacementParameters.cardDateSeparation
+                        + mPlacementParameters.dateWidth
+                        + mPlacementParameters.dateCvcSeparation;
         final int cvcStartMargin = cvcDestination + (dateStartMargin - dateDestination);
 
         Animation slideCvcRightAnimation = new Animation() {
@@ -893,41 +870,6 @@ public class CardInputWidget extends LinearLayout {
     }
 
     /**
-     * Represents a listener for card input events. Note that events are
-     * not one-time events. For instance, a user can "complete" the CVC many times
-     * by deleting and re-entering the value.
-     */
-    public interface CardInputListener {
-
-        /**
-         * Called whenever the field of focus within the widget changes.
-         *
-         * @param focusField a {@link FocusField} to which the focus has just changed.
-         */
-        void onFocusChange(@FocusField String focusField);
-
-        /**
-         * Called when a potentially valid card number has been completed in the
-         * {@link CardNumberEditText}. May be called multiple times if the user edits
-         * the field.
-         */
-        void onCardComplete();
-
-        /**
-         * Called when a expiration date (one that has not yet passed) has been entered.
-         * May be called multiple times, if the user edits the date.
-         */
-        void onExpirationComplete();
-
-        /**
-         * Called when a potentially valid CVC has been entered. The only verification performed
-         * on the number is that it is the correct length. May be called multiple times, if
-         * the user edits the CVC.
-         */
-        void onCvcComplete();
-    }
-
-    /**
      * Interface useful for testing calculations without generating real views.
      */
     @VisibleForTesting
@@ -985,22 +927,22 @@ public class CardInputWidget extends LinearLayout {
         public String toString() {
             String touchBufferData = String.format(Locale.ENGLISH,
                     "Touch Buffer Data:\n" +
-                    "CardTouchBufferLimit = %d\n" +
-                    "DateStartPosition = %d\n" +
-                    "DateRightTouchBufferLimit = %d\n" +
-                    "CvcStartPosition = %d",
+                            "CardTouchBufferLimit = %d\n" +
+                            "DateStartPosition = %d\n" +
+                            "DateRightTouchBufferLimit = %d\n" +
+                            "CvcStartPosition = %d",
                     cardTouchBufferLimit,
                     dateStartPosition,
                     dateRightTouchBufferLimit,
                     cvcStartPosition);
             String elementSizeData = String.format(Locale.ENGLISH,
                     "CardWidth = %d\n" +
-                    "HiddenCardWidth = %d\n" +
-                    "PeekCardWidth = %d\n" +
-                    "CardDateSeparation = %d\n" +
-                    "DateWidth = %d\n" +
-                    "DateCvcSeparation = %d\n" +
-                    "CvcWidth = %d\n",
+                            "HiddenCardWidth = %d\n" +
+                            "PeekCardWidth = %d\n" +
+                            "CardDateSeparation = %d\n" +
+                            "DateWidth = %d\n" +
+                            "DateCvcSeparation = %d\n" +
+                            "CvcWidth = %d\n",
                     cardWidth,
                     hiddenCardWidth,
                     peekCardWidth,

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -11,6 +11,7 @@ import android.support.design.widget.TextInputLayout;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -176,6 +177,7 @@ public class CardMultilineWidget extends LinearLayout {
         // This sets the value of mShouldShowPostalCode
         checkAttributeSet(attrs);
 
+
         TextInputLayout cardInputLayout = findViewById(R.id.tl_add_source_card_number_ml);
         TextInputLayout expiryInputLayout = findViewById(R.id.tl_add_source_expiry_ml);
         // We dynamically set the hint of the CVC field, so we need to keep a reference.
@@ -190,8 +192,6 @@ public class CardMultilineWidget extends LinearLayout {
 
         initErrorMessages();
         initFocusChangeListeners();
-
-
         initDeleteEmptyListeners();
 
         mCardNumberEditText.setCardBrandChangeListener(
@@ -258,6 +258,7 @@ public class CardMultilineWidget extends LinearLayout {
                     });
         }
 
+        mCardNumberEditText.updateLengthFilter();
         updateBrand(Card.UNKNOWN);
     }
 
@@ -366,12 +367,14 @@ public class CardMultilineWidget extends LinearLayout {
     private void updateCvc(@NonNull @Card.CardBrand String brand) {
         if (Card.AMERICAN_EXPRESS.equals(brand)) {
             mCvcEditText.setFilters(
-                    new InputFilter[] {new InputFilter.LengthFilter(Card.CVC_LENGTH_COMMON)});
+                    new InputFilter[] {
+                            new InputFilter.LengthFilter(Card.CVC_LENGTH_AMERICAN_EXPRESS)
+                    });
             mCvcTextInputLayout.setHint(getResources().getString(R.string.cvc_amex_hint));
         } else {
             mCvcEditText.setFilters(
                     new InputFilter[] {
-                            new InputFilter.LengthFilter(Card.CVC_LENGTH_AMERICAN_EXPRESS)});
+                            new InputFilter.LengthFilter(Card.CVC_LENGTH_COMMON)});
             mCvcTextInputLayout.setHint(getResources().getString(R.string.cvc_number_hint));
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -11,7 +11,6 @@ import android.support.design.widget.TextInputLayout;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -173,7 +172,7 @@ public class CardMultilineWidget extends LinearLayout {
         mCardNumberEditText = findViewById(R.id.et_add_source_card_number_ml);
         mExpiryDateEditText = findViewById(R.id.et_add_source_expiry_ml);
         mCvcEditText = findViewById(R.id.et_add_source_cvc_ml);
-        mPostalCodeEditText = findViewById(R.id.et_add_source_zip_ml);
+        mPostalCodeEditText = findViewById(R.id.et_add_source_postal_ml);
         mTintColorInt = mCardNumberEditText.getHintTextColors().getDefaultColor();
 
         // This sets the value of mShouldShowPostalCode
@@ -184,7 +183,7 @@ public class CardMultilineWidget extends LinearLayout {
         TextInputLayout expiryInputLayout = findViewById(R.id.tl_add_source_expiry_ml);
         // We dynamically set the hint of the CVC field, so we need to keep a reference.
         mCvcTextInputLayout = findViewById(R.id.tl_add_source_cvc_ml);
-        TextInputLayout postalInputLayout = findViewById(R.id.tl_add_source_zip_ml);
+        TextInputLayout postalInputLayout = findViewById(R.id.tl_add_source_postal_ml);
 
         initTextInputLayoutErrorHandlers(
                 cardInputLayout,

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -1,0 +1,367 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.design.widget.TextInputLayout;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.text.InputFilter;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import com.stripe.android.R;
+import com.stripe.android.model.Card;
+import com.stripe.android.CardUtils;
+
+import static com.stripe.android.model.Card.BRAND_RESOURCE_MAP;
+import static com.stripe.android.model.Card.CVC_LENGTH_AMERICAN_EXPRESS;
+import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_EXPIRY;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_POSTAL;
+
+public class CardMultilineWidget extends LinearLayout {
+
+    static final String CARD_MULTILINE_TOKEN = "CardMultilineView";
+
+    private @Nullable CardInputListener mCardInputListener;
+    private CardNumberEditText mCardNumberEditText;
+    private ExpiryDateEditText mExpiryDateEditText;
+    private StripeEditText mCvcEditText;
+    private StripeEditText mPostalCodeEditText;
+    private TextInputLayout mCvcTextInputLayout;
+
+    private boolean mShouldShowPostalCode = true;
+    private @Card.CardBrand String mCardBrand;
+    private @ColorInt int mTintColorInt;
+
+    public CardMultilineWidget(Context context) {
+        super(context);
+        initView(null);
+    }
+
+    public CardMultilineWidget(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initView(attrs);
+    }
+
+    public CardMultilineWidget(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initView(attrs);
+    }
+
+    /**
+     * @param cardInputListener A {@link CardInputListener} to be notified of changes
+     *                          to the user's focused field
+     */
+    public void setCardInputListener(@Nullable CardInputListener cardInputListener) {
+        mCardInputListener = cardInputListener;
+    }
+
+    /**
+     * Gets a {@link Card} object from the user input, if all fields are valid. If not, returns
+     * {@code null}.
+     *
+     * @return a valid {@link Card} object based on user input, or {@code null} if any field is
+     * invalid
+     */
+    @Nullable
+    public Card getCard() {
+        String cardNumber = mCardNumberEditText.getCardNumber();
+        int[] cardDate = mExpiryDateEditText.getValidDateFields();
+        if (cardNumber == null || cardDate == null || cardDate.length != 2) {
+            return null;
+        }
+
+        String cvcValue = mCvcEditText.getText().toString();
+        if (validateAllFields()) {
+            Card card = new Card(cardNumber, cardDate[0], cardDate[1], cvcValue);
+            if (mShouldShowPostalCode) {
+                card.setAddressZip(mPostalCodeEditText.getText().toString());
+            }
+            return card.addLoggingToken(CARD_MULTILINE_TOKEN);
+        }
+
+        return null;
+    }
+
+    /**
+     * Validates all fields and shows error messages if appropriate.
+     */
+    public boolean validateAllFields() {
+        mCardNumberEditText.setShouldShowError(
+                !CardUtils.isValidCardNumber(mCardNumberEditText.getCardNumber()));
+        mExpiryDateEditText.setShouldShowError(
+                mExpiryDateEditText.getValidDateFields() == null ||
+                        !mExpiryDateEditText.isDateValid());
+        mCvcEditText.setShouldShowError(!isCvcMaximalLength(mCardBrand,
+                mCvcEditText.getText().toString()));
+        boolean postalCodeIsValidOrGone;
+        if (mShouldShowPostalCode) {
+            mPostalCodeEditText.setShouldShowError(!isPostalCodeMaximalLength(true,
+                    mPostalCodeEditText.getText().toString()));
+            postalCodeIsValidOrGone = mPostalCodeEditText.getShouldShowError();
+        } else {
+            postalCodeIsValidOrGone = true;
+        }
+
+        return !mCardNumberEditText.getShouldShowError()
+                && !mExpiryDateEditText.getShouldShowError()
+                && !mCvcEditText.getShouldShowError()
+                && postalCodeIsValidOrGone;
+    }
+
+    void initView(AttributeSet attrs) {
+        setOrientation(VERTICAL);
+        inflate(getContext(), R.layout.card_multiline_widget, this);
+
+        mShouldShowPostalCode = true;
+        mCardNumberEditText = findViewById(R.id.et_add_source_card_number_ml);
+        mExpiryDateEditText = findViewById(R.id.et_add_source_expiry_ml);
+        mCvcEditText = findViewById(R.id.et_add_source_cvc_ml);
+        mPostalCodeEditText = findViewById(R.id.et_add_source_zip_ml);
+        mTintColorInt = mCardNumberEditText.getHintTextColors().getDefaultColor();
+
+        TextInputLayout cardInputLayout = findViewById(R.id.tl_add_source_card_number_ml);
+        TextInputLayout expiryInputLayout = findViewById(R.id.tl_add_source_expiry_ml);
+        mCvcTextInputLayout = findViewById(R.id.tl_add_source_cvc_ml);
+        TextInputLayout postalInputLayout = findViewById(R.id.tl_add_source_zip_ml);
+
+        mCardNumberEditText.setErrorMessage(getContext().getString(R.string.invalid_card_number));
+        mExpiryDateEditText.setErrorMessage(getContext().getString(R.string.invalid_expiry_year));
+        mCvcEditText.setErrorMessage(getContext().getString(R.string.invalid_cvc));
+        mPostalCodeEditText.setErrorMessage(getContext().getString(R.string.invalid_zip));
+
+        mCardNumberEditText.setErrorMessageListener(new ErrorListener(cardInputLayout));
+        mCardNumberEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    if (mCardInputListener != null) {
+                        mCardInputListener.onFocusChange(FOCUS_CARD);
+                    }
+                }
+            }
+        });
+
+        mExpiryDateEditText.setErrorMessageListener(new ErrorListener(expiryInputLayout));
+        mExpiryDateEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    if (mCardInputListener != null) {
+                        mCardInputListener.onFocusChange(FOCUS_EXPIRY);
+                    }
+                }
+            }
+        });
+
+        mCvcEditText.setErrorMessageListener(new ErrorListener(mCvcTextInputLayout));
+        mCvcEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    if (mCardInputListener != null) {
+                        mCardInputListener.onFocusChange(FOCUS_CVC);
+                    }
+                }
+            }
+        });
+
+        mPostalCodeEditText.setErrorMessageListener(new ErrorListener(postalInputLayout));
+        mPostalCodeEditText.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    if (mCardInputListener != null) {
+                        mCardInputListener.onFocusChange(FOCUS_POSTAL);
+                    }
+                }
+            }
+        });
+
+        mExpiryDateEditText.setDeleteEmptyListener(
+                new BackUpFieldDeleteListener(mCardNumberEditText));
+
+        mCvcEditText.setDeleteEmptyListener(
+                new BackUpFieldDeleteListener(mExpiryDateEditText));
+
+        mPostalCodeEditText.setDeleteEmptyListener(
+                new BackUpFieldDeleteListener(mCvcEditText));
+
+        mCardNumberEditText.setCardBrandChangeListener(
+                new CardNumberEditText.CardBrandChangeListener() {
+                    @Override
+                    public void onCardBrandChanged(@NonNull @Card.CardBrand String brand) {
+                        updateBrand(brand);
+                    }
+                });
+
+        mCardNumberEditText.setCardNumberCompleteListener(
+                new CardNumberEditText.CardNumberCompleteListener() {
+                    @Override
+                    public void onCardNumberComplete() {
+                        mExpiryDateEditText.requestFocus();
+                        if (mCardInputListener != null) {
+                            mCardInputListener.onCardComplete();
+                        }
+                    }
+                });
+
+        mExpiryDateEditText.setExpiryDateEditListener(
+                new ExpiryDateEditText.ExpiryDateEditListener() {
+                    @Override
+                    public void onExpiryDateComplete() {
+                        mCvcEditText.requestFocus();
+                        if (mCardInputListener != null) {
+                            mCardInputListener.onExpirationComplete();
+                        }
+                    }
+                });
+
+        mCvcEditText.setAfterTextChangedListener(
+                new StripeEditText.AfterTextChangedListener() {
+                    @Override
+                    public void onTextChanged(String text) {
+                        if (isCvcMaximalLength(mCardBrand, text)) {
+                            mPostalCodeEditText.requestFocus();
+                            if (mCardInputListener != null) {
+                                mCardInputListener.onCvcComplete();
+                            }
+                        }
+                        mCvcEditText.setShouldShowError(false);
+                    }
+                });
+
+        adjustViewForPostalCodeAttribute(postalInputLayout);
+
+
+        mPostalCodeEditText.setAfterTextChangedListener(
+                new StripeEditText.AfterTextChangedListener() {
+                    @Override
+                    public void onTextChanged(String text) {
+                        if (isPostalCodeMaximalLength(true, text) && mCardInputListener != null) {
+                            mCardInputListener.onPostalCodeComplete();
+                        }
+                        mPostalCodeEditText.setShouldShowError(false);
+                    }
+                });
+
+        updateBrand(Card.UNKNOWN);
+    }
+
+    void adjustViewForPostalCodeAttribute(@NonNull TextInputLayout postalInputLayout) {
+        if (!mShouldShowPostalCode) {
+            mCvcEditText.setNextFocusForwardId(NO_ID);
+            mCvcEditText.setNextFocusDownId(NO_ID);
+            postalInputLayout.setVisibility(View.GONE);
+            LinearLayout secondRowLayout = findViewById(R.id.second_row_layout);
+            secondRowLayout.removeView(postalInputLayout);
+            LinearLayout.LayoutParams linearParams = (LinearLayout.LayoutParams) mCvcTextInputLayout.getLayoutParams();
+            linearParams.setMargins(0,0,0,0);
+            mCvcTextInputLayout.setLayoutParams(linearParams);
+        }
+    }
+    private static boolean isCvcMaximalLength(
+            @NonNull @Card.CardBrand String cardBrand,
+            @Nullable String cvcText) {
+        if (cvcText == null) {
+            return false;
+        }
+
+        if (Card.AMERICAN_EXPRESS.equals(cardBrand)) {
+            return cvcText.length() == CVC_LENGTH_AMERICAN_EXPRESS;
+        } else {
+            return cvcText.length() == CVC_LENGTH_COMMON;
+        }
+    }
+
+    private static boolean isPostalCodeMaximalLength(boolean isZip, @Nullable String text) {
+        return isZip && text != null && text.length() == 5;
+    }
+
+    private void updateBrand(@NonNull @Card.CardBrand String brand) {
+        mCardBrand = brand;
+        updateCvc(mCardBrand);
+
+        int iconPadding = mCardNumberEditText.getCompoundDrawablePadding();
+        Drawable[] drawables = mCardNumberEditText.getCompoundDrawables();
+        Drawable original = drawables[0];
+        if (original == null) {
+            return;
+        }
+
+        Drawable icon = getResources().getDrawable(BRAND_RESOURCE_MAP.get(brand));
+        icon.setBounds(original.copyBounds());
+        Drawable compatIcon = DrawableCompat.wrap(icon);
+        if (Card.UNKNOWN.equals(brand)) {
+            DrawableCompat.setTint(compatIcon.mutate(), mTintColorInt);
+        }
+
+        mCardNumberEditText.setCompoundDrawablePadding(iconPadding);
+        mCardNumberEditText.setCompoundDrawables(compatIcon, null, null, null);
+    }
+
+    private void updateCvc(@NonNull @Card.CardBrand String brand) {
+        if (Card.AMERICAN_EXPRESS.equals(brand)) {
+            mCvcEditText.setFilters(
+                    new InputFilter[] {new InputFilter.LengthFilter(Card.CVC_LENGTH_COMMON)});
+            mCvcTextInputLayout.setHint(getResources().getString(R.string.cvc_amex_hint));
+        } else {
+            mCvcEditText.setFilters(
+                    new InputFilter[] {
+                            new InputFilter.LengthFilter(Card.CVC_LENGTH_AMERICAN_EXPRESS)});
+            mCvcTextInputLayout.setHint(getResources().getString(R.string.cvc_number_hint));
+        }
+    }
+
+    /**
+     * Class used to encapsulate the functionality of "backing up" via the delete/backspace key
+     * from one text field to the previous. We use this to simulate multiple fields being all part
+     * of the same EditText, so a delete key entry from field N+1 deletes the last character in
+     * field N. Each BackUpFieldDeleteListener is attached to the N+1 field, from which it gets
+     * its {@link #onDeleteEmpty()} call, and given a reference to the N field, upon which
+     * it will be acting.
+     */
+    private class BackUpFieldDeleteListener implements StripeEditText.DeleteEmptyListener {
+
+        private StripeEditText backUpTarget;
+
+        BackUpFieldDeleteListener(StripeEditText backUpTarget) {
+            this.backUpTarget = backUpTarget;
+        }
+
+        @Override
+        public void onDeleteEmpty() {
+            String fieldText = backUpTarget.getText().toString();
+            if (fieldText.length() > 1) {
+                backUpTarget.setText(
+                        fieldText.substring(0, fieldText.length() - 1));
+            }
+            backUpTarget.requestFocus();
+            backUpTarget.setSelection(backUpTarget.length());
+        }
+    }
+
+    private class ErrorListener implements StripeEditText.ErrorMessageListener {
+
+        TextInputLayout textInputLayout;
+
+        ErrorListener(TextInputLayout textInputLayout) {
+            this.textInputLayout = textInputLayout;
+        }
+
+        @Override
+        public void displayErrorMessage(@Nullable String message) {
+            if (message == null) {
+                textInputLayout.setErrorEnabled(false);
+            } else {
+                textInputLayout.setError(message);
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -107,13 +107,15 @@ public class CardMultilineWidget extends LinearLayout {
      * @return {@code true} if all shown fields are valid, {@code false} otherwise
      */
     public boolean validateAllFields() {
-        mCardNumberEditText.setShouldShowError(
-                !CardUtils.isValidCardNumber(mCardNumberEditText.getCardNumber()));
-        mExpiryDateEditText.setShouldShowError(
-                mExpiryDateEditText.getValidDateFields() == null ||
-                        !mExpiryDateEditText.isDateValid());
-        mCvcEditText.setShouldShowError(!ViewUtils.isCvcMaximalLength(mCardBrand,
-                mCvcEditText.getText().toString()));
+        boolean cardNumberIsValid =
+                CardUtils.isValidCardNumber(mCardNumberEditText.getCardNumber());
+        boolean expiryIsValid = mExpiryDateEditText.getValidDateFields() != null &&
+                mExpiryDateEditText.isDateValid();
+        boolean cvcIsValid = ViewUtils.isCvcMaximalLength(
+                mCardBrand, mCvcEditText.getText().toString());
+        mCardNumberEditText.setShouldShowError(!cardNumberIsValid);
+        mExpiryDateEditText.setShouldShowError(!expiryIsValid);
+        mCvcEditText.setShouldShowError(!cvcIsValid);
         boolean postalCodeIsValidOrGone;
         if (mShouldShowPostalCode) {
             postalCodeIsValidOrGone = isPostalCodeMaximalLength(true,
@@ -123,9 +125,9 @@ public class CardMultilineWidget extends LinearLayout {
             postalCodeIsValidOrGone = true;
         }
 
-        return !mCardNumberEditText.getShouldShowError()
-                && !mExpiryDateEditText.getShouldShowError()
-                && !mCvcEditText.getShouldShowError()
+        return cardNumberIsValid
+                && expiryIsValid
+                && cvcIsValid
                 && postalCodeIsValidOrGone;
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -8,6 +8,7 @@ import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.widget.EditText;
 
 import com.stripe.android.model.Card;
@@ -100,6 +101,10 @@ public class CardNumberEditText extends StripeEditText {
         // Immediately display the brand if known, in case this method is invoked when
         // partial data already exists.
         mCardBrandChangeListener.onCardBrandChanged(mCardBrand);
+    }
+
+    void updateLengthFilter() {
+        setFilters(new InputFilter[] {new InputFilter.LengthFilter(mLengthMax)});
     }
 
     /**
@@ -236,7 +241,7 @@ public class CardNumberEditText extends StripeEditText {
             return;
         }
 
-        setFilters(new InputFilter[] {new InputFilter.LengthFilter(mLengthMax)});
+        updateLengthFilter();
     }
 
     private void updateCardBrandFromNumber(String partialNumber) {

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -8,7 +8,6 @@ import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.widget.EditText;
 
 import com.stripe.android.model.Card;

--- a/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
+++ b/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
@@ -13,20 +13,20 @@ import java.lang.reflect.Method;
  * a DrawableLeft, instead of just straight up beside it. If the Support Libraries ever
  * officially support this behavior, this class should be removed to avoid Reflection.
  */
-class IconTextInputLayout extends TextInputLayout {
+public class IconTextInputLayout extends TextInputLayout {
     private Object mCollapsingTextHelper;
     private Rect mBounds;
     private Method mRecalculateMethod;
 
-    IconTextInputLayout(Context context) {
+    public IconTextInputLayout(Context context) {
         this(context, null);
     }
 
-    IconTextInputLayout(Context context, AttributeSet attrs) {
+    public IconTextInputLayout(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
     }
 
-    IconTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+    public IconTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init();
     }
@@ -39,6 +39,10 @@ class IconTextInputLayout extends TextInputLayout {
     }
 
     private void init() {
+        int x = 5;
+        if (x == 5) {
+            return;
+        }
         try {
             Field textHeaderField = TextInputLayout.class.getDeclaredField("mCollapsingTextHelper");
             textHeaderField.setAccessible(true);

--- a/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
+++ b/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
@@ -1,0 +1,74 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.support.design.widget.TextInputLayout;
+import android.util.AttributeSet;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * This class uses Reflection to make the Support Library's floating hint text move above
+ * a DrawableLeft, instead of just straight up beside it. If the Support Libraries ever
+ * officially support this behavior, this class should be removed to avoid Reflection.
+ */
+class IconTextInputLayout extends TextInputLayout {
+    private Object mCollapsingTextHelper;
+    private Rect mBounds;
+    private Method mRecalculateMethod;
+
+    IconTextInputLayout(Context context) {
+        this(context, null);
+    }
+
+    IconTextInputLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    IconTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        adjustBounds();
+    }
+
+    private void init() {
+        try {
+            Field textHeaderField = TextInputLayout.class.getDeclaredField("mCollapsingTextHelper");
+            textHeaderField.setAccessible(true);
+            mCollapsingTextHelper = textHeaderField.get(this);
+
+            Field boundsField = mCollapsingTextHelper.getClass().getDeclaredField("mCollapsedBounds");
+            boundsField.setAccessible(true);
+            mBounds = (Rect) boundsField.get(mCollapsingTextHelper);
+
+            mRecalculateMethod = mCollapsingTextHelper.getClass().getDeclaredMethod("recalculate");
+
+        } catch (Exception e) {
+            mCollapsingTextHelper = null;
+            mBounds = null;
+            mRecalculateMethod = null;
+            e.printStackTrace();
+        }
+    }
+
+    private void adjustBounds() {
+        if (mCollapsingTextHelper == null || getEditText() == null) {
+            return;
+        }
+
+        try {
+            mBounds.left = getEditText().getLeft() + getEditText().getPaddingLeft();
+            mRecalculateMethod.invoke(mCollapsingTextHelper);
+        }
+        catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -1,13 +1,31 @@
 package com.stripe.android.view;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.stripe.android.model.Card;
+
+import static com.stripe.android.model.Card.CVC_LENGTH_AMERICAN_EXPRESS;
+import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
 
 /**
  * Static utility functions needed for View classes.
  */
 class ViewUtils {
+
+    static boolean isCvcMaximalLength(
+            @NonNull @Card.CardBrand String cardBrand,
+            @Nullable String cvcText) {
+        if (cvcText == null) {
+            return false;
+        }
+
+        if (Card.AMERICAN_EXPRESS.equals(cardBrand)) {
+            return cvcText.length() == CVC_LENGTH_AMERICAN_EXPRESS;
+        } else {
+            return cvcText.length() == CVC_LENGTH_COMMON;
+        }
+    }
 
     /**
      * Separates a card number according to the brand requirements, including prefixes of card

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -21,9 +21,9 @@ class ViewUtils {
         }
 
         if (Card.AMERICAN_EXPRESS.equals(cardBrand)) {
-            return cvcText.length() == CVC_LENGTH_AMERICAN_EXPRESS;
+            return cvcText.trim().length() == CVC_LENGTH_AMERICAN_EXPRESS;
         } else {
-            return cvcText.length() == CVC_LENGTH_COMMON;
+            return cvcText.trim().length() == CVC_LENGTH_COMMON;
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -13,7 +13,7 @@ import com.stripe.android.model.SourceCardData;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.SourceSepaDebitData;
 import com.stripe.android.model.Token;
-import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.testharness.JsonTestUtils;
 
 import org.junit.Before;

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -12,7 +12,7 @@ import org.robolectric.annotation.Config;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/stripe/src/test/java/com/stripe/android/testharness/TestFocusChangeListener.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestFocusChangeListener.java
@@ -1,0 +1,37 @@
+package com.stripe.android.testharness;
+
+import android.support.annotation.IdRes;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+/**
+ * Test class that listens for global focus changes and stores the transition.
+ */
+public class TestFocusChangeListener implements ViewTreeObserver.OnGlobalFocusChangeListener {
+    private View mOldFocus;
+    private View mNewFocus;
+
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        mOldFocus = oldFocus;
+        mNewFocus = newFocus;
+    }
+
+    @IdRes
+    public int getOldFocusId() {
+        return mOldFocus.getId();
+    }
+
+    @IdRes
+    public int getNewFocusId() {
+        return mNewFocus.getId();
+    }
+
+    public boolean hasOldFocus() {
+        return mOldFocus != null;
+    }
+
+    public boolean hasNewFocus() {
+        return mNewFocus != null;
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardInputTestActivity.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputTestActivity.java
@@ -1,20 +1,16 @@
-package com.stripe.android.testharness;
+package com.stripe.android.view;
 
-import android.app.Activity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.widget.LinearLayout;
 
 import com.stripe.android.R;
-import com.stripe.android.view.CardInputWidget;
-import com.stripe.android.view.CardNumberEditText;
-import com.stripe.android.view.StripeEditText;
-import com.stripe.android.view.ExpiryDateEditText;
 
 /**
  * Activity used to test UI components. We add the layout programmatically to avoid needing test
  * resource files.
  */
-public class CardInputTestActivity extends Activity {
+public class CardInputTestActivity extends AppCompatActivity {
 
     public static final String VALID_AMEX_NO_SPACES = "378282246310005";
     public static final String VALID_AMEX_WITH_SPACES = "3782 822463 10005";
@@ -24,14 +20,21 @@ public class CardInputTestActivity extends Activity {
     public static final String VALID_VISA_WITH_SPACES = "4242 4242 4242 4242";
 
     private CardInputWidget mCardInputWidget;
+    private CardMultilineWidget mCardMultilineWidget;
+    private CardMultilineWidget mNoZipCardMulitlineWidget;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        setTheme(R.style.Theme_AppCompat);
         mCardInputWidget = new CardInputWidget(this);
+        mCardMultilineWidget = new CardMultilineWidget(this, true);
+        mNoZipCardMulitlineWidget = new CardMultilineWidget(this, false);
         LinearLayout linearLayout = new LinearLayout(this);
         linearLayout.addView(mCardInputWidget);
+        linearLayout.addView(mCardMultilineWidget);
+        linearLayout.addView(mNoZipCardMulitlineWidget);
         setContentView(linearLayout);
     }
 
@@ -49,5 +52,13 @@ public class CardInputTestActivity extends Activity {
 
     public CardInputWidget getCardInputWidget() {
         return mCardInputWidget;
+    }
+
+    public CardMultilineWidget getCardMultilineWidget() {
+        return mCardMultilineWidget;
+    }
+
+    public CardMultilineWidget getNoZipCardMulitlineWidget() {
+        return mNoZipCardMulitlineWidget;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verify;
 public class CardInputWidgetTest {
 
     // Every Card made by the CardInputView should have the card widget token.
-    private static final String[] EXPECTED_LOGGING_ARRAY = { LOGGING_TOKEN };
+    private static final String[] EXPECTED_LOGGING_ARRAY = {LOGGING_TOKEN};
     private CardInputWidget mCardInputWidget;
     private CardNumberEditText mCardNumberEditText;
     private ImageView mIconView;
@@ -64,7 +64,8 @@ public class CardInputWidgetTest {
 
     private CardInputWidget.DimensionOverrideSettings mDimensionOverrides;
 
-    @Mock CardInputListener mCardInputListener;
+    @Mock
+    CardInputListener mCardInputListener;
 
     @Before
     public void setup() {

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -26,8 +26,12 @@ import org.robolectric.util.ActivityController;
 
 import java.util.Calendar;
 
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
 import static com.stripe.android.view.CardInputWidget.LOGGING_TOKEN;
 import static com.stripe.android.view.CardInputWidget.shouldIconShowBrand;
+
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_EXPIRY;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_NO_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
 import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
@@ -65,7 +69,7 @@ public class CardInputWidgetTest {
 
     private CardInputWidget.DimensionOverrideSettings mDimensionOverrides;
 
-    @Mock CardInputWidget.CardInputListener mCardInputListener;
+    @Mock CardInputListener mCardInputListener;
 
     @Before
     public void setup() {
@@ -256,7 +260,7 @@ public class CardInputWidgetTest {
         mCardNumberEditText.setText(VALID_VISA_WITH_SPACES);
 
         verify(mCardInputListener, times(1)).onCardComplete();
-        verify(mCardInputListener, times(1)).onFocusChange(CardInputWidget.FOCUS_EXPIRY);
+        verify(mCardInputListener, times(1)).onFocusChange(FOCUS_EXPIRY);
         assertEquals(R.id.et_card_number, mOnGlobalFocusChangeListener.getOldFocusId());
         assertEquals(R.id.et_expiry_date, mOnGlobalFocusChangeListener.getNewFocusId());
     }
@@ -271,7 +275,7 @@ public class CardInputWidgetTest {
         reset(mCardInputListener);
 
         ViewTestUtils.sendDeleteKeyEvent(mExpiryEditText);
-        verify(mCardInputListener, times(1)).onFocusChange(CardInputWidget.FOCUS_CARD);
+        verify(mCardInputListener, times(1)).onFocusChange(FOCUS_CARD);
         assertEquals(R.id.et_expiry_date, mOnGlobalFocusChangeListener.getOldFocusId());
         assertEquals(R.id.et_card_number, mOnGlobalFocusChangeListener.getNewFocusId());
 
@@ -301,20 +305,20 @@ public class CardInputWidgetTest {
         mCardNumberEditText.setText(VALID_VISA_WITH_SPACES);
 
         verify(mCardInputListener).onCardComplete();
-        verify(mCardInputListener).onFocusChange(CardInputWidget.FOCUS_EXPIRY);
+        verify(mCardInputListener).onFocusChange(FOCUS_EXPIRY);
 
         mExpiryEditText.append("12");
         mExpiryEditText.append("79");
 
         verify(mCardInputListener).onExpirationComplete();
-        verify(mCardInputListener).onFocusChange(CardInputWidget.FOCUS_CVC);
+        verify(mCardInputListener).onFocusChange(FOCUS_CVC);
         assertTrue(mCvcEditText.hasFocus());
 
         // Clearing already-verified data.
         reset(mCardInputListener);
 
         ViewTestUtils.sendDeleteKeyEvent(mCvcEditText);
-        verify(mCardInputListener).onFocusChange(CardInputWidget.FOCUS_EXPIRY);
+        verify(mCardInputListener).onFocusChange(FOCUS_EXPIRY);
         assertEquals(R.id.et_cvc_number, mOnGlobalFocusChangeListener.getOldFocusId());
         assertEquals(R.id.et_expiry_date, mOnGlobalFocusChangeListener.getNewFocusId());
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -1,17 +1,14 @@
 package com.stripe.android.view;
 
-import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
-import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.EditText;
 import android.widget.ImageView;
 
 import com.stripe.android.BuildConfig;
 import com.stripe.android.R;
 import com.stripe.android.model.Card;
-import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.testharness.TestFocusChangeListener;
 import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
@@ -21,8 +18,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.util.ActivityController;
 
 import java.util.Calendar;
 
@@ -32,12 +29,12 @@ import static com.stripe.android.view.CardInputWidget.LOGGING_TOKEN;
 import static com.stripe.android.view.CardInputWidget.shouldIconShowBrand;
 
 import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_EXPIRY;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_WITH_SPACES;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -50,12 +47,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * Test class for {@link CardInputWidget}. Note that we have to test against SDK 22
- * because of a <a href="https://github.com/robolectric/robolectric/issues/1932">known issue</a> in
- * Robolectric.
+ * Test class for {@link CardInputWidget}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 22)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class CardInputWidgetTest {
 
     // Every Card made by the CardInputView should have the card widget token.
@@ -74,7 +69,7 @@ public class CardInputWidgetTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController activityController =
+        ActivityController<CardInputTestActivity> activityController =
                 Robolectric.buildActivity(CardInputTestActivity.class)
                         .create().start();
 
@@ -92,19 +87,18 @@ public class CardInputWidgetTest {
             }
         };
 
-        mCardInputWidget = ((CardInputTestActivity) activityController.get()).getCardInputWidget();
+        mCardInputWidget = activityController.get().getCardInputWidget();
         mCardInputWidget.setDimensionOverrideSettings(mDimensionOverrides);
         mOnGlobalFocusChangeListener = new TestFocusChangeListener();
         mCardInputWidget.getViewTreeObserver()
                 .addOnGlobalFocusChangeListener(mOnGlobalFocusChangeListener);
 
-        mCardNumberEditText =
-                ((CardInputTestActivity) activityController.get()).getCardNumberEditText();
+        mCardNumberEditText = activityController.get().getCardNumberEditText();
         mCardNumberEditText.setText("");
 
-        mExpiryEditText = (StripeEditText) mCardInputWidget.findViewById(R.id.et_expiry_date);
-        mCvcEditText = (StripeEditText) mCardInputWidget.findViewById(R.id.et_cvc_number);
-        mIconView = (ImageView) mCardInputWidget.findViewById(R.id.iv_card_icon);
+        mExpiryEditText = mCardInputWidget.findViewById(R.id.et_expiry_date);
+        mCvcEditText = mCardInputWidget.findViewById(R.id.et_cvc_number);
+        mIconView = mCardInputWidget.findViewById(R.id.iv_card_icon);
 
         // Set the width of the icon and its margin so that test calculations have
         // an expected value that is repeatable on all systems.
@@ -704,34 +698,5 @@ public class CardInputWidgetTest {
         assertTrue(shouldIconShowBrand(Card.MASTERCARD, true, "919"));
         assertTrue(shouldIconShowBrand(Card.DINERS_CLUB, true, "415"));
         assertTrue(shouldIconShowBrand(Card.UNKNOWN, true, "212"));
-    }
-
-    class TestFocusChangeListener implements ViewTreeObserver.OnGlobalFocusChangeListener {
-        View mOldFocus;
-        View mNewFocus;
-
-        @Override
-        public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-            mOldFocus = oldFocus;
-            mNewFocus = newFocus;
-        }
-
-        @IdRes
-        int getOldFocusId() {
-            return mOldFocus.getId();
-        }
-
-        @IdRes
-        int getNewFocusId() {
-            return mNewFocus.getId();
-        }
-
-        boolean hasOldFocus() {
-            return mOldFocus != null;
-        }
-
-        boolean hasNewFocus() {
-            return mNewFocus != null;
-        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
@@ -328,7 +328,7 @@ public class CardMultilineWidgetTest {
             cardNumberEditText = parentWidget.findViewById(R.id.et_add_source_card_number_ml);
             expiryDateEditText = parentWidget.findViewById(R.id.et_add_source_expiry_ml);
             cvcEditText = parentWidget.findViewById(R.id.et_add_source_cvc_ml);
-            postalCodeEditText = parentWidget.findViewById(R.id.et_add_source_zip_ml);
+            postalCodeEditText = parentWidget.findViewById(R.id.et_add_source_postal_ml);
             secondRowLayout = parentWidget.findViewById(R.id.second_row_layout);
         }
     }

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
@@ -1,0 +1,335 @@
+package com.stripe.android.view;
+
+import android.support.annotation.NonNull;
+import android.widget.LinearLayout;
+
+import com.stripe.android.R;
+import com.stripe.android.BuildConfig;
+import com.stripe.android.model.Card;
+import com.stripe.android.testharness.ViewTestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import java.util.Calendar;
+
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_EXPIRY;
+import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_POSTAL;
+import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_WITH_SPACES;
+import static com.stripe.android.view.CardMultilineWidget.CARD_MULTILINE_TOKEN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class for {@link CardMultilineWidget}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 25)
+public class CardMultilineWidgetTest {
+
+    // Every Card made by the CardInputView should have the card widget token.
+    private static final String[] EXPECTED_LOGGING_ARRAY = { CARD_MULTILINE_TOKEN };
+
+    private CardMultilineWidget mCardMultilineWidget;
+    private CardMultilineWidget mNoZipCardMultilineWidget;
+    private WidgetControlGroup mFullGroup;
+    private WidgetControlGroup mNoZipGroup;
+
+    @Mock CardInputListener mFullCardListener;
+    @Mock CardInputListener mNoZipCardListener;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        ActivityController<CardInputTestActivity> activityController =
+                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
+        mCardMultilineWidget = activityController.get().getCardMultilineWidget();
+        mFullGroup = new WidgetControlGroup(mCardMultilineWidget);
+
+        mNoZipCardMultilineWidget = activityController.get().getNoZipCardMulitlineWidget();
+        mNoZipGroup = new WidgetControlGroup(mNoZipCardMultilineWidget);
+
+        mFullGroup.cardNumberEditText.setText("");
+    }
+
+    @Test
+    public void testExistence() {
+        assertNotNull(mCardMultilineWidget);
+        assertNotNull(mFullGroup.cardNumberEditText);
+        assertNotNull(mFullGroup.expiryDateEditText);
+        assertNotNull(mFullGroup.cvcEditText);
+        assertNotNull(mFullGroup.postalCodeEditText);
+        assertNotNull(mFullGroup.secondRowLayout);
+
+        assertNotNull(mNoZipCardMultilineWidget);
+        assertNotNull(mNoZipGroup.cardNumberEditText);
+        assertNotNull(mNoZipGroup.expiryDateEditText);
+        assertNotNull(mNoZipGroup.cvcEditText);
+        // The No ZIP Group will get eliminated because its layout loses the reference
+        assertNull(mNoZipGroup.postalCodeEditText);
+        assertNotNull(mNoZipGroup.secondRowLayout);
+    }
+
+    @Test
+    public void getCard_whenInputIsValidVisaWithZip_returnsCardObjectWithLoggingToken() {
+        // The input date here will be invalid after 2050. Please update the test.
+        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
+
+        mFullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+        mFullGroup.cvcEditText.append("123");
+        mFullGroup.postalCodeEditText.append("12345");
+
+        Card card = mCardMultilineWidget.getCard();
+        assertNotNull(card);
+        assertEquals(VALID_VISA_NO_SPACES, card.getNumber());
+        assertNotNull(card.getExpMonth());
+        assertNotNull(card.getExpYear());
+        assertEquals(12, card.getExpMonth().intValue());
+        assertEquals(2050, card.getExpYear().intValue());
+        assertEquals("123", card.getCVC());
+        assertEquals("12345", card.getAddressZip());
+        assertTrue(card.validateCard());
+        assertArrayEquals(EXPECTED_LOGGING_ARRAY, card.getLoggingTokens().toArray());
+    }
+
+    @Test
+    public void isPostalCodeMaximalLength_whenZipEnteredAndIsMaximalLength_returnsTrue() {
+        assertTrue(CardMultilineWidget.isPostalCodeMaximalLength(true, "12345"));
+    }
+
+    @Test
+    public void isPostalCodeMaximalLength_whenZipEnteredAndIsNotMaximalLength_returnsFalse() {
+        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(true, "123"));
+    }
+
+    @Test
+    public void isPostalCodeMaximalLength_whenZipEnteredAndIsEmpty_returnsFalse() {
+        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(true, ""));
+    }
+
+    @Test
+    public void isPostalCodeMaximalLength_whenZipEnteredAndIsNull_returnsFalse() {
+        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(true, null));
+    }
+
+    /**
+     * This test should change when we allow and validate postal codes outside of the US
+     * in this control.
+     */
+    @Test
+    public void isPostalCodeMaximalLength_whenNotZip_returnsFalse() {
+        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(false, "12345"));
+    }
+
+    @Test
+    public void getCard_whenInputIsValidVisaButInputHasNoZip_returnsNull() {
+        // The input date here will be invalid after 2050. Please update the test.
+        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
+
+        mFullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+        mFullGroup.cvcEditText.append("123");
+
+        Card card = mCardMultilineWidget.getCard();
+        assertNull(card);
+    }
+
+    @Test
+    public void getCard_whenInputIsValidVisaAndNoZipRequired_returnsFullCardAndExpectedLogging() {
+        // The input date here will be invalid after 2050. Please update the test.
+        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
+
+        mNoZipGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        mNoZipGroup.expiryDateEditText.append("12");
+        mNoZipGroup.expiryDateEditText.append("50");
+        mNoZipGroup.cvcEditText.append("123");
+        Card card = mNoZipCardMultilineWidget.getCard();
+        assertNotNull(card);
+        assertEquals(VALID_VISA_NO_SPACES, card.getNumber());
+        assertNotNull(card.getExpMonth());
+        assertNotNull(card.getExpYear());
+        assertEquals(12, card.getExpMonth().intValue());
+        assertEquals(2050, card.getExpYear().intValue());
+        assertEquals("123", card.getCVC());
+        assertNull(card.getAddressZip());
+        assertTrue(card.validateCard());
+        assertArrayEquals(EXPECTED_LOGGING_ARRAY, card.getLoggingTokens().toArray());
+    }
+
+    @Test
+    public void initView_whenZipRequired_secondRowContainsThreeElements() {
+        assertEquals(3, mFullGroup.secondRowLayout.getChildCount());
+    }
+
+    @Test
+    public void initView_whenNoZipRequired_secondRowContainsTwoElements() {
+        assertEquals(2, mNoZipGroup.secondRowLayout.getChildCount());
+    }
+
+    @Test
+    public void onCompleteCardNumber_whenValid_shiftsFocusToExpiryDate() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+        mNoZipCardMultilineWidget.setCardInputListener(mNoZipCardListener);
+
+        mFullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        verify(mFullCardListener, times(1)).onCardComplete();
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_EXPIRY);
+        assertTrue(mFullGroup.expiryDateEditText.hasFocus());
+
+        mNoZipGroup.cardNumberEditText.setText(VALID_AMEX_WITH_SPACES);
+        verify(mNoZipCardListener, times(1)).onCardComplete();
+        verify(mNoZipCardListener, times(1)).onFocusChange(FOCUS_EXPIRY);
+        assertTrue(mNoZipGroup.expiryDateEditText.hasFocus());
+    }
+
+    @Test
+    public void onCompleteExpiry_whenValid_shiftsFocusToCvc() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+        mNoZipCardMultilineWidget.setCardInputListener(mNoZipCardListener);
+
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+        verify(mFullCardListener, times(1)).onExpirationComplete();
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_CVC);
+        assertTrue(mFullGroup.cvcEditText.hasFocus());
+
+        mNoZipGroup.expiryDateEditText.append("12");
+        mNoZipGroup.expiryDateEditText.append("50");
+        verify(mNoZipCardListener, times(1)).onExpirationComplete();
+        verify(mNoZipCardListener, times(1)).onFocusChange(FOCUS_CVC);
+        assertTrue(mNoZipGroup.cvcEditText.hasFocus());
+    }
+
+    @Test
+    public void onCompleteCvc_whenValid_shiftsFocusOnlyIfPostalCodeShown() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+        mNoZipCardMultilineWidget.setCardInputListener(mNoZipCardListener);
+
+        mFullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+        mFullGroup.cvcEditText.append("123");
+        verify(mFullCardListener, times(1)).onCvcComplete();
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_POSTAL);
+        assertTrue(mFullGroup.postalCodeEditText.hasFocus());
+
+        mNoZipGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+        mNoZipGroup.expiryDateEditText.append("12");
+        mNoZipGroup.expiryDateEditText.append("50");
+        mNoZipGroup.cvcEditText.append("123");
+        verify(mNoZipCardListener, times(1)).onCvcComplete();
+        verify(mNoZipCardListener, times(0)).onFocusChange(FOCUS_POSTAL);
+        assertTrue(mNoZipGroup.cvcEditText.hasFocus());
+    }
+
+    @Test
+    public void deleteWhenEmpty_fromExpiry_shiftsToCardNumber() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+        mNoZipCardMultilineWidget.setCardInputListener(mNoZipCardListener);
+
+        String deleteOneCharacterString = VALID_VISA_WITH_SPACES
+                .substring(0, VALID_VISA_WITH_SPACES.length() - 1);
+        mFullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+
+        reset(mFullCardListener);
+        assertTrue(mFullGroup.expiryDateEditText.hasFocus());
+        ViewTestUtils.sendDeleteKeyEvent(mFullGroup.expiryDateEditText);
+
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_CARD);
+        assertTrue(mFullGroup.cardNumberEditText.hasFocus());
+        assertEquals(deleteOneCharacterString, mFullGroup.cardNumberEditText.getText().toString());
+
+        mNoZipGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES);
+
+        reset(mNoZipCardListener);
+        assertTrue(mNoZipGroup.expiryDateEditText.hasFocus());
+        ViewTestUtils.sendDeleteKeyEvent(mNoZipGroup.expiryDateEditText);
+
+        verify(mNoZipCardListener, times(1)).onFocusChange(FOCUS_CARD);
+        assertTrue(mNoZipGroup.cardNumberEditText.hasFocus());
+        assertEquals(deleteOneCharacterString, mNoZipGroup.cardNumberEditText.getText().toString());
+    }
+
+    @Test
+    public void deleteWhenEmpty_fromCvc_shiftsToExpiry() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+        mNoZipCardMultilineWidget.setCardInputListener(mNoZipCardListener);
+
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+
+        reset(mFullCardListener);
+        assertTrue(mFullGroup.cvcEditText.hasFocus());
+        ViewTestUtils.sendDeleteKeyEvent(mFullGroup.cvcEditText);
+
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_EXPIRY);
+        assertTrue(mFullGroup.expiryDateEditText.hasFocus());
+        assertEquals("12/5", mFullGroup.expiryDateEditText.getText().toString());
+
+        mNoZipGroup.expiryDateEditText.append("12");
+        mNoZipGroup.expiryDateEditText.append("50");
+
+        reset(mNoZipCardListener);
+        assertTrue(mNoZipGroup.cvcEditText.hasFocus());
+        ViewTestUtils.sendDeleteKeyEvent(mNoZipGroup.cvcEditText);
+
+        verify(mNoZipCardListener, times(1)).onFocusChange(FOCUS_EXPIRY);
+        assertTrue(mNoZipGroup.expiryDateEditText.hasFocus());
+        assertEquals("12/5", mNoZipGroup.expiryDateEditText.getText().toString());
+    }
+
+    @Test
+    public void deleteWhenEmpty_fromPostalCode_shiftsToCvc() {
+        mCardMultilineWidget.setCardInputListener(mFullCardListener);
+
+        mFullGroup.cardNumberEditText.setText(VALID_DINERS_CLUB_WITH_SPACES);
+        mFullGroup.expiryDateEditText.append("12");
+        mFullGroup.expiryDateEditText.append("50");
+        mFullGroup.cvcEditText.append("123");
+
+        reset(mFullCardListener);
+        ViewTestUtils.sendDeleteKeyEvent(mFullGroup.postalCodeEditText);
+
+        verify(mFullCardListener, times(1)).onFocusChange(FOCUS_CVC);
+        assertEquals("12", mFullGroup.cvcEditText.getText().toString());
+    }
+
+    static class WidgetControlGroup {
+
+        private CardNumberEditText cardNumberEditText;
+        private ExpiryDateEditText expiryDateEditText;
+        private StripeEditText cvcEditText;
+        private StripeEditText postalCodeEditText;
+        private LinearLayout secondRowLayout;
+
+        WidgetControlGroup(@NonNull CardMultilineWidget parentWidget) {
+            cardNumberEditText = parentWidget.findViewById(R.id.et_add_source_card_number_ml);
+            expiryDateEditText = parentWidget.findViewById(R.id.et_add_source_expiry_ml);
+            cvcEditText = parentWidget.findViewById(R.id.et_add_source_cvc_ml);
+            postalCodeEditText = parentWidget.findViewById(R.id.et_add_source_zip_ml);
+            secondRowLayout = parentWidget.findViewById(R.id.second_row_layout);
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,7 +1,7 @@
 package com.stripe.android.view;
 
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Card;
-import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
@@ -11,15 +11,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.util.ActivityController;
 
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_NO_SPACES;
-import static com.stripe.android.testharness.CardInputTestActivity.VALID_VISA_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_DINERS_CLUB_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_DINERS_CLUB_WITH_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
+import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_WITH_SPACES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -31,12 +31,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
- * Test class for {@link CardNumberEditText}. Note that we have to test against SDK 22
- * because of a <a href="https://github.com/robolectric/robolectric/issues/1932">known issue</a> in
- * Robolectric.
+ * Test class for {@link CardNumberEditText}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 22)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class CardNumberEditTextTest {
 
     @Mock CardNumberEditText.CardNumberCompleteListener mCardNumberCompleteListener;
@@ -46,7 +44,7 @@ public class CardNumberEditTextTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController activityController =
+        ActivityController<CardInputTestActivity> activityController =
                 Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
         mCardNumberEditText =

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -1,6 +1,6 @@
 package com.stripe.android.view;
 
-import com.stripe.android.testharness.CardInputTestActivity;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
@@ -10,8 +10,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.util.ActivityController;
 
 import java.util.Calendar;
 
@@ -26,12 +26,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
- * Test class for {@link ExpiryDateEditText}.Note that we have to test against SDK 22
- * because of a <a href="https://github.com/robolectric/robolectric/issues/1932">known issue</a> in
- * Robolectric.
+ * Test class for {@link ExpiryDateEditText}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 22)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class ExpiryDateEditTextTest {
 
     @Mock ExpiryDateEditText.ExpiryDateEditListener mExpiryDateEditListener;
@@ -40,11 +38,10 @@ public class ExpiryDateEditTextTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController activityController =
+        ActivityController<CardInputTestActivity> activityController =
                 Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
-        mExpiryDateEditText =
-                ((CardInputTestActivity) activityController.get()).getExpiryDateEditText();
+        mExpiryDateEditText = activityController.get().getExpiryDateEditText();
         mExpiryDateEditText.setText("");
         mExpiryDateEditText.setExpiryDateEditListener(mExpiryDateEditListener);
     }

--- a/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
@@ -1,0 +1,40 @@
+package com.stripe.android.view;
+
+import android.support.design.widget.TextInputLayout;
+
+import com.stripe.android.BuildConfig;
+import com.stripe.android.R;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test class for {@link IconTextInputLayout} to ensure that the Reflection doesn't break
+ * during an upgrade. This class exists only to wrap {@link TextInputLayout}, so there
+ * is no need to otherwise test the behavior.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 25)
+public class IconTextInputLayoutTest {
+
+    @Test
+    public void init_successfullyFindsFields() {
+        ActivityController<CardInputTestActivity> activityController =
+                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
+
+        IconTextInputLayout iconTextInputLayout =
+                activityController.get().getCardMultilineWidget()
+                        .findViewById(R.id.tl_add_source_card_number_ml);
+
+        assertNotNull(iconTextInputLayout.mCollapsingTextHelper);
+        assertNotNull(iconTextInputLayout.mBounds);
+        assertNotNull(iconTextInputLayout.mRecalculateMethod);
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -3,8 +3,8 @@ package com.stripe.android.view;
 import android.graphics.Color;
 import android.support.annotation.ColorInt;
 
+import com.stripe.android.BuildConfig;
 import com.stripe.android.R;
-import com.stripe.android.testharness.CardInputTestActivity;
 import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
@@ -14,9 +14,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.util.ActivityController;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,7 +30,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  * Test class for {@link StripeEditText}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 22)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class StripeEditTextTest {
 
     @Mock StripeEditText.AfterTextChangedListener mAfterTextChangedListener;

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
@@ -8,7 +8,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for {@link ViewUtils}
@@ -121,5 +123,56 @@ public class ViewUtilsTest {
         assertEquals("0566", groups[1]);
         assertEquals("5566", groups[2]);
         assertEquals("555", groups[3]);
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenThreeDigitsAndNotAmEx_returnsTrue() {
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.VISA, "123"));
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.MASTERCARD, "345"));
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.JCB, "678"));
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.DINERS_CLUB, "910"));
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.DISCOVER, "234"));
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.UNKNOWN, "333"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenThreeDigitsAndIsAmEx_returnsFalse() {
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, "123"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenFourDigitsAndIsAmEx_returnsTrue() {
+        assertTrue(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, "1234"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenTooManyDigits_returnsFalse() {
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, "12345"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.VISA, "1234"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.MASTERCARD, "123456"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.DINERS_CLUB, "1234567"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.DISCOVER, "12345678"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.JCB, "123456789012345"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenNotEnoughDigits_returnsFalse() {
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, ""));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.VISA, "1"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.MASTERCARD, "12"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.DINERS_CLUB, ""));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.DISCOVER, "8"));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.JCB, "1"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenWhitespaceAndNotEnoughDigits_returnsFalse() {
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, "   "));
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.VISA, "  1"));
+    }
+
+    @Test
+    public void isCvcMaximalLength_whenNull_returnsFalse() {
+        assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, null));
     }
 }


### PR DESCRIPTION
r? @ksun-stripe 
cc @joeydong-stripe @bg-stripe 

Adding the material-style Card widget in this diff. A lot of the logic for validation is shared with the web-style CardInputWidget, so as much as possible I pulled that logic out to separate classes. The Multiline widget relies on reflection to get the animation we want -- it feel like an oversight in the support library's part not to include this simple change (animate hint text over the DrawableLeft instead of straight up beside it), but until it does, this is the only way to get that without recreating the entire control. The class IconTextInputLayoutTest exists solely to break in the event that a support library upgrade doesn't keep this behavior.