### PR TITLE
Use Canadian and UK postal code validation instead of US validation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.java
@@ -156,10 +156,10 @@ public class ShippingInfoWidget extends LinearLayout {
             postalCodeValid = CountryUtils.isUSZipCodeValid(mPostalCodeEditText.getText()
                     .toString().trim());
         } else if (countrySelected.equals(Locale.UK.getCountry())) {
-            postalCodeValid = CountryUtils.isUSZipCodeValid(mPostalCodeEditText.getText()
+            postalCodeValid = CountryUtils.isUKPostcodeValid(mPostalCodeEditText.getText()
                     .toString().trim());
         } else if (countrySelected.equals(Locale.CANADA.getCountry())) {
-            postalCodeValid = CountryUtils.isUSZipCodeValid(mPostalCodeEditText.getText()
+            postalCodeValid = CountryUtils.isCanadianPostalCodeValid(mPostalCodeEditText.getText()
                     .toString().trim());
         } else if (CountryUtils.doesCountryUsePostalCode(countrySelected)) {
             postalCodeValid = !mPostalCodeEditText.getText().toString().isEmpty();


### PR DESCRIPTION
Updated the ShippingInfoWidget to use the correct functions to validate Canadian and UK postal codes