### PR TITLE
adding simple error dialog handling to PaymentFlowActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -5,12 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.AlertDialog;
 
 import com.stripe.android.CustomerSession;
 import com.stripe.android.R;
@@ -32,7 +29,6 @@ public class PaymentFlowActivity extends StripeActivity {
     public static final String EVENT_SHIPPING_INFO_SUBMITTED = "shipping_info_submitted";
 
     private BroadcastReceiver mAlertBroadcastReceiver;
-    @Nullable private AlertMessageListener mAlertMessageListener;
     private PaymentFlowPagerAdapter mPaymentFlowPagerAdapter;
     private ViewPager mViewPager;
 
@@ -96,11 +92,6 @@ public class PaymentFlowActivity extends StripeActivity {
                         new IntentFilter(CustomerSession.ACTION_API_EXCEPTION));
     }
 
-    @VisibleForTesting
-    void setAlertMessageListener(@NonNull AlertMessageListener listener) {
-        mAlertMessageListener = listener;
-    }
-
     private void onAddressSave() {
         ShippingInfoWidget shippingInfoWidget = findViewById(R.id.shipping_info_widget);
         ShippingInformation shippingInformation = shippingInfoWidget.getShippingInformation();
@@ -138,16 +129,7 @@ public class PaymentFlowActivity extends StripeActivity {
             return;
         }
 
-        String alertMessage = exception.getLocalizedMessage();
-
-        if (mAlertMessageListener != null) {
-            mAlertMessageListener.onUserAlert(alertMessage);
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(this)
-                .setMessage(alertMessage)
-                .setNeutralButton(android.R.string.ok, null);
-        builder.show();
+        showError(exception.getLocalizedMessage());
     }
 
     @Override
@@ -157,9 +139,5 @@ public class PaymentFlowActivity extends StripeActivity {
             return;
         }
         super.onBackPressed();
-    }
-
-    interface AlertMessageListener {
-        void onUserAlert(String message);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeActivity.java
@@ -21,6 +21,7 @@ import com.stripe.android.R;
  */
 abstract class StripeActivity extends AppCompatActivity {
 
+    @Nullable AlertMessageListener mAlertMessageListener;
     boolean mCommunicating;
     Toolbar mToolbar;
     ProgressBar mProgressBar;
@@ -89,7 +90,15 @@ abstract class StripeActivity extends AppCompatActivity {
         supportInvalidateOptionsMenu();
     }
 
+    void setAlertMessageListener(@Nullable AlertMessageListener listener) {
+        mAlertMessageListener = listener;
+    }
+
     void showError(@NonNull String error) {
+        if (mAlertMessageListener != null) {
+            mAlertMessageListener.onAlertMessageDisplayed(error);
+        }
+
         AlertDialog alertDialog = new AlertDialog.Builder(this)
                 .setMessage(error)
                 .setCancelable(true)
@@ -103,4 +112,7 @@ abstract class StripeActivity extends AppCompatActivity {
         alertDialog.show();
     }
 
+    interface AlertMessageListener {
+        void onAlertMessageDisplayed(String message);
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -3,6 +3,7 @@ package com.stripe.android.view;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v7.app.AlertDialog;
 
 import com.stripe.android.BuildConfig;
 import com.stripe.android.PaymentConfiguration;
@@ -19,6 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowAlertDialog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,9 +98,9 @@ public class PaymentFlowActivityTest {
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
 
-        PaymentFlowActivity.AlertMessageListener alertMessageListener =
-                mock(PaymentFlowActivity.AlertMessageListener.class);
-        mActivityController.get().setAlertMessageListener(alertMessageListener);
+        StripeActivity.AlertMessageListener mockListener =
+                mock(StripeActivity.AlertMessageListener.class);
+        mActivityController.get().setAlertMessageListener(mockListener);
 
         Bundle bundle = new Bundle();
         bundle.putSerializable(EXTRA_EXCEPTION, new APIException("Something's wrong", "ID123", 400, null));
@@ -107,7 +109,7 @@ public class PaymentFlowActivityTest {
         LocalBroadcastManager.getInstance(mActivityController.get())
                 .sendBroadcast(errorIntent);
 
-        verify(alertMessageListener).onUserAlert("Something's wrong");
+        verify(mockListener).onAlertMessageDisplayed("Something's wrong");
     }
 
     private void initializePaymentConfig() {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -3,7 +3,6 @@ package com.stripe.android.view;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v7.app.AlertDialog;
 
 import com.stripe.android.BuildConfig;
 import com.stripe.android.PaymentConfiguration;
@@ -20,7 +19,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
-import org.robolectric.shadows.ShadowAlertDialog;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
r? @ksun-stripe 
cc @anelder-stripe 

Adding error dialogs to the PaymentFlowActivity whenever they are dispatched from our API (in CustomerSession). Using simple Support v7 Alert dialogs because those can be styled by the customer (and will pick up styling that the merchant has already applied).