### PR TITLE
Update PaymentIntent to reflect API changes

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -32,26 +32,30 @@ import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 public class PaymentIntent extends StripeJsonModel {
     private static final String VALUE_PAYMENT_INTENT = "payment_intent";
 
-    private static final String FIELD_ID = "id";
-    private static final String FIELD_OBJECT = "object";
-    private static final String FIELD_ALLOWED_SOURCE_TYPES = "allowed_source_types";
-    private static final String FIELD_AMOUNT = "amount";
-    private static final String FIELD_CREATED = "created";
-    private static final String FIELD_CANCELED = "canceled_at";
-    private static final String FIELD_CAPTURE_METHOD = "capture_method";
-    private static final String FIELD_CLIENT_SECRET = "client_secret";
-    private static final String FIELD_CONFIRMATION_METHOD = "confirmation_method";
-    private static final String FIELD_CURRENCY = "currency";
-    private static final String FIELD_DESCRIPTION = "description";
-    private static final String FIELD_LIVEMODE = "livemode";
-    private static final String FIELD_NEXT_SOURCE_ACTION = "next_source_action";
-    private static final String FIELD_RECEIPT_EMAIL = "receipt_email";
-    private static final String FIELD_SOURCE = "source";
-    private static final String FIELD_STATUS = "status";
+    static final String FIELD_ID = "id";
+    static final String FIELD_OBJECT = "object";
+    static final String FIELD_ALLOWED_SOURCE_TYPES = "allowed_source_types";
+    static final String FIELD_AMOUNT = "amount";
+    static final String FIELD_CREATED = "created";
+    static final String FIELD_CANCELED = "canceled_at";
+    static final String FIELD_CAPTURE_METHOD = "capture_method";
+    static final String FIELD_CLIENT_SECRET = "client_secret";
+    static final String FIELD_CONFIRMATION_METHOD = "confirmation_method";
+    static final String FIELD_CURRENCY = "currency";
+    static final String FIELD_DESCRIPTION = "description";
+    static final String FIELD_LIVEMODE = "livemode";
+    static final String FIELD_NEXT_ACTION = "next_action";
+    static final String FIELD_NEXT_SOURCE_ACTION = "next_source_action";
+    static final String FIELD_PAYMENT_METHOD_TYPES = "payment_method_types";
+    static final String FIELD_RECEIPT_EMAIL = "receipt_email";
+    static final String FIELD_SOURCE = "source";
+    static final String FIELD_STATUS = "status";
+    static final String FIELD_TYPE = "type";
 
     @Nullable private final String mId;
     @Nullable private final String mObjectType;
     @NonNull private final List<String> mAllowedSourceTypes;
+    @NonNull private final List<String> mPaymentMethodTypes;
     @Nullable private final Long mAmount;
     @Nullable private final Long mCanceledAt;
     @Nullable private final String mCaptureMethod;
@@ -62,6 +66,8 @@ public class PaymentIntent extends StripeJsonModel {
     @Nullable private final String mDescription;
     @Nullable private final Boolean mLiveMode;
     @Nullable private final Map<String, Object> mNextSourceAction;
+    @Nullable private final Map<String, Object> mNextAction;
+
     @Nullable private final String mReceiptEmail;
     @Nullable private final String mSource;
     @Nullable private final String mStatus;
@@ -71,9 +77,18 @@ public class PaymentIntent extends StripeJsonModel {
         return mId;
     }
 
+    /**
+     * @deprecated use {@link #getPaymentMethodTypes()}
+     */
+    @Deprecated
     @NonNull
     public List<String> getAllowedSourceTypes() {
         return mAllowedSourceTypes;
+    }
+
+    @NonNull
+    public List<String> getPaymentMethodTypes() {
+        return mPaymentMethodTypes;
     }
 
     @Nullable
@@ -121,24 +136,60 @@ public class PaymentIntent extends StripeJsonModel {
         return mLiveMode;
     }
 
+    /**
+     * @deprecated use {@link #getNextAction()}
+     */
+    @Deprecated
     @Nullable
     public Map<String, Object> getNextSourceAction() {
         return mNextSourceAction;
     }
 
     @Nullable
-    public Uri getAuthorizationUrl() {
-        if ("requires_source_action".equals(mStatus) &&
-                mNextSourceAction.containsKey("authorize_with_url") &&
-                mNextSourceAction.get("authorize_with_url") instanceof Map) {
-            final Map<String, Object> authorizeWithUrlMap =
-                    (Map) mNextSourceAction.get("authorize_with_url");
-            if (authorizeWithUrlMap.containsKey("url") &&
-                    authorizeWithUrlMap.get("url") instanceof String) {
-                return Uri.parse((String) authorizeWithUrlMap.get("url"));
+    public Map<String, Object> getNextAction() {
+        return mNextAction;
+    }
+
+    @Nullable
+    public Uri getRedirectUrl() {
+        final Map<String, Object> nextAction;
+
+        final Status status = Status.fromCode(mStatus);
+        if (Status.RequiresAction == status) {
+            nextAction = mNextAction;
+        } else if (Status.RequiresSourceAction == status) {
+            nextAction = mNextSourceAction;
+        } else {
+            nextAction = null;
+        }
+
+        if (nextAction == null) {
+            return null;
+        }
+
+        final NextActionType nextActionType = NextActionType
+                .fromCode((String) nextAction.get(FIELD_TYPE));
+        if (NextActionType.RedirectToUrl == nextActionType ||
+                NextActionType.AuthorizeWithUrl == nextActionType) {
+            final Object redirectToUrl = nextAction.get(nextActionType.code);
+            if (redirectToUrl instanceof Map) {
+                final Object url = ((Map) redirectToUrl).get("url");
+                if (url instanceof String) {
+                    return Uri.parse((String) url);
+                }
             }
         }
+
         return null;
+    }
+
+    /**
+     * @deprecated use {@link #getRedirectUrl()}
+     */
+    @Deprecated
+    @Nullable
+    public Uri getAuthorizationUrl() {
+        return getRedirectUrl();
     }
 
     @Nullable
@@ -160,6 +211,7 @@ public class PaymentIntent extends StripeJsonModel {
             @Nullable String id,
             @Nullable String objectType,
             @NonNull List<String> allowedSourceTypes,
+            @NonNull List<String> paymentMethodTypes,
             @Nullable Long amount,
             @Nullable Long canceledAt,
             @Nullable String captureMethod,
@@ -170,6 +222,7 @@ public class PaymentIntent extends StripeJsonModel {
             @Nullable String description,
             @Nullable Boolean liveMode,
             @Nullable Map<String, Object> nextSourceAction,
+            @Nullable Map<String, Object> nextAction,
             @Nullable String receiptEmail,
             @Nullable String source,
             @Nullable String status
@@ -177,6 +230,7 @@ public class PaymentIntent extends StripeJsonModel {
         mId = id;
         mObjectType = objectType;
         mAllowedSourceTypes = allowedSourceTypes;
+        mPaymentMethodTypes = paymentMethodTypes;
         mAmount = amount;
         mCanceledAt = canceledAt;
         mCaptureMethod = captureMethod;
@@ -187,6 +241,7 @@ public class PaymentIntent extends StripeJsonModel {
         mDescription = description;
         mLiveMode = liveMode;
         mNextSourceAction = nextSourceAction;
+        mNextAction = nextAction;
         mReceiptEmail = receiptEmail;
         mSource = source;
         mStatus = status;
@@ -212,38 +267,33 @@ public class PaymentIntent extends StripeJsonModel {
                 !VALUE_PAYMENT_INTENT.equals(jsonObject.optString(FIELD_OBJECT))) {
             return null;
         }
-        String id = optString(jsonObject, FIELD_ID);
-        String objectType = optString(jsonObject, FIELD_OBJECT);
 
-        JSONArray allowedSourceTypesJSONArray = jsonObject.optJSONArray(FIELD_ALLOWED_SOURCE_TYPES);
-        final List<String> allowedSourceTypes = new ArrayList<>();
-        if (allowedSourceTypesJSONArray != null) {
-            for (int i = 0; i < allowedSourceTypesJSONArray.length(); i++) {
-                try {
-                    allowedSourceTypes.add(allowedSourceTypesJSONArray.getString(i));
-                } catch (JSONException ignored) {
-                }
-            }
-        }
-
-        Long amount = optLong(jsonObject, FIELD_AMOUNT);
-        Long canceledAt = optLong(jsonObject, FIELD_CANCELED);
-        String captureMethod = optString(jsonObject, FIELD_CAPTURE_METHOD);
-        String clientSecret = optString(jsonObject, FIELD_CLIENT_SECRET);
-        String confirmationMethod = optString(jsonObject, FIELD_CONFIRMATION_METHOD);
-        Long created = optLong(jsonObject, FIELD_CREATED);
-        String currency = optCurrency(jsonObject, FIELD_CURRENCY);
-        String description = optString(jsonObject, FIELD_DESCRIPTION);
-        Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
-        String receiptEmail = optString(jsonObject, FIELD_RECEIPT_EMAIL);
-        String status = optString(jsonObject, FIELD_STATUS);
-        Map<String, Object> nextSourceAction = optMap(jsonObject, FIELD_NEXT_SOURCE_ACTION);
-        String source = optString(jsonObject, FIELD_SOURCE);
+        final String id = optString(jsonObject, FIELD_ID);
+        final String objectType = optString(jsonObject, FIELD_OBJECT);
+        final List<String> allowedSourceTypes = jsonArrayToList(
+                jsonObject.optJSONArray(FIELD_ALLOWED_SOURCE_TYPES));
+        final List<String> paymentMethodTypes = jsonArrayToList(
+                jsonObject.optJSONArray(FIELD_PAYMENT_METHOD_TYPES));
+        final Long amount = optLong(jsonObject, FIELD_AMOUNT);
+        final Long canceledAt = optLong(jsonObject, FIELD_CANCELED);
+        final String captureMethod = optString(jsonObject, FIELD_CAPTURE_METHOD);
+        final String clientSecret = optString(jsonObject, FIELD_CLIENT_SECRET);
+        final String confirmationMethod = optString(jsonObject, FIELD_CONFIRMATION_METHOD);
+        final Long created = optLong(jsonObject, FIELD_CREATED);
+        final String currency = optCurrency(jsonObject, FIELD_CURRENCY);
+        final String description = optString(jsonObject, FIELD_DESCRIPTION);
+        final Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
+        final String receiptEmail = optString(jsonObject, FIELD_RECEIPT_EMAIL);
+        final String status = optString(jsonObject, FIELD_STATUS);
+        final Map<String, Object> nextSourceAction = optMap(jsonObject, FIELD_NEXT_SOURCE_ACTION);
+        final Map<String, Object> nextAction = optMap(jsonObject, FIELD_NEXT_ACTION);
+        final String source = optString(jsonObject, FIELD_SOURCE);
 
         return new PaymentIntent(
                 id,
                 objectType,
                 allowedSourceTypes,
+                paymentMethodTypes,
                 amount,
                 canceledAt,
                 captureMethod,
@@ -254,9 +304,25 @@ public class PaymentIntent extends StripeJsonModel {
                 description,
                 livemode,
                 nextSourceAction,
+                nextAction,
                 receiptEmail,
                 source,
                 status);
+    }
+
+    @NonNull
+    private static List<String> jsonArrayToList(@Nullable JSONArray jsonArray) {
+        final List<String> list = new ArrayList<>();
+        if (jsonArray != null) {
+            for (int i = 0; i < jsonArray.length(); i++) {
+                try {
+                    list.add(jsonArray.getString(i));
+                } catch (JSONException ignored) {
+                }
+            }
+        }
+
+        return list;
     }
 
     @NonNull
@@ -267,6 +333,8 @@ public class PaymentIntent extends StripeJsonModel {
         putStringIfNotNull(jsonObject, FIELD_OBJECT, mObjectType);
         putArrayIfNotNull(jsonObject, FIELD_ALLOWED_SOURCE_TYPES,
                 listToJsonArray(mAllowedSourceTypes));
+        putArrayIfNotNull(jsonObject, FIELD_PAYMENT_METHOD_TYPES,
+                listToJsonArray(mPaymentMethodTypes));
         putLongIfNotNull(jsonObject, FIELD_AMOUNT, mAmount);
         putLongIfNotNull(jsonObject, FIELD_CANCELED, mCanceledAt);
         putStringIfNotNull(jsonObject, FIELD_CAPTURE_METHOD, mCaptureMethod);
@@ -277,6 +345,7 @@ public class PaymentIntent extends StripeJsonModel {
         putStringIfNotNull(jsonObject, FIELD_DESCRIPTION, mDescription);
         putBooleanIfNotNull(jsonObject, FIELD_LIVEMODE, mLiveMode);
         putMapIfNotNull(jsonObject, FIELD_NEXT_SOURCE_ACTION, mNextSourceAction);
+        putMapIfNotNull(jsonObject, FIELD_NEXT_ACTION, mNextAction);
         putStringIfNotNull(jsonObject, FIELD_RECEIPT_EMAIL, mReceiptEmail);
         putStringIfNotNull(jsonObject, FIELD_SOURCE, mSource);
         putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
@@ -290,6 +359,7 @@ public class PaymentIntent extends StripeJsonModel {
         map.put(FIELD_ID, mId);
         map.put(FIELD_OBJECT, mObjectType);
         map.put(FIELD_ALLOWED_SOURCE_TYPES, mAllowedSourceTypes);
+        map.put(FIELD_PAYMENT_METHOD_TYPES, mPaymentMethodTypes);
         map.put(FIELD_AMOUNT, mAmount);
         map.put(FIELD_CANCELED, mCanceledAt);
         map.put(FIELD_CLIENT_SECRET, mClientSecret);
@@ -300,6 +370,7 @@ public class PaymentIntent extends StripeJsonModel {
         map.put(FIELD_DESCRIPTION, mDescription);
         map.put(FIELD_LIVEMODE, mLiveMode);
         map.put(FIELD_NEXT_SOURCE_ACTION, mNextSourceAction);
+        map.put(FIELD_NEXT_ACTION, mNextAction);
         map.put(FIELD_RECEIPT_EMAIL, mReceiptEmail);
         map.put(FIELD_STATUS, mStatus);
         map.put(FIELD_SOURCE, mSource);
@@ -307,4 +378,57 @@ public class PaymentIntent extends StripeJsonModel {
         return map;
     }
 
+    public enum NextActionType {
+        RedirectToUrl("redirect_to_url"),
+        AuthorizeWithUrl("authorize_with_url");
+
+        @NonNull public final String code;
+
+        NextActionType(@NonNull String code) {
+            this.code = code;
+        }
+
+        @Nullable
+        public static NextActionType fromCode(@Nullable String code) {
+            if (code == null) {
+                return null;
+            }
+
+            for (NextActionType nextActionType : values()) {
+                if (nextActionType.code.equals(code)) {
+                    return nextActionType;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public enum Status {
+        RequiresSource("requires_source"),
+        RequiresPaymentMethod("requires_payment_method"),
+        RequiresSourceAction("requires_source_action"),
+        RequiresAction("requires_action");
+
+        @NonNull public final String code;
+
+        Status(@NonNull String code) {
+            this.code = code;
+        }
+
+        @Nullable
+        public static Status fromCode(@Nullable String code) {
+            if (code == null) {
+                return null;
+            }
+
+            for (Status status : values()) {
+                if (status.code.equals(code)) {
+                    return status;
+                }
+            }
+
+            return null;
+        }
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -18,12 +17,11 @@ import static com.stripe.android.testharness.JsonTestUtils.assertJsonEqualsExclu
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentIntentTest {
 
-    private static final String EXAMPLE_PAYMENT_INTENT_SOURCE= "{\n" +
+    private static final String PAYMENT_INTENT_WITH_SOURCE_JSON = "{\n" +
             "  \"id\": \"pi_1CkiBMLENEVhOs7YMtUehLau\",\n" +
             "  \"object\": \"payment_intent\",\n" +
             "  \"allowed_source_types\": [\n" +
@@ -47,7 +45,7 @@ public class PaymentIntentTest {
 
     private static final String BAD_URL = "nonsense-blahblah";
 
-    private static final String EXAMPLE_PAYMENT_INTENT_SOURCE_WITH_BAD_AUTH_URL = "{\n" +
+    private static final String PAYMENT_INTENT_WITH_SOURCE_WITH_BAD_AUTH_URL_JSON = "{\n" +
             "  \"id\": \"pi_1CkiBMLENEVhOs7YMtUehLau\",\n" +
             "  \"object\": \"payment_intent\",\n" +
             "  \"allowed_source_types\": [\n" +
@@ -63,6 +61,7 @@ public class PaymentIntentTest {
             "  \"description\": \"Example PaymentIntent charge\",\n" +
             "  \"livemode\": false,\n" +
             "  \"next_source_action\": {" +
+            "       \"type\": \"authorize_with_url\"," +
             "       authorize_with_url: {" +
         "           url: \""+ BAD_URL +"\" } " +
             "       },\n" +
@@ -72,71 +71,174 @@ public class PaymentIntentTest {
             "  \"status\": \"requires_source_action\"\n" +
             "}\n";
 
-    private static List<String> ALLOWED_SOURCE_TYPES = new ArrayList<String>() {{
+    private static final String PAYMENT_INTENT_WITH_PAYMENT_METHODS_JSON = "{\n" +
+            "  \"id\": \"pi_Aabcxyz01aDfoo\",\n" +
+            "  \"object\": \"payment_intent\",\n" +
+            "  \"amount\": 750,\n" +
+            "  \"amount_capturable\": 0,\n" +
+            "  \"amount_received\": 750,\n" +
+            "  \"application\": null,\n" +
+            "  \"application_fee_amount\": null,\n" +
+            "  \"canceled_at\": null,\n" +
+            "  \"cancellation_reason\": null,\n" +
+            "  \"capture_method\": \"automatic\",\n" +
+            "  \"charges\": {\n" +
+            "    \"object\": \"list\",\n" +
+            "    \"data\": [],\n" +
+            "    \"has_more\": false,\n" +
+            "    \"total_count\": 0,\n" +
+            "    \"url\": \"/v1/charges?payment_intent=pi_Aabcxyz01aDfoo\"\n" +
+            "  },\n" +
+            "  \"client_secret\": null,\n" +
+            "  \"confirmation_method\": \"publishable\",\n" +
+            "  \"created\": 123456789,\n" +
+            "  \"currency\": \"usd\",\n" +
+            "  \"customer\": null,\n" +
+            "  \"description\": \"PaymentIntent Description\",\n" +
+            "  \"last_payment_error\": null,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"metadata\": {\n" +
+            "    \"order_id\": \"123456789\"\n" +
+            "  },\n" +
+            "  \"next_action\": null,\n" +
+            "  \"on_behalf_of\": null,\n" +
+            "  \"payment_method\": null,\n" +
+            "  \"payment_method_types\": [\n" +
+            "    \"card\"\n" +
+            "  ],\n" +
+            "  \"receipt_email\": \"jenny@example.com\",\n" +
+            "  \"review\": null,\n" +
+            "  \"shipping\": {\n" +
+            "    \"address\": {\n" +
+            "      \"city\": \"Stockholm\",\n" +
+            "      \"country\": \"Sweden\",\n" +
+            "      \"line1\": \"Mega street 5\",\n" +
+            "      \"line2\": \"Mega street 5\",\n" +
+            "      \"postal_code\": \"12233JJHH\",\n" +
+            "      \"state\": \"NYC\"\n" +
+            "    },\n" +
+            "    \"carrier\": null,\n" +
+            "    \"name\": \"Mohit  Name\",\n" +
+            "    \"phone\": null,\n" +
+            "    \"tracking_number\": null\n" +
+            "  },\n" +
+            "  \"source\": \"src_1E884r2eZvKYlo2CTft0qEyY\",\n" +
+            "  \"statement_descriptor\": \"PaymentIntent Statement Descriptor\",\n" +
+            "  \"status\": \"succeeded\",\n" +
+            "  \"transfer_data\": null,\n" +
+            "  \"transfer_group\": null\n" +
+            "}";
+
+    private static final String PARTIAL_PAYMENT_INTENT_WITH_REDIRECT_URL_JSON = "{\n" +
+            "\t\"id\": \"pi_Aabcxyz01aDfoo\",\n" +
+            "\t\"object\": \"payment_intent\",\n" +
+            "\t\"status\": \"requires_action\",\n" +
+            "\t\"next_action\": {\n" +
+            "\t\t\"type\": \"redirect_to_url\",\n" +
+            "\t\t\"redirect_to_url\": {\n" +
+            "\t\t\t\"url\": \"https://example.com/redirect\"\n" +
+            "\t\t}\n" +
+            "\t}\n" +
+            "}";
+
+    private static final String PARTIAL_PAYMENT_INTENT_WITH_AUTHORIZE_WITH_URL_JSON = "{\n" +
+            "\t\"id\": \"pi_Aabcxyz01aDfoo\",\n" +
+            "\t\"object\": \"payment_intent\",\n" +
+            "\t\"status\": \"requires_action\",\n" +
+            "\t\"next_action\": {\n" +
+            "\t\t\"type\": \"authorize_with_url\",\n" +
+            "\t\t\"authorize_with_url\": {\n" +
+            "\t\t\t\"url\": \"https://example.com/redirect\"\n" +
+            "\t\t}\n" +
+            "\t}\n" +
+            "}";
+
+    private static final List<String> ALLOWED_SOURCE_TYPES = new ArrayList<String>() {{
         add("card");
     }};
 
-    private static final Map<String, Object> EXAMPLE_PAYMENT_INTENT_MAP = new HashMap<String, Object>() {{
-        put("id", "pi_1CkiBMLENEVhOs7YMtUehLau");
-        put("object", "payment_intent");
-        put("allowed_source_types", ALLOWED_SOURCE_TYPES);
-        put("amount", 1000L);
-        put("canceled_at", 1530839340L);
-        put("client_secret", "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA");
-        put("confirmation_method", "publishable");
-        put("created", 1530838340L);
-        put("currency", "usd");
-        put("description", "Example PaymentIntent charge");
-        put("livemode", false);
-        put("source", "src_1CkiC3LENEVhOs7YMSa4yx4G");
-        put("capture_method", "automatic");
-        put("status", "succeeded");
-    }};
+    private static final Map<String, Object> PAYMENT_INTENT_WITH_SOURCE_MAP =
+            new HashMap<String, Object>() {{
+                put(PaymentIntent.FIELD_ID, "pi_1CkiBMLENEVhOs7YMtUehLau");
+                put(PaymentIntent.FIELD_OBJECT, "payment_intent");
+                put(PaymentIntent.FIELD_ALLOWED_SOURCE_TYPES, ALLOWED_SOURCE_TYPES);
+                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, new ArrayList<>());
+                put(PaymentIntent.FIELD_AMOUNT, 1000L);
+                put(PaymentIntent.FIELD_CANCELED, 1530839340L);
+                put(PaymentIntent.FIELD_CLIENT_SECRET,
+                        "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA");
+                put(PaymentIntent.FIELD_CONFIRMATION_METHOD, "publishable");
+                put(PaymentIntent.FIELD_CREATED, 1530838340L);
+                put(PaymentIntent.FIELD_CURRENCY, "usd");
+                put(PaymentIntent.FIELD_DESCRIPTION, "Example PaymentIntent charge");
+                put(PaymentIntent.FIELD_LIVEMODE, false);
+                put(PaymentIntent.FIELD_SOURCE, "src_1CkiC3LENEVhOs7YMSa4yx4G");
+                put(PaymentIntent.FIELD_CAPTURE_METHOD, "automatic");
+                put(PaymentIntent.FIELD_STATUS, "succeeded");
+            }};
 
-    private PaymentIntent mPaymentIntent;
-
-    @Before
-    public void setup() {
-        mPaymentIntent = PaymentIntent.fromString(EXAMPLE_PAYMENT_INTENT_SOURCE);
-        assertNotNull(mPaymentIntent);
-    }
+    private static final PaymentIntent PAYMENT_INTENT_WITH_SOURCE = PaymentIntent
+            .fromString(PAYMENT_INTENT_WITH_SOURCE_JSON);
 
     @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() {
-        try {
-            JSONObject rawConversion = new JSONObject(EXAMPLE_PAYMENT_INTENT_SOURCE);
-            JSONObject actualObject = mPaymentIntent.toJson();
-            assertJsonEqualsExcludingNulls(rawConversion, actualObject);
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
+    public void fromJsonString_backToJson_createsIdenticalElement() throws JSONException {
+        assertNotNull(PAYMENT_INTENT_WITH_SOURCE);
+        JSONObject rawConversion = new JSONObject(PAYMENT_INTENT_WITH_SOURCE_JSON);
+        JSONObject actualObject = PAYMENT_INTENT_WITH_SOURCE.toJson();
+        assertJsonEqualsExcludingNulls(rawConversion, actualObject);
     }
 
     @Test
     public void fromJsonString_toMap_createsExpectedMap() {
-        Map<String, Object> paymentIntentMap = mPaymentIntent.toMap();
-        assertMapEquals(paymentIntentMap, EXAMPLE_PAYMENT_INTENT_MAP);
+        assertNotNull(PAYMENT_INTENT_WITH_SOURCE);
+        final Map<String, Object> paymentIntentMap = PAYMENT_INTENT_WITH_SOURCE.toMap();
+        assertMapEquals(paymentIntentMap, PAYMENT_INTENT_WITH_SOURCE_MAP);
     }
 
     @Test
     public void getAuthorizationUrl_whenProvidedBadUrl_doesNotCrash() {
-        PaymentIntent paymentIntent = PaymentIntent.fromString(
-                EXAMPLE_PAYMENT_INTENT_SOURCE_WITH_BAD_AUTH_URL);
+        final PaymentIntent paymentIntent = PaymentIntent.fromString(
+                PAYMENT_INTENT_WITH_SOURCE_WITH_BAD_AUTH_URL_JSON);
         assertNotNull(paymentIntent);
 
-        Uri authUrl = paymentIntent.getAuthorizationUrl();
+        final Uri authUrl = paymentIntent.getAuthorizationUrl();
         assertNotNull(authUrl);
 
         assertEquals(BAD_URL, authUrl.getEncodedPath());
     }
 
     @Test
+    public void getRedirectUrl_withRedirectToUrlPopulate_returnsRedirectUrl() {
+        final PaymentIntent paymentIntent = PaymentIntent
+                .fromString(PARTIAL_PAYMENT_INTENT_WITH_REDIRECT_URL_JSON);
+        assertNotNull(paymentIntent);
+        final Uri redirectUrl = paymentIntent.getRedirectUrl();
+        assertNotNull(redirectUrl);
+        assertEquals("https://example.com/redirect", redirectUrl.toString());
+    }
+
+    @Test
+    public void getRedirectUrl_withAuthorizeWithUrlPopulated_returnsRedirectUrl() {
+        final PaymentIntent paymentIntent = PaymentIntent
+                .fromString(PARTIAL_PAYMENT_INTENT_WITH_AUTHORIZE_WITH_URL_JSON);
+        assertNotNull(paymentIntent);
+        final Uri redirectUrl = paymentIntent.getRedirectUrl();
+        assertNotNull(redirectUrl);
+        assertEquals("https://example.com/redirect", redirectUrl.toString());
+    }
+
+    @Test
     public void parseIdFromClientSecret_parsesCorrectly() {
-        String clientSecret = "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA";
-
-        String id = PaymentIntent.parseIdFromClientSecret(clientSecret);
-
+        final String clientSecret = "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA";
+        final String id = PaymentIntent.parseIdFromClientSecret(clientSecret);
         assertEquals("pi_1CkiBMLENEVhOs7YMtUehLau", id);
     }
 
+    @Test
+    public void parsePaymentIntentWithPaymentMethods() {
+        final PaymentIntent paymentIntent =
+                PaymentIntent.fromString(PAYMENT_INTENT_WITH_PAYMENT_METHODS_JSON);
+        assertNotNull(paymentIntent);
+        assertEquals("card", paymentIntent.getPaymentMethodTypes().get(0));
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -27,6 +27,9 @@ public class PaymentIntentTest {
             "  \"allowed_source_types\": [\n" +
             "    \"card\"\n" +
             "  ],\n" +
+            "  \"payment_method_types\": [\n" +
+            "    \"card\"\n" +
+            "  ],\n" +
             "  \"amount\": 1000,\n" +
             "  \"canceled_at\": 1530839340,\n" +
             "  \"capture_method\": \"automatic\",\n" +
@@ -62,8 +65,8 @@ public class PaymentIntentTest {
             "  \"livemode\": false,\n" +
             "  \"next_source_action\": {" +
             "       \"type\": \"authorize_with_url\"," +
-            "       authorize_with_url: {" +
-        "           url: \""+ BAD_URL +"\" } " +
+            "           authorize_with_url: {" +
+            "           url: \""+ BAD_URL +"\" } " +
             "       },\n" +
             "  \"receipt_email\": null,\n" +
             "  \"shipping\": null,\n" +
@@ -162,7 +165,7 @@ public class PaymentIntentTest {
                 put(PaymentIntent.FIELD_ID, "pi_1CkiBMLENEVhOs7YMtUehLau");
                 put(PaymentIntent.FIELD_OBJECT, "payment_intent");
                 put(PaymentIntent.FIELD_ALLOWED_SOURCE_TYPES, ALLOWED_SOURCE_TYPES);
-                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, new ArrayList<>());
+                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, ALLOWED_SOURCE_TYPES);
                 put(PaymentIntent.FIELD_AMOUNT, 1000L);
                 put(PaymentIntent.FIELD_CANCELED, 1530839340L);
                 put(PaymentIntent.FIELD_CLIENT_SECRET,


### PR DESCRIPTION
## Summary
1. PaymentIntent changes
- update to `"status"` field
  - add `"requires_payment_method`", `"requires_action"`
  - deprecate `"requires_source"`, `"requires_source_action"`
- update `"next_action"` field
  - add `"redirect_to_url"`
  - deprecate `"authorize_with_url"`
- add `"payment_method_types"` field
- deprecate `"allowed_source_types"` field

2. update PaymentIntent usage in example app

## Motivation
MOBILE3DS2-198

## Testing
Wrote unit tests