### PR TITLE
Fix bug calling onKeyUpdate when should not, and better error messages

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -216,7 +216,7 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromString(@Nullable String rawJson, Class ephemeralKeyClass) throws JSONException {
         if (rawJson == null) {
-            return null;
+            throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass+ " null raw key");
         }
         JSONObject object = new JSONObject(rawJson);
         return fromJson(object, ephemeralKeyClass);
@@ -226,21 +226,32 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromJson(@Nullable JSONObject jsonObject, Class ephemeralKeyClass) {
         if (jsonObject == null) {
-            return null;
+            throw new IllegalArgumentException("Exception instantiating " +
+                    ephemeralKeyClass.getSimpleName() +
+                    " null JSON");
         }
 
         try {
             return (TEphemeralKey)
                     ephemeralKeyClass.getConstructor(JSONObject.class).newInstance(jsonObject);
         } catch (InstantiationException e) {
-            throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass, e);
+            throw new IllegalArgumentException("Exception instantiating " +
+                    ephemeralKeyClass.getSimpleName(), e);
         } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass, e);
+            throw new IllegalArgumentException("Exception instantiating " +
+                    ephemeralKeyClass.getSimpleName(), e);
         } catch (InvocationTargetException e) {
-            throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass, e);
+            if (e.getTargetException() != null){
+                throw new IllegalArgumentException("Improperly formatted JSON for ephemeral key " +
+                        ephemeralKeyClass.getSimpleName() +
+                        " - " + e.getTargetException().getMessage(),
+                        e.getTargetException());
+            }
+            throw new IllegalArgumentException("Improperly formatted JSON for ephemeral key " +
+                    ephemeralKeyClass.getSimpleName(), e);
         } catch (NoSuchMethodException e) {
             throw new IllegalArgumentException("Class " +
-                    ephemeralKeyClass +
+                    ephemeralKeyClass.getSimpleName() +
                     " does not have an accessible (JSONObject) constructor", e);
         }
     }

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -216,8 +216,8 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromString(@Nullable String rawJson, Class ephemeralKeyClass) throws JSONException {
         if (rawJson == null) {
-            throw new IllegalArgumentException("Exception instantiating " +
-                    ephemeralKeyClass.getSimpleName() + ": null raw key");
+            throw new IllegalArgumentException("Attempted to instantiate " +
+                    ephemeralKeyClass.getSimpleName() + " with null raw key");
         }
         JSONObject object = new JSONObject(rawJson);
         return fromJson(object, ephemeralKeyClass);

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -216,7 +216,8 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromString(@Nullable String rawJson, Class ephemeralKeyClass) throws JSONException {
         if (rawJson == null) {
-            throw new IllegalArgumentException("Exception instantiating " + ephemeralKeyClass+ " null raw key");
+            throw new IllegalArgumentException("Exception instantiating " +
+                    ephemeralKeyClass.getSimpleName() + ": null raw key");
         }
         JSONObject object = new JSONObject(rawJson);
         return fromJson(object, ephemeralKeyClass);

--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -242,7 +242,7 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
             throw new IllegalArgumentException("Exception instantiating " +
                     ephemeralKeyClass.getSimpleName(), e);
         } catch (InvocationTargetException e) {
-            if (e.getTargetException() != null){
+            if (e.getTargetException() != null) {
                 throw new IllegalArgumentException("Improperly formatted JSON for ephemeral key " +
                         ephemeralKeyClass.getSimpleName() +
                         " - " + e.getTargetException().getMessage(),

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -74,13 +74,13 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                             "a value that could not be JSON parsed: ["
-                            + e.getLocalizedMessage() + "] the raw body from Stripe's response" +
+                            + e.getLocalizedMessage() + "]. The raw body from Stripe's response" +
                             " should be passed");
         } catch (Exception e) {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                             "a value that failed to be parsed: ["
-                            + e.getLocalizedMessage() + "] the raw body from Stripe's response" +
+                            + e.getLocalizedMessage() + "]. The raw body from Stripe's response" +
                             " should be passed");
         }
     }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -58,14 +58,29 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             @NonNull String key,
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
+        // Key is coming from the user, so even if it's @NonNull annotated we
+        // want to double check it
+        if (key == null) {
+            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                    "EphemeralKeyUpdateListener.onKeyUpdate was called " +
+                            "with a null value");
+        }
         try {
             mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
+            mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
         } catch (JSONException e) {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
-                    "The JSON from the key could not be parsed: "
-                            + e.getLocalizedMessage());
+                    "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
+                            "a value that could not be JSON parsed: ["
+                            + e.getLocalizedMessage() + "] the raw body from Stripe's response" +
+                            " should be passed");
+        } catch (Exception e) {
+            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                    "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
+                            "a value that failed to be parsed: ["
+                            + e.getLocalizedMessage() + "] the raw body from Stripe's response" +
+                            " should be passed");
         }
-        mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
     }
 
     private void updateKeyError(int errorCode, @Nullable String errorMessage) {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -79,7 +79,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         } catch (Exception e) {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
-                            "a value that failed to be parsed: ["
+                            "a JSON String that was invalid: ["
                             + e.getLocalizedMessage() + "]. The raw body from Stripe's response" +
                             " should be passed");
         }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -54,6 +54,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         return mEphemeralKey;
     }
 
+    @SuppressWarnings("checkstyle:IllegalCatch")
     private void updateKey(
             @NonNull String key,
             @Nullable String actionString,

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -65,6 +65,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was called " +
                             "with a null value");
+            return;
         }
         try {
             mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
@@ -11,9 +11,9 @@ public interface EphemeralKeyUpdateListener {
     /**
      * Called when a key update request from your server comes back successfully.
      *
-     * @param rawJsonBodyReturnedByStripe the raw String returned from Stripe's servers
+     * @param stripeResponseJson the raw JSON String returned from Stripe's servers
      */
-    void onKeyUpdate(@NonNull String rawJsonBodyReturnedByStripe);
+    void onKeyUpdate(@NonNull String stripeResponseJson);
 
     /**
      * Called when a key update request from your server comes back with an error.

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
@@ -11,9 +11,9 @@ public interface EphemeralKeyUpdateListener {
     /**
      * Called when a key update request from your server comes back successfully.
      *
-     * @param rawKey the raw String returned from Stripe's servers
+     * @param rawJsonBodyReturnedByStripe the raw String returned from Stripe's servers
      */
-    void onKeyUpdate(@NonNull String rawKey);
+    void onKeyUpdate(@NonNull String rawJsonBodyReturnedByStripe);
 
     /**
      * Called when a key update request from your server comes back with an error.

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -295,4 +295,23 @@ public class EphemeralKeyManagerTest {
                         "from Stripe's response should be passed");
         assertNull(keyManager.getEphemeralKey());
     }
+
+    @Test
+    public void triggerCorrectErrorOnNullKey() {
+
+        mTestEphemeralKeyProvider.setNextRawEphemeralKey(null);
+        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager(
+                mTestEphemeralKeyProvider,
+                mKeyManagerListener,
+                TEST_SECONDS_BUFFER,
+                null,
+                CustomerEphemeralKey.class);
+
+        verify(mKeyManagerListener, times(0)).onKeyUpdate(
+                (CustomerEphemeralKey) isNull(), (String) isNull(), (Map<String, Object>) isNull());
+        verify(mKeyManagerListener, times(1)).onKeyError(
+                HttpURLConnection.HTTP_INTERNAL_ERROR,
+                "EphemeralKeyUpdateListener.onKeyUpdate was called with a null value");
+        assertNull(keyManager.getEphemeralKey());
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -270,7 +270,7 @@ public class EphemeralKeyManagerTest {
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                 "EphemeralKeyUpdateListener.onKeyUpdate was passed a value that " +
                         "could not be JSON parsed: [Value Not_a_JSON of type java.lang.String " +
-                        "cannot be converted to JSONObject] the raw body from Stripe's " +
+                        "cannot be converted to JSONObject]. The raw body from Stripe's " +
                         "response should be passed");
         assertNull(keyManager.getEphemeralKey());
     }
@@ -292,7 +292,7 @@ public class EphemeralKeyManagerTest {
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                 "EphemeralKeyUpdateListener.onKeyUpdate was passed a value " +
                         "that failed to be parsed: [Improperly formatted JSON for ephemeral " +
-                        "key CustomerEphemeralKey - No value for created] the raw body " +
+                        "key CustomerEphemeralKey - No value for created]. The raw body " +
                         "from Stripe's response should be passed");
         assertNull(keyManager.getEphemeralKey());
     }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -256,14 +257,14 @@ public class EphemeralKeyManagerTest {
     public void triggerCorrectErrorOnInvalidRawKey() {
 
         mTestEphemeralKeyProvider.setNextRawEphemeralKey("Not_a_JSON");
-        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager(
+        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager<>(
                 mTestEphemeralKeyProvider,
                 mKeyManagerListener,
                 TEST_SECONDS_BUFFER,
                 null,
                 CustomerEphemeralKey.class);
 
-        verify(mKeyManagerListener, times(0)).onKeyUpdate(
+        verify(mKeyManagerListener, never()).onKeyUpdate(
                 (CustomerEphemeralKey) isNull(), (String) isNull(), (Map<String, Object>) isNull());
         verify(mKeyManagerListener, times(1)).onKeyError(
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
@@ -278,14 +279,14 @@ public class EphemeralKeyManagerTest {
     public void triggerCorrectErrorOnInvalidJsonKey() {
 
         mTestEphemeralKeyProvider.setNextRawEphemeralKey("{}");
-        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager(
+        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager<>(
                 mTestEphemeralKeyProvider,
                 mKeyManagerListener,
                 TEST_SECONDS_BUFFER,
                 null,
                 CustomerEphemeralKey.class);
 
-        verify(mKeyManagerListener, times(0)).onKeyUpdate(
+        verify(mKeyManagerListener, never()).onKeyUpdate(
                 (CustomerEphemeralKey) isNull(), (String) isNull(), (Map<String, Object>) isNull());
         verify(mKeyManagerListener, times(1)).onKeyError(
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
@@ -300,14 +301,14 @@ public class EphemeralKeyManagerTest {
     public void triggerCorrectErrorOnNullKey() {
 
         mTestEphemeralKeyProvider.setNextRawEphemeralKey(null);
-        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager(
+        EphemeralKeyManager<CustomerEphemeralKey> keyManager = new EphemeralKeyManager<>(
                 mTestEphemeralKeyProvider,
                 mKeyManagerListener,
                 TEST_SECONDS_BUFFER,
                 null,
                 CustomerEphemeralKey.class);
 
-        verify(mKeyManagerListener, times(0)).onKeyUpdate(
+        verify(mKeyManagerListener, never()).onKeyUpdate(
                 (CustomerEphemeralKey) isNull(), (String) isNull(), (Map<String, Object>) isNull());
         verify(mKeyManagerListener, times(1)).onKeyError(
                 HttpURLConnection.HTTP_INTERNAL_ERROR,

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -290,8 +290,8 @@ public class EphemeralKeyManagerTest {
                 (CustomerEphemeralKey) isNull(), (String) isNull(), (Map<String, Object>) isNull());
         verify(mKeyManagerListener, times(1)).onKeyError(
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
-                "EphemeralKeyUpdateListener.onKeyUpdate was passed a value " +
-                        "that failed to be parsed: [Improperly formatted JSON for ephemeral " +
+                "EphemeralKeyUpdateListener.onKeyUpdate was passed a JSON String " +
+                        "that was invalid: [Improperly formatted JSON for ephemeral " +
                         "key CustomerEphemeralKey - No value for created]. The raw body " +
                         "from Stripe's response should be passed");
         assertNull(keyManager.getEphemeralKey());

--- a/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.java
@@ -27,6 +27,9 @@ public class TestEphemeralKeyProvider implements EphemeralKeyProvider {
             keyUpdateListener.onKeyUpdate(mRawEphemeralKey);
         } else if (mErrorCode != INVALID_ERROR_CODE) {
             keyUpdateListener.onKeyUpdateFailure(mErrorCode, mErrorMessage);
+        } else {
+            // Useful to test edge cases
+            keyUpdateListener.onKeyUpdate(null);
         }
     }
 


### PR DESCRIPTION
- `onKeyUpdate` was called outside a `try` clause which is not ideal
- The error messages where not incredibly useful, made them a tad better