### PR TITLE
removing the logs after each action, adding them when appropriate

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -140,6 +140,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
 
     @VisibleForTesting
     static void clearInstance() {
+        if (mInstance == null) {
+            return;
+        }
         mInstance.mThreadPoolExecutor.shutdown();
         mInstance.mProductUsageTokens.clear();
         mInstance.mNetworkQueue.clear();

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -143,9 +143,7 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         if (mInstance == null) {
             return;
         }
-        mInstance.mThreadPoolExecutor.shutdown();
-        mInstance.mProductUsageTokens.clear();
-        mInstance.mNetworkQueue.clear();
+        mInstance.mThreadPoolExecutor.shutdownNow();
         mInstance = null;
     }
 

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -51,11 +51,12 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
     private static final String KEY_SOURCE = "source";
     private static final String KEY_SOURCE_TYPE = "source_type";
     private static final String KEY_SHIPPING_INFO = "shipping_info";
+    private static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
     private static final Set<String> VALID_TOKENS =
             new HashSet<>(Arrays.asList("AddSourceActivity",
                     "PaymentMethodsActivity",
                     "PaymentFlowActivity",
-                    "PaymentSession",
+                    TOKEN_PAYMENT_SESSION,
                     "ShippingInfoScreen",
                     "ShippingMethodScreen"));
 
@@ -119,6 +120,16 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         return mInstance;
     }
 
+    /**
+     * End the singleton instance of a {@link CustomerSession}.
+     * Calls to {@link CustomerSession#getInstance()} will throw an {@link IllegalStateException}
+     * after this call, until the user calls
+     * {@link CustomerSession#initCustomerSession(EphemeralKeyProvider)} again.
+     */
+    public static void endCustomerSession() {
+        clearInstance();
+    }
+
     @VisibleForTesting
     static void initCustomerSession(
             @NonNull EphemeralKeyProvider keyProvider,
@@ -129,6 +140,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
 
     @VisibleForTesting
     static void clearInstance() {
+        mInstance.mThreadPoolExecutor.shutdown();
+        mInstance.mProductUsageTokens.clear();
+        mInstance.mNetworkQueue.clear();
         mInstance = null;
     }
 
@@ -257,7 +271,7 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         mEphemeralKeyManager.retrieveEphemeralKey(ACTION_SET_DEFAULT_SOURCE, arguments);
     }
 
-    void clearUsageTokens() {
+    void resetUsageTokens() {
         mProductUsageTokens.clear();
     }
 
@@ -292,14 +306,15 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
             @NonNull final WeakReference<Context> contextWeakReference,
             @NonNull final EphemeralKey key,
             @NonNull final String sourceId,
-            @NonNull final String sourceType) {
+            @NonNull final String sourceType,
+            @NonNull final List<String> productUsageTokens) {
         Runnable fetchCustomerRunnable = new Runnable() {
             @Override
             public void run() {
                 Source source = addCustomerSourceWithKey(
                         contextWeakReference,
                         key,
-                        new ArrayList<>(mProductUsageTokens),
+                        new ArrayList<>(productUsageTokens),
                         sourceId,
                         sourceType,
                         mStripeApiProxy);
@@ -321,14 +336,15 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
             @NonNull final WeakReference<Context> contextWeakReference,
             @NonNull final EphemeralKey key,
             @NonNull final String sourceId,
-            @NonNull final String sourceType) {
+            @NonNull final String sourceType,
+            @NonNull final List<String> productUsageTokens) {
         Runnable fetchCustomerRunnable = new Runnable() {
             @Override
             public void run() {
                 Customer customer = setCustomerSourceDefaultWithKey(
                         contextWeakReference,
                         key,
-                        new ArrayList<>(mProductUsageTokens),
+                        new ArrayList<>(productUsageTokens),
                         sourceId,
                         sourceType,
                         mStripeApiProxy);
@@ -343,14 +359,15 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
     private void setCustomerShippingInformation(
             @NonNull final WeakReference<Context> contextWeakReference,
             @NonNull final EphemeralKey key,
-            @NonNull final ShippingInformation shippingInformation) {
+            @NonNull final ShippingInformation shippingInformation,
+            @NonNull final List<String> productUsageTokens) {
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
                 Customer customer = setCustomerShippingInfoWithKey(
                         contextWeakReference,
                         key,
-                        new ArrayList<>(mProductUsageTokens),
+                        new ArrayList<>(productUsageTokens),
                         shippingInformation,
                         mStripeApiProxy);
                 Message message = mUiThreadHandler.obtainMessage(CUSTOMER_SHIPPING_INFO_SAVED, customer);
@@ -405,7 +422,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
                         mCachedContextReference,
                         mEphemeralKey,
                         (String) arguments.get(KEY_SOURCE),
-                        (String) arguments.get(KEY_SOURCE_TYPE));
+                        (String) arguments.get(KEY_SOURCE_TYPE),
+                        new ArrayList<>(mProductUsageTokens));
+                resetUsageTokens();
             } else if (ACTION_SET_DEFAULT_SOURCE.equals(actionString)
                     && mCachedContextReference != null
                     && arguments != null
@@ -415,7 +434,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
                         mCachedContextReference,
                         mEphemeralKey,
                         (String) arguments.get(KEY_SOURCE),
-                        (String) arguments.get(KEY_SOURCE_TYPE));
+                        (String) arguments.get(KEY_SOURCE_TYPE),
+                        new ArrayList<>(mProductUsageTokens));
+                resetUsageTokens();
             } else if (ACTION_SET_CUSTOMER_SHIPPING_INFO.equals(actionString)
                     && mCachedContextReference != null
                     && arguments != null
@@ -423,8 +444,9 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
                 setCustomerShippingInformation(
                         mCachedContextReference,
                         mEphemeralKey,
-                        (ShippingInformation) arguments.get(KEY_SHIPPING_INFO)
-                );
+                        (ShippingInformation) arguments.get(KEY_SHIPPING_INFO),
+                        new ArrayList<>(mProductUsageTokens));
+                resetUsageTokens();
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -16,9 +16,11 @@ import com.stripe.android.view.PaymentMethodsActivity;
  */
 public class PaymentSession {
 
+    public static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
+    public static final String EXTRA_PAYMENT_SESSION_ACTIVE = "payment_session_active";
+
     static final int PAYMENT_SHIPPING_DETAILS_REQUEST = 3004;
     static final int PAYMENT_METHOD_REQUEST = 3003;
-    static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
 
     public static final String PAYMENT_SESSION_DATA_KEY = "payment_session_data";
     public static final String PAYMENT_SESSION_CONFIG = "payment_session_config";
@@ -52,7 +54,7 @@ public class PaymentSession {
                     @Override
                     public void onPaymentResult(@NonNull @PaymentResult String paymentResult) {
                         mPaymentSessionData.setPaymentResult(paymentResult);
-                        CustomerSession.getInstance().clearUsageTokens();
+                        CustomerSession.getInstance().resetUsageTokens();
                         if (mPaymentSessionListener != null) {
                             mPaymentSessionListener
                                     .onPaymentSessionDataChanged(mPaymentSessionData);
@@ -149,7 +151,7 @@ public class PaymentSession {
         // will throw a runtime exception if none is ready.
         try {
             if (savedInstanceState == null) {
-                CustomerSession.getInstance().clearUsageTokens();
+                CustomerSession.getInstance().resetUsageTokens();
             }
             CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
         } catch (IllegalStateException illegalState) {
@@ -176,9 +178,9 @@ public class PaymentSession {
      * or to add a new one.
      */
     public void presentPaymentMethodSelection() {
-        mHostActivity.startActivityForResult(
-                PaymentMethodsActivity.newIntent(mHostActivity),
-                PAYMENT_METHOD_REQUEST);
+        Intent paymentMethodsIntent = PaymentMethodsActivity.newIntent(mHostActivity);
+        paymentMethodsIntent.putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
+        mHostActivity.startActivityForResult(paymentMethodsIntent, PAYMENT_METHOD_REQUEST);
     }
 
     /**
@@ -208,6 +210,7 @@ public class PaymentSession {
         Intent intent = new Intent(mHostActivity, PaymentFlowActivity.class);
         intent.putExtra(PAYMENT_SESSION_CONFIG, mPaymentSessionConfig);
         intent.putExtra(PAYMENT_SESSION_DATA_KEY, mPaymentSessionData);
+        intent.putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
         mHostActivity.startActivityForResult(
                 intent,
                 PAYMENT_SHIPPING_DETAILS_REQUEST);

--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -18,6 +18,9 @@ import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.StripePaymentSource;
 
+import static com.stripe.android.PaymentSession.EXTRA_PAYMENT_SESSION_ACTIVE;
+import static com.stripe.android.PaymentSession.TOKEN_PAYMENT_SESSION;
+
 /**
  * Activity used to display a {@link CardMultilineWidget} and receive the resulting
  * {@link Source} in the {@link #onActivityResult(int, int, Intent)} of the launching activity.
@@ -35,6 +38,7 @@ public class AddSourceActivity extends StripeActivity {
     FrameLayout mErrorLayout;
     StripeProvider mStripeProvider;
 
+    private boolean mStartedFromPaymentSession;
     private boolean mUpdatesCustomer;
 
     /**
@@ -65,11 +69,15 @@ public class AddSourceActivity extends StripeActivity {
         mErrorLayout = findViewById(R.id.add_source_error_container);
         boolean showZip = getIntent().getBooleanExtra(EXTRA_SHOW_ZIP, false);
         mUpdatesCustomer = getIntent().getBooleanExtra(EXTRA_UPDATE_CUSTOMER, false);
+        mStartedFromPaymentSession =
+                getIntent().getBooleanExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
         mCardMultilineWidget.setShouldShowPostalCode(showZip);
 
-        if (mUpdatesCustomer && !getIntent().getBooleanExtra(EXTRA_PROXY_DELAY, false)) {
-            CustomerSession.getInstance().addProductUsageTokenIfValid(ADD_SOURCE_ACTIVITY);
+        if (!getIntent().getBooleanExtra(EXTRA_PROXY_DELAY, false)) {
+            logToCustomerSessionIf(ADD_SOURCE_ACTIVITY, mUpdatesCustomer);
+            logToCustomerSessionIf(TOKEN_PAYMENT_SESSION, mStartedFromPaymentSession);
         }
+
         setTitle(R.string.title_add_a_card);
     }
 
@@ -140,6 +148,12 @@ public class AddSourceActivity extends StripeActivity {
                     listener);
         } else {
             mCustomerSessionProxy.addCustomerSource(source.getId(), listener);
+        }
+    }
+
+    private void logToCustomerSessionIf(@NonNull String logToken, boolean condition) {
+        if (condition) {
+            CustomerSession.getInstance().addProductUsageTokenIfValid(logToken);
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.java
@@ -1,6 +1,7 @@
 package com.stripe.android.view;
 
 import android.content.Context;
+import android.support.annotation.RestrictTo;
 import android.support.annotation.VisibleForTesting;
 import android.support.design.widget.TextInputLayout;
 import android.util.AttributeSet;
@@ -16,7 +17,8 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Map;
 
-class CountryAutoCompleteTextView extends FrameLayout {
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+public class CountryAutoCompleteTextView extends FrameLayout {
     private AutoCompleteTextView mCountryAutocomplete;
     private TextInputLayout mCountryTextInputLayout;
     private Map<String, String> mCountryNameToCode;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -113,8 +113,8 @@ public class PaymentFlowActivity extends StripeActivity {
     @Override
     protected void onActionSave() {
         if (mPaymentFlowPagerAdapter.getPageAt(
-                mViewPager.getCurrentItem()).equals(PaymentFlowPagerEnum.ADDRESS)) {
-            onAddressSave();
+                mViewPager.getCurrentItem()).equals(PaymentFlowPagerEnum.SHIPPING_INFO)) {
+            onShippingInfoSubmitted();
         } else {
             onShippingMethodSave();
         }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.java
@@ -22,6 +22,7 @@ import java.util.List;
 import static com.stripe.android.CustomerSession.EVENT_SHIPPING_INFO_SAVED;
 import static com.stripe.android.PaymentSession.PAYMENT_SESSION_CONFIG;
 import static com.stripe.android.PaymentSession.PAYMENT_SESSION_DATA_KEY;
+import static com.stripe.android.PaymentSession.TOKEN_PAYMENT_SESSION;
 
 /**
  * Activity containing a two-part payment flow that allows users to provide a shipping address
@@ -51,6 +52,7 @@ public class PaymentFlowActivity extends StripeActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
         CustomerSession.getInstance().addProductUsageTokenIfValid(TOKEN_PAYMENT_FLOW_ACTIVITY);
         mViewStub.setLayoutResource(R.layout.activity_shipping_flow);
         mViewStub.inflate();
@@ -77,7 +79,6 @@ public class PaymentFlowActivity extends StripeActivity {
             public void onPageScrollStateChanged(int i) {
 
             }
-
         });
         mShippingInfoSubmittedBroadcastReceiver = new BroadcastReceiver() {
             @Override
@@ -111,8 +112,9 @@ public class PaymentFlowActivity extends StripeActivity {
 
     @Override
     protected void onActionSave() {
-        if (mPaymentFlowPagerAdapter.getPageAt(mViewPager.getCurrentItem()).equals(PaymentFlowPagerEnum.SHIPPING_INFO)) {
-            onShippingInfoSubmitted();
+        if (mPaymentFlowPagerAdapter.getPageAt(
+                mViewPager.getCurrentItem()).equals(PaymentFlowPagerEnum.ADDRESS)) {
+            onAddressSave();
         } else {
             onShippingMethodSave();
         }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -33,6 +33,7 @@ import static android.app.Activity.RESULT_OK;
 import static com.stripe.android.CustomerSessionTest.FIRST_SAMPLE_KEY_RAW;
 import static com.stripe.android.CustomerSessionTest.FIRST_TEST_CUSTOMER_OBJECT;
 import static com.stripe.android.CustomerSessionTest.SECOND_TEST_CUSTOMER_OBJECT;
+import static com.stripe.android.PaymentSession.EXTRA_PAYMENT_SESSION_ACTIVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -197,7 +198,7 @@ public class PaymentSessionTest {
     }
 
     @Test
-    public void selectPaymentMethod_launchesPaymentMethodsActivity() {
+    public void selectPaymentMethod_launchesPaymentMethodsActivityWithLog() {
         EphemeralKey firstKey = EphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -212,13 +213,14 @@ public class PaymentSessionTest {
         PaymentSession paymentSession = new PaymentSession(mActivityController.get());
         paymentSession.init(mockListener, new PaymentSessionConfig.Builder().build());
 
-
         paymentSession.presentPaymentMethodSelection();
+
         ShadowActivity.IntentForResult intentForResult =
                 mShadowActivity.getNextStartedActivityForResult();
         assertNotNull(intentForResult);
         assertEquals(PaymentMethodsActivity.class.getName(),
                 intentForResult.intent.getComponent().getClassName());
+        assertTrue(intentForResult.intent.hasExtra(EXTRA_PAYMENT_SESSION_ACTIVE));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
@@ -32,6 +32,9 @@ import org.robolectric.shadows.ShadowActivity;
 import java.util.Calendar;
 
 import static android.app.Activity.RESULT_OK;
+import static com.stripe.android.PaymentSession.EXTRA_PAYMENT_SESSION_ACTIVE;
+import static com.stripe.android.PaymentSession.TOKEN_PAYMENT_SESSION;
+import static com.stripe.android.view.AddSourceActivity.ADD_SOURCE_ACTIVITY;
 import static com.stripe.android.view.AddSourceActivity.EXTRA_PROXY_DELAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -89,6 +92,7 @@ public class AddSourceActivityTest {
     private void setUpForProxySessionTest() {
         Intent intent = AddSourceActivity.newIntent(RuntimeEnvironment.application, true, true);
         intent.putExtra(EXTRA_PROXY_DELAY, true);
+        intent.putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
         mActivityController = Robolectric.buildActivity(AddSourceActivity.class, intent)
                 .create().start().resume().visible();
         mCardMultilineWidget = mActivityController.get()
@@ -107,6 +111,7 @@ public class AddSourceActivityTest {
                 };
         mActivityController.get().setStripeProvider(mockStripeProvider);
         mActivityController.get().setCustomerSessionProxy(mCustomerSessionProxy);
+        mActivityController.get().initCustomerSessionTokens();
     }
 
     @Test
@@ -209,6 +214,8 @@ public class AddSourceActivityTest {
         ArgumentCaptor<String> sourceIdCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<CustomerSession.SourceRetrievalListener> listenerArgumentCaptor =
                 ArgumentCaptor.forClass(CustomerSession.SourceRetrievalListener.class);
+        verify(mCustomerSessionProxy).addProductUsageTokenIfValid(ADD_SOURCE_ACTIVITY);
+        verify(mCustomerSessionProxy).addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION);
         verify(mCustomerSessionProxy).addCustomerSource(
                 sourceIdCaptor.capture(),
                 listenerArgumentCaptor.capture());


### PR DESCRIPTION
r? @ksun-stripe 

Clearing out all logging whenever an action speaking with the server occurs, adding tokens when the views are shown (including payment session).