### PR TITLE
adding equals and hashcode overrides to all StripeJsonModels

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/StripeJsonModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeJsonModel.java
@@ -28,6 +28,21 @@ public abstract class StripeJsonModel {
         return this.toJson().toString();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof StripeJsonModel)) {
+            return false;
+        }
+
+        StripeJsonModel otherModel = (StripeJsonModel) obj;
+        return this.toString().equals(otherModel.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
     static void putStripeJsonModelMapIfNotNull(
         @NonNull Map<String, Object> upperLevelMap,
         @NonNull @Size(min = 1) String key,

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -33,8 +33,11 @@ public class StripeJsonModelTest {
 
     @Test
     public void equals_whenEquals_returnsTrue() {
+        assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
+
         Card firstCard = Card.fromString(CardTest.JSON_CARD);
         Card secondCard = Card.fromString(CardTest.JSON_CARD);
+
         assertEquals(firstCard, secondCard);
         // Just confirming for sanity
         assertFalse(firstCard == secondCard);
@@ -42,6 +45,8 @@ public class StripeJsonModelTest {
 
     @Test
     public void equals_whenNotEquals_returnsFalse() {
+        assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
+
         Card firstCard = Card.fromString(CardTest.JSON_CARD);
         Card secondCard = Card.fromString(CardTest.JSON_CARD);
 
@@ -57,15 +62,20 @@ public class StripeJsonModelTest {
 
     @Test
     public void hashCode_whenEquals_returnsSameValue() {
+        assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
+
         Card firstCard = Card.fromString(CardTest.JSON_CARD);
         Card secondCard = Card.fromString(CardTest.JSON_CARD);
         assertNotNull(firstCard);
         assertNotNull(secondCard);
+
         assertEquals(firstCard.hashCode(), secondCard.hashCode());
     }
 
     @Test
     public void hashCode_whenNotEquals_returnsDifferentValues() {
+        assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
+
         Card firstCard = Card.fromString(CardTest.JSON_CARD);
         Card secondCard = Card.fromString(CardTest.JSON_CARD);
 

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -27,8 +28,56 @@ import static org.junit.Assert.fail;
  * Test class for {@link StripeJsonModel}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class StripeJsonModelTest {
+
+    @Test
+    public void equals_whenEquals_returnsTrue() {
+        Card firstCard = Card.fromString(CardTest.JSON_CARD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+        assertEquals(firstCard, secondCard);
+        // Just confirming for sanity
+        assertFalse(firstCard == secondCard);
+    }
+
+    @Test
+    public void equals_whenNotEquals_returnsFalse() {
+        Card firstCard = Card.fromString(CardTest.JSON_CARD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+
+        assertNotNull(firstCard);
+        assertNotNull(secondCard);
+
+        String firstName = firstCard.getName();
+        String secondName = firstName == null ? "a non-null value" : firstName + "a change";
+        secondCard.setName(secondName);
+
+        assertNotEquals(firstCard, secondCard);
+    }
+
+    @Test
+    public void hashCode_whenEquals_returnsSameValue() {
+        Card firstCard = Card.fromString(CardTest.JSON_CARD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+        assertNotNull(firstCard);
+        assertNotNull(secondCard);
+        assertEquals(firstCard.hashCode(), secondCard.hashCode());
+    }
+
+    @Test
+    public void hashCode_whenNotEquals_returnsDifferentValues() {
+        Card firstCard = Card.fromString(CardTest.JSON_CARD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+
+        assertNotNull(firstCard);
+        assertNotNull(secondCard);
+
+        String firstCurrency = firstCard.getCurrency();
+        String secondCurrency = "USD".equals(firstCurrency) ? "EUR" : "USD";
+        secondCard.setCurrency(secondCurrency);
+
+        assertNotEquals(firstCard.hashCode(), secondCard.hashCode());
+    }
 
     @Test
     public void putStripeJsonModelListIfNotNull_forMapsWhenNull_doesNothing() {


### PR DESCRIPTION
r? @ksun-stripe 

This is an easy and meaningful way to have an equals and a hashcode method on all of our StripeJsonModel objects. It is not the most efficient way to do it (because it builds a string), but these aren't objects that would be compared in our libraries at high rates.