### PR TITLE
Prevent AddSourceActivity's SourceCallback from being GCed

### DIFF
--- a/stripe/src/main/java/com/stripe/android/SourceCallback.java
+++ b/stripe/src/main/java/com/stripe/android/SourceCallback.java
@@ -1,5 +1,7 @@
 package com.stripe.android;
 
+import androidx.annotation.NonNull;
+
 import com.stripe.android.model.Source;
 
 /**
@@ -12,11 +14,11 @@ public interface SourceCallback {
      * Error callback method.
      * @param error the error that occurred.
      */
-    void onError(Exception error);
+    void onError(@NonNull Exception error);
 
     /**
      * Success callback method.
      * @param source the {@link Source} that was found or created.
      */
-    void onSuccess(Source source);
+    void onSuccess(@NonNull Source source);
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -763,7 +763,8 @@ public class Stripe {
         }
     }
 
-    private void executeTask(Executor executor, AsyncTask<Void, Void, ResponseWrapper> task) {
+    private void executeTask(@Nullable Executor executor,
+                             @NonNull AsyncTask<Void, Void, ResponseWrapper> task) {
         if (executor != null) {
             task.executeOnExecutor(executor);
         } else {
@@ -772,23 +773,23 @@ public class Stripe {
     }
 
     private static class ResponseWrapper {
-        final Source source;
-        final Token token;
-        final Exception error;
+        @Nullable final Source source;
+        @Nullable final Token token;
+        @Nullable final Exception error;
 
-        private ResponseWrapper(Token token) {
+        private ResponseWrapper(@Nullable Token token) {
             this.token = token;
             this.source = null;
             this.error = null;
         }
 
-        private ResponseWrapper(Source source) {
+        private ResponseWrapper(@Nullable Source source) {
             this.source = source;
             this.error = null;
             this.token = null;
         }
 
-        private ResponseWrapper(Exception error) {
+        private ResponseWrapper(@NonNull Exception error) {
             this.error = error;
             this.source = null;
             this.token = null;
@@ -850,7 +851,7 @@ public class Stripe {
         }
 
         @Override
-        protected void onPostExecute(ResponseWrapper responseWrapper) {
+        protected void onPostExecute(@NonNull ResponseWrapper responseWrapper) {
             final SourceCallback sourceCallback = mSourceCallbackRef.get();
             if (sourceCallback != null) {
                 if (responseWrapper.source != null) {


### PR DESCRIPTION
**Summary**
`Stripe#CreateSourceTask` holds a `WeakReference` to the
`SourceCallback`. In some cases, this reference was being
garbage collected, causing callback (either `onSuccess()` or
`onError()`) to never happen.

Making the `SourceCallback` an instance variable seems to fix
this issue.

**Motivation**
Because the callback was never happening, the user would be
stuck on the "Add a Card" screen.

![screenshot_1548884709](https://user-images.githubusercontent.com/45020849/52015178-655d4980-24af-11e9-9aea-c32d2d55b333.png)


**Testing**
Tested manually on various API levels.