### PR TITLE
Continue refactoring StripeApiHandler

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeResponse.java
+++ b/stripe/src/main/java/com/stripe/android/StripeResponse.java
@@ -37,6 +37,10 @@ class StripeResponse {
         return mResponseCode;
     }
 
+    boolean hasErrorCode() {
+        return mResponseCode < 200 || mResponseCode >= 300;
+    }
+
     /**
      * @return the {@link #mResponseBody response body}.
      */
@@ -51,5 +55,19 @@ class StripeResponse {
     @Nullable
     Map<String, List<String>> getResponseHeaders() {
         return mResponseHeaders;
+    }
+
+    @Nullable
+    String getRequestId() {
+        final Map<String, List<String>> headers = getResponseHeaders();
+        final List<String> requestIdList = headers == null ? null : headers.get("Request-Id");
+        final String requestId;
+        if (requestIdList != null && requestIdList.size() > 0) {
+            requestId = requestIdList.get(0);
+        } else {
+            requestId = null;
+        }
+
+        return requestId;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -56,7 +56,7 @@ public class StripeApiHandlerTest {
     @NonNull private final StripeApiHandler mApiHandler =
             new StripeApiHandler(ApplicationProvider.getApplicationContext());
 
-    @Mock private StripeApiHandler.ConnectionFactory mConnectionFactory;
+    @Mock private StripeApiHandler.RequestExecutor mRequestExecutor;
 
     @Before
     public void before() {
@@ -350,7 +350,7 @@ public class StripeApiHandlerTest {
             APIConnectionException {
         final StripeApiHandler apiHandler = new StripeApiHandler(
                 ApplicationProvider.getApplicationContext(),
-                new StripeApiHandler.ConnectionFactory(),
+                new StripeApiHandler.RequestExecutor(),
                 false
         );
         final Source source = apiHandler.createSource(
@@ -367,12 +367,12 @@ public class StripeApiHandlerTest {
     public void logApiCall_whenShouldLogRequestIsFalse_doesNotCreateAConnection() {
         final StripeApiHandler apiHandler = new StripeApiHandler(
                 ApplicationProvider.getApplicationContext(),
-                mConnectionFactory,
+                mRequestExecutor,
                 false
         );
         apiHandler.logApiCall(new HashMap<String, Object>(),
                 RequestOptions.builder("some_key")
                         .build());
-        verifyNoMoreInteractions(mConnectionFactory);
+        verifyNoMoreInteractions(mRequestExecutor);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -32,7 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.stripe.android.StripeApiHandler.POST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -182,7 +181,7 @@ public class StripeApiHandlerTest {
                         .hashMapFromCard(CARD);
         final String expectedValue = "product_usage=&card%5Bnumber%5D=4242424242424242&card%5B" +
                 "cvc%5D=123&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050";
-        final String query = mApiHandler.createQuery(cardMap);
+        final String query = new StripeApiHandler.ConnectionFactory().createQuery(cardMap);
         assertEquals(expectedValue, query);
     }
 
@@ -256,7 +255,7 @@ public class StripeApiHandlerTest {
             APIConnectionException {
         final String connectAccountId = "acct_1Acj2PBUgO3KuWzz";
         final StripeResponse response = mApiHandler.requestData(
-                POST, mApiHandler.getSourcesUrl(),
+                StripeApiHandler.RestMethod.POST, mApiHandler.getSourcesUrl(),
                 SourceParams.createCardParams(CARD).toParamMap(),
                 RequestOptions.builder("pk_test_fdjfCYpGSwAX24KUEiuaAAWX",
                         connectAccountId, RequestOptions.TYPE_QUERY)

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1280,7 +1280,7 @@ public class StripeTest {
         final Stripe stripe = new Stripe(
                 new StripeApiHandler(
                         context,
-                        new StripeApiHandler.ConnectionFactory(),
+                        new StripeApiHandler.RequestExecutor(),
                         false),
                 new LoggingUtils(context),
                 new StripeNetworkUtils(context));


### PR DESCRIPTION
## Summary
Move appropriate methods from StripeApiHandler to
`StripeApiHandler.ConnectionFactory` to clarify logic.

## Motivation
Clean up logic and make it easier to mock `ConnectionFactory`

## Testing
Updated unit tests
