### PR TITLE
Update State then tell listeners

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -85,8 +85,8 @@ public class PaymentSession {
                 case PAYMENT_SHIPPING_DETAILS_REQUEST:
                     PaymentSessionData paymentSessionData = data.getParcelableExtra(PAYMENT_SESSION_DATA_KEY);
                     mPaymentSessionData = paymentSessionData;
-                    mPaymentSessionListener.onPaymentSessionDataChanged(paymentSessionData);
                     updateIsPaymentReadyToCharge(mPaymentSessionConfig, paymentSessionData);
+                    mPaymentSessionListener.onPaymentSessionDataChanged(paymentSessionData);
                     return true;
                 default:
                     break;


### PR DESCRIPTION
update state on the object before passing the data object to listener so that objects don't need to check the PaymentSession directly

r? @mrmcduff-stripe 