### PR TITLE
adding the new api methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -48,7 +48,7 @@ public class Stripe {
                         @Override
                         protected ResponseWrapper doInBackground(Void... params) {
                             try {
-                                Source source = StripeApiHandler.createSourceOnServer(
+                                Source source = StripeApiHandler.createSource(
                                         null,
                                         mContext,
                                         sourceParams,
@@ -95,7 +95,7 @@ public class Stripe {
                                                 publishableKey,
                                                 stripeAccount,
                                                 RequestOptions.TYPE_QUERY).build();
-                                Token token = StripeApiHandler.createTokenOnServer(
+                                Token token = StripeApiHandler.createToken(
                                         mContext,
                                         tokenParams,
                                         requestOptions,
@@ -273,7 +273,7 @@ public class Stripe {
                 publishableKey,
                 mStripeAccount,
                 RequestOptions.TYPE_QUERY).build();
-        return StripeApiHandler.createTokenOnServer(
+        return StripeApiHandler.createToken(
                 mContext,
                 hashMapFromBankAccount(mContext, bankAccount),
                 requestOptions,
@@ -429,7 +429,7 @@ public class Stripe {
         if (apiKey == null) {
             return null;
         }
-        return StripeApiHandler.createSourceOnServer(
+        return StripeApiHandler.createSource(
                 null, mContext, params, apiKey, mStripeAccount, mLoggingResponseListener);
     }
 
@@ -482,7 +482,7 @@ public class Stripe {
                 publishableKey,
                 mStripeAccount,
                 RequestOptions.TYPE_QUERY).build();
-        return StripeApiHandler.createTokenOnServer(
+        return StripeApiHandler.createToken(
                 mContext,
                 hashMapFromCard(mContext, card),
                 requestOptions,
@@ -537,7 +537,7 @@ public class Stripe {
                 publishableKey,
                 mStripeAccount,
                 RequestOptions.TYPE_QUERY).build();
-        return StripeApiHandler.createTokenOnServer(
+        return StripeApiHandler.createToken(
                 mContext,
                 hashMapFromPersonalId(mContext, personalId),
                 requestOptions,

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -4,7 +4,6 @@ import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Card;
-import com.stripe.android.model.Customer;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 
@@ -61,6 +60,21 @@ public class StripeApiHandlerTest {
         String tokenId = "tok_sample";
         String requestApi = StripeApiHandler.getRetrieveTokenApiUrl(tokenId);
         assertEquals("https://api.stripe.com/v1/tokens/" + tokenId, requestApi);
+    }
+
+    @Test
+    public void testGetRetrieveCustomerUrl() {
+        String customerId = "cus_123abc";
+        String customerRequestUrl = StripeApiHandler.getRetrieveCustomerUrl(customerId);
+        assertEquals("https://api.stripe.com/v1/customers/" + customerId, customerRequestUrl);
+    }
+
+    @Test
+    public void testGetAddCustomerSourceUrl() {
+        String customerId = "cus_123abc";
+        String addSourceUrl = StripeApiHandler.getAddCustomerSourceUrl(customerId);
+        assertEquals("https://api.stripe.com/v1/customers/" + customerId + "/sources",
+                addSourceUrl);
     }
 
     @Test
@@ -165,7 +179,7 @@ public class StripeApiHandlerTest {
             };
 
             Card card = new Card("4242424242424242", 1, 2050, "123");
-            Source source = StripeApiHandler.createSourceOnServer(
+            Source source = StripeApiHandler.createSource(
                     provider,
                     RuntimeEnvironment.application.getApplicationContext(),
                     SourceParams.createCardParams(card),
@@ -211,7 +225,7 @@ public class StripeApiHandlerTest {
 
             final String connectAccountId = "acct_1Acj2PBUgO3KuWzz";
             Card card = new Card("4242424242424242", 1, 2050, "123");
-            Source source = StripeApiHandler.createSourceOnServer(
+            Source source = StripeApiHandler.createSource(
                     provider,
                     RuntimeEnvironment.application.getApplicationContext(),
                     SourceParams.createCardParams(card),
@@ -248,7 +262,7 @@ public class StripeApiHandlerTest {
             TestLoggingListener testLoggingListener = new TestLoggingListener(false);
 
             Card card = new Card("4242424242424242", 1, 2050, "123");
-            Source source = StripeApiHandler.createSourceOnServer(
+            Source source = StripeApiHandler.createSource(
                     null,
                     RuntimeEnvironment.application.getApplicationContext(),
                     SourceParams.createCardParams(card),


### PR DESCRIPTION
r? @ksun-stripe 

Adding the addCustomerSource and setDefaultCustomerSource methods to the StripeApiHandler.

Because this diff is focused exclusively on the StripeApiHandler class, I also removed an unused package-private method and the "onServer" item on the ends of "createTokenOnServer" and "createSourceOnServer"