### PR TITLE
Remove LoggingResponseListener.shouldLogTest()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -82,9 +82,8 @@ public class Stripe {
      * @param context {@link Context} for resolving resources
      */
     public Stripe(@NonNull Context context) {
-        mApiHandler = new StripeApiHandler(context);
-        mLoggingUtils = new LoggingUtils(context);
-        mStripeNetworkUtils = new StripeNetworkUtils(context);
+        this(new StripeApiHandler(context), new LoggingUtils(context),
+                new StripeNetworkUtils(context));
     }
 
     /**
@@ -93,11 +92,18 @@ public class Stripe {
      * @param context {@link Context} for resolving resources
      * @param publishableKey the client's publishable key
      */
-    public Stripe(@NonNull Context context, String publishableKey) {
-        mApiHandler = new StripeApiHandler(context);
-        mLoggingUtils = new LoggingUtils(context);
-        mStripeNetworkUtils = new StripeNetworkUtils(context);
+    public Stripe(@NonNull Context context, @NonNull String publishableKey) {
+        this(new StripeApiHandler(context), new LoggingUtils(context),
+                new StripeNetworkUtils(context));
         setDefaultPublishableKey(publishableKey);
+    }
+
+    @VisibleForTesting
+    Stripe(@NonNull StripeApiHandler apiHandler, @NonNull LoggingUtils loggingUtils,
+           @NonNull StripeNetworkUtils stripeNetworkUtils) {
+        mApiHandler = apiHandler;
+        mLoggingUtils = loggingUtils;
+        mStripeNetworkUtils = stripeNetworkUtils;
     }
 
     /**
@@ -838,7 +844,7 @@ public class Stripe {
     }
 
     @VisibleForTesting
-    void setLoggingResponseListener(StripeApiHandler.LoggingResponseListener listener) {
+    void setLoggingResponseListener(@NonNull StripeApiHandler.LoggingResponseListener listener) {
         mLoggingResponseListener = listener;
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -186,7 +186,7 @@ public class StripeApiHandlerTest {
             APIConnectionException {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.
-        TestLoggingListener testLoggingListener = new TestLoggingListener(true);
+        TestLoggingListener testLoggingListener = new TestLoggingListener();
 
         final Source source = mApiHandler.createSource(
                 SourceParams.createCardParams(CARD),
@@ -208,7 +208,7 @@ public class StripeApiHandlerTest {
             APIConnectionException {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.
-        TestLoggingListener testLoggingListener = new TestLoggingListener(true);
+        TestLoggingListener testLoggingListener = new TestLoggingListener();
 
         final String connectAccountId = "acct_1Acj2PBUgO3KuWzz";
         Source source = mApiHandler.createSource(
@@ -312,9 +312,13 @@ public class StripeApiHandlerTest {
     public void createSource_withNonLoggingListener_doesNotLogButDoesCreateSource()
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
-        final TestLoggingListener testLoggingListener = new TestLoggingListener(false);
+        final TestLoggingListener testLoggingListener = new TestLoggingListener();
 
-        final Source source = mApiHandler.createSource(
+        final StripeApiHandler apiHandler = new StripeApiHandler(
+                ApplicationProvider.getApplicationContext(),
+                new StripeApiHandler.ConnectionFactory(),
+                false);
+        final Source source = apiHandler.createSource(
                 SourceParams.createCardParams(CARD),
                 FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
                 null,
@@ -328,26 +332,16 @@ public class StripeApiHandlerTest {
     }
 
     private static class TestLoggingListener implements StripeApiHandler.LoggingResponseListener {
-        private boolean mShouldLogTest;
         private StripeResponse mStripeResponse;
         private StripeException mStripeException;
 
-        TestLoggingListener(boolean shouldLogTest) {
-            mShouldLogTest = shouldLogTest;
-        }
-
         @Override
-        public boolean shouldLogTest() {
-            return mShouldLogTest;
-        }
-
-        @Override
-        public void onLoggingResponse(StripeResponse response) {
+        public void onLoggingResponse(@NonNull StripeResponse response) {
             mStripeResponse = response;
         }
 
         @Override
-        public void onStripeException(StripeException exception) {
+        public void onStripeException(@NonNull StripeException exception) {
             mStripeException = exception;
         }
     }


### PR DESCRIPTION
## Summary
This flag can be injected via constructor (`shouldLogRequest`)

## Motivation
Simplify logic of `StripeApiHandler`

## Testing
Updated tests
