### PR TITLE
Fix memory leaks in example app

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
@@ -50,7 +50,7 @@ public class CustomerSessionActivity extends AppCompatActivity {
                         @Override
                         public void onStringResponse(String string) {
                             if (string.startsWith("Error: ")) {
-                                mErrorDialogHandler.showError(string);
+                                mErrorDialogHandler.show(string);
                             }
                         }
                     }));
@@ -68,7 +68,7 @@ public class CustomerSessionActivity extends AppCompatActivity {
                     public void onError(int httpCode, @Nullable String errorMessage,
                                         @Nullable StripeError stripeError) {
                         mSelectSourceButton.setEnabled(false);
-                        mErrorDialogHandler.showError(errorMessage);
+                        mErrorDialogHandler.show(errorMessage);
                         mProgressBar.setVisibility(View.INVISIBLE);
                     }
                 });

--- a/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.java
@@ -1,6 +1,7 @@
 package com.stripe.example.activity;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.ListView;
@@ -37,7 +38,9 @@ public class PaymentMultilineActivity extends AppCompatActivity {
     ErrorDialogHandler mErrorDialogHandler;
 
     CardMultilineWidget mCardMultilineWidget;
-    CompositeSubscription mCompositeSubscription;
+
+    @NonNull private final CompositeSubscription mCompositeSubscription =
+            new CompositeSubscription();
 
     private SimpleAdapter mSimpleAdapter;
     private List<Map<String, String>> mCardSources= new ArrayList<>();
@@ -47,11 +50,10 @@ public class PaymentMultilineActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_payment_multiline);
 
-        mCompositeSubscription = new CompositeSubscription();
         mCardMultilineWidget = findViewById(R.id.card_multiline_widget);
 
-        mProgressDialogController =
-                new ProgressDialogController(getSupportFragmentManager());
+        mProgressDialogController = new ProgressDialogController(getSupportFragmentManager(),
+                getResources());
 
         mErrorDialogHandler = new ErrorDialogHandler(getSupportFragmentManager());
 
@@ -100,14 +102,14 @@ public class PaymentMultilineActivity extends AppCompatActivity {
                         new Action0() {
                             @Override
                             public void call() {
-                                mProgressDialogController.startProgress();
+                                mProgressDialogController.show(R.string.progressMessage);
                             }
                         })
                 .doOnUnsubscribe(
                         new Action0() {
                             @Override
                             public void call() {
-                                mProgressDialogController.finishProgress();
+                                mProgressDialogController.dismiss();
                             }
                         })
                 .subscribe(
@@ -120,7 +122,7 @@ public class PaymentMultilineActivity extends AppCompatActivity {
                         new Action1<Throwable>() {
                             @Override
                             public void call(Throwable throwable) {
-                                mErrorDialogHandler.showError(throwable.getLocalizedMessage());
+                                mErrorDialogHandler.show(throwable.getLocalizedMessage());
                             }
                         }));
     }
@@ -139,4 +141,9 @@ public class PaymentMultilineActivity extends AppCompatActivity {
         mSimpleAdapter.notifyDataSetChanged();
     }
 
+    @Override
+    protected void onDestroy() {
+        mCompositeSubscription.unsubscribe();
+        super.onDestroy();
+    }
 }

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.java
@@ -123,7 +123,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
                             @Override
                             public void onStringResponse(String string) {
                                 if (string.startsWith("Error: ")) {
-                                    mErrorDialogHandler.showError(string);
+                                    mErrorDialogHandler.show(string);
                                 }
                             }
                         }));
@@ -142,7 +142,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
                         mCustomer = null;
                         mSelectPaymentButton.setEnabled(false);
                         mSelectShippingButton.setEnabled(false);
-                        mErrorDialogHandler.showError(errorMessage);
+                        mErrorDialogHandler.show(errorMessage);
                         mProgressBar.setVisibility(View.INVISIBLE);
                     }
                 });
@@ -287,7 +287,7 @@ public class PaymentSessionActivity extends AppCompatActivity {
                 return;
             }
 
-            activity.mErrorDialogHandler.showError(errorMessage);
+            activity.mErrorDialogHandler.show(errorMessage);
         }
 
         @Override

--- a/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/RedirectActivity.java
@@ -44,8 +44,10 @@ public class RedirectActivity extends AppCompatActivity {
     private static final String QUERY_CLIENT_SECRET = "client_secret";
     private static final String QUERY_SOURCE_ID = "source";
 
+    @NonNull private final CompositeSubscription mCompositeSubscription =
+            new CompositeSubscription();
+
     private CardInputWidget mCardInputWidget;
-    private CompositeSubscription mCompositeSubscription;
     private RedirectAdapter mRedirectAdapter;
     private ErrorDialogHandler mErrorDialogHandler;
     private RedirectDialogController mRedirectDialogController;
@@ -58,10 +60,10 @@ public class RedirectActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_polling);
 
-        mCompositeSubscription = new CompositeSubscription();
         mCardInputWidget = findViewById(R.id.card_widget_three_d);
         mErrorDialogHandler = new ErrorDialogHandler(this.getSupportFragmentManager());
-        mProgressDialogController = new ProgressDialogController(this.getSupportFragmentManager());
+        mProgressDialogController = new ProgressDialogController(this.getSupportFragmentManager(),
+                getResources());
         mRedirectDialogController = new RedirectDialogController(this);
         mStripe = new Stripe(getApplicationContext());
 
@@ -113,8 +115,8 @@ public class RedirectActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         mCompositeSubscription.unsubscribe();
+        super.onDestroy();
     }
 
     void beginSequence() {
@@ -149,8 +151,7 @@ public class RedirectActivity extends AppCompatActivity {
                 .doOnSubscribe(new Action0() {
                     @Override
                     public void call() {
-                        mProgressDialogController.setMessageResource(R.string.createSource);
-                        mProgressDialogController.startProgress();
+                        mProgressDialogController.show(R.string.createSource);
                     }
                 })
                 .subscribe(
@@ -176,7 +177,7 @@ public class RedirectActivity extends AppCompatActivity {
                                     // The card Source can be used to create a 3DS Source
                                     createThreeDSecureSource(source.getId());
                                 } else {
-                                    mProgressDialogController.finishProgress();
+                                    mProgressDialogController.dismiss();
                                 }
 
                             }
@@ -184,7 +185,7 @@ public class RedirectActivity extends AppCompatActivity {
                         new Action1<Throwable>() {
                             @Override
                             public void call(Throwable throwable) {
-                                mErrorDialogHandler.showError(throwable.getMessage());
+                                mErrorDialogHandler.show(throwable.getMessage());
                             }
                         }
                 ));
@@ -221,7 +222,7 @@ public class RedirectActivity extends AppCompatActivity {
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
-                        mProgressDialogController.finishProgress();
+                        mProgressDialogController.dismiss();
                     }
                 })
                 .subscribe(
@@ -238,7 +239,7 @@ public class RedirectActivity extends AppCompatActivity {
                         new Action1<Throwable>() {
                             @Override
                             public void call(Throwable throwable) {
-                                mErrorDialogHandler.showError(throwable.getMessage());
+                                mErrorDialogHandler.show(throwable.getMessage());
                             }
                         }
                 ));

--- a/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.java
@@ -12,6 +12,7 @@ import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 import com.stripe.android.view.CardInputWidget;
+import com.stripe.example.R;
 
 /**
  * Logic needed to create tokens using the {@link android.os.AsyncTask} methods included in the
@@ -21,7 +22,6 @@ public class AsyncTaskTokenController {
 
     @NonNull private final Stripe mStripe;
     @NonNull private final ErrorDialogHandler mErrorDialogHandler;
-    @NonNull private final ListViewController mOutputListController;
     @NonNull private final ProgressDialogController mProgressDialogController;
 
     @Nullable private CardInputWidget mCardInputWidget;
@@ -30,19 +30,22 @@ public class AsyncTaskTokenController {
             @NonNull Button button,
             @NonNull CardInputWidget cardInputWidget,
             @NonNull Context context,
-            @NonNull ErrorDialogHandler errorDialogHandler,
-            @NonNull ListViewController outputListController,
-            @NonNull ProgressDialogController progressDialogController) {
+            @NonNull final ErrorDialogHandler errorDialogHandler,
+            @NonNull final ListViewController outputListController,
+            @NonNull final ProgressDialogController progressDialogController) {
         mCardInputWidget = cardInputWidget;
         mStripe = new Stripe(context);
         mErrorDialogHandler = errorDialogHandler;
         mProgressDialogController = progressDialogController;
-        mOutputListController = outputListController;
 
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                saveCard();
+                saveCard(new TokenCallbackImpl(
+                        errorDialogHandler,
+                        outputListController,
+                        progressDialogController
+                ));
             }
         });
     }
@@ -51,25 +54,39 @@ public class AsyncTaskTokenController {
         mCardInputWidget = null;
     }
 
-    private void saveCard() {
-        final Card cardToSave = mCardInputWidget.getCard();
+    private void saveCard(@NonNull TokenCallback tokenCallback) {
+        final Card cardToSave = mCardInputWidget != null ? mCardInputWidget.getCard() : null;
         if (cardToSave == null) {
-            mErrorDialogHandler.showError("Invalid Card Data");
+            mErrorDialogHandler.show("Invalid Card Data");
             return;
         }
-        mProgressDialogController.startProgress();
+        mProgressDialogController.show(R.string.progressMessage);
         mStripe.createToken(
                 cardToSave,
                 PaymentConfiguration.getInstance().getPublishableKey(),
-                new TokenCallback() {
-                    public void onSuccess(@NonNull Token token) {
-                        mOutputListController.addToList(token);
-                        mProgressDialogController.finishProgress();
-                    }
-                    public void onError(@NonNull Exception error) {
-                        mErrorDialogHandler.showError(error.getLocalizedMessage());
-                        mProgressDialogController.finishProgress();
-                    }
-                });
+                tokenCallback);
+    }
+
+    private static class TokenCallbackImpl implements TokenCallback {
+        @NonNull private final ErrorDialogHandler mErrorDialogHandler;
+        @NonNull private final ListViewController mOutputListController;
+        @NonNull private final ProgressDialogController mProgressDialogController;
+
+        private TokenCallbackImpl(@NonNull ErrorDialogHandler errorDialogHandler,
+                                 @NonNull ListViewController outputListController,
+                                 @NonNull ProgressDialogController progressDialogController) {
+            this.mErrorDialogHandler = errorDialogHandler;
+            this.mOutputListController = outputListController;
+            this.mProgressDialogController = progressDialogController;
+        }
+
+        public void onSuccess(@NonNull Token token) {
+            mOutputListController.addToList(token);
+            mProgressDialogController.dismiss();
+        }
+        public void onError(@NonNull Exception error) {
+            mErrorDialogHandler.show(error.getLocalizedMessage());
+            mProgressDialogController.dismiss();
+        }
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/ErrorDialogHandler.java
+++ b/example/src/main/java/com/stripe/example/controller/ErrorDialogHandler.java
@@ -1,7 +1,6 @@
 package com.stripe.example.controller;
 
 import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
 
 import com.stripe.example.R;
@@ -18,9 +17,8 @@ public class ErrorDialogHandler {
         mFragmentManager = fragmentManager;
     }
 
-    public void showError(@NonNull String errorMessage) {
-        DialogFragment fragment = ErrorDialogFragment.newInstance(
-                R.string.validationErrors, errorMessage);
-        fragment.show(mFragmentManager, "error");
+    public void show(@NonNull String errorMessage) {
+        ErrorDialogFragment.newInstance(R.string.validationErrors, errorMessage)
+                .show(mFragmentManager, "error");
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/IntentServiceTokenController.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 
 import com.stripe.android.model.Card;
 import com.stripe.android.view.CardInputWidget;
+import com.stripe.example.R;
 import com.stripe.example.service.TokenIntentService;
 
 /**
@@ -30,14 +31,14 @@ public class IntentServiceTokenController {
     @Nullable private TokenBroadcastReceiver mTokenBroadcastReceiver;
 
     public IntentServiceTokenController (
-            @NonNull Activity appCompatActivity,
+            @NonNull Activity activity,
             @NonNull Button button,
             @NonNull CardInputWidget cardInputWidget,
             @NonNull ErrorDialogHandler errorDialogHandler,
             @NonNull ListViewController outputListController,
             @NonNull ProgressDialogController progressDialogController) {
 
-        mActivity = appCompatActivity;
+        mActivity = activity;
         mCardInputWidget = cardInputWidget;
         mErrorDialogHandler = errorDialogHandler;
         mOutputListViewController = outputListController;
@@ -75,7 +76,7 @@ public class IntentServiceTokenController {
     private void saveCard() {
         final Card cardToSave = mCardInputWidget.getCard();
         if (cardToSave == null) {
-            mErrorDialogHandler.showError("Invalid Card Data");
+            mErrorDialogHandler.show("Invalid Card Data");
             return;
         }
         final Intent tokenServiceIntent = TokenIntentService.createTokenIntent(
@@ -84,7 +85,7 @@ public class IntentServiceTokenController {
                 cardToSave.getExpMonth(),
                 cardToSave.getExpYear(),
                 cardToSave.getCVC());
-        mProgressDialogController.startProgress();
+        mProgressDialogController.show(R.string.progressMessage);
         mActivity.startService(tokenServiceIntent);
     }
 
@@ -95,14 +96,14 @@ public class IntentServiceTokenController {
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            mProgressDialogController.finishProgress();
+            mProgressDialogController.dismiss();
 
             if (intent == null) {
                 return;
             }
 
             if (intent.hasExtra(TokenIntentService.STRIPE_ERROR_MESSAGE)) {
-                mErrorDialogHandler.showError(
+                mErrorDialogHandler.show(
                         intent.getStringExtra(TokenIntentService.STRIPE_ERROR_MESSAGE));
                 return;
             }

--- a/example/src/main/java/com/stripe/example/controller/ListViewController.java
+++ b/example/src/main/java/com/stripe/example/controller/ListViewController.java
@@ -39,7 +39,7 @@ public class ListViewController {
         addToList(token.getCard().getLast4(), token.getId());
     }
 
-    public void addToList(@NonNull String last4, @NonNull String tokenId) {
+    void addToList(@NonNull String last4, @NonNull String tokenId) {
         final Map<String, String> map = new HashMap<>();
         map.put("last4", mResources.getString(R.string.endingIn) + " " + last4);
         map.put("tokenId", tokenId);

--- a/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/ProgressDialogController.java
@@ -1,6 +1,8 @@
 package com.stripe.example.controller;
 
+import android.content.res.Resources;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.FragmentManager;
 
@@ -12,27 +14,28 @@ import com.stripe.example.dialog.ProgressDialogFragment;
  */
 public class ProgressDialogController {
 
+    @NonNull private final Resources mRes;
     @NonNull private final FragmentManager mFragmentManager;
-    private ProgressDialogFragment mProgressFragment;
+    @Nullable private ProgressDialogFragment mProgressFragment;
 
-    public ProgressDialogController(@NonNull FragmentManager fragmentManager) {
+    public ProgressDialogController(@NonNull FragmentManager fragmentManager,
+                                    @NonNull Resources res) {
         mFragmentManager = fragmentManager;
-        mProgressFragment = ProgressDialogFragment.newInstance(R.string.progressMessage);
+        mRes = res;
     }
 
-    public void setMessageResource(@StringRes int resId) {
-        if (mProgressFragment.isVisible()) {
+    public void show(@StringRes int resId) {
+        if (mProgressFragment != null && mProgressFragment.isVisible()) {
             mProgressFragment.dismiss();
             mProgressFragment = null;
         }
-        mProgressFragment = ProgressDialogFragment.newInstance(resId);
-    }
-
-    public void startProgress() {
+        mProgressFragment = ProgressDialogFragment.newInstance(mRes.getString(resId));
         mProgressFragment.show(mFragmentManager, "progress");
     }
 
-    public void finishProgress() {
-        mProgressFragment.dismiss();
+    public void dismiss() {
+        if (mProgressFragment != null) {
+            mProgressFragment.dismiss();
+        }
     }
 }

--- a/example/src/main/java/com/stripe/example/controller/RxTokenController.java
+++ b/example/src/main/java/com/stripe/example/controller/RxTokenController.java
@@ -11,6 +11,7 @@ import com.stripe.android.Stripe;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Token;
 import com.stripe.android.view.CardInputWidget;
+import com.stripe.example.R;
 
 import java.util.concurrent.Callable;
 
@@ -71,7 +72,7 @@ public class RxTokenController {
     private void saveCard() {
         final Card cardToSave = mCardInputWidget.getCard();
         if (cardToSave == null) {
-            mErrorDialogHandler.showError("Invalid Card Data");
+            mErrorDialogHandler.show("Invalid Card Data");
             return;
         }
         final Stripe stripe = new Stripe(mContext);
@@ -95,14 +96,14 @@ public class RxTokenController {
                         new Action0() {
                             @Override
                             public void call() {
-                                mProgressDialogController.startProgress();
+                                mProgressDialogController.show(R.string.progressMessage);
                             }
                         })
                 .doOnUnsubscribe(
                         new Action0() {
                             @Override
                             public void call() {
-                                mProgressDialogController.finishProgress();
+                                mProgressDialogController.dismiss();
                             }
                         })
                 .subscribe(
@@ -115,7 +116,7 @@ public class RxTokenController {
                         new Action1<Throwable>() {
                             @Override
                             public void call(Throwable throwable) {
-                                mErrorDialogHandler.showError(throwable.getLocalizedMessage());
+                                mErrorDialogHandler.show(throwable.getLocalizedMessage());
                             }
                         }));
     }

--- a/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.java
+++ b/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.java
@@ -3,14 +3,17 @@ package com.stripe.example.dialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 
 public class ProgressDialogFragment extends DialogFragment {
-    public static ProgressDialogFragment newInstance(int msgId) {
+    @NonNull
+    public static ProgressDialogFragment newInstance(@NonNull String message) {
         ProgressDialogFragment fragment = new ProgressDialogFragment();
 
         Bundle args = new Bundle();
-        args.putInt("msgId", msgId);
+        args.putString("message", message);
 
         fragment.setArguments(args);
 
@@ -21,11 +24,16 @@ public class ProgressDialogFragment extends DialogFragment {
         // Empty constructor required for DialogFragment
     }
 
+    @NonNull
     @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int msgId = getArguments().getInt("msgId");
-        ProgressDialog dialog = new ProgressDialog(getActivity());
-        dialog.setMessage(getActivity().getResources().getString(msgId));
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        final ProgressDialog dialog = new ProgressDialog(getActivity());
+        dialog.setMessage(getMessage());
         return dialog;
+    }
+
+    @Nullable
+    private String getMessage() {
+        return getArguments() != null ? getArguments().getString("message") : null;
     }
 }

--- a/example/src/main/java/com/stripe/example/module/DependencyHandler.java
+++ b/example/src/main/java/com/stripe/example/module/DependencyHandler.java
@@ -26,7 +26,7 @@ public class DependencyHandler {
     @Nullable private AsyncTaskTokenController mAsyncTaskController;
     @NonNull private final CardInputWidget mCardInputWidget;
     @NonNull private final Context mContext;
-    @NonNull private final ProgressDialogController mProgresDialogController;
+    @NonNull private final ProgressDialogController mProgressDialogController;
     @NonNull private final ErrorDialogHandler mErrorDialogHandler;
     @Nullable private IntentServiceTokenController mIntentServiceTokenController;
     @NonNull private final ListViewController mListViewController;
@@ -40,8 +40,10 @@ public class DependencyHandler {
         mCardInputWidget = cardInputWidget;
         mContext = activity.getApplicationContext();
 
-        mProgresDialogController =
-                new ProgressDialogController(activity.getSupportFragmentManager());
+        mProgressDialogController = new ProgressDialogController(
+                activity.getSupportFragmentManager(),
+                activity.getResources()
+        );
 
         mListViewController = new ListViewController(outputListView);
 
@@ -64,7 +66,7 @@ public class DependencyHandler {
                     mContext,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController);
+                    mProgressDialogController);
         }
         return mAsyncTaskController;
     }
@@ -89,7 +91,7 @@ public class DependencyHandler {
                     mCardInputWidget,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController);
+                    mProgressDialogController);
         }
         return mIntentServiceTokenController;
     }
@@ -112,7 +114,7 @@ public class DependencyHandler {
                     mContext,
                     mErrorDialogHandler,
                     mListViewController,
-                    mProgresDialogController);
+                    mProgressDialogController);
         }
         return mRxTokenController;
     }

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -165,10 +165,10 @@ public class PaymentActivity extends AppCompatActivity {
      */
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         mCompositeSubscription.unsubscribe();
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mBroadcastReceiver);
         mPaymentSession.onDestroy();
+        super.onDestroy();
     }
 
     @Override

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -61,8 +61,10 @@ public class PaymentActivity extends AppCompatActivity {
     private static final String TOTAL_LABEL = "Total:";
     private static final String SHIPPING = "Shipping";
 
+    @NonNull private final CompositeSubscription mCompositeSubscription =
+            new CompositeSubscription();
+
     private BroadcastReceiver mBroadcastReceiver;
-    private CompositeSubscription mCompositeSubscription;
     private ProgressDialogFragment mProgressDialogFragment;
 
     private LinearLayout mCartItemLayout;
@@ -93,10 +95,9 @@ public class PaymentActivity extends AppCompatActivity {
         mCartItemLayout = findViewById(R.id.cart_list_items);
 
         addCartItems();
-        mCompositeSubscription = new CompositeSubscription();
 
-        mProgressDialogFragment =
-                ProgressDialogFragment.newInstance(R.string.completing_purchase);
+        mProgressDialogFragment = ProgressDialogFragment
+                .newInstance(getString(R.string.completing_purchase));
 
         mConfirmPaymentButton = findViewById(R.id.btn_purchase);
         updateConfirmPaymentButton();
@@ -165,10 +166,7 @@ public class PaymentActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (mCompositeSubscription != null) {
-            mCompositeSubscription.unsubscribe();
-            mCompositeSubscription = null;
-        }
+        mCompositeSubscription.unsubscribe();
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mBroadcastReceiver);
         mPaymentSession.onDestroy();
     }

--- a/samplestore/src/main/java/com/stripe/samplestore/ProgressDialogFragment.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/ProgressDialogFragment.java
@@ -3,15 +3,18 @@ package com.stripe.samplestore;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 
 public class ProgressDialogFragment extends DialogFragment {
 
-    public static ProgressDialogFragment newInstance(int msgId) {
+    @NonNull
+    public static ProgressDialogFragment newInstance(@NonNull String message) {
         ProgressDialogFragment fragment = new ProgressDialogFragment();
 
-        Bundle args = new Bundle();
-        args.putInt("msgId", msgId);
+        final Bundle args = new Bundle();
+        args.putString("message", message);
 
         fragment.setArguments(args);
 
@@ -22,11 +25,16 @@ public class ProgressDialogFragment extends DialogFragment {
         // Empty constructor required for DialogFragment
     }
 
+    @NonNull
     @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        int msgId = getArguments().getInt("msgId");
-        ProgressDialog dialog = new ProgressDialog(getActivity());
-        dialog.setMessage(getActivity().getResources().getString(msgId));
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        final ProgressDialog dialog = new ProgressDialog(getActivity());
+        dialog.setMessage(getMessage());
         return dialog;
+    }
+
+    @Nullable
+    private String getMessage() {
+        return getArguments() != null ? getArguments().getString("message") : null;
     }
 }

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
@@ -2,6 +2,7 @@ package com.stripe.samplestore;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -116,9 +117,11 @@ public class StoreActivity
                 new SampleStoreEphemeralKeyProvider(
                         new SampleStoreEphemeralKeyProvider.ProgressListener() {
                             @Override
-                            public void onStringResponse(String string) {
+                            public void onStringResponse(@NonNull String string) {
                                 if (string.startsWith("Error: ")) {
-                                    new AlertDialog.Builder(StoreActivity.this).setMessage(string).show();
+                                    new AlertDialog.Builder(StoreActivity.this)
+                                            .setMessage(string)
+                                            .show();
                                 }
                             }
                         }));

--- a/samplestore/src/main/java/com/stripe/samplestore/service/SampleStoreEphemeralKeyProvider.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/service/SampleStoreEphemeralKeyProvider.java
@@ -19,13 +19,12 @@ import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
 public class SampleStoreEphemeralKeyProvider implements EphemeralKeyProvider {
-    private @NonNull
-    CompositeSubscription mCompositeSubscription;
-    private @NonNull StripeService mStripeService;
-    private @NonNull ProgressListener mProgressListener;
+    @NonNull private final CompositeSubscription mCompositeSubscription;
+    @NonNull private final StripeService mStripeService;
+    @NonNull private final ProgressListener mProgressListener;
 
     public SampleStoreEphemeralKeyProvider(@NonNull ProgressListener progressListener) {
-        Retrofit retrofit = RetrofitFactory.getInstance();
+        final Retrofit retrofit = RetrofitFactory.getInstance();
         mStripeService = retrofit.create(StripeService.class);
         mCompositeSubscription = new CompositeSubscription();
         mProgressListener = progressListener;
@@ -34,7 +33,7 @@ public class SampleStoreEphemeralKeyProvider implements EphemeralKeyProvider {
     @Override
     public void createEphemeralKey(@NonNull @Size(min = 4) String apiVersion,
                                    @NonNull final EphemeralKeyUpdateListener keyUpdateListener) {
-        Map<String, String> apiParamMap = new HashMap<>();
+        final Map<String, String> apiParamMap = new HashMap<>();
         apiParamMap.put("api_version", apiVersion);
 
         mCompositeSubscription.add(
@@ -48,8 +47,7 @@ public class SampleStoreEphemeralKeyProvider implements EphemeralKeyProvider {
                                     String rawKey = response.string();
                                     keyUpdateListener.onKeyUpdate(rawKey);
                                     mProgressListener.onStringResponse(rawKey);
-                                } catch (IOException iox) {
-
+                                } catch (IOException ignored) {
                                 }
                             }
                         }, new Action1<Throwable>() {
@@ -61,6 +59,6 @@ public class SampleStoreEphemeralKeyProvider implements EphemeralKeyProvider {
     }
 
     public interface ProgressListener {
-        void onStringResponse(String string);
+        void onStringResponse(@NonNull String string);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/ActivitySourceCallback.java
+++ b/stripe/src/main/java/com/stripe/android/ActivitySourceCallback.java
@@ -1,0 +1,24 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Abstract implementation of {@link SourceCallback} that holds a {@link WeakReference} to
+ * an {@link Activity} object.
+ */
+public abstract class ActivitySourceCallback<A extends Activity> implements SourceCallback {
+    @NonNull private final WeakReference<A> mActivityRef;
+
+    public ActivitySourceCallback(@NonNull A activity) {
+        mActivityRef = new WeakReference<>(activity);
+    }
+
+    @Nullable
+    public A getActivity() {
+        return mActivityRef.get();
+    }
+}


### PR DESCRIPTION
## Summary
- Create `ActivitySourceCallback` to help with memory
  handling
- Refactor and clean-up classes in example app to fix
  memory leaks as identified by LeakCanary
- Call `CompositeSubscription#unsubscribe()` in
  `Activity#onDestroy()` where missing

## Motivation
ANDROID-349

## Testing
Tested on example app