### PR TITLE
Remove group setting in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ licenses:
     - 'google-gdk-license-.+'
     - '.+'
 
-group: deprecated-2017Q3
-
 before_install:
   - yes | sdkmanager "platforms;android-28"
 


### PR DESCRIPTION
This was added in #368 because builds were failing, but now that builds are passing without it, we can remove it.