### PR TITLE
iDeal Source with connected account

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -696,7 +696,7 @@ public class Stripe {
         if (apiKey == null) {
             return null;
         }
-        return StripeApiHandler.retrieveSource(sourceId, clientSecret, apiKey);
+        return StripeApiHandler.retrieveSource(sourceId, clientSecret, apiKey, mStripeAccount);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -210,14 +210,14 @@ class StripeApiHandler {
            APIException {
        Map<String, Object> paramMap = SourceParams.createRetrieveSourceParams(clientSecret);
        RequestOptions options;
-        if (stripeAccount == null) {
-            options = RequestOptions.builder(publishableKey).build();
-        } else {
-            options = RequestOptions.builder(
-                    publishableKey,
-                    stripeAccount,
-                    RequestOptions.TYPE_QUERY).build();
-        }
+       if (stripeAccount == null) {
+           options = RequestOptions.builder(publishableKey).build();
+       } else {
+           options = RequestOptions.builder(
+               publishableKey,
+               stripeAccount,
+               RequestOptions.TYPE_QUERY).build();
+       }
        try {
            StripeResponse response =
                    requestData(GET, getRetrieveSourceApiUrl(sourceId), paramMap, options);

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -211,12 +211,16 @@ class StripeApiHandler {
        Map<String, Object> paramMap = SourceParams.createRetrieveSourceParams(clientSecret);
        RequestOptions options;
        if (stripeAccount == null) {
-           options = RequestOptions.builder(publishableKey).build();
+           options = RequestOptions.builder(publishableKey)
+               .setApiVersion(API_VERSION)
+               .build();
        } else {
            options = RequestOptions.builder(
                publishableKey,
                stripeAccount,
-               RequestOptions.TYPE_QUERY).build();
+               RequestOptions.TYPE_QUERY)
+               .setApiVersion(API_VERSION)
+               .build();
        }
        try {
            StripeResponse response =

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -212,14 +212,12 @@ class StripeApiHandler {
        RequestOptions options;
        if (stripeAccount == null) {
            options = RequestOptions.builder(publishableKey)
-               .setApiVersion(API_VERSION)
                .build();
        } else {
            options = RequestOptions.builder(
                publishableKey,
                stripeAccount,
                RequestOptions.TYPE_QUERY)
-               .setApiVersion(API_VERSION)
                .build();
        }
        try {

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -189,6 +189,7 @@ class StripeApiHandler {
      * @param sourceId the {@link Source#mId} field for the Source to query
      * @param clientSecret the {@link Source#mClientSecret} field for the Source to query
      * @param publishableKey an API key
+     * @param stripeAccount a connected Stripe Account ID
      * @return a {@link Source} if one could be retrieved for the input params, or {@code null} if
      * no such Source could be found.
      *
@@ -201,13 +202,22 @@ class StripeApiHandler {
     static Source retrieveSource(
            @NonNull String sourceId,
            @NonNull String clientSecret,
-           @NonNull String publishableKey)
+           @NonNull String publishableKey,
+           @Nullable String stripeAccount)
            throws AuthenticationException,
            InvalidRequestException,
            APIConnectionException,
            APIException {
        Map<String, Object> paramMap = SourceParams.createRetrieveSourceParams(clientSecret);
-       RequestOptions options = RequestOptions.builder(publishableKey).build();
+       RequestOptions options;
+        if (stripeAccount == null) {
+            options = RequestOptions.builder(publishableKey).build();
+        } else {
+            options = RequestOptions.builder(
+                    publishableKey,
+                    stripeAccount,
+                    RequestOptions.TYPE_QUERY).build();
+        }
        try {
            StripeResponse response =
                    requestData(GET, getRetrieveSourceApiUrl(sourceId), paramMap, options);


### PR DESCRIPTION
When an iDeal source is created it uses the connected account (mStripeAccount) in the RequestOptions (StripeApiHandler:152).
But when you try go get the source status, although connected account is set, it's not used for RequestOptions resulting in exception com.stripe.android.exception.InvalidRequestException: No such source (StripeApiHandler:200).

With this modifications the checkSource passes with or without connected account.

This was not a problem with iOS or PHP version (maybe you can check why it works there).