### PR TITLE
Reduce visibility of recently added Stripe methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -697,8 +697,9 @@ public class Stripe {
      * See {@link #createAccountTokenSynchronous(AccountParams)}
      */
     @Nullable
-    public Token createAccountTokenSynchronous(@NonNull final AccountParams accountParams,
-                                               @NonNull final ApiVersion apiVersion)
+    @VisibleForTesting
+    Token createAccountTokenSynchronous(@NonNull final AccountParams accountParams,
+                                        @NonNull final ApiVersion apiVersion)
             throws AuthenticationException,
             InvalidRequestException,
             APIConnectionException,
@@ -723,6 +724,17 @@ public class Stripe {
      */
     @Nullable
     public Token createAccountTokenSynchronous(
+            @NonNull final AccountParams accountParams,
+            @Nullable String publishableKey)
+            throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            APIException {
+        return createAccountTokenSynchronous(accountParams, publishableKey, null);
+    }
+
+    @Nullable
+    private Token createAccountTokenSynchronous(
             @NonNull final AccountParams accountParams,
             @Nullable String publishableKey,
             @Nullable ApiVersion apiVersion)


### PR DESCRIPTION
## Summary
Overloaded `Stripe` methods that take an `ApiVersion` should not be publicly accessible.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
