### PR TITLE
moving over one of the few parts of the android pay library we'll need

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PayWithGoogleUtils.java
+++ b/stripe/src/main/java/com/stripe/android/PayWithGoogleUtils.java
@@ -1,0 +1,62 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Currency;
+
+/**
+ * Public utility class for common Pay with Google-related tasks.
+ */
+public class PayWithGoogleUtils {
+
+    /**
+     * Converts an integer price in the lowest currency denomination to a Google string value.
+     * For instance: (100L, USD) -> "1.00", but (100L, JPY) -> "100".
+     * @param price the price in the lowest available currency denomination
+     * @param currency the {@link Currency} used to determine how many digits after the decimal
+     * @return a String that can be used as a Pay with Google price string
+     */
+    @NonNull
+    public static String getPriceString(@NonNull long price, @NonNull Currency currency) {
+        int fractionDigits = currency.getDefaultFractionDigits();
+        int totalLength = String.valueOf(price).length();
+        StringBuilder builder = new StringBuilder();
+
+        if (fractionDigits == 0) {
+            for (int i = 0; i < totalLength; i++) {
+                builder.append('#');
+            }
+            DecimalFormat noDecimalCurrencyFormat = new DecimalFormat(builder.toString());
+            noDecimalCurrencyFormat.setCurrency(currency);
+            noDecimalCurrencyFormat.setGroupingUsed(false);
+            return noDecimalCurrencyFormat.format(price);
+        }
+
+        int beforeDecimal = totalLength - fractionDigits;
+        for (int i = 0; i < beforeDecimal; i++) {
+            builder.append('#');
+        }
+
+        // So we display "0.55" instead of ".55"
+        if (totalLength <= fractionDigits) {
+            builder.append('0');
+        }
+        builder.append('.');
+        for (int i = 0; i < fractionDigits; i++) {
+            builder.append('0');
+        }
+        double modBreak = Math.pow(10, fractionDigits);
+        double decimalPrice = price / modBreak;
+
+        // No matter the Locale, Android Pay requires a dot for the decimal separator.
+        DecimalFormatSymbols symbolOverride = new DecimalFormatSymbols();
+        symbolOverride.setDecimalSeparator('.');
+        DecimalFormat decimalFormat = new DecimalFormat(builder.toString(), symbolOverride);
+        decimalFormat.setCurrency(currency);
+        decimalFormat.setGroupingUsed(false);
+
+        return decimalFormat.format(decimalPrice);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
@@ -1,0 +1,57 @@
+package com.stripe.android;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Currency;
+import java.util.Locale;
+
+import static com.stripe.android.PayWithGoogleUtils.getPriceString;
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Test class for {@link PayWithGoogleUtils}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 25)
+public class PayWithGoogleUtilsTest {
+
+    @Test
+    public void getPriceString_whenCurrencyWithDecimals_returnsExpectedValue() {
+        String priceString = getPriceString(100L, Currency.getInstance("USD"));
+        assertEquals("1.00", priceString);
+
+        String littlePrice = getPriceString(8L, Currency.getInstance("EUR"));
+        assertEquals("0.08", littlePrice);
+
+        String bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"));
+        assertEquals("200000.00", bigPrice);
+    }
+
+    @Test
+    public void getPriceString_whenLocaleWithCommas_returnsExpectedValue() {
+        Locale.setDefault(Locale.FRENCH);
+        String priceString = getPriceString(100L, Currency.getInstance("USD"));
+        assertEquals("1.00", priceString);
+
+        String littlePrice = getPriceString(8L, Currency.getInstance("EUR"));
+        assertEquals("0.08", littlePrice);
+
+        String bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"));
+        assertEquals("200000.00", bigPrice);
+    }
+
+    @Test
+    public void getPriceString_whenCurrencyWithoutDecimals_returnsExpectedValue() {
+        String priceString = getPriceString(250L, Currency.getInstance("JPY"));
+        assertEquals("250", priceString);
+
+        String bigPrice = getPriceString(250000L, Currency.getInstance("KRW"));
+        assertEquals("250000", bigPrice);
+
+        String littlePrice = getPriceString(7L, Currency.getInstance("CLP"));
+        assertEquals("7", littlePrice);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
@@ -1,22 +1,26 @@
 package com.stripe.android;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Currency;
 import java.util.Locale;
 
 import static com.stripe.android.PayWithGoogleUtils.getPriceString;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test class for {@link PayWithGoogleUtils}.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 25)
 public class PayWithGoogleUtilsTest {
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(Locale.US);
+    }
 
     @Test
     public void getPriceString_whenCurrencyWithDecimals_returnsExpectedValue() {

--- a/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.java
@@ -32,6 +32,7 @@ public class CountryAdapterTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
+        Locale.setDefault(Locale.US);
 
         ActivityController<ShippingInfoTestActivity> activityController =
                 Robolectric.buildActivity(ShippingInfoTestActivity.class).create().start();

--- a/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -29,6 +30,7 @@ public class SelectShippingMethodWidgetTest {
 
     @Before
     public void setup() {
+        Locale.setDefault(Locale.US);
         ActivityController<SelectShippingMethodTestActivity> activityController =
                 Robolectric.buildActivity(SelectShippingMethodTestActivity.class).create().start();
         mSelectShippingMethodWidget = activityController.get().getSelectShippingMethodWidget();


### PR DESCRIPTION
r? @ksun-stripe 

Note: just moving over the utility function, not yet using it in the Sample Store (in order to reduce PR size). It can't be deleted from `stripe-android-pay` without making a lot of changes to that library, and since we are deprecating that library, it seems not worth removing.
