### PR TITLE
v8.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+### 8.1.0 2018-11-13
+* Add support for latest version of PaymentIntents
+* Fix NPEs in `CountryAutocompleteTextView`
+* Fix NPEs in `PaymentContext` experiences
+* Helper method for converting tokens to sources
+* Fix bug with Canadian and UK postal code validation
+
 ### 8.0.0 2018-7-13
 * **BREAKING** Renamed PaymentIntentParams methods for readibility [#609](https://github.com/stripe/stripe-android/pull/609)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Stripe Android SDK makes it quick and easy to build an excellent payment exp
 No need to clone the repository or download any files -- just add this line to your app's `build.gradle` inside the `dependencies` section:
 
 ```
-compile 'com.stripe:stripe-android:8.0.0'
+compile 'com.stripe:stripe-android:8.1.0'
 ```
 
 Note: We recommend that you don't use `compile 'com.stripe:stripe-android:+`, as future versions of the SDK may not maintain full backwards compatibility. When such a change occurs, a major version number change will accompany it.

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.stripe.android"
-          android:versionCode="26"
-          android:versionName="8.0.0"
+          android:versionCode="28"
+          android:versionName="8.1.0"
     >
 
     <application>

--- a/stripe/gradle.properties
+++ b/stripe/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.0.0
+VERSION_NAME=8.1.0
 POM_DESCRIPTION=Stripe Android Bindings
 POM_NAME=stripe-android
 POM_ARTIFACT_ID=stripe-android


### PR DESCRIPTION
Updates:

* CHANGELOG
* README
* AndroidManifest.xml - bumped versionCode by 2, since this was skipped for 8.0.0
* gradle.properties