### PR TITLE
Make tests pass from commandline

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.java
@@ -47,9 +47,11 @@ class ShippingMethodAdapter extends RecyclerView.Adapter<ShippingMethodAdapter.V
         return mShippingMethods.get(mSelectedIndex);
     }
 
-    void setShippingMethods(List<ShippingMethod> shippingMethods, ShippingMethod
-            defaultShippingMethod) {
-        mShippingMethods = shippingMethods;
+    void setShippingMethods(List<ShippingMethod> shippingMethods,
+                            ShippingMethod defaultShippingMethod) {
+        if (shippingMethods != null) {
+            mShippingMethods = shippingMethods;
+        }
         if (defaultShippingMethod == null) {
             mSelectedIndex = 0;
         } else {


### PR DESCRIPTION
Theoretically, we wouldn't be accessing the shippingmethods if it's null -- but it looks like we do in some of our tests when run from commandline.

r? @mrmcduff-stripe 