### PR TITLE
Rename methods to include params

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -157,7 +157,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
                             @Override
                             public PaymentIntent call() throws Exception {
                                 PaymentIntentParams paymentIntentParams =
-                                        PaymentIntentParams.createRetrievePaymentIntent(clientSecret);
+                                        PaymentIntentParams.createRetrievePaymentIntentParams(clientSecret);
                                 return mStripe.retrievePaymentIntentSynchronous(
                                         paymentIntentParams,
                                         PaymentConfiguration.getInstance().getPublishableKey());
@@ -207,7 +207,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
                             @Override
                             public PaymentIntent call() throws Exception {
                                 PaymentIntentParams paymentIntentParams =
-                                        PaymentIntentParams.createConfirmPaymentIntentWithSourceData(
+                                        PaymentIntentParams.createConfirmPaymentIntentWithSourceDataParams(
                                                 sourceParams,
                                                 clientSecret,
                                                 RETURN_URL);

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
@@ -43,7 +43,7 @@ public class PaymentIntentParams {
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
-    public static PaymentIntentParams createConfirmPaymentIntentWithSourceData(
+    public static PaymentIntentParams createConfirmPaymentIntentWithSourceDataParams(
             @Nullable SourceParams sourceParams,
             @NonNull String clientSecret,
             @Nullable String returnUrl) {
@@ -65,7 +65,7 @@ public class PaymentIntentParams {
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
-    public static PaymentIntentParams createConfirmPaymentIntentWithSourceId(
+    public static PaymentIntentParams createConfirmPaymentIntentWithSourceIdParams(
             @Nullable String sourceId,
             @NonNull String clientSecret,
             @Nullable String returnUrl) {
@@ -82,7 +82,7 @@ public class PaymentIntentParams {
      * @return params that can be used to retrieve a PaymentIntent
      */
     @NonNull
-    public static PaymentIntentParams createRetrievePaymentIntent(
+    public static PaymentIntentParams createRetrievePaymentIntentParams(
             @NonNull String clientSecret) {
         return new PaymentIntentParams().setClientSecret(clientSecret);
     }

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -273,7 +273,7 @@ public class StripeApiHandlerTest {
         try {
 
             Card card = new Card("4242424242424242", 1, 2050, "123");
-            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createConfirmPaymentIntentWithSourceData(
+            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createConfirmPaymentIntentWithSourceDataParams(
                     SourceParams.createCardParams(card),
                     clientSecret,
                     null
@@ -300,7 +300,7 @@ public class StripeApiHandlerTest {
         String publicKey = "put a public key that matches the private key here";
         String sourceId = "id of the source created on the backend";
         try {
-            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createConfirmPaymentIntentWithSourceId(
+            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createConfirmPaymentIntentWithSourceIdParams(
                     sourceId,
                     clientSecret,
                     null
@@ -326,7 +326,7 @@ public class StripeApiHandlerTest {
         String publicKey = "put a public key that matches the private key here";
         try {
 
-            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createRetrievePaymentIntent(
+            PaymentIntentParams paymentIntentParams = PaymentIntentParams.createRetrievePaymentIntentParams(
                     clientSecret
             );
             PaymentIntent paymentIntent = StripeApiHandler.retrievePaymentIntent(

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
@@ -38,7 +38,7 @@ public class PaymentIntentParamsTest {
     @Test
     public void createConfirmPaymentIntentWithSourceData_withAllFields_hasExpectedFields() {
         SourceParams sourceParams = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
-        PaymentIntentParams params = PaymentIntentParams.createConfirmPaymentIntentWithSourceData(
+        PaymentIntentParams params = PaymentIntentParams.createConfirmPaymentIntentWithSourceDataParams(
                 sourceParams,
                 TEST_CLIENT_SECRET,
                 TEST_RETURN_URL);
@@ -50,7 +50,7 @@ public class PaymentIntentParamsTest {
 
     @Test
     public void createConfirmPaymentIntentWithSourceId_withAllFields_hasExpectedFields() {
-        PaymentIntentParams params = PaymentIntentParams.createConfirmPaymentIntentWithSourceId(
+        PaymentIntentParams params = PaymentIntentParams.createConfirmPaymentIntentWithSourceIdParams(
                 TEST_SOURCE_ID,
                 TEST_CLIENT_SECRET,
                 TEST_RETURN_URL);
@@ -62,7 +62,7 @@ public class PaymentIntentParamsTest {
 
     @Test
     public void createRetrievePaymentIntentWithSourceId_hasExpectedFields() {
-        PaymentIntentParams params = PaymentIntentParams.createRetrievePaymentIntent(
+        PaymentIntentParams params = PaymentIntentParams.createRetrievePaymentIntentParams(
                 TEST_CLIENT_SECRET);
 
         Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
@@ -91,7 +91,7 @@ public class PaymentIntentParamsTest {
 
     @Test
     public void toParamMap_whenExtraParamsProvided_createsExpectedMap() {
-        PaymentIntentParams paymentIntentParams = PaymentIntentParams.createRetrievePaymentIntent(
+        PaymentIntentParams paymentIntentParams = PaymentIntentParams.createRetrievePaymentIntentParams(
                 TEST_CLIENT_SECRET);
         Map<String, Object> extraParams = new HashMap<>();
         String extraParamKey1 = "extra_param_key_1";


### PR DESCRIPTION
Per https://www.google.com/url?hl=en&q=https://git.corp.stripe.com/stripe-internal/pay-server/pull/100790%23discussion_r350269&source=gmail&ust=1531590867887000&usg=AFQjCNH-8yMe9QkzB2CutxftNNIUqmaCIg

Separate from this we will want to make sure we update all the docs to contain the strong method string names 