### PR TITLE
Use strong references to callbacks in Stripe and CustomerSession

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -947,7 +947,7 @@ public class Stripe {
         @NonNull private final SourceParams mSourceParams;
         @NonNull private final String mPublishableKey;
         @Nullable private final String mStripeAccount;
-        @NonNull private final WeakReference<SourceCallback> mSourceCallbackRef;
+        @NonNull private final SourceCallback mSourceCallback;
 
         CreateSourceTask(@NonNull Context context,
                          @NonNull StripeApiHandler apiHandler,
@@ -960,7 +960,7 @@ public class Stripe {
             mSourceParams = sourceParams;
             mPublishableKey = publishableKey;
             mStripeAccount = stripeAccount;
-            mSourceCallbackRef = new WeakReference<>(sourceCallback);
+            mSourceCallback = sourceCallback;
         }
 
         @Override
@@ -981,13 +981,10 @@ public class Stripe {
 
         @Override
         protected void onPostExecute(@NonNull ResponseWrapper responseWrapper) {
-            final SourceCallback sourceCallback = mSourceCallbackRef.get();
-            if (sourceCallback != null) {
-                if (responseWrapper.source != null) {
-                    sourceCallback.onSuccess(responseWrapper.source);
-                } else if (responseWrapper.error != null) {
-                    sourceCallback.onError(responseWrapper.error);
-                }
+            if (responseWrapper.source != null) {
+                mSourceCallback.onSuccess(responseWrapper.source);
+            } else if (responseWrapper.error != null) {
+                mSourceCallback.onError(responseWrapper.error);
             }
         }
     }
@@ -999,7 +996,7 @@ public class Stripe {
         @NonNull private final String mPublishableKey;
         @Nullable private final String mStripeAccount;
         @NonNull @Token.TokenType private final String mTokenType;
-        @NonNull private final WeakReference<TokenCallback> mCallbackRef;
+        @NonNull private final TokenCallback mCallback;
         @Nullable private final StripeApiHandler.LoggingResponseListener mLoggingResponseListener;
 
         CreateTokenTask(@NonNull Context context,
@@ -1008,7 +1005,7 @@ public class Stripe {
                 @NonNull final String publishableKey,
                 @Nullable final String stripeAccount,
                 @NonNull @Token.TokenType final String tokenType,
-                @Nullable final TokenCallback callback,
+                @NonNull final TokenCallback callback,
                 @Nullable final StripeApiHandler.LoggingResponseListener loggingResponseListener) {
             mContextRef = new WeakReference<>(context);
             mApiHandler = apiHandler;
@@ -1017,7 +1014,7 @@ public class Stripe {
             mStripeAccount = stripeAccount;
             mTokenType = tokenType;
             mLoggingResponseListener = loggingResponseListener;
-            mCallbackRef = new WeakReference<>(callback);
+            mCallback = callback;
         }
 
         @Override
@@ -1043,16 +1040,13 @@ public class Stripe {
         }
 
         private void tokenTaskPostExecution(@NonNull ResponseWrapper result) {
-            final TokenCallback callback = mCallbackRef.get();
-            if (callback != null) {
-                if (result.token != null) {
-                    callback.onSuccess(result.token);
-                } else if (result.error != null) {
-                    callback.onError(result.error);
-                } else {
-                    callback.onError(new RuntimeException("Somehow got neither a token response or"
-                            + " an error response"));
-                }
+            if (result.token != null) {
+                mCallback.onSuccess(result.token);
+            } else if (result.error != null) {
+                mCallback.onError(result.error);
+            } else {
+                mCallback.onError(new RuntimeException(
+                        "Somehow got neither a token response or an error response"));
             }
         }
     }


### PR DESCRIPTION
## Summary
`Stripe` and `CustomerSession` methods accept callback objects
that typically hold references to `Activity` objects. The best
practice in Android is that references to `Activity` objects
should be weakly held for long-running background tasks, because
the `Activity` may go away (e.g. user leaves activity before task
is complete). The change was first introduced in #666.

After this change, users began reporting that callback objects
would mysteriously be garbage-collected by the OS. I was able
to reproduce this as well, and found a work-around by moving
anonymous inline classes to instance variables - see 2b74328.

Android will GC objects that are no longer strongly referenced.
When inlined, the callback objects were no longer strongly
referenced once the method completed (e.g. in 2b74328, the
left-side of `AddSourceActivity#onActionSave`); moving these
objects to be instance variables meant that they were now
strongly-referenced by the Activity. This explains why the GC
issues were resolved with this change.

In conclusion, the correct solution is to have the callback
objects weakly-reference `Activity` objects, rather than
weakly-reference the callback objects themselves.

## Motivation
ANDROID-340

## Testing
Manually tested
