### PR TITLE
Fix dutch dates

### DIFF
--- a/stripe/res/values-nl/strings.xml
+++ b/stripe/res/values-nl/strings.xml
@@ -4,7 +4,7 @@
     <string name="acc_label_expiry_date">Vervaldatum</string>
     <string name="acc_label_zip">Postcode</string>
     <string name="acc_label_zip_short">ZIP</string>
-    <string name="expiry_date_hint">MM/YY</string>
+    <string name="expiry_date_hint">MM/JJ</string>
     <string name="expiry_label_short">Verval</string>
     <string name="invalid_card_number">Uw kaartnummer is ongeldig.</string>
     <string name="invalid_expiry_month">De vervalmaand van uw kaart is ongeldig.</string>


### PR DESCRIPTION
Dutch dates are supposed to be MM/JJ. Make it correct.

r? @anelder-stripe 