### PR TITLE
- missing break in switch statement

### DIFF
--- a/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
+++ b/android-pay/src/main/java/com/stripe/wrap/pay/activity/StripeAndroidPayActivity.java
@@ -230,6 +230,7 @@ public abstract class StripeAndroidPayActivity extends AppCompatActivity
                         handleError(errorCode);
                         break;
                 }
+                break;
             case WalletConstants.RESULT_ERROR:
                 handleError(errorCode);
                 break;


### PR DESCRIPTION
There is a `break` missing in `StripeAndroidPayActivity` `onActivityResult` which causes `handleError` to be called unnecessarily 