### PR TITLE
updating the emoji store to remove stripe-android-pay entirely

### DIFF
--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -12,9 +12,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
     }
 
     lintOptions {
@@ -37,8 +35,6 @@ dependencies {
 
     /* This line is all you need for the stripe-android bindings */
     compile project(':stripe')
-
-    compile 'com.google.android.gms:play-services-wallet:11.4.2'
 
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -38,28 +38,26 @@ dependencies {
     /* This line is all you need for the stripe-android bindings */
     compile project(':stripe')
 
-    /* To use the Stripe android pay wrapper, you need these two lines */
-    compile 'com.stripe:stripe-android-pay:4.1.6'
-    compile 'com.google.android.gms:play-services-wallet:11.0.4'
+    compile 'com.google.android.gms:play-services-wallet:11.4.2'
 
     /* Needed for RxAndroid */
     compile 'io.reactivex:rxandroid:1.2.1'
-    compile 'io.reactivex:rxjava:1.1.6'
+    compile 'io.reactivex:rxjava:1.3.0'
 
     /* Needed for Rx Bindings on views */
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
 
     /* Used for server calls */
-    compile 'com.squareup.okio:okio:1.11.0'
-    compile 'com.squareup.retrofit2:retrofit:2.2.0'
+    compile 'com.squareup.okio:okio:1.13.0'
+    compile 'com.squareup.retrofit2:retrofit:2.3.0'
 
     /* Used to make Retrofit easier and GSON & Rx-compatible*/
-    compile 'com.google.code.gson:gson:2.8.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.2'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0'
+    compile 'com.google.code.gson:gson:2.8.2'
+    compile 'com.squareup.retrofit2:adapter-rxjava:2.3.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.3.0'
 
     /* Used to debug your Retrofit connections */
-    compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.9.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.3.2'

--- a/samplestore/src/main/AndroidManifest.xml
+++ b/samplestore/src/main/AndroidManifest.xml
@@ -12,10 +12,6 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <meta-data
-            android:name="com.google.android.gms.wallet.api.enabled"
-            android:value="true" />
-
         <activity android:name=".StoreActivity"
                   android:theme="@style/AppTheme.NoActionBar">
 

--- a/samplestore/src/main/java/com/stripe/samplestore/RetrofitFactory.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/RetrofitFactory.java
@@ -16,7 +16,7 @@ public class RetrofitFactory {
 
     // Put your Base URL here. Unless you customized it, the URL will be something like
     // https://hidden-beach-12345.herokuapp.com/
-    private static final String BASE_URL = "put your base url here";
+    private static final String BASE_URL = "https://serene-ridge-62892.herokuapp.com/";
     private static Retrofit mInstance = null;
 
     public static Retrofit getInstance() {

--- a/samplestore/src/main/java/com/stripe/samplestore/RetrofitFactory.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/RetrofitFactory.java
@@ -16,7 +16,7 @@ public class RetrofitFactory {
 
     // Put your Base URL here. Unless you customized it, the URL will be something like
     // https://hidden-beach-12345.herokuapp.com/
-    private static final String BASE_URL = "https://serene-ridge-62892.herokuapp.com/";
+    private static final String BASE_URL = "put your base url here";
     private static Retrofit mInstance = null;
 
     public static Retrofit getInstance() {

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
@@ -13,8 +13,8 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.stripe.android.CustomerSession;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.samplestore.service.SampleStoreEphemeralKeyProvider;
-import com.stripe.wrap.pay.AndroidPayConfiguration;
 
 public class StoreActivity
         extends AppCompatActivity
@@ -22,7 +22,7 @@ public class StoreActivity
 
     // Put your publishable key here. It should start with "pk_test_"
     private static final String PUBLISHABLE_KEY =
-            "put your publishable key here";
+            "pk_test_9UVLd6CCQln8IhUSsmRyqQu4";
 
     static final int PURCHASE_REQUEST = 37;
 
@@ -42,16 +42,14 @@ public class StoreActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_store);
 
-        initAndroidPay();
-
+        PaymentConfiguration.init(PUBLISHABLE_KEY);
         mGoToCartButton = findViewById(R.id.fab_checkout);
         mStoreAdapter = new StoreAdapter(this);
         ItemDivider dividerDecoration = new ItemDivider(this, R.drawable.item_divider);
         RecyclerView recyclerView = findViewById(R.id.rv_store_items);
 
-
         mGoToCartButton.hide();
-        Toolbar myToolBar = (Toolbar) findViewById(R.id.my_toolbar);
+        Toolbar myToolBar = findViewById(R.id.my_toolbar);
         setSupportActionBar(myToolBar);
 
         RecyclerView.LayoutManager linearLayoutManager = new LinearLayoutManager(this);
@@ -72,7 +70,9 @@ public class StoreActivity
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (requestCode == PURCHASE_REQUEST && resultCode == RESULT_OK) {
+        if (requestCode == PURCHASE_REQUEST
+                && resultCode == RESULT_OK
+                && data.getExtras() != null) {
             long price = data.getExtras().getLong(EXTRA_PRICE_PAID, -1L);
             if (price != -1L) {
                 displayPurchase(price);
@@ -88,13 +88,6 @@ public class StoreActivity
         } else {
             mGoToCartButton.hide();
         }
-    }
-
-    private void initAndroidPay() {
-        AndroidPayConfiguration payConfiguration =
-                AndroidPayConfiguration.init(PUBLISHABLE_KEY, "USD");
-        payConfiguration.setPhoneNumberRequired(false);
-        payConfiguration.setShippingAddressRequired(true);
     }
 
     private void displayPurchase(long price) {

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
@@ -20,9 +20,13 @@ public class StoreActivity
         extends AppCompatActivity
         implements StoreAdapter.TotalItemsChangedListener{
 
-    // Put your publishable key here. It should start with "pk_test_"
+    /*
+     * Change this to your publishable key.
+     *
+     * You can get your key here: https://dashboard.stripe.com/account/apikeys
+     */
     private static final String PUBLISHABLE_KEY =
-            "pk_test_9UVLd6CCQln8IhUSsmRyqQu4";
+            "put your publishable key here";
 
     static final int PURCHASE_REQUEST = 37;
 

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreAdapter.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreAdapter.java
@@ -10,10 +10,6 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.google.android.gms.wallet.Cart;
-import com.stripe.wrap.pay.utils.CartContentException;
-import com.stripe.wrap.pay.utils.CartManager;
-
 import java.util.Currency;
 
 public class StoreAdapter extends RecyclerView.Adapter<StoreAdapter.ViewHolder> {
@@ -63,11 +59,11 @@ public class StoreAdapter extends RecyclerView.Adapter<StoreAdapter.ViewHolder> 
         private int mPosition;
         ViewHolder(final LinearLayout pollingLayout, Currency currency) {
             super(pollingLayout);
-            mEmojiTextView = (TextView) pollingLayout.findViewById(R.id.tv_emoji);
-            mPriceTextView = (TextView) pollingLayout.findViewById(R.id.tv_price);
-            mQuantityTextView = (TextView) pollingLayout.findViewById(R.id.tv_quantity);
-            mAddButton = (ImageButton) pollingLayout.findViewById(R.id.tv_plus);
-            mRemoveButton = (ImageButton) pollingLayout.findViewById(R.id.tv_minus);
+            mEmojiTextView = pollingLayout.findViewById(R.id.tv_emoji);
+            mPriceTextView = pollingLayout.findViewById(R.id.tv_price);
+            mQuantityTextView = pollingLayout.findViewById(R.id.tv_quantity);
+            mAddButton = pollingLayout.findViewById(R.id.tv_plus);
+            mRemoveButton = pollingLayout.findViewById(R.id.tv_minus);
 
             mCurrency = currency;
             mAddButton.setOnClickListener(new View.OnClickListener() {
@@ -172,23 +168,18 @@ public class StoreAdapter extends RecyclerView.Adapter<StoreAdapter.ViewHolder> 
     }
 
     public void launchPurchaseActivityWithCart() {
-        // Generating a CartManager using the current currency in my AndroidPayConfiguration
-        CartManager cartManager = new CartManager();
+        StoreCart cart = new StoreCart(mCurrency);
         for (int i = 0; i < mQuantityOrdered.length; i++) {
             if (mQuantityOrdered[i] > 0) {
-                cartManager.addLineItem(StoreUtils.getEmojiByUnicode(EMOJI_CLOTHES[i]),
-                        (double) mQuantityOrdered[i], EMOJI_PRICES[i]);
+                cart.addStoreLineItem(
+                        StoreUtils.getEmojiByUnicode(EMOJI_CLOTHES[i]),
+                        mQuantityOrdered[i], EMOJI_PRICES[i]);
             }
         }
 
-        try {
-            Cart cart = cartManager.buildCart();
-            Intent paymentLaunchIntent = PaymentActivity.createIntent(mActivity, cart);
-            mActivity.startActivityForResult(
-                    paymentLaunchIntent, StoreActivity.PURCHASE_REQUEST);
-        } catch (CartContentException unexpected) {
-            // There shouldn't be any cart content exceptions because we used the CartManager tools.
-        }
+        Intent paymentLaunchIntent = PaymentActivity.createIntent(mActivity, cart);
+        mActivity.startActivityForResult(
+                paymentLaunchIntent, StoreActivity.PURCHASE_REQUEST);
     }
 
     public void clearItemSelections() {

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreCart.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreCart.java
@@ -1,0 +1,101 @@
+package com.stripe.samplestore;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+
+public class StoreCart implements Parcelable {
+
+    @NonNull private Currency mCurrency;
+    @NonNull private LinkedHashMap<String, StoreLineItem> mStoreLineItems;
+
+    public StoreCart(@NonNull Currency currency) {
+        mCurrency = currency;
+        // LinkedHashMap because we want iteration order to be the same.
+        mStoreLineItems = new LinkedHashMap<>();
+    }
+
+    public StoreCart(@NonNull String currencyCode) {
+        this(Currency.getInstance(currencyCode));
+    }
+
+    public String addStoreLineItem(@NonNull String description, int quantity, long unitPrice) {
+        return addStoreLineItem(new StoreLineItem(description, quantity, unitPrice));
+    }
+
+    @NonNull
+    public String addStoreLineItem(@NonNull StoreLineItem storeLineItem) {
+        String uuid = UUID.randomUUID().toString();
+        mStoreLineItems.put(uuid, storeLineItem);
+        return uuid;
+    }
+
+    public boolean removeLineItem(@NonNull String itemId) {
+        return mStoreLineItems.remove(itemId) != null;
+    }
+
+    @NonNull
+    public List<StoreLineItem> getLineItems() {
+        return new ArrayList<>(mStoreLineItems.values());
+    }
+
+    public int getSize() {
+        return mStoreLineItems.size();
+    }
+
+    @NonNull
+    public Currency getCurrency() {
+        return mCurrency;
+    }
+
+    public long getTotalPrice() {
+        long total = 0L;
+        for(StoreLineItem item : mStoreLineItems.values()) {
+            total += item.getTotalPrice();
+        }
+        return total;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeSerializable(mCurrency);
+        dest.writeInt(mStoreLineItems.size());
+        for (String key : mStoreLineItems.keySet()) {
+            dest.writeString(key);
+            dest.writeParcelable(mStoreLineItems.get(key), 0);
+        }
+    }
+
+    protected StoreCart(Parcel in) {
+        mCurrency = (Currency) in.readSerializable();
+        int count = in.readInt();
+        mStoreLineItems = new LinkedHashMap<>();
+        for(int i = 0; i < count; i++) {
+            mStoreLineItems.put(in.readString(),
+                    (StoreLineItem) in.readParcelable(StoreLineItem.class.getClassLoader()));
+        }
+    }
+
+    public static final Parcelable.Creator<StoreCart> CREATOR = new Parcelable.Creator<StoreCart>() {
+        @Override
+        public StoreCart createFromParcel(Parcel source) {
+            return new StoreCart(source);
+        }
+
+        @Override
+        public StoreCart[] newArray(int size) {
+            return new StoreCart[size];
+        }
+    };
+}

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreLineItem.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreLineItem.java
@@ -1,0 +1,68 @@
+package com.stripe.samplestore;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+/**
+ * Represents a single line item for purchase in this store.
+ */
+public class StoreLineItem implements Parcelable {
+
+    @NonNull private String mDescription;
+    private int mQuantity;
+    private long mUnitPrice;
+
+    public StoreLineItem(@NonNull String description, int quantity, long unitPrice) {
+        mDescription = description;
+        mQuantity = quantity;
+        mUnitPrice = unitPrice;
+    }
+
+    @NonNull
+    public String getDescription() {
+        return mDescription;
+    }
+
+    public int getQuantity() {
+        return mQuantity;
+    }
+
+    public long getUnitPrice() {
+        return mUnitPrice;
+    }
+
+    public long getTotalPrice() {
+        return mUnitPrice * mQuantity;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.mDescription);
+        dest.writeInt(this.mQuantity);
+        dest.writeLong(this.mUnitPrice);
+    }
+
+    protected StoreLineItem(Parcel in) {
+        this.mDescription = in.readString();
+        this.mQuantity = in.readInt();
+        this.mUnitPrice = in.readLong();
+    }
+
+    public static final Parcelable.Creator<StoreLineItem> CREATOR = new Parcelable.Creator<StoreLineItem>() {
+        @Override
+        public StoreLineItem createFromParcel(Parcel source) {
+            return new StoreLineItem(source);
+        }
+
+        @Override
+        public StoreLineItem[] newArray(int size) {
+            return new StoreLineItem[size];
+        }
+    };
+}


### PR DESCRIPTION
r? @ksun-stripe 

Note: this does not actually implement google pay in the app - it simply removes the (unused) dependency on stripe-android-pay. Right now PaymentSession doesn't sync well with google pay because we don't have a shortcut to add shipping address from the PwG data.