### PR TITLE
Add StripeError field to StripeException

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
@@ -80,8 +80,7 @@ public class CustomerSessionActivity extends AppCompatActivity {
     }
 
     private void launchWithCustomer() {
-        Intent payIntent = PaymentMethodsActivity.newIntent(this);
-        startActivityForResult(payIntent, REQUEST_CODE_SELECT_SOURCE);
+        startActivityForResult(PaymentMethodsActivity.newIntent(this), REQUEST_CODE_SELECT_SOURCE);
     }
 
     @Override
@@ -98,6 +97,7 @@ public class CustomerSessionActivity extends AppCompatActivity {
         }
     }
 
+    @NonNull
     private String buildCardString(@NonNull SourceCardData data) {
         return data.getBrand() + getString(R.string.ending_in) + data.getLast4();
     }

--- a/stripe/src/main/java/com/stripe/android/ErrorParser.java
+++ b/stripe/src/main/java/com/stripe/android/ErrorParser.java
@@ -47,26 +47,4 @@ class ErrorParser {
         return new StripeError(type, message, code, param, declineCode, charge);
     }
 
-    /**
-     * A model for error objects sent from the server.
-     */
-    static class StripeError {
-        @Nullable public final String type;
-        @Nullable public final String message;
-        @Nullable public final String code;
-        @Nullable public final String param;
-        @Nullable public final String declineCode;
-        @Nullable public final String charge;
-
-        StripeError(@Nullable String type, @Nullable String message, @Nullable String code,
-                           @Nullable String param, @Nullable String declineCode,
-                           @Nullable String charge) {
-            this.type = type;
-            this.message = message;
-            this.code = code;
-            this.param = param;
-            this.declineCode = declineCode;
-            this.charge = charge;
-        }
-    }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeError.java
+++ b/stripe/src/main/java/com/stripe/android/StripeError.java
@@ -1,0 +1,34 @@
+package com.stripe.android;
+
+import androidx.annotation.Nullable;
+
+/**
+ * A model for error objects sent from the Stripe API.
+ *
+ * https://stripe.com/docs/api/errors
+ */
+public class StripeError {
+
+    // https://stripe.com/docs/api/errors (e.g. "invalid_request_error")
+    @Nullable public final String type;
+    @Nullable public final String message;
+
+    // https://stripe.com/docs/error-codes (e.g. "payment_method_unactivated")
+    @Nullable public final String code;
+    @Nullable public final String param;
+
+    // see https://stripe.com/docs/declines/codes
+    @Nullable public final String declineCode;
+
+    @Nullable public final String charge;
+
+    StripeError(@Nullable String type, @Nullable String message, @Nullable String code,
+                @Nullable String param, @Nullable String declineCode, @Nullable String charge) {
+        this.type = type;
+        this.message = message;
+        this.code = code;
+        this.param = param;
+        this.declineCode = declineCode;
+        this.charge = charge;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.java
@@ -12,7 +12,7 @@ public class APIConnectionException extends StripeException {
     }
 
     public APIConnectionException(@Nullable String message, @Nullable Throwable e) {
-        super(message, null, 0, e);
+        super(null, message, null, 0, e);
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/exception/APIException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/APIException.java
@@ -2,13 +2,16 @@ package com.stripe.android.exception;
 
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * An {@link Exception} that represents an internal problem with Stripe's servers.
  */
 public class APIException extends StripeException {
 
     public APIException(@Nullable String message, @Nullable String requestId,
-                        @Nullable Integer statusCode, @Nullable Throwable e) {
-        super(message, requestId, statusCode, e);
+                        @Nullable Integer statusCode, @Nullable StripeError stripeError,
+                        @Nullable Throwable e) {
+        super(stripeError, message, requestId, statusCode, e);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/exception/AuthenticationException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/AuthenticationException.java
@@ -2,13 +2,16 @@ package com.stripe.android.exception;
 
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * An {@link Exception} that represents a failure to authenticate yourself to the server.
  */
 public class AuthenticationException extends StripeException {
 
     public AuthenticationException(@Nullable String message, @Nullable String requestId,
-                                   @Nullable Integer statusCode) {
-        super(message, requestId, statusCode);
+                                   @Nullable Integer statusCode,
+                                   @Nullable StripeError stripeError) {
+        super(stripeError, message, requestId, statusCode);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/exception/CardException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/CardException.java
@@ -1,6 +1,9 @@
 package com.stripe.android.exception;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.stripe.android.StripeError;
 
 /**
  * An {@link Exception} indicating that there is a problem with a Card used for a request.
@@ -17,8 +20,8 @@ public class CardException extends StripeException {
     public CardException(@Nullable String message, @Nullable String requestId,
                          @Nullable String code, @Nullable String param,
                          @Nullable String declineCode, @Nullable String charge,
-                         @Nullable Integer statusCode, @Nullable Throwable e) {
-        super(message, requestId, statusCode, e);
+                         @Nullable Integer statusCode, @NonNull StripeError stripeError) {
+        super(stripeError, message, requestId, statusCode);
         mCode = code;
         mParam = param;
         mDeclineCode = declineCode;

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.java
@@ -3,6 +3,8 @@ package com.stripe.android.exception;
 
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * An {@link Exception} indicating that invalid parameters were used in a request.
  */
@@ -15,8 +17,8 @@ public class InvalidRequestException extends StripeException {
     public InvalidRequestException(@Nullable String message, @Nullable String param,
                                    @Nullable String requestId, @Nullable Integer statusCode,
                                    @Nullable String errorCode, @Nullable String errorDeclineCode,
-                                   @Nullable Throwable e) {
-        super(message, requestId, statusCode, e);
+                                   @Nullable StripeError stripeError, @Nullable Throwable e) {
+        super(stripeError, message, requestId, statusCode, e);
         mParam = param;
         mErrorCode = errorCode;
         mErrorDeclineCode = errorDeclineCode;

--- a/stripe/src/main/java/com/stripe/android/exception/PermissionException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/PermissionException.java
@@ -2,6 +2,8 @@ package com.stripe.android.exception;
 
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * A type of {@link AuthenticationException} resulting from incorrect permissions
  * to perform the requested action.
@@ -9,7 +11,7 @@ import androidx.annotation.Nullable;
 public class PermissionException extends AuthenticationException {
 
     public PermissionException(@Nullable String message, @Nullable String requestId,
-                               @Nullable Integer statusCode) {
-        super(message, requestId, statusCode);
+                               @Nullable Integer statusCode, @Nullable StripeError stripeError) {
+        super(message, requestId, statusCode, stripeError);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/exception/RateLimitException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/RateLimitException.java
@@ -2,6 +2,8 @@ package com.stripe.android.exception;
 
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * An {@link Exception} indicating that too many requests have hit the API too quickly.
  */
@@ -12,7 +14,7 @@ public class RateLimitException extends InvalidRequestException {
             @Nullable String param,
             @Nullable String requestId,
             @Nullable Integer statusCode,
-            @Nullable Throwable e) {
-        super(message, param, requestId, statusCode, null, null, e);
+            @Nullable StripeError stripeError) {
+        super(message, param, requestId, statusCode, null, null, stripeError, null);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/exception/StripeException.java
+++ b/stripe/src/main/java/com/stripe/android/exception/StripeException.java
@@ -3,6 +3,8 @@ package com.stripe.android.exception;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.stripe.android.StripeError;
+
 /**
  * A base class for Stripe-related {@link Exception Exceptions}.
  */
@@ -10,37 +12,55 @@ public abstract class StripeException extends Exception {
 
     protected static final long serialVersionUID = 1L;
 
-    @Nullable private final String requestId;
-    @Nullable private final Integer statusCode;
+    @Nullable private final String mRequestId;
+    @Nullable private final Integer mStatusCode;
+    @Nullable private final StripeError mStripeError;
 
     public StripeException(@Nullable String message, @Nullable String requestId,
                            @Nullable Integer statusCode) {
-        this(message, requestId, statusCode, null);
+        this(null, message, requestId, statusCode);
+    }
+
+    public StripeException(@Nullable StripeError stripeError, @Nullable String message,
+                           @Nullable String requestId, @Nullable Integer statusCode) {
+        this(stripeError, message, requestId, statusCode, null);
     }
 
     public StripeException(@Nullable String message, @Nullable String requestId,
                            @Nullable Integer statusCode, @Nullable Throwable e) {
+        this(null, message, requestId, statusCode, e);
+    }
+
+    public StripeException(@Nullable StripeError stripeError, @Nullable String message,
+                           @Nullable String requestId, @Nullable Integer statusCode,
+                           @Nullable Throwable e) {
         super(message, e);
-        this.statusCode = statusCode;
-        this.requestId = requestId;
+        mStripeError = stripeError;
+        mStatusCode = statusCode;
+        mRequestId = requestId;
     }
 
     @Nullable
     public String getRequestId() {
-        return requestId;
+        return mRequestId;
     }
 
     @Nullable
     public Integer getStatusCode() {
-        return statusCode;
+        return mStatusCode;
+    }
+
+    @Nullable
+    public StripeError getStripeError() {
+        return mStripeError;
     }
 
     @NonNull
     @Override
     public String toString() {
         final String reqIdStr;
-        if (requestId != null) {
-            reqIdStr = "; request-id: " + requestId;
+        if (mRequestId != null) {
+            reqIdStr = "; request-id: " + mRequestId;
         } else {
             reqIdStr = "";
         }

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -207,10 +207,7 @@ public class CustomerSessionTest {
                     anyString(),
                     anyString(),
                     anyString()))
-                    .thenThrow(new APIException(
-                            "The card is invalid",
-                            "request_123",
-                            404,
+                    .thenThrow(new APIException("The card is invalid", "request_123", 404, null,
                             null));
             when(mStripeApiProxy.deleteCustomerSourceWithKey(
                     any(Context.class),
@@ -227,10 +224,7 @@ public class CustomerSessionTest {
                     ArgumentMatchers.<String>anyList(),
                     anyString(),
                     anyString()))
-                    .thenThrow(new APIException(
-                            "The card does not exist",
-                            "request_123",
-                            404,
+                    .thenThrow(new APIException("The card does not exist", "request_123", 404, null,
                             null));
             when(mStripeApiProxy.setDefaultCustomerSourceWithKey(
                     any(Context.class),
@@ -250,7 +244,7 @@ public class CustomerSessionTest {
                     anyString(),
                     anyString(),
                     anyString()))
-                    .thenThrow(new APIException("auth error", "reqId", 405, null));
+                    .thenThrow(new APIException("auth error", "reqId", 405, null, null));
         } catch (StripeException exception) {
             fail("Exception when accessing mock api proxy: " + exception.getMessage());
         }

--- a/stripe/src/test/java/com/stripe/android/ErrorParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/ErrorParserTest.java
@@ -43,7 +43,7 @@ public class ErrorParserTest {
 
     @Test
     public void parseError_withInvalidRequestError_createsCorrectObject() {
-        final ErrorParser.StripeError parsedStripeError =
+        final StripeError parsedStripeError =
                 ErrorParser.parseError(RAW_INVALID_REQUEST_ERROR);
         String errorMessage = "The Stripe API is only accessible over HTTPS.  " +
                 "Please see <https://stripe.com/docs> for more information.";
@@ -54,7 +54,7 @@ public class ErrorParserTest {
 
     @Test
     public void parseError_withNoErrorMessage_addsInvalidResponseMessage() {
-        final ErrorParser.StripeError badStripeError =
+        final StripeError badStripeError =
                 ErrorParser.parseError(RAW_INCORRECT_FORMAT_ERROR);
         assertEquals(ErrorParser.MALFORMED_RESPONSE_MESSAGE, badStripeError.message);
         assertNull(badStripeError.type);
@@ -62,7 +62,7 @@ public class ErrorParserTest {
 
     @Test
     public void parseError_withAllFields_parsesAllFields() {
-        final ErrorParser.StripeError error = ErrorParser.parseError(RAW_ERROR_WITH_ALL_FIELDS);
+        final StripeError error = ErrorParser.parseError(RAW_ERROR_WITH_ALL_FIELDS);
         assertEquals("code_value", error.code);
         assertEquals("param_value", error.param);
         assertEquals("charge_value", error.charge);

--- a/stripe/src/test/java/com/stripe/android/StripeErrorFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/StripeErrorFixtures.java
@@ -1,0 +1,11 @@
+package com.stripe.android;
+
+public class StripeErrorFixtures {
+    public final static StripeError INVALID_REQUEST_ERROR = new StripeError(
+            "invalid_request_error",
+            "This payment method (bancontact) is not activated for your account.",
+            "payment_method_unactivated",
+            "type",
+            "",
+            "");
+}

--- a/stripe/src/test/java/com/stripe/android/exception/InvalidRequestExceptionTest.java
+++ b/stripe/src/test/java/com/stripe/android/exception/InvalidRequestExceptionTest.java
@@ -1,0 +1,17 @@
+package com.stripe.android.exception;
+
+import com.stripe.android.StripeErrorFixtures;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InvalidRequestExceptionTest {
+
+    @Test
+    public void getStripeError_shouldReturnStripeError() {
+        final StripeException stripeException = new InvalidRequestException(null, null, null, null,
+                null, null, StripeErrorFixtures.INVALID_REQUEST_ERROR, null);
+        assertEquals(StripeErrorFixtures.INVALID_REQUEST_ERROR, stripeException.getStripeError());
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -159,7 +159,7 @@ public class PaymentFlowActivityTest {
 
         Bundle bundle = new Bundle();
         bundle.putSerializable(EXTRA_EXCEPTION,
-                new APIException("Something's wrong", "ID123", 400, null));
+                new APIException("Something's wrong", "ID123", 400, null, null));
         Intent errorIntent = new Intent(ACTION_API_EXCEPTION);
         errorIntent.putExtras(bundle);
         LocalBroadcastManager.getInstance(paymentFlowActivity)


### PR DESCRIPTION
**Summary**
Add a `StripeError` field to `StripeException`.
Access via `StripeException#getStripeError()`

**Motivation**
The error code is an important field for SDK users
to be able to determine why a request failed, and
allows them to better react to the failure.

For example, a `"payment_method_not_available"` code
may suggest to the developer to invite a customer to
use another payment method. Additionally, a developer
may choose to localize an user-facing error based on
this code.

Fixes #792

**Testing**
Wrote automated tests.