### PR TITLE
updating proguard files to automatically protect needed classes

### DIFF
--- a/android-pay/build.gradle
+++ b/android-pay/build.gradle
@@ -12,9 +12,9 @@ android {
     compileSdkVersion 26
     buildToolsVersion '26.0.1'
     defaultConfig {
-        // Min SDK of 14 a requirement of play-services-wallet dependency
         minSdkVersion 14
         targetSdkVersion 26
+        consumerProguardFiles 'proguard-rules.txt'
     }
     sourceSets {
         main {

--- a/android-pay/proguard-rules.txt
+++ b/android-pay/proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn com.stripe.wrap.pay.**

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -29,6 +29,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
+        consumerProguardFiles 'proguard-rules.txt'
     }
     sourceSets {
         main {

--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -1,0 +1,3 @@
+-keep class android.support.design.widget.TextInputLayout { *; }
+-keep class android.support.design.widget.CollapsingTextHelper { *; }
+-dontwarn com.stripe.android.view.**


### PR DESCRIPTION
r? @ksun-stripe 
cc @anelder-stripe 

Adding consumer proguard files so that now users can build our SDK and minify it without bothering to proguard our own classes.

Tested by building a sample application in release mode with minifyEnabled true and an otherwise empty proguard file.