### PR TITLE
adding more styling and theming options

### DIFF
--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -8,14 +8,8 @@
         <item name="android:textColorSecondary">@android:color/secondary_text_light</item>
     </style>
 
-    <style name="ToolBarStyle" parent="">
-        <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
-        <item name="theme">@style/ThemeOverlay.AppCompat</item>
-        <item name="colorControlNormal">@android:color/white</item>
-        <item name="colorPrimary">@color/toolbar_color_default</item>
-        <item name="titleTextColor">@android:color/white</item>
-        <item name="android:textColorPrimary">@android:color/white</item>
-        <item name="titleTextAppearance">@style/TextAppearance.Widget.AppCompat.Toolbar.Title</item>
+    <style name="ToolBarStyle" parent="@style/ThemeOverlay.AppCompat">
+        <item name="colorControlNormal">?attr/titleTextColor</item>
     </style>
 
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -89,11 +89,13 @@ public class AddSourceActivity extends AppCompatActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem saveItem = menu.findItem(R.id.action_save);
-        Drawable tintedIcon = ViewUtils.getTintedIcon(
-                this,
-                R.drawable.ic_checkmark,
-                android.R.color.primary_text_dark);
-        saveItem.setIcon(tintedIcon);
+        Drawable compatIcon =
+                ViewUtils.getTintedIconWithAttribute(
+                        this,
+                        getTheme(),
+                        R.attr.titleTextColor,
+                        R.drawable.ic_checkmark);
+        saveItem.setIcon(compatIcon);
         return super.onPrepareOptionsMenu(menu);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -113,11 +113,13 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem saveItem = menu.findItem(R.id.action_save);
-        Drawable tintedIcon = ViewUtils.getTintedIcon(
-                this,
-                R.drawable.ic_checkmark,
-                android.R.color.primary_text_dark);
-        saveItem.setIcon(tintedIcon);
+        Drawable compatIcon =
+                ViewUtils.getTintedIconWithAttribute(
+                        this,
+                        getTheme(),
+                        R.attr.titleTextColor,
+                        R.drawable.ic_checkmark);
+        saveItem.setIcon(compatIcon);
         return super.onPrepareOptionsMenu(menu);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.annotation.AttrRes;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
@@ -85,6 +86,26 @@ class ViewUtils {
             icon = context.getResources().getDrawable(iconResourceId, context.getTheme());
         }  else {
             color = context.getResources().getColor(colorResourceId);
+            icon = context.getResources().getDrawable(iconResourceId);
+        }
+        Drawable compatIcon = DrawableCompat.wrap(icon);
+        DrawableCompat.setTint(compatIcon.mutate(), color);
+        return compatIcon;
+    }
+
+    @SuppressWarnings("deprecation")
+    static Drawable getTintedIconWithAttribute(
+            @NonNull Context context,
+            @NonNull Resources.Theme theme,
+            @AttrRes int attributeResource,
+            @DrawableRes int iconResourceId) {
+        TypedValue typedValue = new TypedValue();
+        theme.resolveAttribute(attributeResource, typedValue, true);
+        @ColorInt int color = typedValue.data;
+        Drawable icon;
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+            icon = context.getResources().getDrawable(iconResourceId, theme);
+        } else {
             icon = context.getResources().getDrawable(iconResourceId);
         }
         Drawable compatIcon = DrawableCompat.wrap(icon);


### PR DESCRIPTION
r? @anelder-stripe 
cc @joeydong-stripe 

Fixing the applied themes so that you can make the colors of our controls be whatever you like.

(default)
<img width="327" alt="screenshot 2017-08-30 17 16 40" src="https://user-images.githubusercontent.com/23323692/29900693-47ae9e1a-8da8-11e7-80a6-bbb7b7f2006e.png">

(style_everything)
<img width="329" alt="screenshot 2017-08-30 17 24 02" src="https://user-images.githubusercontent.com/23323692/29900698-54df3108-8da8-11e7-8ac6-8f26fe3d7944.png">

(style everything on add source)
<img width="328" alt="screenshot 2017-08-30 17 14 57" src="https://user-images.githubusercontent.com/23323692/29900705-5d3942d0-8da8-11e7-9328-38b30106bcd4.png">

This isn't too testable due to all the changes being in XML and affecting only what colors are on the screen.

