### PR TITLE
Prepare for 8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # CHANGELOG
 
-### On Deck
-* Update Android SDK Build Tools to 28.0.3
-* Update Android Gradle plugin to 3.2.1
-* Update compileSdkVersion and targetSdkVersion to 28
-* Update Android Support Library to 28.0.0
+### 8.2.0 2019-01-10
+* Add support for Android 28 [#675]
+    * Update Android SDK Build Tools to 28.0.3
+    * Update Android Gradle plugin to 3.2.1
+    * Update compileSdkVersion and targetSdkVersion to 28
+    * Update Android Support Library to 28.0.0
+* Add ability to set card number and validate on `CardMultilineWidget` [#671]
+* Add support for iDeal Source with connected account [#537]
+* Add support for Portuguese [#669]
+* Add ability to cancel callbacks without destroying `CustomerSession` instance [#624]
+* Improve accessibility on card input fields [#673]
+* Add `AccessibilityNodeInfo` to widgets [#656]
+* Fix crash in `ShippingMethodView` on API 16 [#678]
 
 ### 8.1.0 2018-11-13
 * Add support for latest version of PaymentIntents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Stripe Android SDK makes it quick and easy to build an excellent payment exp
 No need to clone the repository or download any files -- just add this line to your app's `build.gradle` inside the `dependencies` section:
 
 ```
-implementation 'com.stripe:stripe-android:8.1.0'
+implementation 'com.stripe:stripe-android:8.2.0'
 ```
 
 Note: We recommend that you don't use `compile 'com.stripe:stripe-android:+`, as future versions of the SDK may not maintain full backwards compatibility. When such a change occurs, a major version number change will accompany it.

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.stripe.android"
-          android:versionCode="28"
-          android:versionName="8.1.0"
+          android:versionCode="29"
+          android:versionName="8.2.0"
     >
 
     <application>

--- a/stripe/gradle.properties
+++ b/stripe/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.1.0
+VERSION_NAME=8.2.0
 POM_DESCRIPTION=Stripe Android Bindings
 POM_NAME=stripe-android
 POM_ARTIFACT_ID=stripe-android


### PR DESCRIPTION
Changelog

Add support for Android 28 [#675]
Update Android SDK Build Tools to 28.0.3
Update Android Gradle plugin to 3.2.1
Update compileSdkVersion and targetSdkVersion to 28
Update Android Support Library to 28.0.0
Add ability to set card number and validate on CardMultilineWidget [#671]
Add support for iDeal Source with connected account [#537]
Add support for Portuguese [#669]
Add ability to cancel callbacks without destroying CustomerSession instance [#624]
Improve accessibility on card input fields [#673]
Fix crash in ShippingMethodView on API 16 [#678]