### PR TITLE
Make StripeSourceTypeModel public

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
@@ -12,8 +12,11 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.stripe.android.model.StripeJsonUtils.optInteger;
 import static com.stripe.android.model.StripeJsonUtils.optString;
@@ -51,6 +54,20 @@ public class SourceCardData extends StripeSourceTypeModel {
     public static final String FIELD_THREE_D_SECURE = "three_d_secure";
     public static final String FIELD_TOKENIZATION_METHOD = "tokenization_method";
 
+    private static final Set<String> STANDARD_FIELDS = new HashSet<>(Arrays.asList(
+            FIELD_ADDRESS_LINE1_CHECK,
+            FIELD_ADDRESS_ZIP_CHECK,
+            FIELD_BRAND,
+            FIELD_COUNTRY,
+            FIELD_CVC_CHECK,
+            FIELD_DYNAMIC_LAST4,
+            FIELD_EXP_MONTH,
+            FIELD_EXP_YEAR,
+            FIELD_FUNDING,
+            FIELD_LAST4,
+            FIELD_THREE_D_SECURE,
+            FIELD_TOKENIZATION_METHOD));
+
     private String mAddressLine1Check;
     private String mAddressZipCheck;
     private @Card.CardBrand String mBrand;
@@ -65,20 +82,7 @@ public class SourceCardData extends StripeSourceTypeModel {
     private String mTokenizationMethod;
 
     private SourceCardData() {
-        super();
-        addStandardFields(
-                FIELD_ADDRESS_LINE1_CHECK,
-                FIELD_ADDRESS_ZIP_CHECK,
-                FIELD_BRAND,
-                FIELD_COUNTRY,
-                FIELD_CVC_CHECK,
-                FIELD_DYNAMIC_LAST4,
-                FIELD_EXP_MONTH,
-                FIELD_EXP_YEAR,
-                FIELD_FUNDING,
-                FIELD_LAST4,
-                FIELD_THREE_D_SECURE,
-                FIELD_TOKENIZATION_METHOD);
+        super(STANDARD_FIELDS);
     }
 
     @Nullable
@@ -286,7 +290,7 @@ public class SourceCardData extends StripeSourceTypeModel {
 
     @Nullable
     @ThreeDSecureStatus
-    static String asThreeDSecureStatus(@Nullable String threeDSecureStatus) {
+    private static String asThreeDSecureStatus(@Nullable String threeDSecureStatus) {
         String nullChecked = StripeJsonUtils.nullIfNullOrEmpty(threeDSecureStatus);
         if (nullChecked == null) {
             return null;

--- a/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
@@ -9,8 +9,11 @@ import com.stripe.android.StripeNetworkUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
 import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
@@ -28,6 +31,15 @@ public class SourceSepaDebitData extends StripeSourceTypeModel {
     private static final String FIELD_MANDATE_REFERENCE = "mandate_reference";
     private static final String FIELD_MANDATE_URL = "mandate_url";
 
+    private static final Set<String> STANDARD_FIELDS = new HashSet<>(Arrays.asList(
+            FIELD_BANK_CODE,
+            FIELD_BRANCH_CODE,
+            FIELD_COUNTRY,
+            FIELD_FINGERPRINT,
+            FIELD_LAST4,
+            FIELD_MANDATE_REFERENCE,
+            FIELD_MANDATE_URL));
+
     private String mBankCode;
     private String mBranchCode;
     private String mCountry;
@@ -37,15 +49,7 @@ public class SourceSepaDebitData extends StripeSourceTypeModel {
     private String mMandateUrl;
 
     private SourceSepaDebitData() {
-        super();
-        addStandardFields(
-                FIELD_BANK_CODE,
-                FIELD_BRANCH_CODE,
-                FIELD_COUNTRY,
-                FIELD_FINGERPRINT,
-                FIELD_LAST4,
-                FIELD_MANDATE_REFERENCE,
-                FIELD_MANDATE_URL);
+        super(STANDARD_FIELDS);
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
@@ -14,23 +14,20 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-abstract class StripeSourceTypeModel extends StripeJsonModel {
-
-    Map<String, Object> mAdditionalFields;
-    Set<String> mStandardFields = new HashSet<>();
+public abstract class StripeSourceTypeModel extends StripeJsonModel {
     private static final String NULL = "null";
 
-    StripeSourceTypeModel() {
+    Map<String, Object> mAdditionalFields;
+    @NonNull final Set<String> mStandardFields;
+
+    StripeSourceTypeModel(@NonNull Set<String> standardFields) {
+        mStandardFields = standardFields;
         mAdditionalFields = new HashMap<>();
     }
 
     @NonNull
     public Map<String, Object> getAdditionalFields() {
         return mAdditionalFields;
-    }
-
-    void addStandardFields(String... fields) {
-        Collections.addAll(mStandardFields, fields);
     }
 
     void setAdditionalFields(@NonNull Map<String, Object> additionalFields) {

--- a/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
@@ -24,7 +24,8 @@ public class SourceCardDataTest {
 
     @Test
     public void fromExampleJsonCard_createsExpectedObject() {
-        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
+        final SourceCardData cardData = SourceCardData
+                .fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
         assertNotNull(cardData);
         assertEquals(Card.VISA, cardData.getBrand());
         assertEquals(0, cardData.getAdditionalFields().size());
@@ -41,9 +42,11 @@ public class SourceCardDataTest {
 
     @Test
     public void fromExampleJsonCard_toMap_createsExpectedMapping() {
-        SourceCardData cardData = SourceCardData.fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
-        Map<String, Object> cardDataMap = cardData.toMap();
+        final SourceCardData cardData = SourceCardData
+                .fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY);
+        assertNotNull(cardData);
 
+        final Map<String, Object> cardDataMap = cardData.toMap();
         assertNotNull(cardDataMap);
         assertEquals("US", cardDataMap.get("country"));
         assertEquals("4242", cardDataMap.get("last4"));


### PR DESCRIPTION
## Summary
- Make `StripeSourceTypeModel` public
- Clean up the internal structure of `StripeSourceTypeModel`

## Motivation
`Source#getSourceTypeModel()` is a public method, but it returns
a type (`StripeSourceTypeModel`) that is package-private, causing
warnings in the IDE. This is a safe change, because the methods in
`StripeSourceTypeModel` that should not be accessed publicly are
still package-private. In addition, `StripeSourceTypeModel` extends
`StripeJsonModel`, which itself is public.

Fixes #616

## Testing
Existing unit test coverage.