### PR TITLE
Allow unidentified card brands 

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CardUtils.java
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.java
@@ -105,7 +105,9 @@ public class CardUtils {
         if (cardNumber == null) {
             return false;
         }
-
+        if (Card.UNKNOWN.equals(cardBrand)) {
+            return true;
+        }
         int length = cardNumber.length();
         switch (cardBrand) {
             case Card.AMERICAN_EXPRESS:

--- a/stripe/src/main/java/com/stripe/android/CardUtils.java
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.java
@@ -102,7 +102,7 @@ public class CardUtils {
     static boolean isValidCardLength(
             @Nullable String cardNumber,
             @NonNull @CardBrand String cardBrand) {
-        if (cardNumber == null || Card.UNKNOWN.equals(cardBrand)) {
+        if (cardNumber == null) {
             return false;
         }
 

--- a/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
@@ -140,11 +140,11 @@ public class CardUtilsTest {
     }
 
     @Test
-    public void isValidCardLengthWithBrand_whenBrandUnknown_alwaysReturnsFalse() {
+    public void isShortCardLength_whenCardBrandUnknown_returnsFalse() {
         String validVisa = "4242424242424242";
-        // Adding this check to ensure the input number is correct
         assertTrue(CardUtils.isValidCardLength(validVisa));
-        assertFalse(CardUtils.isValidCardLength(validVisa, Card.UNKNOWN));
+        String validDiners = "30569309025904";
+        assertFalse(CardUtils.isValidCardLength(validDiners, Card.UNKNOWN));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
@@ -140,11 +140,11 @@ public class CardUtilsTest {
     }
 
     @Test
-    public void isShortCardLength_whenCardBrandUnknown_returnsFalse() {
+    public void isValidCardLength_whenCardBrandUnknown_returnsTrue() {
         String validVisa = "4242424242424242";
         assertTrue(CardUtils.isValidCardLength(validVisa));
-        String validDiners = "30569309025904";
-        assertFalse(CardUtils.isValidCardLength(validDiners, Card.UNKNOWN));
+        String shortCard = "30565904";
+        assertTrue(CardUtils.isValidCardLength(shortCard, Card.UNKNOWN));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -226,8 +226,8 @@ public class CardTest {
     }
 
     @Test
-    public void shouldFailValidateNumberIfTooShort() {
-        Card card = new Card("0", null, null, null);
+    public void shouldFailValidateNumberIfTooShortAndBranded() {
+        Card card = new Card("34", null, null, null);
         assertFalse(card.validateNumber());
     }
 


### PR DESCRIPTION
Right now we only allow a card to be sent to the server if we can identify the card brand from the BIN number. This sometimes causes false negatives where valid cards are rejected. Instead, allow unidentified cards which pass the luhn test to be passed to the server (and let the server return any errors). 

For context, payments web does not require the card brand to be identified to be passed along to the server. (does iOS?)

r? @bdorfman-stripe 
