### PR TITLE
Makes SourceCodeVerification's getters public

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
@@ -45,7 +45,7 @@ public class SourceCodeVerification extends StripeJsonModel {
         mStatus = status;
     }
 
-    int getAttemptsRemaining() {
+    public int getAttemptsRemaining() {
         return mAttemptsRemaining;
     }
 
@@ -54,7 +54,7 @@ public class SourceCodeVerification extends StripeJsonModel {
     }
 
     @Status
-    String getStatus() {
+    public String getStatus() {
         return mStatus;
     }
 


### PR DESCRIPTION
## Proposed changes
- Make all getters defined in class `SourceCodeVerification` publicly accessible.