### PR TITLE
fixing npe in CardInputWidget

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -32,8 +32,6 @@ import com.stripe.android.StripeTextUtils;
 import java.util.Locale;
 
 import static com.stripe.android.model.Card.BRAND_RESOURCE_MAP;
-import static com.stripe.android.model.Card.CVC_LENGTH_AMERICAN_EXPRESS;
-import static com.stripe.android.model.Card.CVC_LENGTH_COMMON;
 import static com.stripe.android.model.Card.CardBrand;
 import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
 import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
@@ -202,6 +200,20 @@ public class CardInputWidget extends LinearLayout {
         mCardNumberEditText.setEnabled(isEnabled);
         mExpiryDateEditText.setEnabled(isEnabled);
         mCvcNumberEditText.setEnabled(isEnabled);
+    }
+
+    /**
+     * Override of {@link View#isEnabled()} that returns {@code true} only
+     * if all three sub-controls are enabled.
+     *
+     * @return {@code true} if the card number field, expiry field, and cvc field are enabled,
+     * {@code false} otherwise
+     */
+    @Override
+    public boolean isEnabled() {
+        return mCardNumberEditText.isEnabled() &&
+                mExpiryDateEditText.isEnabled() &&
+                mCvcNumberEditText.isEnabled();
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -96,6 +96,10 @@ public class StripeEditText extends TextInputEditText {
 
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
+        if (inputConnection == null) {
+            return null;
+        }
         return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
     }
 


### PR DESCRIPTION
r? @ksun-stripe 
https://github.com/stripe/stripe-android/issues/391

It looks like this is a very rare NPE, but digging into the source code it appears that the super.onCreateInputConnection method absolutely can return null, and that you need to be sure not to use that value in any other calls if it is.

For context, some others have run into this on SO
https://stackoverflow.com/questions/36498605/inputconnection-finishcomposingtext-nullpointerexception