### PR TITLE
Fix some edge cases

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -75,6 +75,7 @@ public class PaymentSession {
      */
     public boolean handlePaymentData(int requestCode, int resultCode, @NonNull Intent data) {
         if (resultCode == Activity.RESULT_CANCELED) {
+            fetchCustomer();
             return false;
         } else if (resultCode == Activity.RESULT_OK) {
             switch (requestCode) {
@@ -83,9 +84,9 @@ public class PaymentSession {
                     return true;
                 case PAYMENT_SHIPPING_DETAILS_REQUEST:
                     PaymentSessionData paymentSessionData = data.getParcelableExtra(PAYMENT_SESSION_DATA_KEY);
+                    mPaymentSessionData = paymentSessionData;
                     mPaymentSessionListener.onPaymentSessionDataChanged(paymentSessionData);
                     updateIsPaymentReadyToCharge(mPaymentSessionConfig, paymentSessionData);
-                    mPaymentSessionData = paymentSessionData;
                     return true;
                 default:
                     break;


### PR DESCRIPTION
Update mPaymentData before announcing change.

Handle the case where users add source and hit back instead of done.

r? @mrmcduff-stripe 