### PR TITLE
Issuing PIN Management service and utils (+tests)

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api "com.android.support:design:${rootProject.ext.supportLibVersion}"
 
+
+
     javadocDeps "com.android.support:support-annotations:${rootProject.ext.supportLibVersion}"
     javadocDeps "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     javadocDeps "com.android.support:design:${rootProject.ext.supportLibVersion}"
@@ -27,6 +29,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoCoreVersion}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.robolectricVersion}"
     testImplementation 'androidx.test:core:1.1.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.1'
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -18,8 +18,6 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api "com.android.support:design:${rootProject.ext.supportLibVersion}"
 
-
-
     javadocDeps "com.android.support:support-annotations:${rootProject.ext.supportLibVersion}"
     javadocDeps "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     javadocDeps "com.android.support:design:${rootProject.ext.supportLibVersion}"
@@ -29,7 +27,6 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoCoreVersion}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.robolectricVersion}"
     testImplementation 'androidx.test:core:1.1.0'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.1'
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
@@ -35,7 +35,8 @@ class CustomerEphemeralKey extends AbstractEphemeralKey {
 
     }
 
-    protected CustomerEphemeralKey(
+    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
+    public CustomerEphemeralKey(
             @Nullable JSONObject jsonObject
     ) throws JSONException {
         super(jsonObject);

--- a/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
@@ -10,7 +10,7 @@ import org.json.JSONObject;
 
 class CustomerEphemeralKey extends AbstractEphemeralKey {
 
-    protected CustomerEphemeralKey(Parcel in) {
+    protected CustomerEphemeralKey(@NonNull Parcel in) {
         super(in);
     }
 
@@ -35,14 +35,12 @@ class CustomerEphemeralKey extends AbstractEphemeralKey {
 
     }
 
-    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
-    public CustomerEphemeralKey(
+    protected CustomerEphemeralKey(
             @Nullable JSONObject jsonObject
     ) throws JSONException {
         super(jsonObject);
 
     }
-
 
     @NonNull
     String getCustomerId() {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -551,7 +551,9 @@ public class CustomerSession
     }
 
     @Override
-    public void onKeyError(int errorCode, @Nullable String errorMessage) {
+    public void onKeyError(int errorCode,
+                           @Nullable String errorMessage,
+                           @Nullable Map<String, Object> arguments) {
         // Any error eliminates all listeners
 
         if (mCustomerRetrievalListener != null) {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -59,9 +59,11 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
     }
 
-    private void updateKeyError(int errorCode, @Nullable String errorMessage) {
+    private void updateKeyError(int errorCode,
+                                @Nullable String errorMessage,
+                                @Nullable Map<String, Object> arguments) {
         mEphemeralKey = null;
-        mListener.onKeyError(errorCode, errorMessage);
+        mListener.onKeyError(errorCode, errorMessage, arguments);
     }
 
     static boolean shouldRefreshKey(
@@ -84,7 +86,9 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
                          @Nullable String action,
                          @Nullable Map<String, Object> arguments);
 
-        void onKeyError(int errorCode, @Nullable String errorMessage);
+        void onKeyError(int errorCode,
+                        @Nullable String errorMessage,
+                        @Nullable Map<String, Object> arguments);
     }
 
     private static class ClientKeyUpdateListener implements EphemeralKeyUpdateListener {
@@ -115,7 +119,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         public void onKeyUpdateFailure(int responseCode, @Nullable String message) {
             final EphemeralKeyManager keyManager = mEphemeralKeyManagerWeakReference.get();
             if (keyManager != null) {
-                keyManager.updateKeyError(responseCode, message);
+                keyManager.updateKeyError(responseCode, message, mArguments);
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -63,7 +63,8 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         } catch (JSONException e) {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "The JSON from the key could not be parsed: "
-                            + e.getLocalizedMessage());
+                            + e.getLocalizedMessage(),
+                    arguments);
         }
         mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
     }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -62,7 +62,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
         } catch (JSONException e) {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
-                    "The JSON from the key could not be parsed: "
+                    "The JSON for the ephemeral key could not be parsed: "
                             + e.getLocalizedMessage(),
                     arguments);
         }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
@@ -63,7 +63,7 @@ class IssuingCardEphemeralKey extends AbstractEphemeralKey {
     };
 
     @Nullable
-    static IssuingCardEphemeralKey fromString(@Nullable String rawJson) {
+    static IssuingCardEphemeralKey fromString(@Nullable String rawJson) throws JSONException {
         return (IssuingCardEphemeralKey) AbstractEphemeralKey
                 .fromString(rawJson, IssuingCardEphemeralKey.class);
     }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
@@ -34,7 +34,6 @@ class IssuingCardEphemeralKey extends AbstractEphemeralKey {
 
     }
 
-    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
     public IssuingCardEphemeralKey(
             @Nullable JSONObject jsonObject
     ) throws JSONException {

--- a/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
@@ -1,0 +1,76 @@
+package com.stripe.android;
+
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+class IssuingCardEphemeralKey extends AbstractEphemeralKey {
+
+    protected IssuingCardEphemeralKey(Parcel in) {
+        super(in);
+    }
+
+    protected IssuingCardEphemeralKey(
+            long created,
+            @NonNull String issuingCardId,
+            long expires,
+            @NonNull String id,
+            boolean liveMode,
+            @NonNull String object,
+            @NonNull String secret,
+            @NonNull String type
+    ) {
+        super(created,
+                issuingCardId,
+                expires,
+                id,
+                liveMode,
+                object,
+                secret,
+                type);
+
+    }
+
+    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
+    public IssuingCardEphemeralKey(
+            @Nullable JSONObject jsonObject
+    ) throws JSONException {
+        super(jsonObject);
+
+    }
+
+
+    @NonNull
+    public String getIssuingCardId() {
+        return mObjectId;
+    }
+
+    public static final Creator<IssuingCardEphemeralKey> CREATOR
+            = new Creator<IssuingCardEphemeralKey>() {
+
+        @Override
+        public IssuingCardEphemeralKey createFromParcel(Parcel in) {
+            return new IssuingCardEphemeralKey(in);
+        }
+
+        @Override
+        public IssuingCardEphemeralKey[] newArray(int size) {
+            return new IssuingCardEphemeralKey[size];
+        }
+    };
+
+    @Nullable
+    static IssuingCardEphemeralKey fromString(@Nullable String rawJson) {
+        return (IssuingCardEphemeralKey) AbstractEphemeralKey
+                .fromString(rawJson, IssuingCardEphemeralKey.class);
+    }
+
+    @Nullable
+    static IssuingCardEphemeralKey fromJson(@Nullable JSONObject jsonObject) {
+        return (IssuingCardEphemeralKey) AbstractEphemeralKey
+                .fromJson(jsonObject, IssuingCardEphemeralKey.class);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
@@ -34,6 +34,7 @@ class IssuingCardEphemeralKey extends AbstractEphemeralKey {
 
     }
 
+    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
     public IssuingCardEphemeralKey(
             @Nullable JSONObject jsonObject
     ) throws JSONException {

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -43,6 +43,7 @@ public class IssuingCardPinService
      * @param keyProvider an {@link EphemeralKeyProvider} used to get
      *                    {@link CustomerEphemeralKey EphemeralKeys} as needed
      */
+    @NonNull
     public static IssuingCardPinService create(@NonNull EphemeralKeyProvider keyProvider) {
         return new IssuingCardPinService(keyProvider);
     }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -111,7 +111,8 @@ public class IssuingCardPinService
     public void onKeyUpdate(
             @Nullable IssuingCardEphemeralKey ephemeralKey,
             @Nullable String action,
-            @Nullable Map<String, Object> arguments) {
+            @Nullable Map<String, Object> arguments
+    ) {
 
         if (PIN_RETRIEVE.equals(action)) {
             String cardId = (String) arguments.get("cardId");

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -81,13 +81,13 @@ public class IssuingCardPinService
 
     @Nullable
     private <Listener> Listener getListener(@Nullable Map<String, Object> arguments) {
-        if(arguments == null){
+        if (arguments == null) {
             return null;
         }
         WeakReference<Listener> listenerReference =
                 (WeakReference<Listener>) arguments.get(ARGUMENT_LISTENER);
-        if(listenerReference == null){
-            return  null;
+        if (listenerReference == null) {
+            return null;
         }
         return listenerReference.get();
     }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -24,7 +24,6 @@ public class IssuingCardPinService
     private static final String PIN_RETRIEVE = "PIN_RETRIEVE";
     private static final String PIN_UPDATE = "PIN_UPDATE";
 
-    private static IssuingCardPinService mInstance;
     private @NonNull
     EphemeralKeyManager<IssuingCardEphemeralKey> mEphemeralKeyManager;
     private IssuingCardPinRetrievalListener mCardPinRetrievalListener;
@@ -47,9 +46,8 @@ public class IssuingCardPinService
      * @param keyProvider an {@link EphemeralKeyProvider} used to get
      *                    {@link CustomerEphemeralKey EphemeralKeys} as needed
      */
-    public static IssuingCardPinService init(@NonNull EphemeralKeyProvider keyProvider) {
-        mInstance = new IssuingCardPinService(keyProvider);
-        return mInstance;
+    public static IssuingCardPinService create(@NonNull EphemeralKeyProvider keyProvider) {
+        return new IssuingCardPinService(keyProvider);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -112,7 +112,8 @@ public class IssuingCardPinService
             String cardId = (String) arguments.get("cardId");
             String verificationId = (String) arguments.get("verificationId");
             String userOneTimeCode = (String) arguments.get("userOneTimeCode");
-            IssuingCardPinRetrievalListener listener = (IssuingCardPinRetrievalListener) arguments.get("listener");
+            IssuingCardPinRetrievalListener listener =
+                    (IssuingCardPinRetrievalListener) arguments.get("listener");
 
             try {
                 String pin = StripeApiHandler.retrieveIssuingCardPin(
@@ -168,7 +169,8 @@ public class IssuingCardPinService
             String newPin = (String) arguments.get("newPin");
             String verificationId = (String) arguments.get("verificationId");
             String userOneTimeCode = (String) arguments.get("userOneTimeCode");
-            IssuingCardPinUpdateListener listener = (IssuingCardPinUpdateListener) arguments.get("listener");
+            IssuingCardPinUpdateListener listener =
+                    (IssuingCardPinUpdateListener) arguments.get("listener");
 
             try {
                 StripeApiHandler.updateIssuingCardPin(
@@ -226,7 +228,7 @@ public class IssuingCardPinService
                            @Nullable String errorMessage,
                            @Nullable Map<String, Object> arguments) {
         Object listener = arguments.get("listener");
-        if(listener == null){
+        if (listener == null){
             return;
         }
         if (listener instanceof IssuingCardPinRetrievalListener) {

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -23,9 +23,8 @@ public class IssuingCardPinService
     private static final long KEY_REFRESH_BUFFER_IN_SECONDS = 30L;
     private static final String PIN_RETRIEVE = "PIN_RETRIEVE";
     private static final String PIN_UPDATE = "PIN_UPDATE";
-
-    private @NonNull
-    EphemeralKeyManager<IssuingCardEphemeralKey> mEphemeralKeyManager;
+    @NonNull
+    private final EphemeralKeyManager<IssuingCardEphemeralKey> mEphemeralKeyManager;
     private IssuingCardPinRetrievalListener mCardPinRetrievalListener;
     private IssuingCardPinUpdateListener mCardPinUpdateListener;
 

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -17,7 +17,8 @@ import java.util.Map;
 /*
  * Methods for retrieval / update of a Stripe Issuing card
  */
-public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerListener<IssuingCardEphemeralKey> {
+public class IssuingCardPinService
+        implements EphemeralKeyManager.KeyManagerListener<IssuingCardEphemeralKey> {
 
     private static final long KEY_REFRESH_BUFFER_IN_SECONDS = 30L;
     private static final String PIN_RETRIEVE = "PIN_RETRIEVE";
@@ -107,14 +108,21 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
     }
 
     @Override
-    public void onKeyUpdate(@Nullable IssuingCardEphemeralKey ephemeralKey, @Nullable String action, @Nullable Map<String, Object> arguments) {
+    public void onKeyUpdate(
+            @Nullable IssuingCardEphemeralKey ephemeralKey,
+            @Nullable String action,
+            @Nullable Map<String, Object> arguments) {
 
         if (PIN_RETRIEVE.equals(action)) {
             String cardId = (String) arguments.get("cardId");
             String verificationId = (String) arguments.get("verificationId");
             String userOneTimeCode = (String) arguments.get("userOneTimeCode");
             try {
-                String pin = StripeApiHandler.retrieveIssuingCardPin(cardId, verificationId, userOneTimeCode, ephemeralKey.getSecret());
+                String pin = StripeApiHandler.retrieveIssuingCardPin(
+                        cardId,
+                        verificationId,
+                        userOneTimeCode,
+                        ephemeralKey.getSecret());
 
                 if (mCardPinRetrievalListener != null) {
                     mCardPinRetrievalListener.onIssuingCardPinRetrieved(pin);
@@ -122,20 +130,39 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
             } catch (InvalidRequestException e) {
                 if (mCardPinRetrievalListener != null) {
                     if ("expired".equals(e.getCode())) {
-                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_EXPIRED, "The one-time code has expired", null);
+                        mCardPinRetrievalListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_EXPIRED,
+                                "The one-time code has expired",
+                                null);
                     }
                     if ("incorrect_code".equals(e.getCode())) {
-                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_INCORRECT, "The one-time code was incorrect", null);
+                        mCardPinRetrievalListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_INCORRECT,
+                                "The one-time code was incorrect",
+                                null);
                     }
                     if ("too_many_attempts".equals(e.getCode())) {
-                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS, "The verification challenge was attempted too many times", null);
+                        mCardPinRetrievalListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
+                                "The verification challenge was attempted too many times",
+                                null);
                     } else {
-                        mCardPinRetrievalListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                        mCardPinRetrievalListener.onError(
+                                CardPinActionError.UNKNOWN_ERROR,
+                                "An error occurred retrieving the PIN",
+                                e);
                     }
                 }
-            } catch (APIConnectionException | APIException | AuthenticationException | JSONException | CardException e) {
+            } catch (APIConnectionException |
+                    APIException |
+                    AuthenticationException |
+                    JSONException |
+                    CardException e) {
                 if (mCardPinRetrievalListener != null) {
-                    mCardPinRetrievalListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                    mCardPinRetrievalListener.onError(
+                            CardPinActionError.UNKNOWN_ERROR,
+                            "An error occurred retrieving the PIN",
+                            e);
                 }
             }
         }
@@ -145,7 +172,12 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
             String verificationId = (String) arguments.get("verificationId");
             String userOneTimeCode = (String) arguments.get("userOneTimeCode");
             try {
-                StripeApiHandler.updateIssuingCardPin(cardId, newPin, verificationId, userOneTimeCode, ephemeralKey.getSecret());
+                StripeApiHandler.updateIssuingCardPin(
+                        cardId,
+                        newPin,
+                        verificationId,
+                        userOneTimeCode,
+                        ephemeralKey.getSecret());
 
                 if (mCardPinUpdateListener != null) {
                     mCardPinUpdateListener.onIssuingCardPinUpdated();
@@ -153,20 +185,38 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
             } catch (InvalidRequestException e) {
                 if (mCardPinUpdateListener != null) {
                     if ("expired".equals(e.getCode())) {
-                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_EXPIRED, "The one-time code has expired", null);
+                        mCardPinUpdateListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_EXPIRED,
+                                "The one-time code has expired",
+                                null);
                     }
                     if ("incorrect_code".equals(e.getCode())) {
-                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_INCORRECT, "The one-time code was incorrect", null);
+                        mCardPinUpdateListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_INCORRECT,
+                                "The one-time code was incorrect",
+                                null);
                     }
                     if ("too_many_attempts".equals(e.getCode())) {
-                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS, "The verification challenge was attempted too many times", null);
+                        mCardPinUpdateListener.onError(
+                                CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
+                                "The verification challenge was attempted too many times",
+                                null);
                     } else {
-                        mCardPinUpdateListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                        mCardPinUpdateListener.onError(
+                                CardPinActionError.UNKNOWN_ERROR,
+                                "An error occurred retrieving the PIN",
+                                e);
                     }
                 }
-            } catch (APIConnectionException | APIException | AuthenticationException | CardException e) {
+            } catch (APIConnectionException |
+                    APIException |
+                    AuthenticationException |
+                    CardException e) {
                 if (mCardPinUpdateListener != null) {
-                    mCardPinUpdateListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                    mCardPinUpdateListener.onError(
+                            CardPinActionError.UNKNOWN_ERROR,
+                            "An error occurred retrieving the PIN",
+                            e);
                 }
             }
         }
@@ -175,10 +225,16 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
     @Override
     public void onKeyError(int errorCode, @Nullable String errorMessage) {
         if (mCardPinRetrievalListener != null) {
-            mCardPinRetrievalListener.onError(CardPinActionError.EPHEMERAL_KEY_ERROR, errorMessage, null);
+            mCardPinRetrievalListener.onError(
+                    CardPinActionError.EPHEMERAL_KEY_ERROR,
+                    errorMessage,
+                    null);
         }
         if (mCardPinUpdateListener != null) {
-            mCardPinUpdateListener.onError(CardPinActionError.EPHEMERAL_KEY_ERROR, errorMessage, null);
+            mCardPinUpdateListener.onError(
+                    CardPinActionError.EPHEMERAL_KEY_ERROR,
+                    errorMessage,
+                    null);
         }
     }
 
@@ -193,13 +249,19 @@ public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerList
     public interface IssuingCardPinRetrievalListener {
         void onIssuingCardPinRetrieved(@NonNull String pin);
 
-        void onError(CardPinActionError errorCode, @Nullable String errorMessage, @Nullable Throwable exception);
+        void onError(
+                CardPinActionError errorCode,
+                @Nullable String errorMessage,
+                @Nullable Throwable exception);
     }
 
     public interface IssuingCardPinUpdateListener {
         void onIssuingCardPinUpdated();
 
-        void onError(CardPinActionError errorCode, @Nullable String errorMessage, @Nullable Throwable exception);
+        void onError(
+                CardPinActionError errorCode,
+                @Nullable String errorMessage,
+                @Nullable Throwable exception);
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -1,0 +1,205 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.exception.APIConnectionException;
+import com.stripe.android.exception.APIException;
+import com.stripe.android.exception.AuthenticationException;
+import com.stripe.android.exception.CardException;
+import com.stripe.android.exception.InvalidRequestException;
+
+import org.json.JSONException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * Methods for retrieval / update of a Stripe Issuing card
+ */
+public class IssuingCardPinService implements EphemeralKeyManager.KeyManagerListener<IssuingCardEphemeralKey> {
+
+    private static final long KEY_REFRESH_BUFFER_IN_SECONDS = 30L;
+    private static final String PIN_RETRIEVE = "PIN_RETRIEVE";
+    private static final String PIN_UPDATE = "PIN_UPDATE";
+
+    private static IssuingCardPinService mInstance;
+    private @NonNull
+    EphemeralKeyManager<IssuingCardEphemeralKey> mEphemeralKeyManager;
+    private IssuingCardPinRetrievalListener mCardPinRetrievalListener;
+    private IssuingCardPinUpdateListener mCardPinUpdateListener;
+
+    private IssuingCardPinService(
+            @NonNull EphemeralKeyProvider keyProvider
+    ) {
+        mEphemeralKeyManager = new EphemeralKeyManager<>(
+                keyProvider,
+                this,
+                KEY_REFRESH_BUFFER_IN_SECONDS,
+                null,
+                IssuingCardEphemeralKey.class);
+    }
+
+    /**
+     * Create a IssuingCardPinService with the provided {@link EphemeralKeyProvider}.
+     *
+     * @param keyProvider an {@link EphemeralKeyProvider} used to get
+     *                    {@link CustomerEphemeralKey EphemeralKeys} as needed
+     */
+    public static IssuingCardPinService init(@NonNull EphemeralKeyProvider keyProvider) {
+        mInstance = new IssuingCardPinService(keyProvider);
+        return mInstance;
+    }
+
+    /**
+     * Retrieves a PIN for a given card
+     *
+     * @param cardId          the ID of the card (looks like ic_abcdef1234)
+     * @param verificationId  the ID of the verification that was sent to the cardholder
+     *                        (typically server-side, through /v1/issuing/verifications)
+     * @param userOneTimeCode the one-time code that was sent to the cardholder through sms or email
+     * @param listener        a listener for either the PIN, or any error that can occur
+     */
+    public void retrievePin(
+            @NonNull String cardId,
+            @NonNull String verificationId,
+            @NonNull String userOneTimeCode,
+            @Nullable IssuingCardPinRetrievalListener listener
+    ) {
+        mCardPinUpdateListener = null;
+        mCardPinRetrievalListener = listener;
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("cardId", cardId);
+        arguments.put("verificationId", verificationId);
+        arguments.put("userOneTimeCode", userOneTimeCode);
+
+        mEphemeralKeyManager.retrieveEphemeralKey(PIN_RETRIEVE, arguments);
+    }
+
+    /**
+     * Retrieves a PIN for a given card
+     *
+     * @param cardId          the ID of the card (looks like ic_abcdef1234)
+     * @param newPin          the new desired PIN
+     * @param verificationId  the ID of the verification that was sent to the cardholder
+     *                        (typically server-side, through /v1/issuing/verifications)
+     * @param userOneTimeCode the one-time code that was sent to the cardholder through sms or email
+     * @param listener        a listener for either the PIN, or any error that can occur
+     */
+    public void updatePin(
+            @NonNull String cardId,
+            @NonNull String newPin,
+            @NonNull String verificationId,
+            @NonNull String userOneTimeCode,
+            @Nullable IssuingCardPinUpdateListener listener
+    ) {
+        mCardPinRetrievalListener = null;
+        mCardPinUpdateListener = listener;
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("cardId", cardId);
+        arguments.put("newPin", newPin);
+        arguments.put("verificationId", verificationId);
+        arguments.put("userOneTimeCode", userOneTimeCode);
+
+        mEphemeralKeyManager.retrieveEphemeralKey(PIN_UPDATE, arguments);
+    }
+
+    @Override
+    public void onKeyUpdate(@Nullable IssuingCardEphemeralKey ephemeralKey, @Nullable String action, @Nullable Map<String, Object> arguments) {
+
+        if (PIN_RETRIEVE.equals(action)) {
+            String cardId = (String) arguments.get("cardId");
+            String verificationId = (String) arguments.get("verificationId");
+            String userOneTimeCode = (String) arguments.get("userOneTimeCode");
+            try {
+                String pin = StripeApiHandler.retrieveIssuingCardPin(cardId, verificationId, userOneTimeCode, ephemeralKey.getSecret());
+
+                if (mCardPinRetrievalListener != null) {
+                    mCardPinRetrievalListener.onIssuingCardPinRetrieved(pin);
+                }
+            } catch (InvalidRequestException e) {
+                if (mCardPinRetrievalListener != null) {
+                    if ("expired".equals(e.getCode())) {
+                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_EXPIRED, "The one-time code has expired", null);
+                    }
+                    if ("incorrect_code".equals(e.getCode())) {
+                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_INCORRECT, "The one-time code was incorrect", null);
+                    }
+                    if ("too_many_attempts".equals(e.getCode())) {
+                        mCardPinRetrievalListener.onError(CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS, "The verification challenge was attempted too many times", null);
+                    } else {
+                        mCardPinRetrievalListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                    }
+                }
+            } catch (APIConnectionException | APIException | AuthenticationException | JSONException | CardException e) {
+                if (mCardPinRetrievalListener != null) {
+                    mCardPinRetrievalListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                }
+            }
+        }
+        if (PIN_UPDATE.equals(action)) {
+            String cardId = (String) arguments.get("cardId");
+            String newPin = (String) arguments.get("newPin");
+            String verificationId = (String) arguments.get("verificationId");
+            String userOneTimeCode = (String) arguments.get("userOneTimeCode");
+            try {
+                StripeApiHandler.updateIssuingCardPin(cardId, newPin, verificationId, userOneTimeCode, ephemeralKey.getSecret());
+
+                if (mCardPinUpdateListener != null) {
+                    mCardPinUpdateListener.onIssuingCardPinUpdated();
+                }
+            } catch (InvalidRequestException e) {
+                if (mCardPinUpdateListener != null) {
+                    if ("expired".equals(e.getCode())) {
+                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_EXPIRED, "The one-time code has expired", null);
+                    }
+                    if ("incorrect_code".equals(e.getCode())) {
+                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_INCORRECT, "The one-time code was incorrect", null);
+                    }
+                    if ("too_many_attempts".equals(e.getCode())) {
+                        mCardPinUpdateListener.onError(CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS, "The verification challenge was attempted too many times", null);
+                    } else {
+                        mCardPinUpdateListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                    }
+                }
+            } catch (APIConnectionException | APIException | AuthenticationException | CardException e) {
+                if (mCardPinUpdateListener != null) {
+                    mCardPinUpdateListener.onError(CardPinActionError.UNKNOWN_ERROR, "An error occurred retrieving the PIN", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onKeyError(int errorCode, @Nullable String errorMessage) {
+        if (mCardPinRetrievalListener != null) {
+            mCardPinRetrievalListener.onError(CardPinActionError.EPHEMERAL_KEY_ERROR, errorMessage, null);
+        }
+        if (mCardPinUpdateListener != null) {
+            mCardPinUpdateListener.onError(CardPinActionError.EPHEMERAL_KEY_ERROR, errorMessage, null);
+        }
+    }
+
+    public enum CardPinActionError {
+        UNKNOWN_ERROR,
+        EPHEMERAL_KEY_ERROR,
+        ONE_TIME_CODE_INCORRECT,
+        ONE_TIME_CODE_EXPIRED,
+        ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
+    }
+
+    public interface IssuingCardPinRetrievalListener {
+        void onIssuingCardPinRetrieved(@NonNull String pin);
+
+        void onError(CardPinActionError errorCode, @Nullable String errorMessage, @Nullable Throwable exception);
+    }
+
+    public interface IssuingCardPinUpdateListener {
+        void onIssuingCardPinUpdated();
+
+        void onError(CardPinActionError errorCode, @Nullable String errorMessage, @Nullable Throwable exception);
+    }
+
+}

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -244,7 +244,7 @@ public class IssuingCardPinService
     public void onKeyError(int errorCode,
                            @Nullable String errorMessage,
                            @Nullable Map<String, Object> arguments) {
-        Object listener = arguments.get(ARGUMENT_LISTENER);
+        Object listener = getListener(arguments);
         if (listener instanceof IssuingCardPinRetrievalListener) {
             ((IssuingCardPinRetrievalListener) listener).onError(
                     CardPinActionError.EPHEMERAL_KEY_ERROR,

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -79,12 +79,14 @@ class StripeApiHandler {
 
     // Used for HTTP-level tests
     private static @Nullable MockGetStripeResponse mockGetStripeResponse;
+
     interface MockGetStripeResponse{
         StripeResponse getStripeResponse(@RestMethod String method,
                                          String url,
                                          Map<String, Object> params,
                                          RequestOptions options);
     }
+
     @VisibleForTesting
     static void setMockGetStripeResponse(MockGetStripeResponse aMockGetStripeResponse){
         mockGetStripeResponse = aMockGetStripeResponse;
@@ -1164,7 +1166,7 @@ class StripeApiHandler {
             Map<String, Object> params,
             RequestOptions options)
             throws InvalidRequestException, APIConnectionException {
-        if(mockGetStripeResponse != null){
+        if (mockGetStripeResponse != null){
             return mockGetStripeResponse.getStripeResponse(method, url, params, options);
         }
         // HTTPSURLConnection verifies SSL cert by default

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -627,6 +627,7 @@ class StripeApiHandler {
         return Customer.fromString(response.getResponseBody());
     }
 
+    @NonNull
     static Map<String, Object> createVerificationParam(
             @NonNull String verificationId,
             @NonNull String userOneTimeCode){
@@ -636,7 +637,7 @@ class StripeApiHandler {
         return verificationMap;
     }
 
-    @Nullable
+    @NonNull
     static String retrieveIssuingCardPin(
             @NonNull String cardId,
             @NonNull String verificationId,
@@ -662,7 +663,6 @@ class StripeApiHandler {
         return jsonResponse.getString("pin");
     }
 
-    @Nullable
     static void updateIssuingCardPin(
             @NonNull String cardId,
             @NonNull String newPin,

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -807,12 +807,12 @@ class StripeApiHandler {
 
     @VisibleForTesting
     static String getRetrieveIssuingCardPinUrl(@NonNull String cardId) {
-        return String.format(Locale.ENGLISH, "%s/v1/issuing/cards/%s/pin", LIVE_API_BASE, cardId);
+        return String.format(Locale.ROOT, "%s/v1/issuing/cards/%s/pin", LIVE_API_BASE, cardId);
     }
 
     @VisibleForTesting
     static String getUpdateIssuingCardPinUrl(@NonNull String cardId) {
-        return String.format(Locale.ENGLISH, "%s/v1/issuing/cards/%s/pin", LIVE_API_BASE, cardId);
+        return String.format(Locale.ROOT, "%s/v1/issuing/cards/%s/pin", LIVE_API_BASE, cardId);
     }
 
     static void convertErrorsToExceptionsAndThrowIfNecessary(StripeResponse response) throws

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -1166,7 +1166,7 @@ class StripeApiHandler {
             Map<String, Object> params,
             RequestOptions options)
             throws InvalidRequestException, APIConnectionException {
-        if (mockGetStripeResponse != null){
+        if (mockGetStripeResponse != null) {
             return mockGetStripeResponse.getStripeResponse(method, url, params, options);
         }
         // HTTPSURLConnection verifies SSL cert by default

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -654,7 +654,7 @@ class StripeApiHandler {
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         JSONObject jsonResponse = new JSONObject(response.getResponseBody());
-        return (String) jsonResponse.get("pin");
+        return jsonResponse.getString("pin");
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -627,6 +627,15 @@ class StripeApiHandler {
         return Customer.fromString(response.getResponseBody());
     }
 
+    static Map<String, Object> createVerificationParam(
+            @NonNull String verificationId,
+            @NonNull String userOneTimeCode){
+        Map<String, Object> verificationMap = new HashMap<>();
+        verificationMap.put("id", verificationId);
+        verificationMap.put("one_time_code", userOneTimeCode);
+        return verificationMap;
+    }
+
     @Nullable
     static String retrieveIssuingCardPin(
             @NonNull String cardId,
@@ -640,11 +649,7 @@ class StripeApiHandler {
             CardException, JSONException {
         Map<String, Object> paramsMap = new HashMap<>();
 
-        Map<String, Object> verificationMap = new HashMap<>();
-        verificationMap.put("id", verificationId);
-        verificationMap.put("one_time_code", userOneTimeCode);
-
-        paramsMap.put("verification", verificationMap);
+        paramsMap.put("verification", createVerificationParam(verificationId, userOneTimeCode));
 
         StripeResponse response = getStripeResponse(
                 GET,
@@ -671,11 +676,7 @@ class StripeApiHandler {
             CardException {
         Map<String, Object> paramsMap = new HashMap<>();
 
-        Map<String, Object> verificationMap = new HashMap<>();
-        verificationMap.put("id", verificationId);
-        verificationMap.put("one_time_code", userOneTimeCode);
-
-        paramsMap.put("verification", verificationMap);
+        paramsMap.put("verification", createVerificationParam(verificationId, userOneTimeCode));
         paramsMap.put("pin", newPin);
 
         StripeResponse response = getStripeResponse(

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
@@ -9,6 +9,8 @@ import android.support.annotation.Nullable;
 public class InvalidRequestException extends StripeException {
 
     private final String param;
+
+    @Nullable
     private final String code;
 
     public InvalidRequestException(String message,
@@ -24,9 +26,7 @@ public class InvalidRequestException extends StripeException {
 
     public InvalidRequestException(String message, String param, String requestId, Integer
             statusCode, Throwable e) {
-        super(message, requestId, statusCode, e);
-        this.param = param;
-        this.code = null;
+        this(message, param, null, requestId, statusCode, e);
     }
 
     public String getParam() {

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
@@ -1,6 +1,8 @@
 package com.stripe.android.exception;
 
 
+import android.support.annotation.Nullable;
+
 /**
  * An {@link Exception} indicating that invalid parameters were used in a request.
  */
@@ -31,6 +33,7 @@ public class InvalidRequestException extends StripeException {
         return param;
     }
 
+    @Nullable
     public String getCode() {
         return code;
     }

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
@@ -9,8 +9,12 @@ public class InvalidRequestException extends StripeException {
     private final String param;
     private final String code;
 
-    public InvalidRequestException(String message, String param, String code, String requestId, Integer
-            statusCode, Throwable e) {
+    public InvalidRequestException(String message,
+                                   String param,
+                                   String code,
+                                   String requestId,
+                                   Integer statusCode,
+                                   Throwable e) {
         super(message, requestId, statusCode, e);
         this.param = param;
         this.code = code;
@@ -26,6 +30,7 @@ public class InvalidRequestException extends StripeException {
     public String getParam() {
         return param;
     }
+
     public String getCode() {
         return code;
     }

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
@@ -7,15 +7,27 @@ package com.stripe.android.exception;
 public class InvalidRequestException extends StripeException {
 
     private final String param;
+    private final String code;
+
+    public InvalidRequestException(String message, String param, String code, String requestId, Integer
+            statusCode, Throwable e) {
+        super(message, requestId, statusCode, e);
+        this.param = param;
+        this.code = code;
+    }
 
     public InvalidRequestException(String message, String param, String requestId, Integer
             statusCode, Throwable e) {
         super(message, requestId, statusCode, e);
         this.param = param;
+        this.code = null;
     }
 
     public String getParam() {
         return param;
+    }
+    public String getCode() {
+        return code;
     }
 
 }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -234,7 +234,7 @@ public class EphemeralKeyManagerTest {
         // It should be necessary to update because the key is expired.
         keyManager.retrieveEphemeralKey(null, null);
 
-        verify(mKeyManagerListener, times(1)).onKeyError(404, errorMessage);
+        verify(mKeyManagerListener, times(1)).onKeyError(404, errorMessage, null);
         verifyNoMoreInteractions(mKeyManagerListener);
         assertNull(keyManager.getEphemeralKey());
     }

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.verify;
 @RunWith(RobolectricTestRunner.class)
 public class IssuingCardPinServiceTest {
 
-    static final String EPHEMERAL_KEY = "{\n" +
+    private static final String EPHEMERAL_KEY = "{\n" +
             "  \"id\": \"ephkey_123\",\n" +
             "  \"object\": \"ephemeral_key\",\n" +
             "  \"secret\": \"ek_test_123\",\n" +
@@ -46,7 +46,7 @@ public class IssuingCardPinServiceTest {
         StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
             @Override
             public StripeResponse getStripeResponse(String method, String url, Map<String, Object> params, RequestOptions options) {
-                if (method != "GET") {
+                if (!"GET".equals(method)) {
                     throw new RuntimeException("Invalid method " + method);
                 }
                 if (!url.equals("https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin")) {
@@ -87,7 +87,7 @@ public class IssuingCardPinServiceTest {
         StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
             @Override
             public StripeResponse getStripeResponse(String method, String url, Map<String, Object> params, RequestOptions options) {
-                if (method != "POST") {
+                if (!"POST".equals(method)) {
                     throw new RuntimeException("Invalid method " + method);
                 }
                 if (!url.equals("https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin")) {

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -32,11 +32,6 @@ public class IssuingCardPinServiceTest {
             "            }]\n" +
             "}";
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
     public void testRetrieval() {
         TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -1,0 +1,151 @@
+package com.stripe.android;
+
+import com.stripe.android.testharness.TestEphemeralKeyProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class for {@link IssuingCardPinService}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class IssuingCardPinServiceTest {
+
+    static final String EPHEMERAL_KEY = "{\n" +
+            "  \"id\": \"ephkey_123\",\n" +
+            "  \"object\": \"ephemeral_key\",\n" +
+            "  \"secret\": \"ek_test_123\",\n" +
+            "  \"created\": 1501179335,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"expires\": 1501199335,\n" +
+            "  \"associated_objects\": [{\n" +
+            "            \"type\": \"issuing.card\",\n" +
+            "            \"id\": \"ic_abcd\"\n" +
+            "            }]\n" +
+            "}";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testRetrieval() {
+        TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
+        ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
+        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+
+        StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
+            @Override
+            public StripeResponse getStripeResponse(String method, String url, Map<String, Object> params, RequestOptions options) {
+                if (method != "GET") {
+                    throw new RuntimeException("Invalid method " + method);
+                }
+                if (!url.equals("https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin")) {
+                    throw new RuntimeException("Invalid url " + url);
+                }
+                if (params.get("verification") == null) {
+                    throw new RuntimeException("Missing params");
+                }
+                Map verification = (Map) params.get("verification");
+                if (!verification.get("id").equals("iv_abcd") || !verification.get("one_time_code").equals("123-456")) {
+                    throw new RuntimeException("Invalid verification");
+                }
+                if (!options.getPublishableApiKey().equals("ek_test_123")) {
+                    throw new RuntimeException("Invalid ephemeral key " + options.getPublishableApiKey());
+                }
+                return new StripeResponse(200, "{\"card\":\"ic_abcdef\",\"pin\":\"1234\"}", null);
+            }
+        });
+
+        IssuingCardPinService.IssuingCardPinRetrievalListener mockListener =
+                mock(IssuingCardPinService.IssuingCardPinRetrievalListener.class);
+
+        service.retrievePin(
+                "ic_abcdef",
+                "iv_abcd",
+                "123-456",
+                mockListener);
+
+        verify(mockListener).onIssuingCardPinRetrieved("1234");
+    }
+
+    @Test
+    public void testUpdate() {
+        TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
+        ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
+        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+
+        StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
+            @Override
+            public StripeResponse getStripeResponse(String method, String url, Map<String, Object> params, RequestOptions options) {
+                if (method != "POST") {
+                    throw new RuntimeException("Invalid method " + method);
+                }
+                if (!url.equals("https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin")) {
+                    throw new RuntimeException("Invalid url " + url);
+                }
+                if (params.get("pin") != "1234") {
+                    throw new RuntimeException("Incorrect params pin: " + params.get("pin"));
+                }
+                if (params.get("verification") == null) {
+                    throw new RuntimeException("Missing params");
+                }
+                Map verification = (Map) params.get("verification");
+                if (!verification.get("id").equals("iv_abcd") || !verification.get("one_time_code").equals("123-456")) {
+                    throw new RuntimeException("Invalid verification");
+                }
+                if (!options.getPublishableApiKey().equals("ek_test_123")) {
+                    throw new RuntimeException("Invalid ephemeral key " + options.getPublishableApiKey());
+                }
+                return new StripeResponse(200, "{\"card\":\"ic_abcdef\",\"pin\":\"\"}", null);
+            }
+        });
+
+        IssuingCardPinService.IssuingCardPinUpdateListener mockListener =
+                mock(IssuingCardPinService.IssuingCardPinUpdateListener.class);
+
+        service.updatePin(
+                "ic_abcdef",
+                "1234",
+                "iv_abcd",
+                "123-456",
+                mockListener);
+
+        verify(mockListener).onIssuingCardPinUpdated();
+    }
+
+    @Test
+    public void testRetrievalFailsWithReason() {
+        TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
+        ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
+        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+
+        StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
+            @Override
+            public StripeResponse getStripeResponse(String method, String url, Map<String, Object> params, RequestOptions options) {
+                return new StripeResponse(400, "{\"error\": {\"code\": \"incorrect_code\", \"message\": \"Verification failed\", \"type\": \"invalid_request_error\"}}", null);
+            }
+        });
+
+        IssuingCardPinService.IssuingCardPinRetrievalListener mockListener =
+                mock(IssuingCardPinService.IssuingCardPinRetrievalListener.class);
+
+        service.retrievePin(
+                "ic_abcdef",
+                "iv_abcd",
+                "123-456",
+                mockListener);
+
+        verify(mockListener).onError(IssuingCardPinService.CardPinActionError.ONE_TIME_CODE_INCORRECT, "The one-time code was incorrect", null);
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -41,7 +41,7 @@ public class IssuingCardPinServiceTest {
     public void testRetrieval() {
         TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
         ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
-        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+        IssuingCardPinService service = IssuingCardPinService.create(ephemeralKeyProvider);
 
         StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
             @Override
@@ -82,7 +82,7 @@ public class IssuingCardPinServiceTest {
     public void testUpdate() {
         TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
         ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
-        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+        IssuingCardPinService service = IssuingCardPinService.create(ephemeralKeyProvider);
 
         StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
             @Override
@@ -127,7 +127,7 @@ public class IssuingCardPinServiceTest {
     public void testRetrievalFailsWithReason() {
         TestEphemeralKeyProvider ephemeralKeyProvider = new TestEphemeralKeyProvider();
         ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY);
-        IssuingCardPinService service = IssuingCardPinService.init(ephemeralKeyProvider);
+        IssuingCardPinService service = IssuingCardPinService.create(ephemeralKeyProvider);
 
         StripeApiHandler.setMockGetStripeResponse(new StripeApiHandler.MockGetStripeResponse() {
             @Override


### PR DESCRIPTION
Helpers for PIN Management API for Stripe Issuing

- Introduces a new `IssuingCardEphemeralKey`
- Introduces a new `IssuingCardPinService` that works in a similar fashion to `CustomerSession`
- new methods in `StripeApiHandler` to call the PIN retrieve/update API endpoints
- Added a way to test `StripeApiHandler` closer to the HTTP level for convenience
- tests for the above