### PR TITLE
adding logging for app name and version

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -558,12 +558,18 @@ public class Stripe {
         Map<String, Object> loggingMap = null;
         if (paymentSource instanceof Token) {
             Token token = (Token) paymentSource;
-            loggingMap = LoggingUtils.getTokenCreationParams(productUsageTokens,
-                    mDefaultPublishableKey, token.getType());
+            loggingMap = LoggingUtils.getTokenCreationParams(
+                    mContext,
+                    productUsageTokens,
+                    mDefaultPublishableKey,
+                    token.getType());
         } else {
             Source source = (Source) paymentSource;
-            loggingMap = LoggingUtils.getSourceCreationParams(productUsageTokens,
-                    mDefaultPublishableKey, source.getType());
+            loggingMap = LoggingUtils.getSourceCreationParams(
+                    mContext,
+                    productUsageTokens,
+                    mDefaultPublishableKey,
+                    source.getType());
         }
         StripeApiHandler.logApiCall(loggingMap, options, mLoggingResponseListener);
     }

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -160,6 +160,7 @@ class StripeApiHandler {
 
             setTelemetryData(context, loggingResponseListener);
             Map<String, Object> loggingParams = LoggingUtils.getSourceCreationParams(
+                    context,
                     null,
                     apiKey,
                     sourceParams.getType());
@@ -264,7 +265,7 @@ class StripeApiHandler {
             setTelemetryData(context, listener);
 
             Map<String, Object> loggingParams =
-                    LoggingUtils.getTokenCreationParams(loggingTokens, apiKey, tokenType);
+                    LoggingUtils.getTokenCreationParams(context, loggingTokens, apiKey, tokenType);
             logApiCall(loggingParams, options, listener);
         } catch (ClassCastException classCastEx) {
             // This can only happen if someone puts a weird object in the map.

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ import static org.junit.Assert.fail;
  * Test class for {@link Stripe}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 22)
+@Config(constants = BuildConfig.class, sdk = 25)
 public class StripeTest {
 
     private static final String DEFAULT_PUBLISHABLE_KEY = "pk_default";
@@ -68,12 +69,11 @@ public class StripeTest {
     private Card mCard;
     private int mYear;
 
-    @Mock Context mContext;
+    private Context mContext;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
+        mContext = RuntimeEnvironment.application;
         String cvc = "123";
         int month = 12;
         Calendar rightNow = Calendar.getInstance();


### PR DESCRIPTION
r? @bg-stripe 
cc @ksun-stripe @joeydong-stripe 

Adding logging for the application name and application version number. Note that this will log version code instead of number, so we'll be able to better track progression (code updates in whole numbers only, whereas version name would be 1.4.7, etc, and would be harder for us to parse)