### PR TITLE
Use dated version in Google Pay example

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
@@ -156,7 +156,7 @@ public class PayWithGoogleActivity extends AppCompatActivity {
                 .addParameter("gateway", "stripe")
                 .addParameter("stripe:publishableKey",
                         PaymentConfiguration.getInstance().getPublishableKey())
-                .addParameter("stripe:version", "5.1.1")
+                .addParameter("stripe:version", "2018-10-31")
                 .build();
     }
 

--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.java
@@ -156,7 +156,7 @@ public class PayWithGoogleActivity extends AppCompatActivity {
                 .addParameter("gateway", "stripe")
                 .addParameter("stripe:publishableKey",
                         PaymentConfiguration.getInstance().getPublishableKey())
-                .addParameter("stripe:version", "2018-10-31")
+                .addParameter("stripe:version", "2018-11-08")
                 .build();
     }
 


### PR DESCRIPTION
Pass a dated version to the Google Pay API in the example activity. Set the string to the current version published on the Stripe developer site.
https://stripe.com/docs/api/versioning