### PR TITLE
Add check for RequiresSourceAction in PaymentIntent example

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -241,7 +241,8 @@ public class PaymentIntentActivity extends AppCompatActivity {
                                     final PaymentIntent.Status status = PaymentIntent.Status
                                             .fromCode(paymentIntent.getStatus());
 
-                                    if (PaymentIntent.Status.RequiresAction == status) {
+                                    if (PaymentIntent.Status.RequiresAction == status ||
+                                            PaymentIntent.Status.RequiresSourceAction == status) {
                                         startActivity(new Intent(Intent.ACTION_VIEW,
                                                 paymentIntent.getRedirectUrl()));
                                     }


### PR DESCRIPTION
Both `PaymentIntent.Status.RequiresSourceAction` and `PaymentIntent.Status.RequiresAction` are valid until we release an SDK pinned to latest API version.