### PR TITLE
Trim long credit card numbers

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.java
@@ -171,6 +171,9 @@ class ViewUtils {
     @NonNull
     static String[] separateCardNumberGroups(@NonNull String spacelessCardNumber,
                                                     @NonNull @Card.CardBrand String brand) {
+        if (spacelessCardNumber.length() > 16) {
+            spacelessCardNumber = spacelessCardNumber.substring(0, 16);
+        }
         String[] numberGroups;
         if (brand.equals(Card.AMERICAN_EXPRESS)) {
             numberGroups = new String[3];

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
@@ -9,10 +9,8 @@ import com.stripe.android.model.Card;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
@@ -268,5 +266,13 @@ public class ViewUtilsTest {
         assertTrue(ViewUtils.isColorDark(darkPurple));
         assertTrue(ViewUtils.isColorDark(darkishRed));
         assertTrue(ViewUtils.isColorDark(Color.BLACK));
+    }
+
+    @Test
+    public void separateCardNumberGroups_forLongInputs_doesNotCrash() {
+        String testCardNumber = "1234567890123456789";
+        String[] groups = ViewUtils.separateCardNumberGroups(
+                testCardNumber, Card.VISA);
+        assertEquals(4, groups.length);
     }
 }


### PR DESCRIPTION
Right now our SDK only handles 16 digit credit card numbers. If a longer number is copy pasted into the card view, it will crash. This PR trims the input so we do not crash and adds a test to check this.

r? @anelder-stripe @mrmcduff-stripe 

