### PR TITLE
filtering out apple_pay type sources from the customer source list

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -121,6 +121,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     private static final String FIELD_NAME = "name";
     private static final String FIELD_LAST4 = "last4";
     private static final String FIELD_ID = "id";
+    private static final String FIELD_TOKENIZATION_METHOD = "tokenization_method";
 
     private String number;
     private String cvc;
@@ -145,6 +146,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     private String cvcCheck;
     private String id;
     @NonNull private List<String> loggingTokens = new ArrayList<>();
+    @Nullable private String tokenizationMethod;
 
     /**
      * Builder class for a {@link Card} model.
@@ -172,6 +174,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         private String customer;
         private String cvcCheck;
         private String id;
+        private String tokenizationMethod;
 
         /**
          * Constructor with most common {@link Card} fields.
@@ -192,93 +195,117 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
             this.cvc = cvc;
         }
 
+        @NonNull
         public Builder name(String name) {
             this.name = name;
             return this;
         }
 
+        @NonNull
         public Builder addressLine1(String address) {
             this.addressLine1 = address;
             return this;
         }
 
+        @NonNull
         public Builder addressLine1Check(String addressLine1Check) {
             this.addressLine1Check = addressLine1Check;
             return this;
         }
 
+        @NonNull
         public Builder addressLine2(String address) {
             this.addressLine2 = address;
             return this;
         }
 
+        @NonNull
         public Builder addressCity(String city) {
             this.addressCity = city;
             return this;
         }
 
+        @NonNull
         public Builder addressState(String state) {
             this.addressState = state;
             return this;
         }
 
+        @NonNull
         public Builder addressZip(String zip) {
             this.addressZip = zip;
             return this;
         }
 
+        @NonNull
         public Builder addressZipCheck(String zipCheck) {
             this.addressZipCheck = zipCheck;
             return this;
         }
 
+        @NonNull
         public Builder addressCountry(String country) {
             this.addressCountry = country;
             return this;
         }
 
+        @NonNull
         public Builder brand(@CardBrand String brand) {
             this.brand = brand;
             return this;
         }
 
+        @NonNull
         public Builder fingerprint(String fingerprint) {
             this.fingerprint = fingerprint;
             return this;
         }
 
+        @NonNull
         public Builder funding(@FundingType String funding) {
             this.funding = funding;
             return this;
         }
 
+        @NonNull
         public Builder country(String country) {
             this.country = country;
             return this;
         }
 
+        @NonNull
         public Builder currency(String currency) {
             this.currency = currency;
             return this;
         }
 
+        @NonNull
         public Builder customer(String customer) {
             this.customer = customer;
             return this;
         }
 
+        @NonNull
         public Builder cvcCheck(String cvcCheck) {
             this.cvcCheck = cvcCheck;
             return this;
         }
 
+        @NonNull
         public Builder last4(String last4) {
             this.last4 = last4;
             return this;
         }
 
+        @NonNull
         public Builder id(String id) {
             this.id = id;
+            return this;
+        }
+
+        @NonNull
+        public Builder tokenizationMethod(@Nullable String tokenizationMethod) {
+            this.tokenizationMethod = tokenizationMethod;
             return this;
         }
 
@@ -950,6 +977,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         putStringIfNotNull(object, FIELD_CVC_CHECK, cvcCheck);
         putStringIfNotNull(object, FIELD_LAST4, last4);
         putStringIfNotNull(object, FIELD_ID, id);
+        putStringIfNotNull(object, FIELD_TOKENIZATION_METHOD, tokenizationMethod);
         putStringIfNotNull(object, FIELD_OBJECT, VALUE_CARD);
         return object;
     }
@@ -978,9 +1006,15 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         map.put(FIELD_FUNDING, funding);
         map.put(FIELD_ID, id);
         map.put(FIELD_LAST4, last4);
+        map.put(FIELD_TOKENIZATION_METHOD, tokenizationMethod);
         map.put(FIELD_OBJECT, VALUE_CARD);
         StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
+    }
+
+    @Nullable
+    String getTokenizationMethod() {
+        return this.tokenizationMethod;
     }
 
     boolean validateCard(Calendar now) {
@@ -1028,6 +1062,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         this.customerId = StripeTextUtils.nullIfBlank(builder.customer);
         this.cvcCheck = StripeTextUtils.nullIfBlank(builder.cvcCheck);
         this.id = StripeTextUtils.nullIfBlank(builder.id);
+        this.tokenizationMethod = StripeTextUtils.nullIfBlank(builder.tokenizationMethod);
     }
 
     private String normalizeCardNumber(String number) {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -430,6 +430,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         builder.id(optString(jsonObject, FIELD_ID));
         builder.last4(optString(jsonObject, FIELD_LAST4));
         builder.name(optString(jsonObject, FIELD_NAME));
+        builder.tokenizationMethod(optString(jsonObject, FIELD_TOKENIZATION_METHOD));
 
         return builder.build();
     }

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -2,6 +2,7 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.StripeNetworkUtils;
 
@@ -43,14 +44,14 @@ public class Customer extends StripeJsonModel {
 
     private static final String VALUE_APPLE_PAY = "apple_pay";
 
-    private String mId;
-    private String mDefaultSource;
-    private ShippingInformation mShippingInformation;
+    private @Nullable String mId;
+    private @Nullable String mDefaultSource;
+    private @Nullable ShippingInformation mShippingInformation;
 
-    private List<CustomerSource> mSources = new ArrayList<>();
-    private Boolean mHasMore;
-    private Integer mTotalCount;
-    private String mUrl;
+    private @NonNull List<CustomerSource> mSources = new ArrayList<>();
+    private @Nullable Boolean mHasMore;
+    private @Nullable Integer mTotalCount;
+    private @Nullable String mUrl;
 
     private Customer() { }
 
@@ -66,6 +67,7 @@ public class Customer extends StripeJsonModel {
         return mShippingInformation;
     }
 
+    @NonNull
     public List<CustomerSource> getSources() {
         return mSources;
     }
@@ -80,6 +82,16 @@ public class Customer extends StripeJsonModel {
 
     public String getUrl() {
         return mUrl;
+    }
+
+    @VisibleForTesting
+    void addSource(@NonNull CustomerSource customerSource) {
+        mSources.add(customerSource);
+        if (mTotalCount == null) {
+            mTotalCount = 1;
+        } else {
+            mTotalCount++;
+        }
     }
 
     @Nullable
@@ -177,8 +189,8 @@ public class Customer extends StripeJsonModel {
             JSONArray dataArray = sources.optJSONArray(FIELD_DATA);
             for (int i = 0; i < dataArray.length(); i++) {
                 try {
-                    CustomerSource sourceData =
-                            CustomerSource.fromJson(dataArray.getJSONObject(i));
+                    JSONObject customerSourceObject = dataArray.getJSONObject(i);
+                    CustomerSource sourceData = CustomerSource.fromJson(customerSourceObject);
                     if (sourceData == null ||
                             VALUE_APPLE_PAY.equals(sourceData.getTokenizationMethod())) {
                         continue;

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -41,6 +41,8 @@ public class Customer extends StripeJsonModel {
     private static final String VALUE_LIST = "list";
     private static final String VALUE_CUSTOMER = "customer";
 
+    private static final String VALUE_APPLE_PAY = "apple_pay";
+
     private String mId;
     private String mDefaultSource;
     private ShippingInformation mShippingInformation;
@@ -177,6 +179,10 @@ public class Customer extends StripeJsonModel {
                 try {
                     CustomerSource sourceData =
                             CustomerSource.fromJson(dataArray.getJSONObject(i));
+                    if (sourceData == null ||
+                            VALUE_APPLE_PAY.equals(sourceData.getTokenizationMethod())) {
+                        continue;
+                    }
                     sourceDataList.add(sourceData);
                 } catch (JSONException ignored) { }
             }

--- a/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
+++ b/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
@@ -42,6 +42,21 @@ public class CustomerSource extends StripeJsonModel implements StripePaymentSour
     }
 
     @Nullable
+    public String getTokenizationMethod() {
+        Source paymentAsSource = asSource();
+        Card paymentAsCard = asCard();
+        if (paymentAsSource != null && paymentAsSource.getType().equals(Source.CARD)) {
+            SourceCardData cardData = (SourceCardData) paymentAsSource.getSourceTypeModel();
+            if (cardData != null) {
+                return cardData.getTokenizationMethod();
+            }
+        } else if (paymentAsCard != null) {
+            return paymentAsCard.getTokenizationMethod();
+        }
+        return null;
+    }
+
+    @Nullable
     public Card asCard() {
         if (mStripePaymentSource instanceof Card) {
             return (Card) mStripePaymentSource;

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.fail;
  * Test class for {@link Card}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class CardTest {
     private static final int YEAR_IN_FUTURE = 2100;
 

--- a/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
@@ -14,14 +14,40 @@ import static com.stripe.android.model.SourceTest.EXAMPLE_BITCOIN_SOURCE;
 import static com.stripe.android.model.SourceTest.EXAMPLE_JSON_SOURCE_WITHOUT_NULLS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link CustomerSource} model class.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class CustomerSourceTest {
+
+    static final String JSON_APPLE_PAY_CARD = "{\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": \"Des Moines\",\n" +
+            "    \"address_country\": \"US\",\n" +
+            "    \"address_line1\": \"123 Any Street\",\n" +
+            "    \"address_line1_check\": \"unavailable\",\n" +
+            "    \"address_line2\": \"456\",\n" +
+            "    \"address_state\": \"IA\",\n" +
+            "    \"address_zip\": \"50305\",\n" +
+            "    \"address_zip_check\": \"unavailable\",\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"currency\": \"usd\",\n" +
+            "    \"customer\": \"customer77\",\n" +
+            "    \"cvc_check\": \"unavailable\",\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"fingerprint\": \"abc123\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"name\": \"John Cardholder\",\n" +
+            "    \"tokenization_method\": \"apple_pay\"\n" +
+            "  }";
 
     @Test
     public void fromJson_whenCard_createsCustomerSourceData() {
@@ -31,6 +57,21 @@ public class CustomerSourceTest {
             assertNotNull(sourceData);
             assertNotNull(sourceData.asCard());
             assertEquals("card_189fi32eZvKYlo2CHK8NPRME", sourceData.getId());
+            assertNull(sourceData.getTokenizationMethod());
+        } catch (JSONException jsonException) {
+            fail("Test data failure: " + jsonException.getMessage());
+        }
+    }
+
+    @Test
+    public void fromJson_whenCardWithTokenization_createsSourceDataWithTokenization() {
+        try {
+            JSONObject jsonCard = new JSONObject(JSON_APPLE_PAY_CARD);
+            CustomerSource sourceData = CustomerSource.fromJson(jsonCard);
+            assertNotNull(sourceData);
+            assertNotNull(sourceData.asCard());
+            assertEquals("card_189fi32eZvKYlo2CHK8NPRME", sourceData.getId());
+            assertEquals("apple_pay", sourceData.getTokenizationMethod());
         } catch (JSONException jsonException) {
             fail("Test data failure: " + jsonException.getMessage());
         }

--- a/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
@@ -2,6 +2,7 @@ package com.stripe.android.model;
 
 import com.stripe.android.testharness.JsonTestUtils;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -9,17 +10,22 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static com.stripe.android.model.CardTest.JSON_CARD;
+import static com.stripe.android.model.CustomerSourceTest.JSON_APPLE_PAY_CARD;
+import static com.stripe.android.model.SourceTest.EXAMPLE_BITCOIN_SOURCE;
+import static com.stripe.android.model.SourceTest.EXAMPLE_JSON_SOURCE_WITHOUT_NULLS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link Customer} model object.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class CustomerTest {
 
     private static final String NON_CUSTOMER_OBJECT =
@@ -70,6 +76,16 @@ public class CustomerTest {
     }
 
     @Test
+    public void fromJson_whenCustomerHasApplePay_returnsCustomerWithoutApplePaySources() {
+        Customer customer = Customer.fromString(createTestCustomerObjectWithApplePaySource());
+        assertNotNull(customer);
+        assertEquals(2, customer.getSources().size());
+        // Note that filtering the apple_pay sources intentionally does not change the total
+        // count value.
+        assertEquals(Integer.valueOf(5), customer.getTotalCount());
+    }
+
+    @Test
     public void fromJson_toJson_createsSameObject() {
         try {
             JSONObject rawJsonCustomer = new JSONObject(TEST_CUSTOMER_OBJECT);
@@ -79,5 +95,51 @@ public class CustomerTest {
         } catch (JSONException testDataException) {
             fail("Test data failure: " + testDataException.getMessage());
         }
+    }
+
+    private String createTestCustomerObjectWithApplePaySource() {
+        try {
+            JSONObject rawJsonCustomer = new JSONObject(TEST_CUSTOMER_OBJECT);
+            JSONObject sourcesObject = rawJsonCustomer.getJSONObject("sources");
+            JSONArray sourcesArray = sourcesObject.getJSONArray("data");
+
+            sourcesObject.put("total_count", 5);
+            CustomerSource applePayCard = CustomerSource.fromString(JSON_APPLE_PAY_CARD);
+            assertNotNull(applePayCard);
+            sourcesArray.put(applePayCard.toJson());
+
+            Card testCard = Card.fromString(JSON_CARD);
+            assertNotNull(testCard);
+
+            JSONObject manipulatedCard = new JSONObject(JSON_CARD);
+            manipulatedCard.put("id", "card_id55555");
+            manipulatedCard.put("tokenization_method", "apple_pay");
+            Card manipulatedApplePayCard = Card.fromJson(manipulatedCard);
+            assertNotNull(manipulatedApplePayCard);
+
+            Source sourceCardWithApplePay = Source.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS);
+            // Note that we don't yet explicitly support bitcoin sources, but this data is
+            // convenient for the test because it is not an apple pay source.
+            Source bitcoinSource = Source.fromString(EXAMPLE_BITCOIN_SOURCE);
+            assertNotNull(sourceCardWithApplePay);
+            assertNotNull(bitcoinSource);
+            sourcesArray.put(sourceCardWithApplePay.toJson());
+            sourcesArray.put(bitcoinSource.toJson());
+
+            sourcesArray.put(testCard.toJson());
+            sourcesArray.put(manipulatedApplePayCard.toJson());
+            sourcesObject.put("data", sourcesArray);
+
+            rawJsonCustomer.put("sources", sourcesObject);
+
+            // Verify JSON manipulation
+            assertTrue(rawJsonCustomer.has("sources"));
+            assertTrue(rawJsonCustomer.getJSONObject("sources").has("data"));
+            assertEquals(5, rawJsonCustomer.getJSONObject("sources").getJSONArray("data").length());
+            return rawJsonCustomer.toString();
+        } catch (JSONException testDataException) {
+            fail("Test data failure: " + testDataException.getMessage());
+        }
+        return null;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
@@ -10,23 +10,25 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Test class for {@link SourceCardData}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class SourceCardDataTest {
 
-    private static final String EXAMPLE_JSON_CARD = "{\"exp_month\":12,\"exp_year\":2050," +
+    static final String EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY =
+            "{\"exp_month\":12,\"exp_year\":2050," +
             "\"address_line1_check\":\"unchecked\",\"address_zip_check\":" +
             "\"unchecked\",\"brand\":\"Visa\",\"country\":\"US\",\"cvc_check\"" +
             ":\"unchecked\",\"funding\":\"credit\",\"last4\":\"4242\",\"three_d_secure\"" +
-            ":\"optional\",\"tokenization_method\":null,\"dynamic_last4\":null}";
+            ":\"optional\",\"tokenization_method\":\"apple_pay\",\"dynamic_last4\":\"4242\"}";
 
     @Test
     public void fromExampleJsonCard_createsExpectedObject() {
-        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_CARD);
+        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
         assertNotNull(cardData);
         assertEquals(Card.VISA, cardData.getBrand());
         assertEquals(0, cardData.getAdditionalFields().size());
@@ -38,11 +40,12 @@ public class SourceCardDataTest {
         assertEquals(2050, cardData.getExpiryYear().intValue());
         assertEquals("US", cardData.getCountry());
         assertEquals("optional", cardData.getThreeDSecureStatus());
+        assertEquals("apple_pay", cardData.getTokenizationMethod());
     }
 
     @Test
     public void fromExampleJsonCard_toMap_createsExpectedMapping() {
-        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_CARD);
+        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
         Map<String, Object> cardDataMap = cardData.toMap();
 
         assertNotNull(cardDataMap);
@@ -53,7 +56,7 @@ public class SourceCardDataTest {
         assertEquals(Card.FUNDING_CREDIT, cardDataMap.get("funding"));
         assertEquals(Card.VISA, cardDataMap.get("brand"));
         assertEquals("optional", cardDataMap.get("three_d_secure"));
-        assertFalse(cardDataMap.containsKey("tokenization_method"));
-        assertFalse(cardDataMap.containsKey("dynamic_last4"));
+        assertEquals("apple_pay", cardDataMap.get("tokenization_method"));
+        assertEquals("4242", cardDataMap.get("dynamic_last4"));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -11,6 +11,7 @@ import org.robolectric.annotation.Config;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.stripe.android.model.SourceCardDataTest.EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY;
 import static com.stripe.android.model.SourceCodeVerificationTest.EXAMPLE_JSON_CODE_VERIFICATION;
 import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_JSON_OWNER_WITHOUT_NULLS;
 import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_MAP_OWNER;
@@ -28,7 +29,7 @@ import static org.junit.Assert.fail;
  * Test class for {@link Source} model.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
+@Config(sdk = 25)
 public class SourceTest {
 
     static final String EXAMPLE_BITCOIN_SOURCE = "{\n" +
@@ -95,16 +96,9 @@ public class SourceTest {
             "\"amount_returned\": 0\n"+
             "},\n"+
             "\"status\": \"pending\",\n"+
-            "\"type\": \"bitcoin\",\n"+
+            "\"type\": \"card\",\n"+
             "\"usage\": \"single_use\",\n"+
-            "\"bitcoin\": {\n" +
-            "\"address\": \"test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N\",\n" +
-            "\"amount\": 2371000,\n" +
-            "\"amount_charged\": 0,\n" +
-            "\"amount_received\": 0,\n" +
-            "\"amount_returned\": 0,\n" +
-            "\"uri\": \"bitcoin:test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N?amount=0.02371000\"\n" +
-            "}" +
+            "\"card\": " + EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY + "\n"+
             "}";
 
     private static final String DOGE_COIN = "dogecoin";


### PR DESCRIPTION
r? @ksun-stripe 
cc @bdorfman-stripe 

Filtering out all sources that have `"tokenization_type" : "apple_pay"` in them from appearing in the sources field of a Customer object. Intentionally leaving the total count alone, as it simply indicates that there are more sources on the server that you can't yet see, which is the correct behavior.