### PR TITLE
Fix crash from SEPA source in AddCardActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/MaskedCardAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/MaskedCardAdapter.java
@@ -39,7 +39,9 @@ class MaskedCardAdapter extends RecyclerView.Adapter<MaskedCardAdapter.ViewHolde
     }
 
     void updateCustomer(@NonNull Customer customer) {
-        mCustomerSourceList = customer.getSources();
+        mCustomerSourceList.clear();
+        CustomerSource[] customerSources = new CustomerSource[customer.getSources().size()];
+        addCustomerSourceIfSupported(customer.getSources().toArray(customerSources));
         String sourceId = customer.getDefaultSource();
         if (sourceId == null) {
             updateSelectedIndex(NO_SELECTION);

--- a/stripe/src/main/java/com/stripe/android/view/MaskedCardView.java
+++ b/stripe/src/main/java/com/stripe/android/view/MaskedCardView.java
@@ -204,6 +204,9 @@ public class MaskedCardView extends LinearLayout {
     }
 
     private void updateBrandIcon() {
+        if (!TEMPLATE_RESOURCE_MAP.containsKey(mCardBrand)) {
+            return;
+        }
         @DrawableRes int iconResourceId = TEMPLATE_RESOURCE_MAP.get(mCardBrand);
         updateDrawable(iconResourceId, mCardIconImageView, false);
     }

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardAdapterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardAdapterTest.java
@@ -3,6 +3,7 @@ package com.stripe.android.view;
 import android.support.v7.widget.RecyclerView;
 
 import com.stripe.android.BuildConfig;
+import com.stripe.android.model.Card;
 import com.stripe.android.model.Customer;
 import com.stripe.android.model.CustomerSource;
 
@@ -10,11 +11,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -86,6 +89,23 @@ public class MaskedCardAdapterTest {
         assertEquals(2, mMaskedCardAdapter.getItemCount());
         assertNotNull(mMaskedCardAdapter.getSelectedSource());
         assertEquals(customer.getDefaultSource(), mMaskedCardAdapter.getSelectedSource().getId());
-        verify(mAdapterDataObserver, times(3)).onChanged();
+        verify(mAdapterDataObserver, times(4)).onChanged();
+    }
+
+    @Test
+    public void updateCustomer_filtersOutNonCardSources() {
+        List<CustomerSource> customerSourceList = new ArrayList<CustomerSource>();
+        CustomerSource cardCustomerSource = Mockito.mock(CustomerSource.class);
+        Card card = Mockito.mock(Card.class);
+        Mockito.when(cardCustomerSource.asCard()).thenReturn(card);
+        CustomerSource nonCardCustomerSource = Mockito.mock(CustomerSource.class);
+        customerSourceList.add(cardCustomerSource);
+        customerSourceList.add(nonCardCustomerSource);
+        Customer customer = Mockito.mock(Customer.class);
+        Mockito.when(customer.getSources()).thenReturn(customerSourceList);
+
+        mMaskedCardAdapter.updateCustomer(customer);
+
+        assertEquals(1, mMaskedCardAdapter.getItemCount());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
@@ -2,7 +2,6 @@ package com.stripe.android.view;
 
 import android.support.v4.graphics.ColorUtils;
 import android.support.v7.widget.AppCompatImageView;
-import android.support.v7.widget.AppCompatTextView;
 import android.view.View;
 
 import com.stripe.android.BuildConfig;
@@ -15,6 +14,7 @@ import com.stripe.android.model.SourceCardData;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
@@ -156,5 +156,13 @@ public class MaskedCardViewTest {
         mMaskedCardView.toggleSelected();
         assertFalse(mMaskedCardView.isSelected());
         assertEquals(View.INVISIBLE, mSelectedImageView.getVisibility());
+    }
+
+    @Test
+    public void whenSourceNotCard_doesNotCrash() {
+        SourceCardData sourceCardData = Mockito.mock(SourceCardData.class);
+        Mockito.when(sourceCardData.getBrand()).thenReturn("unrecognized_brand");
+        Mockito.when(sourceCardData.getLast4()).thenReturn("");
+        mMaskedCardView.setSourceCardData(sourceCardData);
     }
 }


### PR DESCRIPTION
Two fixes with tests here
1. MaskedCardAdapter should only attempt to show sources that are cards. Previously, update customer wasn't checking that.
2. Non card sources were crashing the app because it was attempting to find an icon in a hashmap. Instead of crashes, we don't render a brand specific icon.

r? @joeydong-stripe 
