### PR TITLE
Add LeakCanary to example and samplestore apps

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -8,7 +8,8 @@
 
     <application
         android:icon="@drawable/ic_launcher"
-        android:label="@string/appName">
+        android:label="@string/appName"
+        android:name=".ExampleApplication">
 
         <!-- Enables the Google Payment API -->
         <meta-data

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -26,6 +26,11 @@ dependencies {
 
     /* Used to debug your Retrofit connections */
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.3'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.3'
+    // Optional, if you use support library fragments:
+    debugImplementation 'com.squareup.leakcanary:leakcanary-support-fragment:1.6.3'
 }
 
 android {

--- a/example/src/main/java/com/stripe/example/ExampleApplication.java
+++ b/example/src/main/java/com/stripe/example/ExampleApplication.java
@@ -1,0 +1,23 @@
+package com.stripe.example;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class ExampleApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        if (BuildConfig.DEBUG && LeakCanary.isInAnalyzerProcess(this)) {
+            // This process is dedicated to LeakCanary for heap analysis.
+            // You should not init your app in this process.
+            return;
+        }
+
+        if (BuildConfig.DEBUG) {
+            LeakCanary.install(this);
+        }
+    }
+}

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -51,4 +51,9 @@ dependencies {
 
     /* Used to debug your Retrofit connections */
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.3'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.3'
+    // Optional, if you use support library fragments:
+    debugImplementation 'com.squareup.leakcanary:leakcanary-support-fragment:1.6.3'
 }

--- a/samplestore/src/main/AndroidManifest.xml
+++ b/samplestore/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".SampleStoreApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/samplestore/src/main/java/com/stripe/samplestore/SampleStoreApplication.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/SampleStoreApplication.java
@@ -1,0 +1,23 @@
+package com.stripe.samplestore;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class SampleStoreApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        if (BuildConfig.DEBUG && LeakCanary.isInAnalyzerProcess(this)) {
+            // This process is dedicated to LeakCanary for heap analysis.
+            // You should not init your app in this process.
+            return;
+        }
+
+        if (BuildConfig.DEBUG) {
+            LeakCanary.install(this);
+        }
+    }
+}


### PR DESCRIPTION
This will help us discovery memory leaks in the `stripe-android` SDK
