### PR TITLE
Stripe Activity to reuse UI code

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -83,7 +83,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".activity.AddAddressActivity"
+            android:name=".activity.AddAddressExampleActivity"
             android:theme="@style/SampleThemeDefault">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/example/res/layout/activity_add_address_example.xml
+++ b/example/res/layout/activity_add_address_example.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     >
 
     <com.stripe.android.view.AddAddressWidget
@@ -11,4 +10,4 @@
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
         />
-</LinearLayout>
+</FrameLayout>

--- a/example/src/main/java/com/stripe/example/activity/AddAddressExampleActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/AddAddressExampleActivity.java
@@ -6,11 +6,11 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.stripe.example.R;
 
-public class AddAddressActivity extends AppCompatActivity {
+public class AddAddressExampleActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.add_address_activity);
+        setContentView(R.layout.activity_add_address_example);
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -8,6 +8,7 @@ import android.widget.Button;
 
 import com.google.android.gms.wallet.Cart;
 import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.view.AddAddressActivity;
 import com.stripe.example.R;
 import com.stripe.wrap.pay.AndroidPayConfiguration;
 import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
@@ -70,6 +71,7 @@ public class LauncherActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(LauncherActivity.this, AddAddressActivity.class);
+                startActivity(intent);
             }
         });
 

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -1,16 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.stripe.android"
-          android:versionCode="15"
-          android:versionName="4.1.6">
+    package="com.stripe.android"
+    android:versionCode="15"
+    android:versionName="4.1.6"
+    >
 
     <application>
-        <activity android:name=".view.AddSourceActivity"
-            android:theme="@style/StripeDefaultTheme">
+        <activity
+            android:name=".view.AddSourceActivity"
+            android:theme="@style/StripeDefaultTheme"
+            >
         </activity>
 
-        <activity android:name=".view.PaymentMethodsActivity"
-                  android:theme="@style/StripeDefaultTheme">
+        <activity
+            android:name=".view.PaymentMethodsActivity"
+            android:theme="@style/StripeDefaultTheme"
+            >
+        </activity>
+
+        <activity
+            android:name=".view.AddAddressActivity"
+            android:theme="@style/StripeDefaultTheme"
+            >
         </activity>
     </application>
 

--- a/stripe/res/layout/activity_add_address.xml
+++ b/stripe/res/layout/activity_add_address.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    >
+
+    <com.stripe.android.view.AddAddressWidget
+        android:id="@+id/add_address_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="12dp"
+        />
+</FrameLayout>

--- a/stripe/res/layout/activity_add_source.xml
+++ b/stripe/res/layout/activity_add_source.xml
@@ -1,36 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
-
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/add_source_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="@dimen/toolbar_elevation"
-        app:title="@string/title_add_a_card"
-        android:theme="@style/ToolBarStyle"
-        />
 
     <com.stripe.android.view.CardMultilineWidget
         android:id="@+id/add_source_card_entry_widget"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/add_source_toolbar"
         android:layout_margin="@dimen/add_card_total_margin"
-        />
-
-    <ProgressBar
-        android:id="@+id/add_source_progress_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:indeterminate="true"
-        android:layout_below="@id/add_source_toolbar"
         />
 
     <FrameLayout

--- a/stripe/res/layout/activity_stripe.xml
+++ b/stripe/res/layout/activity_stripe.xml
@@ -12,15 +12,16 @@
         android:id="@+id/toolbar_as"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true"
         android:background="?attr/colorPrimary"
         android:elevation="@dimen/toolbar_elevation"
         android:theme="@style/ToolBarStyle"
         />
 
     <ScrollView
-        android:layout_below="@+id/toolbar_as"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@+id/toolbar_as"
         >
 
         <ViewStub
@@ -35,6 +36,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@+id/toolbar_as"
         android:indeterminate="true"
         />
 

--- a/stripe/res/layout/activity_stripe.xml
+++ b/stripe/res/layout/activity_stripe.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <android.support.v7.widget.Toolbar
+
+        android:id="@+id/toolbar_as"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="@dimen/toolbar_elevation"
+        android:theme="@style/ToolBarStyle"
+        />
+
+    <ScrollView
+        android:layout_below="@+id/toolbar_as"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        >
+
+        <ViewStub
+            android:id="@+id/widget_viewstub_as"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            />
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/progress_bar_as"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        />
+
+
+</RelativeLayout>

--- a/stripe/res/layout/add_address_widget.xml
+++ b/stripe/res/layout/add_address_widget.xml
@@ -8,7 +8,6 @@
         android:id="@+id/spinner_country_aaw"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
         />
 
     <android.support.design.widget.TextInputLayout

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="payment_method_add_new_card">Add new card&#8230;</string>
     <string name="title_add_a_card">Add a Card</string>
     <string name="title_payment_method">Payment Method</string>
+    <string name="title_add_an_address">Add an Address</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/AddAddressActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddAddressActivity.java
@@ -5,6 +5,9 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.R;
 
+/**
+ * Activity that can take accept an address. Uses {@link AddAddressWidget}
+ */
 public class AddAddressActivity extends StripeActivity {
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/view/AddAddressActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddAddressActivity.java
@@ -1,0 +1,23 @@
+package com.stripe.android.view;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.R;
+
+public class AddAddressActivity extends StripeActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mViewStub.setLayoutResource(R.layout.activity_add_address);
+        mViewStub.inflate();
+        setTitle(R.string.title_add_an_address);
+    }
+
+    @Override
+    protected void onActionSave() {
+
+    }
+}
+

--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -28,13 +28,12 @@ public class AddSourceActivity extends StripeActivity {
     static final String ADD_SOURCE_ACTIVITY = "AddSourceActivity";
     static final String EXTRA_SHOW_ZIP = "show_zip";
     static final String EXTRA_UPDATE_CUSTOMER = "update_customer";
+    static final long FADE_DURATION_MS = 100L;
     CardMultilineWidget mCardMultilineWidget;
     CustomerSessionProxy mCustomerSessionProxy;
     TextView mErrorTextView;
     FrameLayout mErrorLayout;
     StripeProvider mStripeProvider;
-
-    static final long FADE_DURATION_MS = 100L;
 
     private boolean mUpdatesCustomer;
 

--- a/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
@@ -1,0 +1,91 @@
+package com.stripe.android.view;
+
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewStub;
+import android.widget.ProgressBar;
+
+import com.stripe.android.R;
+
+/**
+ * Provides a toolbar, save button, and loading states for the save button.
+ */
+abstract class StripeActivity extends AppCompatActivity {
+
+    boolean mCommunicating;
+    Toolbar mToolbar;
+    ProgressBar mProgressBar;
+    ViewStub mViewStub;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_stripe);
+        mProgressBar = findViewById(R.id.progress_bar_as);
+        mToolbar = findViewById(R.id.toolbar_as);
+        mViewStub = findViewById(R.id.widget_viewstub_as);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+        setSupportActionBar(mToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+        setCommunicatingProgress(false);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.add_source_menu, menu);
+        menu.findItem(R.id.action_save).setEnabled(!mCommunicating);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_save) {
+            onActionSave();
+            return true;
+        } else {
+            boolean handled = super.onOptionsItemSelected(item);
+            if (!handled) {
+                onBackPressed();
+            }
+            return handled;
+        }
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        MenuItem saveItem = menu.findItem(R.id.action_save);
+        Drawable tintedIcon = ViewUtils.getTintedIcon(
+                this,
+                R.drawable.ic_checkmark,
+                android.R.color.primary_text_dark);
+        saveItem.setIcon(tintedIcon);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+
+    protected void setCommunicatingProgress(boolean communicating) {
+        mCommunicating = communicating;
+        if (communicating) {
+            mProgressBar.setVisibility(View.VISIBLE);
+        } else {
+            mProgressBar.setVisibility(View.GONE);
+        }
+        supportInvalidateOptionsMenu();
+    }
+
+    protected abstract void onActionSave();
+
+}

--- a/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
@@ -64,7 +64,6 @@ abstract class StripeActivity extends AppCompatActivity {
 
 
     @Override
-    @SuppressWarnings("deprecation")
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem saveItem = menu.findItem(R.id.action_save);
         Drawable tintedIcon = ViewUtils.getTintedIcon(

--- a/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
@@ -73,7 +73,7 @@ public class AddSourceActivityTest {
         mCardMultilineWidget = mActivityController.get()
                 .findViewById(R.id.add_source_card_entry_widget);
         mProgressBar = mActivityController.get()
-                .findViewById(R.id.add_source_progress_bar);
+                .findViewById(R.id.progress_bar_as);
         mErrorTextView = mActivityController.get()
                 .findViewById(R.id.tv_add_source_error);
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);
@@ -96,7 +96,7 @@ public class AddSourceActivityTest {
         mCardMultilineWidget = mActivityController.get()
                 .findViewById(R.id.add_source_card_entry_widget);
         mProgressBar = mActivityController.get()
-                .findViewById(R.id.add_source_progress_bar);
+                .findViewById(R.id.progress_bar_as);
         mErrorTextView = mActivityController.get()
                 .findViewById(R.id.tv_add_source_error);
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);


### PR DESCRIPTION
Changes:
Created a StripeActivity that allows up to reuse UI code. I pulled the header into it but not the error rendering. 

Also:
-Old AddAddressActivity is replaced with AddAddressActivityExample. AddAddressExample be will added back in the example app before merging into master. New AddAddressActivity around to test UI.
- Reformatted Manifest
- Ported AddSourcesActivity to StripeActivity


r? @mrmcduff-stripe 

![screen shot 2017-08-18 at 1 55 36 pm](https://user-images.githubusercontent.com/30061905/29479969-ff2f9f2c-8429-11e7-8509-a0db5a17a4e4.png)

![screen shot 2017-08-18 at 3 30 27 pm](https://user-images.githubusercontent.com/30061905/29480009-410d3d64-842a-11e7-84ff-265228985671.png)
![screen shot 2017-08-18 at 3 30 20 pm](https://user-images.githubusercontent.com/30061905/29480010-42d3f6c4-842a-11e7-92f8-9369496c4ff7.png)

UI tests continue to pass? LMK if you have good ideas for things in the StripeActivity to test