### PR TITLE
Fix NPE in CountryAutocompleteTextView

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.java
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.java
@@ -20,7 +20,8 @@ import java.util.Map;
 public class CountryAutoCompleteTextView extends FrameLayout {
     private AutoCompleteTextView mCountryAutocomplete;
     private Map<String, String> mCountryNameToCode;
-    private String mCountrySelected;
+    @VisibleForTesting
+    protected String mCountrySelected;
     private CountryChangeListener mCountryChangeListener;
 
     public CountryAutoCompleteTextView(Context context) {
@@ -50,6 +51,9 @@ public class CountryAutoCompleteTextView extends FrameLayout {
      *                    the full country display name.
      */
     void setCountrySelected(String countryCode) {
+        if (countryCode == null) {
+            return;
+        }
         Locale locale = new Locale("", countryCode);
         updateUIForCountryEntered(locale.getDisplayCountry());
     }
@@ -69,7 +73,7 @@ public class CountryAutoCompleteTextView extends FrameLayout {
         mCountryAutocomplete.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                String countryEntered =  mCountryAutocomplete.getText().toString();
+                String countryEntered = mCountryAutocomplete.getText().toString();
                 updateUIForCountryEntered(countryEntered);
             }
         });
@@ -79,7 +83,7 @@ public class CountryAutoCompleteTextView extends FrameLayout {
         mCountryAutocomplete.setOnFocusChangeListener(new OnFocusChangeListener() {
             @Override
             public void onFocusChange(View view, boolean focused) {
-                String countryEntered =  mCountryAutocomplete.getText().toString();
+                String countryEntered = mCountryAutocomplete.getText().toString();
                 if (focused) {
                     mCountryAutocomplete.showDropDown();
                 } else {
@@ -100,7 +104,7 @@ public class CountryAutoCompleteTextView extends FrameLayout {
                 }
             }
             mCountryAutocomplete.setText(displayCountryEntered);
-        } else {
+        } else if (mCountrySelected != null) {
             // Revert back to last valid country if country is not recognized.
             String displayCountry = new Locale("", mCountrySelected).getDisplayCountry();
             mCountryAutocomplete.setText(displayCountry);

--- a/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.java
@@ -5,6 +5,7 @@ import android.widget.AutoCompleteTextView;
 import com.stripe.android.BuildConfig;
 import com.stripe.android.R;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +72,18 @@ public class CountryAutoCompleteTextViewTest {
         assertFalse(mAutoCompleteTextView.isPopupShowing());
         mAutoCompleteTextView.requestFocus();
         assertTrue(mAutoCompleteTextView.isPopupShowing());
+    }
+
+    @Test
+    public void updateUIForCountryEntered_whenCountrySelectedNullAndNoLocale_doesNotCrash() {
+        Locale.setDefault(Locale.CHINA);
+        mCountryAutoCompleteTextView.mCountrySelected = null;
+        mCountryAutoCompleteTextView.updateUIForCountryEntered(null);
+    }
+
+    @After
+    public void teardown() {
+        Locale.setDefault(Locale.US);
     }
 
 }

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
@@ -86,13 +86,6 @@ public class ShippingInfoWidgetTest {
     }
 
     @Test
-    public void updateUIForCountryEntered_whenCountrySelectedNullAndNoLocale_doesNotCrash() {
-        Locale.setDefault(Locale.CHINA);
-        mCountryAutoCompleteTextView.mCountrySelected = null;
-        mCountryAutoCompleteTextView.updateUIForCountryEntered(null);
-    }
-
-    @Test
     public void shippingInfoWidget_whenCountryChanged_fieldsRenderCorrectly() {
         mCountryAutoCompleteTextView.updateUIForCountryEntered(Locale.US.getDisplayCountry());
         assertEquals(mAddressLine1TextInputLayout.getHint(), mShippingInfoWidget.getResources().getString(R.string.address_label_address));

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
@@ -86,6 +86,13 @@ public class ShippingInfoWidgetTest {
     }
 
     @Test
+    public void updateUIForCountryEntered_whenCountrySelectedNullAndNoLocale_doesNotCrash() {
+        Locale.setDefault(Locale.CHINA);
+        mCountryAutoCompleteTextView.mCountrySelected = null;
+        mCountryAutoCompleteTextView.updateUIForCountryEntered(null);
+    }
+
+    @Test
     public void shippingInfoWidget_whenCountryChanged_fieldsRenderCorrectly() {
         mCountryAutoCompleteTextView.updateUIForCountryEntered(Locale.US.getDisplayCountry());
         assertEquals(mAddressLine1TextInputLayout.getHint(), mShippingInfoWidget.getResources().getString(R.string.address_label_address));


### PR DESCRIPTION
If the default locale doesn't have a country (ex: China), the country can be null causing an NPE.
Guard against this. What will happen in this case is that the autocomplete textview will not be pre-filled with a country when first loaded.

