### PR TITLE
Improve PaymentMethodCreateParams.Card creation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
@@ -128,12 +128,25 @@ public class PaymentMethodCreateParams {
         @Nullable private final String mCvc;
         @Nullable private final String mToken;
 
+        @NonNull
+        public static Card create(@NonNull String token) {
+            return new Card(token);
+        }
+
+        private Card(@NonNull String token) {
+            this.mToken = token;
+            this.mNumber = null;
+            this.mExpiryMonth = null;
+            this.mExpiryYear = null;
+            this.mCvc = null;
+        }
+
         private Card(@NonNull Card.Builder builder) {
             this.mNumber = builder.mNumber;
             this.mExpiryMonth = builder.mExpiryMonth;
             this.mExpiryYear = builder.mExpiryYear;
             this.mCvc = builder.mCvc;
-            this.mToken = builder.mToken;
+            this.mToken = null;
         }
 
         @Override
@@ -180,12 +193,15 @@ public class PaymentMethodCreateParams {
             return map;
         }
 
+        /**
+         * Used to create a {@link Card} object with the user's card details. To create a
+         * {@link Card} with a Stripe token (e.g. for Google Pay), use {@link Card#create(String)}.
+         */
         public static final class Builder {
             @Nullable private String mNumber;
             @Nullable private Integer mExpiryMonth;
             @Nullable private Integer mExpiryYear;
             @Nullable private String mCvc;
-            @Nullable private String mToken;
 
             @NonNull
             public Builder setNumber(@Nullable String number) {
@@ -208,12 +224,6 @@ public class PaymentMethodCreateParams {
             @NonNull
             public Builder setCvc(@Nullable String cvc) {
                 this.mCvc = cvc;
-                return this;
-            }
-
-            @NonNull
-            public Builder setToken(@Nullable String token) {
-                this.mToken = token;
                 return this;
             }
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1236,9 +1236,8 @@ public class StripeTest {
 
         final PaymentMethodCreateParams paymentMethodCreateParams =
                 PaymentMethodCreateParams.create(
-                        new PaymentMethodCreateParams.Card.Builder()
-                                .setToken(token.getId())
-                                .build(), null);
+                        PaymentMethodCreateParams.Card.create(token.getId()),
+                        null);
         final PaymentMethod createdPaymentMethod = stripe.createPaymentMethodSynchronous(
                 paymentMethodCreateParams, FUNCTIONAL_PUBLISHABLE_KEY);
         assertNotNull(createdPaymentMethod);


### PR DESCRIPTION
## Summary
When creating a `PaymentMethod` with a card, the card object
can either be created from the user's card details (e.g. card
number, CVC, expiration), or via a Stripe token (e.g. Google
Pay). `PaymentMethodCreateParams.Card.Builder`'s setters made
it confusing to the developer that there were two separate
approaches to creating a `PaymentMethodCreateParams.Card`.

With this change, the Builder will be used when creating with
card details, and `PaymentMethodCreateParams.Card#create` will
be used when creating with a Stripe token.

## Motivation
ANDROID-346

## Testing
Updated tests