### PR TITLE
Continue PaymentMethod migration

### DIFF
--- a/example/res/layout/activity_launcher.xml
+++ b/example/res/layout/activity_launcher.xml
@@ -41,12 +41,12 @@
             />
 
         <Button
-            android:id="@+id/btn_make_card_sources"
+            android:id="@+id/btn_make_card_payment_methods"
             android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="10dp"
-            android:text="@string/createCardSources"
+            android:text="@string/createCardPaymentMethods"
             />
 
         <Button

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="validationErrors">Validation Errors</string>
 
     <string name="createCardTokens">Create Card Tokens</string>
-    <string name="createCardSources">Create Card Sources</string>
+    <string name="createCardPaymentMethods">Create Card PaymentMethods</string>
     <string name="createThreeDSecure">Create 3DS Sources</string>
     <string name="cardNumber">Card Number</string>
     <string name="createSource">Creating source&#8230;</string>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -39,12 +39,14 @@ public class LauncherActivity extends AppCompatActivity {
             }
         });
 
-        findViewById(R.id.btn_make_card_sources).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                startActivity(new Intent(LauncherActivity.this, PaymentMultilineActivity.class));
-            }
-        });
+        findViewById(R.id.btn_make_card_payment_methods)
+                .setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        startActivity(new Intent(LauncherActivity.this,
+                                PaymentMultilineActivity.class));
+                    }
+                });
 
         findViewById(R.id.btn_make_sources).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/example/src/main/java/com/stripe/example/adapter/RedirectAdapter.java
+++ b/example/src/main/java/com/stripe/example/adapter/RedirectAdapter.java
@@ -1,6 +1,7 @@
 package com.stripe.example.adapter;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -37,38 +38,40 @@ public class RedirectAdapter extends RecyclerView.Adapter<RedirectAdapter.ViewHo
             mSourceTypeView = pollingLayout.findViewById(R.id.tv_source_type);
         }
 
-        public void setFinalStatus(String finalStatus) {
+        void setFinalStatus(@Nullable String finalStatus) {
             mFinalStatusView.setText(finalStatus);
         }
 
-        public void setSourceId(String sourceId) {
+        void setSourceId(@Nullable String sourceId) {
             final String last6 = sourceId == null || sourceId.length() < 6
                     ? sourceId
                     : sourceId.substring(sourceId.length() - 6);
             mSourceIdView.setText(last6);
         }
 
-        public void setSourceType(String sourceType) {
-            String viewableType = sourceType;
+        void setSourceType(@Nullable String sourceType) {
+            final String viewableType;
             if (Source.THREE_D_SECURE.equals(sourceType)) {
                 viewableType = "3DS";
+            } else {
+                viewableType = sourceType;
             }
             mSourceTypeView.setText(viewableType);
         }
 
-        public void setRedirectStatus(String redirectStatus) {
+        void setRedirectStatus(@Nullable String redirectStatus) {
             mRedirectStatusView.setText(redirectStatus);
         }
     }
 
     private static class ViewModel {
-        private final String mFinalStatus;
-        private final String mRedirectStatus;
-        private final String mSourceId;
-        private final String mSourceType;
+        @Nullable private final String mFinalStatus;
+        @Nullable private final String mRedirectStatus;
+        @Nullable private final String mSourceId;
+        @Nullable private final String mSourceType;
 
-        private ViewModel(String finalStatus, String redirectStatus, String sourceId,
-                          String sourceType) {
+        private ViewModel(@Nullable String finalStatus, @Nullable String redirectStatus,
+                          @Nullable String sourceId, @Nullable String sourceType) {
             mFinalStatus = finalStatus;
             mRedirectStatus = redirectStatus;
             mSourceId = sourceId;
@@ -85,10 +88,8 @@ public class RedirectAdapter extends RecyclerView.Adapter<RedirectAdapter.ViewHo
     public RedirectAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent,
                                                          int viewType) {
         // create a new view
-
-        LinearLayout pollingView = (LinearLayout) LayoutInflater.from(parent.getContext())
+        final ViewGroup pollingView = (LinearLayout) LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.polling_list_item, parent, false);
-
         return new ViewHolder(pollingView);
     }
 
@@ -97,7 +98,7 @@ public class RedirectAdapter extends RecyclerView.Adapter<RedirectAdapter.ViewHo
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         // - get element from your dataset at this position
         // - replace the contents of the view with that element
-        ViewModel model = mDataset.get(position);
+        final ViewModel model = mDataset.get(position);
         holder.setFinalStatus(model.mFinalStatus);
         holder.setRedirectStatus(model.mRedirectStatus);
         holder.setSourceId(model.mSourceId);
@@ -110,7 +111,8 @@ public class RedirectAdapter extends RecyclerView.Adapter<RedirectAdapter.ViewHo
         return mDataset.size();
     }
 
-    public void addItem(String finalStatus, String redirectStatus, String sourceId, String sourceType) {
+    public void addItem(@Nullable String finalStatus, @Nullable String redirectStatus,
+                        @Nullable String sourceId, @Nullable String sourceType) {
         mDataset.add(new ViewModel(finalStatus, redirectStatus, sourceId, sourceType));
         notifyDataSetChanged();
     }

--- a/example/src/main/java/com/stripe/example/controller/RedirectDialogController.java
+++ b/example/src/main/java/com/stripe/example/controller/RedirectDialogController.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
@@ -19,26 +18,26 @@ public class RedirectDialogController {
     @NonNull private final Activity mActivity;
     private AlertDialog mAlertDialog;
 
-    public RedirectDialogController(@NonNull Activity appCompatActivity) {
-        mActivity = appCompatActivity;
+    public RedirectDialogController(@NonNull Activity activity) {
+        mActivity = activity;
     }
 
-    public void showDialog(final String url) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
-        View dialogView = LayoutInflater.from(mActivity).inflate(R.layout.polling_dialog, null);
+    public void showDialog(@NonNull final String url) {
+        final View dialogView = mActivity.getLayoutInflater()
+                .inflate(R.layout.polling_dialog, null);
 
-        TextView linkView = dialogView.findViewById(R.id.tv_link_redirect);
+        final TextView linkView = dialogView.findViewById(R.id.tv_link_redirect);
         linkView.setText(R.string.verify);
         linkView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                mActivity.startActivity(browserIntent);
+                mActivity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
             }
         });
-        builder.setView(dialogView);
 
-        mAlertDialog = builder.create();
+        mAlertDialog = new AlertDialog.Builder(mActivity)
+                .setView(dialogView)
+                .create();
         mAlertDialog.show();
     }
 

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -409,6 +409,7 @@ public class Stripe {
      * @throws APIException any other type of problem (for instance, a temporary issue with
      * Stripe's servers
      */
+    @Nullable
     public Source createSourceSynchronous(
             @NonNull SourceParams params,
             @Nullable String publishableKey)

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -34,7 +34,6 @@ public class PaymentIntent extends StripeJsonModel {
 
     static final String FIELD_ID = "id";
     static final String FIELD_OBJECT = "object";
-    static final String FIELD_ALLOWED_SOURCE_TYPES = "allowed_source_types";
     static final String FIELD_AMOUNT = "amount";
     static final String FIELD_CREATED = "created";
     static final String FIELD_CANCELED = "canceled_at";
@@ -54,7 +53,6 @@ public class PaymentIntent extends StripeJsonModel {
 
     @Nullable private final String mId;
     @Nullable private final String mObjectType;
-    @NonNull private final List<String> mAllowedSourceTypes;
     @NonNull private final List<String> mPaymentMethodTypes;
     @Nullable private final Long mAmount;
     @Nullable private final Long mCanceledAt;
@@ -75,15 +73,6 @@ public class PaymentIntent extends StripeJsonModel {
     @Nullable
     public String getId() {
         return mId;
-    }
-
-    /**
-     * @deprecated use {@link #getPaymentMethodTypes()}
-     */
-    @Deprecated
-    @NonNull
-    public List<String> getAllowedSourceTypes() {
-        return mAllowedSourceTypes;
     }
 
     @NonNull
@@ -210,7 +199,6 @@ public class PaymentIntent extends StripeJsonModel {
     private PaymentIntent(
             @Nullable String id,
             @Nullable String objectType,
-            @NonNull List<String> allowedSourceTypes,
             @NonNull List<String> paymentMethodTypes,
             @Nullable Long amount,
             @Nullable Long canceledAt,
@@ -229,7 +217,6 @@ public class PaymentIntent extends StripeJsonModel {
     ) {
         mId = id;
         mObjectType = objectType;
-        mAllowedSourceTypes = allowedSourceTypes;
         mPaymentMethodTypes = paymentMethodTypes;
         mAmount = amount;
         mCanceledAt = canceledAt;
@@ -270,8 +257,6 @@ public class PaymentIntent extends StripeJsonModel {
 
         final String id = optString(jsonObject, FIELD_ID);
         final String objectType = optString(jsonObject, FIELD_OBJECT);
-        final List<String> allowedSourceTypes = jsonArrayToList(
-                jsonObject.optJSONArray(FIELD_ALLOWED_SOURCE_TYPES));
         final List<String> paymentMethodTypes = jsonArrayToList(
                 jsonObject.optJSONArray(FIELD_PAYMENT_METHOD_TYPES));
         final Long amount = optLong(jsonObject, FIELD_AMOUNT);
@@ -292,7 +277,6 @@ public class PaymentIntent extends StripeJsonModel {
         return new PaymentIntent(
                 id,
                 objectType,
-                allowedSourceTypes,
                 paymentMethodTypes,
                 amount,
                 canceledAt,
@@ -331,8 +315,6 @@ public class PaymentIntent extends StripeJsonModel {
         final JSONObject jsonObject = new JSONObject();
         putStringIfNotNull(jsonObject, FIELD_ID, mId);
         putStringIfNotNull(jsonObject, FIELD_OBJECT, mObjectType);
-        putArrayIfNotNull(jsonObject, FIELD_ALLOWED_SOURCE_TYPES,
-                listToJsonArray(mAllowedSourceTypes));
         putArrayIfNotNull(jsonObject, FIELD_PAYMENT_METHOD_TYPES,
                 listToJsonArray(mPaymentMethodTypes));
         putLongIfNotNull(jsonObject, FIELD_AMOUNT, mAmount);
@@ -358,7 +340,6 @@ public class PaymentIntent extends StripeJsonModel {
         final AbstractMap<String, Object> map = new HashMap<>();
         map.put(FIELD_ID, mId);
         map.put(FIELD_OBJECT, mObjectType);
-        map.put(FIELD_ALLOWED_SOURCE_TYPES, mAllowedSourceTypes);
         map.put(FIELD_PAYMENT_METHOD_TYPES, mPaymentMethodTypes);
         map.put(FIELD_AMOUNT, mAmount);
         map.put(FIELD_CANCELED, mCanceledAt);
@@ -386,7 +367,6 @@ public class PaymentIntent extends StripeJsonModel {
     private boolean typedEquals(@NonNull PaymentIntent paymentIntent) {
         return ObjectUtils.equals(mId, paymentIntent.mId)
                 && ObjectUtils.equals(mObjectType, paymentIntent.mObjectType)
-                && ObjectUtils.equals(mAllowedSourceTypes, paymentIntent.mAllowedSourceTypes)
                 && ObjectUtils.equals(mAmount, paymentIntent.mAmount)
                 && ObjectUtils.equals(mCanceledAt, paymentIntent.mCanceledAt)
                 && ObjectUtils.equals(mCaptureMethod, paymentIntent.mCaptureMethod)
@@ -404,7 +384,7 @@ public class PaymentIntent extends StripeJsonModel {
 
     @Override
     public int hashCode() {
-        return ObjectUtils.hash(mId, mObjectType, mAllowedSourceTypes, mAmount, mCanceledAt,
+        return ObjectUtils.hash(mId, mObjectType, mAmount, mCanceledAt,
                 mCaptureMethod, mClientSecret, mConfirmationMethod, mCreated, mCurrency,
                 mDescription, mLiveMode, mNextSourceAction, mReceiptEmail, mSource, mStatus);
     }

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -46,7 +46,7 @@ public class StripeApiHandlerTest {
     private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
             "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
 
-    private static final String STRIPE_ACCOUNT_RESPONSE_HEADER = "stripe-account";
+    private static final String STRIPE_ACCOUNT_RESPONSE_HEADER = "Stripe-Account";
 
     private static final Card CARD =
             new Card("4242424242424242", 1, 2050, "123");

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -24,9 +24,6 @@ public class PaymentIntentTest {
     private static final String PAYMENT_INTENT_WITH_SOURCE_JSON = "{\n" +
             "  \"id\": \"pi_1CkiBMLENEVhOs7YMtUehLau\",\n" +
             "  \"object\": \"payment_intent\",\n" +
-            "  \"allowed_source_types\": [\n" +
-            "    \"card\"\n" +
-            "  ],\n" +
             "  \"payment_method_types\": [\n" +
             "    \"card\"\n" +
             "  ],\n" +
@@ -51,9 +48,6 @@ public class PaymentIntentTest {
     private static final String PAYMENT_INTENT_WITH_SOURCE_WITH_BAD_AUTH_URL_JSON = "{\n" +
             "  \"id\": \"pi_1CkiBMLENEVhOs7YMtUehLau\",\n" +
             "  \"object\": \"payment_intent\",\n" +
-            "  \"allowed_source_types\": [\n" +
-            "    \"card\"\n" +
-            "  ],\n" +
             "  \"amount\": 1000,\n" +
             "  \"canceled_at\": 1530839340,\n" +
             "  \"capture_method\": \"automatic\",\n" +
@@ -156,7 +150,7 @@ public class PaymentIntentTest {
             "\t}\n" +
             "}";
 
-    private static final List<String> ALLOWED_SOURCE_TYPES = new ArrayList<String>() {{
+    private static final List<String> PAYMENT_METHOD_TYPES = new ArrayList<String>() {{
         add("card");
     }};
 
@@ -164,8 +158,7 @@ public class PaymentIntentTest {
             new HashMap<String, Object>() {{
                 put(PaymentIntent.FIELD_ID, "pi_1CkiBMLENEVhOs7YMtUehLau");
                 put(PaymentIntent.FIELD_OBJECT, "payment_intent");
-                put(PaymentIntent.FIELD_ALLOWED_SOURCE_TYPES, ALLOWED_SOURCE_TYPES);
-                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, ALLOWED_SOURCE_TYPES);
+                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, PAYMENT_METHOD_TYPES);
                 put(PaymentIntent.FIELD_AMOUNT, 1000L);
                 put(PaymentIntent.FIELD_CANCELED, 1530839340L);
                 put(PaymentIntent.FIELD_CLIENT_SECRET,


### PR DESCRIPTION
## Summary
- Remove "allowed_source_types" from `PaymentIntent`. This property
  is no longer returned in the latest API version.
- Convert "Create Card Sources" example to use PaymentMethods
- Clean up related example classes

## Motivation
ANDROID-351

## Testing
Manually tested
