### PR TITLE
Remove CustomerSessionProxy from PaymentMethodsActivity

### DIFF
--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -24,7 +24,6 @@ import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.view.PaymentFlowActivity;
 
 import org.json.JSONException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -239,13 +238,6 @@ public class CustomerSessionTest {
                 return null;
             }
         }).when(mThreadPoolExecutor).execute(any(Runnable.class));
-    }
-
-    @After
-    public void teardown() {
-        LocalBroadcastManager.getInstance(mContext)
-                .unregisterReceiver(mBroadcastReceiver);
-        CustomerSession.endCustomerSession();
     }
 
     @Test(expected = IllegalStateException.class)

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTestHelper.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTestHelper.java
@@ -1,0 +1,12 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+
+public class CustomerSessionTestHelper {
+    private CustomerSessionTestHelper() {
+    }
+
+    public static void setInstance(@NonNull CustomerSession customerSession) {
+        CustomerSession.setInstance(customerSession);
+    }
+}


### PR DESCRIPTION
## Summary   
The `CustomerSessionProxy` interface is not necessary and complicates the logic of `PaymentMethodsActivity`. Instead, set a mock `CustomerSession` object as the current instance.

## Motivation
ANDROID-345

