### PR TITLE
Token fromString handles nulls

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -156,6 +156,9 @@ public class Token implements StripePaymentSource {
 
     @Nullable
     public static Token fromString(@Nullable String jsonString) {
+        if (jsonString == null) {
+            return null;
+        }
         try {
             JSONObject tokenObject = new JSONObject(jsonString);
             return fromJson(tokenObject);

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.java
@@ -151,6 +151,13 @@ public class TokenTest {
         assertNull(answerToken.getBankAccount());
     }
 
+
+    @Test
+    public void parseToken_whenNullString_returnsNull() {
+        Token parsedToken = Token.fromString(null);
+        assertNull(parsedToken);
+    }
+
     @Test
     public void parseToken_whenBankAccount_readsObject() {
         Date createdDate = new Date(1484765567L * 1000L);


### PR DESCRIPTION
Method is marked as nullable but doesn't handle nulls. Update the method to handle nulls in the same manager as the others in the class.
