### PR TITLE
Fix IconTextInputLayout's reflection issues

### DIFF
--- a/stripe/src/main/java/com/stripe/android/utils/ClassUtils.java
+++ b/stripe/src/main/java/com/stripe/android/utils/ClassUtils.java
@@ -1,0 +1,69 @@
+package com.stripe.android.utils;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Set;
+
+public class ClassUtils {
+    private ClassUtils() {}
+
+    /**
+     *
+     * @param clazz         the class to search in
+     * @param whitelist     the whitelist of field names
+     * @return  the value of the found field, if exists, on the specified {@param obj}, or null
+     */
+    @Nullable
+    public static Object getInternalObject(@NonNull Class clazz, @NonNull Set<String> whitelist,
+                                           @NonNull Object obj) {
+        final Field field = findField(clazz, whitelist);
+        if (field == null) {
+            return null;
+        }
+
+        try {
+            return field.get(obj);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param clazz         the class to search in
+     * @param whitelist     the whitelist of field names
+     * @return  the {@link Field}, made accessible, if one is found, otherwise null
+     */
+    @Nullable
+    public static Field findField(@NonNull Class clazz, @NonNull Collection<String> whitelist) {
+        final Field[] fields = clazz.getDeclaredFields();
+        for (Field field : fields) {
+            if (whitelist.contains(field.getName())) {
+                field.setAccessible(true);
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param clazz         the class to search in
+     * @param whitelist     the whitelist of method names
+     * @return  the {@link Method} if one is found, otherwise null
+     */
+    @Nullable
+    public static Method findMethod(@NonNull Class clazz, @NonNull Collection<String> whitelist) {
+        final Method[] methods = clazz.getDeclaredMethods();
+        for (Method method : methods) {
+            if (whitelist.contains(method.getName())) {
+                return method;
+            }
+        }
+        return null;
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/utils/ClassUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/utils/ClassUtilsTest.java
@@ -1,0 +1,67 @@
+package com.stripe.android.utils;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ClassUtilsTest {
+
+    @Test
+    public void testfindField_withValidWhitelist_shouldReturnField() {
+        final Field nameField = ClassUtils.findField(FakeClass.class, new HashSet<>(
+            Arrays.asList("mInvalid", "mName")
+        ));
+        assertNotNull(nameField);
+        assertEquals("mName", nameField.getName());
+        assertTrue(nameField.isAccessible());
+    }
+
+    @Test
+    public void testfindField_withEmptyWhitelist_shouldReturnNull() {
+        final Field nameField = ClassUtils.findField(FakeClass.class, new HashSet<String>());
+        assertNull(nameField);
+    }
+
+    @Test
+    public void testFindMethod_withValidWhitelist_shouldReturnMethod() {
+        final Method method = ClassUtils.findMethod(FakeClass.class, new HashSet<>(
+                Arrays.asList("walk", "run")
+        ));
+        assertNotNull(method);
+        assertEquals("run", method.getName());
+    }
+
+    @Test
+    public void testgetInternalObject() {
+        final FakeClass fake = new FakeClass();
+        final OuterFakeClass outerClass = new OuterFakeClass(fake);
+        final Object obj = ClassUtils.getInternalObject(OuterFakeClass.class, new HashSet<>(
+                Arrays.asList("mInvalid", "mFakeClass")
+        ), outerClass);
+        assertEquals(fake, obj);
+    }
+
+    private static class OuterFakeClass {
+        private final FakeClass mFakeClass;
+
+        OuterFakeClass(FakeClass fakeClass) {
+            mFakeClass = fakeClass;
+        }
+    }
+
+    private static class FakeClass {
+        private String mName;
+
+        public void run() {
+
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
@@ -1,8 +1,8 @@
 package com.stripe.android.view;
 
+import android.os.Build;
 import android.support.design.widget.TextInputLayout;
 
-import com.stripe.android.BuildConfig;
 import com.stripe.android.R;
 
 import org.junit.Test;
@@ -12,7 +12,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for {@link IconTextInputLayout} to ensure that the Reflection doesn't break
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertNotNull;
  * is no need to otherwise test the behavior.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 25)
+@Config(sdk = Build.VERSION_CODES.N_MR1)
 public class IconTextInputLayoutTest {
 
     @Test
@@ -32,9 +32,6 @@ public class IconTextInputLayoutTest {
                 activityController.get().getCardMultilineWidget()
                         .findViewById(R.id.tl_add_source_card_number_ml);
 
-        assertNotNull(iconTextInputLayout.mCollapsingTextHelper);
-        assertNotNull(iconTextInputLayout.mBounds);
-        assertNotNull(iconTextInputLayout.mRecalculateMethod);
+        assertTrue(iconTextInputLayout.hasObtainedCollapsingTextHelper());
     }
-
 }


### PR DESCRIPTION
The fields that `IconTextInputLayout` attempts to access via reflection have had their names changed in the latest Support Library upgrade, which causes an exception.

This PR fixes the exception by updating the possible field names to include those in the latest Support Library version.

Ideally we'll find a solution that avoids reflection, but for the time being this works on the current and latest Support Library.

See https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/textfield/TextInputLayout.java for the latest field name

Issue: https://github.com/stripe/stripe-android/issues/663