### PR TITLE
Fix crash when reading HttpUrlConnection.getErrorStream()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -850,10 +850,8 @@ class StripeApiHandler {
             throws IOException {
         //\A is the beginning of
         // the stream boundary
-        String rBody = new Scanner(responseStream, CHARSET)
-                .useDelimiter("\\A")
-                .next(); //
-
+        Scanner scanner = new Scanner(responseStream, CHARSET).useDelimiter("\\A");
+        String rBody = scanner.hasNext() ? scanner.next() : null;
         responseStream.close();
         return rBody;
     }


### PR DESCRIPTION
This PR fixes https://github.com/stripe/stripe-android/issues/518.

The api handler should be checking if the iterator has next before calling next (this is standard java practice).