### PR TITLE
allowing users to create alipay sources

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -58,7 +58,6 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
     static {
         MODELED_TYPES.add(CARD);
         MODELED_TYPES.add(SEPA_DEBIT);
-        MODELED_TYPES.add(ALIPAY);
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -31,6 +31,7 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
+            ALIPAY,
             BITCOIN,
             CARD,
             THREE_D_SECURE,
@@ -42,6 +43,7 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
             UNKNOWN
     })
     public @interface SourceType { }
+    public static final String ALIPAY = "alipay";
     public static final String BITCOIN = "bitcoin";
     public static final String CARD = "card";
     public static final String THREE_D_SECURE = "three_d_secure";
@@ -56,6 +58,7 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
     static {
         MODELED_TYPES.add(CARD);
         MODELED_TYPES.add(SEPA_DEBIT);
+        MODELED_TYPES.add(ALIPAY);
     }
 
     @Retention(RetentionPolicy.SOURCE)
@@ -554,6 +557,8 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
             return SOFORT;
         } else if (BANCONTACT.equals(sourceType)) {
             return BANCONTACT;
+        } else if (ALIPAY.equals(sourceType)) {
+            return ALIPAY;
         } else if (UNKNOWN.equals(sourceType)) {
             return UNKNOWN;
         }

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -25,6 +25,7 @@ public class SourceParams {
     static final String API_PARAM_REDIRECT = "redirect";
     static final String API_PARAM_TYPE = "type";
     static final String API_PARAM_TOKEN = "token";
+    static final String API_PARAM_USAGE = "usage";
 
     static final String API_PARAM_CLIENT_SECRET = "client_secret";
 
@@ -55,9 +56,76 @@ public class SourceParams {
     private Map<String, String> mMetaData;
     private Map<String, Object> mRedirect;
     private String mToken;
+    @Nullable @Source.Usage private String mUsage;
     @SourceType private String mType;
 
     private SourceParams() {}
+
+
+    /**
+     * Create a source to be used with the Alipay SDK for single-use payments.
+     *
+     * @param amount the amount of the purchase
+     * @param currency the currency code of the purchase
+     * @param name the user's name
+     * @param email the user's email
+     * @param returnUrl the return url to reopen the activity
+     * @return a {@link SourceParams} that can be used to create an Alipay single-use source
+     */
+    @NonNull
+    public static SourceParams createAlipaySingleUseParams(
+            @IntRange(from = 0) long amount,
+            @NonNull String currency,
+            @Nullable String name,
+            @Nullable String email,
+            @NonNull String returnUrl) {
+        SourceParams params = new SourceParams()
+                .setType(Source.ALIPAY)
+                .setCurrency(currency)
+                .setAmount(amount)
+                .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
+
+        Map<String, Object> ownerMap = new HashMap<>();
+        ownerMap.put(FIELD_NAME, name);
+        ownerMap.put(FIELD_EMAIL, email);
+        removeNullAndEmptyParams(ownerMap);
+        if (ownerMap.keySet().size() > 0) {
+            params.setOwner(ownerMap);
+        }
+
+        return params;
+    }
+
+    /**
+     * Create parameters used to generate a reusable Alipay source.
+     *
+     * @param currency the currency code that this source will be charged in
+     * @param name the user's name
+     * @param email the user's email
+     * @param returnUrl a url used to reopen the application
+     * @return a {@link SourceParams} that can be used to create an Alipay reusable source
+     */
+    public static SourceParams createAlipayReusableParams(
+            @NonNull String currency,
+            @Nullable String name,
+            @Nullable String email,
+            @NonNull String returnUrl) {
+        SourceParams params = new SourceParams()
+                .setType(Source.ALIPAY)
+                .setCurrency(currency)
+                .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
+                .setUsage(Source.REUSABLE);
+
+        Map<String, Object> ownerMap = new HashMap<>();
+        ownerMap.put(FIELD_NAME, name);
+        ownerMap.put(FIELD_EMAIL, email);
+        removeNullAndEmptyParams(ownerMap);
+        if (ownerMap.keySet().size() > 0) {
+            params.setOwner(ownerMap);
+        }
+
+        return params;
+    }
 
     /**
      * Create a set of parameters used for a Bancontact source.
@@ -397,6 +465,15 @@ public class SourceParams {
     }
 
     /**
+     * @return the current usage of this source, if one has been set
+     */
+    @Nullable
+    @Source.Usage
+    public String getUsage() {
+        return mUsage;
+    }
+
+    /**
      * @return the custom metadata set on these params
      */
     public Map<String, String> getMetaData() {
@@ -520,6 +597,19 @@ public class SourceParams {
     }
 
     /**
+     * Sets a usage value on the parameters. Used for Alipay, and should be
+     * either "single_use" or "reusable". Not setting this value defaults
+     * to "single_use".
+     *
+     * @param usage either "single_use" or "reusable"
+     * @return {@code this} for chaining purposes
+     */
+    public SourceParams setUsage(@NonNull @Source.Usage String usage) {
+        mUsage = usage;
+        return this;
+    }
+
+    /**
      * Create a string-keyed map representing this object that is
      * ready to be sent over the network.
      *
@@ -537,6 +627,7 @@ public class SourceParams {
         networkReadyMap.put(API_PARAM_REDIRECT, mRedirect);
         networkReadyMap.put(API_PARAM_METADATA, mMetaData);
         networkReadyMap.put(API_PARAM_TOKEN, mToken);
+        networkReadyMap.put(API_PARAM_USAGE, mUsage);
         StripeNetworkUtils.removeNullAndEmptyParams(networkReadyMap);
         return networkReadyMap;
     }

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -97,37 +97,6 @@ public class SourceParams {
     }
 
     /**
-     * Create parameters used to generate a reusable Alipay source.
-     *
-     * @param currency the currency code that this source will be charged in
-     * @param name the user's name
-     * @param email the user's email
-     * @param returnUrl a url used to reopen the application
-     * @return a {@link SourceParams} that can be used to create an Alipay reusable source
-     */
-    public static SourceParams createAlipayReusableParams(
-            @NonNull String currency,
-            @Nullable String name,
-            @Nullable String email,
-            @NonNull String returnUrl) {
-        SourceParams params = new SourceParams()
-                .setType(Source.ALIPAY)
-                .setCurrency(currency)
-                .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
-                .setUsage(Source.REUSABLE);
-
-        Map<String, Object> ownerMap = new HashMap<>();
-        ownerMap.put(FIELD_NAME, name);
-        ownerMap.put(FIELD_EMAIL, email);
-        removeNullAndEmptyParams(ownerMap);
-        if (ownerMap.keySet().size() > 0) {
-            params.setOwner(ownerMap);
-        }
-
-        return params;
-    }
-
-    /**
      * Create a set of parameters used for a Bancontact source.
      *
      * @param amount amount to be charged

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -326,6 +326,67 @@ public class StripeTest {
     }
 
     @Test
+    public void createSourceSynchronous_withAlipayReusableParams_passesIntegrationTest() {
+        Stripe stripe = getNonLoggingStripe(mContext);
+        SourceParams alipayParams = SourceParams.createAlipayReusableParams(
+                "usd",
+                "Example Payer",
+                "abc@def.com",
+                "stripe://start");
+
+        try {
+            Source alipaySource =
+                    stripe.createSourceSynchronous(alipayParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+            assertNotNull(alipaySource);
+            assertNotNull(alipaySource.getId());
+            assertNotNull(alipaySource.getClientSecret());
+            assertEquals(Source.ALIPAY, alipaySource.getType());
+            assertEquals("redirect", alipaySource.getFlow());
+            assertNotNull(alipaySource.getOwner());
+            assertEquals("Example Payer", alipaySource.getOwner().getName());
+            assertEquals("abc@def.com", alipaySource.getOwner().getEmail());
+            assertEquals("usd", alipaySource.getCurrency());
+            assertEquals(Source.REUSABLE, alipaySource.getUsage());
+            assertNotNull(alipaySource.getRedirect());
+            assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void createSourceSynchronous_withAlipaySingleUseParams_passesIntegrationTest() {
+        Stripe stripe = getNonLoggingStripe(mContext);
+        SourceParams alipayParams = SourceParams.createAlipaySingleUseParams(
+                1000L,
+                "usd",
+                "Example Payer",
+                "abc@def.com",
+                "stripe://start");
+
+        try {
+            Source alipaySource =
+                    stripe.createSourceSynchronous(alipayParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+            assertNotNull(alipaySource);
+            assertNotNull(alipaySource.getId());
+            assertNotNull(alipaySource.getClientSecret());
+            assertNotNull(alipaySource.getAmount());
+            assertEquals(1000L, alipaySource.getAmount().longValue());
+            assertEquals(Source.ALIPAY, alipaySource.getType());
+            assertEquals("redirect", alipaySource.getFlow());
+            assertNotNull(alipaySource.getOwner());
+            assertEquals("Example Payer", alipaySource.getOwner().getName());
+            assertEquals("abc@def.com", alipaySource.getOwner().getEmail());
+            assertEquals("usd", alipaySource.getCurrency());
+            assertEquals(Source.SINGLE_USE, alipaySource.getUsage());
+            assertNotNull(alipaySource.getRedirect());
+            assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
+    @Test
     public void createSourceSynchronous_withBitcoinParams_passesIntegrationTest() {
         Stripe stripe = getNonLoggingStripe(mContext);
         SourceParams bitcoinParams = SourceParams.createBitcoinParams(1000L, "usd", "abc@def.com");

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -326,35 +326,6 @@ public class StripeTest {
     }
 
     @Test
-    public void createSourceSynchronous_withAlipayReusableParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
-        SourceParams alipayParams = SourceParams.createAlipayReusableParams(
-                "usd",
-                "Example Payer",
-                "abc@def.com",
-                "stripe://start");
-
-        try {
-            Source alipaySource =
-                    stripe.createSourceSynchronous(alipayParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
-            assertNotNull(alipaySource);
-            assertNotNull(alipaySource.getId());
-            assertNotNull(alipaySource.getClientSecret());
-            assertEquals(Source.ALIPAY, alipaySource.getType());
-            assertEquals("redirect", alipaySource.getFlow());
-            assertNotNull(alipaySource.getOwner());
-            assertEquals("Example Payer", alipaySource.getOwner().getName());
-            assertEquals("abc@def.com", alipaySource.getOwner().getEmail());
-            assertEquals("usd", alipaySource.getCurrency());
-            assertEquals(Source.REUSABLE, alipaySource.getUsage());
-            assertNotNull(alipaySource.getRedirect());
-            assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
-        }
-    }
-
-    @Test
     public void createSourceSynchronous_withAlipaySingleUseParams_passesIntegrationTest() {
         Stripe stripe = getNonLoggingStripe(mContext);
         SourceParams alipayParams = SourceParams.createAlipaySingleUseParams(

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -22,7 +23,7 @@ import static org.junit.Assert.assertTrue;
  * Test class for {@link SourceParams}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class SourceParamsTest {
 
     private static Card FULL_FIELDS_VISA_CARD =
@@ -38,6 +39,86 @@ public class SourceParamsTest {
                     "94107",
                     "US",
                     "usd");
+
+    @Test
+    public void createAlipaySingleUseParams_withAllFields_hasExpectedFields() {
+        SourceParams params = SourceParams.createAlipaySingleUseParams(
+                1000L,
+                "aud",
+                "Jane Tester",
+                "jane@test.com",
+                "stripe://testactivity");
+
+        assertEquals(Source.ALIPAY, params.getType());
+        assertNotNull(params.getAmount());
+        assertEquals(1000L, params.getAmount().longValue());
+        assertEquals("aud", params.getCurrency());
+        assertNotNull(params.getOwner());
+        assertEquals("Jane Tester", params.getOwner().get("name"));
+        assertEquals("jane@test.com", params.getOwner().get("email"));
+        assertNotNull(params.getRedirect());
+        assertEquals("stripe://testactivity", params.getRedirect().get("return_url"));
+    }
+
+    @Test
+    public void createAlipaySingleUseParams_withoutOwner_hasNoOwnerFields() {
+        SourceParams params = SourceParams.createAlipaySingleUseParams(
+                555L,
+                "eur",
+                null,
+                null,
+                "stripe://testactivity2");
+
+        assertEquals(Source.ALIPAY, params.getType());
+        assertNotNull(params.getAmount());
+        assertEquals(555L, params.getAmount().longValue());
+        assertEquals("eur", params.getCurrency());
+
+        assertNull(params.getOwner());
+
+        assertNotNull(params.getRedirect());
+        assertEquals("stripe://testactivity2", params.getRedirect().get("return_url"));
+    }
+
+    @Test
+    public void createAlipayReusableParams_withAllFields_hasExpectedFields() {
+        SourceParams params = SourceParams.createAlipayReusableParams(
+                "usd",
+                "Jean Valjean",
+                "jdog@lesmis.net",
+                "stripe://start");
+
+        assertEquals(Source.ALIPAY, params.getType());
+        assertEquals(Source.REUSABLE, params.getUsage());
+        assertNull(params.getAmount());
+        assertEquals("usd", params.getCurrency());
+        assertNotNull(params.getRedirect());
+        assertEquals("stripe://start", params.getRedirect().get("return_url"));
+
+        assertNotNull(params.getOwner());
+        assertEquals("Jean Valjean", params.getOwner().get("name"));
+        assertEquals("jdog@lesmis.net", params.getOwner().get("email"));
+    }
+
+    @Test
+    public void createAlipayReusableParams_withOnlyName_hasOnlyExpectedFields() {
+        SourceParams params = SourceParams.createAlipayReusableParams(
+                "cad",
+                "Harry Seldon",
+                null,
+                "stripe://start");
+
+        assertEquals(Source.ALIPAY, params.getType());
+        assertEquals(Source.REUSABLE, params.getUsage());
+        assertNull(params.getAmount());
+        assertEquals("cad", params.getCurrency());
+        assertNotNull(params.getRedirect());
+        assertEquals("stripe://start", params.getRedirect().get("return_url"));
+
+        assertNotNull(params.getOwner());
+        assertEquals("Harry Seldon", params.getOwner().get("name"));
+        assertFalse(params.getOwner().containsKey("email"));
+    }
 
     @Test
     public void createBancontactParams_hasExpectedFields() {

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -81,46 +81,6 @@ public class SourceParamsTest {
     }
 
     @Test
-    public void createAlipayReusableParams_withAllFields_hasExpectedFields() {
-        SourceParams params = SourceParams.createAlipayReusableParams(
-                "usd",
-                "Jean Valjean",
-                "jdog@lesmis.net",
-                "stripe://start");
-
-        assertEquals(Source.ALIPAY, params.getType());
-        assertEquals(Source.REUSABLE, params.getUsage());
-        assertNull(params.getAmount());
-        assertEquals("usd", params.getCurrency());
-        assertNotNull(params.getRedirect());
-        assertEquals("stripe://start", params.getRedirect().get("return_url"));
-
-        assertNotNull(params.getOwner());
-        assertEquals("Jean Valjean", params.getOwner().get("name"));
-        assertEquals("jdog@lesmis.net", params.getOwner().get("email"));
-    }
-
-    @Test
-    public void createAlipayReusableParams_withOnlyName_hasOnlyExpectedFields() {
-        SourceParams params = SourceParams.createAlipayReusableParams(
-                "cad",
-                "Harry Seldon",
-                null,
-                "stripe://start");
-
-        assertEquals(Source.ALIPAY, params.getType());
-        assertEquals(Source.REUSABLE, params.getUsage());
-        assertNull(params.getAmount());
-        assertEquals("cad", params.getCurrency());
-        assertNotNull(params.getRedirect());
-        assertEquals("stripe://start", params.getRedirect().get("return_url"));
-
-        assertNotNull(params.getOwner());
-        assertEquals("Harry Seldon", params.getOwner().get("name"));
-        assertFalse(params.getOwner().containsKey("email"));
-    }
-
-    @Test
     public void createBancontactParams_hasExpectedFields() {
         SourceParams params = SourceParams.createBancontactParams(
                 1000L,


### PR DESCRIPTION
r? @ksun-stripe 
cc @pehrlich-stripe, @bdorfman-stripe 

Adding the ability to create alipay sources, both reusable and single-use. Not adding an example activity using it for reasons similar to lack of example with Bancontact, iDEAL, etc -- documentation will direct the use. (Tests for SourceParams and Source creation included)