### PR TITLE
Allow more nullable fields on Sepa source

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -465,9 +465,9 @@ public class SourceParams {
             @NonNull String iban,
             @Nullable String email,
             @Nullable String addressLine1,
-            @NonNull String city,
-            @NonNull String postalCode,
-            @NonNull @Size(2) String country) {
+            @Nullable String city,
+            @Nullable String postalCode,
+            @Nullable @Size(2) String country) {
         SourceParams params = new SourceParams()
                 .setType(Source.SEPA_DEBIT)
                 .setCurrency(Source.EURO);

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -636,6 +636,38 @@ public class StripeTest {
         }
     }
 
+
+    @Test
+    public void createSourceSynchronous_withSepaDebitParamsWithMinimalValues_passesIntegrationTest() {
+        Stripe stripe = getNonLoggingStripe(mContext);
+        String validIban = "DE89370400440532013000";
+        SourceParams params = SourceParams.createSepaDebitParams(
+                "Sepa Account Holder",
+                validIban,
+                null,
+                null,
+                null,
+                null,
+                null);
+        Map<String, String> metamap = new HashMap<String, String>() {{
+            put("water source", "well");
+            put("type", "brackish");
+            put("value", "100000");
+        }};
+        params.setMetaData(metamap);
+        try {
+            Source sepaDebitSource =
+                    stripe.createSourceSynchronous(params, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+            assertNotNull(sepaDebitSource);
+            assertNotNull(sepaDebitSource.getClientSecret());
+            assertNotNull(sepaDebitSource.getId());
+            assertEquals(Source.SEPA_DEBIT, sepaDebitSource.getType());
+            JsonTestUtils.assertMapEquals(metamap ,sepaDebitSource.getMetaData());
+        } catch (StripeException stripeEx) {
+            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
+        }
+    }
+
     @Test
     public void createSourceSynchronous_withNoEmail_passesIntegrationTest() {
         Stripe stripe = getNonLoggingStripe(mContext);


### PR DESCRIPTION
Our signature on the sepa source requires more fields than API needs. Make the non-required fields optional.

