### PR TITLE
stripe:version to API version in example app

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
@@ -156,7 +156,7 @@ public class PayWithGoogleActivity extends AppCompatActivity {
                 .addParameter("gateway", "stripe")
                 .addParameter("stripe:publishableKey",
                         PaymentConfiguration.getInstance().getPublishableKey())
-                .addParameter("stripe:version", "5.1.1")
+                .addParameter("stripe:version", "2017-08-15")
                 .build();
     }
 


### PR DESCRIPTION
r? @ksun-stripe

stripe:version is set to the SDK version in the example app, but looks like it should be set to the API version from the google docs:
https://developers.google.com/web/fundamentals/payments/android-pay#integration_using_gateway_token