### PR TITLE
Fix account token failure on latest API version

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiVersion.java
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.java
@@ -1,0 +1,56 @@
+package com.stripe.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.stripe.android.utils.ObjectUtils;
+
+/**
+ * A class that represents a Stripe API version.
+ *
+ * See <a href="https://stripe.com/docs/api/versioning">https://stripe.com/docs/api/versioning</a>
+ * for documentation on API versioning.
+ *
+ * See <a href="https://stripe.com/docs/upgrades">https://stripe.com/docs/upgrades</a> for latest
+ * API changes.
+ */
+public class ApiVersion {
+    static final String DEFAULT_API_VERSION = "2017-06-05";
+
+    @NonNull private static final ApiVersion DEFAULT_INSTANCE = new ApiVersion(DEFAULT_API_VERSION);
+
+    @NonNull private final String mCode;
+
+    @NonNull
+    public static ApiVersion create(@NonNull String code) {
+        return new ApiVersion(code);
+    }
+
+    @NonNull
+    public static ApiVersion getDefault() {
+        return DEFAULT_INSTANCE;
+    }
+
+    private ApiVersion(@NonNull String code) {
+        this.mCode = code;
+    }
+
+    @NonNull
+    public String getCode() {
+        return mCode;
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mCode);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof ApiVersion && typedEquals((ApiVersion) obj));
+    }
+
+    private boolean typedEquals(@NonNull ApiVersion apiVersion) {
+        return ObjectUtils.equals(mCode, apiVersion.mCode);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -41,7 +41,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
                 mEphemeralKey,
                 mTimeBufferInSeconds,
                 mOverrideCalendar)) {
-            mEphemeralKeyProvider.createEphemeralKey(StripeApiHandler.API_VERSION,
+            mEphemeralKeyProvider.createEphemeralKey(ApiVersion.DEFAULT_API_VERSION,
                     new ClientKeyUpdateListener(this, actionString, arguments));
         } else {
             mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);

--- a/stripe/src/main/java/com/stripe/android/RequestOptions.java
+++ b/stripe/src/main/java/com/stripe/android/RequestOptions.java
@@ -94,6 +94,7 @@ public class RequestOptions {
         return builder(publishableApiKey, TYPE_QUERY);
     }
 
+    @NonNull
     public static RequestOptions.RequestOptionsBuilder builder(
             @Nullable String publishableApiKey,
             @Nullable String stripeAccount,
@@ -191,6 +192,14 @@ public class RequestOptions {
                     ? null
                     : apiVersion;
             return this;
+        }
+
+        /**
+         * Convenience method for {@link #setApiVersion(String)}
+         */
+        @NonNull
+        RequestOptionsBuilder setApiVersion(@Nullable ApiVersion apiVersion) {
+            return setApiVersion(apiVersion != null ? apiVersion.getCode() : null);
         }
 
         @NonNull

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -684,12 +684,26 @@ public class Stripe {
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers)
      */
+    @Nullable
     public Token createAccountTokenSynchronous(@NonNull final AccountParams accountParams)
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
             APIException {
-        return createAccountTokenSynchronous(accountParams, mDefaultPublishableKey);
+        return createAccountTokenSynchronous(accountParams, mDefaultPublishableKey, null);
+    }
+
+    /**
+     * See {@link #createAccountTokenSynchronous(AccountParams)}
+     */
+    @Nullable
+    public Token createAccountTokenSynchronous(@NonNull final AccountParams accountParams,
+                                               @NonNull final ApiVersion apiVersion)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            APIException {
+        return createAccountTokenSynchronous(accountParams, mDefaultPublishableKey, apiVersion);
     }
 
     /**
@@ -707,9 +721,11 @@ public class Stripe {
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers)
      */
+    @Nullable
     public Token createAccountTokenSynchronous(
             @NonNull final AccountParams accountParams,
-            @Nullable String publishableKey)
+            @Nullable String publishableKey,
+            @Nullable ApiVersion apiVersion)
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
@@ -720,9 +736,9 @@ public class Stripe {
         }
         validateKey(publishableKey);
         RequestOptions requestOptions = RequestOptions.builder(
-                publishableKey,
-                mStripeAccount,
-                RequestOptions.TYPE_QUERY).build();
+                publishableKey, mStripeAccount, RequestOptions.TYPE_QUERY)
+                .setApiVersion(apiVersion)
+                .build();
         try {
             return StripeApiHandler.createToken(
                     mContext,

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -78,8 +78,6 @@ class StripeApiHandler {
     private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
     private static final SSLSocketFactory SSL_SOCKET_FACTORY = new StripeSSLSocketFactory();
 
-    static final String API_VERSION = "2017-06-05";
-
     static void logApiCall(
             @NonNull Map<String, Object> loggingMap,
             @NonNull RequestOptions options,
@@ -127,7 +125,7 @@ class StripeApiHandler {
                 publishableKey,
                 stripeAccount,
                 RequestOptions.TYPE_QUERY)
-                .setApiVersion(API_VERSION)
+                .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
                 .build();
 
         try {
@@ -179,7 +177,7 @@ class StripeApiHandler {
                 publishableKey,
                 stripeAccount,
                 RequestOptions.TYPE_QUERY)
-                .setApiVersion(API_VERSION)
+                .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
                 .build();
 
         try {
@@ -457,8 +455,9 @@ class StripeApiHandler {
                     context, productUsageTokens, publicKey, sourceType);
 
             // We use the public key to log, so we need different RequestOptions.
-            final RequestOptions loggingOptions =
-                    RequestOptions.builder(publicKey).setApiVersion(API_VERSION).build();
+            final RequestOptions loggingOptions = RequestOptions.builder(publicKey)
+                    .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                    .build();
             logApiCall(loggingParamsMap, loggingOptions, listener);
         }
 
@@ -466,7 +465,9 @@ class StripeApiHandler {
                 POST,
                 getAddCustomerSourceUrl(customerId),
                 paramsMap,
-                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+                RequestOptions.builder(secret)
+                        .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                        .build());
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         return Source.fromString(response.getResponseBody());
@@ -492,8 +493,9 @@ class StripeApiHandler {
                     LoggingUtils.getDeleteSourceParams(context, productUsageTokens, publicKey);
 
             // We use the public key to log, so we need different RequestOptions.
-            final RequestOptions loggingOptions =
-                    RequestOptions.builder(publicKey).setApiVersion(API_VERSION).build();
+            final RequestOptions loggingOptions = RequestOptions.builder(publicKey)
+                    .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                    .build();
             logApiCall(loggingParamsMap, loggingOptions, listener);
         }
 
@@ -501,7 +503,9 @@ class StripeApiHandler {
                 DELETE,
                 getDeleteCustomerSourceUrl(customerId, sourceId),
                 paramsMap,
-                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+                RequestOptions.builder(secret)
+                        .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                        .build());
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         return Source.fromString(response.getResponseBody());
@@ -528,7 +532,7 @@ class StripeApiHandler {
         // Context can be nullable because this action is performed with only a weak reference
         if (context != null) {
             final RequestOptions loggingOptions = RequestOptions.builder(publicKey)
-                    .setApiVersion(API_VERSION)
+                    .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
                     .build();
 
             final Map<String, Object> loggingParameters = LoggingUtils.getEventLoggingParams(
@@ -546,7 +550,9 @@ class StripeApiHandler {
                 POST,
                 getRetrieveCustomerUrl(customerId),
                 paramsMap,
-                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+                RequestOptions.builder(secret)
+                        .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                        .build());
 
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -573,7 +579,7 @@ class StripeApiHandler {
         // Context can be nullable because this action is performed with only a weak reference
         if (context != null) {
             final RequestOptions loggingOptions = RequestOptions.builder(publicKey)
-                    .setApiVersion(API_VERSION)
+                    .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
                     .build();
 
             final Map<String, Object> loggingParameters = LoggingUtils.getEventLoggingParams(
@@ -591,7 +597,9 @@ class StripeApiHandler {
                 POST,
                 getRetrieveCustomerUrl(customerId),
                 paramsMap,
-                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+                RequestOptions.builder(secret)
+                        .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                        .build());
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         return Customer.fromString(response.getResponseBody());
@@ -609,7 +617,9 @@ class StripeApiHandler {
                 GET,
                 getRetrieveCustomerUrl(customerId),
                 null,
-                RequestOptions.builder(secret).setApiVersion(API_VERSION).build());
+                RequestOptions.builder(secret)
+                        .setApiVersion(ApiVersion.DEFAULT_API_VERSION)
+                        .build());
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         return Customer.fromString(response.getResponseBody());
     }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -977,34 +977,113 @@ public class StripeTest {
     }
 
     @Test
-    public void createTokenSynchronous_withValidAccount_passesIntegrationTest() {
-        try {
-            final Address exampleAddress = new Address
-                    .Builder()
-                    .setCity("SF")
-                    .setCountry("US")
-                    .setState("CA").build();
-           final Map<String, Object> exampleLegalEntity = new HashMap<String, Object>() {{
-                put("personal_address", exampleAddress.toMap());
-                put("type", "individual");
-                put("ssn_last_4", "1234");
-                put("first_name", "Kathy");
-                put("last_name", "Sun");
-            }};
-            Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
-            Token token = stripe.createAccountTokenSynchronous(
-                    AccountParams.createAccountParams(true, exampleLegalEntity));
-            assertNotNull(token);
-            assertEquals(Token.TYPE_ACCOUNT, token.getType());
-            assertFalse(token.getLivemode());
-            assertFalse(token.getUsed());
-            assertNotNull(token.getId());
-            assertAllLogsAreValid(listener, 2);
-        } catch (StripeException stripeEx) {
-            fail(stripeEx.getMessage());
-        }
+    public void createTokenSynchronous_withValidAccountOnApi20170605_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Address exampleAddress = new Address.Builder()
+                .setCity("SF")
+                .setCountry("US")
+                .setState("CA")
+                .build();
+       final Map<String, Object> legalEntityData = new HashMap<String, Object>() {{
+            put("personal_address", exampleAddress.toMap());
+            put("type", "individual");
+            put("ssn_last_4", "1234");
+            put("first_name", "Kathy");
+            put("last_name", "Sun");
+        }};
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        final TestLoggingListener listener = new TestLoggingListener(true);
+        stripe.setLoggingResponseListener(listener);
+        final Token token = stripe.createAccountTokenSynchronous(
+                AccountParams.createAccountParams(true, legalEntityData),
+                ApiVersion.getDefault());
+        assertNotNull(token);
+        assertEquals(Token.TYPE_ACCOUNT, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
+        assertAllLogsAreValid(listener, 2);
+    }
+
+    @Test
+    public void createTokenSynchronous_withoutLegalEntityOnApi20170605_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        final TestLoggingListener listener = new TestLoggingListener(true);
+        stripe.setLoggingResponseListener(listener);
+        final Token token = stripe.createAccountTokenSynchronous(
+                AccountParams.createAccountParams(true, null),
+                ApiVersion.getDefault());
+        assertNotNull(token);
+        assertEquals(Token.TYPE_ACCOUNT, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
+        assertAllLogsAreValid(listener, 2);
+    }
+
+    @Test
+    public void createTokenSynchronous_withIndividualEntityOnApi20190219_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Address exampleAddress = new Address
+                .Builder()
+                .setCity("SF")
+                .setCountry("US")
+                .setState("CA").build();
+        final Map<String, Object> businessData = new HashMap<String, Object>() {{
+            put("address", exampleAddress.toMap());
+            put("ssn_last_4", "1234");
+            put("first_name", "Kathy");
+            put("last_name", "Sun");
+        }};
+
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        final TestLoggingListener listener = new TestLoggingListener(true);
+        stripe.setLoggingResponseListener(listener);
+        final Token token = stripe.createAccountTokenSynchronous(
+                AccountParams.createAccountParams(true,
+                        AccountParams.BusinessType.Individual, businessData),
+                ApiVersion.create("2019-02-19"));
+        assertNotNull(token);
+        assertEquals(Token.TYPE_ACCOUNT, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
+        assertAllLogsAreValid(listener, 2);
+    }
+
+
+    @Test
+    public void createTokenSynchronous_withCompanyEntityOnApi20190219_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Address exampleAddress = new Address
+                .Builder()
+                .setCity("SF")
+                .setCountry("US")
+                .setState("CA").build();
+        final Map<String, Object> businessData = new HashMap<String, Object>() {{
+            put("address", exampleAddress.toMap());
+            put("tax_id", "123-23-1234");
+            put("name", "My Corp.");
+        }};
+
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        final TestLoggingListener listener = new TestLoggingListener(true);
+        stripe.setLoggingResponseListener(listener);
+        final Token token = stripe.createAccountTokenSynchronous(
+                AccountParams.createAccountParams(true,
+                        AccountParams.BusinessType.Company, businessData),
+                ApiVersion.create("2019-02-19"));
+        assertNotNull(token);
+        assertEquals(Token.TYPE_ACCOUNT, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
+        assertAllLogsAreValid(listener, 2);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Create `ApiVersion` class to represent a Stripe API version
- Overload `Stripe#createAccountTokenSynchronous` methods that accept `ApiVersion` argument
- Update `AccountParams` to support `individual` and `company` business types

## Motivation
Fixes #821

## Testing
- Add tests for `2019-02-19` API changes to the Account API
