### PR TITLE
Use Application context instead of Activity in Stripe.java

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentActivity.java
@@ -24,14 +24,15 @@ public class PaymentActivity extends AppCompatActivity {
                 (CardInputWidget) findViewById(R.id.card_input_widget),
                 (ListView) findViewById(R.id.listview));
 
-        Button saveButton = (Button) findViewById(R.id.save);
+        final Button saveButton = findViewById(R.id.save);
         mDependencyHandler.attachAsyncTaskTokenController(saveButton);
 
-        Button saveRxButton = (Button) findViewById(R.id.saverx);
+        final Button saveRxButton = findViewById(R.id.saverx);
         mDependencyHandler.attachRxTokenController(saveRxButton);
 
-        Button saveIntentServiceButton = (Button) findViewById(R.id.saveWithService);
-        mDependencyHandler.attachIntentServiceTokenController(this, saveIntentServiceButton);
+        final Button saveIntentServiceButton = findViewById(R.id.saveWithService);
+        mDependencyHandler.attachIntentServiceTokenController(this,
+                saveIntentServiceButton);
     }
 
     @Override

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -71,7 +71,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
 
         mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
         mCompositeSubscription = new CompositeSubscription();
-        mStripe = new Stripe(this);
+        mStripe = new Stripe(getApplicationContext());
         Retrofit retrofit = RetrofitFactory.getInstance();
         mStripeService = retrofit.create(StripeService.class);
 

--- a/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
@@ -75,12 +75,12 @@ public class PaymentMultilineActivity extends AppCompatActivity {
     }
 
     private void saveCard() {
-        Card card = mCardMultilineWidget.getCard();
+        final Card card = mCardMultilineWidget.getCard();
         if (card == null) {
             return;
         }
 
-        final Stripe stripe = new Stripe(this);
+        final Stripe stripe = new Stripe(getApplicationContext());
         final SourceParams cardSourceParams = SourceParams.createCardParams(card);
         // Note: using this style of Observable creation results in us having a method that
         // will not be called until we subscribe to it.

--- a/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
@@ -60,13 +60,13 @@ public class RedirectActivity extends AppCompatActivity {
         setContentView(R.layout.activity_polling);
 
         mCompositeSubscription = new CompositeSubscription();
-        mCardInputWidget = (CardInputWidget) findViewById(R.id.card_widget_three_d);
+        mCardInputWidget = findViewById(R.id.card_widget_three_d);
         mErrorDialogHandler = new ErrorDialogHandler(this.getSupportFragmentManager());
         mProgressDialogController = new ProgressDialogController(this.getSupportFragmentManager());
         mRedirectDialogController = new RedirectDialogController(this);
-        mStripe = new Stripe(this);
+        mStripe = new Stripe(getApplicationContext());
 
-        Button threeDSecureButton = (Button) findViewById(R.id.btn_three_d_secure);
+        Button threeDSecureButton = findViewById(R.id.btn_three_d_secure);
         threeDSecureButton.setOnClickListener(
                 new View.OnClickListener() {
                     @Override
@@ -75,7 +75,7 @@ public class RedirectActivity extends AppCompatActivity {
                     }
                 });
 
-        Button threeDSyncButton = (Button) findViewById(R.id.btn_three_d_secure_sync);
+        Button threeDSyncButton = findViewById(R.id.btn_three_d_secure_sync);
         threeDSyncButton.setOnClickListener(
                 new View.OnClickListener() {
                     @Override
@@ -83,7 +83,7 @@ public class RedirectActivity extends AppCompatActivity {
                         beginSequence();
                     }
                 });
-        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+        RecyclerView recyclerView = findViewById(R.id.recycler_view);
 
         RecyclerView.LayoutManager linearLayoutManager = new LinearLayoutManager(this);
         recyclerView.setHasFixedSize(true);

--- a/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.widget.Button;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
@@ -19,11 +20,12 @@ import com.stripe.android.view.CardInputWidget;
  */
 public class AsyncTaskTokenController {
 
-    private CardInputWidget mCardInputWidget;
-    private Context mContext;
-    private ErrorDialogHandler mErrorDialogHandler;
-    private ListViewController mOutputListController;
-    private ProgressDialogController mProgressDialogController;
+    @NonNull private final Context mContext;
+    @NonNull private final ErrorDialogHandler mErrorDialogHandler;
+    @NonNull private ListViewController mOutputListController;
+    @NonNull private final ProgressDialogController mProgressDialogController;
+
+    @Nullable private CardInputWidget mCardInputWidget;
 
     public AsyncTaskTokenController(
             @NonNull Button button,

--- a/example/src/main/java/com/stripe/example/controller/ErrorDialogHandler.java
+++ b/example/src/main/java/com/stripe/example/controller/ErrorDialogHandler.java
@@ -1,5 +1,6 @@
 package com.stripe.example.controller;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
@@ -11,13 +12,13 @@ import com.stripe.example.dialog.ErrorDialogFragment;
  */
 public class ErrorDialogHandler {
 
-    FragmentManager mFragmentManager;
+    @NonNull private final FragmentManager mFragmentManager;
 
-    public ErrorDialogHandler(FragmentManager fragmentManager) {
+    public ErrorDialogHandler(@NonNull FragmentManager fragmentManager) {
         mFragmentManager = fragmentManager;
     }
 
-    public void showError(String errorMessage) {
+    public void showError(@NonNull String errorMessage) {
         DialogFragment fragment = ErrorDialogFragment.newInstance(
                 R.string.validationErrors, errorMessage);
         fragment.show(mFragmentManager, "error");

--- a/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.Button;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
@@ -22,13 +23,13 @@ import com.stripe.example.service.TokenIntentService;
  */
 public class IntentServiceTokenController {
 
-    private Activity mActivity;
-    private CardInputWidget mCardInputWidget;
-    private ErrorDialogHandler mErrorDialogHandler;
-    private ListViewController mOutputListViewController;
-    private ProgressDialogController mProgressDialogController;
+    @NonNull private final ErrorDialogHandler mErrorDialogHandler;
+    @NonNull private final ListViewController mOutputListViewController;
+    @NonNull private final ProgressDialogController mProgressDialogController;
 
-    private TokenBroadcastReceiver mTokenBroadcastReceiver;
+    private Activity mActivity;
+    @Nullable private CardInputWidget mCardInputWidget;
+    @Nullable private TokenBroadcastReceiver mTokenBroadcastReceiver;
 
     public IntentServiceTokenController (
             @NonNull AppCompatActivity appCompatActivity,
@@ -74,12 +75,12 @@ public class IntentServiceTokenController {
     }
 
     private void saveCard() {
-        Card cardToSave = mCardInputWidget.getCard();
+        final Card cardToSave = mCardInputWidget.getCard();
         if (cardToSave == null) {
             mErrorDialogHandler.showError("Invalid Card Data");
             return;
         }
-        Intent tokenServiceIntent = TokenIntentService.createTokenIntent(
+        final Intent tokenServiceIntent = TokenIntentService.createTokenIntent(
                 mActivity,
                 cardToSave.getNumber(),
                 cardToSave.getExpMonth(),

--- a/example/src/main/java/com/stripe/example/controller/ListViewController.java
+++ b/example/src/main/java/com/stripe/example/controller/ListViewController.java
@@ -1,6 +1,7 @@
 package com.stripe.example.controller;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
 
@@ -19,31 +20,31 @@ import java.util.Map;
  */
 public class ListViewController {
 
-    private SimpleAdapter mAdatper;
-    private List<Map<String, String>> mCardTokens = new ArrayList<Map<String, String>>();
-    private Context mContext;
+    @NonNull private final SimpleAdapter mAdapter;
+    @NonNull private final List<Map<String, String>> mCardTokens = new ArrayList<>();
+    @NonNull private final Resources mResources;
 
-    public ListViewController(ListView listView) {
-        mContext = listView.getContext();
-        mAdatper = new SimpleAdapter(
-                mContext,
+    public ListViewController(@NonNull ListView listView) {
+        final Context context = listView.getContext();
+        mResources = context.getResources();
+        mAdapter = new SimpleAdapter(
+                context,
                 mCardTokens,
                 R.layout.list_item_layout,
                 new String[]{"last4", "tokenId"},
                 new int[]{R.id.last4, R.id.tokenId});
-        listView.setAdapter(mAdatper);
+        listView.setAdapter(mAdapter);
     }
 
-    void addToList(Token token) {
+    void addToList(@NonNull Token token) {
         addToList(token.getCard().getLast4(), token.getId());
     }
 
     public void addToList(@NonNull String last4, @NonNull String tokenId) {
-        String endingIn = mContext.getString(R.string.endingIn);
-        Map<String, String> map = new HashMap<>();
-        map.put("last4", endingIn + " " + last4);
+        final Map<String, String> map = new HashMap<>();
+        map.put("last4", mResources.getString(R.string.endingIn) + " " + last4);
         map.put("tokenId", tokenId);
         mCardTokens.add(map);
-        mAdatper.notifyDataSetChanged();
+        mAdapter.notifyDataSetChanged();
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
@@ -12,7 +12,7 @@ import com.stripe.example.dialog.ProgressDialogFragment;
  */
 public class ProgressDialogController {
 
-    private FragmentManager mFragmentManager;
+    @NonNull private final FragmentManager mFragmentManager;
     private ProgressDialogFragment mProgressFragment;
 
     public ProgressDialogController(@NonNull FragmentManager fragmentManager) {

--- a/example/src/main/java/com/stripe/example/controller/RedirectDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/RedirectDialogController.java
@@ -1,13 +1,14 @@
 package com.stripe.example.controller;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.stripe.example.R;
 
@@ -16,10 +17,10 @@ import com.stripe.example.R;
  */
 public class RedirectDialogController {
 
-    AppCompatActivity mActivity;
-    AlertDialog mAlertDialog;
+    @NonNull private final Activity mActivity;
+    private AlertDialog mAlertDialog;
 
-    public RedirectDialogController(AppCompatActivity appCompatActivity) {
+    public RedirectDialogController(@NonNull Activity appCompatActivity) {
         mActivity = appCompatActivity;
     }
 
@@ -27,7 +28,7 @@ public class RedirectDialogController {
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
         View dialogView = LayoutInflater.from(mActivity).inflate(R.layout.polling_dialog, null);
 
-        TextView linkView = (TextView) dialogView.findViewById(R.id.tv_link_redirect);
+        TextView linkView = dialogView.findViewById(R.id.tv_link_redirect);
         linkView.setText(R.string.verify);
         linkView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/example/src/main/java/com/stripe/example/controller/RxTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/RxTokenController.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.widget.Button;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.jakewharton.rxbinding.view.RxView;
 import com.stripe.android.PaymentConfiguration;
@@ -27,14 +28,15 @@ import rx.subscriptions.CompositeSubscription;
  */
 public class RxTokenController {
 
-    private CardInputWidget mCardInputWidget;
-    private CompositeSubscription mCompositeSubscription;
-    private Context mContext;
-    private ErrorDialogHandler mErrorDialogHandler;
-    private ListViewController mOutputListController;
-    private ProgressDialogController mProgressDialogController;
+    @NonNull private final CompositeSubscription mCompositeSubscription;
+    @NonNull private final Context mContext;
+    @NonNull private final ErrorDialogHandler mErrorDialogHandler;
+    @NonNull private final ListViewController mOutputListController;
+    @NonNull private final ProgressDialogController mProgressDialogController;
 
-    public RxTokenController (
+    @Nullable private CardInputWidget mCardInputWidget;
+
+    public RxTokenController(
             @NonNull Button button,
             @NonNull CardInputWidget cardInputWidget,
             @NonNull Context context,
@@ -63,9 +65,7 @@ public class RxTokenController {
      * Release subscriptions to prevent memory leaks.
      */
     public void detach() {
-        if  (mCompositeSubscription != null) {
-            mCompositeSubscription.unsubscribe();
-        }
+        mCompositeSubscription.unsubscribe();
         mCardInputWidget = null;
     }
 

--- a/example/src/main/java/com/stripe/example/module/DependencyHandler.java
+++ b/example/src/main/java/com/stripe/example/module/DependencyHandler.java
@@ -5,6 +5,7 @@ import android.widget.Button;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.stripe.android.model.Card;
@@ -22,22 +23,22 @@ import com.stripe.example.controller.RxTokenController;
  */
 public class DependencyHandler {
 
-    private AsyncTaskTokenController mAsyncTaskController;
-    private CardInputWidget mCardInputWidget;
-    private Context mContext;
-    private ErrorDialogHandler mErrorDialogHandler;
-    private IntentServiceTokenController mIntentServiceTokenController;
-    private ListViewController mListViewController;
-    private RxTokenController mRxTokenController;
-    private ProgressDialogController mProgresDialogController;
+    @Nullable private AsyncTaskTokenController mAsyncTaskController;
+    @NonNull private final CardInputWidget mCardInputWidget;
+    @NonNull private final Context mContext;
+    @NonNull private final ProgressDialogController mProgresDialogController;
+    @NonNull private final ErrorDialogHandler mErrorDialogHandler;
+    @Nullable private IntentServiceTokenController mIntentServiceTokenController;
+    @NonNull private final ListViewController mListViewController;
+    @Nullable private RxTokenController mRxTokenController;
 
     public DependencyHandler(
-            AppCompatActivity activity,
-            CardInputWidget cardInputWidget,
-            ListView outputListView) {
+            @NonNull AppCompatActivity activity,
+            @NonNull CardInputWidget cardInputWidget,
+            @NonNull ListView outputListView) {
 
         mCardInputWidget = cardInputWidget;
-        mContext = activity.getBaseContext();
+        mContext = activity.getApplicationContext();
 
         mProgresDialogController =
                 new ProgressDialogController(activity.getSupportFragmentManager());

--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.java
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.java
@@ -30,6 +30,7 @@ public class TokenIntentService extends IntentService {
     private static final String EXTRA_YEAR = "com.stripe.example.service.extra.year";
     private static final String EXTRA_CVC = "com.stripe.example.service.extra.cvc";
 
+    @NonNull
     public static Intent createTokenIntent(
             @NonNull Activity launchingActivity,
             @Nullable String cardNumber,
@@ -52,14 +53,14 @@ public class TokenIntentService extends IntentService {
         String errorMessage = null;
         Token token = null;
         if (intent != null) {
-            String cardNumber = intent.getStringExtra(EXTRA_CARD_NUMBER);
-            Integer month = (Integer) intent.getExtras().get(EXTRA_MONTH);
-            Integer year = (Integer) intent.getExtras().get(EXTRA_YEAR);
-            String cvc = intent.getStringExtra(EXTRA_CVC);
+            final String cardNumber = intent.getStringExtra(EXTRA_CARD_NUMBER);
+            final Integer month = (Integer) intent.getExtras().get(EXTRA_MONTH);
+            final Integer year = (Integer) intent.getExtras().get(EXTRA_YEAR);
+            final String cvc = intent.getStringExtra(EXTRA_CVC);
 
-            Card card = new Card(cardNumber, month, year, cvc);
+            final Card card = new Card(cardNumber, month, year, cvc);
 
-            Stripe stripe = new Stripe(this);
+            final Stripe stripe = new Stripe(getApplicationContext());
             try {
                 token = stripe.createTokenSynchronous(card,
                         PaymentConfiguration.getInstance().getPublishableKey());
@@ -68,7 +69,7 @@ public class TokenIntentService extends IntentService {
             }
         }
 
-        Intent localIntent = new Intent(TOKEN_ACTION);
+        final Intent localIntent = new Intent(TOKEN_ACTION);
         if (token != null) {
             localIntent.putExtra(STRIPE_CARD_LAST_FOUR, token.getCard().getLast4());
             localIntent.putExtra(STRIPE_CARD_TOKEN_ID, token.getId());

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -77,7 +77,7 @@ public class Stripe {
      * @param context {@link Context} for resolving resources
      */
     public Stripe(@NonNull Context context) {
-        mContext = context;
+        mContext = context.getApplicationContext();
     }
 
     /**
@@ -87,7 +87,7 @@ public class Stripe {
      * @param publishableKey the client's publishable key
      */
     public Stripe(@NonNull Context context, String publishableKey) {
-        mContext = context;
+        mContext = context.getApplicationContext();
         setDefaultPublishableKey(publishableKey);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddSourceActivity.java
@@ -47,7 +47,7 @@ public class AddSourceActivity extends StripeActivity {
     private boolean mStartedFromPaymentSession;
     private boolean mUpdatesCustomer;
 
-    private TextView.OnEditorActionListener mOnEditorActionListener =
+    @NonNull private final TextView.OnEditorActionListener mOnEditorActionListener =
             new TextView.OnEditorActionListener() {
                 @Override
                 public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
@@ -74,13 +74,13 @@ public class AddSourceActivity extends StripeActivity {
      * return a source.
      * @return an {@link Intent} that can be used to start this activity
      */
+    @NonNull
     public static Intent newIntent(@NonNull Context context,
                                    boolean requirePostalField,
                                    boolean updatesCustomer) {
-        Intent intent = new Intent(context, AddSourceActivity.class);
-        intent.putExtra(EXTRA_SHOW_ZIP, requirePostalField);
-        intent.putExtra(EXTRA_UPDATE_CUSTOMER, updatesCustomer);
-        return intent;
+        return new Intent(context, AddSourceActivity.class)
+                .putExtra(EXTRA_SHOW_ZIP, requirePostalField)
+                .putExtra(EXTRA_UPDATE_CUSTOMER, updatesCustomer);
     }
 
     @Override
@@ -123,17 +123,17 @@ public class AddSourceActivity extends StripeActivity {
 
     @Override
     protected void onActionSave() {
-        Card card = mCardMultilineWidget.getCard();
+        final Card card = mCardMultilineWidget.getCard();
         if (card == null) {
             // In this case, the error will be displayed on the card widget itself.
             return;
         }
 
         card.addLoggingToken(ADD_SOURCE_ACTIVITY);
-        Stripe stripe = getStripe();
+        final Stripe stripe = getStripe();
         stripe.setDefaultPublishableKey(PaymentConfiguration.getInstance().getPublishableKey());
 
-        SourceParams sourceParams = SourceParams.createCardParams(card);
+        final SourceParams sourceParams = SourceParams.createCardParams(card);
         setCommunicatingProgress(true);
 
         stripe.createSource(sourceParams, new SourceCallback() {
@@ -173,7 +173,7 @@ public class AddSourceActivity extends StripeActivity {
                 };
 
         if (mCustomerSessionProxy == null) {
-            @Source.SourceType String sourceType;
+            @Source.SourceType final String sourceType;
             if (source instanceof Source) {
                 sourceType = ((Source) source).getType();
             } else if (source instanceof Card){
@@ -218,9 +218,10 @@ public class AddSourceActivity extends StripeActivity {
         finish();
     }
 
+    @NonNull
     private Stripe getStripe() {
         if (mStripeProvider == null) {
-            return new Stripe(this);
+            return new Stripe(getApplicationContext());
         } else {
             return mStripeProvider.getStripe(this);
         }
@@ -245,7 +246,7 @@ public class AddSourceActivity extends StripeActivity {
     }
 
     interface StripeProvider {
-        Stripe getStripe(@NonNull Context context);
+        @NonNull Stripe getStripe(@NonNull Context context);
     }
 
     interface CustomerSessionProxy {

--- a/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
@@ -86,14 +86,13 @@ public class AddSourceActivityTest {
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);
 
         mShadowActivity = shadowOf(addSourceActivity);
-        AddSourceActivity.StripeProvider mockStripeProvider =
-                new AddSourceActivity.StripeProvider() {
-                    @Override
-                    public Stripe getStripe(@NonNull Context context) {
-                        return mStripe;
-                    }
-                };
-        addSourceActivity.setStripeProvider(mockStripeProvider);
+        addSourceActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
+            @NonNull
+            @Override
+            public Stripe getStripe(@NonNull Context context) {
+                return mStripe;
+            }
+        });
     }
 
     private void setUpForProxySessionTest() {
@@ -110,14 +109,13 @@ public class AddSourceActivityTest {
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);
 
         mShadowActivity = shadowOf(addSourceActivity);
-        AddSourceActivity.StripeProvider mockStripeProvider =
-                new AddSourceActivity.StripeProvider() {
-                    @Override
-                    public Stripe getStripe(@NonNull Context context) {
-                        return mStripe;
-                    }
-                };
-        addSourceActivity.setStripeProvider(mockStripeProvider);
+        addSourceActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
+            @NonNull
+            @Override
+            public Stripe getStripe(@NonNull Context context) {
+                return mStripe;
+            }
+        });
         addSourceActivity.setCustomerSessionProxy(mCustomerSessionProxy);
         addSourceActivity.initCustomerSessionTokens();
     }


### PR DESCRIPTION
**Summary**
The crux of this change is making Stripe constructors use
Application context instead of Activity context.

This change also marks instance variables as `final` and
`@NonNull` where applicable.

**Motivation**
Relying on activity context for asynchronous tasks can
lead to memory leaks. We would only need an Activity
context to access the UI, which is not the case for any
of the logic in Stripe.java.

**Testing**
Interacted with all of the screens in the example app.