### PR TITLE
Fix crash in ShippingMethodView on API 16

### DIFF
--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -28,4 +28,5 @@
     <dimen name="shipping_widget_vertical_margin">4dp</dimen>
     <dimen name="shipping_widget_horizontal_margin">16dp</dimen>
     <dimen name="shipping_widget_outer_margin">12dp</dimen>
+    <dimen name="shipping_method_view_height">21dp</dimen>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -27,8 +27,7 @@ public class PaymentSessionData implements Parcelable {
     public PaymentSessionData() { }
 
     /**
-     * Get the selected payment method ID for the associated {@link PaymentSession}.
-     * @return
+     * @return the selected payment method ID for the associated {@link PaymentSession}
      */
     @Nullable
     public String getSelectedPaymentMethodId() {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -37,7 +37,7 @@ import static com.stripe.android.StripeNetworkUtils.hashMapFromPersonalId;
  */
 public class Stripe {
 
-    private SourceCreator mSourceCreator = new SourceCreator() {
+    private final SourceCreator mSourceCreator = new SourceCreator() {
         @Override
         public void create(
                 @NonNull final SourceParams sourceParams,

--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.java
@@ -16,7 +16,7 @@ import java.util.List;
 class ShippingMethodAdapter extends RecyclerView.Adapter<ShippingMethodAdapter.ViewHolder> {
 
     @NonNull private List<ShippingMethod> mShippingMethods = new ArrayList<>();
-    @NonNull private int mSelectedIndex = 0;
+    private int mSelectedIndex = 0;
 
     ShippingMethodAdapter() {}
 
@@ -30,14 +30,16 @@ class ShippingMethodAdapter extends RecyclerView.Adapter<ShippingMethodAdapter.V
         return super.getItemId(position);
     }
 
+    @NonNull
     @Override
-    public ShippingMethodAdapter.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+    public ShippingMethodAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup,
+                                                               int i) {
         ShippingMethodView shippingMethodView = new ShippingMethodView(viewGroup.getContext());
         return new ViewHolder(shippingMethodView);
     }
 
     @Override
-    public void onBindViewHolder(ViewHolder holder, int i) {
+    public void onBindViewHolder(@NonNull ViewHolder holder, int i) {
         holder.setShippingMethod(mShippingMethods.get(i));
         holder.setIndex(i);
         holder.setUIAsSelected(i == mSelectedIndex);

--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodView.java
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodView.java
@@ -1,6 +1,7 @@
 package com.stripe.android.view;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
@@ -71,10 +72,15 @@ class ShippingMethodView extends RelativeLayout {
         mUnselectedTextColorPrimaryInt = getThemeTextColorPrimary(getContext()).data;
         mUnselectedTextColorSecondaryInt = getThemeTextColorSecondary(getContext()).data;
         useDefaultColorsIfThemeColorsAreInvisible();
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(LayoutParams
+
+        final RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(LayoutParams
                 .MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        params.addRule(Gravity.CENTER_VERTICAL);
-        params.height = ViewUtils.getPxFromDp(getContext(), 72);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            params.addRule(Gravity.CENTER_VERTICAL);
+        }
+        final int height = getResources()
+                .getDimensionPixelSize(R.dimen.shipping_method_view_height);
+        params.height = ViewUtils.getPxFromDp(getContext(), height);
         setLayoutParams(params);
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/ShippingMethodViewJellyBeanTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingMethodViewJellyBeanTest.java
@@ -1,0 +1,20 @@
+package com.stripe.android.view;
+
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import androidx.test.core.app.ApplicationProvider;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.JELLY_BEAN)
+public class ShippingMethodViewJellyBeanTest {
+
+    @Test
+    public void testConstructor() {
+        new ShippingMethodView(ApplicationProvider.getApplicationContext());
+    }
+}


### PR DESCRIPTION
`addRule(Gravity.CENTER_VERTICAL)` was causing an `ArrayIndexOutOfBoundsException` because the specified constant is not available on API 16