### PR TITLE
Fix crash on ExpiryDateEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -151,7 +151,8 @@ public class ExpiryDateEditText extends StripeEditText {
                 int cursorPosition = updateSelectionIndex(
                         formattedDate.length(),
                         latestChangeStart,
-                        latestInsertionSize);
+                        latestInsertionSize,
+                        MAX_INPUT_LENGTH);
 
                 ignoreChanges = true;
                 setText(formattedDate);
@@ -206,8 +207,8 @@ public class ExpiryDateEditText extends StripeEditText {
     int updateSelectionIndex(
             int newLength,
             int editActionStart,
-            int editActionAddition) {
-        int newPosition, gapsJumped = 0;
+            int editActionAddition,
+            int maxInputLength) { int newPosition, gapsJumped = 0;
 
         boolean skipBack = false;
         if (editActionStart <= 2 && editActionStart + editActionAddition >= 2) {
@@ -224,8 +225,8 @@ public class ExpiryDateEditText extends StripeEditText {
         if (skipBack && newPosition > 0) {
             newPosition--;
         }
-
-        return newPosition <= newLength ? newPosition : newLength;
+        int untruncatedPosition = newPosition <= newLength ? newPosition : newLength;
+        return Math.min(maxInputLength, untruncatedPosition);
     }
 
     private void updateInputValues(@NonNull @Size(2) String[] parts) {

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -133,17 +133,22 @@ public class ExpiryDateEditTextTest {
 
     @Test
     public void updateSelectionIndex_whenMovingAcrossTheGap_movesToEnd() {
-        assertEquals(3, mExpiryDateEditText.updateSelectionIndex(3, 1, 1));
+        assertEquals(3, mExpiryDateEditText.updateSelectionIndex(3, 1, 1, 5));
     }
 
     @Test
     public void updateSelectionIndex_atStart_onlyMovesForwardByOne() {
-        assertEquals(1, mExpiryDateEditText.updateSelectionIndex(1, 0, 1));
+        assertEquals(1, mExpiryDateEditText.updateSelectionIndex(1, 0, 1, 5));
     }
 
     @Test
     public void updateSelectionIndex_whenDeletingAcrossTheGap_staysAtEnd() {
-        assertEquals(2, mExpiryDateEditText.updateSelectionIndex(2, 4, 0));
+        assertEquals(2, mExpiryDateEditText.updateSelectionIndex(2, 4, 0, 5));
+    }
+
+    @Test
+    public void updateSelectionIndex_whenInputVeryLong_respectMaxInputLength() {
+        assertEquals(5, mExpiryDateEditText.updateSelectionIndex(6, 4, 2, 5));
     }
 
     @Test


### PR DESCRIPTION
r? @danj-stripe @csabol-stripe 

ExpiryDateEditText was crashing. Underlying cause was we were trying to set the cursor to an index beyond the max index specified on the input. 

Max input is 5 characters MM/DD to allow one character for a / 
The slash is added onTextChanged. If a bunch of characters are added in copy paste, 5 characters will get picked up and then a slash will be added making it 6 characters. However, the input will trim the input back to 5 characters.

https://github.com/stripe/stripe-android/issues/563

