### PR TITLE
Create ErrorMessageTranslator and default implementation

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
@@ -65,7 +65,7 @@ public class CustomerSessionActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onError(int errorCode, @Nullable String errorMessage,
+                    public void onError(int httpCode, @Nullable String errorMessage,
                                         @Nullable StripeError stripeError) {
                         mSelectSourceButton.setEnabled(false);
                         mErrorDialogHandler.showError(errorMessage);

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
@@ -129,7 +129,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onError(int errorCode, @Nullable String errorMessage,
+                    public void onError(int httpCode, @Nullable String errorMessage,
                                         @Nullable StripeError stripeError) {
                         mCustomer = null;
                         mSelectPaymentButton.setEnabled(false);
@@ -188,7 +188,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onError(int errorCode, @Nullable String errorMessage,
+                    public void onError(int httpCode, @Nullable String errorMessage,
                                         @Nullable StripeError stripeError) {
                         mProgressBar.setVisibility(View.INVISIBLE);
                     }

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -261,7 +261,7 @@ public class PaymentActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onError(int errorCode, @Nullable String errorMessage,
+            public void onError(int httpCode, @Nullable String errorMessage,
                                 @Nullable StripeError stripeError) {
                 displayError("Error getting payment method");
             }
@@ -402,7 +402,7 @@ public class PaymentActivity extends AppCompatActivity {
                         }
 
                         @Override
-                        public void onError(int errorCode, @Nullable String errorMessage,
+                        public void onError(int httpCode, @Nullable String errorMessage,
                                             @Nullable StripeError stripeError) {
                             displayError(errorMessage);
                         }

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -548,16 +548,16 @@ public class CustomerSession
     }
 
     @Override
-    public void onKeyError(int errorCode, @Nullable String errorMessage) {
+    public void onKeyError(int httpCode, @Nullable String errorMessage) {
         // Any error eliminates all listeners
 
         if (mCustomerRetrievalListener != null) {
-            mCustomerRetrievalListener.onError(errorCode, errorMessage, null);
+            mCustomerRetrievalListener.onError(httpCode, errorMessage, null);
             mCustomerRetrievalListener = null;
         }
 
         if (mSourceRetrievalListener != null) {
-            mSourceRetrievalListener.onError(errorCode, errorMessage, null);
+            mSourceRetrievalListener.onError(httpCode, errorMessage, null);
             mSourceRetrievalListener = null;
         }
     }
@@ -806,7 +806,7 @@ public class CustomerSession
     public interface CustomerRetrievalListener {
         void onCustomerRetrieved(@NonNull Customer customer);
 
-        void onError(int errorCode, @Nullable String errorMessage,
+        void onError(int httpCode, @Nullable String errorMessage,
                      @Nullable StripeError stripeError);
     }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -256,10 +256,10 @@ public class PaymentSession {
                     }
 
                     @Override
-                    public void onError(int errorCode, @Nullable String errorMessage,
+                    public void onError(int httpCode, @Nullable String errorMessage,
                                         @Nullable StripeError stripeError) {
                         if (mPaymentSessionListener != null) {
-                            mPaymentSessionListener.onError(errorCode, errorMessage);
+                            mPaymentSessionListener.onError(httpCode, errorMessage);
                             mPaymentSessionListener.onCommunicatingStateChanged(false);
                         }
                     }

--- a/stripe/src/main/java/com/stripe/android/view/i18n/ErrorMessageTranslator.java
+++ b/stripe/src/main/java/com/stripe/android/view/i18n/ErrorMessageTranslator.java
@@ -1,0 +1,33 @@
+package com.stripe.android.view.i18n;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.stripe.android.StripeError;
+
+public interface ErrorMessageTranslator {
+    /**
+     * See https://stripe.com/docs/api/errors for a list of error codes and associated messages
+     *
+     * @param httpCode The HTTP code associated with the error response.
+     * @param errorMessage A human-readable message providing more details about the error.
+     *                     For card errors, these messages can be shown to your users.
+     * @param stripeError The {@link StripeError} that represents detailed information about the
+     *                    error. Specifically, {@link StripeError#code} is useful for understanding
+     *                    the underlying error (e.g. "payment_method_unactivated").
+     *
+     * @return a non-null error message
+     */
+    @NonNull
+    String translate(int httpCode, @Nullable String errorMessage,
+                     @Nullable StripeError stripeError);
+
+    class Default implements ErrorMessageTranslator {
+        @NonNull
+        @Override
+        public String translate(int httpCode, @Nullable String errorMessage,
+                                @Nullable StripeError stripeError) {
+            return errorMessage == null ? "" : errorMessage;
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/i18n/TranslatorManager.java
+++ b/stripe/src/main/java/com/stripe/android/view/i18n/TranslatorManager.java
@@ -1,0 +1,50 @@
+package com.stripe.android.view.i18n;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A class that provides a {@link ErrorMessageTranslator} for translating server-provided error
+ * messages, as defined in https://stripe.com/docs/api/errors.
+ *
+ * See {@link com.stripe.android.view.PaymentMethodsActivity} for example usage.
+ *
+ * To use a custom {@link ErrorMessageTranslator} in your app,
+ * override {@link Application#onCreate()} in your app's Application subclass and call
+ * {@link #setErrorMessageTranslator(ErrorMessageTranslator)}.
+ *
+ * <pre>
+ * <code>
+ * public class MyApp extends Application {
+ *   public void onCreate() {
+ *     super.onCreate();
+ *     TranslatorManager.setErrorMessageTranslator(new MyErrorMessageTranslator());
+ *   }
+ * }
+ * </code>
+ * </pre>
+ */
+public class TranslatorManager {
+    @NonNull
+    private static final ErrorMessageTranslator DEFAULT_ERROR_MESSAGE_TRANSLATOR =
+            new ErrorMessageTranslator.Default();
+
+    @Nullable
+    private static ErrorMessageTranslator mErrorMessageTranslator;
+
+    private TranslatorManager() {
+    }
+
+    @NonNull
+    public static ErrorMessageTranslator getErrorMessageTranslator() {
+        return mErrorMessageTranslator != null ?
+                mErrorMessageTranslator : DEFAULT_ERROR_MESSAGE_TRANSLATOR;
+    }
+
+    public static void setErrorMessageTranslator(
+            @Nullable ErrorMessageTranslator errorMessageTranslator) {
+        mErrorMessageTranslator = errorMessageTranslator;
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/i18n/TranslatorManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/i18n/TranslatorManagerTest.java
@@ -1,0 +1,42 @@
+package com.stripe.android.view.i18n;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.stripe.android.StripeError;
+import com.stripe.android.StripeErrorFixtures;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TranslatorManagerTest {
+    private static final StripeError STRIPE_ERROR = StripeErrorFixtures.INVALID_REQUEST_ERROR;
+
+    @Before
+    public void setup() {
+        TranslatorManager.setErrorMessageTranslator(null);
+    }
+
+    @Test
+    public void testDefaultErrorMessageTranslator() {
+        assertEquals("error!",
+                TranslatorManager.getErrorMessageTranslator()
+                        .translate(0, "error!", STRIPE_ERROR));
+    }
+
+    @Test
+    public void testCustomErrorMessageTranslator() {
+        TranslatorManager.setErrorMessageTranslator(new ErrorMessageTranslator() {
+            @NonNull
+            @Override
+            public String translate(int httpCode, @Nullable String errorMessage,
+                                    @Nullable StripeError stripeError) {
+                return "custom message";
+            }
+        });
+        assertEquals("custom message", TranslatorManager.getErrorMessageTranslator()
+                .translate(0, "original message", STRIPE_ERROR));
+    }
+}


### PR DESCRIPTION
## Summary
ErrorMessageTranslator is an interface that a user can
implement to specify custom translations for
server-provided errors.

## Motivation
Stripe error messages are in English. In a few places,
we show these messages on screen in dialogs. An app
developer may wish to provide their own translation of
these messages so that are legibile to their customers.

Fixes #680

## Testing
Added unit tests.