### PR TITLE
fixing the double-notification error in AddSourceActivity during a cu…

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -105,6 +105,8 @@ public class AddSourceActivity extends StripeActivity {
             @Override
             public void onError(Exception error) {
                 setCommunicatingProgress(false);
+                // This error is independent of the CustomerSession, so
+                // we have to surface it here.
                 showError(error.getLocalizedMessage());
             }
 
@@ -129,6 +131,8 @@ public class AddSourceActivity extends StripeActivity {
 
                     @Override
                     public void onError(int errorCode, @Nullable String errorMessage) {
+                        // No need to show this error, because it will be broadcast
+                        // from the CustomerSession
                         setCommunicatingProgress(false);
                     }
                 };

--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -129,9 +129,7 @@ public class AddSourceActivity extends StripeActivity {
 
                     @Override
                     public void onError(int errorCode, @Nullable String errorMessage) {
-                        String displayedError = errorMessage == null ? "" : errorMessage;
                         setCommunicatingProgress(false);
-                        showError(displayedError);
                     }
                 };
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -213,6 +213,10 @@ public class PaymentMethodsActivity extends AppCompatActivity {
 
                     @Override
                     public void onError(int errorCode, @Nullable String errorMessage) {
+                        // Note: if this Activity is changed to subclass StripeActivity,
+                        // this code will make the error message show twice, since StripeActivity
+                        // will listen to the broadcast version of the error
+                        // coming from CustomerSession
                         String displayedError = errorMessage == null ? "" : errorMessage;
                         showError(displayedError);
                         setCommunicatingProgress(false);


### PR DESCRIPTION
…stomer session

r? @ksun-stripe @danj-stripe 

So, it turns out that we actually display an error twice in the `AddSourceActivity` if the source creation works, but there's an error when trying to add said source to a customer (during a CustomerSession). A test card with an expected error, like `4000 0000 0000 0002` will show the (un)desired error.

The duplication stems from the fact that we listen for the error in the `AddSourceActivity` itself (because on success, we use that result), and we listen in `CustomerSession` for the error that comes back from the API. The `CustomerSession` error is then broadcast as an `ACTION_API_ERROR`, which is received in `AddSourceActivity`'s parent class, `StripeActivity`, which then displays the error again.

This PR fixes the error (by not displaying it from `AddSourceActivity` and leaving the more deeply connected version), and adds a test to make sure a regression doesn't occur.