### PR TITLE
adding the finishing touches to the card multiline widget

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -9,10 +9,9 @@
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/appName">
-
         <meta-data
             android:name="com.google.android.gms.wallet.api.enabled"
-            android:value="true" />
+            android:value="true"/>
 
         <activity
             android:name=".activity.PaymentActivity"
@@ -51,7 +50,6 @@
                     android:scheme="stripe"/>
             </intent-filter>
         </activity>
-
         <activity
             android:name=".activity.LauncherActivity"
             android:launchMode="singleTask"
@@ -62,9 +60,15 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-
-        <activity android:name=".activity.AndroidPayActivity"
+        <activity
+            android:name=".activity.AndroidPayActivity"
             android:theme="@style/SampleTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+            </intent-filter>
+        </activity>
+        <activity android:name=".activity.PaymentMultilineActivity"
+                  android:theme="@style/SampleTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,12 +11,13 @@ dependencies {
     compile project(':stripe')
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
-    compile 'com.google.android.gms:play-services-wallet:11.0.4'
     /* Needed for RxAndroid */
     /* Needed for Rx Bindings on views */
+    compile 'com.google.android.gms:play-services-wallet:11.0.4'
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }
 
 android {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,13 +11,12 @@ dependencies {
     compile project(':stripe')
     compile 'com.android.support:appcompat-v7:' + android_support_version
     compile 'com.android.support:recyclerview-v7:' + android_support_version
+    compile 'com.google.android.gms:play-services-wallet:11.0.4'
     /* Needed for RxAndroid */
     /* Needed for Rx Bindings on views */
-    compile 'com.google.android.gms:play-services-wallet:11.0.4'
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }
 
 android {

--- a/example/res/layout/activity_launcher.xml
+++ b/example/res/layout/activity_launcher.xml
@@ -25,6 +25,15 @@
         />
 
     <Button
+        android:id="@+id/btn_make_card_sources"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="10dp"
+        android:text="@string/createCardSources"
+        />
+
+    <Button
         android:id="@+id/btn_make_sources"
         android:layout_width="200dp"
         android:layout_height="wrap_content"

--- a/example/res/layout/activity_payment_multiline.xml
+++ b/example/res/layout/activity_payment_multiline.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="8dp"
+    android:paddingStart="8dp"
+    android:paddingRight="8dp"
+    android:paddingEnd="8dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <TextView android:id="@+id/payment_form_title"
+              android:text="@string/addPayment"
+              style="@style/Header.Light" />
+
+    <com.stripe.android.view.CardMultilineWidget
+        android:id="@+id/card_multiline_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:shouldShowPostalCode="true"/>
+
+    <Button
+        android:id="@+id/save_payment"
+        android:layout_height="wrap_content"
+        android:layout_width="160dp"
+        android:text="@string/save"
+        />
+
+    <TextView android:id="@+id/source_list_title"
+              android:text="@string/paymentMethods"
+              android:layout_marginTop="12dp"
+              style="@style/Header.Light" />
+
+    <ListView
+        android:id="@+id/source_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+
+</LinearLayout>

--- a/example/res/layout/payment_activity.xml
+++ b/example/res/layout/payment_activity.xml
@@ -20,6 +20,12 @@
         android:layout_height="wrap_content"
         />
 
+    <com.stripe.android.view.CardMultilineWidget
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        app:shouldShowPostalCode="true"/>
+
     <Button
         android:id="@+id/save"
         android:layout_height="wrap_content"

--- a/example/res/layout/payment_activity.xml
+++ b/example/res/layout/payment_activity.xml
@@ -20,12 +20,6 @@
         android:layout_height="wrap_content"
         />
 
-    <com.stripe.android.view.CardMultilineWidget
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        app:shouldShowPostalCode="true"/>
-
     <Button
         android:id="@+id/save"
         android:layout_height="wrap_content"

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -13,6 +13,7 @@
 
     <string name="createAndroidPayTokens">Create Android Pay Tokens</string>
     <string name="createCardTokens">Create Card Tokens</string>
+    <string name="createCardSources">Create Card Sources</string>
     <string name="createThreeDSecure">Create 3DS Sources</string>
     <string name="cardNumber">Card Number</string>
     <string name="createSource">Creating source&#8230;</string>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -22,7 +22,7 @@ public class LauncherActivity extends AppCompatActivity {
      * You can get your key here: https://dashboard.stripe.com/account/apikeys
      */
     private static final String PUBLISHABLE_KEY =
-            "put your key here";
+            "put your test key here";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,7 +30,7 @@ public class LauncherActivity extends AppCompatActivity {
         setContentView(R.layout.activity_launcher);
 
         PaymentConfiguration.init(PUBLISHABLE_KEY);
-        Button tokenButton = (Button) findViewById(R.id.btn_make_card_tokens);
+        Button tokenButton = findViewById(R.id.btn_make_card_tokens);
         tokenButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -39,7 +39,16 @@ public class LauncherActivity extends AppCompatActivity {
             }
         });
 
-        Button sourceButton = (Button) findViewById(R.id.btn_make_sources);
+        Button multilineButton = findViewById(R.id.btn_make_card_sources);
+        multilineButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent intent = new Intent(LauncherActivity.this, PaymentMultilineActivity.class);
+                startActivity(intent);
+            }
+        });
+
+        Button sourceButton = findViewById(R.id.btn_make_sources);
         sourceButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -48,7 +57,7 @@ public class LauncherActivity extends AppCompatActivity {
             }
         });
 
-        Button androidPayButton = (Button) findViewById(R.id.btn_android_pay_launch);
+        Button androidPayButton = findViewById(R.id.btn_android_pay_launch);
         androidPayButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -22,7 +22,7 @@ public class LauncherActivity extends AppCompatActivity {
      * You can get your key here: https://dashboard.stripe.com/account/apikeys
      */
     private static final String PUBLISHABLE_KEY =
-            "put your test key here";
+            "put your key here";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
@@ -1,0 +1,157 @@
+package com.stripe.example.activity;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.SimpleAdapter;
+
+import com.jakewharton.rxbinding.view.RxView;
+import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.Stripe;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceCardData;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
+import com.stripe.android.view.CardMultilineWidget;
+import com.stripe.example.R;
+import com.stripe.example.controller.ErrorDialogHandler;
+import com.stripe.example.controller.ListViewController;
+import com.stripe.example.controller.ProgressDialogController;
+import com.stripe.example.controller.RxTokenController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
+import rx.subscriptions.CompositeSubscription;
+
+public class PaymentMultilineActivity extends AppCompatActivity {
+
+    ProgressDialogController mProgressDialogController;
+    ErrorDialogHandler mErrorDialogHandler;
+
+    CardMultilineWidget mCardMultilineWidget;
+    CompositeSubscription mCompositeSubscription;
+
+    private List<Map<String, String>> mCardSources = new ArrayList<Map<String, String>>();
+
+    SimpleAdapter mAdapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_payment_multiline);
+
+        mCompositeSubscription = new CompositeSubscription();
+        mCardMultilineWidget = findViewById(R.id.card_multiline_widget);
+
+        mProgressDialogController =
+                new ProgressDialogController(getSupportFragmentManager());
+
+        ListView listView = findViewById(R.id.source_list);
+
+        mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
+
+        mAdapter = new SimpleAdapter(
+                this,
+                mCardSources,
+                R.layout.list_item_layout,
+                new String[]{"last4", "tokenId"},
+                new int[]{R.id.last4, R.id.tokenId});
+        listView.setAdapter(mAdapter);
+
+        mCompositeSubscription.add(
+                RxView.clicks(findViewById(R.id.save_payment)).subscribe(new Action1<Void>() {
+                    @Override
+                    public void call(Void aVoid) {
+                        saveCard();
+                    }
+                }));
+    }
+
+    private void saveCard() {
+        Card card = mCardMultilineWidget.getCard();
+        if (card == null) {
+            return;
+        }
+
+        final Stripe stripe = new Stripe(this);
+        final SourceParams cardSourceParams = SourceParams.createCardParams(card);
+        // Note: using this style of Observable creation results in us having a method that
+        // will not be called until we subscribe to it.
+        final Observable<Source> tokenObservable =
+                Observable.fromCallable(
+                        new Callable<Source>() {
+                            @Override
+                            public Source call() throws Exception {
+                                return stripe.createSourceSynchronous(cardSourceParams,
+                                        PaymentConfiguration.getInstance().getPublishableKey());
+                            }
+                        });
+
+        mCompositeSubscription.add(tokenObservable
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe(
+                        new Action0() {
+                            @Override
+                            public void call() {
+                                mProgressDialogController.startProgress();
+                            }
+                        })
+                .doOnUnsubscribe(
+                        new Action0() {
+                            @Override
+                            public void call() {
+                                mProgressDialogController.finishProgress();
+                            }
+                        })
+                .subscribe(
+                        new Action1<Source>() {
+                            @Override
+                            public void call(Source source) {
+                                addToList(source);
+                            }
+                        },
+                        new Action1<Throwable>() {
+                            @Override
+                            public void call(Throwable throwable) {
+                                mErrorDialogHandler.showError(throwable.getLocalizedMessage());
+                            }
+                        }));
+    }
+
+    private void addToList(@Nullable Source source) {
+        if (source == null || !Source.CARD.equals(source.getType())) {
+            return;
+        }
+
+        String token = source.getId();
+        SourceCardData sourceCardData = (SourceCardData) source.getSourceTypeModel();
+        String last4 = sourceCardData.getLast4();
+        if (last4 == null) {
+            last4 = "missing last4";
+        }
+        addToList(last4, token);
+    }
+
+    private void addToList(@NonNull String last4, @NonNull String tokenId) {
+        String endingIn = getString(R.string.endingIn);
+        Map<String, String> map = new HashMap<>();
+        map.put("last4", endingIn + " " + last4);
+        map.put("tokenId", tokenId);
+        mCardSources.add(map);
+        mAdapter.notifyDataSetChanged();
+    }
+}

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -7,6 +7,7 @@
         android:id="@+id/tl_add_source_card_number_ml"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:hint="@string/acc_label_card_number"
         android:layout_marginTop="@dimen/add_card_element_vertical_margin"
         >
 
@@ -16,9 +17,8 @@
             android:layout_height="wrap_content"
             android:digits="@string/valid_digits"
             android:drawableLeft="@drawable/ic_unknown"
-            android:drawablePadding="@dimen/card_icon_padding"
+            android:drawablePadding="@dimen/card_icon_multiline_padding"
             android:drawableStart="@drawable/ic_unknown"
-            android:hint="@string/acc_label_card_number"
             android:inputType="number"
             android:nextFocusDown="@+id/et_add_source_expiry_ml"
             android:nextFocusForward="@+id/et_add_source_expiry_ml"
@@ -42,13 +42,13 @@
             android:layout_marginEnd="@dimen/add_card_expiry_middle_margin"
             android:layout_marginRight="@dimen/add_card_expiry_middle_margin"
             android:layout_weight="1"
+            android:hint="@string/acc_label_expiry_date"
             >
 
             <com.stripe.android.view.ExpiryDateEditText
                 android:id="@+id/et_add_source_expiry_ml"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/acc_label_expiry_date"
                 android:inputType="date"
                 android:maxLength="@integer/date_length"
                 android:nextFocusDown="@+id/et_add_source_cvc_ml"

--- a/stripe/res/values-de/strings.xml
+++ b/stripe/res/values-de/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Kartennummer"</string>
-    <string name="acc_label_expiry_date">"Gültig bis"</string>
+    <string name="acc_label_card_number">Kartennummer</string>
+    <string name="acc_label_expiry_date">Gültig bis</string>
     <string name="acc_label_zip">Postleitzahl</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/JJ</string>
+    <string name="expiry_label_short">Gültig bis</string>
     <string name="invalid_card_number">Die Kartennummer ist ungültig.</string>
     <string name="invalid_expiry_month">Die Monatsangabe Ihrer Karte ist ungültig.</string>
     <string name="invalid_expiry_year">Die Jahresangabe Ihrer Karte ist ungültig.</string>

--- a/stripe/res/values-es/strings.xml
+++ b/stripe/res/values-es/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Número de tarjeta"</string>
-    <string name="acc_label_expiry_date">"Fecha de vencimiento"</string>
+    <string name="acc_label_card_number">Número de tarjeta</string>
+    <string name="acc_label_expiry_date">Fecha de vencimiento</string>
     <string name="acc_label_zip">Código postal</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/AA</string>
+    <string name="expiry_label_short">Venc.</string>
     <string name="invalid_card_number">El número de tarjeta no es válido.</string>
     <string name="invalid_expiry_month">El mes de vencimiento de la tarjeta no es válido.</string>
     <string name="invalid_expiry_year">El año de vencimiento de la tarjeta no es válido.</string>

--- a/stripe/res/values-fr/strings.xml
+++ b/stripe/res/values-fr/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Numéro de carte"</string>
-    <string name="acc_label_expiry_date">"Date d’expiration"</string>
+    <string name="acc_label_card_number">Numéro de carte</string>
+    <string name="acc_label_expiry_date">Date d’expiration</string>
     <string name="acc_label_zip">Code postal</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/AA</string>
+    <string name="expiry_label_short">Expire</string>
     <string name="invalid_card_number">Le numéro de carte n’est pas valide.</string>
     <string name="invalid_expiry_month">Le mois d’expiration de votre carte n’est pas valide.</string>
     <string name="invalid_expiry_year">L’année d’expiration de votre carte n’est pas valide.</string>

--- a/stripe/res/values-it/strings.xml
+++ b/stripe/res/values-it/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Numero della carta"</string>
-    <string name="acc_label_expiry_date">"Data di scadenza"</string>
+    <string name="acc_label_card_number">Numero della carta</string>
+    <string name="acc_label_expiry_date">Data di scadenza</string>
     <string name="acc_label_zip">Codice postale</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/AA</string>
+    <string name="expiry_label_short">Scad.</string>
     <string name="invalid_card_number">Il numero della carta non è valido.</string>
     <string name="invalid_expiry_month">Il mese di scadenza della carta non è valido.</string>
     <string name="invalid_expiry_year">L\'anno di scadenza della carta non è valido.</string>

--- a/stripe/res/values-ja/strings.xml
+++ b/stripe/res/values-ja/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"カード番号"</string>
-    <string name="acc_label_expiry_date">"有効期限"</string>
+    <string name="acc_label_card_number">カード番号</string>
+    <string name="acc_label_expiry_date">有効期限</string>
     <string name="acc_label_zip">郵便番号</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/YY</string>
+    <string name="expiry_label_short">有効期限</string>
     <string name="invalid_card_number">カードの番号が無効です。</string>
     <string name="invalid_expiry_month">カードの有効期限として指定した月が無効です。</string>
     <string name="invalid_expiry_year">カードの有効期限として指定した年が無効です。</string>

--- a/stripe/res/values-nl/strings.xml
+++ b/stripe/res/values-nl/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Kaartnummer"</string>
-    <string name="acc_label_expiry_date">"Vervaldatum"</string>
+    <string name="acc_label_card_number">Kaartnummer</string>
+    <string name="acc_label_expiry_date">Vervaldatum</string>
     <string name="acc_label_zip">Postcode</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/YY</string>
+    <string name="expiry_label_short">Verval</string>
     <string name="invalid_card_number">Uw kaartnummer is ongeldig.</string>
     <string name="invalid_expiry_month">De vervalmaand van uw kaart is ongeldig.</string>
     <string name="invalid_expiry_year">Het vervaljaar van uw kaart is ongeldig.</string>

--- a/stripe/res/values-zh/strings.xml
+++ b/stripe/res/values-zh/strings.xml
@@ -5,6 +5,7 @@
     <string name="acc_label_zip">邮政编码</string>
     <string name="acc_label_zip_short">邮政编码</string>
     <string name="expiry_date_hint">月 / 年</string>
+    <string name="expiry_label_short">有效期</string>
     <string name="invalid_card_number">您的卡号无效。</string>
     <string name="invalid_expiry_month">您的银行卡有效日期的月份无效。</string>
     <string name="invalid_expiry_year">您的银行卡有效日期的年份无效。</string>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -10,4 +10,5 @@
     <dimen name="android_pay_confirmation_margin">8dp</dimen>
     <dimen name="android_pay_button_separation">8dp</dimen>
     <dimen name="card_icon_multiline_width">24dp</dimen>
+    <dimen name="card_icon_multiline_padding">8dp</dimen>
 </resources>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -11,4 +11,5 @@
     <dimen name="android_pay_button_separation">8dp</dimen>
     <dimen name="card_icon_multiline_width">24dp</dimen>
     <dimen name="card_icon_multiline_padding">8dp</dimen>
+    <dimen name="card_icon_multiline_padding_bottom">1.52380955dp</dimen>
 </resources>

--- a/stripe/res/values/donottranslate.xml
+++ b/stripe/res/values/donottranslate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="card_number_hint">1234 5678 9012 3456</string>
+    <string name="card_number_hint">1234 1234 1234 1234</string>
     <string name="cvc_number_hint">CVC</string>
     <string name="cvc_amex_hint">CVV</string>
     <string name="cvc_multiline_helper">123</string>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="acc_label_card_number">"Card number"</string>
-    <string name="acc_label_expiry_date">"Expiration date"</string>
+    <string name="acc_label_card_number">Card number</string>
+    <string name="acc_label_expiry_date">Expiration date</string>
     <string name="acc_label_zip">ZIP Code</string>
     <string name="acc_label_zip_short">ZIP</string>
     <string name="expiry_date_hint">MM/YY</string>
+    <string name="expiry_label_short">Expiry</string>
     <string name="invalid_card_number">Your card\'s number is invalid.</string>
     <string name="invalid_expiry_month">Your card\'s expiration month is invalid.</string>
     <string name="invalid_expiry_year">Your card\'s expiration year is invalid.</string>

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.os.Build;
+import android.os.Handler;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.design.widget.TextInputEditText;
 import android.support.v7.widget.AppCompatEditText;
 import android.text.Editable;
@@ -19,6 +21,8 @@ import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputConnectionWrapper;
 
 import com.stripe.android.R;
+
+import static com.stripe.android.view.ViewUtils.isColorDark;
 
 /**
  * Extension of {@link AppCompatEditText} that listens for users pressing the delete key when there is
@@ -36,6 +40,7 @@ public class StripeEditText extends TextInputEditText {
     @ColorRes private int mDefaultErrorColorResId;
     @ColorInt private int mErrorColor;
 
+    private Handler mHandler;
     private String mErrorMessage;
     private ErrorMessageListener mErrorMessageListener;
 
@@ -52,62 +57,6 @@ public class StripeEditText extends TextInputEditText {
     public StripeEditText(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         initView();
-    }
-
-    @Override
-    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
-    }
-
-    /**
-     * Sets a listener that can react to changes in text, but only by reflecting the new
-     * text in the field.
-     *
-     * @param afterTextChangedListener the {@link AfterTextChangedListener} to attach to this view
-     */
-    void setAfterTextChangedListener(
-            @Nullable AfterTextChangedListener afterTextChangedListener) {
-        mAfterTextChangedListener = afterTextChangedListener;
-    }
-
-    /**
-     * Sets a listener that can react to the user attempting to delete the empty string.
-     *
-     * @param deleteEmptyListener the {@link DeleteEmptyListener} to attach to this view
-     */
-    void setDeleteEmptyListener(@Nullable DeleteEmptyListener deleteEmptyListener) {
-        mDeleteEmptyListener = deleteEmptyListener;
-    }
-
-    void setErrorMessageListener(@Nullable ErrorMessageListener errorMessageListener) {
-        mErrorMessageListener = errorMessageListener;
-    }
-
-    void setErrorMessage(@Nullable String errorMessage) {
-        mErrorMessage = errorMessage;
-    }
-
-    /**
-     * Sets whether or not the text should be put into "error mode," which displays
-     * the text in an error color determined by the original text color.
-     *
-     * @param shouldShowError whether or not we should display text in an error state.
-     */
-    @SuppressWarnings("deprecation")
-    public void setShouldShowError(boolean shouldShowError) {
-        if (mErrorMessage != null && mErrorMessageListener != null) {
-            String errorMessage = shouldShowError ? mErrorMessage : null;
-            mErrorMessageListener.displayErrorMessage(errorMessage);
-        } else {
-            mShouldShowError = shouldShowError;
-            if (mShouldShowError) {
-                setTextColor(mErrorColor);
-            } else {
-                setTextColor(mCachedColorStateList);
-            }
-
-            refreshDrawableState();
-        }
     }
 
     @Nullable
@@ -145,6 +94,39 @@ public class StripeEditText extends TextInputEditText {
         return errorColor;
     }
 
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
+    }
+
+    /**
+     * Sets a listener that can react to changes in text, but only by reflecting the new
+     * text in the field.
+     *
+     * @param afterTextChangedListener the {@link AfterTextChangedListener} to attach to this view
+     */
+    void setAfterTextChangedListener(
+            @Nullable AfterTextChangedListener afterTextChangedListener) {
+        mAfterTextChangedListener = afterTextChangedListener;
+    }
+
+    /**
+     * Sets a listener that can react to the user attempting to delete the empty string.
+     *
+     * @param deleteEmptyListener the {@link DeleteEmptyListener} to attach to this view
+     */
+    void setDeleteEmptyListener(@Nullable DeleteEmptyListener deleteEmptyListener) {
+        mDeleteEmptyListener = deleteEmptyListener;
+    }
+
+    void setErrorMessageListener(@Nullable ErrorMessageListener errorMessageListener) {
+        mErrorMessageListener = errorMessageListener;
+    }
+
+    void setErrorMessage(@Nullable String errorMessage) {
+        mErrorMessage = errorMessage;
+    }
+
     /**
      * Sets the error text color on this {@link StripeEditText}.
      *
@@ -155,34 +137,53 @@ public class StripeEditText extends TextInputEditText {
     }
 
     /**
-     * A crude mechanism by which we check whether or not a color is "dark."
-     * This is subject to much interpretation, but we attempt to follow traditional
-     * design standards.
+     * Change the hint value of this control after a delay.
      *
-     * @param color an integer representation of a color
-     * @return {@code true} if the color is "dark," else {@link false}
+     * @param hintResource the string resource for the hint to be set
+     * @param delayMilliseconds a delay period, measured in milliseconds
      */
-    static boolean isColorDark(@ColorInt int color){
-        // Forumla comes from W3C standards and conventional theory
-        // about how to calculate the "brightness" of a color, often
-        // thought of as how far along the spectrum from white to black the
-        // grayscale version would be.
-        // See https://www.w3.org/TR/AERT#color-contrast and
-        // http://paulbourke.net/texture_colour/colourspace/ for further reading.
-        double luminescence = 0.299*Color.red(color)
-                + 0.587*Color.green(color)
-                + 0.114* Color.blue(color);
+    public void setHintDelayed(@StringRes final int hintResource, long delayMilliseconds) {
+        final Runnable hintRunnable = new Runnable() {
+            @Override
+            public void run() {
+                setHint(hintResource);
+            }
+        };
+        mHandler.postDelayed(hintRunnable, delayMilliseconds);
+    }
 
-        // Because the colors are all hex integers.
-        double luminescencePercentage = luminescence / 255;
-        if (luminescencePercentage > 0.5) {
-            return false;
+    /**
+     * Sets whether or not the text should be put into "error mode," which displays
+     * the text in an error color determined by the original text color.
+     *
+     * @param shouldShowError whether or not we should display text in an error state.
+     */
+    @SuppressWarnings("deprecation")
+    public void setShouldShowError(boolean shouldShowError) {
+        if (mErrorMessage != null && mErrorMessageListener != null) {
+            String errorMessage = shouldShowError ? mErrorMessage : null;
+            mErrorMessageListener.displayErrorMessage(errorMessage);
         } else {
-            return true;
+            mShouldShowError = shouldShowError;
+            if (mShouldShowError) {
+                setTextColor(mErrorColor);
+            } else {
+                setTextColor(mCachedColorStateList);
+            }
+
+            refreshDrawableState();
         }
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        // Passing a null token removes all callbacks and messages to the handler.
+        mHandler.removeCallbacksAndMessages(null);
+    }
+
     private void initView() {
+        mHandler = new Handler();
         listenForTextChanges();
         listenForDeleteEmpty();
         determineDefaultErrorColor();

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -1,9 +1,16 @@
 package com.stripe.android.view;
 
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.DisplayMetrics;
+import android.util.Log;
 
 import com.stripe.android.model.Card;
+
+import java.util.Locale;
 
 import static com.stripe.android.model.Card.CVC_LENGTH_AMERICAN_EXPRESS;
 import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
@@ -12,6 +19,57 @@ import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
  * Static utility functions needed for View classes.
  */
 class ViewUtils {
+
+    /**
+     * This method converts dp unit to equivalent pixels, depending on device density.
+     *
+     * @param dp A value in dp (density independent pixels) unit. Which we need to convert into pixels
+     * @return A float value to represent px equivalent to dp depending on device density
+     */
+    public static float convertDpToPixel(float dp){
+        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        return dp * ((float) metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+    }
+
+    /**
+     * This method converts device specific pixels to density independent pixels.
+     *
+     * @param px A value in px (pixels) unit. Which we need to convert into db
+     * @return A float value to represent dp equivalent to px value
+     */
+    public static float convertPixelsToDp(float px){
+        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        Log.d("chewie", String.format(Locale.ENGLISH, "My density is %.2f", metrics.density));
+        return px / ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+    }
+
+    /**
+     * A crude mechanism by which we check whether or not a color is "dark."
+     * This is subject to much interpretation, but we attempt to follow traditional
+     * design standards.
+     *
+     * @param color an integer representation of a color
+     * @return {@code true} if the color is "dark," else {@link false}
+     */
+    static boolean isColorDark(@ColorInt int color){
+        // Forumla comes from W3C standards and conventional theory
+        // about how to calculate the "brightness" of a color, often
+        // thought of as how far along the spectrum from white to black the
+        // grayscale version would be.
+        // See https://www.w3.org/TR/AERT#color-contrast and
+        // http://paulbourke.net/texture_colour/colourspace/ for further reading.
+        double luminescence = 0.299* Color.red(color)
+                + 0.587*Color.green(color)
+                + 0.114* Color.blue(color);
+
+        // Because the colors are all hex integers.
+        double luminescencePercentage = luminescence / 255;
+        if (luminescencePercentage > 0.5) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 
     static boolean isCvcMaximalLength(
             @NonNull @Card.CardBrand String cardBrand,

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
@@ -1,6 +1,8 @@
 package com.stripe.android.view;
 
+import android.content.res.Resources;
 import android.support.annotation.NonNull;
+import android.support.design.widget.TextInputLayout;
 import android.widget.LinearLayout;
 
 import com.stripe.android.R;
@@ -87,6 +89,25 @@ public class CardMultilineWidgetTest {
         // The No ZIP Group will get eliminated because its layout loses the reference
         assertNull(mNoZipGroup.postalCodeEditText);
         assertNotNull(mNoZipGroup.secondRowLayout);
+    }
+
+    @Test
+    public void onCreate_setsCorrectHintForExpiry() {
+        TextInputLayout shortExpiryContainer = mCardMultilineWidget
+                .findViewById(R.id.tl_add_source_expiry_ml);
+
+        TextInputLayout longExpiryContainer = mNoZipCardMultilineWidget
+                .findViewById(R.id.tl_add_source_expiry_ml);
+
+        String shortExpiryHint = mCardMultilineWidget
+                .getResources().getString(R.string.expiry_label_short);
+        String longExpiryHint = mCardMultilineWidget
+                .getResources().getString(R.string.acc_label_expiry_date);
+
+        assertNotNull(shortExpiryContainer.getHint());
+        assertEquals(shortExpiryHint, shortExpiryContainer.getHint().toString());
+        assertNotNull(longExpiryContainer.getHint());
+        assertEquals(longExpiryHint, longExpiryContainer.getHint().toString());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -96,36 +96,6 @@ public class StripeEditTextTest {
     }
 
     @Test
-    public void isColorDark_forExampleLightColors_returnsFalse() {
-        @ColorInt int middleGray = 0x888888;
-        @ColorInt int offWhite = 0xfaebd7;
-        @ColorInt int lightCyan = 0x8feffb;
-        @ColorInt int lightYellow = 0xfcf4b2;
-        @ColorInt int lightBlue = 0x9cdbff;
-
-        assertFalse(StripeEditText.isColorDark(middleGray));
-        assertFalse(StripeEditText.isColorDark(offWhite));
-        assertFalse(StripeEditText.isColorDark(lightCyan));
-        assertFalse(StripeEditText.isColorDark(lightYellow));
-        assertFalse(StripeEditText.isColorDark(lightBlue));
-        assertFalse(StripeEditText.isColorDark(Color.WHITE));
-    }
-
-    @Test
-    public void isColorDark_forExampleDarkColors_returnsTrue() {
-        @ColorInt int logoBlue = 0x6772e5;
-        @ColorInt int slate = 0x525f7f;
-        @ColorInt int darkPurple = 0x6b3791;
-        @ColorInt int darkishRed = 0x9e2146;
-
-        assertTrue(StripeEditText.isColorDark(logoBlue));
-        assertTrue(StripeEditText.isColorDark(slate));
-        assertTrue(StripeEditText.isColorDark(darkPurple));
-        assertTrue(StripeEditText.isColorDark(darkishRed));
-        assertTrue(StripeEditText.isColorDark(Color.BLACK));
-    }
-
-    @Test
     @SuppressWarnings("deprecation")
     public void getDefaultErrorColorInt_onDarkTheme_returnsDarkError() {
         mEditText.setTextColor(

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
@@ -1,5 +1,8 @@
 package com.stripe.android.view;
 
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+
 import com.stripe.android.model.Card;
 
 import org.junit.Test;
@@ -174,5 +177,35 @@ public class ViewUtilsTest {
     @Test
     public void isCvcMaximalLength_whenNull_returnsFalse() {
         assertFalse(ViewUtils.isCvcMaximalLength(Card.AMERICAN_EXPRESS, null));
+    }
+
+    @Test
+    public void isColorDark_forExampleLightColors_returnsFalse() {
+        @ColorInt int middleGray = 0x888888;
+        @ColorInt int offWhite = 0xfaebd7;
+        @ColorInt int lightCyan = 0x8feffb;
+        @ColorInt int lightYellow = 0xfcf4b2;
+        @ColorInt int lightBlue = 0x9cdbff;
+
+        assertFalse(ViewUtils.isColorDark(middleGray));
+        assertFalse(ViewUtils.isColorDark(offWhite));
+        assertFalse(ViewUtils.isColorDark(lightCyan));
+        assertFalse(ViewUtils.isColorDark(lightYellow));
+        assertFalse(ViewUtils.isColorDark(lightBlue));
+        assertFalse(ViewUtils.isColorDark(Color.WHITE));
+    }
+
+    @Test
+    public void isColorDark_forExampleDarkColors_returnsTrue() {
+        @ColorInt int logoBlue = 0x6772e5;
+        @ColorInt int slate = 0x525f7f;
+        @ColorInt int darkPurple = 0x6b3791;
+        @ColorInt int darkishRed = 0x9e2146;
+
+        assertTrue(ViewUtils.isColorDark(logoBlue));
+        assertTrue(ViewUtils.isColorDark(slate));
+        assertTrue(ViewUtils.isColorDark(darkPurple));
+        assertTrue(ViewUtils.isColorDark(darkishRed));
+        assertTrue(ViewUtils.isColorDark(Color.BLACK));
     }
 }


### PR DESCRIPTION
r? @joeydong-stripe 
cc @bg-stripe @ksun-stripe 

Adding the finishing touches to the card multiline widget, including:

1. Moving the card brand icon slightly up (requested by design)
1. Adding placeholder text after the label has moved out of the way, and waiting a slight delay before adding it
1. Switching the card brand icon over to the CVC input icon when the user is in the CVC field and not yet finished entering the value
1. Setting the label to a shorter value for the Expiration Date field if there are three things in a line.


![multiline](https://user-images.githubusercontent.com/23323692/28984530-43858b7c-7913-11e7-886a-b7feed65daf0.gif)
