### PR TITLE
upgrading the support libraries to 26

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-def android_support_version = '25.3.1'
+def android_support_version = '26.0.0'
 
 version = VERSION_NAME
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ allprojects {
 
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,7 +4,7 @@ repositories {
     mavenCentral()
 }
 
-def android_support_version = '25.3.1'
+def android_support_version = '26.0.0'
 
 dependencies {
     compile project(':android-pay')

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 
-def android_support_version = '25.3.1'
+def android_support_version = '26.0.0'
 
 android {
     compileSdkVersion 26

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-def android_support_version = '25.3.1'
+def android_support_version = '26.0.0'
 
 version = VERSION_NAME
 
@@ -27,7 +27,7 @@ android {
     compileSdkVersion 26
     buildToolsVersion '26.0.1'
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 14
         targetSdkVersion 26
     }
     sourceSets {


### PR DESCRIPTION
r? @ksun-stripe 
cc @joeydong-stripe @teich-stripe 

Upgrading our support library dependencies to the latest versions. Note that this requires upgrading the minimum build version from 11 to 14. However:
1) this is already on a breaking branch, and we get to include the breaking support library upgrade (25->26)
2) [Global distribution of versions](https://developer.android.com/about/dashboards/index.html) 10-14 is collectively 0.7% of devices 
3) We've literally never had a tokenization by a device with sdk lower than 15 since we've been collecting data in the android sdk (so, the last nine months)

We should probably consider making version 15 our minimum. I'm updating to 14 here because it is required by the design support library version 26.
