### PR TITLE
Wrap number format in try catch

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentUtils.java
@@ -32,11 +32,16 @@ public class PaymentUtils {
     static String formatPriceString(double amount, @NonNull Currency currency) {
         double majorUnitAmount = amount / Math.pow(10, currency.getDefaultFractionDigits());
         NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
-        DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat)
-                .getDecimalFormatSymbols();
-        decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
-        ((java.text.DecimalFormat) currencyFormat).setDecimalFormatSymbols(decimalFormatSymbols);
-        return currencyFormat.format(majorUnitAmount);
+        try {
+            DecimalFormatSymbols decimalFormatSymbols = ((java.text.DecimalFormat) currencyFormat)
+                    .getDecimalFormatSymbols();
+            decimalFormatSymbols.setCurrencySymbol(currency.getSymbol(Locale.getDefault()));
+            ((java.text.DecimalFormat) currencyFormat)
+                    .setDecimalFormatSymbols(decimalFormatSymbols);
+            return currencyFormat.format(majorUnitAmount);
+        } catch (ClassCastException e) {
+            return currencyFormat.format(majorUnitAmount);
+        }
     }
 
 }


### PR DESCRIPTION
Based on Google docs:
https://developer.android.com/reference/java/text/NumberFormat.html

"You can also control the display of numbers with such methods as setMinimumFractionDigits. If you want even more control over the format or parsing, or want to give your users more control, you can try casting the NumberFormat you get from the factory methods to a DecimalFormat. This will work for the vast majority of locales; just remember to put it in a try block in case you encounter an unusual one."

We should wrap this in a try catch in case we get an unusual one.