### PR TITLE
Add support for EPS and Multibanco SourceParams creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-26.0.2
+    - build-tools-27.0.3
     - android-27
     - extra-google-google_play_services
     - extra-google-m2repository

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+    Add EPS and Multibanco support to `SourceParams` (https://github.com/stripe/stripe-android/pull/583)
+
 7.0.1 2018-05-25
     Make iDEAL params match API - `name` is optional and optional ideal `bank` and `statement_descriptor` can be set independently
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
     }
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.3'
+    gradleVersion = '4.4'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 
@@ -20,8 +20,8 @@ allprojects {
     group = GROUP
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     task checkstyle(type: Checkstyle) {
@@ -39,7 +39,7 @@ allprojects {
 }
 
 ext {
-    buildToolsVersion = "26.0.2"
+    buildToolsVersion = "27.0.3"
     compileSdkVersion = 27
     supportLibVersion = "27.1.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jun 07 15:12:23 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -52,6 +52,8 @@ public class Source extends StripeJsonModel implements StripePaymentSource {
     public static final String SOFORT = "sofort";
     public static final String BANCONTACT = "bancontact";
     public static final String P24 = "p24";
+    public static final String EPS = "eps";
+    public static final String MULTIBANCO = "multibanco";
     public static final String UNKNOWN = "unknown";
 
     public static final Set<String> MODELED_TYPES = new HashSet<>();

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -68,25 +68,31 @@ public class SourceParams {
     private SourceParams() {}
 
     /**
-     * Create parameters used to generate a P24 source.
+     * Create parameters necessary for creating a P24 source.
      *
-     * @param currency the currency code that this source will be charged in.
-     * @param name the user's name
-     * @param email the user's email
-     * @param returnUrl a url used to reopen the application
-     * @return a {@link SourceParams} that can be used to create an Alipay reusable source
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *               charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param currency `eur` or `pln` (P24 payments must be in either Euros or Polish Zloty).
+     * @param name The name of the account holder (optional).
+     * @param email The email address of the account holder.
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                  process.
+     * @return a {@link SourceParams} that can be used to create a P24 source
+     *
+     * @see <a href="https://stripe.com/docs/sources/p24">https://stripe.com/docs/sources/p24</a>
      */
     public static SourceParams createP24Params(
             @IntRange(from = 0) long amount,
             @NonNull String currency,
-            @NonNull String name,
-            @Nullable String email,
+            @Nullable String name,
+            @NonNull String email,
             @NonNull String returnUrl) {
         SourceParams params = new SourceParams()
                 .setAmount(amount)
                 .setType(Source.P24)
                 .setCurrency(currency)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
+
         Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
@@ -94,6 +100,7 @@ public class SourceParams {
         if (ownerMap.keySet().size() > 0) {
             params.setOwner(ownerMap);
         }
+
         return params;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -105,13 +105,18 @@ public class SourceParams {
     }
 
     /**
-     * Create parameters used to generate a reusable Alipay source.
+     * Create parameters necessary for creating a reusable Alipay source.
      *
-     * @param currency the currency code that this source will be charged in
-     * @param name the user's name
-     * @param email the user's email
-     * @param returnUrl a url used to reopen the application
+     * @param currency The currency of the payment. Must be the default currency for your country.
+     *                 Can be aud, cad, eur, gbp, hkd, jpy, nzd, sgd, or usd. Users in Denmark,
+     *                 Norway, Sweden, or Switzerland must use eur.
+     * @param name The name of the account holder (optional).
+     * @param email The email address of the account holder (optional).
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                 process.
      * @return a {@link SourceParams} that can be used to create an Alipay reusable source
+     *
+     * @see <a href="https://stripe.com/docs/sources/alipay">https://stripe.com/docs/sources/alipay</a>
      */
     public static SourceParams createAlipayReusableParams(
             @NonNull String currency,
@@ -136,14 +141,20 @@ public class SourceParams {
     }
 
     /**
-     * Create a source to be used with the Alipay SDK for single-use payments.
+     * Create parameters necessary for creating a single use Alipay source.
      *
-     * @param amount the amount of the purchase
-     * @param currency the currency code of the purchase
-     * @param name the user's name
-     * @param email the user's email
-     * @param returnUrl the return url to reopen the activity
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *              charge the customer (e.g., 1099 for a $10.99 payment).
+     * @param currency The currency of the payment. Must be the default currency for your country.
+     *                Can be aud, cad, eur, gbp, hkd, jpy, nzd, sgd, or usd. Users in Denmark,
+     *                Norway, Sweden, or Switzerland must use eur.
+     * @param name The name of the account holder (optional).
+     * @param email The email address of the account holder (optional).
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                 process.
      * @return a {@link SourceParams} that can be used to create an Alipay single-use source
+     *
+     * @see <a href="https://stripe.com/docs/sources/alipay">https://stripe.com/docs/sources/alipay</a>
      */
     @NonNull
     public static SourceParams createAlipaySingleUseParams(
@@ -170,13 +181,18 @@ public class SourceParams {
     }
 
     /**
-     * Create a set of parameters used for a Bancontact source.
+     * Create parameters necessary for creating a Bancontact source.
      *
-     * @param amount amount to be charged
-     * @param name account owner name
-     * @param returnUrl a URL redirect
-     * @param statementDescriptor a description of the transaction to put on the customer statement
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *              charge the customer (e.g., 1099 for a €10.99 payment). The charge amount must be
+     *              at least €1 or its equivalent in the given currency.
+     * @param name The full name of the account holder.
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                 process.
+     * @param statementDescriptor A custom statement descriptor for the payment (optional).
      * @return a {@link SourceParams} object that can be used to create a Bancontact source
+     *
+     * @see <a href="https://stripe.com/docs/sources/bancontact">https://stripe.com/docs/sources/bancontact</a>
      */
     @NonNull
     public static SourceParams createBancontactParams(
@@ -212,10 +228,12 @@ public class SourceParams {
     }
 
     /**
-     * Create a set of parameters for a credit card source.
+     * Create parameters necessary for creating a card source.
      *
-     * @param card a {@link Card} object containing the details necessary for the source
-     * @return a {@link SourceParams} object that can be used to create a card source
+     * @param card A {@link Card} object containing the details necessary for the source.
+     * @return a {@link SourceParams} object that can be used to create a card source.
+     *
+     * @see <a href="https://stripe.com/docs/sources/cards">https://stripe.com/docs/sources/cards</a>
      */
     @NonNull
     public static SourceParams createCardParams(@NonNull Card card) {
@@ -293,11 +311,15 @@ public class SourceParams {
     /**
      * Create parameters necessary for creating a Giropay source
      *
-     * @param amount amount of the transaction
-     * @param name source owner name
-     * @param returnUrl redirect URL
-     * @param statementDescriptor a description of the transaction
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *              charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param name The full name of the account holder.
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                  process.
+     * @param statementDescriptor A custom statement descriptor for the payment (optional).
      * @return a {@link SourceParams} object that can be used to create a Giropay source
+     *
+     * @see <a href="https://stripe.com/docs/sources/giropay">https://stripe.com/docs/sources/giropay</a>
      */
     @NonNull
     public static SourceParams createGiropayParams(
@@ -322,14 +344,18 @@ public class SourceParams {
     }
 
     /**
-     * Create parameters needed to make an iDEAL source.
+     * Create parameters necessary for creating an iDEAL source.
      *
-     * @param amount amount of the transaction
-     * @param name owner name
-     * @param returnUrl redirect URL
-     * @param statementDescriptor a description of the transaction
-     * @param bank bank id for the iDEAL source
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *               charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param name The full name of the account holder (optional).
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                 process.
+     * @param statementDescriptor A custom statement descriptor for the payment (optional).
+     * @param bank The customer’s bank (optional).
      * @return a {@link SourceParams} object that can be used to create an iDEAL source
+     *
+     * @see <a href="https://stripe.com/docs/sources/ideal">https://stripe.com/docs/sources/ideal</a>
      */
     @NonNull
     public static SourceParams createIdealParams(
@@ -399,13 +425,16 @@ public class SourceParams {
     /**
      * Create parameters necessary to create a SEPA debit source
      *
-     * @param name owner name
-     * @param iban bank IBAN
-     * @param addressLine1 1-line address of the owner
-     * @param city city of source owner's address
-     * @param postalCode postal code for source owner's address
-     * @param country country code for source owner's address
+     * @param name The full name of the account holder.
+     * @param iban The IBAN number for the bank account that you wish to debit.
+     * @param email The full email address of the owner (optional).
+     * @param addressLine1 The first line of the owner's address (optional).
+     * @param city The city of the owner's address.
+     * @param postalCode The postal code of the owner's address.
+     * @param country The ISO-3166 2-letter country code of the owner's address.
      * @return a {@link SourceParams} object that can be used to create a SEPA debit source
+     *
+     * @see <a href="https://stripe.com/docs/sources/sepa-debit">https://stripe.com/docs/sources/sepa-debit</a>
      */
     @NonNull
     public static SourceParams createSepaDebitParams(
@@ -436,13 +465,17 @@ public class SourceParams {
     }
 
     /**
-     * Create parameters needed to make a SOFORT source.
+     * Create parameters necessary to create a SOFORT source.
      *
-     * @param amount the amount of the transaction
-     * @param returnUrl the redirect URL
-     * @param country the country code for the source
-     * @param statementDescriptor a description of the transaction
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *              charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                  process.
+     * @param country The ISO-3166 2-letter country code of the customer’s bank.
+     * @param statementDescriptor A custom statement descriptor for the payment (optional).
      * @return a {@link SourceParams} object that can be used to create a SOFORT source
+     *
+     * @see <a href="https://stripe.com/docs/sources/sofort">https://stripe.com/docs/sources/sofort</a>
      */
     @NonNull
     public static SourceParams createSofortParams(
@@ -467,13 +500,16 @@ public class SourceParams {
     }
 
     /**
-     * Create parameters needed to make a 3D-Secure source.
+     * Create parameters necessary to create a 3D Secure source.
      *
-     * @param amount amount of the transaction
-     * @param currency currency code for the transaction
-     * @param returnUrl the redirect url
-     * @param cardID the ID from the card source object used to create this 3DS source
-     * @return a {@link SourceParams} object that can be used to create a 3D-Secure source
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *              charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param currency The currency the payment is being created in (e.g., eur).
+     * @param returnUrl The URL the customer should be redirected to after the verification process.
+     * @param cardID The ID of the card source.
+     * @return a {@link SourceParams} object that can be used to create a 3D Secure source
+     *
+     * @see <a href="https://stripe.com/docs/sources/three-d-secure">https://stripe.com/docs/sources/three-d-secure</a>
      */
     @NonNull
     public static SourceParams createThreeDSecureParams(
@@ -493,8 +529,11 @@ public class SourceParams {
     /**
      * Create parameters needed to make a Visa Checkout source.
      *
-     * @param callId the ID from the Visa Checkout SDK
+     * @param callId The payment request ID (callId) from the Visa Checkout SDK.
      * @return a {@link SourceParams} object that can be used to create a Visa Checkout Card Source.
+     *
+     * @see <a href="https://stripe.com/docs/visa-checkout">https://stripe.com/docs/visa-checkout</a>
+     * @see <a href="https://developer.visa.com/capabilities/visa_checkout/docs">https://developer.visa.com/capabilities/visa_checkout/docs</a>
      */
     public static SourceParams createVisaCheckoutParams(@NonNull String callId) {
         SourceParams params = new SourceParams().setType(Source.CARD);
@@ -506,10 +545,16 @@ public class SourceParams {
 
     /**
      * Create parameters needed to make a Masterpass source
-     * @param transactionId the ID from the Masterpass SDK
-     * @param cartID the cart ID provided when creating a cart for checkout in the Masterpass SDK
+     *
+     * @param transactionId The transaction ID from the Masterpass SDK.
+     * @param cartID A unique string that you generate to identify the purchase when creating a cart
+     *               for checkout in the Masterpass SDK.
      *
      * @return a {@link SourceParams} object that can be used to create a Masterpass Card Source.
+     *
+     * @see <a href="https://stripe.com/docs/masterpass">https://stripe.com/docs/masterpass</a>
+     * @see <a href="https://developer.mastercard.com/product/masterpass">https://developer.mastercard.com/product/masterpass</a>
+     * @see <a href="https://developer.mastercard.com/page/masterpass-merchant-mobile-checkout-sdk-for-android-v2">https://developer.mastercard.com/page/masterpass-merchant-mobile-checkout-sdk-for-android-v2</a>
      */
     public static SourceParams createMasterpassParams(
             @NonNull String transactionId,

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -256,6 +256,41 @@ public class SourceParams {
     }
 
     /**
+     * Create parameters necessary for creating an EPS source.
+     *
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *               charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param name The full name of the account holder.
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                  process.
+     * @param statementDescriptor A custom statement descriptor for the payment (optional).
+     * @return a {@link SourceParams} object that can be used to create an EPS source
+     *
+     * @see <a href="https://stripe.com/docs/sources/eps">https://stripe.com/docs/sources/eps</a>
+     */
+    @NonNull
+    public static SourceParams createEPSParams(
+            @IntRange(from = 0) long amount,
+            @NonNull String name,
+            @NonNull String returnUrl,
+            @Nullable String statementDescriptor) {
+        SourceParams params = new SourceParams()
+                .setType(Source.EPS)
+                .setCurrency(Source.EURO)
+                .setAmount(amount)
+                .setOwner(createSimpleMap(FIELD_NAME, name))
+                .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
+
+        if (statementDescriptor != null) {
+            Map<String, Object> additionalParamsMap =
+                    createSimpleMap(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
+            params.setApiParameterMap(additionalParamsMap);
+        }
+
+        return params;
+    }
+
+    /**
      * Create parameters necessary for creating a Giropay source
      *
      * @param amount amount of the transaction
@@ -321,6 +356,32 @@ public class SourceParams {
         if (!additionalParamsMap.isEmpty()) {
             params.setApiParameterMap(additionalParamsMap);
         }
+        return params;
+    }
+
+    /**
+     * Create parameters necessary to create a Multibanco source.
+     *
+     * @param amount A positive integer in the smallest currency unit representing the amount to
+     *               charge the customer (e.g., 1099 for a €10.99 payment).
+     * @param returnUrl The URL the customer should be redirected to after the authorization
+     *                  process.
+     * @param email The full email address of the customer.
+     * @return a {@link SourceParams} object that can be used to create a Multibanco source
+     *
+     * @see <a href="https://stripe.com/docs/sources/multibanco">https://stripe.com/docs/sources/multibanco</a>
+     */
+    @NonNull
+    public static SourceParams createMultibancoParams(
+            @IntRange(from = 0) long amount,
+            @NonNull String returnUrl,
+            @NonNull String email) {
+        SourceParams params = new SourceParams()
+                .setType(Source.MULTIBANCO)
+                .setCurrency(Source.EURO)
+                .setAmount(amount)
+                .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
+                .setOwner(createSimpleMap(FIELD_EMAIL, email));
         return params;
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -347,12 +347,12 @@ public class SourceParamsTest {
     }
 
     @Test
-    public void createP24Params_withNullEmail_hasExpectedFields() {
+    public void createP24Params_withNullName_hasExpectedFields() {
         SourceParams params = SourceParams.createP24Params(
                 1000L,
                 "eur",
-                "Jane Tester",
                 null,
+                "jane@test.com",
                 "stripe://testactivity");
 
         assertEquals(Source.P24, params.getType());
@@ -360,8 +360,8 @@ public class SourceParamsTest {
         assertEquals(1000L, params.getAmount().longValue());
         assertEquals("eur", params.getCurrency());
         assertNotNull(params.getOwner());
-        assertEquals("Jane Tester", params.getOwner().get("name"));
-        assertNull(params.getOwner().get("email"));
+        assertNull(params.getOwner().get("name"));
+        assertEquals("jane@test.com", params.getOwner().get("email"));
         assertNotNull(params.getRedirect());
         assertEquals("stripe://testactivity", params.getRedirect().get("return_url"));
     }

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -1,6 +1,7 @@
 package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.stripe.android.testharness.JsonTestUtils;
 
@@ -217,6 +218,65 @@ public class SourceParamsTest {
     }
 
     @Test
+    public void createEPSParams_hasExpectedFields() {
+        SourceParams params = SourceParams.createEPSParams(
+                150L,
+                "Stripe",
+                "stripe://return",
+                "stripe descriptor");
+
+        assertEquals(Source.EPS, params.getType());
+        assertEquals(Source.EURO, params.getCurrency());
+        assertEquals("Stripe", params.getOwner().get("name"));
+        assertEquals("stripe://return", params.getRedirect().get("return_url"));
+
+        Map<String, Object> apiMap = params.getApiParameterMap();
+        assertEquals("stripe descriptor", apiMap.get("statement_descriptor"));
+    }
+
+    @Test
+    public void createEPSParams_toParamMap_createsExpectedMap() {
+        SourceParams params = SourceParams.createEPSParams(
+                150L,
+                "Stripe",
+                "stripe://return",
+                "stripe descriptor");
+
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("type", Source.EPS);
+        expectedMap.put("currency", Source.EURO);
+        expectedMap.put("amount", 150L);
+        expectedMap.put("owner", new HashMap<String, Object>() {{ put("name", "Stripe"); }});
+        expectedMap.put("redirect",
+                new HashMap<String, Object>() {{ put("return_url", "stripe://return"); }});
+        expectedMap.put(Source.EPS,
+                new HashMap<String, Object>() {{
+                    put("statement_descriptor", "stripe descriptor");
+                }});
+
+        JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
+    }
+
+    @Test
+    public void createEPSParams_toParamMap_createsExpectedMap_noStatementDescriptor() {
+        SourceParams params = SourceParams.createEPSParams(
+                150L,
+                "Stripe",
+                "stripe://return",
+                null);
+
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("type", Source.EPS);
+        expectedMap.put("currency", Source.EURO);
+        expectedMap.put("amount", 150L);
+        expectedMap.put("owner", new HashMap<String, Object>() {{ put("name", "Stripe"); }});
+        expectedMap.put("redirect",
+                new HashMap<String, Object>() {{ put("return_url", "stripe://return"); }});
+
+        JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
+    }
+
+    @Test
     public void createGiropayParams_hasExpectedFields() {
         SourceParams params = SourceParams.createGiropayParams(
                 150L,
@@ -364,6 +424,39 @@ public class SourceParamsTest {
         assertEquals("jane@test.com", params.getOwner().get("email"));
         assertNotNull(params.getRedirect());
         assertEquals("stripe://testactivity", params.getRedirect().get("return_url"));
+    }
+
+    @Test
+    public void createMultibancoParams_hasExpectedFields() {
+        SourceParams params = SourceParams.createMultibancoParams(
+                150L,
+                "stripe://testactivity",
+                "multibancoholder@stripe.com");
+
+        assertEquals(Source.MULTIBANCO, params.getType());
+        assertEquals(Source.EURO, params.getCurrency());
+        assertEquals(150L, params.getAmount().longValue());
+        assertEquals("stripe://testactivity", params.getRedirect().get("return_url"));
+        assertEquals("multibancoholder@stripe.com", params.getOwner().get("email"));
+    }
+
+    @Test
+    public void createMultibancoParams_toParamMap_createsExpectedMap() {
+        SourceParams params = SourceParams.createMultibancoParams(
+                150L,
+                "stripe://testactivity",
+                "multibancoholder@stripe.com");
+
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("type", Source.MULTIBANCO);
+        expectedMap.put("currency", Source.EURO);
+        expectedMap.put("amount", 150L);
+        expectedMap.put("owner",
+                new HashMap<String, Object>() {{ put("email", "multibancoholder@stripe.com"); }});
+        expectedMap.put("redirect",
+                new HashMap<String, Object>() {{ put("return_url", "stripe://testactivity"); }});
+
+        JsonTestUtils.assertMapEquals(expectedMap, params.toParamMap());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -1,7 +1,6 @@
 package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import com.stripe.android.testharness.JsonTestUtils;
 


### PR DESCRIPTION
- Add `createEPSParams` and `createMultibancoParams` methods to `SourceParams` class
- Some function documentation cleanup to be more informational and consistent. See individual commits.