### PR TITLE
Launch PaymentFlowActivity With PaymentSession

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -82,6 +82,13 @@
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".activity.PaymentSessionActivity"
+            android:theme="@style/SampleThemeDefault">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/example/res/layout/activity_launcher.xml
+++ b/example/res/layout/activity_launcher.xml
@@ -68,12 +68,12 @@
             />
 
         <Button
-            android:id="@+id/btn_select_shipping_method_launch"
+            android:id="@+id/btn_payment_session_launch"
             android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="10dp"
-            android:text="@string/selectShippingMethod"
+            android:text="@string/launchPaymentSession"
             />
 
     </LinearLayout>

--- a/example/res/layout/activity_payment_session.xml
+++ b/example/res/layout/activity_payment_session.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+    <ProgressBar
+        android:id="@+id/customer_progress_bar"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        />
+
+    <Button
+        android:id="@+id/btn_start_payment_flow"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/example_vertical_spacing"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/startPaymentFlow"
+        />
+
+</LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="changeDetails">Change payment details</string>
     <string name="customer_payment_data_example">Customer Payment Selection</string>
     <string name="launch_customer_session">Launch Customer Session</string>
+    <string name="launchPaymentSession">Launch Payment Session</string>
     <string name="pollingSource">Polling for source changes&#8230;</string>
     <string name="save">Save</string>
     <string name="saverx">Save Rx</string>
@@ -35,6 +36,7 @@
     <string name="verify">Verify</string>
     <string name="updatedSources">Source results</string>
     <string name="cvc">CVC</string>
+    <string name="startPaymentFlow">Start Payment Flow</string>
 
     <string name="load_items">Load Items</string>
     <string name="ok">OK</string>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -9,7 +9,6 @@ import android.widget.Button;
 import com.google.android.gms.wallet.Cart;
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.ShippingMethod;
-import com.stripe.android.view.PaymentFlowActivity;
 import com.stripe.example.R;
 import com.stripe.wrap.pay.AndroidPayConfiguration;
 import com.stripe.wrap.pay.activity.StripeAndroidPayActivity;
@@ -80,11 +79,11 @@ public class LauncherActivity extends AppCompatActivity {
             }
         });
 
-        Button selectShippingAddressButton = findViewById(R.id.btn_select_shipping_method_launch);
+        Button selectShippingAddressButton = findViewById(R.id.btn_payment_session_launch);
         selectShippingAddressButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent intent = new PaymentFlowActivity.IntentBuilder().build(LauncherActivity.this);
+                Intent intent = new Intent(LauncherActivity.this, PaymentSessionActivity.class);
                 startActivity(intent);
             }
         });

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
@@ -1,0 +1,124 @@
+package com.stripe.example.activity;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ProgressBar;
+
+import com.stripe.android.CustomerSession;
+import com.stripe.android.PaymentSession;
+import com.stripe.android.PaymentSessionData;
+import com.stripe.android.model.Customer;
+import com.stripe.android.view.PaymentFlowConfig;
+import com.stripe.example.R;
+import com.stripe.example.controller.ErrorDialogHandler;
+import com.stripe.example.service.ExampleEphemeralKeyProvider;
+
+import static com.stripe.android.view.PaymentFlowActivity.EVENT_SHIPPING_INFO_PROCESSED;
+import static com.stripe.android.view.PaymentFlowActivity.EVENT_SHIPPING_INFO_SUBMITTED;
+import static com.stripe.android.view.PaymentFlowActivity.EXTRA_IS_SHIPPING_INFO_VALID;
+
+/**
+ * An example activity that handles working with a {@link com.stripe.android.PaymentSession}, allowing you to
+ * collect information needed to request payment for the current customer.
+ */
+public class PaymentSessionActivity extends AppCompatActivity {
+
+
+    private Button mStartPaymentFlowButton;
+    private ProgressBar mProgressBar;
+    private ErrorDialogHandler mErrorDialogHandler;
+    private PaymentSession mPaymentSession;
+    private BroadcastReceiver mMessageReceiver;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_payment_session);
+        mProgressBar = findViewById(R.id.customer_progress_bar);
+        mProgressBar.setVisibility(View.VISIBLE);
+        mStartPaymentFlowButton = findViewById(R.id.btn_start_payment_flow);
+        mStartPaymentFlowButton.setEnabled(false);
+        mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
+        setupCustomerSession();
+        setupPaymentSession();
+        mMessageReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                intent = new Intent(EVENT_SHIPPING_INFO_PROCESSED);
+                intent.putExtra(EXTRA_IS_SHIPPING_INFO_VALID, true);
+                LocalBroadcastManager.getInstance(PaymentSessionActivity.this).sendBroadcast(intent);
+            }
+        };
+        LocalBroadcastManager.getInstance(this).registerReceiver(mMessageReceiver,
+                new IntentFilter(EVENT_SHIPPING_INFO_SUBMITTED));
+        mStartPaymentFlowButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mPaymentSession.launchShippingFlow(new PaymentFlowConfig.Builder().build());
+            }
+        });
+
+    }
+
+    private void setupCustomerSession() {
+        CustomerSession.initCustomerSession(
+                new ExampleEphemeralKeyProvider(
+                        new ExampleEphemeralKeyProvider.ProgressListener() {
+                            @Override
+                            public void onStringResponse(String string) {
+                                if (string.startsWith("Error: ")) {
+                                    mErrorDialogHandler.showError(string);
+                                }
+                            }
+                        }));
+        CustomerSession.getInstance().retrieveCurrentCustomer(
+                new CustomerSession.CustomerRetrievalListener() {
+                    @Override
+                    public void onCustomerRetrieved(@NonNull Customer customer) {
+                        mStartPaymentFlowButton.setEnabled(true);
+                        mProgressBar.setVisibility(View.INVISIBLE);
+                    }
+
+                    @Override
+                    public void onError(int errorCode, @Nullable String errorMessage) {
+                        mStartPaymentFlowButton.setEnabled(false);
+                        mErrorDialogHandler.showError(errorMessage);
+                        mProgressBar.setVisibility(View.INVISIBLE);
+                    }
+                });
+    }
+
+    private void setupPaymentSession() {
+        mPaymentSession = new PaymentSession(this);
+        mPaymentSession.init(new PaymentSession.PaymentSessionListener() {
+            @Override
+            public void onCommunicatingStateChanged(boolean isCommunicating) {
+                if (isCommunicating) {
+                    mProgressBar.setVisibility(View.VISIBLE);
+                } else {
+                    mProgressBar.setVisibility(View.INVISIBLE);
+                }
+            }
+
+            @Override
+            public void onError(int errorCode, @Nullable String errorMessage) {
+                mErrorDialogHandler.showError(errorMessage);
+            }
+
+            @Override
+            public void onPaymentSessionDataChanged(@NonNull PaymentSessionData data) {
+                // TODO: update UI
+            }
+        });
+    }
+
+}

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
@@ -32,12 +32,12 @@ import static com.stripe.android.view.PaymentFlowActivity.EXTRA_IS_SHIPPING_INFO
  */
 public class PaymentSessionActivity extends AppCompatActivity {
 
-
-    private Button mStartPaymentFlowButton;
-    private ProgressBar mProgressBar;
+    private BroadcastReceiver mBroadcastReceiver;
     private ErrorDialogHandler mErrorDialogHandler;
     private PaymentSession mPaymentSession;
-    private BroadcastReceiver mMessageReceiver;
+    private ProgressBar mProgressBar;
+    private Button mStartPaymentFlowButton;
+
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -50,7 +50,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
         mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
         setupCustomerSession();
         setupPaymentSession();
-        mMessageReceiver = new BroadcastReceiver() {
+        mBroadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 intent = new Intent(EVENT_SHIPPING_INFO_PROCESSED);
@@ -58,12 +58,12 @@ public class PaymentSessionActivity extends AppCompatActivity {
                 LocalBroadcastManager.getInstance(PaymentSessionActivity.this).sendBroadcast(intent);
             }
         };
-        LocalBroadcastManager.getInstance(this).registerReceiver(mMessageReceiver,
+        LocalBroadcastManager.getInstance(this).registerReceiver(mBroadcastReceiver,
                 new IntentFilter(EVENT_SHIPPING_INFO_SUBMITTED));
         mStartPaymentFlowButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPaymentSession.launchShippingFlow(new PaymentFlowConfig.Builder().build());
+                mPaymentSession.presentShippingFlow(new PaymentFlowConfig.Builder().build());
             }
         });
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -150,7 +150,7 @@ public class PaymentSession {
      * @param paymentFlowConfig config that allows the {@link PaymentFlowActivity} to know what UI
      *                          to render.
      */
-    public void launchShippingFlow(PaymentFlowConfig paymentFlowConfig) {
+    public void presentShippingFlow(PaymentFlowConfig paymentFlowConfig) {
         Intent intent = new Intent(mHostActivity, PaymentFlowActivity.class);
         intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
         intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_SESSION_DATA, mPaymentSessionData);

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -6,9 +6,10 @@ import android.os.Bundle;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.stripe.android.model.Customer;
+import com.stripe.android.view.PaymentFlowActivity;
+import com.stripe.android.view.PaymentFlowConfig;
 import com.stripe.android.view.PaymentMethodsActivity;
 
 /**
@@ -141,6 +142,21 @@ public class PaymentSession {
      */
     public void setCartTotal(@IntRange(from = 0) long cartTotal) {
         mPaymentSessionData.setCartTotal(cartTotal);
+    }
+
+    /**
+     * Launch the {@link PaymentFlowActivity} to allow the user to fill in payment details.
+     *
+     * @param paymentFlowConfig config that allows the {@link PaymentFlowActivity} to know what UI
+     *                          to render.
+     */
+    public void launchShippingFlow(PaymentFlowConfig paymentFlowConfig) {
+        Intent intent = new Intent(mHostActivity, PaymentFlowActivity.class);
+        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_SESSION_DATA, mPaymentSessionData);
+        mHostActivity.startActivityForResult(
+                intent,
+                PAYMENT_METHOD_REQUEST);
     }
 
     private void fetchCustomer() {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -1,18 +1,14 @@
 package com.stripe.android.view;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.ViewPager;
 
 import com.stripe.android.R;
 import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.ShippingMethod;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Activity containing a two-part payment flow that allows users to provide a shipping address
@@ -20,81 +16,15 @@ import java.util.List;
  */
 public class PaymentFlowActivity extends StripeActivity {
 
+    public static final String EXTRA_PAYMENT_FLOW_CONFIG = "payment_flow_config";
+    public static final String EXTRA_PAYMENT_SESSION_DATA = "payment_session_data";
+    public static final String EXTRA_SHIPPING_INFO_DATA = "shipping_info_data";
+    public static final String EVENT_SHIPPING_INFO_SUBMITTED = "shipping_info_submitted";
+    public static final String EVENT_SHIPPING_INFO_PROCESSED = "shipping_info_processed";
+    public static final String EXTRA_IS_SHIPPING_INFO_VALID = "shipping_is_shipping_info_valid";
+
     private ViewPager mViewPager;
     private PaymentFlowPagerAdapter mPaymentFlowPagerAdapter;
-
-    static final String EXTRA_PAYMENT_FLOW_CONFIG = "payment_flow_config";
-
-    public static class IntentBuilder {
-        private List mHiddenAddressFields;
-        private List mOptionalAddressFields;
-        private ShippingInformation mPrepopulatedShippingInfo;
-        private boolean mHideAddressScreen;
-        private boolean mHideShippingScreen;
-
-        public IntentBuilder() {
-            mHiddenAddressFields = new ArrayList();
-            mOptionalAddressFields = new ArrayList();
-            mPrepopulatedShippingInfo = new ShippingInformation();
-        }
-
-        /**
-         * @param hiddenAddressFields sets address fields that should be hidden on the address
-         *                            screen. Hidden fields are automatically optional.
-         */
-        public IntentBuilder setHiddenAddressFields(@NonNull List hiddenAddressFields) {
-            mHiddenAddressFields = hiddenAddressFields;
-            return this;
-        }
-
-        /**
-         * @param optionalAddressFields sets address fields that should be optional.
-         */
-        public IntentBuilder setOptionalAddressFields(@NonNull List optionalAddressFields) {
-            mOptionalAddressFields = optionalAddressFields;
-            return this;
-        }
-
-        /**
-         *
-         * @param shippingInformation set an address to be prepopulated into the add address input
-         *                            fields.
-         */
-        public IntentBuilder setPrepopulatedShippingInformation(@NonNull ShippingInformation shippingInformation) {
-            mPrepopulatedShippingInfo = shippingInformation;
-            return this;
-        }
-
-        /**
-         * Sets the add shipping address screen to be skipped.
-         */
-        public IntentBuilder setHideAddressScreen(boolean isHideAddressScreen) {
-            mHideAddressScreen = isHideAddressScreen;
-            return this;
-        }
-
-        /**
-         * Sets the select shipping method screen to be skipped.
-         */
-        public IntentBuilder setHideShippingScreen(boolean isHideShippingScreen) {
-            mHideShippingScreen = isHideShippingScreen;
-            return this;
-        }
-
-        public Intent build(Context context) {
-            Intent intent = new Intent(context, PaymentFlowActivity.class);
-            PaymentFlowConfig paymentFlowConfig =
-                    new PaymentFlowConfig(
-                            mHiddenAddressFields,
-                            mOptionalAddressFields,
-                            mPrepopulatedShippingInfo,
-                            mHideAddressScreen,
-                            mHideShippingScreen);
-            intent.putExtra(EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
-            return intent;
-        }
-
-    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -139,15 +69,14 @@ public class PaymentFlowActivity extends StripeActivity {
         ShippingInformation shippingInformation = shippingInfoWidget.getShippingInformation();
         if (shippingInformation !=  null) {
             setCommunicatingProgress(true);
-            // TODO: Call into payment context
-            setCommunicatingProgress(false);
-            mPaymentFlowPagerAdapter.setAddressSaved(true);
-            if (hasNextPage()) {
-                mViewPager.setCurrentItem(mViewPager.getCurrentItem() + 1);
-            } else {
-                finish();
-            }
+            broadcastShippingInfoSubmitted(shippingInformation);
         }
+    }
+
+    private void broadcastShippingInfoSubmitted(ShippingInformation shippingInformation) {
+        Intent intent = new Intent(EVENT_SHIPPING_INFO_SUBMITTED);
+        intent.putExtra(EXTRA_SHIPPING_INFO_DATA, shippingInformation);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
     }
 
     private boolean hasNextPage() {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -16,12 +16,12 @@ import com.stripe.android.model.ShippingMethod;
  */
 public class PaymentFlowActivity extends StripeActivity {
 
+    public static final String EXTRA_IS_SHIPPING_INFO_VALID = "shipping_is_shipping_info_valid";
     public static final String EXTRA_PAYMENT_FLOW_CONFIG = "payment_flow_config";
     public static final String EXTRA_PAYMENT_SESSION_DATA = "payment_session_data";
     public static final String EXTRA_SHIPPING_INFO_DATA = "shipping_info_data";
-    public static final String EVENT_SHIPPING_INFO_SUBMITTED = "shipping_info_submitted";
     public static final String EVENT_SHIPPING_INFO_PROCESSED = "shipping_info_processed";
-    public static final String EXTRA_IS_SHIPPING_INFO_VALID = "shipping_is_shipping_info_valid";
+    public static final String EVENT_SHIPPING_INFO_SUBMITTED = "shipping_info_submitted";
 
     private ViewPager mViewPager;
     private PaymentFlowPagerAdapter mPaymentFlowPagerAdapter;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowConfig.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowConfig.java
@@ -10,35 +10,91 @@ import com.stripe.android.model.ShippingInformation;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Class that tells {@link PaymentFlowActivity} what UI to render
+ */
 public class PaymentFlowConfig implements Parcelable {
 
-    @NonNull private List<String> mHiddenAddressFields;
-    @NonNull private List<String> mOptionalAddressFields;
-    @NonNull private ShippingInformation mShippingInformation;
-    private boolean mHideAddressScreen;
-    private boolean mHideShippingScreen;
 
-    public PaymentFlowConfig(
-            @NonNull List<String> hiddenAddressFields,
-            @NonNull List<String> optionalAddressFields,
-            @NonNull ShippingInformation shippingInformation,
-            boolean hideAddressScreen,
-            boolean hideShippingScreen) {
-        mHiddenAddressFields = hiddenAddressFields;
-        mOptionalAddressFields = optionalAddressFields;
-        mShippingInformation = shippingInformation;
-        mHideAddressScreen = hideAddressScreen;
-        mHideShippingScreen = hideShippingScreen;
+    @NonNull private List<String> mHiddenShippingInfoFields;
+    @NonNull private List<String> mOptionalShippingInfoFields;
+    @NonNull private ShippingInformation mShippingInformation;
+    private boolean mHideShippingInfoScreen;
+    private boolean mHideShippingMethodsScreen;
+
+     public static class Builder {
+        private boolean mHideShippingInfoScreen;
+        private boolean mHideShippingMethodsScreen;
+        @NonNull private List<String> mHiddenShippingInfoFields;
+        @NonNull private List<String> mOptionalShippingInfoFields;
+        @NonNull private ShippingInformation mShippingInformation;
+
+        /**
+         * @param hiddenShippingInfoFields that should be hidden in the {@link ShippingInfoWidget}.
+         */
+        public Builder setHiddenShippingInfoFields(List<String> hiddenShippingInfoFields) {
+            mHiddenShippingInfoFields = hiddenShippingInfoFields;
+            return this;
+        }
+
+        /**
+         * @param optionalShippingInfoFields that should be optional in the {@link ShippingInfoWidget}
+         */
+        public Builder setOptionalShippingInfoFields(List<String> optionalShippingInfoFields) {
+            mOptionalShippingInfoFields = optionalShippingInfoFields;
+            return this;
+        }
+
+        /**
+         *
+         * @param shippingInfo that should be prepopulated into the {@link ShippingInfoWidget}
+         * @return
+         */
+        public Builder setPrepopulatedShippingInfo(ShippingInformation shippingInfo) {
+            mShippingInformation = shippingInfo;
+            return this;
+        }
+
+        /**
+         * @param hideShippingInfoScreen whether a screen with a {@link ShippingInfoWidget} to collect
+         *                               {@link ShippingInformation} should be shown.
+         */
+        public Builder setHideShippingInfoScreen(boolean hideShippingInfoScreen) {
+            mHideShippingInfoScreen = hideShippingInfoScreen;
+            return this;
+        }
+
+        /**
+         * @param hideShippingMethodsScreen whether a screen with a {@link SelectShippingMethodWidget}
+         *                                  to select a {@link com.stripe.android.model.ShippingMethod}
+         */
+        public Builder setHideShippingMethodsScreen(boolean hideShippingMethodsScreen) {
+            mHideShippingMethodsScreen = hideShippingMethodsScreen;
+            return this;
+        }
+
+        public PaymentFlowConfig build() {
+            return new PaymentFlowConfig(this);
+        }
+
+    }
+
+    PaymentFlowConfig(Builder builder) {
+        mHiddenShippingInfoFields = builder.mHiddenShippingInfoFields;
+        mOptionalShippingInfoFields = builder.mOptionalShippingInfoFields;
+        mShippingInformation = builder.mShippingInformation;
+        mHideShippingInfoScreen = builder.mHideShippingInfoScreen;
+        mHideShippingMethodsScreen = builder.mHideShippingMethodsScreen;
     }
 
     private PaymentFlowConfig(Parcel in) {
-        mHiddenAddressFields = new ArrayList<>();
-        in.readStringList(mHiddenAddressFields);
-        mOptionalAddressFields = new ArrayList<>();
-        in.readStringList(mOptionalAddressFields);
+        mHiddenShippingInfoFields = new ArrayList<>();
+        in.readStringList(mHiddenShippingInfoFields);
+        mOptionalShippingInfoFields = new ArrayList<>();
+        in.readStringList(mOptionalShippingInfoFields);
         mShippingInformation = in.readParcelable(Address.class.getClassLoader());
-        mHideAddressScreen = in.readInt() == 1;
-        mHideShippingScreen = in.readInt() == 1;
+        mHideShippingInfoScreen = in.readInt() == 1;
+        mHideShippingMethodsScreen = in.readInt() == 1;
     }
 
     @Override
@@ -48,10 +104,10 @@ public class PaymentFlowConfig implements Parcelable {
 
         PaymentFlowConfig that = (PaymentFlowConfig) o;
 
-        if (isHideAddressScreen() != that.isHideAddressScreen()) return false;
-        if (isHideShippingScreen() != that.isHideShippingScreen()) return false;
-        if (!getHiddenAddressFields().equals(that.getHiddenAddressFields())) return false;
-        if (!getOptionalAddressFields().equals(that.getOptionalAddressFields())) return false;
+        if (isHideShippingInfoScreen() != that.isHideShippingInfoScreen()) return false;
+        if (isHideShippingMethodsScreen() != that.isHideShippingMethodsScreen()) return false;
+        if (!getHiddenShippingInfoFields().equals(that.getHiddenShippingInfoFields())) return false;
+        if (!getOptionalShippingInfoFields().equals(that.getOptionalShippingInfoFields())) return false;
         return getPrepopulatedShippingInfo().equals(that.getPrepopulatedShippingInfo());
     }
 
@@ -62,19 +118,19 @@ public class PaymentFlowConfig implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel parcel, int flags) {
-        parcel.writeStringList(mHiddenAddressFields);
-        parcel.writeStringList(mOptionalAddressFields);
+        parcel.writeStringList(mHiddenShippingInfoFields);
+        parcel.writeStringList(mOptionalShippingInfoFields);
         parcel.writeParcelable(mShippingInformation, flags);
-        parcel.writeInt(mHideAddressScreen ? 1 : 0);
-        parcel.writeInt(mHideShippingScreen? 1: 0);
+        parcel.writeInt(mHideShippingInfoScreen ? 1 : 0);
+        parcel.writeInt(mHideShippingMethodsScreen ? 1: 0);
     }
 
-    @NonNull List<String> getHiddenAddressFields() {
-        return mHiddenAddressFields;
+    @NonNull List<String> getHiddenShippingInfoFields() {
+        return mHiddenShippingInfoFields;
     }
 
-    @NonNull List<String> getOptionalAddressFields() {
-        return mOptionalAddressFields;
+    @NonNull List<String> getOptionalShippingInfoFields() {
+        return mOptionalShippingInfoFields;
     }
 
     @NonNull
@@ -82,12 +138,12 @@ public class PaymentFlowConfig implements Parcelable {
         return mShippingInformation;
     }
 
-    boolean isHideAddressScreen() {
-        return mHideAddressScreen;
+    boolean isHideShippingInfoScreen() {
+        return mHideShippingInfoScreen;
     }
 
-    boolean isHideShippingScreen() {
-        return mHideShippingScreen;
+    boolean isHideShippingMethodsScreen() {
+        return mHideShippingMethodsScreen;
     }
 
     static final Parcelable.Creator<PaymentFlowConfig> CREATOR

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowConfig.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowConfig.java
@@ -110,6 +110,16 @@ public class PaymentFlowConfig implements Parcelable {
         if (!getOptionalShippingInfoFields().equals(that.getOptionalShippingInfoFields())) return false;
         return getPrepopulatedShippingInfo().equals(that.getPrepopulatedShippingInfo());
     }
+    
+    @Override
+    public int hashCode() {
+        int result = getHiddenShippingInfoFields().hashCode();
+        result = 31 * result + getOptionalShippingInfoFields().hashCode();
+        result = 31 * result + mShippingInformation.hashCode();
+        result = 31 * result + (isHideShippingInfoScreen() ? 1 : 0);
+        result = 31 * result + (isHideShippingMethodsScreen() ? 1 : 0);
+        return result;
+    }
 
     @Override
     public int describeContents() {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
@@ -25,7 +25,7 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
         mContext = context;
         mPaymentFlowConfig = paymentFlowConfig;
         mPages = new ArrayList<>();
-        if (!mPaymentFlowConfig.isHideAddressScreen()) {
+        if (!mPaymentFlowConfig.isHideShippingInfoScreen()) {
             mPages.add(PaymentFlowPagerEnum.ADDRESS);
         }
         if (!shouldHideShippingScreen()) {
@@ -34,7 +34,7 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
     }
 
     private boolean shouldHideShippingScreen() {
-        return mPaymentFlowConfig.isHideShippingScreen() || (!mPaymentFlowConfig.isHideAddressScreen() && !mAddressSaved);
+        return mPaymentFlowConfig.isHideShippingMethodsScreen() || (!mPaymentFlowConfig.isHideShippingInfoScreen() && !mAddressSaved);
     }
 
     void setAddressSaved(boolean addressSaved) {
@@ -56,8 +56,8 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
         }
         if (paymentFlowPagerEnum.equals(PaymentFlowPagerEnum.ADDRESS)) {
             ShippingInfoWidget shippingInfoWidget = layout.findViewById(R.id.shipping_info_widget);
-            shippingInfoWidget.setHiddenFields(mPaymentFlowConfig.getHiddenAddressFields());
-            shippingInfoWidget.setOptionalFields(mPaymentFlowConfig.getOptionalAddressFields());
+            shippingInfoWidget.setHiddenFields(mPaymentFlowConfig.getHiddenShippingInfoFields());
+            shippingInfoWidget.setOptionalFields(mPaymentFlowConfig.getOptionalShippingInfoFields());
             shippingInfoWidget.populateShippingInfo(mPaymentFlowConfig.getPrepopulatedShippingInfo());
         }
 


### PR DESCRIPTION
Changes:
- Remove intent builder in favor for payconfig intent since we are launching from PaymentFlowActivity
- Remove tests that don't make sense anymore
- Create an activity in example to to launch UI

r? @mrmcduff-stripe 