### PR TITLE
Add metadata field to Card

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
 
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,43 +17,43 @@ import static com.stripe.android.model.Source.SourceType;
  */
 public class SourceParams {
 
-    static final String API_PARAM_AMOUNT = "amount";
-    static final String API_PARAM_CURRENCY = "currency";
-    static final String API_PARAM_METADATA = "metadata";
-    static final String API_PARAM_OWNER = "owner";
-    static final String API_PARAM_REDIRECT = "redirect";
-    static final String API_PARAM_TYPE = "type";
-    static final String API_PARAM_TOKEN = "token";
-    static final String API_PARAM_USAGE = "usage";
+    private static final String API_PARAM_AMOUNT = "amount";
+    private static final String API_PARAM_CURRENCY = "currency";
+    private static final String API_PARAM_METADATA = "metadata";
+    private static final String API_PARAM_OWNER = "owner";
+    private static final String API_PARAM_REDIRECT = "redirect";
+    private static final String API_PARAM_TYPE = "type";
+    private static final String API_PARAM_TOKEN = "token";
+    private static final String API_PARAM_USAGE = "usage";
 
-    static final String API_PARAM_CLIENT_SECRET = "client_secret";
+    private static final String API_PARAM_CLIENT_SECRET = "client_secret";
 
-    static final String FIELD_ADDRESS = "address";
-    static final String FIELD_BANK = "bank";
-    static final String FIELD_CARD = "card";
-    static final String FIELD_CITY = "city";
-    static final String FIELD_COUNTRY = "country";
-    static final String FIELD_CVC = "cvc";
-    static final String FIELD_EMAIL = "email";
-    static final String FIELD_EXP_MONTH = "exp_month";
-    static final String FIELD_EXP_YEAR = "exp_year";
-    static final String FIELD_IBAN = "iban";
-    static final String FIELD_LINE_1 = "line1";
-    static final String FIELD_LINE_2 = "line2";
-    static final String FIELD_NAME = "name";
-    static final String FIELD_NUMBER = "number";
-    static final String FIELD_POSTAL_CODE = "postal_code";
-    static final String FIELD_RETURN_URL = "return_url";
-    static final String FIELD_STATE = "state";
-    static final String FIELD_STATEMENT_DESCRIPTOR = "statement_descriptor";
-    static final String FIELD_PREFERRED_LANGUAGE = "preferred_language";
+    private static final String FIELD_ADDRESS = "address";
+    private static final String FIELD_BANK = "bank";
+    private static final String FIELD_CARD = "card";
+    private static final String FIELD_CITY = "city";
+    private static final String FIELD_COUNTRY = "country";
+    private static final String FIELD_CVC = "cvc";
+    private static final String FIELD_EMAIL = "email";
+    private static final String FIELD_EXP_MONTH = "exp_month";
+    private static final String FIELD_EXP_YEAR = "exp_year";
+    private static final String FIELD_IBAN = "iban";
+    private static final String FIELD_LINE_1 = "line1";
+    private static final String FIELD_LINE_2 = "line2";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_NUMBER = "number";
+    private static final String FIELD_POSTAL_CODE = "postal_code";
+    private static final String FIELD_RETURN_URL = "return_url";
+    private static final String FIELD_STATE = "state";
+    private static final String FIELD_STATEMENT_DESCRIPTOR = "statement_descriptor";
+    private static final String FIELD_PREFERRED_LANGUAGE = "preferred_language";
 
-    static final String VISA_CHECKOUT = "visa_checkout";
-    static final String CALL_ID = "callid";
+    private static final String VISA_CHECKOUT = "visa_checkout";
+    private static final String CALL_ID = "callid";
 
-    static final String MASTERPASS = "masterpass";
-    static final String TRANSACTION_ID = "transaction_id";
-    static final String CART_ID = "cart_id";
+    private static final String MASTERPASS = "masterpass";
+    private static final String TRANSACTION_ID = "transaction_id";
+    private static final String CART_ID = "cart_id";
 
     @IntRange(from = 0) private Long mAmount;
     private Map<String, Object> mApiParameterMap;
@@ -82,19 +83,20 @@ public class SourceParams {
      *
      * @see <a href="https://stripe.com/docs/sources/p24">https://stripe.com/docs/sources/p24</a>
      */
+    @NonNull
     public static SourceParams createP24Params(
             @IntRange(from = 0) long amount,
             @NonNull String currency,
             @Nullable String name,
             @NonNull String email,
             @NonNull String returnUrl) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setAmount(amount)
                 .setType(Source.P24)
                 .setCurrency(currency)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
-        Map<String, Object> ownerMap = new HashMap<>();
+        final AbstractMap<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
         removeNullAndEmptyParams(ownerMap);
@@ -119,18 +121,19 @@ public class SourceParams {
      *
      * @see <a href="https://stripe.com/docs/sources/alipay">https://stripe.com/docs/sources/alipay</a>
      */
+    @NonNull
     public static SourceParams createAlipayReusableParams(
             @NonNull String currency,
             @Nullable String name,
             @Nullable String email,
             @NonNull String returnUrl) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.ALIPAY)
                 .setCurrency(currency)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
                 .setUsage(Source.REUSABLE);
 
-        Map<String, Object> ownerMap = new HashMap<>();
+        final AbstractMap<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
         removeNullAndEmptyParams(ownerMap);
@@ -164,13 +167,13 @@ public class SourceParams {
             @Nullable String name,
             @Nullable String email,
             @NonNull String returnUrl) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.ALIPAY)
                 .setCurrency(currency)
                 .setAmount(amount)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
-        Map<String, Object> ownerMap = new HashMap<>();
+        final AbstractMap<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
         removeNullAndEmptyParams(ownerMap);
@@ -205,7 +208,7 @@ public class SourceParams {
             @NonNull String returnUrl,
             @Nullable String statementDescriptor,
             @Nullable String preferredLanguage) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.BANCONTACT)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
@@ -213,7 +216,7 @@ public class SourceParams {
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
         if (statementDescriptor != null || preferredLanguage != null) {
-            Map<String, Object> additionalParamsMap = new HashMap<>();
+            final AbstractMap<String, Object> additionalParamsMap = new HashMap<>();
 
             additionalParamsMap.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
             additionalParamsMap.put(FIELD_PREFERRED_LANGUAGE, preferredLanguage);
@@ -260,11 +263,11 @@ public class SourceParams {
      */
     @NonNull
     public static SourceParams createCardParams(@NonNull Card card) {
-        SourceParams params = new SourceParams().setType(Source.CARD);
+        final SourceParams params = new SourceParams().setType(Source.CARD);
 
         // Not enforcing all fields to exist at this level.
         // Instead, the server will return an error for invalid data.
-        Map<String, Object> basicInfoMap = new HashMap<>();
+        final AbstractMap<String, Object> basicInfoMap = new HashMap<>();
         basicInfoMap.put(FIELD_NUMBER, card.getNumber());
         basicInfoMap.put(FIELD_EXP_MONTH, card.getExpMonth());
         basicInfoMap.put(FIELD_EXP_YEAR, card.getExpYear());
@@ -273,7 +276,7 @@ public class SourceParams {
 
         params.setApiParameterMap(basicInfoMap);
 
-        Map<String, Object> addressMap = new HashMap<>();
+        final Map<String, Object> addressMap = new HashMap<>();
         addressMap.put(FIELD_LINE_1, card.getAddressLine1());
         addressMap.put(FIELD_LINE_2, card.getAddressLine2());
         addressMap.put(FIELD_CITY, card.getAddressCity());
@@ -283,7 +286,7 @@ public class SourceParams {
         removeNullAndEmptyParams(addressMap);
 
         // If there are any keys left...
-        Map<String, Object> ownerMap = new HashMap<>();
+        final Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, card.getName());
         if (addressMap.keySet().size() > 0) {
             ownerMap.put(FIELD_ADDRESS, addressMap);
@@ -291,6 +294,11 @@ public class SourceParams {
         removeNullAndEmptyParams(ownerMap);
         if (ownerMap.keySet().size() > 0) {
             params.setOwner(ownerMap);
+        }
+
+        final Map<String, String> metadata = card.getMetadata();
+        if (metadata != null) {
+            params.setMetaData(metadata);
         }
 
         return params;
@@ -315,7 +323,7 @@ public class SourceParams {
             @NonNull String name,
             @NonNull String returnUrl,
             @Nullable String statementDescriptor) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.EPS)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
@@ -350,7 +358,7 @@ public class SourceParams {
             @NonNull String name,
             @NonNull String returnUrl,
             @Nullable String statementDescriptor) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.GIROPAY)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
@@ -387,7 +395,7 @@ public class SourceParams {
             @NonNull String returnUrl,
             @Nullable String statementDescriptor,
             @Nullable String bank) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.IDEAL)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
@@ -395,7 +403,7 @@ public class SourceParams {
         if (name != null) {
             params.setOwner(createSimpleMap(FIELD_NAME, name));
         }
-        Map<String, Object> additionalParamsMap = new HashMap<>();
+        final Map<String, Object> additionalParamsMap = new HashMap<>();
         if (statementDescriptor != null) {
             additionalParamsMap.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
         }
@@ -425,13 +433,12 @@ public class SourceParams {
             @IntRange(from = 0) long amount,
             @NonNull String returnUrl,
             @NonNull String email) {
-        SourceParams params = new SourceParams()
+        return new SourceParams()
                 .setType(Source.MULTIBANCO)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
                 .setOwner(createSimpleMap(FIELD_EMAIL, email));
-        return params;
     }
 
     @NonNull
@@ -468,23 +475,24 @@ public class SourceParams {
             @Nullable String city,
             @Nullable String postalCode,
             @Nullable @Size(2) String country) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.SEPA_DEBIT)
                 .setCurrency(Source.EURO);
 
-        Map<String, Object> address = new HashMap<>();
+        final AbstractMap<String, Object> address = new HashMap<>();
         address.put(FIELD_LINE_1, addressLine1);
         address.put(FIELD_CITY, city);
         address.put(FIELD_POSTAL_CODE, postalCode);
         address.put(FIELD_COUNTRY, country);
 
-        Map<String, Object> ownerMap = new HashMap<>();
+        final AbstractMap<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
         ownerMap.put(FIELD_ADDRESS, address);
 
-        params.setOwner(ownerMap).setApiParameterMap(createSimpleMap(FIELD_IBAN, iban));
-        return params;
+        return params
+                .setOwner(ownerMap)
+                .setApiParameterMap(createSimpleMap(FIELD_IBAN, iban));
     }
 
     /**
@@ -506,13 +514,13 @@ public class SourceParams {
             @NonNull String returnUrl,
             @NonNull @Size(2) String country,
             @Nullable String statementDescriptor) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.SOFORT)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
-        Map<String, Object> sofortMap = createSimpleMap(FIELD_COUNTRY, country);
+        final Map<String, Object> sofortMap = createSimpleMap(FIELD_COUNTRY, country);
         if (statementDescriptor != null) {
             sofortMap.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
         }
@@ -540,7 +548,7 @@ public class SourceParams {
             @NonNull String currency,
             @NonNull String returnUrl,
             @NonNull String cardID) {
-        SourceParams params = new SourceParams()
+        final SourceParams params = new SourceParams()
                 .setType(Source.THREE_D_SECURE)
                 .setCurrency(currency)
                 .setAmount(amount)
@@ -558,12 +566,12 @@ public class SourceParams {
      * @see <a href="https://stripe.com/docs/visa-checkout">https://stripe.com/docs/visa-checkout</a>
      * @see <a href="https://developer.visa.com/capabilities/visa_checkout/docs">https://developer.visa.com/capabilities/visa_checkout/docs</a>
      */
+    @NonNull
     public static SourceParams createVisaCheckoutParams(@NonNull String callId) {
-        SourceParams params = new SourceParams().setType(Source.CARD);
-        Map<String, Object> visaCheckoutMap =
-                createSimpleMap(VISA_CHECKOUT, createSimpleMap(CALL_ID, callId));
-        params.setApiParameterMap(visaCheckoutMap);
-        return params;
+        return new SourceParams()
+                .setType(Source.CARD)
+                .setApiParameterMap(
+                        createSimpleMap(VISA_CHECKOUT, createSimpleMap(CALL_ID, callId)));
     }
 
     /**
@@ -579,16 +587,16 @@ public class SourceParams {
      * @see <a href="https://developer.mastercard.com/product/masterpass">https://developer.mastercard.com/product/masterpass</a>
      * @see <a href="https://developer.mastercard.com/page/masterpass-merchant-mobile-checkout-sdk-for-android-v2">https://developer.mastercard.com/page/masterpass-merchant-mobile-checkout-sdk-for-android-v2</a>
      */
+    @NonNull
     public static SourceParams createMasterpassParams(
             @NonNull String transactionId,
             @NonNull String cartID) {
-        SourceParams params = new SourceParams().setType(Source.CARD);
-        Map map = createSimpleMap(TRANSACTION_ID, transactionId);
+        final Map<String, Object> map = createSimpleMap(TRANSACTION_ID, transactionId);
         map.put(CART_ID, cartID);
-        Map<String, Object> masterpassMap =
-                createSimpleMap(MASTERPASS, map);
-        params.setApiParameterMap(masterpassMap);
-        return params;
+
+        return new SourceParams()
+                .setType(Source.CARD)
+                .setApiParameterMap(createSimpleMap(MASTERPASS, map));
     }
 
     /**
@@ -602,7 +610,7 @@ public class SourceParams {
     @NonNull
     public static Map<String, Object> createRetrieveSourceParams(
             @NonNull @Size(min = 1) String clientSecret) {
-        Map<String, Object> params = new HashMap<>();
+        final Map<String, Object> params = new HashMap<>();
         params.put(API_PARAM_CLIENT_SECRET, clientSecret);
         return params;
     }
@@ -827,7 +835,7 @@ public class SourceParams {
      */
     @NonNull
     public Map<String, Object> toParamMap() {
-        Map<String, Object> networkReadyMap = new HashMap<>();
+        final AbstractMap<String, Object> networkReadyMap = new HashMap<>();
 
         networkReadyMap.put(API_PARAM_TYPE, mTypeRaw);
         networkReadyMap.put(mTypeRaw, mApiParameterMap);

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -259,7 +259,7 @@ public class StripeApiHandlerTest {
             assertNotNull(response);
             assertNotNull(response.getResponseHeaders());
             assertTrue(response.getResponseHeaders().containsKey("Stripe-Account"));
-            List<String> accounts = response.getResponseHeaders().get("Stripe-Account");
+            final List<String> accounts = response.getResponseHeaders().get("Stripe-Account");
             assertNotNull(accounts);
             assertEquals(1, accounts.size());
             assertEquals(connectAccountId, accounts.get(0));

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -444,11 +444,11 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withCardParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        final Stripe stripe = getNonLoggingStripe(mContext);
         stripe.setDefaultPublishableKey("pk_test_dCyfhfyeO2CZkcvT5xyIDdJj");
         stripe.setStripeAccount("acct_19YLYlE7cWSP2tMo");
 
-        Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
+        final Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         card.setAddressCity("Sheboygan");
         card.setAddressCountry("US");
         card.setAddressLine1("123 Main St");
@@ -456,8 +456,8 @@ public class StripeTest {
         card.setAddressZip("53081");
         card.setAddressState("WI");
         card.setName("Winnie Hoop");
-        SourceParams params = SourceParams.createCardParams(card);
-        Map<String, String> metamap = new HashMap<String, String>() {{
+        final SourceParams params = SourceParams.createCardParams(card);
+        final Map<String, String> metamap = new HashMap<String, String>() {{
             put("addons", "cream");
             put("type", "halfandhalf");
         }};

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model;
 
+import androidx.annotation.NonNull;
+
 import com.stripe.android.testharness.JsonTestUtils;
 
 import org.json.JSONException;
@@ -10,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.stripe.android.model.Card.asCardBrand;
@@ -49,7 +52,11 @@ public class CardTest {
             "    \"funding\": \"credit\",\n" +
             "    \"fingerprint\": \"abc123\",\n" +
             "    \"last4\": \"4242\",\n" +
-            "    \"name\": \"John Cardholder\"\n" +
+            "    \"name\": \"John Cardholder\",\n" +
+            "    \"metadata\": {\n" +
+            "      \"color\": \"blue\",\n" +
+            "      \"animal\": \"dog\"\n" +
+            "    }\n" +
             "  }";
 
     private static final String BAD_JSON = "{ \"id\": ";
@@ -646,8 +653,8 @@ public class CardTest {
                 null,
                 null,
                 null,
-                null
-                );
+                null,
+                null);
         assertEquals("1234", card.getLast4());
     }
 
@@ -671,8 +678,8 @@ public class CardTest {
                 null,
                 null,
                 null,
-                null
-        );
+                null,
+                null);
         assertEquals(Card.AMERICAN_EXPRESS, card.getBrand());
         //noinspection deprecation
         assertEquals(Card.AMERICAN_EXPRESS, card.getType());
@@ -680,9 +687,9 @@ public class CardTest {
 
     @Test
     public void fromString_whenStringIsValidJson_returnsExpectedCard() {
-        Card expectedCard = buildEquivalentJsonCard();
+        final Card expectedCard = buildEquivalentJsonCard();
 
-        Card cardFromJson = Card.fromString(JSON_CARD);
+        final Card cardFromJson = Card.fromString(JSON_CARD);
 
         assertNotNull(cardFromJson);
         assertEquals(expectedCard.getBrand(), cardFromJson.getBrand());
@@ -705,6 +712,7 @@ public class CardTest {
         assertEquals(expectedCard.getCustomerId(), cardFromJson.getCustomerId());
         assertEquals(expectedCard.getFingerprint(), cardFromJson.getFingerprint());
         assertEquals(expectedCard.getId(), cardFromJson.getId());
+        assertEquals(expectedCard.getMetadata(), cardFromJson.getMetadata());
     }
 
     @Test
@@ -724,9 +732,9 @@ public class CardTest {
     @Test
     public void toMap_catchesAllFields_fromRawJson() {
         try {
-            JSONObject rawJsonObject = new JSONObject(JSON_CARD);
-            Map<String, Object> rawMap = StripeJsonUtils.jsonObjectToMap(rawJsonObject);
-            Card expectedCard = buildEquivalentJsonCard();
+            final JSONObject rawJsonObject = new JSONObject(JSON_CARD);
+            final Map<String, Object> rawMap = StripeJsonUtils.jsonObjectToMap(rawJsonObject);
+            final Card expectedCard = buildEquivalentJsonCard();
             JsonTestUtils.assertMapEquals(rawMap, expectedCard.toMap());
         } catch (JSONException unexpected) {
             fail();
@@ -738,23 +746,29 @@ public class CardTest {
         assertNull(Card.fromString(BAD_JSON));
     }
 
+    @NonNull
     private static Card buildEquivalentJsonCard() {
-        Card.Builder builder = new Card.Builder(null, 8, 2017, null);
-        builder.brand(Card.VISA);
-        builder.funding(Card.FUNDING_CREDIT);
-        builder.last4("4242");
-        builder.id("card_189fi32eZvKYlo2CHK8NPRME");
-        builder.country("US");
-        builder.currency("usd");
-        builder.addressCountry("US");
-        builder.addressCity("Des Moines");
-        builder.addressState("IA").addressZip("50305").addressZipCheck("unavailable");
-        builder.addressLine1("123 Any Street").addressLine1Check("unavailable").addressLine2("456");
-        builder.name("John Cardholder");
-        builder.cvcCheck("unavailable");
-        builder.customer("customer77");
-        builder.fingerprint("abc123");
-        return builder.build();
+        final Map<String, String> metadata = new HashMap<>(2);
+        metadata.put("color", "blue");
+        metadata.put("animal", "dog");
+
+        return new Card.Builder(null, 8, 2017, null)
+                .brand(Card.VISA)
+                .funding(Card.FUNDING_CREDIT)
+                .last4("4242")
+                .id("card_189fi32eZvKYlo2CHK8NPRME")
+                .country("US")
+                .currency("usd")
+                .addressCountry("US")
+                .addressCity("Des Moines")
+                .addressState("IA").addressZip("50305").addressZipCheck("unavailable")
+                .addressLine1("123 Any Street").addressLine1Check("unavailable").addressLine2("456")
+                .name("John Cardholder")
+                .cvcCheck("unavailable")
+                .customer("customer77")
+                .fingerprint("abc123")
+                .metadata(metadata)
+                .build();
     }
 }
 

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
@@ -13,7 +13,7 @@ import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentIntentParamsTest {
-    private static Card FULL_FIELDS_VISA_CARD =
+    private static final Card FULL_FIELDS_VISA_CARD =
             new Card(VALID_VISA_NO_SPACES,
                     12,
                     2050,
@@ -25,13 +25,14 @@ public class PaymentIntentParamsTest {
                     "CA",
                     "94107",
                     "US",
-                    "usd");
+                    "usd",
+                    null);
 
-    private static String TEST_CLIENT_SECRET =
+    private static final String TEST_CLIENT_SECRET =
             "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA";
 
-    private static String TEST_RETURN_URL = "stripe://return_url";
-    private static String TEST_SOURCE_ID = "src_123testsourceid";
+    private static final String TEST_RETURN_URL = "stripe://return_url";
+    private static final String TEST_SOURCE_ID = "src_123testsourceid";
 
     @Test
     public void createConfirmPaymentIntentWithSourceDataParams_withAllFields_hasExpectedFields() {

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -24,23 +24,31 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class SourceParamsTest {
 
-    private static Card FULL_FIELDS_VISA_CARD =
-            new Card(VALID_VISA_NO_SPACES,
-                    12,
-                    2050,
-                    "123",
-                    "Captain Cardholder",
-                    "1 ABC Street",
-                    "Apt. 123",
-                    "San Francisco",
-                    "CA",
-                    "94107",
-                    "US",
-                    "usd");
+    private static final Card FULL_FIELDS_VISA_CARD;
+
+    static {
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("color", "blue");
+        metadata.put("animal", "dog");
+
+        FULL_FIELDS_VISA_CARD = new Card(VALID_VISA_NO_SPACES,
+                12,
+                2050,
+                "123",
+                "Captain Cardholder",
+                "1 ABC Street",
+                "Apt. 123",
+                "San Francisco",
+                "CA",
+                "94107",
+                "US",
+                "usd",
+                metadata);
+    }
 
     @Test
     public void createAlipayReusableParams_withAllFields_hasExpectedFields() {
-        SourceParams params = SourceParams.createAlipayReusableParams(
+        final SourceParams params = SourceParams.createAlipayReusableParams(
                 "usd",
                 "Jean Valjean",
                 "jdog@lesmis.net",
@@ -60,7 +68,7 @@ public class SourceParamsTest {
 
     @Test
     public void createAlipayReusableParams_withOnlyName_hasOnlyExpectedFields() {
-        SourceParams params = SourceParams.createAlipayReusableParams(
+        final SourceParams params = SourceParams.createAlipayReusableParams(
                 "cad",
                 "Hari Seldon",
                 null,
@@ -80,7 +88,7 @@ public class SourceParamsTest {
 
     @Test
     public void createAlipaySingleUseParams_withAllFields_hasExpectedFields() {
-        SourceParams params = SourceParams.createAlipaySingleUseParams(
+        final SourceParams params = SourceParams.createAlipaySingleUseParams(
                 1000L,
                 "aud",
                 "Jane Tester",
@@ -100,7 +108,7 @@ public class SourceParamsTest {
 
     @Test
     public void createAlipaySingleUseParams_withoutOwner_hasNoOwnerFields() {
-        SourceParams params = SourceParams.createAlipaySingleUseParams(
+        final SourceParams params = SourceParams.createAlipaySingleUseParams(
                 555L,
                 "eur",
                 null,
@@ -120,7 +128,7 @@ public class SourceParamsTest {
 
     @Test
     public void createBancontactParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createBancontactParams(
+        final SourceParams params = SourceParams.createBancontactParams(
                 1000L,
                 "Stripe",
                 "return/url/3000",
@@ -144,7 +152,7 @@ public class SourceParamsTest {
 
     @Test
     public void createBancontactParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createBancontactParams(
+        final SourceParams params = SourceParams.createBancontactParams(
                 1000L,
                 "Stripe",
                 "return/url/3000",
@@ -169,7 +177,7 @@ public class SourceParamsTest {
 
     @Test
     public void createBancontactParams_hasExpectedFields_optionalStatementDescriptor() {
-        SourceParams params = SourceParams.createBancontactParams(
+        final SourceParams params = SourceParams.createBancontactParams(
                 1000L,
                 "Stripe",
                 "return/url/3000",
@@ -184,7 +192,7 @@ public class SourceParamsTest {
 
     @Test
     public void createBancontactParams_hasExpectedFields_optionalPreferredLanguage() {
-        SourceParams params = SourceParams.createBancontactParams(
+        final SourceParams params = SourceParams.createBancontactParams(
                 1000L,
                 "Stripe",
                 "return/url/3000",
@@ -199,7 +207,7 @@ public class SourceParamsTest {
 
     @Test
     public void createBancontactParams_hasExpectedFields_optionalEverything() {
-        SourceParams params = SourceParams.createBancontactParams(
+        final SourceParams params = SourceParams.createBancontactParams(
                 1000L,
                 "Stripe",
                 "return/url/3000",
@@ -211,9 +219,9 @@ public class SourceParamsTest {
 
     @Test
     public void createCardParams_hasBothExpectedMaps() {
-        SourceParams params = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
+        final SourceParams params = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
 
-        Map<String, Object> apiMap = params.getApiParameterMap();
+        final Map<String, Object> apiMap = params.getApiParameterMap();
         assertNotNull(apiMap);
         assertEquals(VALID_VISA_NO_SPACES, apiMap.get("number"));
         assertEquals(12, apiMap.get("exp_month"));
@@ -223,20 +231,26 @@ public class SourceParamsTest {
         assertNotNull(params.getOwner());
         assertEquals("Captain Cardholder", params.getOwner().get("name"));
         assertEquals(2, params.getOwner().size());
-        Map<String, Object> addressMap = getMapFromOwner(params, "address");
+
+        final Map<String, Object> addressMap = getMapFromOwner(params, "address");
         assertEquals("1 ABC Street", addressMap.get("line1"));
         assertEquals("Apt. 123", addressMap.get("line2"));
         assertEquals("San Francisco", addressMap.get("city"));
         assertEquals("CA", addressMap.get("state"));
         assertEquals("94107", addressMap.get("postal_code"));
         assertEquals("US", addressMap.get("country"));
+
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("color", "blue");
+        metadata.put("animal", "dog");
+        assertEquals(metadata, params.getMetaData());
     }
 
     @Test
     public void createCardParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
+        final SourceParams params = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
 
-        Map<String, Object> expectedCardMap = new HashMap<>();
+        final Map<String, Object> expectedCardMap = new HashMap<>();
         expectedCardMap.put("number", VALID_VISA_NO_SPACES);
         expectedCardMap.put("exp_month", 12);
         expectedCardMap.put("exp_year", 2050);
@@ -250,7 +264,7 @@ public class SourceParamsTest {
         expectedAddressMap.put("postal_code", "94107");
         expectedAddressMap.put("country", "US");
 
-        Map<String, Object> totalExpectedMap = new HashMap<>();
+        final Map<String, Object> totalExpectedMap = new HashMap<>();
         totalExpectedMap.put("type", "card");
         totalExpectedMap.put("card", expectedCardMap);
         totalExpectedMap.put("owner",
@@ -259,12 +273,17 @@ public class SourceParamsTest {
                     put("name", "Captain Cardholder");
                 }});
 
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("color", "blue");
+        metadata.put("animal", "dog");
+        totalExpectedMap.put("metadata", metadata);
+
         JsonTestUtils.assertMapEquals(totalExpectedMap, params.toParamMap());
     }
 
     @Test
     public void createEPSParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createEPSParams(
+        final SourceParams params = SourceParams.createEPSParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -281,7 +300,7 @@ public class SourceParamsTest {
 
     @Test
     public void createEPSParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createEPSParams(
+        final SourceParams params = SourceParams.createEPSParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -304,7 +323,7 @@ public class SourceParamsTest {
 
     @Test
     public void createEPSParams_toParamMap_createsExpectedMap_noStatementDescriptor() {
-        SourceParams params = SourceParams.createEPSParams(
+        final SourceParams params = SourceParams.createEPSParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -323,7 +342,7 @@ public class SourceParamsTest {
 
     @Test
     public void createGiropayParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createGiropayParams(
+        final SourceParams params = SourceParams.createGiropayParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -344,7 +363,7 @@ public class SourceParamsTest {
 
     @Test
     public void createGiropayParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createGiropayParams(
+        final SourceParams params = SourceParams.createGiropayParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -367,7 +386,7 @@ public class SourceParamsTest {
 
     @Test
     public void createGiropayParams_withNullStatementDescriptor_hasExpectedFieldsButNoApiParams() {
-        SourceParams params = SourceParams.createGiropayParams(
+        final SourceParams params = SourceParams.createGiropayParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -386,7 +405,7 @@ public class SourceParamsTest {
 
     @Test
     public void createIdealParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createIdealParams(
+        final SourceParams params = SourceParams.createIdealParams(
                 900L,
                 "Default Name",
                 "stripe://anotherurl",
@@ -407,7 +426,7 @@ public class SourceParamsTest {
 
     @Test
     public void createIdealParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createIdealParams(
+        final SourceParams params = SourceParams.createIdealParams(
                 900L,
                 "Default Name",
                 "stripe://anotherurl",
@@ -433,7 +452,7 @@ public class SourceParamsTest {
 
     @Test
     public void createP24Params_withAllFields_hasExpectedFields() {
-        SourceParams params = SourceParams.createP24Params(
+        final SourceParams params = SourceParams.createP24Params(
                 1000L,
                 "eur",
                 "Jane Tester",
@@ -453,7 +472,7 @@ public class SourceParamsTest {
 
     @Test
     public void createP24Params_withNullName_hasExpectedFields() {
-        SourceParams params = SourceParams.createP24Params(
+        final SourceParams params = SourceParams.createP24Params(
                 1000L,
                 "eur",
                 null,
@@ -473,7 +492,7 @@ public class SourceParamsTest {
 
     @Test
     public void createMultibancoParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createMultibancoParams(
+        final SourceParams params = SourceParams.createMultibancoParams(
                 150L,
                 "stripe://testactivity",
                 "multibancoholder@stripe.com");
@@ -487,7 +506,7 @@ public class SourceParamsTest {
 
     @Test
     public void createMultibancoParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createMultibancoParams(
+        final SourceParams params = SourceParams.createMultibancoParams(
                 150L,
                 "stripe://testactivity",
                 "multibancoholder@stripe.com");
@@ -506,7 +525,7 @@ public class SourceParamsTest {
 
     @Test
     public void createSepaDebitParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createSepaDebitParams(
+        final SourceParams params = SourceParams.createSepaDebitParams(
                 "Jai Testa",
                 "ibaniban",
                 "sepaholder@stripe.com",
@@ -567,7 +586,7 @@ public class SourceParamsTest {
 
     @Test
     public void createSofortParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createSofortParams(
+        final SourceParams params = SourceParams.createSofortParams(
                 50000L,
                 "example://return",
                 "UK",
@@ -586,7 +605,7 @@ public class SourceParamsTest {
 
     @Test
     public void createSofortParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createSofortParams(
+        final SourceParams params = SourceParams.createSofortParams(
                 50000L,
                 "example://return",
                 "UK",
@@ -609,7 +628,7 @@ public class SourceParamsTest {
 
     @Test
     public void createThreeDSecureParams_hasExpectedFields() {
-        SourceParams params = SourceParams.createThreeDSecureParams(
+        final SourceParams params = SourceParams.createThreeDSecureParams(
                 99000L,
                 "brl",
                 "stripe://returnaddress",
@@ -631,7 +650,7 @@ public class SourceParamsTest {
 
     @Test
     public void createThreeDSecureParams_toParamMap_createsExpectedMap() {
-        SourceParams params = SourceParams.createThreeDSecureParams(
+        final SourceParams params = SourceParams.createThreeDSecureParams(
                 99000L,
                 "brl",
                 "stripe://returnaddress",
@@ -654,7 +673,7 @@ public class SourceParamsTest {
         // Using the Giropay constructor to add some free params and expected values,
         // including a source type params
         final String DOGECOIN = "dogecoin";
-        SourceParams params = SourceParams.createGiropayParams(
+        final SourceParams params = SourceParams.createGiropayParams(
                 150L,
                 "Stripe",
                 "stripe://return",
@@ -678,7 +697,7 @@ public class SourceParamsTest {
 
     @Test
     public void setCustomType_forEmptyParams_setsTypeToUnknown() {
-        SourceParams params = SourceParams.createCustomParams();
+        final SourceParams params = SourceParams.createCustomParams();
         params.setTypeRaw("dogecoin");
         assertEquals(Source.UNKNOWN, params.getType());
         assertEquals("dogecoin", params.getTypeRaw());
@@ -686,7 +705,7 @@ public class SourceParamsTest {
 
     @Test
     public void setCustomType_forStandardParams_overridesStandardType() {
-        SourceParams params = SourceParams.createThreeDSecureParams(
+        final SourceParams params = SourceParams.createThreeDSecureParams(
                 99000L,
                 "brl",
                 "stripe://returnaddress",

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -126,7 +126,6 @@ public class StripeJsonModelTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void putStripeJsonModelListIfNotNull_forJsonWhenNotNull_addsExpectedList() {
         List<ExampleJsonModel> exampleJsonModels = new ArrayList<>();
         exampleJsonModels.add(new ExampleJsonModel());
@@ -147,7 +146,7 @@ public class StripeJsonModelTest {
         JsonTestUtils.assertJsonArrayEquals(expectedArray, jsonArray);
     }
 
-    class ExampleJsonModel extends StripeJsonModel {
+    private static class ExampleJsonModel extends StripeJsonModel {
 
         @NonNull
         @Override


### PR DESCRIPTION
**Summary**
`metadata` is a field that exists on several Stripe objects. For this
patch, it will only be enabled for Card-based `Source` objects.

Setting `metadata` on a `Card` will ultimately populate the `metadata`
field in `SourceParams` via `SourceParams#createCardParams`, which is
passed along with the request to create a Card-based `Source`.

See https://stripe.com/docs/api/metadata

This patch also does cleanup on some of the related classes (e.g.
make variables final, add nullity annotations)

**Motivation**
Being able to set `metadata` is a [user-requested feature](https://github.com/stripe/stripe-android/issues/472#issuecomment-344250374). Most of
the wiring was in place to support it, the user just needed a way
to set it on a `Card`.

**Testing**
- Added automated tests.
- In the example app, added metadata to the `Card` used in
  `PaymentMultilineActivity#saveCard`. Confirmed using the
  Dashboard's Logs feature that the metadata was included
  in the request and returned in the response.

Fixes #472