### PR TITLE
Add support for creating a CVC update Token

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executor;
 import static com.stripe.android.StripeNetworkUtils.hashMapFromBankAccount;
 import static com.stripe.android.StripeNetworkUtils.hashMapFromCard;
 import static com.stripe.android.StripeNetworkUtils.hashMapFromPersonalId;
+import static com.stripe.android.StripeNetworkUtils.mapFromCvc;
 
 /**
  * Class that handles {@link Token} creation from charges, {@link Card}, and accounts.
@@ -228,6 +229,42 @@ public class Stripe {
                 requestOptions,
                 Token.TYPE_BANK_ACCOUNT,
                 mLoggingResponseListener);
+    }
+
+    /**
+     * The simplest way to create a CVC update token. This runs on the default
+     * {@link Executor} and with the currently set {@link #mDefaultPublishableKey}.
+     *
+     * @param cvc the CVC used to create this token
+     * @param callback a {@link TokenCallback} to receive either the token or an error
+     */
+    public void createCvcUpdateToken(
+            @NonNull @Size(min = 3, max = 4) final String cvc,
+            @NonNull final TokenCallback callback) {
+        createCvcUpdateToken(cvc, mDefaultPublishableKey, null, callback);
+    }
+
+    /**
+     * Call to create a {@link Token} for CVC with the publishable key and
+     * {@link Executor} specified.
+     *
+     * @param cvc the CVC used to create this token
+     * @param publishableKey the publishable key to use
+     * @param executor an {@link Executor} to run this operation on. If null, this is run on a
+     *                 default non-ui executor
+     * @param callback a {@link TokenCallback} to receive the result or error message
+     */
+    public void createCvcUpdateToken(
+            @NonNull @Size(min = 3, max = 4) final String cvc,
+            @NonNull @Size(min = 1) final String publishableKey,
+            @Nullable final Executor executor,
+            @NonNull final TokenCallback callback) {
+        createTokenFromParams(
+                mapFromCvc(cvc),
+                publishableKey,
+                Token.TYPE_CVC_UPDATE,
+                executor,
+                callback);
     }
 
     /**
@@ -544,6 +581,64 @@ public class Stripe {
                 hashMapFromPersonalId(personalId),
                 requestOptions,
                 Token.TYPE_PII,
+                mLoggingResponseListener);
+    }
+
+    /**
+     * Blocking method to create a {@link Token} for CVC updating. Do not call this on the UI thread
+     * or your app will crash. The method uses the currently set {@link #mDefaultPublishableKey}.
+     *
+     * @param cvc the CVC to use for this token
+     * @return a {@link Token} that can be used for this card
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    @Nullable
+    public Token createCvcUpdateTokenSynchronous(@NonNull String cvc)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        return createCvcUpdateTokenSynchronous(cvc, mDefaultPublishableKey);
+    }
+
+    /**
+     * Blocking method to create a {@link Token} for CVC updating. Do not call this on the UI thread
+     * or your app will crash.
+     *
+     * @param cvc the CVC to use for this token
+     * @param publishableKey the publishable key to use with this request
+     * @return a {@link Token} that can be used for this card
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with
+     * Stripe's servers)
+     */
+    @Nullable
+    public Token createCvcUpdateTokenSynchronous(@NonNull String cvc,
+                                                 @NonNull String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            CardException,
+            APIException {
+        validateKey(publishableKey);
+        final RequestOptions requestOptions = RequestOptions.builder(
+                publishableKey,
+                mStripeAccount,
+                RequestOptions.TYPE_QUERY).build();
+        return StripeApiHandler.createToken(
+                mContext,
+                mapFromCvc(cvc),
+                requestOptions,
+                Token.TYPE_CVC_UPDATE,
                 mLoggingResponseListener);
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -399,7 +399,7 @@ class StripeApiHandler {
             tokenParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
         }
 
-        return requestToken(getApiUrl(), tokenParams, options);
+        return requestToken(getTokensUrl(), tokenParams, options);
     }
 
     @Nullable
@@ -641,7 +641,7 @@ class StripeApiHandler {
     }
 
     @VisibleForTesting
-    static String getApiUrl() {
+    static String getTokensUrl() {
         return String.format(Locale.ENGLISH, "%s/v1/%s", LIVE_API_BASE, TOKENS);
     }
 
@@ -702,7 +702,7 @@ class StripeApiHandler {
 
     @VisibleForTesting
     static String getRetrieveTokenApiUrl(@NonNull String tokenId) {
-        return String.format(Locale.ROOT, "%s/%s", getApiUrl(), tokenId);
+        return String.format(Locale.ROOT, "%s/%s", getTokensUrl(), tokenId);
     }
 
     private static void convertErrorsToExceptionsAndThrowIfNecessary(
@@ -1109,7 +1109,7 @@ class StripeApiHandler {
                                     + "If this problem persists, you should check Stripe's "
                                     + "service status at https://twitter.com/stripestatus, "
                                     + "or let us know at support@stripe.com.",
-                            getApiUrl(), e.getMessage()), e);
+                            getTokensUrl(), e.getMessage()), e);
         } finally {
             if (conn != null) {
                 conn.disconnect();

--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
@@ -48,6 +48,15 @@ public class StripeNetworkUtils {
     }
 
     @NonNull
+    static Map<String, Object> mapFromCvc(@NonNull String cvc) {
+        final Map<String, Object> tokenParams = new HashMap<>();
+        tokenParams.put("cvc", cvc);
+        final Map<String, Object> cvcParams = new HashMap<>();
+        cvcParams.put(Token.TYPE_CVC_UPDATE, tokenParams);
+        return cvcParams;
+    }
+
+    @NonNull
     private static Map<String, Object> hashMapFromCard(
             @Nullable UidProvider provider,
             @NonNull Context context,

--- a/stripe/src/test/java/com/stripe/android/LoggingUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/LoggingUtilsTest.java
@@ -57,6 +57,25 @@ public class LoggingUtilsTest {
     }
 
     @Test
+    public void getCvcUpdateTokenCreationParams_withValidInput_createsCorrectMap() {
+        List<String> tokensList = new ArrayList<>();
+        tokensList.add("CardInputView");
+        // Correctness of these methods will be tested elsewhere. Assume validity for this test.
+        final String expectedTokenName =
+                LoggingUtils.getEventParamName(LoggingUtils.EVENT_TOKEN_CREATION);
+
+        Map<String, Object> params = LoggingUtils.getTokenCreationParams(
+                ApplicationProvider.getApplicationContext(),
+                tokensList,
+                DUMMY_API_KEY,
+                Token.TYPE_CVC_UPDATE);
+        // Size is SIZE-1 because tokens don't have a source_type field
+        assertEquals(LoggingUtils.VALID_PARAM_FIELDS.size() - 1, params.size());
+        assertEquals(expectedTokenName, params.get(LoggingUtils.FIELD_EVENT));
+        assertEquals(Token.TYPE_CVC_UPDATE, params.get(LoggingUtils.FIELD_TOKEN_TYPE));
+    }
+
+    @Test
     public void getSourceCreationParams_withValidInput_createsCorrectMap() {
         // Size is SIZE-1 because tokens don't have a token_type field
         final int expectedSize = LoggingUtils.VALID_PARAM_FIELDS.size() - 1;

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -43,7 +43,7 @@ public class StripeApiHandlerTest {
 
     @Test
     public void testGetApiUrl() {
-        String tokensApi = StripeApiHandler.getApiUrl();
+        String tokensApi = StripeApiHandler.getTokensUrl();
         assertEquals("https://api.stripe.com/v1/tokens", tokensApi);
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -5,8 +5,11 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.stripe.android.exception.APIConnectionException;
+import com.stripe.android.exception.APIException;
 import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
+import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.Address;
@@ -951,6 +954,24 @@ public class StripeTest {
         } catch (StripeException stripeEx) {
             fail("Unexpected exception making PII token");
         }
+    }
+
+    @Test
+    public void createTokenSynchronous_withValidCvc_passesIntegrationTest()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        final TestLoggingListener listener = new TestLoggingListener(true);
+        stripe.setLoggingResponseListener(listener);
+
+        final Token token = stripe.createCvcUpdateTokenSynchronous("1234");
+        assertNotNull(token);
+        assertEquals(Token.TYPE_CVC_UPDATE, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
+        assertTrue(token.getId().startsWith("cvctok_"));
+        assertAllLogsAreValid(listener, 2);
     }
 
     @Test


### PR DESCRIPTION
**Summary**
Create `Stripe.createCvcUpdateToken(cvc, callback)` to support the following use case:

```
$ curl -i https://api.stripe.com/v1/tokens -d 'cvc_update[cvc]=123'

{
  "id": "cvctok_1Dy4anCRMbs6",
  "object": "token",
  "created": 1548799085,
  "livemode": false,
  "type": "cvc_update",
  "used": false
}
```

**Motivation**
Enable CVC recollection

**Testing**
- Wrote automated tests, included end-to-end test
  `StripeTest#createTokenSynchronous_withValidCvc_passesIntegrationTest`