### PR TITLE
Allow users to set text watchers

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -14,6 +14,7 @@ import android.support.annotation.VisibleForTesting;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
 import android.text.Layout;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -200,6 +201,33 @@ public class CardInputWidget extends LinearLayout {
         mCardNumberEditText.setEnabled(isEnabled);
         mExpiryDateEditText.setEnabled(isEnabled);
         mCvcNumberEditText.setEnabled(isEnabled);
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the card number is changed.
+     *
+     * @param cardNumberTextWatcher
+     */
+    public void setCardNumberTextWatcher(TextWatcher cardNumberTextWatcher) {
+        mCardNumberEditText.addTextChangedListener(cardNumberTextWatcher);
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the expiry date is changed.
+     *
+     * @param expiryDateTextWatcher
+     */
+    public void setExpiryDateTextWatcher(TextWatcher expiryDateTextWatcher) {
+        mExpiryDateEditText.addTextChangedListener(expiryDateTextWatcher);
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the cvc number is changed.
+     *
+     * @param cvcNumberTextWatcher
+     */
+    public void setCvcNumberTextWatcher(TextWatcher cvcNumberTextWatcher) {
+        mCardNumberEditText.addTextChangedListener(cvcNumberTextWatcher);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -15,6 +15,7 @@ import android.support.annotation.VisibleForTesting;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -169,6 +170,33 @@ public class CardMultilineWidget extends LinearLayout {
     public void setShouldShowPostalCode(boolean shouldShowPostalCode) {
         mShouldShowPostalCode = shouldShowPostalCode;
         adjustViewForPostalCodeAttribute();
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the card number is changed.
+     *
+     * @param cardNumberTextWatcher
+     */
+    public void setCardNumberTextWatcher(TextWatcher cardNumberTextWatcher) {
+        mCardNumberEditText.addTextChangedListener(cardNumberTextWatcher);
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the expiry date is changed.
+     *
+     * @param expiryDateTextWatcher
+     */
+    public void setExpiryDateTextWatcher(TextWatcher expiryDateTextWatcher) {
+        mExpiryDateEditText.addTextChangedListener(expiryDateTextWatcher);
+    }
+
+    /**
+     * Expose a text watcher to receive updates when the cvc number is changed.
+     *
+     * @param cvcNumberTextWatcher
+     */
+    public void setCvcNumberTextWatcher(TextWatcher cvcNumberTextWatcher) {
+        mCardNumberEditText.addTextChangedListener(cvcNumberTextWatcher);
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -199,6 +199,15 @@ public class CardMultilineWidget extends LinearLayout {
         mCardNumberEditText.addTextChangedListener(cvcNumberTextWatcher);
     }
 
+    /**
+     * Expose a text watcher to receive updates when the cvc number is changed.
+     *
+     * @param postalCodeTextWatcher
+     */
+    public void setPostalCodeTextWatcher(TextWatcher postalCodeTextWatcher) {
+        mPostalCodeEditText.addTextChangedListener(postalCodeTextWatcher);
+    }
+
     @Override
     public boolean isEnabled() {
         return mIsEnabled;


### PR DESCRIPTION
In response to: https://github.com/stripe/stripe-android/issues/479

Allow users to access text watcher for character by character access to inputs to the CardInputView and CardMultilineWidget. 

r? @bdorfman-stripe 