### PR TITLE
Fix issues with CustomerSession listeners

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/AbstractEphemeralKey.java
@@ -205,7 +205,7 @@ abstract class AbstractEphemeralKey extends StripeJsonModel implements Parcelabl
         return mType;
     }
 
-    @Nullable
+    @NonNull
     protected static <TEphemeralKey extends AbstractEphemeralKey> TEphemeralKey
     fromString(@Nullable String rawJson, Class ephemeralKeyClass) throws JSONException {
         if (rawJson == null) {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -354,9 +354,9 @@ public class CustomerSession
     private void addCustomerSource(
             @NonNull final Context context,
             @NonNull final CustomerEphemeralKey key,
-            @Nullable final String operationId,
             @NonNull final String sourceId,
-            @NonNull final String sourceType) {
+            @NonNull final String sourceType,
+            @Nullable final String operationId) {
         final Runnable fetchCustomerRunnable = new Runnable() {
             @Override
             public void run() {
@@ -518,9 +518,10 @@ public class CustomerSession
                 arguments.containsKey(KEY_SOURCE_TYPE)) {
             addCustomerSource(mContext,
                     ephemeralKey,
-                    operationId,
                     (String) arguments.get(KEY_SOURCE),
-                    (String) arguments.get(KEY_SOURCE_TYPE));
+                    (String) arguments.get(KEY_SOURCE_TYPE),
+                    operationId
+            );
             resetUsageTokens();
         } else if (ACTION_DELETE_SOURCE.equals(actionString) &&
                 arguments.containsKey(KEY_SOURCE)) {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -32,19 +32,20 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         mListener = keyManagerListener;
         mTimeBufferInSeconds = timeBufferInSeconds;
         mOverrideCalendar = overrideCalendar;
-        retrieveEphemeralKey(null, null);
+        retrieveEphemeralKey(null, null, null);
     }
 
-    void retrieveEphemeralKey(@Nullable String actionString,
+    void retrieveEphemeralKey(@Nullable String operationId,
+                              @Nullable String actionString,
                               @Nullable Map<String, Object> arguments) {
         if (shouldRefreshKey(
                 mEphemeralKey,
                 mTimeBufferInSeconds,
                 mOverrideCalendar)) {
             mEphemeralKeyProvider.createEphemeralKey(ApiVersion.DEFAULT_API_VERSION,
-                    new ClientKeyUpdateListener(this, actionString, arguments));
+                    new ClientKeyUpdateListener(this, operationId, actionString, arguments));
         } else {
-            mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
+            mListener.onKeyUpdate(mEphemeralKey, operationId, actionString, arguments);
         }
     }
 
@@ -56,28 +57,31 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
 
     @SuppressWarnings("checkstyle:IllegalCatch")
     private void updateKey(
+            @Nullable String operationId,
             @NonNull String key,
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
         // Key is coming from the user, so even if it's @NonNull annotated we
         // want to double check it
         if (key == null) {
-            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
-                    "EphemeralKeyUpdateListener.onKeyUpdate was called " +
-                            "with a null value");
+            mListener.onKeyError(operationId,
+                    HttpURLConnection.HTTP_INTERNAL_ERROR,
+                    "EphemeralKeyUpdateListener.onKeyUpdate was called with a null value");
             return;
         }
         try {
             mEphemeralKey = AbstractEphemeralKey.fromString(key, mEphemeralKeyClass);
-            mListener.onKeyUpdate(mEphemeralKey, actionString, arguments);
+            mListener.onKeyUpdate(mEphemeralKey, operationId, actionString, arguments);
         } catch (JSONException e) {
-            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+            mListener.onKeyError(operationId,
+                    HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                             "a value that could not be JSON parsed: ["
                             + e.getLocalizedMessage() + "]. The raw body from Stripe's response" +
                             " should be passed");
         } catch (Exception e) {
-            mListener.onKeyError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+            mListener.onKeyError(operationId,
+                    HttpURLConnection.HTTP_INTERNAL_ERROR,
                     "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                             "a JSON String that was invalid: ["
                             + e.getLocalizedMessage() + "]. The raw body from Stripe's response" +
@@ -85,9 +89,10 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         }
     }
 
-    private void updateKeyError(int errorCode, @Nullable String errorMessage) {
+    private void updateKeyError(@Nullable String operationId, int errorCode,
+                                @Nullable String errorMessage) {
         mEphemeralKey = null;
-        mListener.onKeyError(errorCode, errorMessage);
+        mListener.onKeyError(operationId, errorCode, errorMessage);
     }
 
     static boolean shouldRefreshKey(
@@ -106,24 +111,26 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
     }
 
     interface KeyManagerListener<TEphemeralKey extends AbstractEphemeralKey> {
-        void onKeyUpdate(@NonNull TEphemeralKey ephemeralKey,
-                         @Nullable String action,
-                         @Nullable Map<String, Object> arguments);
+        void onKeyUpdate(@NonNull TEphemeralKey ephemeralKey, @Nullable String operationId,
+                         @Nullable String action, @Nullable Map<String, Object> arguments);
 
-        void onKeyError(int errorCode, @Nullable String errorMessage);
+        void onKeyError(@Nullable String operationId, int errorCode, @Nullable String errorMessage);
     }
 
     private static class ClientKeyUpdateListener implements EphemeralKeyUpdateListener {
 
         @Nullable private final String mActionString;
+        @Nullable private final String mOperationId;
         @Nullable private final Map<String, Object> mArguments;
         @NonNull private final WeakReference<EphemeralKeyManager> mEphemeralKeyManagerRef;
 
         ClientKeyUpdateListener(
                 @NonNull EphemeralKeyManager keyManager,
+                @Nullable String operationId,
                 @Nullable String actionString,
                 @Nullable Map<String, Object> arguments) {
             mEphemeralKeyManagerRef = new WeakReference<>(keyManager);
+            mOperationId = operationId;
             mActionString = actionString;
             mArguments = arguments;
         }
@@ -132,7 +139,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         public void onKeyUpdate(@NonNull String rawKey) {
             final EphemeralKeyManager keyManager = mEphemeralKeyManagerRef.get();
             if (keyManager != null) {
-                keyManager.updateKey(rawKey, mActionString, mArguments);
+                keyManager.updateKey(mOperationId, rawKey, mActionString, mArguments);
             }
         }
 
@@ -140,7 +147,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         public void onKeyUpdateFailure(int responseCode, @Nullable String message) {
             final EphemeralKeyManager keyManager = mEphemeralKeyManagerRef.get();
             if (keyManager != null) {
-                keyManager.updateKeyError(responseCode, message);
+                keyManager.updateKeyError(mOperationId, responseCode, message);
             }
         }
     }


### PR DESCRIPTION
## Motivation
The previous implementation of `CustomerSession` listeners
had a reference to a single `CustomerRetrievalListener` and
`SourceRetrievalListener`. After a listener is called, it
would be nulled out.

This logic was buggy because it resulted in possible race
conditions in which two calls are both in flight, and the
first call that completes nulls out the listener for the
second.

## Summary
The solution to this issue is to associate an `operationId`
(i.e. UUID) with each listener. This avoids the race condition
and ambiguity about which listener is being referenced.

Additionally, the listeners were being held with a strong
reference, which could lead to memory leaks if the listener
held a reference to an Activity.

## Testing
Manually verified with samplestore and example apps.
