### PR TITLE
Changed compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Stripe Android SDK makes it quick and easy to build an excellent payment exp
 No need to clone the repository or download any files -- just add this line to your app's `build.gradle` inside the `dependencies` section:
 
 ```
-compile 'com.stripe:stripe-android:8.0.0'
+implementation 'com.stripe:stripe-android:8.0.0'
 ```
 
 Note: We recommend that you don't use `compile 'com.stripe:stripe-android:+`, as future versions of the SDK may not maintain full backwards compatibility. When such a change occurs, a major version number change will accompany it.


### PR DESCRIPTION
FIX WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.