### PR TITLE
PaymentSessionConfig + IsPaymentReadyToCharge boolean

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
@@ -21,7 +21,7 @@ import com.stripe.android.model.Address;
 import com.stripe.android.model.Customer;
 import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.ShippingMethod;
-import com.stripe.android.view.PaymentFlowConfig;
+import com.stripe.android.PaymentSessionConfig;
 import com.stripe.example.R;
 import com.stripe.example.controller.ErrorDialogHandler;
 import com.stripe.example.service.ExampleEphemeralKeyProvider;
@@ -60,7 +60,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
         mStartPaymentFlowButton.setEnabled(false);
         mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
         mResultTitleTextView = findViewById(R.id.tv_payment_session_data_title);
-        mResultTextView =  findViewById(R.id.tv_payment_session_data);
+        mResultTextView = findViewById(R.id.tv_payment_session_data);
         setupCustomerSession(); // CustomerSession only needs to be initialized once per app.
         mBroadcastReceiver = new BroadcastReceiver() {
             @Override
@@ -83,10 +83,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
         mStartPaymentFlowButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPaymentSession.presentShippingFlow(
-                        new PaymentFlowConfig.Builder()
-                                .setPrepopulatedShippingInfo(getExampleShippingInfo())
-                                .build());
+                mPaymentSession.presentShippingFlow();
             }
         });
 
@@ -142,7 +139,9 @@ public class PaymentSessionActivity extends AppCompatActivity {
                 mResultTitleTextView.setVisibility(View.VISIBLE);
                 mResultTextView.setText(formatStringResults(data));
             }
-        });
+        }, new PaymentSessionConfig.Builder()
+                .setPrepopulatedShippingInfo(getExampleShippingInfo())
+                .build());
         if (paymentSessionInitialized) {
             mStartPaymentFlowButton.setEnabled(true);
         }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -82,8 +82,8 @@ public class PaymentSession {
      */
     public boolean updateIsPaymentReadyToCharge(PaymentSessionConfig paymentSessionConfig, PaymentSessionData paymentSessionData) {
         if (StripeTextUtils.isBlank(paymentSessionData.getSelectedPaymentMethodId()) ||
-                (paymentSessionConfig.isRequireShippingInfo() && paymentSessionData.getShippingInformation() == null) ||
-                (paymentSessionConfig.isRequireShippingMethods() && paymentSessionData.getShippingMethod() == null)) {
+                (paymentSessionConfig.isShippingInfoRequired() && paymentSessionData.getShippingInformation() == null) ||
+                (paymentSessionConfig.isShippingMethodRequired() && paymentSessionData.getShippingMethod() == null)) {
             paymentSessionData.setPaymentReadyToCharge(false);
             return false;
         }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -90,6 +90,7 @@ public class PaymentSession {
         paymentSessionData.setPaymentReadyToCharge(true);
         return true;
     }
+    
     /**
      * Initialize the PaymentSession with a {@link PaymentSessionListener} to be notified of
      * data changes.

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
@@ -19,12 +19,12 @@ public class PaymentSessionConfig implements Parcelable {
     @NonNull private List<String> mHiddenShippingInfoFields;
     @NonNull private List<String> mOptionalShippingInfoFields;
     @NonNull private ShippingInformation mShippingInformation;
-    private boolean mRequireShippingInfo;
-    private boolean mRequireShippingMethods;
+    private boolean mShippingInfoRequired;
+    private boolean mShippingMethodRequired;
 
      public static class Builder {
-        private boolean mRequireShippingInfo = true;
-        private boolean mRequireShippingMethods = true;
+        private boolean mShippingInfoRequired = true;
+        private boolean mShippingMethodsRequired = true;
         @NonNull private List<String> mHiddenShippingInfoFields;
         @NonNull private List<String> mOptionalShippingInfoFields;
         @NonNull private ShippingInformation mShippingInformation;
@@ -55,23 +55,23 @@ public class PaymentSessionConfig implements Parcelable {
         }
 
         /**
-         * @param requireShippingInfo whether a {@link ShippingInformation} should be required. If it is
+         * @param shippingInfoRequired whether a {@link ShippingInformation} should be required. If it is
          *                            required, a screen with a {@link ShippingInfoWidget} can be
          *                            shown to collect it.
          */
-        public Builder setRequireShippingInfo(boolean requireShippingInfo) {
-            mRequireShippingInfo = requireShippingInfo;
+        public Builder setShippingInfoRequired(boolean shippingInfoRequired) {
+            mShippingInfoRequired = shippingInfoRequired;
             return this;
         }
 
         /**
-         * @param requireShippingMethods whether a {@link com.stripe.android.model.ShippingMethod}
+         * @param shippingMethodsRequired whether a {@link com.stripe.android.model.ShippingMethod}
          *                               should be required. If it is required, a screen with a
          *                               {@link com.stripe.android.view.SelectShippingMethodWidget}
          *                               can be shown to collect it.
          */
-        public Builder setRequireShippingMethods(boolean requireShippingMethods) {
-            mRequireShippingMethods = requireShippingMethods;
+        public Builder setShippingMethodsRequired(boolean shippingMethodsRequired) {
+            mShippingMethodsRequired = shippingMethodsRequired;
             return this;
         }
 
@@ -85,8 +85,8 @@ public class PaymentSessionConfig implements Parcelable {
         mHiddenShippingInfoFields = builder.mHiddenShippingInfoFields;
         mOptionalShippingInfoFields = builder.mOptionalShippingInfoFields;
         mShippingInformation = builder.mShippingInformation;
-        mRequireShippingInfo = builder.mRequireShippingInfo;
-        mRequireShippingMethods = builder.mRequireShippingMethods;
+        mShippingInfoRequired = builder.mShippingInfoRequired;
+        mShippingMethodRequired = builder.mShippingMethodsRequired;
     }
 
     private PaymentSessionConfig(Parcel in) {
@@ -95,8 +95,8 @@ public class PaymentSessionConfig implements Parcelable {
         mOptionalShippingInfoFields = new ArrayList<>();
         in.readStringList(mOptionalShippingInfoFields);
         mShippingInformation = in.readParcelable(Address.class.getClassLoader());
-        mRequireShippingInfo = in.readInt() == 1;
-        mRequireShippingMethods = in.readInt() == 1;
+        mShippingInfoRequired = in.readInt() == 1;
+        mShippingMethodRequired = in.readInt() == 1;
     }
 
     @Override
@@ -106,8 +106,8 @@ public class PaymentSessionConfig implements Parcelable {
 
         PaymentSessionConfig that = (PaymentSessionConfig) o;
 
-        if (isRequireShippingInfo() != that.isRequireShippingInfo()) return false;
-        if (isRequireShippingMethods() != that.isRequireShippingMethods()) return false;
+        if (isShippingInfoRequired() != that.isShippingInfoRequired()) return false;
+        if (isShippingMethodRequired() != that.isShippingMethodRequired()) return false;
         if (!getHiddenShippingInfoFields().equals(that.getHiddenShippingInfoFields())) return false;
         if (!getOptionalShippingInfoFields().equals(that.getOptionalShippingInfoFields())) return false;
         return getPrepopulatedShippingInfo().equals(that.getPrepopulatedShippingInfo());
@@ -118,8 +118,8 @@ public class PaymentSessionConfig implements Parcelable {
         int result = getHiddenShippingInfoFields().hashCode();
         result = 31 * result + getOptionalShippingInfoFields().hashCode();
         result = 31 * result + mShippingInformation.hashCode();
-        result = 31 * result + (isRequireShippingInfo() ? 1 : 0);
-        result = 31 * result + (isRequireShippingMethods() ? 1 : 0);
+        result = 31 * result + (isShippingInfoRequired() ? 1 : 0);
+        result = 31 * result + (isShippingMethodRequired() ? 1 : 0);
         return result;
     }
 
@@ -133,8 +133,8 @@ public class PaymentSessionConfig implements Parcelable {
         parcel.writeStringList(mHiddenShippingInfoFields);
         parcel.writeStringList(mOptionalShippingInfoFields);
         parcel.writeParcelable(mShippingInformation, flags);
-        parcel.writeInt(mRequireShippingInfo ? 1 : 0);
-        parcel.writeInt(mRequireShippingMethods ? 1: 0);
+        parcel.writeInt(mShippingInfoRequired ? 1 : 0);
+        parcel.writeInt(mShippingMethodRequired ? 1: 0);
     }
 
     public @NonNull List<String> getHiddenShippingInfoFields() {
@@ -150,12 +150,12 @@ public class PaymentSessionConfig implements Parcelable {
         return mShippingInformation;
     }
 
-    public boolean isRequireShippingInfo() {
-        return mRequireShippingInfo;
+    public boolean isShippingInfoRequired() {
+        return mShippingInfoRequired;
     }
 
-    public boolean isRequireShippingMethods() {
-        return mRequireShippingMethods;
+    public boolean isShippingMethodRequired() {
+        return mShippingMethodRequired;
     }
 
     static final Parcelable.Creator<PaymentSessionConfig> CREATOR

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
@@ -1,4 +1,4 @@
-package com.stripe.android.view;
+package com.stripe.android;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -6,25 +6,25 @@ import android.support.annotation.NonNull;
 
 import com.stripe.android.model.Address;
 import com.stripe.android.model.ShippingInformation;
+import com.stripe.android.view.ShippingInfoWidget;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Class that tells {@link PaymentFlowActivity} what UI to render
+ * Class that tells {@link com.stripe.android.PaymentSession} what functionality it is supporting.
  */
-public class PaymentFlowConfig implements Parcelable {
-
+public class PaymentSessionConfig implements Parcelable {
 
     @NonNull private List<String> mHiddenShippingInfoFields;
     @NonNull private List<String> mOptionalShippingInfoFields;
     @NonNull private ShippingInformation mShippingInformation;
-    private boolean mHideShippingInfoScreen;
-    private boolean mHideShippingMethodsScreen;
+    private boolean mRequireShippingInfo;
+    private boolean mRequireShippingMethods;
 
      public static class Builder {
-        private boolean mHideShippingInfoScreen;
-        private boolean mHideShippingMethodsScreen;
+        private boolean mRequireShippingInfo = true;
+        private boolean mRequireShippingMethods = true;
         @NonNull private List<String> mHiddenShippingInfoFields;
         @NonNull private List<String> mOptionalShippingInfoFields;
         @NonNull private ShippingInformation mShippingInformation;
@@ -46,7 +46,6 @@ public class PaymentFlowConfig implements Parcelable {
         }
 
         /**
-         *
          * @param shippingInfo that should be prepopulated into the {@link ShippingInfoWidget}
          * @return
          */
@@ -56,45 +55,48 @@ public class PaymentFlowConfig implements Parcelable {
         }
 
         /**
-         * @param hideShippingInfoScreen whether a screen with a {@link ShippingInfoWidget} to collect
-         *                               {@link ShippingInformation} should be shown.
+         * @param requireShippingInfo whether a {@link ShippingInformation} should be required. If it is
+         *                            required, a screen with a {@link ShippingInfoWidget} can be
+         *                            shown to collect it.
          */
-        public Builder setHideShippingInfoScreen(boolean hideShippingInfoScreen) {
-            mHideShippingInfoScreen = hideShippingInfoScreen;
+        public Builder setRequireShippingInfo(boolean requireShippingInfo) {
+            mRequireShippingInfo = requireShippingInfo;
             return this;
         }
 
         /**
-         * @param hideShippingMethodsScreen whether a screen with a {@link SelectShippingMethodWidget}
-         *                                  to select a {@link com.stripe.android.model.ShippingMethod}
+         * @param requireShippingMethods whether a {@link com.stripe.android.model.ShippingMethod}
+         *                               should be required. If it is required, a screen with a
+         *                               {@link com.stripe.android.view.SelectShippingMethodWidget}
+         *                               can be shown to collect it.
          */
-        public Builder setHideShippingMethodsScreen(boolean hideShippingMethodsScreen) {
-            mHideShippingMethodsScreen = hideShippingMethodsScreen;
+        public Builder setRequireShippingMethods(boolean requireShippingMethods) {
+            mRequireShippingMethods = requireShippingMethods;
             return this;
         }
 
-        public PaymentFlowConfig build() {
-            return new PaymentFlowConfig(this);
+        public PaymentSessionConfig build() {
+            return new PaymentSessionConfig(this);
         }
 
     }
 
-    PaymentFlowConfig(Builder builder) {
+    PaymentSessionConfig(Builder builder) {
         mHiddenShippingInfoFields = builder.mHiddenShippingInfoFields;
         mOptionalShippingInfoFields = builder.mOptionalShippingInfoFields;
         mShippingInformation = builder.mShippingInformation;
-        mHideShippingInfoScreen = builder.mHideShippingInfoScreen;
-        mHideShippingMethodsScreen = builder.mHideShippingMethodsScreen;
+        mRequireShippingInfo = builder.mRequireShippingInfo;
+        mRequireShippingMethods = builder.mRequireShippingMethods;
     }
 
-    private PaymentFlowConfig(Parcel in) {
+    private PaymentSessionConfig(Parcel in) {
         mHiddenShippingInfoFields = new ArrayList<>();
         in.readStringList(mHiddenShippingInfoFields);
         mOptionalShippingInfoFields = new ArrayList<>();
         in.readStringList(mOptionalShippingInfoFields);
         mShippingInformation = in.readParcelable(Address.class.getClassLoader());
-        mHideShippingInfoScreen = in.readInt() == 1;
-        mHideShippingMethodsScreen = in.readInt() == 1;
+        mRequireShippingInfo = in.readInt() == 1;
+        mRequireShippingMethods = in.readInt() == 1;
     }
 
     @Override
@@ -102,10 +104,10 @@ public class PaymentFlowConfig implements Parcelable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        PaymentFlowConfig that = (PaymentFlowConfig) o;
+        PaymentSessionConfig that = (PaymentSessionConfig) o;
 
-        if (isHideShippingInfoScreen() != that.isHideShippingInfoScreen()) return false;
-        if (isHideShippingMethodsScreen() != that.isHideShippingMethodsScreen()) return false;
+        if (isRequireShippingInfo() != that.isRequireShippingInfo()) return false;
+        if (isRequireShippingMethods() != that.isRequireShippingMethods()) return false;
         if (!getHiddenShippingInfoFields().equals(that.getHiddenShippingInfoFields())) return false;
         if (!getOptionalShippingInfoFields().equals(that.getOptionalShippingInfoFields())) return false;
         return getPrepopulatedShippingInfo().equals(that.getPrepopulatedShippingInfo());
@@ -116,8 +118,8 @@ public class PaymentFlowConfig implements Parcelable {
         int result = getHiddenShippingInfoFields().hashCode();
         result = 31 * result + getOptionalShippingInfoFields().hashCode();
         result = 31 * result + mShippingInformation.hashCode();
-        result = 31 * result + (isHideShippingInfoScreen() ? 1 : 0);
-        result = 31 * result + (isHideShippingMethodsScreen() ? 1 : 0);
+        result = 31 * result + (isRequireShippingInfo() ? 1 : 0);
+        result = 31 * result + (isRequireShippingMethods() ? 1 : 0);
         return result;
     }
 
@@ -131,42 +133,42 @@ public class PaymentFlowConfig implements Parcelable {
         parcel.writeStringList(mHiddenShippingInfoFields);
         parcel.writeStringList(mOptionalShippingInfoFields);
         parcel.writeParcelable(mShippingInformation, flags);
-        parcel.writeInt(mHideShippingInfoScreen ? 1 : 0);
-        parcel.writeInt(mHideShippingMethodsScreen ? 1: 0);
+        parcel.writeInt(mRequireShippingInfo ? 1 : 0);
+        parcel.writeInt(mRequireShippingMethods ? 1: 0);
     }
 
-    @NonNull List<String> getHiddenShippingInfoFields() {
+    public @NonNull List<String> getHiddenShippingInfoFields() {
         return mHiddenShippingInfoFields;
     }
 
-    @NonNull List<String> getOptionalShippingInfoFields() {
+    public @NonNull List<String> getOptionalShippingInfoFields() {
         return mOptionalShippingInfoFields;
     }
 
     @NonNull
-    ShippingInformation getPrepopulatedShippingInfo() {
+    public ShippingInformation getPrepopulatedShippingInfo() {
         return mShippingInformation;
     }
 
-    boolean isHideShippingInfoScreen() {
-        return mHideShippingInfoScreen;
+    public boolean isRequireShippingInfo() {
+        return mRequireShippingInfo;
     }
 
-    boolean isHideShippingMethodsScreen() {
-        return mHideShippingMethodsScreen;
+    public boolean isRequireShippingMethods() {
+        return mRequireShippingMethods;
     }
 
-    static final Parcelable.Creator<PaymentFlowConfig> CREATOR
-            = new Parcelable.Creator<PaymentFlowConfig>() {
+    static final Parcelable.Creator<PaymentSessionConfig> CREATOR
+            = new Parcelable.Creator<PaymentSessionConfig>() {
 
         @Override
-        public PaymentFlowConfig createFromParcel(Parcel in) {
-            return new PaymentFlowConfig(in);
+        public PaymentSessionConfig createFromParcel(Parcel in) {
+            return new PaymentSessionConfig(in);
         }
 
         @Override
-        public PaymentFlowConfig[] newArray(int size) {
-            return new PaymentFlowConfig[size];
+        public PaymentSessionConfig[] newArray(int size) {
+            return new PaymentSessionConfig[size];
         }
     };
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -16,6 +16,7 @@ public class PaymentSessionData implements Parcelable {
     private static final String NO_PAYMENT = "NO_PAYMENT";
 
     private long mCartTotal = 0L;
+    private boolean mIsPaymentReadyToCharge;
     @NonNull private String mSelectedPaymentMethodId = NO_PAYMENT;
     private long mShippingTotal = 0L;
     private ShippingInformation mShippingInformation;
@@ -42,6 +43,25 @@ public class PaymentSessionData implements Parcelable {
     }
 
     /**
+     * Get the whether the all the payment data is ready for making a charge. This can be used to
+     * set a buy button to enabled for prompt a user to fill in more information.
+     *
+     * @return whether the payment data is ready for making a charge.
+     */
+    public boolean isPaymentReadyToCharge() {
+        return mIsPaymentReadyToCharge;
+    }
+
+    /**
+     * Set whether the payment data is ready for making a charge.
+     *
+     * @param paymentReadyToCharge whether the payment data is ready for making a charge.
+     */
+    public void setPaymentReadyToCharge(boolean paymentReadyToCharge) {
+        mIsPaymentReadyToCharge = paymentReadyToCharge;
+    }
+
+    /**
      * Get the value of shipping items in the associated {@link PaymentSession}
      *
      * @return the current value of the shipping items in the cart
@@ -50,18 +70,40 @@ public class PaymentSessionData implements Parcelable {
         return mShippingTotal;
     }
 
+    /**
+     * Get the {@link ShippingInformation} collected as part of the associated {@link PaymentSession}
+     * payment flow.
+     *
+     * @return {@link ShippingInformation} where the items being purchased should be shipped.
+     */
     public ShippingInformation getShippingInformation() {
         return mShippingInformation;
     }
 
+    /**
+     * Set the {@link ShippingInformation} for the associated {@link PaymentSession}
+     *
+     * @param shippingInformation where the items being purchased should be shipped.
+     */
     public void setShippingInformation(ShippingInformation shippingInformation) {
         mShippingInformation = shippingInformation;
     }
 
+    /**
+     * Get the {@link ShippingMethod} collected as part of the associated {@link PaymentSession}
+     * payment flow.
+     *
+     * @return {@link ShippingMethod} how the items being purchased should be shipped.
+     */
     public ShippingMethod getShippingMethod() {
         return mShippingMethod;
     }
 
+    /**
+     * Set the {@link ShippingMethod} for the associated {@link PaymentSession}
+     *
+     * @param shippingMethod how the items being purchased should be shipped.
+     */
     public void setShippingMethod(ShippingMethod shippingMethod) {
         mShippingMethod = shippingMethod;
     }
@@ -89,6 +131,7 @@ public class PaymentSessionData implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeLong(mCartTotal);
+        parcel.writeInt(mIsPaymentReadyToCharge ? 1 : 0);
         parcel.writeString(mSelectedPaymentMethodId);
         parcel.writeLong(mShippingTotal);
         parcel.writeParcelable(mShippingInformation, i);
@@ -108,6 +151,7 @@ public class PaymentSessionData implements Parcelable {
 
     private PaymentSessionData(Parcel in) {
         mCartTotal = in.readLong();
+        mIsPaymentReadyToCharge = in.readInt() == 1;
         mSelectedPaymentMethodId = in.readString();
         mShippingTotal = in.readLong();
         mShippingInformation = in.readParcelable(ShippingInformation.class.getClassLoader());

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -11,6 +11,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.ViewPager;
 
 import com.stripe.android.CustomerSession;
+import com.stripe.android.PaymentSessionConfig;
 import com.stripe.android.PaymentSessionData;
 import com.stripe.android.R;
 import com.stripe.android.exception.StripeException;
@@ -19,6 +20,7 @@ import com.stripe.android.model.ShippingMethod;
 
 import java.util.List;
 
+import static com.stripe.android.PaymentSession.PAYMENT_SESSION_CONFIG;
 import static com.stripe.android.PaymentSession.PAYMENT_SESSION_DATA_KEY;
 
 /**
@@ -29,7 +31,6 @@ public class PaymentFlowActivity extends StripeActivity {
 
     public static final String EXTRA_DEFAULT_SHIPPING_METHOD = "default_shipping_method";
     public static final String EXTRA_IS_SHIPPING_INFO_VALID = "shipping_is_shipping_info_valid";
-    public static final String EXTRA_PAYMENT_FLOW_CONFIG = "payment_flow_config";
     public static final String EXTRA_SHIPPING_INFO_DATA = "shipping_info_data";
     public static final String EXTRA_SHIPPING_INFO_ERROR = "shipping_info_error";
     public static final String EVENT_SHIPPING_INFO_PROCESSED = "shipping_info_processed";
@@ -49,9 +50,9 @@ public class PaymentFlowActivity extends StripeActivity {
         mViewStub.setLayoutResource(R.layout.activity_shipping_flow);
         mViewStub.inflate();
         mViewPager = findViewById(R.id.shipping_flow_viewpager);
-        final PaymentFlowConfig paymentFlowConfig = getIntent().getParcelableExtra(EXTRA_PAYMENT_FLOW_CONFIG);
+        final PaymentSessionConfig paymentSessionConfig = getIntent().getParcelableExtra(PAYMENT_SESSION_CONFIG);
         mPaymentSessionData = getIntent().getParcelableExtra(PAYMENT_SESSION_DATA_KEY);
-        mPaymentFlowPagerAdapter = new PaymentFlowPagerAdapter(this, paymentFlowConfig);
+        mPaymentFlowPagerAdapter = new PaymentFlowPagerAdapter(this, paymentSessionConfig);
         mViewPager.setAdapter(mPaymentFlowPagerAdapter);
         mViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
@@ -29,7 +29,7 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
         mContext = context;
         mPaymentSessionConfig = paymentSessionConfig;
         mPages = new ArrayList<>();
-        if (mPaymentSessionConfig.isRequireShippingInfo()) {
+        if (mPaymentSessionConfig.isShippingInfoRequired()) {
             mPages.add(PaymentFlowPagerEnum.ADDRESS);
         }
         if (shouldAddShippingScreen()) {
@@ -38,8 +38,8 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
     }
 
     private boolean shouldAddShippingScreen() {
-        return mPaymentSessionConfig.isRequireShippingMethods() &&
-                ((mPaymentSessionConfig.isRequireShippingInfo() && mAddressSaved) || !mPaymentSessionConfig.isRequireShippingInfo()) &&
+        return mPaymentSessionConfig.isShippingMethodRequired() &&
+                ((mPaymentSessionConfig.isShippingInfoRequired() && mAddressSaved) || !mPaymentSessionConfig.isShippingInfoRequired()) &&
                     !mPages.contains(PaymentFlowPagerEnum.SHIPPING_METHOD);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.stripe.android.PaymentSessionConfig;
 import com.stripe.android.R;
 import com.stripe.android.model.ShippingMethod;
 
@@ -17,18 +18,18 @@ import java.util.List;
 class PaymentFlowPagerAdapter extends PagerAdapter {
 
     @NonNull private Context mContext;
-    @NonNull private PaymentFlowConfig mPaymentFlowConfig;
+    @NonNull private PaymentSessionConfig mPaymentSessionConfig;
     @NonNull private List<PaymentFlowPagerEnum> mPages;
 
     private boolean mAddressSaved;
     private List<ShippingMethod> mValidShippingMethods = new ArrayList<>();
     private ShippingMethod mDefaultShippingMethod;
 
-    PaymentFlowPagerAdapter(@NonNull Context context, @NonNull PaymentFlowConfig paymentFlowConfig) {
+    PaymentFlowPagerAdapter(@NonNull Context context, @NonNull PaymentSessionConfig paymentSessionConfig) {
         mContext = context;
-        mPaymentFlowConfig = paymentFlowConfig;
+        mPaymentSessionConfig = paymentSessionConfig;
         mPages = new ArrayList<>();
-        if (!mPaymentFlowConfig.isHideShippingInfoScreen()) {
+        if (mPaymentSessionConfig.isRequireShippingInfo()) {
             mPages.add(PaymentFlowPagerEnum.ADDRESS);
         }
         if (shouldAddShippingScreen()) {
@@ -37,8 +38,8 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
     }
 
     private boolean shouldAddShippingScreen() {
-        return !mPaymentFlowConfig.isHideShippingMethodsScreen() &&
-                ((!mPaymentFlowConfig.isHideShippingInfoScreen() && mAddressSaved) || mPaymentFlowConfig.isHideShippingInfoScreen()) &&
+        return mPaymentSessionConfig.isRequireShippingMethods() &&
+                ((mPaymentSessionConfig.isRequireShippingInfo() && mAddressSaved) || !mPaymentSessionConfig.isRequireShippingInfo()) &&
                     !mPages.contains(PaymentFlowPagerEnum.SHIPPING_METHOD);
     }
 
@@ -72,9 +73,9 @@ class PaymentFlowPagerAdapter extends PagerAdapter {
         }
         if (paymentFlowPagerEnum.equals(PaymentFlowPagerEnum.ADDRESS)) {
             ShippingInfoWidget shippingInfoWidget = layout.findViewById(R.id.shipping_info_widget);
-            shippingInfoWidget.setHiddenFields(mPaymentFlowConfig.getHiddenShippingInfoFields());
-            shippingInfoWidget.setOptionalFields(mPaymentFlowConfig.getOptionalShippingInfoFields());
-            shippingInfoWidget.populateShippingInfo(mPaymentFlowConfig.getPrepopulatedShippingInfo());
+            shippingInfoWidget.setHiddenFields(mPaymentSessionConfig.getHiddenShippingInfoFields());
+            shippingInfoWidget.setOptionalFields(mPaymentSessionConfig.getOptionalShippingInfoFields());
+            shippingInfoWidget.populateShippingInfo(mPaymentSessionConfig.getPrepopulatedShippingInfo());
         }
         collection.addView(layout);
         return layout;

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -114,7 +114,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
         Set<String> tokenSet = CustomerSession.getInstance().getProductUsageTokens();
         assertTrue(tokenSet.contains(PaymentSession.TOKEN_PAYMENT_SESSION));
@@ -136,7 +136,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
         verify(mockListener).onCommunicatingStateChanged(eq(true));
         verify(mockListener).onPaymentSessionDataChanged(any(PaymentSessionData.class));
         verify(mockListener).onCommunicatingStateChanged(eq(false));
@@ -156,7 +156,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
         ArgumentCaptor<PaymentSessionData> dataArgumentCaptor = getDataCaptor();
 
@@ -182,7 +182,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener, PaymentSessionConfig);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
         // We have already tested the functionality up to here.
         reset(mockListener);
@@ -208,7 +208,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
 
         paymentSession.selectPaymentMethod();
@@ -233,7 +233,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
         ArgumentCaptor<PaymentSessionData> paySessionDataCaptor = getDataCaptor();
         paymentSession.setCartTotal(300L);
@@ -246,7 +246,7 @@ public class PaymentSessionTest {
                 mock(PaymentSession.PaymentSessionListener.class);
         ArgumentCaptor<PaymentSessionData> secondSessionDataCaptor = getDataCaptor();
 
-        paymentSession.init(secondListener, bundle);
+        paymentSession.init(secondListener, new PaymentSessionConfig.Builder().build(), bundle);
         verify(secondListener).onPaymentSessionDataChanged(secondSessionDataCaptor.capture());
 
         PaymentSessionData firstData = paySessionDataCaptor.getValue();

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -182,7 +182,7 @@ public class PaymentSessionTest {
         PaymentSession.PaymentSessionListener mockListener =
                 mock(PaymentSession.PaymentSessionListener.class);
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
-        paymentSession.init(mockListener);
+        paymentSession.init(mockListener, PaymentSessionConfig);
 
         // We have already tested the functionality up to here.
         reset(mockListener);

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -10,6 +10,7 @@ import android.view.View;
 
 import com.stripe.android.BuildConfig;
 import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.PaymentSessionConfig;
 import com.stripe.android.PaymentSessionData;
 import com.stripe.android.R;
 import com.stripe.android.exception.APIException;
@@ -33,6 +34,7 @@ import org.robolectric.shadows.ShadowActivity;
 
 import static com.stripe.android.CustomerSession.ACTION_API_EXCEPTION;
 import static com.stripe.android.CustomerSession.EXTRA_EXCEPTION;
+import static com.stripe.android.PaymentSession.PAYMENT_SESSION_CONFIG;
 import static com.stripe.android.PaymentSession.PAYMENT_SESSION_DATA_KEY;
 import static com.stripe.android.view.PaymentFlowActivity.EVENT_SHIPPING_INFO_PROCESSED;
 import static com.stripe.android.view.PaymentFlowActivity.EXTRA_IS_SHIPPING_INFO_VALID;
@@ -72,10 +74,10 @@ public class PaymentFlowActivityTest {
     public void launchPaymentFlowActivity_withHideShippingInfoConfig_hidesShippingInfoView() {
         PaymentConfiguration.init("FAKE PUBLISHABLE KEY");
         Intent intent = new Intent();
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
-                .setHideShippingInfoScreen(true)
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
+                .setRequireShippingInfo(false)
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
         assertNull(mActivityController.get().findViewById(R.id.shipping_info_widget));
@@ -85,9 +87,9 @@ public class PaymentFlowActivityTest {
     @Test
     public void onShippingInfoSave_whenShippingNotPopulated_doesNotFinish() {
         Intent intent = new Intent();
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
         mShadowActivity = shadowOf(mActivityController.get());
@@ -101,9 +103,9 @@ public class PaymentFlowActivityTest {
     @Test
     public void onShippingInfoSave_whenShippingInfoNotPopulated_doesNotContinue() {
         Intent intent = new Intent();
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
         mShadowActivity = shadowOf(mActivityController.get());
@@ -118,10 +120,10 @@ public class PaymentFlowActivityTest {
     @Test
     public void onShippingInfoSave_whenShippingPopulated_sendsCorrectIntent() {
         Intent intent = new Intent();
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
                 .setPrepopulatedShippingInfo(getExampleShippingInfo())
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
         mShippingInfoWidget = mActivityController.get().findViewById(R.id.shipping_info_widget);
@@ -139,9 +141,9 @@ public class PaymentFlowActivityTest {
     @Test
     public void onErrorBroadcast_displaysAlertDialog() {
         Intent intent = new Intent();
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)
                 .create().start().resume().visible();
 
@@ -162,10 +164,10 @@ public class PaymentFlowActivityTest {
     @Test
     public void onShippingInfoProcessed_whenShippingInfoSubmitted_rendersCorrectly() {
         Intent intent = new Intent(RuntimeEnvironment.application, PaymentFlowActivity.class);
-        PaymentFlowConfig paymentFlowConfig = new PaymentFlowConfig.Builder()
+        PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
                 .setPrepopulatedShippingInfo(getExampleShippingInfo())
                 .build();
-        intent.putExtra(PaymentFlowActivity.EXTRA_PAYMENT_FLOW_CONFIG, paymentFlowConfig);
+        intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         PaymentSessionData paymentSessionData = Mockito.mock(PaymentSessionData.class);
         intent.putExtra(PAYMENT_SESSION_DATA_KEY, paymentSessionData);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -75,7 +75,7 @@ public class PaymentFlowActivityTest {
         PaymentConfiguration.init("FAKE PUBLISHABLE KEY");
         Intent intent = new Intent();
         PaymentSessionConfig paymentSessionConfig = new PaymentSessionConfig.Builder()
-                .setRequireShippingInfo(false)
+                .setShippingInfoRequired(false)
                 .build();
         intent.putExtra(PAYMENT_SESSION_CONFIG, paymentSessionConfig);
         mActivityController = Robolectric.buildActivity(PaymentFlowActivity.class, intent)


### PR DESCRIPTION
Description: Changes required to support having a IsPaymentReadyToCharge boolean

Changes:
PaymentFlowConfig becomes PaymentSessionConfig and will be used as the config for payment session. PaymentSessionConfig is now required in the constructor.
Added a isPaymentReadyToCharge boolean that gets updated.

r? @mrmcduff-stripe 
cc: @bdorfman-stripe  (as discussed offline)