### PR TITLE
Method to only cancel async calls without destroying CustomerSessions instance.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -79,7 +79,7 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
     // A queue of Runnables for doing customer updates
     private final BlockingQueue<Runnable> mNetworkQueue = new LinkedBlockingQueue<>();
 
-    private @NonNull ThreadPoolExecutor mThreadPoolExecutor;
+    private final @NonNull ThreadPoolExecutor mThreadPoolExecutor;
 
     private static final int CUSTOMER_RETRIEVED = 7;
     private static final int CUSTOMER_ERROR = 11;
@@ -133,21 +133,6 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         clearInstance();
     }
 
-    /**
-     * End any async calls in process and will not invoke callback listeners.
-     * It will not clear the singleton instance of a {@link CustomerSession} so it can be
-     * safely used when a view is being removed/destroyed to avoid null pointer exceptions
-     * due to async operation delay.
-     * No need to call {@link CustomerSession#initCustomerSession(EphemeralKeyProvider)} again
-     * after this operation.
-     */
-    public static void cancelCallbacks(){
-        if (mInstance == null) {
-            return;
-        }
-        mInstance.mThreadPoolExecutor.shutdownNow();
-    }
-
     @VisibleForTesting
     static void initCustomerSession(
             @NonNull EphemeralKeyProvider keyProvider,
@@ -158,11 +143,23 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
 
     @VisibleForTesting
     static void clearInstance() {
+        cancelCallbacks();
+        mInstance = null;
+    }
+
+    /**
+     * End any async calls in process and will not invoke callback listeners.
+     * It will not clear the singleton instance of a {@link CustomerSession} so it can be
+     * safely used when a view is being removed/destroyed to avoid null pointer exceptions
+     * due to async operation delay.
+     * No need to call {@link CustomerSession#initCustomerSession(EphemeralKeyProvider)} again
+     * after this operation.
+     */
+    public static void cancelCallbacks() {
         if (mInstance == null) {
             return;
         }
         mInstance.mThreadPoolExecutor.shutdownNow();
-        mInstance = null;
     }
 
     private CustomerSession(

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -133,6 +133,21 @@ public class CustomerSession implements EphemeralKeyManager.KeyManagerListener {
         clearInstance();
     }
 
+    /**
+     * End any async calls in process and will not invoke callback listeners.
+     * It will not clear the singleton instance of a {@link CustomerSession} so it can be
+     * safely used when a view is being removed/destroyed to avoid null pointer exceptions
+     * due to async operation delay.
+     * No need to call {@link CustomerSession#initCustomerSession(EphemeralKeyProvider)} again
+     * after this operation.
+     */
+    public static void cancelCallbacks(){
+        if (mInstance == null) {
+            return;
+        }
+        mInstance.mThreadPoolExecutor.shutdownNow();
+    }
+
     @VisibleForTesting
     static void initCustomerSession(
             @NonNull EphemeralKeyProvider keyProvider,


### PR DESCRIPTION
Added a static method to cancel async calls without clearing the user session.
This will be helpful when a view is destroyed but the network call has not ended, to avoid null pointer exceptions in callbacks for views references.
In reference to my issue #576 
