### PR TITLE
removing user-unfriendly erroneous error message and adding error bro…

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -461,13 +461,10 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
                     case SOURCE_RETRIEVED:
                         if (messageObject instanceof Source && mSourceRetrievalListener != null) {
                             mSourceRetrievalListener.onSourceRetrieved((Source) messageObject);
-                            mSourceRetrievalListener = null;
-                        } else {
-                            if (mSourceRetrievalListener != null) {
-                                mSourceRetrievalListener.onError(400, "Not a source");
-                                mSourceRetrievalListener = null;
-                            }
                         }
+
+                        // A source listener only listens once.
+                        mSourceRetrievalListener = null;
                         // Clear our context reference so we don't use a stale one.
                         mCachedContextReference = null;
                         break;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -114,9 +114,6 @@ public class PaymentFlowActivity extends StripeActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        LocalBroadcastManager.getInstance(this)
-                .registerReceiver(mAlertBroadcastReceiver,
-                        new IntentFilter(CustomerSession.ACTION_API_EXCEPTION));
         LocalBroadcastManager.getInstance(this).registerReceiver(mBroadcastReceiver,
                 new IntentFilter(EVENT_SHIPPING_INFO_PROCESSED));
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -36,7 +36,6 @@ public class PaymentFlowActivity extends StripeActivity {
     public static final String EVENT_SHIPPING_INFO_SUBMITTED = "shipping_info_submitted";
     public static final String EXTRA_VALID_SHIPPING_METHODS = "valid_shipping_methods";
 
-    private BroadcastReceiver mAlertBroadcastReceiver;
     private BroadcastReceiver mBroadcastReceiver;
     private PaymentFlowPagerAdapter mPaymentFlowPagerAdapter;
     private ViewPager mViewPager;
@@ -95,15 +94,6 @@ public class PaymentFlowActivity extends StripeActivity {
             }
         };
         setTitle(mPaymentFlowPagerAdapter.getPageTitle(mViewPager.getCurrentItem()));
-
-        mAlertBroadcastReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                StripeException exception = (StripeException)
-                        intent.getSerializableExtra(CustomerSession.EXTRA_EXCEPTION);
-                alertUser(exception);
-            }
-        };
     }
 
     @Override
@@ -118,7 +108,6 @@ public class PaymentFlowActivity extends StripeActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(mAlertBroadcastReceiver);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mBroadcastReceiver);
     }
 
@@ -178,14 +167,6 @@ public class PaymentFlowActivity extends StripeActivity {
         intent.putExtra(PAYMENT_SESSION_DATA_KEY, mPaymentSessionData);
         setResult(RESULT_OK, intent);
         finish();
-    }
-
-    private void alertUser(@Nullable StripeException exception) {
-        if (exception == null) {
-            return;
-        }
-
-        showError(exception.getLocalizedMessage());
     }
 
     @Override


### PR DESCRIPTION
…adcast listeners to all StripeActivities

r? @ksun-stripe 

Note that the tests still check that it works in PaymentFlowActivity. Other activities would require more extensive proxys than are quite worth it for this test.