### PR TITLE
Support save to customer param on PaymentIntent confirm

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
@@ -18,6 +18,8 @@ public class PaymentIntentParams {
     static final String API_PARAM_RETURN_URL = "return_url";
     static final String API_PARAM_CLIENT_SECRET = "client_secret";
 
+    static final String API_PARAM_SAVE_PAYMENT_METHOD = "save_payment_method";
+
     @Nullable private PaymentMethodCreateParams mPaymentMethodCreateParams;
     @Nullable private String mPaymentMethodId;
     @Nullable private SourceParams mSourceParams;
@@ -26,6 +28,8 @@ public class PaymentIntentParams {
     @Nullable private Map<String, Object> mExtraParams;
     @Nullable private String mClientSecret;
     @Nullable private String mReturnUrl;
+
+    private boolean mSaveToCustomer;
 
     private PaymentIntentParams() {
     }
@@ -42,7 +46,6 @@ public class PaymentIntentParams {
         return new PaymentIntentParams();
     }
 
-
     /**
      * Create the parameters necessary for confirming a PaymentIntent while attaching a
      * PaymentMethod that already exits.
@@ -52,17 +55,33 @@ public class PaymentIntentParams {
      * @param clientSecret client secret from the PaymentIntent being confirmed
      * @param returnUrl the URL the customer should be redirected to after the authorization
      *                  process
+     * @param saveToCustomer Set to {@code true} to save this PaymentIntent’s payment method to the
+     *                       associated Customer, if the payment method is not already attached.
+     *                       This parameter only applies to the payment method passed in the same
+     *                       request or the current payment method attached to the PaymentIntent and
+     *                       must be specified again if a new payment method is added.
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
     public static PaymentIntentParams createConfirmPaymentIntentWithPaymentMethodId(
             @Nullable String paymentMethodId,
             @NonNull String clientSecret,
-            @NonNull String returnUrl) {
+            @NonNull String returnUrl,
+            boolean saveToCustomer) {
         return new PaymentIntentParams()
                 .setPaymentMethodId(paymentMethodId)
                 .setClientSecret(clientSecret)
-                .setReturnUrl(returnUrl);
+                .setReturnUrl(returnUrl)
+                .setSaveToCustomer(saveToCustomer);
+    }
+
+    @NonNull
+    public static PaymentIntentParams createConfirmPaymentIntentWithPaymentMethodId(
+            @Nullable String paymentMethodId,
+            @NonNull String clientSecret,
+            @NonNull String returnUrl) {
+        return createConfirmPaymentIntentWithPaymentMethodId(paymentMethodId, clientSecret,
+                returnUrl, false);
     }
 
     /**
@@ -74,17 +93,33 @@ public class PaymentIntentParams {
      * @param clientSecret client secret from the PaymentIntent that is to be confirmed
      * @param returnUrl the URL the customer should be redirected to after the authorization
      *                  process
+     * @param saveToCustomer Set to {@code true} to save this PaymentIntent’s payment method to the
+     *                       associated Customer, if the payment method is not already attached.
+     *                       This parameter only applies to the payment method passed in the same
+     *                       request or the current payment method attached to the PaymentIntent and
+     *                       must be specified again if a new payment method is added.
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
     public static PaymentIntentParams createConfirmPaymentIntentWithPaymentMethodCreateParams(
             @Nullable PaymentMethodCreateParams paymentMethodCreateParams,
             @NonNull String clientSecret,
-            @NonNull String returnUrl) {
+            @NonNull String returnUrl,
+            boolean saveToCustomer) {
         return new PaymentIntentParams()
                 .setPaymentMethodCreateParams(paymentMethodCreateParams)
                 .setClientSecret(clientSecret)
-                .setReturnUrl(returnUrl);
+                .setReturnUrl(returnUrl)
+                .setSaveToCustomer(saveToCustomer);
+    }
+
+    @NonNull
+    public static PaymentIntentParams createConfirmPaymentIntentWithPaymentMethodCreateParams(
+            @Nullable PaymentMethodCreateParams paymentMethodCreateParams,
+            @NonNull String clientSecret,
+            @NonNull String returnUrl) {
+        return createConfirmPaymentIntentWithPaymentMethodCreateParams(paymentMethodCreateParams,
+                clientSecret, returnUrl, false);
     }
 
     /**
@@ -96,17 +131,33 @@ public class PaymentIntentParams {
      * @param clientSecret client secret from the PaymentIntent being confirmed
      * @param returnUrl the URL the customer should be redirected to after the authorization
      *                  process
+     * @param saveToCustomer Set to {@code true} to save this PaymentIntent’s source to the
+     *                       associated Customer, if the source is not already attached.
+     *                       This parameter only applies to the source passed in the same request
+     *                       or the current source attached to the PaymentIntent and must be
+     *                       specified again if a new source is added.
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
     public static PaymentIntentParams createConfirmPaymentIntentWithSourceIdParams(
             @Nullable String sourceId,
             @NonNull String clientSecret,
-            @NonNull String returnUrl) {
+            @NonNull String returnUrl,
+            boolean saveToCustomer) {
         return new PaymentIntentParams()
                 .setSourceId(sourceId)
                 .setClientSecret(clientSecret)
-                .setReturnUrl(returnUrl);
+                .setReturnUrl(returnUrl)
+                .setSaveToCustomer(saveToCustomer);
+    }
+
+    @NonNull
+    public static PaymentIntentParams createConfirmPaymentIntentWithSourceIdParams(
+            @Nullable String sourceId,
+            @NonNull String clientSecret,
+            @NonNull String returnUrl) {
+        return createConfirmPaymentIntentWithSourceIdParams(sourceId, clientSecret, returnUrl,
+                false);
     }
 
     /**
@@ -116,17 +167,33 @@ public class PaymentIntentParams {
      * @param clientSecret client secret from the PaymentIntent that is to be confirmed
      * @param returnUrl the URL the customer should be redirected to after the authorization
      *                  process
+     * @param saveToCustomer Set to {@code true} to save this PaymentIntent’s source to the
+     *                       associated Customer, if the source is not already attached.
+     *                       This parameter only applies to the source passed in the same request
+     *                       or the current source attached to the PaymentIntent and must be
+     *                       specified again if a new source is added.
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
     public static PaymentIntentParams createConfirmPaymentIntentWithSourceDataParams(
             @Nullable SourceParams sourceParams,
             @NonNull String clientSecret,
-            @NonNull String returnUrl) {
+            @NonNull String returnUrl,
+            boolean saveToCustomer) {
         return new PaymentIntentParams()
                 .setSourceParams(sourceParams)
                 .setClientSecret(clientSecret)
-                .setReturnUrl(returnUrl);
+                .setReturnUrl(returnUrl)
+                .setSaveToCustomer(saveToCustomer);
+    }
+
+    @NonNull
+    public static PaymentIntentParams createConfirmPaymentIntentWithSourceDataParams(
+            @Nullable SourceParams sourceParams,
+            @NonNull String clientSecret,
+            @NonNull String returnUrl) {
+        return createConfirmPaymentIntentWithSourceDataParams(sourceParams, clientSecret, returnUrl,
+                false);
     }
 
     /**
@@ -138,7 +205,8 @@ public class PaymentIntentParams {
     @NonNull
     public static PaymentIntentParams createRetrievePaymentIntentParams(
             @NonNull String clientSecret) {
-        return new PaymentIntentParams().setClientSecret(clientSecret);
+        return new PaymentIntentParams()
+                .setClientSecret(clientSecret);
     }
 
     /**
@@ -228,6 +296,12 @@ public class PaymentIntentParams {
         return this;
     }
 
+    @NonNull
+    public PaymentIntentParams setSaveToCustomer(boolean saveToCustomer) {
+        mSaveToCustomer = saveToCustomer;
+        return this;
+    }
+
     /**
      * Create a string-keyed map representing this object that is
      * ready to be sent over the network.
@@ -256,6 +330,11 @@ public class PaymentIntentParams {
         if (mExtraParams != null) {
             networkReadyMap.putAll(mExtraParams);
         }
+
+        if (mSaveToCustomer) {
+            networkReadyMap.put(API_PARAM_SAVE_PAYMENT_METHOD, true);
+        }
+
         return networkReadyMap;
     }
 
@@ -314,5 +393,9 @@ public class PaymentIntentParams {
     @Nullable
     public String getReturnUrl() {
         return mReturnUrl;
+    }
+
+    public boolean shouldSaveToCustomer() {
+        return mSaveToCustomer;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.stripe.android.view.CardInputTestActivity.VALID_VISA_NO_SPACES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentIntentParamsTest {
@@ -46,6 +49,7 @@ public class PaymentIntentParamsTest {
         Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
         Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
         Assert.assertEquals(sourceParams, params.getSourceParams());
+        assertFalse(params.shouldSaveToCustomer());
     }
 
     @Test
@@ -57,6 +61,22 @@ public class PaymentIntentParamsTest {
         Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
         Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
         Assert.assertEquals(TEST_SOURCE_ID, params.getSourceId());
+        assertFalse(params.shouldSaveToCustomer());
+    }
+
+    @Test
+    public void createConfirmPaymentIntentWithSourceIdParams_withSaveToCustomer_hasExpectedFields() {
+        final PaymentIntentParams params = PaymentIntentParams
+                .createConfirmPaymentIntentWithSourceIdParams(
+                        TEST_SOURCE_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+
+        Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
+        Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        Assert.assertEquals(TEST_SOURCE_ID, params.getSourceId());
+        assertTrue(params.shouldSaveToCustomer());
+
+        assertEquals(Boolean.TRUE,
+                params.toParamMap().get(PaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 
     @Test
@@ -69,10 +89,11 @@ public class PaymentIntentParamsTest {
         Assert.assertNull(params.getExtraParams());
         Assert.assertNull(params.getSourceId());
         Assert.assertNull(params.getSourceParams());
+        assertFalse(params.shouldSaveToCustomer());
     }
 
     @Test
-    public void createRetrievePaymentIntent_withPaymentMethodCreateParams_hasExpectedFields() {
+    public void createRetrievePaymentIntentwithPaymentMethodCreateParams_hasExpectedFields() {
         final PaymentMethodCreateParams paymentMethodCreateParams =
                 PaymentMethodCreateParams.create(new PaymentMethodCreateParams.Card.Builder()
                         .build(), null);
@@ -83,10 +104,11 @@ public class PaymentIntentParamsTest {
         Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
         Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
         Assert.assertEquals(paymentMethodCreateParams, params.getPaymentMethodCreateParams());
+        assertFalse(params.shouldSaveToCustomer());
     }
 
     @Test
-    public void createRetrievePaymentIntent_withPaymentMethodId_hasExpectedFields() {
+    public void createConfirmPaymentIntentWithPaymentMethodId_hasExpectedFields() {
         final PaymentIntentParams params = PaymentIntentParams
                 .createConfirmPaymentIntentWithPaymentMethodId(
                         TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL);
@@ -94,6 +116,37 @@ public class PaymentIntentParamsTest {
         Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
         Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
         Assert.assertEquals(TEST_PAYMENT_METHOD_ID, params.getPaymentMethodId());
+        assertFalse(params.shouldSaveToCustomer());
+    }
+
+    @Test
+    public void createConfirmPaymentIntentWithPaymentMethodCreateParams_withSaveToCustomer_hasExpectedFields() {
+        final PaymentMethodCreateParams paymentMethodCreateParams =
+                PaymentMethodCreateParams.create(new PaymentMethodCreateParams.Card.Builder()
+                        .build(), null);
+        final PaymentIntentParams params = PaymentIntentParams
+                .createConfirmPaymentIntentWithPaymentMethodCreateParams(paymentMethodCreateParams,
+                        TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+
+        Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
+        Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        Assert.assertEquals(paymentMethodCreateParams, params.getPaymentMethodCreateParams());
+        assertTrue(params.shouldSaveToCustomer());
+    }
+
+    @Test
+    public void createConfirmPaymentIntentWithPaymentMethodId_withSaveToCustomer_hasExpectedFields() {
+        final PaymentIntentParams params = PaymentIntentParams
+                .createConfirmPaymentIntentWithPaymentMethodId(
+                        TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+
+        Assert.assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
+        Assert.assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        Assert.assertEquals(TEST_PAYMENT_METHOD_ID, params.getPaymentMethodId());
+        assertTrue(params.shouldSaveToCustomer());
+
+        assertEquals(Boolean.TRUE,
+                params.toParamMap().get(PaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 
     @Test
@@ -110,6 +163,7 @@ public class PaymentIntentParamsTest {
                 paramMap.get(PaymentIntentParams.API_PARAM_CLIENT_SECRET), TEST_CLIENT_SECRET);
         Assert.assertEquals(
                 paramMap.get(PaymentIntentParams.API_PARAM_RETURN_URL), TEST_RETURN_URL);
+        assertFalse(paramMap.containsKey(PaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 
     @Test
@@ -133,5 +187,6 @@ public class PaymentIntentParamsTest {
                 paramMap.get(extraParamKey1), extraParamValue1);
         Assert.assertEquals(
                 paramMap.get(extraParamKey2), extraParamValue2);
+        assertFalse(paramMap.containsKey(PaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 }


### PR DESCRIPTION
## Summary
Add support for setting the `save_payment_method` param when confirming a PaymentIntent

## Motivation
ANDROID-331

## Testing
Wrote unit tests
