### PR TITLE
Bindings to support Custom Connect onboarding in Europe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ licenses:
 
 group: deprecated-2017Q3
 
+before_install:
+  - yes | sdkmanager "platforms;android-27"
+
 script:
   - ./gradlew clean test
   - ./gradlew clean :stripe:checkstyle

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -13,6 +13,7 @@ import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
 import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
@@ -29,7 +30,7 @@ import static com.stripe.android.StripeNetworkUtils.hashMapFromCard;
 import static com.stripe.android.StripeNetworkUtils.hashMapFromPersonalId;
 
 /**
- * Class that handles {@link Token} creation from charges and {@link Card} models.
+ * Class that handles {@link Token} creation from charges, {@link Card}, and accounts.
  */
 public class Stripe {
 
@@ -540,6 +541,68 @@ public class Stripe {
                 hashMapFromPersonalId(mContext, personalId),
                 requestOptions,
                 Token.TYPE_PII,
+                mLoggingResponseListener);
+    }
+
+    /**
+     * Blocking method to create a {@link Token} for a Connect Account. Do not call this on the UI
+     * thread or your app will crash. The method uses the currently set
+     * {@link #mDefaultPublishableKey}.
+     *
+     * @param accountParams params to use for this token.
+     * @return a {@link Token} that can be used for this account.
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    public Token createAccountTokenSynchronous(@NonNull final AccountParams accountParams)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        return createAccountTokenSynchronous(accountParams, mDefaultPublishableKey);
+    }
+
+    /**
+     * Blocking method to create a {@link Token} for a Connect Account. Do not call this on the UI
+     * thread.
+     *
+     * @param accountParams params to use for this token.
+     * @param publishableKey the publishable key to use with this request
+     * @return a {@link Token} that can be used for this account.
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    public Token createAccountTokenSynchronous(
+            @NonNull final AccountParams accountParams,
+            @Nullable String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        String apiKey = publishableKey == null ? mDefaultPublishableKey : publishableKey;
+        if (apiKey == null) {
+            return null;
+        }
+        validateKey(publishableKey);
+        RequestOptions requestOptions = RequestOptions.builder(
+                publishableKey,
+                null,
+                RequestOptions.TYPE_QUERY).build();
+        return StripeApiHandler.createToken(
+                mContext,
+                accountParams.toParamMap(),
+                requestOptions,
+                Token.TYPE_ACCOUNT,
                 mLoggingResponseListener);
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -222,7 +222,7 @@ class StripeApiHandler {
     }
 
     /**
-     * Create a {@link Token} using the input card parameters.
+     * Create a {@link Token} using the input token parameters.
      *
      * @param context the {@link Context} in which this method is working
      * @param tokenParams a mapped set of parameters representing the object for which this token

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -225,7 +225,7 @@ class StripeApiHandler {
      * Create a {@link Token} using the input card parameters.
      *
      * @param context the {@link Context} in which this method is working
-     * @param cardParams a mapped set of parameters representing the object for which this token
+     * @param tokenParams a mapped set of parameters representing the object for which this token
      *                   is being created
      * @param options a {@link RequestOptions} object that contains connection data like the api
      *                key, api version, etc
@@ -243,7 +243,7 @@ class StripeApiHandler {
     @SuppressWarnings("unchecked")
     static Token createToken(
             @NonNull Context context,
-            @NonNull Map<String, Object> cardParams,
+            @NonNull Map<String, Object> tokenParams,
             @NonNull RequestOptions options,
             @NonNull @Token.TokenType String tokenType,
             @Nullable LoggingResponseListener listener)
@@ -260,8 +260,8 @@ class StripeApiHandler {
             }
 
             List<String> loggingTokens =
-                    (List<String>) cardParams.get(LoggingUtils.FIELD_PRODUCT_USAGE);
-            cardParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
+                    (List<String>) tokenParams.get(LoggingUtils.FIELD_PRODUCT_USAGE);
+            tokenParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
 
             setTelemetryData(context, listener);
 
@@ -270,10 +270,10 @@ class StripeApiHandler {
             logApiCall(loggingParams, options, listener);
         } catch (ClassCastException classCastEx) {
             // This can only happen if someone puts a weird object in the map.
-            cardParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
+            tokenParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
         }
 
-        return requestToken(POST, getApiUrl(), cardParams, options);
+        return requestToken(POST, getApiUrl(), tokenParams, options);
     }
 
     @Nullable
@@ -768,7 +768,6 @@ class StripeApiHandler {
         for (Map.Entry<String, Object> entry : params.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
-
             String newPrefix = key;
             if (keyPrefix != null) {
                 newPrefix = String.format("%s[%s]", keyPrefix, key);
@@ -783,7 +782,6 @@ class StripeApiHandler {
     private static List<Parameter> flattenParamsValue(Object value, String keyPrefix)
             throws InvalidRequestException {
         List<Parameter> flatParams;
-
         if (value instanceof Map<?, ?>) {
             flatParams = flattenParamsMap((Map<String, Object>) value, keyPrefix);
         } else if (value instanceof List<?>) {

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -22,10 +22,15 @@ public class AccountParams {
      *                            and links to Stripe's terms of service. Tokens will only generated
      *                            when this is true.
      * @param legalEntity map that specifies the legal entity for which the connect account is being
-     *                    created. Can contain any of the field specified by legal_entity is the API
-     *                    docs.
+     *                    created. Can contain any of the fields specified by legal_entity in the
+     *                    API docs.
+     *
      *                    See {@linktourl https://stripe.com/docs/api#account_object-legal_entity}
-     * @return
+     *
+     *                    The object in the map is expected to be a string or a list or map of
+     *                    strings. All {@link StripeJsonModel} types have a toMap() function that
+     *                    can be used to convert the {@link StripeJsonModel} to map representation
+     *                    that can be passed in here.
      */
     public static AccountParams createAccountParams(
             boolean tosShownAndAccepted,
@@ -49,9 +54,15 @@ public class AccountParams {
 
     /**
      * @param legalEntity map that specifies the legal entity for which the connect account is being
-     *                    created. Can contain any of the field specified by legal_entity is the API
-     *                    docs.
+     *                    created. Can contain any of the fields specified by legal_entity in the
+     *                    API docs.
+     *                    
      *                    See {@linktourl https://stripe.com/docs/api#account_object-legal_entity}
+     *
+     *                    The object in the map is expected to be a string or a list or map of
+     *                    strings. All {@link StripeJsonModel} types have a toMap() function that
+     *                    can be used to convert the {@link StripeJsonModel} to map representation
+     *                    that can be passed in here.
      * @return {@code this}, for chaining purposes
      */
     public AccountParams setLegalEntity(Map<String, Object> legalEntity) {

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -1,0 +1,79 @@
+package com.stripe.android.model;
+
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
+
+/**
+ * Represents a grouping of parameters needed to create a Token for a Connect account on the server.
+ */
+public class AccountParams {
+
+    static final String API_PARAM_LEGAL_ENTITY = "legal_entity";
+    static final String API_TOS_SHOWN_AND_ACCEPTED = "tos_shown_and_accepted";
+    private Boolean mTosShownAndAccepted;
+    private Map<String, Object> mLegalEntity;
+
+    /**
+     * @param tosShownAndAccepted indicates that the platform showed the user the appropriate text
+     *                            and links to Stripe's terms of service. Tokens will only generated
+     *                            when this is true.
+     * @param legalEntity map that specifies the legal entity for which the connect account is being
+     *                    created. Can contain any of the field specified by legal_entity is the API
+     *                    docs.
+     *                    See {@linktourl https://stripe.com/docs/api#account_object-legal_entity}
+     * @return
+     */
+    public static AccountParams createAccountParams(
+            boolean tosShownAndAccepted,
+            Map<String, Object> legalEntity) {
+        AccountParams accountParams = new AccountParams()
+                .setTosShownAndAccepted(tosShownAndAccepted)
+                .setLegalEntity(legalEntity);
+        return accountParams;
+    }
+
+    /**
+     * @param tosShownAndAccepted whether the platform showed the user the appropriate text
+     *                            and links to Stripe's terms of service. Tokens will only generated
+     *                            when this is true.
+     * @return {@code this}, for chaining purposes
+     */
+    public AccountParams setTosShownAndAccepted(boolean tosShownAndAccepted) {
+        mTosShownAndAccepted = tosShownAndAccepted;
+        return this;
+    }
+
+    /**
+     * @param legalEntity map that specifies the legal entity for which the connect account is being
+     *                    created. Can contain any of the field specified by legal_entity is the API
+     *                    docs.
+     *                    See {@linktourl https://stripe.com/docs/api#account_object-legal_entity}
+     * @return {@code this}, for chaining purposes
+     */
+    public AccountParams setLegalEntity(Map<String, Object> legalEntity) {
+        mLegalEntity = legalEntity;
+        return this;
+    }
+
+    /**
+     * Create a string-keyed map representing this object that is
+     * ready to be sent over the network.
+     *
+     * @return a String-keyed map
+     */
+    @NonNull
+    public Map<String, Object> toParamMap() {
+        Map<String, Object> networkReadyMap = new HashMap<>();
+        Map<String, Object> tokenMap = new HashMap<>();
+        tokenMap.put(API_TOS_SHOWN_AND_ACCEPTED, mTosShownAndAccepted);
+        tokenMap.put(API_PARAM_LEGAL_ENTITY, mLegalEntity);
+        networkReadyMap.put("account", tokenMap);
+        removeNullAndEmptyParams(networkReadyMap);
+        return networkReadyMap;
+    }
+
+}

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -56,7 +56,7 @@ public class AccountParams {
      * @param legalEntity map that specifies the legal entity for which the connect account is being
      *                    created. Can contain any of the fields specified by legal_entity in the
      *                    API docs.
-     *                    
+     *
      *                    See {@linktourl https://stripe.com/docs/api#account_object-legal_entity}
      *
      *                    The object in the map is expected to be a string or a list or map of

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -17,11 +17,12 @@ import java.util.Date;
 public class Token implements StripePaymentSource {
 
     @Retention(RetentionPolicy.SOURCE)
-    @StringDef({TYPE_CARD, TYPE_BANK_ACCOUNT, TYPE_PII})
+    @StringDef({TYPE_CARD, TYPE_BANK_ACCOUNT, TYPE_PII, TYPE_ACCOUNT})
     public @interface TokenType {}
     public static final String TYPE_CARD = "card";
     public static final String TYPE_BANK_ACCOUNT = "bank_account";
     public static final String TYPE_PII = "pii";
+    public static final String TYPE_ACCOUNT = "account";
 
     // The key for these object fields is identical to their retrieved values
     // from the Type field.
@@ -85,12 +86,13 @@ public class Token implements StripePaymentSource {
      */
     public Token(
             String id,
+            String type,
             boolean livemode,
             Date created,
             Boolean used
     ) {
         mId = id;
-        mType = TYPE_PII;
+        mType = type;
         mCreated = created;
         mCard = null;
         mBankAccount = null;
@@ -192,10 +194,9 @@ public class Token implements StripePaymentSource {
             }
             Card card = Card.fromJson(cardObject);
             token = new Token(tokenId, liveMode, date, used, card);
-        } else if (Token.TYPE_PII.equals(tokenType)) {
-            token = new Token(tokenId, liveMode, date, used);
+        } else if (Token.TYPE_PII.equals(tokenType) || Token.TYPE_ACCOUNT.equals(tokenType)) {
+            token = new Token(tokenId, tokenType, liveMode, date, used);
         }
-
         return token;
     }
 
@@ -219,6 +220,8 @@ public class Token implements StripePaymentSource {
             return Token.TYPE_BANK_ACCOUNT;
         } else if (Token.TYPE_PII.equals(possibleTokenType)) {
             return Token.TYPE_PII;
+        } else if (Token.TYPE_ACCOUNT.equals(possibleTokenType)) {
+            return Token.TYPE_ACCOUNT;
         }
 
         return null;

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -12,7 +12,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.Date;
 
 /**
- * The model of a Stripe card token.
+ * Tokenization is the process Stripe uses to collect sensitive card, bank account details, Stripe
+ * account details or personally identifiable information (PII), directly from your customers in a
+ * secure manner. A Token representing this information is returned to you to use.
  */
 public class Token implements StripePaymentSource {
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
 import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
@@ -13,14 +14,12 @@ import com.stripe.android.model.SourceCardData;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.SourceSepaDebitData;
 import com.stripe.android.model.Token;
-import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.testharness.JsonTestUtils;
+import com.stripe.android.view.CardInputTestActivity;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -840,6 +839,76 @@ public class StripeTest {
             assertAllLogsAreValid(listener, 2);
         } catch (StripeException stripeEx) {
             fail("Unexpected exception making PII token");
+        }
+    }
+
+    @Test
+    public void createTokenSynchronous_withValidAccount_passesIntegrationTest() {
+        try {
+            final Map<String, Object> exampleMapAddress = new HashMap<String, Object>() {{
+                put("city", "San Francisco");
+                put("country", "US");
+                put("line1", "123 Market St");
+                put("line2", "#345");
+                put("postal_code", "94107");
+                put("state", "CA");
+            }};
+
+           final Map<String, Object> exampleLegalEntity = new HashMap<String, Object>() {{
+                put("personal_address", exampleMapAddress);
+                put("type", "individual");
+                put("ssn_last_4", "1234");
+                put("first_name", "Kathy");
+                put("last_name", "Sun");
+            }};
+            Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+            TestLoggingListener listener = new TestLoggingListener(true);
+            stripe.setLoggingResponseListener(listener);
+            Token token = stripe.createAccountTokenSynchronous(
+                    AccountParams.createAccountParams(true, exampleLegalEntity));
+            assertNotNull(token);
+            assertEquals(Token.TYPE_ACCOUNT, token.getType());
+            assertFalse(token.getLivemode());
+            assertFalse(token.getUsed());
+            assertNotNull(token.getId());
+            assertAllLogsAreValid(listener, 2);
+        } catch (StripeException stripeEx) {
+            fail(stripeEx.getMessage());
+        }
+    }
+
+    @Test
+    public void createTokenSynchronous_withoutTosShown_failsIntegrationTest() {
+        try {
+            final Map<String, Object> exampleMapAddress = new HashMap<String, Object>() {{
+                put("city", "San Francisco");
+                put("country", "US");
+                put("line1", "123 Market St");
+                put("line2", "#345");
+                put("postal_code", "94107");
+                put("state", "CA");
+            }};
+
+            final Map<String, Object> exampleLegalEntity = new HashMap<String, Object>() {{
+                put("personal_address", exampleMapAddress);
+                put("type", "individual");
+                put("ssn_last_4", "1234");
+                put("first_name", "Kathy");
+                put("last_name", "Sun");
+            }};
+            Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+            TestLoggingListener listener = new TestLoggingListener(true);
+            stripe.setLoggingResponseListener(listener);
+            Token token = stripe.createAccountTokenSynchronous(
+                    AccountParams.createAccountParams(false, exampleLegalEntity));
+            assertNotNull(token);
+            assertEquals(Token.TYPE_ACCOUNT, token.getType());
+            assertFalse(token.getLivemode());
+            assertFalse(token.getUsed());
+            assertNotNull(token.getId());
+            assertAllLogsAreValid(listener, 2);
+        } catch (StripeException stripeEx) {
+            fail(stripeEx.getMessage());
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -852,7 +852,7 @@ public class StripeTest {
                     .setCountry("US")
                     .setState("CA").build();
            final Map<String, Object> exampleLegalEntity = new HashMap<String, Object>() {{
-                put("personal_address", exampleAddress);
+                put("personal_address", exampleAddress.toMap());
                 put("type", "individual");
                 put("ssn_last_4", "1234");
                 put("first_name", "Kathy");

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -7,6 +7,7 @@ import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.AccountParams;
+import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
@@ -845,17 +846,13 @@ public class StripeTest {
     @Test
     public void createTokenSynchronous_withValidAccount_passesIntegrationTest() {
         try {
-            final Map<String, Object> exampleMapAddress = new HashMap<String, Object>() {{
-                put("city", "San Francisco");
-                put("country", "US");
-                put("line1", "123 Market St");
-                put("line2", "#345");
-                put("postal_code", "94107");
-                put("state", "CA");
-            }};
-
+            final Address exampleAddress = new Address
+                    .Builder()
+                    .setCity("SF")
+                    .setCountry("US")
+                    .setState("CA").build();
            final Map<String, Object> exampleLegalEntity = new HashMap<String, Object>() {{
-                put("personal_address", exampleMapAddress);
+                put("personal_address", exampleAddress);
                 put("type", "individual");
                 put("ssn_last_4", "1234");
                 put("first_name", "Kathy");


### PR DESCRIPTION
Add bindings to support custom connect onboarding in Europe. I opted against creating a custom object for legal entity because of longer term maintainability concerns. 

r? @danj-stripe 
cc: @basta-stripe @timpeacock-stripe @bg-stripe 