### PR TITLE
Deprecate ShouldUseSourcesForCard setting

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -16,7 +16,7 @@ public class PaymentConfiguration {
     private @NonNull String mPublishableKey;
     private @Address.RequiredBillingAddressFields
     int mRequiredBillingAddressFields;
-    private boolean mShouldUseSourcesForCards;
+    private boolean mShouldUseSourcesForCards; // deprecated- this value is not used.
     private Currency mCurrency;
 
     private PaymentConfiguration(@NonNull String publishableKey) {
@@ -55,10 +55,12 @@ public class PaymentConfiguration {
         return this;
     }
 
+    @Deprecated
     public boolean getShouldUseSourcesForCards() {
         return mShouldUseSourcesForCards;
     }
 
+    @Deprecated
     @NonNull
     public PaymentConfiguration setShouldUseSourcesForCards(boolean shouldUseSourcesForCards) {
         mShouldUseSourcesForCards = shouldUseSourcesForCards;

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
@@ -38,19 +38,16 @@ public class PaymentConfigurationTest {
         PaymentConfiguration payConfig = PaymentConfiguration.getInstance();
         assertEquals("pk_test_key", payConfig.getPublishableKey());
         assertEquals(Address.RequiredBillingAddressFields.NONE, payConfig.getRequiredBillingAddressFields());
-        assertTrue(payConfig.getShouldUseSourcesForCards());
     }
 
     @Test
     public void setValues_setsForSingletonInstance() {
         PaymentConfiguration.init("pk_test_key");
         PaymentConfiguration.getInstance()
-                .setRequiredBillingAddressFields(Address.RequiredBillingAddressFields.FULL)
-                .setShouldUseSourcesForCards(false);
+                .setRequiredBillingAddressFields(Address.RequiredBillingAddressFields.FULL);
 
         assertEquals("pk_test_key", PaymentConfiguration.getInstance().getPublishableKey());
         assertEquals(Address.RequiredBillingAddressFields.FULL,
                 PaymentConfiguration.getInstance().getRequiredBillingAddressFields());
-        assertFalse(PaymentConfiguration.getInstance().getShouldUseSourcesForCards());
     }
 }


### PR DESCRIPTION
r? @ksun-stripe 
cc @stripe/api-libraries 

Per #623, although it is possible to set `ShouldUseSourcesForCard=false`, which implies that it should result in the PaymentSession creating Card objects, currently this functionality is not implemented, so the setting is confusing.

Given that, there are a couple of options:
1. add the functionality to create cards to CustomerSession(adding `addCustomerCard` etc methods) connected to the existing setting.
2. deprecate this setting and/or remove it.

However, as a point against 1), in general it seems that we would prefer to only support Sources going forward in the SDK(ref #573 #453 #582)

Therefore this PR takes approach 2), given the context that in general we may want to only support the usage of Sources. Although stripe-ios has a [similar setting](https://stripe.github.io/stripe-ios/docs/Classes/STPPaymentConfiguration.html#/c:objc(cs)STPPaymentConfiguration(py)createCardSources), it also has support for working with cards(e.g. [didCreateToken](https://stripe.github.io/stripe-ios/docs/Protocols/STPAddCardViewControllerDelegate.html#/c:objc(pl)STPAddCardViewControllerDelegate(im)addCardViewController:didCreateToken:completion:)) which stripe-android does not have currently, and it's not clear if we intend to build such support in future. If we do, then feel free to close this PR!