### PR TITLE
Fix Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,7 @@ licenses:
     - 'google-gdk-license-.+'
     - '.+'
 
+group: deprecated-2017Q3
+
 script:
   - ./gradlew clean test


### PR DESCRIPTION
Trusty image updates means builds are failing. Use the work around until the trusty images stabilize. 

https://blog.travis-ci.com/2017-08-29-trusty-image-updates

r? @anelder-stripe @mrmcduff-stripe @bdorfman-stripe 