### PR TITLE
Upgrade Android Gradle plugin to 3.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
     }
 }


### PR DESCRIPTION
## Summary
Upgrade Android Gradle plugin to 3.3.2

## Motivation
This version of AGP is required by Android Studio 3.3.2

## Testing
<!-- How was the code tested? Be as specific as possible. -->
