### PR TITLE
Remove StripeApiHandler.LoggingResponseListener

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -634,8 +634,8 @@ public class CustomerSession
                 new ArrayList<>(mProductUsageTokens),
                 sourceId,
                 sourceType,
-                key.getSecret(),
-                null);
+                key.getSecret()
+        );
     }
 
     @Nullable
@@ -647,8 +647,8 @@ public class CustomerSession
                 PaymentConfiguration.getInstance().getPublishableKey(),
                 new ArrayList<>(mProductUsageTokens),
                 sourceId,
-                key.getSecret(),
-                null);
+                key.getSecret()
+        );
     }
 
     @Nullable
@@ -660,8 +660,8 @@ public class CustomerSession
                 PaymentConfiguration.getInstance().getPublishableKey(),
                 new ArrayList<>(mProductUsageTokens),
                 shippingInformation,
-                key.getSecret(),
-                null);
+                key.getSecret()
+        );
     }
 
     @Nullable
@@ -675,8 +675,8 @@ public class CustomerSession
                 new ArrayList<>(mProductUsageTokens),
                 sourceId,
                 sourceType,
-                key.getSecret(),
-                null);
+                key.getSecret()
+        );
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -65,11 +65,10 @@ public class Stripe {
                 @Nullable final Executor executor,
                 @NonNull final TokenCallback callback) {
             executeTask(executor, new CreateTokenTask(mApiHandler, tokenParams,
-                    publishableKey, stripeAccount, tokenType, callback, mLoggingResponseListener));
+                    publishableKey, stripeAccount, tokenType, callback));
         }
     };
 
-    @Nullable private StripeApiHandler.LoggingResponseListener mLoggingResponseListener;
     private String mDefaultPublishableKey;
     private String mStripeAccount;
     @NonNull private final StripeApiHandler mApiHandler;
@@ -240,8 +239,8 @@ public class Stripe {
         return mApiHandler.createToken(
                 mStripeNetworkUtils.hashMapFromBankAccount(bankAccount),
                 requestOptions,
-                Token.TYPE_BANK_ACCOUNT,
-                mLoggingResponseListener);
+                Token.TYPE_BANK_ACCOUNT
+        );
     }
 
     /**
@@ -427,7 +426,7 @@ public class Stripe {
         if (apiKey == null) {
             return null;
         }
-        return mApiHandler.createSource(params, apiKey, mStripeAccount, mLoggingResponseListener);
+        return mApiHandler.createSource(params, apiKey, mStripeAccount);
     }
 
     /**
@@ -452,8 +451,8 @@ public class Stripe {
         return mApiHandler.retrievePaymentIntent(
                 paymentIntentParams,
                 publishableKey,
-                mStripeAccount,
-                mLoggingResponseListener);
+                mStripeAccount
+        );
     }
 
     /**
@@ -479,8 +478,8 @@ public class Stripe {
         return mApiHandler.confirmPaymentIntent(
                 paymentIntentParams,
                 publishableKey,
-                mStripeAccount,
-                mLoggingResponseListener);
+                mStripeAccount
+        );
     }
 
     /**
@@ -503,7 +502,7 @@ public class Stripe {
             throws AuthenticationException, InvalidRequestException, APIConnectionException,
             APIException {
         return mApiHandler.createPaymentMethod(paymentMethodCreateParams,
-                publishableKey, mStripeAccount, mLoggingResponseListener);
+                publishableKey, mStripeAccount);
     }
 
     /**
@@ -558,8 +557,8 @@ public class Stripe {
         return mApiHandler.createToken(
                 mStripeNetworkUtils.hashMapFromCard(card),
                 requestOptions,
-                Token.TYPE_CARD,
-                mLoggingResponseListener);
+                Token.TYPE_CARD
+        );
     }
 
     /**
@@ -612,8 +611,8 @@ public class Stripe {
         return mApiHandler.createToken(
                 hashMapFromPersonalId(personalId),
                 requestOptions,
-                Token.TYPE_PII,
-                mLoggingResponseListener);
+                Token.TYPE_PII
+        );
     }
 
     /**
@@ -669,8 +668,8 @@ public class Stripe {
         return mApiHandler.createToken(
                 mapFromCvc(cvc),
                 requestOptions,
-                Token.TYPE_CVC_UPDATE,
-                mLoggingResponseListener);
+                Token.TYPE_CVC_UPDATE
+        );
     }
 
     /**
@@ -731,8 +730,8 @@ public class Stripe {
             return mApiHandler.createToken(
                     accountParams.toParamMap(),
                     requestOptions,
-                    Token.TYPE_ACCOUNT,
-                    mLoggingResponseListener);
+                    Token.TYPE_ACCOUNT
+            );
         } catch (CardException exception) {
             // Should never occur. CardException is only for card related requests.
         }
@@ -763,7 +762,7 @@ public class Stripe {
                     mDefaultPublishableKey,
                     source.getType());
         }
-        mApiHandler.logApiCall(loggingMap, options, mLoggingResponseListener);
+        mApiHandler.logApiCall(loggingMap, options);
     }
 
     /**
@@ -843,11 +842,6 @@ public class Stripe {
      */
     public void setStripeAccount(@NonNull @Size(min = 1) String stripeAccount) {
         mStripeAccount = stripeAccount;
-    }
-
-    @VisibleForTesting
-    void setLoggingResponseListener(@NonNull StripeApiHandler.LoggingResponseListener listener) {
-        mLoggingResponseListener = listener;
     }
 
     private void createTokenFromParams(
@@ -964,8 +958,8 @@ public class Stripe {
                 final Source source = mApiHandler.createSource(
                         mSourceParams,
                         mPublishableKey,
-                        mStripeAccount,
-                        null);
+                        mStripeAccount
+                );
                 return new ResponseWrapper(source);
             } catch (StripeException stripeException) {
                 return new ResponseWrapper(stripeException);
@@ -989,7 +983,6 @@ public class Stripe {
         @Nullable private final String mStripeAccount;
         @NonNull @Token.TokenType private final String mTokenType;
         @NonNull private final TokenCallback mCallback;
-        @Nullable private final StripeApiHandler.LoggingResponseListener mLoggingResponseListener;
 
         CreateTokenTask(
                 @NonNull StripeApiHandler apiHandler,
@@ -997,14 +990,12 @@ public class Stripe {
                 @NonNull final String publishableKey,
                 @Nullable final String stripeAccount,
                 @NonNull @Token.TokenType final String tokenType,
-                @NonNull final TokenCallback callback,
-                @Nullable final StripeApiHandler.LoggingResponseListener loggingResponseListener) {
+                @NonNull final TokenCallback callback) {
             mApiHandler = apiHandler;
             mTokenParams = tokenParams;
             mPublishableKey = publishableKey;
             mStripeAccount = stripeAccount;
             mTokenType = tokenType;
-            mLoggingResponseListener = loggingResponseListener;
             mCallback = callback;
         }
 
@@ -1016,8 +1007,8 @@ public class Stripe {
                 final Token token = mApiHandler.createToken(
                         mTokenParams,
                         requestOptions,
-                        mTokenType,
-                        mLoggingResponseListener);
+                        mTokenType
+                );
                 return new ResponseWrapper(token);
             } catch (StripeException e) {
                 return new ResponseWrapper(e);

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -204,16 +204,15 @@ public class CustomerSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()
+        ))
                 .thenReturn(mAddedSource);
         when(mApiHandler.deleteCustomerSource(
                 anyString(),
                 anyString(),
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()))
                 .thenReturn(Source.fromString(CardInputTestActivity.EXAMPLE_JSON_CARD_SOURCE));
         when(mApiHandler.setDefaultCustomerSource(
                 anyString(),
@@ -221,8 +220,7 @@ public class CustomerSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()))
                 .thenReturn(SECOND_CUSTOMER);
 
         doAnswer(new Answer() {
@@ -306,8 +304,7 @@ public class CustomerSessionTest {
                 eq("pk_test_abc123"),
                 mListArgumentCaptor.capture(),
                 eq(shippingInformation),
-                eq(firstKey.getSecret()),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull());
+                eq(firstKey.getSecret()));
         assertTrue(mListArgumentCaptor.getValue().contains("PaymentMethodsActivity"));
     }
 
@@ -456,8 +453,8 @@ public class CustomerSessionTest {
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
                 eq(Source.CARD),
-                eq(firstKey.getSecret()),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull());
+                eq(firstKey.getSecret())
+        );
         final List<String> productUsage = mListArgumentCaptor.getValue();
         assertEquals(2, productUsage.size());
         assertTrue(productUsage.contains("AddSourceActivity"));
@@ -561,8 +558,7 @@ public class CustomerSessionTest {
                 eq("pk_test_abc123"),
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
-                eq(firstKey.getSecret()),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull());
+                eq(firstKey.getSecret()));
         final List productUsage = mListArgumentCaptor.getValue();
         assertEquals(2, productUsage.size());
         assertTrue(productUsage.contains("AddSourceActivity"));
@@ -664,8 +660,7 @@ public class CustomerSessionTest {
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
                 eq(Source.CARD),
-                eq(firstKey.getSecret()),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull());
+                eq(firstKey.getSecret()));
 
         final List<String> productUsage = mListArgumentCaptor.getValue();
         assertEquals(1, productUsage.size());
@@ -764,8 +759,8 @@ public class CustomerSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()
+        ))
                 .thenThrow(new APIException("The card is invalid", "request_123", 404, null,
                         null));
 
@@ -774,8 +769,7 @@ public class CustomerSessionTest {
                 anyString(),
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()))
                 .thenThrow(new APIException("The card does not exist", "request_123", 404, null,
                         null));
 
@@ -785,8 +779,7 @@ public class CustomerSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()))
                 .thenThrow(new APIException("auth error", "reqId", 405, null, null));
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -98,8 +98,8 @@ public class PaymentSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()
+        ))
                 .thenReturn(addedSource);
         when(mApiHandler.setDefaultCustomerSource(
                 anyString(),
@@ -107,8 +107,7 @@ public class PaymentSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString(),
-                ArgumentMatchers.<StripeApiHandler.LoggingResponseListener>isNull()))
+                anyString()))
                 .thenReturn(secondCustomer);
 
         doAnswer(new Answer() {

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -31,10 +31,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -215,140 +213,101 @@ public class StripeTest {
     }
 
     @Test
-    public void createCardTokenSynchronous_withValidData_returnsToken() {
-        try {
-            Stripe stripe = new Stripe(mContext, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
+    public void createCardTokenSynchronous_withValidData_returnsToken()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = new Stripe(mContext, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+        final Token token = stripe.createTokenSynchronous(CARD);
 
-            Token token = stripe.createTokenSynchronous(CARD);
-
-            assertNotNull(token);
-            Card returnedCard = token.getCard();
-            assertNotNull(returnedCard);
-            assertNull(token.getBankAccount());
-            assertEquals(Token.TYPE_CARD, token.getType());
-            assertEquals(CARD.getLast4(), returnedCard.getLast4());
-            assertEquals(Card.VISA, returnedCard.getBrand());
-            assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
-            assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
-            assertEquals(Card.FUNDING_CREDIT, returnedCard.getFunding());
-
-            assertAllLogsAreValid(listener, 2);
-        } catch (AuthenticationException authEx) {
-            fail("Unexpected error: " + authEx.getLocalizedMessage());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error when connecting to Stripe API: "
-                    + stripeEx.getLocalizedMessage());
-        }
+        assertNotNull(token);
+        Card returnedCard = token.getCard();
+        assertNotNull(returnedCard);
+        assertNull(token.getBankAccount());
+        assertEquals(Token.TYPE_CARD, token.getType());
+        assertEquals(CARD.getLast4(), returnedCard.getLast4());
+        assertEquals(Card.VISA, returnedCard.getBrand());
+        assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
+        assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
+        assertEquals(Card.FUNDING_CREDIT, returnedCard.getFunding());
     }
 
     @Test
-    public void createCardTokenSynchronous_withValidDataAndConnectAccount_returnsToken() {
-        try {
-            Stripe stripe = new Stripe(mContext, "pk_test_fdjfCYpGSwAX24KUEiuaAAWX");
-            stripe.setStripeAccount("acct_1Acj2PBUgO3KuWzz");
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
+    public void createCardTokenSynchronous_withValidDataAndConnectAccount_returnsToken()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = new Stripe(mContext, "pk_test_fdjfCYpGSwAX24KUEiuaAAWX");
+        stripe.setStripeAccount("acct_1Acj2PBUgO3KuWzz");
 
-            Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createTokenSynchronous(CARD);
 
-            assertNotNull(token);
-            Card returnedCard = token.getCard();
-            assertNotNull(returnedCard);
-            assertNull(token.getBankAccount());
-            assertEquals(Token.TYPE_CARD, token.getType());
-            assertEquals(CARD.getLast4(), returnedCard.getLast4());
-            assertEquals(Card.VISA, returnedCard.getBrand());
-            assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
-            assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
-            assertEquals(Card.FUNDING_CREDIT, returnedCard.getFunding());
-
-            assertAllLogsAreValid(listener, 2);
-        } catch (AuthenticationException authEx) {
-            fail("Unexpected error: " + authEx.getLocalizedMessage());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error when connecting to Stripe API: "
-                    + stripeEx.getLocalizedMessage());
-        }
+        assertNotNull(token);
+        Card returnedCard = token.getCard();
+        assertNotNull(returnedCard);
+        assertNull(token.getBankAccount());
+        assertEquals(Token.TYPE_CARD, token.getType());
+        assertEquals(CARD.getLast4(), returnedCard.getLast4());
+        assertEquals(Card.VISA, returnedCard.getBrand());
+        assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
+        assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
+        assertEquals(Card.FUNDING_CREDIT, returnedCard.getFunding());
     }
 
     @Test
-    public void createToken_createSource_returnsSource() {
-        try {
-            final Stripe stripe = createPublishableKeyStripe();
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
+    public void createToken_createSource_returnsSource()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = createPublishableKeyStripe();
+        final Token token = stripe.createTokenSynchronous(CARD);
+        assertNotNull(token);
 
-            Token token = stripe.createTokenSynchronous(CARD);
+        final SourceParams sourceParams = SourceParams.createCustomParams();
+        sourceParams.setType(Source.CARD);
+        sourceParams.setToken(token.getId());
 
-            assertNotNull(token);
-            SourceParams sourceParams = SourceParams.createCustomParams();
-            sourceParams.setType(Source.CARD);
-            sourceParams.setToken(token.getId());
-            Source source = stripe.createSourceSynchronous(sourceParams,
-                    FUNCTIONAL_PUBLISHABLE_KEY);
-            assertNotNull(source);
-            assertAllLogsAreValid(listener, 4);
-        } catch (AuthenticationException authEx) {
-            fail("Unexpected error: " + authEx.getLocalizedMessage());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error when connecting to Stripe API: "
-                    + stripeEx.getLocalizedMessage());
-        }
+        final Source source = stripe.createSourceSynchronous(sourceParams,
+                FUNCTIONAL_PUBLISHABLE_KEY);
+        assertNotNull(source);
     }
 
     @Test
-    public void createToken_createSourceWithTokenToSourceParams_returnsSource() {
-        try {
-            final Stripe stripe = createPublishableKeyStripe();
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
-            Token token = stripe.createTokenSynchronous(CARD);
-            assertNotNull(token);
+    public void createToken_createSourceWithTokenToSourceParams_returnsSource()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException {
+        final Stripe stripe = createPublishableKeyStripe();
+        final Token token = stripe.createTokenSynchronous(CARD);
+        assertNotNull(token);
 
-            SourceParams sourceParams = SourceParams.createSourceFromTokenParams(token.getId());
+        final SourceParams sourceParams = SourceParams.createSourceFromTokenParams(token.getId());
 
-            Source source = stripe.createSourceSynchronous(sourceParams,
-                    FUNCTIONAL_PUBLISHABLE_KEY);
-            assertNotNull(source);
-            assertAllLogsAreValid(listener, 4);
-        } catch (AuthenticationException authEx) {
-            fail("Unexpected error: " + authEx.getLocalizedMessage());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error when connecting to Stripe API: "
-                    + stripeEx.getLocalizedMessage());
-        }
+        final Source source = stripe.createSourceSynchronous(sourceParams,
+                FUNCTIONAL_PUBLISHABLE_KEY);
+        assertNotNull(source);
     }
 
     @Test
-    public void createBankAccountTokenSynchronous_withValidBankAccount_returnsToken() {
-        try {
-            Stripe stripe = getNonLoggingStripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+    public void createBankAccountTokenSynchronous_withValidBankAccount_returnsToken()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        Stripe stripe = getNonLoggingStripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
 
-            Token token = stripe.createBankAccountTokenSynchronous(BANK_ACCOUNT);
-            assertNotNull(token);
-            assertEquals(Token.TYPE_BANK_ACCOUNT, token.getType());
-            assertNull(token.getCard());
+        Token token = stripe.createBankAccountTokenSynchronous(BANK_ACCOUNT);
+        assertNotNull(token);
+        assertEquals(Token.TYPE_BANK_ACCOUNT, token.getType());
+        assertNull(token.getCard());
 
-            BankAccount returnedBankAccount = token.getBankAccount();
-            assertNotNull(returnedBankAccount);
-            String expectedLast4 = TEST_BANK_ACCOUNT_NUMBER
-                    .substring(TEST_BANK_ACCOUNT_NUMBER.length() - 4);
-            assertEquals(expectedLast4, returnedBankAccount.getLast4());
-            assertEquals(BANK_ACCOUNT.getCountryCode(), returnedBankAccount.getCountryCode());
-            assertEquals(BANK_ACCOUNT.getCurrency(), returnedBankAccount.getCurrency());
-            assertEquals(BANK_ACCOUNT.getRoutingNumber(), returnedBankAccount.getRoutingNumber());
-        } catch (AuthenticationException authEx) {
-            fail("Unexpected error: " + authEx.getLocalizedMessage());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error when connecting to Stripe API: "
-                    + stripeEx.getLocalizedMessage());
-        }
+        BankAccount returnedBankAccount = token.getBankAccount();
+        assertNotNull(returnedBankAccount);
+        String expectedLast4 = TEST_BANK_ACCOUNT_NUMBER
+                .substring(TEST_BANK_ACCOUNT_NUMBER.length() - 4);
+        assertEquals(expectedLast4, returnedBankAccount.getLast4());
+        assertEquals(BANK_ACCOUNT.getCountryCode(), returnedBankAccount.getCountryCode());
+        assertEquals(BANK_ACCOUNT.getCurrency(), returnedBankAccount.getCurrency());
+        assertEquals(BANK_ACCOUNT.getRoutingNumber(), returnedBankAccount.getRoutingNumber());
     }
 
     @Test
-    public void createSourceSynchronous_withAlipayReusableParams_passesIntegrationTest() {
+    public void createSourceSynchronous_withAlipayReusableParams_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException, APIConnectionException {
         Stripe stripe = getNonLoggingStripe(mContext);
         SourceParams alipayParams = SourceParams.createAlipayReusableParams(
                 "usd",
@@ -356,24 +315,20 @@ public class StripeTest {
                 "abc@def.com",
                 "stripe://start");
 
-        try {
-            Source alipaySource =
-                    stripe.createSourceSynchronous(alipayParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
-            assertNotNull(alipaySource);
-            assertNotNull(alipaySource.getId());
-            assertNotNull(alipaySource.getClientSecret());
-            assertEquals(Source.ALIPAY, alipaySource.getType());
-            assertEquals("redirect", alipaySource.getFlow());
-            assertNotNull(alipaySource.getOwner());
-            assertEquals("Example Payer", alipaySource.getOwner().getName());
-            assertEquals("abc@def.com", alipaySource.getOwner().getEmail());
-            assertEquals("usd", alipaySource.getCurrency());
-            assertEquals(Source.REUSABLE, alipaySource.getUsage());
-            assertNotNull(alipaySource.getRedirect());
-            assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
-        }
+        Source alipaySource =
+                stripe.createSourceSynchronous(alipayParams, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
+        assertNotNull(alipaySource);
+        assertNotNull(alipaySource.getId());
+        assertNotNull(alipaySource.getClientSecret());
+        assertEquals(Source.ALIPAY, alipaySource.getType());
+        assertEquals("redirect", alipaySource.getFlow());
+        assertNotNull(alipaySource.getOwner());
+        assertEquals("Example Payer", alipaySource.getOwner().getName());
+        assertEquals("abc@def.com", alipaySource.getOwner().getEmail());
+        assertEquals("usd", alipaySource.getCurrency());
+        assertEquals(Source.REUSABLE, alipaySource.getUsage());
+        assertNotNull(alipaySource.getRedirect());
+        assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
     }
 
     @Test
@@ -529,10 +484,10 @@ public class StripeTest {
     }
 
     @Test
-    public void createSourceSynchronous_withGiropayParams_passesIntegrationTest() {
+    public void createSourceSynchronous_withGiropayParams_passesIntegrationTest()
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
         Stripe stripe = new Stripe(mContext, FUNCTIONAL_SOURCE_PUBLISHABLE_KEY);
-        TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         SourceParams params = SourceParams.createGiropayParams(
                 2000L,
                 "Mr. X",
@@ -543,27 +498,23 @@ public class StripeTest {
             put("type", "wrap");
         }};
         params.setMetaData(metamap);
-        try {
-            Source giropaySource =
-                    stripe.createSourceSynchronous(params);
-            assertNotNull(giropaySource);
-            assertNotNull(giropaySource.getClientSecret());
-            assertNotNull(giropaySource.getId());
-            assertNotNull(giropaySource.getAmount());
-            assertEquals("eur", giropaySource.getCurrency());
-            assertEquals(2000L, giropaySource.getAmount().longValue());
-            assertEquals(Source.GIROPAY, giropaySource.getType());
-            assertNotNull(giropaySource.getSourceTypeData());
-            assertNull(giropaySource.getSourceTypeModel());
-            assertNotNull(giropaySource.getOwner());
-            assertNotNull(giropaySource.getRedirect());
-            assertEquals("Mr. X", giropaySource.getOwner().getName());
-            assertEquals("example://redirect", giropaySource.getRedirect().getReturnUrl());
-            assertAllLogsAreValid(listener, 2);
-            JsonTestUtils.assertMapEquals(metamap, giropaySource.getMetaData());
-        } catch (StripeException stripeEx) {
-            fail("Unexpected error: " + stripeEx.getLocalizedMessage());
-        }
+
+        Source giropaySource =
+                stripe.createSourceSynchronous(params);
+        assertNotNull(giropaySource);
+        assertNotNull(giropaySource.getClientSecret());
+        assertNotNull(giropaySource.getId());
+        assertNotNull(giropaySource.getAmount());
+        assertEquals("eur", giropaySource.getCurrency());
+        assertEquals(2000L, giropaySource.getAmount().longValue());
+        assertEquals(Source.GIROPAY, giropaySource.getType());
+        assertNotNull(giropaySource.getSourceTypeData());
+        assertNull(giropaySource.getSourceTypeModel());
+        assertNotNull(giropaySource.getOwner());
+        assertNotNull(giropaySource.getRedirect());
+        assertEquals("Mr. X", giropaySource.getOwner().getName());
+        assertEquals("example://redirect", giropaySource.getRedirect().getReturnUrl());
+        JsonTestUtils.assertMapEquals(metamap, giropaySource.getMetaData());
     }
 
     @Test
@@ -942,22 +893,16 @@ public class StripeTest {
     }
 
     @Test
-    public void createTokenSynchronous_withValidPersonalId_passesIntegrationTest() {
-        try {
-            final Stripe stripe = createPublishableKeyStripe();
-            TestLoggingListener listener = new TestLoggingListener(true);
-            stripe.setLoggingResponseListener(listener);
-
-            Token token = stripe.createPiiTokenSynchronous("0123456789");
-            assertNotNull(token);
-            assertEquals(Token.TYPE_PII, token.getType());
-            assertFalse(token.getLivemode());
-            assertFalse(token.getUsed());
-            assertNotNull(token.getId());
-            assertAllLogsAreValid(listener, 2);
-        } catch (StripeException stripeEx) {
-            fail("Unexpected exception making PII token");
-        }
+    public void createTokenSynchronous_withValidPersonalId_passesIntegrationTest()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = createPublishableKeyStripe();
+        final Token token = stripe.createPiiTokenSynchronous("0123456789");
+        assertNotNull(token);
+        assertEquals(Token.TYPE_PII, token.getType());
+        assertFalse(token.getLivemode());
+        assertFalse(token.getUsed());
+        assertNotNull(token.getId());
     }
 
     @Test
@@ -965,8 +910,6 @@ public class StripeTest {
             throws CardException, APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         final Stripe stripe = createPublishableKeyStripe();
-        final TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
 
         final Token token = stripe.createCvcUpdateTokenSynchronous("1234");
         assertNotNull(token);
@@ -975,7 +918,6 @@ public class StripeTest {
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
         assertTrue(token.getId().startsWith("cvctok_"));
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -995,8 +937,6 @@ public class StripeTest {
         }};
 
         final Stripe stripe = createPublishableKeyStripe();
-        final TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         final Token token = stripe.createAccountTokenSynchronous(
                 AccountParams.createAccountParams(true,
                         AccountParams.BusinessType.Individual, businessData));
@@ -1005,7 +945,6 @@ public class StripeTest {
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -1024,8 +963,6 @@ public class StripeTest {
         }};
 
         final Stripe stripe = createPublishableKeyStripe();
-        final TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         final Token token = stripe.createAccountTokenSynchronous(
                 AccountParams.createAccountParams(true,
                         AccountParams.BusinessType.Company, businessData));
@@ -1034,7 +971,6 @@ public class StripeTest {
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -1053,8 +989,6 @@ public class StripeTest {
         }};
 
         Stripe stripe = createPublishableKeyStripe();
-        TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         Token token = stripe.createAccountTokenSynchronous(
                 AccountParams.createAccountParams(false,
                         AccountParams.BusinessType.Individual, businessData));
@@ -1063,7 +997,6 @@ public class StripeTest {
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -1071,8 +1004,6 @@ public class StripeTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         final Stripe stripe = createPublishableKeyStripe();
-        final TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         final Token token = stripe.createAccountTokenSynchronous(
                 AccountParams.createAccountParams(false,
                         AccountParams.BusinessType.Individual, null));
@@ -1081,7 +1012,6 @@ public class StripeTest {
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -1089,8 +1019,6 @@ public class StripeTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         final Stripe stripe = createPublishableKeyStripe();
-        final TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
         final Token token = stripe.createAccountTokenSynchronous(
                 AccountParams.createAccountParams(false,
                         null, null));
@@ -1099,7 +1027,6 @@ public class StripeTest {
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
-        assertAllLogsAreValid(listener, 2);
     }
 
     @Test
@@ -1117,20 +1044,13 @@ public class StripeTest {
         }
     }
 
-    @Test
-    public void createTokenSynchronous_withoutKey_shouldNotLogAnything() {
-        Stripe stripe = new Stripe(mContext);
+    @Test(expected = IllegalArgumentException.class)
+    public void createTokenSynchronous_withoutKey_shouldThrowException()
+            throws CardException, APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        final Stripe stripe = new Stripe(mContext);
         // This test should not log anything, so we set it to be theoretically capable of logging
-        TestLoggingListener listener = new TestLoggingListener(true);
-        stripe.setLoggingResponseListener(listener);
-        try {
-            stripe.createTokenSynchronous(CARD);
-            fail("We shouldn't be able to make a token without a key.");
-        } catch (Exception exception) {
-            // Note: we're not testing the type of exception in this test.
-            assertEquals(0, listener.responseList.size());
-            assertEquals(0, listener.exceptionList.size());
-        }
+        stripe.createTokenSynchronous(CARD);
     }
 
     @Test
@@ -1343,14 +1263,6 @@ public class StripeTest {
                 createdPaymentMethod.ideal);
     }
 
-    private void assertAllLogsAreValid(@NonNull TestLoggingListener listener, int expectedLogs) {
-        assertEquals(expectedLogs, listener.responseList.size());
-        assertEquals(0, listener.exceptionList.size());
-        for(int i = 0; i < expectedLogs; i++) {
-            assertEquals(200, listener.responseList.get(i).getResponseCode());
-        }
-    }
-
     @NonNull
     private static Stripe getNonLoggingStripe(@NonNull Context context) {
         return createNonLoggingStripe(context, null);
@@ -1375,38 +1287,11 @@ public class StripeTest {
         if (publishableKey != null) {
             stripe.setDefaultPublishableKey(publishableKey);
         }
-        stripe.setLoggingResponseListener(new TestLoggingListener(false));
         return stripe;
     }
 
     @NonNull
     private Stripe createPublishableKeyStripe() {
         return new Stripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
-    }
-
-    private static class TestLoggingListener implements StripeApiHandler.LoggingResponseListener {
-        private final boolean mShouldLogTest;
-        @NonNull private final List<StripeResponse> responseList = new ArrayList<>();
-        @NonNull private final List<StripeException> exceptionList = new ArrayList<>();
-
-        private TestLoggingListener(boolean shouldLogTest) {
-            mShouldLogTest = shouldLogTest;
-        }
-
-        @Override
-        public void onLoggingResponse(@NonNull StripeResponse response) {
-            if (!mShouldLogTest) {
-                fail("Test should not be logged.");
-            }
-            responseList.add(response);
-        }
-
-        @Override
-        public void onStripeException(@NonNull StripeException exception) {
-            if (!mShouldLogTest) {
-                fail("Test should not be logged.");
-            }
-            exceptionList.add(exception);
-        }
     }
 }


### PR DESCRIPTION
## Summary
The functionality that `LoggingResponseListener` was used
for can be accomplished by returning a boolean value
from `StripeApiHandler#fireAndForgetApiCall()`

## Motivation
Simplify `StripeApiHandler` logic

## Testing
Wrote unit tests
