### PR TITLE
Allow to specify others params during SEPA source creation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -685,7 +685,7 @@ public class SourceParams {
         networkReadyMap.put(API_PARAM_METADATA, mMetaData);
         networkReadyMap.put(API_PARAM_TOKEN, mToken);
         networkReadyMap.put(API_PARAM_USAGE, mUsage);
-        if(mExtraParams != null)
+        if (mExtraParams != null)
             networkReadyMap.putAll(mExtraParams);
         removeNullAndEmptyParams(networkReadyMap);
         return networkReadyMap;

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -56,6 +56,7 @@ public class SourceParams {
     private Map<String, Object> mOwner;
     private Map<String, String> mMetaData;
     private Map<String, Object> mRedirect;
+    private Map<String, Object> mExtraParams;
     private String mToken;
     @Nullable @Source.Usage private String mUsage;
     @SourceType private String mType;
@@ -343,6 +344,7 @@ public class SourceParams {
     @NonNull
     public static SourceParams createSepaDebitParams(
             @NonNull String name,
+            @NonNull String email,
             @NonNull String iban,
             @Nullable String addressLine1,
             @NonNull String city,
@@ -360,6 +362,7 @@ public class SourceParams {
 
         Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
+        ownerMap.put(FIELD_EMAIL, email);
         ownerMap.put(FIELD_ADDRESS, address);
 
         params.setOwner(ownerMap).setApiParameterMap(createSimpleMap(FIELD_IBAN, iban));
@@ -575,6 +578,16 @@ public class SourceParams {
         return this;
     }
 
+    /**
+     * Sets extra params for this source object.
+     *
+     * @param extraParams a set of params
+     * @return {@code this}, for chaining purposes
+     */
+    public SourceParams setExtraParams(final Map<String, Object> extraParams) {
+        mExtraParams = extraParams;
+        return this;
+    }
 
     /**
      * @param returnUrl a redirect URL for this source.
@@ -672,6 +685,8 @@ public class SourceParams {
         networkReadyMap.put(API_PARAM_METADATA, mMetaData);
         networkReadyMap.put(API_PARAM_TOKEN, mToken);
         networkReadyMap.put(API_PARAM_USAGE, mUsage);
+        if(mExtraParams != null)
+            networkReadyMap.putAll(mExtraParams);
         removeNullAndEmptyParams(networkReadyMap);
         return networkReadyMap;
     }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -642,6 +642,7 @@ public class StripeTest {
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
+                "sepaholder@stripe.com",
                 validIban,
                 "123 Main St",
                 "Eureka",
@@ -683,6 +684,7 @@ public class StripeTest {
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
+                "sepaholder@stripe.com",
                 validIban,
                 null,
                 "Eureka",

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -440,6 +440,7 @@ public class SourceParamsTest {
     public void createSepaDebitParams_hasExpectedFields() {
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Jai Testa",
+                "sepaholder@stripe.com",
                 "ibaniban",
                 "44 Fourth Street",
                 "Test City",
@@ -464,6 +465,7 @@ public class SourceParamsTest {
     public void createSepaDebitParams_toParamMap_createsExpectedMap() {
         final SourceParams params = SourceParams.createSepaDebitParams(
                 "Jai Testa",
+                "sepaholder@stripe.com",
                 "ibaniban",
                 "44 Fourth Street",
                 "Test City",

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -485,6 +485,7 @@ public class SourceParamsTest {
         expectedMap.put("owner",
                 new HashMap<String, Object>() {{
                     put("name", "Jai Testa");
+                    put("email", "sepaholder@stripe.com");
                     put("address", addressMap);
                 }});
 


### PR DESCRIPTION
As described here https://stripe.com/docs/api#create_source , now you can specify others params during SEPA source creation, like mandate options.
See issue #510 for details