### PR TITLE
Better ephemeral key management

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -222,7 +222,6 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
     }
 
     @Nullable
-    @SuppressWarnings({"checkstyle:LineLength", "checkstyle:IllegalCatch"})
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromJson(@Nullable JSONObject jsonObject, Class ephemeralKeyClass) {
         if (jsonObject == null) {

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -240,8 +240,6 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
             throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass, e);
         } catch (NoSuchMethodException e) {
             throw new IllegalArgumentException("Class " + ephemeralKeyClass + " does not have an accessible (JSONObject) constructor", e);
-        } catch (Exception e) {
-            throw e;
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -239,7 +239,9 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
         } catch (InvocationTargetException e) {
             throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass, e);
         } catch (NoSuchMethodException e) {
-            throw new IllegalArgumentException("Class " + ephemeralKeyClass + " does not have an accessible (JSONObject) constructor", e);
+            throw new IllegalArgumentException("Class " +
+                    ephemeralKeyClass +
+                    " does not have an accessible (JSONObject) constructor", e);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -213,17 +213,12 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
 
     @Nullable
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
-    fromString(@Nullable String rawJson, Class ephemeralKeyClass) {
+    fromString(@Nullable String rawJson, Class ephemeralKeyClass) throws JSONException {
         if (rawJson == null) {
             return null;
         }
-
-        try {
-            JSONObject object = new JSONObject(rawJson);
-            return fromJson(object, ephemeralKeyClass);
-        } catch (JSONException ignored) {
-            return null;
-        }
+        JSONObject object = new JSONObject(rawJson);
+        return fromJson(object, ephemeralKeyClass);
     }
 
     @Nullable
@@ -246,10 +241,6 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
         } catch (NoSuchMethodException e) {
             throw new IllegalArgumentException("Class " + ephemeralKeyClass + " does not have an accessible (JSONObject) constructor", e);
         } catch (Exception e) {
-            if (e instanceof JSONException) {
-                // ignored
-                return null;
-            }
             throw e;
         }
     }

--- a/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
@@ -64,7 +64,7 @@ class CustomerEphemeralKey extends AbstractEphemeralKey {
     };
 
     @Nullable
-    static CustomerEphemeralKey fromString(@Nullable String rawJson) {
+    static CustomerEphemeralKey fromString(@Nullable String rawJson) throws JSONException {
         return (CustomerEphemeralKey) AbstractEphemeralKey
                 .fromString(rawJson, CustomerEphemeralKey.class);
     }

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -499,54 +499,52 @@ public class CustomerSession
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
         mEphemeralKey = ephemeralKey;
-        if (mEphemeralKey != null) {
-            if (actionString == null) {
-                updateCustomer(mEphemeralKey);
-            } else if (ACTION_ADD_SOURCE.equals(actionString)
-                    && mCachedContextReference != null
-                    && arguments != null
-                    && arguments.containsKey(KEY_SOURCE)
-                    && arguments.containsKey(KEY_SOURCE_TYPE)) {
-                addCustomerSource(
-                        mCachedContextReference,
-                        mEphemeralKey,
-                        (String) arguments.get(KEY_SOURCE),
-                        (String) arguments.get(KEY_SOURCE_TYPE),
-                        new ArrayList<>(mProductUsageTokens));
-                resetUsageTokens();
-            } else if (ACTION_DELETE_SOURCE.equals(actionString)
-                    && mCachedContextReference != null
-                    && arguments != null
-                    && arguments.containsKey(KEY_SOURCE)) {
-                deleteCustomerSource(
-                        mCachedContextReference,
-                        mEphemeralKey,
-                        (String) arguments.get(KEY_SOURCE),
-                        new ArrayList<>(mProductUsageTokens));
-                resetUsageTokens();
-            } else if (ACTION_SET_DEFAULT_SOURCE.equals(actionString)
-                    && mCachedContextReference != null
-                    && arguments != null
-                    && arguments.containsKey(KEY_SOURCE)
-                    && arguments.containsKey(KEY_SOURCE_TYPE)) {
-                setCustomerSourceDefault(
-                        mCachedContextReference,
-                        mEphemeralKey,
-                        (String) arguments.get(KEY_SOURCE),
-                        (String) arguments.get(KEY_SOURCE_TYPE),
-                        new ArrayList<>(mProductUsageTokens));
-                resetUsageTokens();
-            } else if (ACTION_SET_CUSTOMER_SHIPPING_INFO.equals(actionString)
-                    && mCachedContextReference != null
-                    && arguments != null
-                    && arguments.containsKey(KEY_SHIPPING_INFO)) {
-                setCustomerShippingInformation(
-                        mCachedContextReference,
-                        mEphemeralKey,
-                        (ShippingInformation) arguments.get(KEY_SHIPPING_INFO),
-                        new ArrayList<>(mProductUsageTokens));
-                resetUsageTokens();
-            }
+        if (actionString == null) {
+            updateCustomer(mEphemeralKey);
+        } else if (ACTION_ADD_SOURCE.equals(actionString)
+                && mCachedContextReference != null
+                && arguments != null
+                && arguments.containsKey(KEY_SOURCE)
+                && arguments.containsKey(KEY_SOURCE_TYPE)) {
+            addCustomerSource(
+                    mCachedContextReference,
+                    mEphemeralKey,
+                    (String) arguments.get(KEY_SOURCE),
+                    (String) arguments.get(KEY_SOURCE_TYPE),
+                    new ArrayList<>(mProductUsageTokens));
+            resetUsageTokens();
+        } else if (ACTION_DELETE_SOURCE.equals(actionString)
+                && mCachedContextReference != null
+                && arguments != null
+                && arguments.containsKey(KEY_SOURCE)) {
+            deleteCustomerSource(
+                    mCachedContextReference,
+                    mEphemeralKey,
+                    (String) arguments.get(KEY_SOURCE),
+                    new ArrayList<>(mProductUsageTokens));
+            resetUsageTokens();
+        } else if (ACTION_SET_DEFAULT_SOURCE.equals(actionString)
+                && mCachedContextReference != null
+                && arguments != null
+                && arguments.containsKey(KEY_SOURCE)
+                && arguments.containsKey(KEY_SOURCE_TYPE)) {
+            setCustomerSourceDefault(
+                    mCachedContextReference,
+                    mEphemeralKey,
+                    (String) arguments.get(KEY_SOURCE),
+                    (String) arguments.get(KEY_SOURCE_TYPE),
+                    new ArrayList<>(mProductUsageTokens));
+            resetUsageTokens();
+        } else if (ACTION_SET_CUSTOMER_SHIPPING_INFO.equals(actionString)
+                && mCachedContextReference != null
+                && arguments != null
+                && arguments.containsKey(KEY_SHIPPING_INFO)) {
+            setCustomerShippingInformation(
+                    mCachedContextReference,
+                    mEphemeralKey,
+                    (ShippingInformation) arguments.get(KEY_SHIPPING_INFO),
+                    new ArrayList<>(mProductUsageTokens));
+            resetUsageTokens();
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -495,7 +495,7 @@ public class CustomerSession
 
     @Override
     public void onKeyUpdate(
-            @Nullable CustomerEphemeralKey ephemeralKey,
+            @NonNull CustomerEphemeralKey ephemeralKey,
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
         mEphemeralKey = ephemeralKey;

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -4,6 +4,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import org.json.JSONException;
+
 import java.lang.ref.WeakReference;
 import java.util.Calendar;
 import java.util.Map;
@@ -55,7 +57,11 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             @NonNull String key,
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
-        mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
+        try {
+            mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
+        } catch (JSONException e) {
+            mListener.onKeyError(500, "The JSON from the key could not be parse "+ e.getLocalizedMessage());
+        }
         mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
     }
 
@@ -80,7 +86,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
     }
 
     interface KeyManagerListener<TEphemeralKey extends AbstractEphemeralKey> {
-        void onKeyUpdate(@Nullable TEphemeralKey ephemeralKey,
+        void onKeyUpdate(@NonNull TEphemeralKey ephemeralKey,
                          @Nullable String action,
                          @Nullable Map<String, Object> arguments);
 

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -7,6 +7,7 @@ import android.support.annotation.VisibleForTesting;
 import org.json.JSONException;
 
 import java.lang.ref.WeakReference;
+import java.net.HttpURLConnection;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +61,9 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         try {
             mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
         } catch (JSONException e) {
-            mListener.onKeyError(500, "The JSON from the key could not be parse "+ e.getLocalizedMessage());
+            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                    "The JSON from the key could not be parsed: "
+                            + e.getLocalizedMessage());
         }
         mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
     }

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -16,6 +16,7 @@ import com.stripe.android.testharness.TestEphemeralKeyProvider;
 import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.view.PaymentFlowActivity;
 
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -156,6 +157,14 @@ public class CustomerSessionTest {
 
     private Source mAddedSource;
 
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+        try {
+            return CustomerEphemeralKey.fromString(key);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -295,7 +304,7 @@ public class CustomerSessionTest {
 
     @Test
     public void create_withoutInvokingFunctions_fetchesKeyAndCustomer() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -320,7 +329,7 @@ public class CustomerSessionTest {
     @Test
     public void setCustomerShippingInfo_withValidInfo_callsWithExpectedArgs(){
         CustomerEphemeralKey firstKey = Objects.requireNonNull(
-                CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW));
+                getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW));
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         Calendar proxyCalendar = Calendar.getInstance();
         CustomerSession.initCustomerSession(
@@ -352,10 +361,10 @@ public class CustomerSessionTest {
 
     @Test
     public void retrieveCustomer_withExpiredCache_updatesCustomer() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
-        CustomerEphemeralKey secondKey = CustomerEphemeralKey.fromString(SECOND_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey secondKey = getCustomerEphemeralKey(SECOND_SAMPLE_KEY_RAW);
         assertNotNull(secondKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -413,7 +422,7 @@ public class CustomerSessionTest {
 
     @Test
     public void retrieveCustomer_withUnExpiredCache_returnsCustomerWithoutHittingApi() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -470,7 +479,7 @@ public class CustomerSessionTest {
 
     @Test
     public void addSourceToCustomer_withUnExpiredCustomer_returnsAddedSourceAndEmptiesLogs() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -532,7 +541,7 @@ public class CustomerSessionTest {
 
     @Test
     public void addSourceToCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -586,7 +595,7 @@ public class CustomerSessionTest {
 
     @Test
     public void removeSourceFromCustomer_withUnExpiredCustomer_returnsRemovedSourceAndEmptiesLogs() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -646,7 +655,7 @@ public class CustomerSessionTest {
 
     @Test
     public void removeSourceFromCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -699,7 +708,7 @@ public class CustomerSessionTest {
 
     @Test
     public void setDefaultSourceForCustomer_withUnExpiredCustomer_returnsCustomerAndClearsLog() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();
@@ -759,7 +768,7 @@ public class CustomerSessionTest {
 
     @Test
     public void setDefaultSourceForCustomer_whenApiThrows_tellsListenerBroadcastsAndClearsLogs() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         Calendar proxyCalendar = Calendar.getInstance();

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 
 import com.stripe.android.exception.APIException;
@@ -157,7 +158,8 @@ public class CustomerSessionTest {
 
     private Source mAddedSource;
 
-    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+    @NonNull
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key) {
         try {
             return CustomerEphemeralKey.fromString(key);
         } catch (JSONException e) {

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -2,6 +2,7 @@ package com.stripe.android;
 
 import com.stripe.android.testharness.TestEphemeralKeyProvider;
 
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +53,14 @@ public class EphemeralKeyManagerTest {
 
     private TestEphemeralKeyProvider mTestEphemeralKeyProvider;
 
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+        try {
+            return CustomerEphemeralKey.fromString(key);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -83,7 +92,7 @@ public class EphemeralKeyManagerTest {
     @Test
     public void shouldRefreshKey_whenKeyExpiryIsAfterBufferFromPresent_returnsFalse() {
         Calendar fixedCalendar = Calendar.getInstance();
-        CustomerEphemeralKey key = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey key = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(key);
 
         long expiryTimeInSeconds = key.getExpires();
@@ -102,7 +111,7 @@ public class EphemeralKeyManagerTest {
     @Test
     public void shouldRefreshKey_whenKeyExpiryIsInThePast_returnsTrue() {
         Calendar fixedCalendar = Calendar.getInstance();
-        CustomerEphemeralKey key = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey key = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(key);
 
         long currentTimeInMillis = fixedCalendar.getTimeInMillis();
@@ -117,7 +126,7 @@ public class EphemeralKeyManagerTest {
     @Test
     public void shouldRefreshKey_whenKeyExpiryIsInFutureButWithinBuffer_returnsTrue() {
         Calendar fixedCalendar = Calendar.getInstance();
-        CustomerEphemeralKey key = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey key = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(key);
 
         long parsedExpiryTimeInMillis = TimeUnit.SECONDS.toMillis(key.getExpires());
@@ -135,7 +144,7 @@ public class EphemeralKeyManagerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void createKeyManager_updatesEphemeralKey_notifiesListener() {
-        CustomerEphemeralKey testKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey testKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(testKey);
 
         mTestEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -155,7 +164,7 @@ public class EphemeralKeyManagerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void retrieveEphemeralKey_whenUpdateNecessary_returnsUpdateAndArguments() {
-        CustomerEphemeralKey testKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey testKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(testKey);
 
         Calendar fixedCalendar = Calendar.getInstance();
@@ -204,7 +213,7 @@ public class EphemeralKeyManagerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void updateKeyIfNecessary_whenReturnsError_setsExistingKeyToNull() {
-        CustomerEphemeralKey testKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey testKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(testKey);
 
         Calendar proxyCalendar = Calendar.getInstance();

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android;
 
+import android.support.annotation.NonNull;
+
 import com.stripe.android.testharness.TestEphemeralKeyProvider;
 
 import org.json.JSONException;
@@ -53,7 +55,8 @@ public class EphemeralKeyManagerTest {
 
     private TestEphemeralKeyProvider mTestEphemeralKeyProvider;
 
-    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+    @NonNull
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key) {
         try {
             return CustomerEphemeralKey.fromString(key);
         } catch (JSONException e) {

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
@@ -1,6 +1,7 @@
 package com.stripe.android;
 
 import android.os.Parcel;
+import android.support.annotation.NonNull;
 
 import com.stripe.android.testharness.JsonTestUtils;
 
@@ -38,7 +39,8 @@ public class EphemeralKeyTest {
             "    ]\n" +
             "}";
 
-    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+    @NonNull
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key) {
         try {
             return CustomerEphemeralKey.fromString(key);
         } catch (JSONException e) {

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
@@ -38,9 +38,17 @@ public class EphemeralKeyTest {
             "    ]\n" +
             "}";
 
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+        try {
+            return CustomerEphemeralKey.fromString(key);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     @Test
     public void fromJson_createsKeyWithExpectedValues() {
-        CustomerEphemeralKey ephemeralKey = CustomerEphemeralKey.fromString(SAMPLE_KEY_RAW);
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
         assertNotNull(ephemeralKey);
         assertEquals("ephkey_123", ephemeralKey.getId());
         assertEquals("ephemeral_key", ephemeralKey.getObject());
@@ -66,7 +74,7 @@ public class EphemeralKeyTest {
 
     @Test
     public void toMap_createsMapWithExpectedValues() {
-        CustomerEphemeralKey ephemeralKey = CustomerEphemeralKey.fromString(SAMPLE_KEY_RAW);
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
         assertNotNull(ephemeralKey);
         Map<String, Object> expectedMap = new HashMap<String, Object>() {{
             put(CustomerEphemeralKey.FIELD_ID, "ephkey_123");
@@ -89,7 +97,7 @@ public class EphemeralKeyTest {
 
     @Test
     public void toParcel_fromParcel_createsExpectedObject() {
-        CustomerEphemeralKey ephemeralKey = CustomerEphemeralKey.fromString(SAMPLE_KEY_RAW);
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
         assertNotNull(ephemeralKey);
         Parcel parcel = Parcel.obtain();
         ephemeralKey.writeToParcel(parcel, 0);

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -13,6 +13,7 @@ import com.stripe.android.testharness.TestEphemeralKeyProvider;
 import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.view.PaymentMethodsActivity;
 
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +57,14 @@ public class PaymentSessionTest {
     private AppCompatActivity mActivity;
     @Mock private CustomerSession.StripeApiProxy mStripeApiProxy;
 
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+        try {
+            return CustomerEphemeralKey.fromString(key);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -117,7 +126,7 @@ public class PaymentSessionTest {
 
     @Test
     public void init_whenEphemeralKeyProviderContinues_fetchesCustomerAndNotifiesListener() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -137,7 +146,7 @@ public class PaymentSessionTest {
 
     @Test
     public void setCartTotal_setsExpectedValueAndNotifiesListener() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -163,7 +172,7 @@ public class PaymentSessionTest {
 
     @Test
     public void handlePaymentData_whenPaymentMethodRequest_notifiesListenerAndFetchesCustomer() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -189,7 +198,7 @@ public class PaymentSessionTest {
 
     @Test
     public void selectPaymentMethod_launchesPaymentMethodsActivityWithLog() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -215,7 +224,7 @@ public class PaymentSessionTest {
 
     @Test
     public void init_withoutSavedState_clearsLoggingTokensAndStartsWithPaymentSession() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -241,7 +250,7 @@ public class PaymentSessionTest {
 
     @Test
     public void init_withSavedStateBundle_doesNotClearLoggingTokens() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -267,7 +276,7 @@ public class PaymentSessionTest {
 
     @Test
     public void completePayment_withLoggedActions_clearsLoggingTokensAndSetsResult() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -308,7 +317,7 @@ public class PaymentSessionTest {
 
     @Test
     public void init_withSavedState_setsPaymentSessionData() {
-        CustomerEphemeralKey firstKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -57,7 +57,8 @@ public class PaymentSessionTest {
     private AppCompatActivity mActivity;
     @Mock private CustomerSession.StripeApiProxy mStripeApiProxy;
 
-    private CustomerEphemeralKey getCustomerEphemeralKey(String key){
+    @NonNull
+    private CustomerEphemeralKey getCustomerEphemeralKey(String key) {
         try {
             return CustomerEphemeralKey.fromString(key);
         } catch (JSONException e) {


### PR DESCRIPTION
in `KeyUpdateListener` it's quite burdensome that `onKeyUpdate` passes a `@Nullable ephemeralKey`, this PR changes the behavior of `EphemeralKeyManager` so a `@NonNull` is passed instead.

Previously `CustomerSession` would have failed silently if the JSON was incorrect. With this implementation, `onKeyError` will be called with the correct error, which is a slight change in behavior, but I'm hoping can't break developers integrations 