### PR TITLE
adding the PaymentSession skeleton and starter methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -41,7 +41,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
     private static final String KEY_SOURCE = "source";
     private static final String KEY_SOURCE_TYPE = "source_type";
     private static final Set<String> VALID_TOKENS =
-            new HashSet<>(Arrays.asList("AddSourceActivity", "PaymentMethodsActivity"));
+            new HashSet<>(Arrays.asList("AddSourceActivity",
+                    "PaymentMethodsActivity",
+                    "PaymentSession"));
 
     private @Nullable Customer mCustomer;
     private long mCustomerCacheTime;
@@ -223,6 +225,10 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         arguments.put(KEY_SOURCE_TYPE, sourceType);
         mCustomerRetrievalListener = listener;
         mEphemeralKeyManager.retrieveEphemeralKey(ACTION_SET_DEFAULT_SOURCE, arguments);
+    }
+
+    void clearUsageTokens() {
+        mProductUsageTokens.clear();
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -9,7 +9,6 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.stripe.android.model.Customer;
-import com.stripe.android.model.CustomerSource;
 import com.stripe.android.view.PaymentMethodsActivity;
 
 /**
@@ -18,15 +17,13 @@ import com.stripe.android.view.PaymentMethodsActivity;
 public class PaymentSession {
 
     static final int PAYMENT_METHOD_REQUEST = 3003;
-    static final String PAYMENT_SESSION_DATA_KEY = "payment_session_data";
+    static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
+
+    private static final String PAYMENT_SESSION_DATA_KEY = "payment_session_data";
 
     @NonNull private Activity mHostActivity;
-    @Nullable private PaymentSessionListener mPaymentSessionListener;
-
-    @Nullable private CustomerSource mSelectedPaymentSource;
     @NonNull private PaymentSessionData mPaymentSessionData;
-
-    private static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
+    @Nullable private PaymentSessionListener mPaymentSessionListener;
 
     /**
      * Create a PaymentSession attached to the given host Activity.
@@ -154,13 +151,10 @@ public class PaymentSession {
                     public void onCustomerRetrieved(@NonNull Customer customer) {
                         String paymentId = customer.getDefaultSource();
                         mPaymentSessionData.setSelectedPaymentMethodId(paymentId);
-                        if (!TextUtils.isEmpty(paymentId)) {
-                            mSelectedPaymentSource =
-                                    customer.getSourceById(paymentId);
-                        }
 
                         if (mPaymentSessionListener != null) {
-                            mPaymentSessionListener.onPaymentMethodSelected();
+                            mPaymentSessionListener
+                                    .onPaymentSessionDataChanged(mPaymentSessionData);
                             mPaymentSessionListener.onCommunicatingStateChanged(false);
                         }
                     }
@@ -170,32 +164,6 @@ public class PaymentSession {
                         if (mPaymentSessionListener != null) {
                             mPaymentSessionListener.onError(errorCode, errorMessage);
                             mPaymentSessionListener.onCommunicatingStateChanged(false);
-                        }
-                    }
-                });
-    }
-
-    private void updateCustomer() {
-        CustomerSession.getInstance().updateCurrentCustomer(
-                new CustomerSession.CustomerRetrievalListener() {
-                    @Override
-                    public void onCustomerRetrieved(@NonNull Customer customer) {
-                        String paymentId = customer.getDefaultSource();
-                        mPaymentSessionData.setSelectedPaymentMethodId(paymentId);
-                        if (!TextUtils.isEmpty(paymentId)) {
-                            mSelectedPaymentSource =
-                                    customer.getSourceById(paymentId);
-                        }
-
-                        if (mPaymentSessionListener != null) {
-                            mPaymentSessionListener.onPaymentMethodSelected();
-                        }
-                    }
-
-                    @Override
-                    public void onError(int errorCode, @Nullable String errorMessage) {
-                        if (mPaymentSessionListener != null) {
-                            mPaymentSessionListener.onError(errorCode, errorMessage);
                         }
                     }
                 });
@@ -222,10 +190,7 @@ public class PaymentSession {
          */
         void onError(int errorCode, @Nullable String errorMessage);
 
-        /**
-         * Notification method called when the user has selected a payment method.
-         */
-        void onPaymentMethodSelected();
+        void onPaymentSessionDataChanged(@NonNull PaymentSessionData data);
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -1,0 +1,85 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.view.PaymentMethodsActivity;
+
+/**
+ * Represents a single start-to-finish payment operation.
+ */
+public class PaymentSession {
+
+    public static final int PAYMENT_METHOD_REQUEST = 3003;
+    @NonNull Activity mHostActivity;
+    @Nullable private PaymentSessionListener mPaymentSessionListener;
+
+    private static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
+
+    /**
+     * Create a PaymentSession attached to the given host Activity.
+     *
+     * @param hostActivity an {@link Activity} from which to launch other Stripe Activities. This
+     *                     Activity will receive results in
+     *                     {@link Activity#onActivityResult(int, int, Intent)} that should be passed
+     *                     back to this session.
+     */
+    public PaymentSession(@NonNull Activity hostActivity) {
+        mHostActivity = hostActivity;
+    }
+
+    public boolean init(@NonNull PaymentSessionListener listener) {
+        try {
+            mPaymentSessionListener = listener;
+            CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
+            PaymentConfiguration.getInstance();
+        } catch (IllegalStateException illegalState) {
+            mPaymentSessionListener = null;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Method to handle Activity results from Stripe activities. Pass data here from your
+     * host Activity's {@link Activity#onActivityResult(int, int, Intent)} function.
+     *
+     * @param requestCode the request code used to open the resulting activity
+     * @param resultCode a result code representing the success of the intended action
+     * @param data an {@link Intent} with the resulting data from the Activity
+     * @return {@code true} if the activity result was handled by this function,
+     * otherwise {@code false}
+     */
+    public boolean handlePaymentData(int requestCode, int resultCode, @NonNull Intent data) {
+        if (resultCode == Activity.RESULT_CANCELED) {
+            return false;
+        } else if (resultCode == Activity.RESULT_OK) {
+            switch (requestCode) {
+                case PAYMENT_METHOD_REQUEST:
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    public void selectPaymentMethod() {
+        mHostActivity.startActivityForResult(
+                PaymentMethodsActivity.newIntent(mHostActivity),
+                PAYMENT_METHOD_REQUEST);
+    }
+
+    /**
+     * Represents a listener for PaymentSession actions, used to update the host activity
+     * when necessary.
+     */
+    public interface PaymentSessionListener {
+        void onPaymentMethodSelected();
+        void onShippingAddressUpdated();
+        void onShippingOptionsSelected();
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -2,9 +2,14 @@ package com.stripe.android;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
+import com.stripe.android.model.Customer;
+import com.stripe.android.model.CustomerSource;
 import com.stripe.android.view.PaymentMethodsActivity;
 
 /**
@@ -12,9 +17,14 @@ import com.stripe.android.view.PaymentMethodsActivity;
  */
 public class PaymentSession {
 
-    public static final int PAYMENT_METHOD_REQUEST = 3003;
-    @NonNull Activity mHostActivity;
+    static final int PAYMENT_METHOD_REQUEST = 3003;
+    static final String PAYMENT_SESSION_DATA_KEY = "payment_session_data";
+
+    @NonNull private Activity mHostActivity;
     @Nullable private PaymentSessionListener mPaymentSessionListener;
+
+    @Nullable private CustomerSource mSelectedPaymentSource;
+    @NonNull private PaymentSessionData mPaymentSessionData;
 
     private static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
 
@@ -28,18 +38,7 @@ public class PaymentSession {
      */
     public PaymentSession(@NonNull Activity hostActivity) {
         mHostActivity = hostActivity;
-    }
-
-    public boolean init(@NonNull PaymentSessionListener listener) {
-        try {
-            mPaymentSessionListener = listener;
-            CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
-            PaymentConfiguration.getInstance();
-        } catch (IllegalStateException illegalState) {
-            mPaymentSessionListener = null;
-            return false;
-        }
-        return true;
+        mPaymentSessionData = new PaymentSessionData();
     }
 
     /**
@@ -58,6 +57,7 @@ public class PaymentSession {
         } else if (resultCode == Activity.RESULT_OK) {
             switch (requestCode) {
                 case PAYMENT_METHOD_REQUEST:
+                    fetchCustomer();
                     break;
                 default:
                     break;
@@ -67,6 +67,57 @@ public class PaymentSession {
         return false;
     }
 
+    /**
+     * Initialize the PaymentSession with a {@link PaymentSessionListener} to be notified of
+     * data changes.
+     *
+     * @param listener a {@link PaymentSessionListener} that will receive notifications of changes
+     *                 in payment session status, including networking status
+     * @return {@code true} if the PaymentSession is initialized, {@code false} if a state error
+     * occurs. Failure can only occur if there is no initialized {@link CustomerSession}.
+     */
+    public boolean init(@NonNull PaymentSessionListener listener) {
+        return init(listener, null);
+    }
+
+    /**
+     * Initialize the PaymentSession with a {@link PaymentSessionListener} to be notified of
+     * data changes.
+     *
+     * @param listener a {@link PaymentSessionListener} that will receive notifications of changes
+     *                 in payment session status, including networking status
+     * @param savedInstanceState a {@link Bundle} containing the saved state of a PaymentSession
+     *                           that was stored in {@link #savePaymentSessionInstanceState(Bundle)}
+     * @return {@code true} if the PaymentSession is initialized, {@code false} if a state error
+     * occurs. Failure can only occur if there is no initialized {@link CustomerSession}.
+     */
+    public boolean init(
+            @NonNull PaymentSessionListener listener,
+            @Nullable Bundle savedInstanceState) {
+
+        try {
+            CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
+        } catch (IllegalStateException illegalState) {
+            mPaymentSessionListener = null;
+            return false;
+        }
+
+        mPaymentSessionListener = listener;
+        if (savedInstanceState != null) {
+            PaymentSessionData data =
+                    savedInstanceState.getParcelable(PAYMENT_SESSION_DATA_KEY);
+            if (data != null) {
+                mPaymentSessionData = data;
+            }
+        }
+        fetchCustomer();
+        return true;
+    }
+
+    /**
+     * Launch the {@link PaymentMethodsActivity} to allow the user to select a payment method,
+     * or to add a new one.
+     */
     public void selectPaymentMethod() {
         mHostActivity.startActivityForResult(
                 PaymentMethodsActivity.newIntent(mHostActivity),
@@ -74,12 +125,107 @@ public class PaymentSession {
     }
 
     /**
+     * Save the data associated with this PaymentSession. This should be called in the host Activity
+     * {@link Activity#onSaveInstanceState(Bundle)} method.
+     *
+     * @param outState the host activity's outgoing {@link Bundle}
+     */
+    public void savePaymentSessionInstanceState(@NonNull Bundle outState) {
+        outState.putParcelable(PAYMENT_SESSION_DATA_KEY, mPaymentSessionData);
+    }
+
+    /**
+     * Set the cart total for this PaymentSession. This should not include shipping costs.
+     *
+     * @param cartTotal the current total price for all non-shipping and non-tax items in
+     *                  a customer's cart
+     */
+    public void setCartTotal(@IntRange(from = 0) long cartTotal) {
+        mPaymentSessionData.setCartTotal(cartTotal);
+    }
+
+    private void fetchCustomer() {
+        if (mPaymentSessionListener != null) {
+            mPaymentSessionListener.onCommunicatingStateChanged(true);
+        }
+        CustomerSession.getInstance().retrieveCurrentCustomer(
+                new CustomerSession.CustomerRetrievalListener() {
+                    @Override
+                    public void onCustomerRetrieved(@NonNull Customer customer) {
+                        String paymentId = customer.getDefaultSource();
+                        mPaymentSessionData.setSelectedPaymentMethodId(paymentId);
+                        if (!TextUtils.isEmpty(paymentId)) {
+                            mSelectedPaymentSource =
+                                    customer.getSourceById(paymentId);
+                        }
+
+                        if (mPaymentSessionListener != null) {
+                            mPaymentSessionListener.onPaymentMethodSelected();
+                            mPaymentSessionListener.onCommunicatingStateChanged(false);
+                        }
+                    }
+
+                    @Override
+                    public void onError(int errorCode, @Nullable String errorMessage) {
+                        if (mPaymentSessionListener != null) {
+                            mPaymentSessionListener.onError(errorCode, errorMessage);
+                            mPaymentSessionListener.onCommunicatingStateChanged(false);
+                        }
+                    }
+                });
+    }
+
+    private void updateCustomer() {
+        CustomerSession.getInstance().updateCurrentCustomer(
+                new CustomerSession.CustomerRetrievalListener() {
+                    @Override
+                    public void onCustomerRetrieved(@NonNull Customer customer) {
+                        String paymentId = customer.getDefaultSource();
+                        mPaymentSessionData.setSelectedPaymentMethodId(paymentId);
+                        if (!TextUtils.isEmpty(paymentId)) {
+                            mSelectedPaymentSource =
+                                    customer.getSourceById(paymentId);
+                        }
+
+                        if (mPaymentSessionListener != null) {
+                            mPaymentSessionListener.onPaymentMethodSelected();
+                        }
+                    }
+
+                    @Override
+                    public void onError(int errorCode, @Nullable String errorMessage) {
+                        if (mPaymentSessionListener != null) {
+                            mPaymentSessionListener.onError(errorCode, errorMessage);
+                        }
+                    }
+                });
+    }
+
+    /**
      * Represents a listener for PaymentSession actions, used to update the host activity
      * when necessary.
      */
     public interface PaymentSessionListener {
+        /**
+         * Notification method called when network communication is beginning or ending.
+         *
+         * @param isCommunicating {@code true} if communication is starting, {@code false} if it
+         * is stopping.
+         */
+        void onCommunicatingStateChanged(boolean isCommunicating);
+
+        /**
+         * Notification method called when an error has occurred.
+         *
+         * @param errorCode a network code associated with the error
+         * @param errorMessage a message associated with the error
+         */
+        void onError(int errorCode, @Nullable String errorMessage);
+
+        /**
+         * Notification method called when the user has selected a payment method.
+         */
         void onPaymentMethodSelected();
-        void onShippingAddressUpdated();
-        void onShippingOptionsSelected();
     }
+
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -55,7 +55,7 @@ public class PaymentSession {
             switch (requestCode) {
                 case PAYMENT_METHOD_REQUEST:
                     fetchCustomer();
-                    break;
+                    return true;
                 default:
                     break;
             }
@@ -92,6 +92,8 @@ public class PaymentSession {
             @NonNull PaymentSessionListener listener,
             @Nullable Bundle savedInstanceState) {
 
+        // Checking to make sure that there is a valid CustomerSession -- the getInstance() call
+        // will throw a runtime exception if none is ready.
         try {
             CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
         } catch (IllegalStateException illegalState) {
@@ -190,6 +192,12 @@ public class PaymentSession {
          */
         void onError(int errorCode, @Nullable String errorMessage);
 
+        /**
+         * Notification method called when the {@link PaymentSessionData} for this
+         * session has changed.
+         *
+         * @param data the updated {@link PaymentSessionData}
+         */
         void onPaymentSessionDataChanged(@NonNull PaymentSessionData data);
     }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -5,7 +5,10 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-class PaymentSessionData implements Parcelable {
+/**
+ * A data class representing the state of the associated {@link PaymentSession}.
+ */
+public class PaymentSessionData implements Parcelable {
 
     private static final String NO_PAYMENT = "NO_PAYMENT";
 
@@ -15,30 +18,44 @@ class PaymentSessionData implements Parcelable {
 
     PaymentSessionData() { }
 
+    /**
+     * Get the selected payment method ID for the associated {@link PaymentSession}.
+     * @return
+     */
     @Nullable
     public String getSelectedPaymentMethodId() {
         return mSelectedPaymentMethodId.equals(NO_PAYMENT) ? null : mSelectedPaymentMethodId;
     }
 
-    public void setSelectedPaymentMethodId(@Nullable String selectedPaymentMethodId) {
+    /**
+     * Get the cart total value, excluding shipping and tax items.
+     *
+     * @return the current value of the items in the cart
+     */
+    public long getCartTotal() {
+        return mCartTotal;
+    }
+
+    /**
+     * Get the value of shipping items in the associated {@link PaymentSession}
+     *
+     * @return the current value of the shipping items in the cart
+     */
+    public long getShippingTotal() {
+        return mShippingTotal;
+    }
+
+    void setCartTotal(long cartTotal) {
+        mCartTotal = cartTotal;
+    }
+
+    void setSelectedPaymentMethodId(@Nullable String selectedPaymentMethodId) {
         mSelectedPaymentMethodId = selectedPaymentMethodId == null
                 ? NO_PAYMENT
                 : selectedPaymentMethodId;
     }
 
-    public long getCartTotal() {
-        return mCartTotal;
-    }
-
-    public void setCartTotal(long cartTotal) {
-        mCartTotal = cartTotal;
-    }
-
-    public long getShippingTotal() {
-        return mShippingTotal;
-    }
-
-    public void setShippingTotal(long shippingTotal) {
+    void setShippingTotal(long shippingTotal) {
         mShippingTotal = shippingTotal;
     }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -1,0 +1,74 @@
+package com.stripe.android;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+class PaymentSessionData implements Parcelable {
+
+    private static final String NO_PAYMENT = "NO_PAYMENT";
+
+    private long mCartTotal = 0L;
+    @NonNull private String mSelectedPaymentMethodId = NO_PAYMENT;
+    private long mShippingTotal = 0L;
+
+    PaymentSessionData() { }
+
+    @Nullable
+    public String getSelectedPaymentMethodId() {
+        return mSelectedPaymentMethodId.equals(NO_PAYMENT) ? null : mSelectedPaymentMethodId;
+    }
+
+    public void setSelectedPaymentMethodId(@Nullable String selectedPaymentMethodId) {
+        mSelectedPaymentMethodId = selectedPaymentMethodId == null
+                ? NO_PAYMENT
+                : selectedPaymentMethodId;
+    }
+
+    public long getCartTotal() {
+        return mCartTotal;
+    }
+
+    public void setCartTotal(long cartTotal) {
+        mCartTotal = cartTotal;
+    }
+
+    public long getShippingTotal() {
+        return mShippingTotal;
+    }
+
+    public void setShippingTotal(long shippingTotal) {
+        mShippingTotal = shippingTotal;
+    }
+
+    /************** Parcelable *********************/
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeLong(mCartTotal);
+        parcel.writeString(mSelectedPaymentMethodId);
+        parcel.writeLong(mShippingTotal);
+    }
+
+    public static final Parcelable.Creator<PaymentSessionData> CREATOR
+            = new Parcelable.Creator<PaymentSessionData>() {
+        public PaymentSessionData createFromParcel(Parcel in) {
+            return new PaymentSessionData(in);
+        }
+
+        public PaymentSessionData[] newArray(int size) {
+            return new PaymentSessionData[size];
+        }
+    };
+
+    private PaymentSessionData(Parcel in) {
+        mCartTotal = in.readLong();
+        mSelectedPaymentMethodId = in.readString();
+        mShippingTotal = in.readLong();
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 25)
 public class CustomerSessionTest {
 
-    private static final String FIRST_SAMPLE_KEY_RAW = "{\n" +
+    public static final String FIRST_SAMPLE_KEY_RAW = "{\n" +
             "  \"id\": \"ephkey_123\",\n" +
             "  \"object\": \"ephemeral_key\",\n" +
             "  \"secret\": \"ek_test_123\",\n" +
@@ -59,7 +59,7 @@ public class CustomerSessionTest {
             "            }]\n" +
             "}";
 
-    private static final String SECOND_SAMPLE_KEY_RAW = "{\n" +
+    public static final String SECOND_SAMPLE_KEY_RAW = "{\n" +
             "  \"id\": \"ephkey_ABC\",\n" +
             "  \"object\": \"ephemeral_key\",\n" +
             "  \"secret\": \"ek_test_456\",\n" +

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -187,9 +187,10 @@ public class PaymentSessionTest {
         // We have already tested the functionality up to here.
         reset(mockListener);
 
-        paymentSession.handlePaymentData(
+        boolean handled = paymentSession.handlePaymentData(
                 PaymentSession.PAYMENT_METHOD_REQUEST, RESULT_OK, new Intent());
 
+        assertTrue(handled);
         verify(mockListener).onPaymentSessionDataChanged(any(PaymentSessionData.class));
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -1,0 +1,261 @@
+package com.stripe.android;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.Customer;
+import com.stripe.android.model.Source;
+import com.stripe.android.testharness.TestEphemeralKeyProvider;
+import com.stripe.android.view.CardInputTestActivity;
+import com.stripe.android.view.PaymentMethodsActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+
+import java.util.Set;
+
+import static android.app.Activity.RESULT_OK;
+import static com.stripe.android.CustomerSessionTest.FIRST_SAMPLE_KEY_RAW;
+import static com.stripe.android.CustomerSessionTest.FIRST_TEST_CUSTOMER_OBJECT;
+import static com.stripe.android.CustomerSessionTest.SECOND_TEST_CUSTOMER_OBJECT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link PaymentSession}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 25)
+public class PaymentSessionTest {
+
+    private TestEphemeralKeyProvider mEphemeralKeyProvider;
+
+    private Customer mFirstCustomer;
+    private Customer mSecondCustomer;
+    private Source mAddedSource;
+
+    private ActivityController<AppCompatActivity> mActivityController;
+    private ShadowActivity mShadowActivity;
+    @Mock CustomerSession.StripeApiProxy mStripeApiProxy;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        PaymentConfiguration.init("pk_test_abc123");
+
+        mEphemeralKeyProvider = new TestEphemeralKeyProvider();
+        CustomerSession.initCustomerSession(mEphemeralKeyProvider, mStripeApiProxy, null);
+        mActivityController =
+                Robolectric.buildActivity(AppCompatActivity.class).create().start();
+        mShadowActivity = Shadows.shadowOf(mActivityController.get());
+
+        mFirstCustomer = Customer.fromString(FIRST_TEST_CUSTOMER_OBJECT);
+        assertNotNull(mFirstCustomer);
+        mSecondCustomer = Customer.fromString(SECOND_TEST_CUSTOMER_OBJECT);
+        assertNotNull(mSecondCustomer);
+
+        mEphemeralKeyProvider = new TestEphemeralKeyProvider();
+
+        mAddedSource = Source.fromString(CardInputTestActivity.EXAMPLE_JSON_CARD_SOURCE);
+        assertNotNull(mAddedSource);
+
+        try {
+            when(mStripeApiProxy.retrieveCustomerWithKey(anyString(), anyString()))
+                    .thenReturn(mFirstCustomer, mSecondCustomer);
+            when(mStripeApiProxy.addCustomerSourceWithKey(
+                    any(Context.class),
+                    anyString(),
+                    anyString(),
+                    ArgumentMatchers.<String>anyList(),
+                    anyString(),
+                    anyString(),
+                    anyString()))
+                    .thenReturn(mAddedSource);
+            when(mStripeApiProxy.setDefaultCustomerSourceWithKey(
+                    any(Context.class),
+                    anyString(),
+                    anyString(),
+                    ArgumentMatchers.<String>anyList(),
+                    anyString(),
+                    anyString(),
+                    anyString()))
+                    .thenReturn(mSecondCustomer);
+        } catch (StripeException exception) {
+            fail("Exception when accessing mock api proxy: " + exception.getMessage());
+        }
+    }
+
+    @Test
+    public void init_addsPaymentSessionToken_andFetchesCustomer() {
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+
+        Set<String> tokenSet = CustomerSession.getInstance().getProductUsageTokens();
+        assertTrue(tokenSet.contains(PaymentSession.TOKEN_PAYMENT_SESSION));
+
+        verify(mockListener).onCommunicatingStateChanged(eq(true));
+    }
+
+    @Test
+    public void init_whenEphemeralKeyProviderContinues_fetchesCustomerAndNotifiesListener() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession.initCustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                null);
+
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+        verify(mockListener).onCommunicatingStateChanged(eq(true));
+        verify(mockListener).onPaymentSessionDataChanged(any(PaymentSessionData.class));
+        verify(mockListener).onCommunicatingStateChanged(eq(false));
+    }
+
+    @Test
+    public void setCartTotal_setsExpectedValueAndNotifiesListener() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession.initCustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                null);
+
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+
+        ArgumentCaptor<PaymentSessionData> dataArgumentCaptor = getDataCaptor();
+
+        paymentSession.setCartTotal(500L);
+
+        verify(mockListener).onPaymentSessionDataChanged(dataArgumentCaptor.capture());
+        PaymentSessionData data = dataArgumentCaptor.getValue();
+        assertNotNull(data);
+        assertEquals(500L, data.getCartTotal());
+    }
+
+    @Test
+    public void handlePaymentData_whenPaymentMethodRequest_notifiesListenerAndFetchesCustomer() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession.initCustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                null);
+
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+
+        // We have already tested the functionality up to here.
+        reset(mockListener);
+
+        paymentSession.handlePaymentData(
+                PaymentSession.PAYMENT_METHOD_REQUEST, RESULT_OK, new Intent());
+
+        verify(mockListener).onPaymentSessionDataChanged(any(PaymentSessionData.class));
+    }
+
+    @Test
+    public void selectPaymentMethod_launchesPaymentMethodsActivity() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession.initCustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                null);
+
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+
+
+        paymentSession.selectPaymentMethod();
+        ShadowActivity.IntentForResult intentForResult =
+                mShadowActivity.getNextStartedActivityForResult();
+        assertNotNull(intentForResult);
+        assertEquals(PaymentMethodsActivity.class.getName(),
+                intentForResult.intent.getComponent().getClassName());
+    }
+
+    @Test
+    public void init_withSavedState_setsPaymentSessionData() {
+        EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        assertNotNull(firstKey);
+
+        mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
+        CustomerSession.initCustomerSession(
+                mEphemeralKeyProvider,
+                mStripeApiProxy,
+                null);
+
+        PaymentSession.PaymentSessionListener mockListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        PaymentSession paymentSession = new PaymentSession(mActivityController.get());
+        paymentSession.init(mockListener);
+
+        ArgumentCaptor<PaymentSessionData> paySessionDataCaptor = getDataCaptor();
+        paymentSession.setCartTotal(300L);
+
+        verify(mockListener).onPaymentSessionDataChanged(paySessionDataCaptor.capture());
+        Bundle bundle = new Bundle();
+        paymentSession.savePaymentSessionInstanceState(bundle);
+
+        PaymentSession.PaymentSessionListener secondListener =
+                mock(PaymentSession.PaymentSessionListener.class);
+        ArgumentCaptor<PaymentSessionData> secondSessionDataCaptor = getDataCaptor();
+
+        paymentSession.init(secondListener, bundle);
+        verify(secondListener).onPaymentSessionDataChanged(secondSessionDataCaptor.capture());
+
+        PaymentSessionData firstData = paySessionDataCaptor.getValue();
+        PaymentSessionData secondData = secondSessionDataCaptor.getValue();
+        assertEquals(firstData.getCartTotal(), secondData.getCartTotal());
+        assertEquals(firstData.getSelectedPaymentMethodId(),
+                secondData.getSelectedPaymentMethodId());
+    }
+
+    private ArgumentCaptor<PaymentSessionData> getDataCaptor() {
+        return ArgumentCaptor.forClass(PaymentSessionData.class);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -1,13 +1,10 @@
 package com.stripe.android.view;
 
-import android.content.Context;
 import android.content.Intent;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.FrameLayout;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import com.stripe.android.BuildConfig;
 import com.stripe.android.CustomerSession;
@@ -43,7 +40,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**


### PR DESCRIPTION
r? @ksun-stripe 
cc @bg-stripe 

Adding the PaymentSession and starter methods. We don't yet have interaction with the address fields and activities, but this diff should sidestep that issue and be ready for those to be plugged in. Also not addressed with this diff: adding a more meaningful cart (slightly out of scope for v5.1) that has more than just a cart total / shipping total.