### PR TITLE
Checkstyle Clean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ group: deprecated-2017Q3
 
 script:
   - ./gradlew clean test
+  - ./gradlew clean :stripe:checkstyle

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,7 @@ allprojects {
 
     task checkstyle(type: Checkstyle) {
         showViolations = true
-        ignoreFailures = true
         configFile file("../settings/checkstyle.xml")
-
         source 'src/main/java'
         include '**/*.java'
         exclude '**/gen/**'

--- a/settings/checkstyle.xml
+++ b/settings/checkstyle.xml
@@ -8,6 +8,7 @@ what the following rules do, please see the checkstyle configuration
 page at http://checkstyle.sourceforge.net/config.html -->
 
 <module name="Checker">
+    <module name="SuppressWarningsFilter" />
 
     <module name="FileTabCharacter">
         <!-- Checks that there are no tab characters in the file.
@@ -41,18 +42,18 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <!-- All Java AST specific tests live under TreeWalker module. -->
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
 
         <!--
         IMPORT CHECKS
         -->
-
         <module name="RedundantImport">
             <!-- Checks for redundant import statements. -->
             <property name="severity" value="error"/>
         </module>
 
         <module name="ImportOrder">
-            <property name="groups" value="*,javax,java"/>
+            <property name="groups" value="*,java, javax"/>
             <property name="ordered" value="true"/>
             <property name="separated" value="false"/>
             <property name="option" value="bottom"/>

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 
-preBuild.dependsOn('checkstyle')
 assemble.dependsOn('lint')
 check.dependsOn('checkstyle')
 

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -468,6 +468,7 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         }
     }
 
+    @SuppressWarnings("checkstyle:MissingSwitchDefault")
     private Handler createMainThreadHandler() {
         return new Handler(Looper.getMainLooper()) {
             @Override

--- a/stripe/src/main/java/com/stripe/android/StripeSSLSocketFactory.java
+++ b/stripe/src/main/java/com/stripe/android/StripeSSLSocketFactory.java
@@ -1,9 +1,5 @@
 package com.stripe.android;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -11,6 +7,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Wraps a SSLSocketFactory and enables more TLS versions on older versions of Android.
@@ -21,7 +22,7 @@ class StripeSSLSocketFactory extends SSLSocketFactory {
     private final SSLSocketFactory under;
     private final boolean tlsv11Supported, tlsv12Supported;
 
-    private static final String TLSv11Proto = "TLSv1.1", TLSv12Proto = "TLSv1.2";
+    private static final String TLS_V11_PROTO = "TLSv1.1", TLS_V12_PROTO = "TLSv1.2";
 
     /**
      * Constructor for a socket factory instance.
@@ -40,9 +41,9 @@ class StripeSSLSocketFactory extends SSLSocketFactory {
         }
 
         for (String proto : supportedProtocols) {
-            if (proto.equals(TLSv11Proto)) {
+            if (proto.equals(TLS_V11_PROTO)) {
                 tlsv11Supported = true;
-            } else if (proto.equals(TLSv12Proto)) {
+            } else if (proto.equals(TLS_V12_PROTO)) {
                 tlsv12Supported = true;
             }
         }
@@ -108,10 +109,10 @@ class StripeSSLSocketFactory extends SSLSocketFactory {
 
         Set<String> protos = new HashSet<>(Arrays.asList(sslSock.getEnabledProtocols()));
         if (tlsv11Supported) {
-            protos.add(TLSv11Proto);
+            protos.add(TLS_V11_PROTO);
         }
         if (tlsv12Supported) {
-            protos.add(TLSv12Proto);
+            protos.add(TLS_V12_PROTO);
         }
 
         sslSock.setEnabledProtocols(protos.toArray(new String[0]));

--- a/stripe/src/main/java/com/stripe/android/TelemetryClientUtil.java
+++ b/stripe/src/main/java/com/stripe/android/TelemetryClientUtil.java
@@ -94,10 +94,10 @@ class TelemetryClientUtil {
     @NonNull
     private static String getAndroidVersionString() {
         StringBuilder builder = new StringBuilder();
-        final String DELIMITER = " ";
-        builder.append("Android").append(DELIMITER)
-                .append(Build.VERSION.RELEASE).append(DELIMITER)
-                .append(Build.VERSION.CODENAME).append(DELIMITER)
+        final String delimiter = " ";
+        builder.append("Android").append(delimiter)
+                .append(Build.VERSION.RELEASE).append(delimiter)
+                .append(Build.VERSION.CODENAME).append(delimiter)
                 .append(Build.VERSION.SDK_INT);
         return builder.toString();
     }

--- a/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
+++ b/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
@@ -48,6 +48,7 @@ public class IconTextInputLayout extends TextInputLayout {
      * and the variable and method names change. We should remove usage of reflection
      * at the first opportunity.
      */
+    @SuppressWarnings("checkstyle:IllegalCatch")
     @VisibleForTesting
     void init() {
         try {


### PR DESCRIPTION
This PR brings our error and warnings to zero! yay!
Changed the config so it works like tests -- you can build without the checkstyle in development but it will fail the build on travis for any errors.

I suppressed the warnings since fixing them has actual code implications - however, @mrmcduff-stripe  if you what to do with them off the top of your head, feel free to add it!

current iteration has a swapped important statement and should fail the travis.

r? @mrmcduff-stripe 

