### PR TITLE
Payment utils for currency strings

### DIFF
--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="invalid_cvc">Your card\'s security code is invalid.</string>
     <string name="invalid_zip">Your postal code is incomplete.</string>
     <string name="payment_method_add_new_card">Add new card&#8230;</string>
+    <string name="price_free">Free</string>
     <string name="title_add_a_card">Add a Card</string>
     <string name="title_payment_method">Payment Method</string>
     <string name="title_add_an_address">Add an Address</string>

--- a/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
@@ -1,9 +1,6 @@
 package com.stripe.android.view;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
-
-import com.stripe.android.R;
 
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -12,17 +9,14 @@ import java.util.Locale;
 
 public class PaymentUtils {
 
-    private static double ZERO_CENTS_EPSILON = 0.001;
-
     /**
-     * Formats a monetary amount into a human friendly string where zero(-ish) is returned
+     * Formats a monetary amount into a human friendly string where zero is returned
      * as free.
      */
-    static String formatPriceStringUsingFree(@NonNull Context context, double amount, @NonNull Currency currency) {
-        if (-ZERO_CENTS_EPSILON < amount && amount < ZERO_CENTS_EPSILON) {
-            return context.getResources().getString(R.string.price_free);
+    static String formatPriceStringUsingFree(long amount, @NonNull Currency currency, String free) {
+        if (amount == 0) {
+            return free;
         }
-
         NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
         DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat).getDecimalFormatSymbols();
         decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
@@ -35,11 +29,12 @@ public class PaymentUtils {
      * Formats a monetary amount into a human friendly string.
      */
     static String formatPriceString(double amount, @NonNull Currency currency) {
+        double majorUnitAmount = amount / Math.pow(10, currency.getDefaultFractionDigits());
         NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
         DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat).getDecimalFormatSymbols();
         decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
         ((java.text.DecimalFormat) currencyFormat).setDecimalFormatSymbols(decimalFormatSymbols);
-        return currencyFormat.format(amount);
+        return currencyFormat.format(majorUnitAmount);
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
@@ -1,0 +1,45 @@
+package com.stripe.android.view;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.stripe.android.R;
+
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Currency;
+import java.util.Locale;
+
+public class PaymentUtils {
+
+    private static double ZERO_CENTS_EPSILON = 0.001;
+
+    /**
+     * Formats a monetary amount into a human friendly string where zero(-ish) is returned
+     * as free.
+     */
+    static String formatPriceStringUsingFree(@NonNull Context context, double amount, @NonNull Currency currency) {
+        if (-ZERO_CENTS_EPSILON < amount && amount < ZERO_CENTS_EPSILON) {
+            return context.getResources().getString(R.string.price_free);
+        }
+
+        NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
+        DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat).getDecimalFormatSymbols();
+        decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
+        ((java.text.DecimalFormat) currencyFormat).setDecimalFormatSymbols(decimalFormatSymbols);
+
+        return formatPriceString(amount, currency);
+    }
+
+    /**
+     * Formats a monetary amount into a human friendly string.
+     */
+    static String formatPriceString(double amount, @NonNull Currency currency) {
+        NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
+        DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat).getDecimalFormatSymbols();
+        decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
+        ((java.text.DecimalFormat) currencyFormat).setDecimalFormatSymbols(decimalFormatSymbols);
+        return currencyFormat.format(amount);
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentUtilsTest.java
@@ -1,16 +1,11 @@
 package com.stripe.android.view;
 
-import android.support.v7.app.AppCompatActivity;
-
 import com.stripe.android.BuildConfig;
-import com.stripe.android.R;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 import java.util.Currency;
@@ -25,37 +20,36 @@ import static junit.framework.Assert.assertEquals;
 @Config(sdk = 25, constants = BuildConfig.class)
 public class PaymentUtilsTest {
 
-    ActivityController<AppCompatActivity> mActivityController;
 
     @Before
     public void setup() {
         Locale.setDefault(Locale.US);
-        mActivityController = Robolectric.buildActivity(AppCompatActivity.class).create().start();
     }
 
     @Test
     public void formatPriceStringUsingFree_whenZero_rendersFree() {
         assertEquals(
                 PaymentUtils.formatPriceStringUsingFree(
-                        mActivityController.get(), 0,
-                        Currency.getInstance("USD")),
-                        mActivityController.get().getResources().getString(R.string.price_free));
+                        0,
+                        Currency.getInstance("USD"),
+                        "Free"),
+                        "Free");
     }
 
     @Test
     public void formatPriceString_whenUSLocale_rendersCorrectSymbols() {
 
         Locale.setDefault(Locale.US);
-        assertEquals(PaymentUtils.formatPriceString(123, Currency.getInstance("USD")), "$123.00");
+        assertEquals(PaymentUtils.formatPriceString(12300, Currency.getInstance("USD")), "$123.00");
 
         Currency euro = Currency.getInstance(Locale.GERMANY);
-        assertEquals(PaymentUtils.formatPriceString(123, euro), "EUR123.00");
+        assertEquals(PaymentUtils.formatPriceString(12300, euro), "EUR123.00");
 
         Currency canadianDollar = Currency.getInstance(Locale.CANADA);
-        assertEquals(PaymentUtils.formatPriceString(123, canadianDollar), "CAD123.00");
+        assertEquals(PaymentUtils.formatPriceString(12300, canadianDollar), "CAD123.00");
 
         Currency britishPound = Currency.getInstance(Locale.UK);
-        assertEquals(PaymentUtils.formatPriceString(100, britishPound), "GBP100.00");
+        assertEquals(PaymentUtils.formatPriceString(10000, britishPound), "GBP100.00");
     }
 
     @Test
@@ -63,7 +57,7 @@ public class PaymentUtilsTest {
 
         Locale.setDefault(Locale.GERMANY);
         Currency euro = Currency.getInstance(Locale.GERMANY);
-        assertEquals(PaymentUtils.formatPriceString(100, euro), "100,00 €");
+        assertEquals(PaymentUtils.formatPriceString(10000, euro), "100,00 €");
 
         Locale.setDefault(Locale.JAPAN);
         Currency yen = Currency.getInstance(Locale.JAPAN);
@@ -72,21 +66,21 @@ public class PaymentUtilsTest {
 
         Locale.setDefault(new Locale("ar", "JO")); //Jordan
         Currency jordanianDinar = Currency.getInstance("JOD");
-        assertEquals(PaymentUtils.formatPriceString(100.123, jordanianDinar), jordanianDinar.getSymbol() + " 100.123");
+        assertEquals(PaymentUtils.formatPriceString(100123, jordanianDinar), jordanianDinar.getSymbol() + " 100.123");
 
         Locale.setDefault(Locale.UK);
         Currency britishPound = Currency.getInstance(Locale.UK);
-        assertEquals(PaymentUtils.formatPriceString(100, britishPound), "£100.00");
+        assertEquals(PaymentUtils.formatPriceString(10000, britishPound), "£100.00");
 
         Locale.setDefault(Locale.CANADA);
         Currency canadianDollar = Currency.getInstance(Locale.CANADA);
-        assertEquals(PaymentUtils.formatPriceString(123, canadianDollar), "$123.00");
+        assertEquals(PaymentUtils.formatPriceString(12300, canadianDollar), "$123.00");
     }
 
     @Test
     public void formatPriceString_whenDecimalAmounts_rendersCorrectDigits() {
-        assertEquals(PaymentUtils.formatPriceString(100.123, Currency.getInstance("USD")), "$100.12");
-        assertEquals(PaymentUtils.formatPriceString(.12, Currency.getInstance("USD")), "$0.12");
+        assertEquals(PaymentUtils.formatPriceString(10012, Currency.getInstance("USD")), "$100.12");
+        assertEquals(PaymentUtils.formatPriceString(12, Currency.getInstance("USD")), "$0.12");
     }
 
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentUtilsTest.java
@@ -1,0 +1,92 @@
+package com.stripe.android.view;
+
+import android.support.v7.app.AppCompatActivity;
+
+import com.stripe.android.BuildConfig;
+import com.stripe.android.R;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import java.util.Currency;
+import java.util.Locale;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Test class for {@link PaymentUtils}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25, constants = BuildConfig.class)
+public class PaymentUtilsTest {
+
+    ActivityController<AppCompatActivity> mActivityController;
+
+    @Before
+    public void setup() {
+        Locale.setDefault(Locale.US);
+        mActivityController = Robolectric.buildActivity(AppCompatActivity.class).create().start();
+    }
+
+    @Test
+    public void formatPriceStringUsingFree_whenZero_rendersFree() {
+        assertEquals(
+                PaymentUtils.formatPriceStringUsingFree(
+                        mActivityController.get(), 0,
+                        Currency.getInstance("USD")),
+                        mActivityController.get().getResources().getString(R.string.price_free));
+    }
+
+    @Test
+    public void formatPriceString_whenUSLocale_rendersCorrectSymbols() {
+
+        Locale.setDefault(Locale.US);
+        assertEquals(PaymentUtils.formatPriceString(123, Currency.getInstance("USD")), "$123.00");
+
+        Currency euro = Currency.getInstance(Locale.GERMANY);
+        assertEquals(PaymentUtils.formatPriceString(123, euro), "EUR123.00");
+
+        Currency canadianDollar = Currency.getInstance(Locale.CANADA);
+        assertEquals(PaymentUtils.formatPriceString(123, canadianDollar), "CAD123.00");
+
+        Currency britishPound = Currency.getInstance(Locale.UK);
+        assertEquals(PaymentUtils.formatPriceString(100, britishPound), "GBP100.00");
+    }
+
+    @Test
+    public void formatPriceString_whenInternationalLocale_rendersCorrectSymbols() {
+
+        Locale.setDefault(Locale.GERMANY);
+        Currency euro = Currency.getInstance(Locale.GERMANY);
+        assertEquals(PaymentUtils.formatPriceString(100, euro), "100,00 €");
+
+        Locale.setDefault(Locale.JAPAN);
+        Currency yen = Currency.getInstance(Locale.JAPAN);
+        // Japan's native local uses narrow yen symbol (there is also a wide yen symbol)
+        assertEquals(PaymentUtils.formatPriceString(100, yen), "￥100");
+
+        Locale.setDefault(new Locale("ar", "JO")); //Jordan
+        Currency jordanianDinar = Currency.getInstance("JOD");
+        assertEquals(PaymentUtils.formatPriceString(100.123, jordanianDinar), jordanianDinar.getSymbol() + " 100.123");
+
+        Locale.setDefault(Locale.UK);
+        Currency britishPound = Currency.getInstance(Locale.UK);
+        assertEquals(PaymentUtils.formatPriceString(100, britishPound), "£100.00");
+
+        Locale.setDefault(Locale.CANADA);
+        Currency canadianDollar = Currency.getInstance(Locale.CANADA);
+        assertEquals(PaymentUtils.formatPriceString(123, canadianDollar), "$123.00");
+    }
+
+    @Test
+    public void formatPriceString_whenDecimalAmounts_rendersCorrectDigits() {
+        assertEquals(PaymentUtils.formatPriceString(100.123, Currency.getInstance("USD")), "$100.12");
+        assertEquals(PaymentUtils.formatPriceString(.12, Currency.getInstance("USD")), "$0.12");
+    }
+
+}


### PR DESCRIPTION
Description: Utils function that can render a currency into a human readable string.

I decided to opt to format it so that we use the format structure that the default locale on the phone with the currency of the actual country. For example, 
US Locale, USD -> $100.00 and US Locale, CAD -> CAD100.00
Canadian Locale, USD -> USD100.00 and Canadian Locale, CAD -> $100.00

More examples are in the unit tests.

Tests: Unit tests

r? @mrmcduff-stripe 
cc? @anelder-stripe