### PR TITLE
try removing deprecated config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,5 @@ licenses:
     - 'google-gdk-license-.+'
     - '.+'
 
-group: deprecated-2017Q3
-
 script:
   - ./gradlew clean test


### PR DESCRIPTION
Travis engineer emailed back saying they deployed a change which they think might fix the stable version of trusty. Seeing if our build works without the deprecated config now.