### PR TITLE
Fix memory leaks in tests

### DIFF
--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -20,10 +20,12 @@ import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.Source;
 import com.stripe.android.testharness.JsonTestUtils;
 import com.stripe.android.testharness.TestEphemeralKeyProvider;
+import com.stripe.android.view.BaseViewTest;
 import com.stripe.android.view.CardInputTestActivity;
 import com.stripe.android.view.PaymentFlowActivity;
 
 import org.json.JSONException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
@@ -65,7 +66,7 @@ import static org.mockito.Mockito.when;
  * Test class for {@link CustomerSession}.
  */
 @RunWith(RobolectricTestRunner.class)
-public class CustomerSessionTest {
+public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     static final String FIRST_SAMPLE_KEY_RAW = "{\n" +
             "  \"id\": \"ephkey_123\",\n" +
@@ -167,6 +168,16 @@ public class CustomerSessionTest {
 
     private TestEphemeralKeyProvider mEphemeralKeyProvider;
     private Source mAddedSource;
+
+    public CustomerSessionTest() {
+        super(PaymentFlowActivity.class);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
 
     @NonNull
     private CustomerEphemeralKey getCustomerEphemeralKey(@NonNull String key) {
@@ -727,9 +738,10 @@ public class CustomerSessionTest {
                 .putExtra(PAYMENT_SESSION_CONFIG, new PaymentSessionConfig.Builder()
                         .build())
                 .putExtra(PAYMENT_SESSION_DATA_KEY, new PaymentSessionData());
-        Robolectric.buildActivity(PaymentFlowActivity.class, intent)
-                .create().start().resume().visible();
-        List<String> actualTokens = new ArrayList<>(customerSession.getProductUsageTokens());
+
+        createActivity(intent);
+
+        final List<String> actualTokens = new ArrayList<>(customerSession.getProductUsageTokens());
         assertTrue(actualTokens.contains("ShippingInfoScreen"));
     }
 
@@ -744,8 +756,8 @@ public class CustomerSessionTest {
                         .build())
                 .putExtra(PAYMENT_SESSION_DATA_KEY, new PaymentSessionData());
 
-        Robolectric.buildActivity(PaymentFlowActivity.class, intent)
-                .create().start().resume().visible();
+        createActivity(intent);
+
         assertTrue(new ArrayList<>(customerSession.getProductUsageTokens())
                 .contains("ShippingMethodScreen"));
     }

--- a/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddSourceActivityTest.java
@@ -21,6 +21,7 @@ import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,9 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
 
 import java.util.Calendar;
@@ -59,16 +58,20 @@ import static org.robolectric.Shadows.shadowOf;
  * Test class for {@link AddSourceActivity}.
  */
 @RunWith(RobolectricTestRunner.class)
-public class AddSourceActivityTest {
+public class AddSourceActivityTest extends BaseViewTest<AddSourceActivity> {
 
-    private ActivityController<AddSourceActivity> mActivityController;
     private CardMultilineWidget mCardMultilineWidget;
     private CardMultilineWidgetTest.WidgetControlGroup mWidgetControlGroup;
     private ProgressBar mProgressBar;
+    private AddSourceActivity mActivity;
     private ShadowActivity mShadowActivity;
 
-    @Mock Stripe mStripe;
-    @Mock AddSourceActivity.CustomerSessionProxy mCustomerSessionProxy;
+    @Mock private Stripe mStripe;
+    @Mock private AddSourceActivity.CustomerSessionProxy mCustomerSessionProxy;
+
+    public AddSourceActivityTest() {
+        super(AddSourceActivity.class);
+    }
 
     @Before
     public void setup() {
@@ -77,16 +80,20 @@ public class AddSourceActivityTest {
         MockitoAnnotations.initMocks(this);
     }
 
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
+
     private void setUpForLocalTest() {
-        mActivityController = Robolectric.buildActivity(AddSourceActivity.class)
-                .create().start().resume().visible();
-        final AddSourceActivity addSourceActivity = mActivityController.get();
-        mCardMultilineWidget = addSourceActivity.findViewById(R.id.add_source_card_entry_widget);
-        mProgressBar = addSourceActivity.findViewById(R.id.progress_bar_as);
+        mActivity = createActivity();
+        mCardMultilineWidget = mActivity.findViewById(R.id.add_source_card_entry_widget);
+        mProgressBar = mActivity.findViewById(R.id.progress_bar_as);
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);
 
-        mShadowActivity = shadowOf(addSourceActivity);
-        addSourceActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
+        mShadowActivity = shadowOf(mActivity);
+        mActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
             @NonNull
             @Override
             public Stripe getStripe(@NonNull Context context) {
@@ -96,28 +103,25 @@ public class AddSourceActivityTest {
     }
 
     private void setUpForProxySessionTest() {
-        Intent intent = AddSourceActivity
+        final Intent intent = AddSourceActivity
                 .newIntent(ApplicationProvider.getApplicationContext(), true, true)
                 .putExtra(EXTRA_PROXY_DELAY, true)
                 .putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
-        mActivityController = Robolectric.buildActivity(AddSourceActivity.class, intent)
-                .create().start().resume().visible();
-        final AddSourceActivity addSourceActivity = mActivityController.get();
-        mCardMultilineWidget = addSourceActivity.findViewById(R.id.add_source_card_entry_widget);
-        mProgressBar = mActivityController.get()
-                .findViewById(R.id.progress_bar_as);
+        mActivity = createActivity(intent);
+        mCardMultilineWidget = mActivity.findViewById(R.id.add_source_card_entry_widget);
+        mProgressBar = mActivity.findViewById(R.id.progress_bar_as);
         mWidgetControlGroup = new CardMultilineWidgetTest.WidgetControlGroup(mCardMultilineWidget);
 
-        mShadowActivity = shadowOf(addSourceActivity);
-        addSourceActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
+        mShadowActivity = shadowOf(mActivity);
+        mActivity.setStripeProvider(new AddSourceActivity.StripeProvider() {
             @NonNull
             @Override
             public Stripe getStripe(@NonNull Context context) {
                 return mStripe;
             }
         });
-        addSourceActivity.setCustomerSessionProxy(mCustomerSessionProxy);
-        addSourceActivity.initCustomerSessionTokens();
+        mActivity.setCustomerSessionProxy(mCustomerSessionProxy);
+        mActivity.initCustomerSessionTokens();
     }
 
     @Test
@@ -172,7 +176,7 @@ public class AddSourceActivityTest {
         assertEquals(RESULT_OK, mShadowActivity.getResultCode());
         Intent intent = mShadowActivity.getResultIntent();
 
-        assertTrue(mActivityController.get().isFinishing());
+        assertTrue(mActivity.isFinishing());
         assertTrue(intent.hasExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
         final Source newSource =
                 Source.fromString(intent.getStringExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
@@ -221,7 +225,7 @@ public class AddSourceActivityTest {
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
 
-        mActivityController.get().onOptionsItemSelected(menuItem);
+        mActivity.onOptionsItemSelected(menuItem);
         verify(mStripe).createSource(
                 paramsArgumentCaptor.capture(),
                 callbackArgumentCaptor.capture());
@@ -239,7 +243,7 @@ public class AddSourceActivityTest {
         assertEquals(RESULT_OK, mShadowActivity.getResultCode());
         Intent intent = mShadowActivity.getResultIntent();
 
-        assertTrue(mActivityController.get().isFinishing());
+        assertTrue(mActivity.isFinishing());
         assertTrue(intent.hasExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
         final Source newSource =
                 Source.fromString(intent.getStringExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
@@ -269,7 +273,7 @@ public class AddSourceActivityTest {
         assertEquals(View.GONE, mProgressBar.getVisibility());
         assertTrue(mCardMultilineWidget.isEnabled());
 
-        mActivityController.get().onOptionsItemSelected(menuItem);
+        mActivity.onOptionsItemSelected(menuItem);
         verify(mStripe).createSource(
                 paramsArgumentCaptor.capture(),
                 callbackArgumentCaptor.capture());
@@ -304,7 +308,7 @@ public class AddSourceActivityTest {
         assertEquals(RESULT_OK, mShadowActivity.getResultCode());
         Intent intent = mShadowActivity.getResultIntent();
 
-        assertTrue(mActivityController.get().isFinishing());
+        assertTrue(mActivity.isFinishing());
         assertTrue(intent.hasExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
         Source source =
                 Source.fromString(intent.getStringExtra(AddSourceActivity.EXTRA_NEW_SOURCE));
@@ -322,7 +326,7 @@ public class AddSourceActivityTest {
 
         StripeActivity.AlertMessageListener alertMessageListener =
                 Mockito.mock(StripeActivity.AlertMessageListener.class);
-        mActivityController.get().setAlertMessageListener(alertMessageListener);
+        mActivity.setAlertMessageListener(alertMessageListener);
 
         // Note: these values do not match what is being mock-sent back in the result.
         mWidgetControlGroup.cardNumberEditText.append(CardInputTestActivity.VALID_AMEX_NO_SPACES);
@@ -336,7 +340,7 @@ public class AddSourceActivityTest {
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
 
-        mActivityController.get().onOptionsItemSelected(menuItem);
+        mActivity.onOptionsItemSelected(menuItem);
         verify(mStripe).createSource(
                 paramsArgumentCaptor.capture(),
                 callbackArgumentCaptor.capture());
@@ -355,7 +359,7 @@ public class AddSourceActivityTest {
 
         Intent intent = mShadowActivity.getResultIntent();
         assertNull(intent);
-        assertFalse(mActivityController.get().isFinishing());
+        assertFalse(mActivity.isFinishing());
         assertEquals(View.GONE, mProgressBar.getVisibility());
         verify(alertMessageListener, times(1)).onAlertMessageDisplayed(errorMessage);
     }
@@ -369,7 +373,7 @@ public class AddSourceActivityTest {
                 ArgumentCaptor.forClass(SourceCallback.class);
         StripeActivity.AlertMessageListener alertMessageListener =
                 Mockito.mock(StripeActivity.AlertMessageListener.class);
-        mActivityController.get().setAlertMessageListener(alertMessageListener);
+        mActivity.setAlertMessageListener(alertMessageListener);
 
         // Note: these values do not match what is being mock-sent back in the result.
         mWidgetControlGroup.cardNumberEditText.append(CardInputTestActivity.VALID_AMEX_NO_SPACES);
@@ -385,7 +389,7 @@ public class AddSourceActivityTest {
         assertEquals(View.GONE, mProgressBar.getVisibility());
         assertTrue(mCardMultilineWidget.isEnabled());
 
-        mActivityController.get().onOptionsItemSelected(menuItem);
+        mActivity.onOptionsItemSelected(menuItem);
         verify(mStripe).createSource(
                 paramsArgumentCaptor.capture(),
                 callbackArgumentCaptor.capture());
@@ -425,11 +429,11 @@ public class AddSourceActivityTest {
         bundle.putSerializable(EXTRA_EXCEPTION, error);
         Intent errorIntent = new Intent(ACTION_API_EXCEPTION);
         errorIntent.putExtras(bundle);
-        LocalBroadcastManager.getInstance(mActivityController.get()).sendBroadcast(errorIntent);
+        LocalBroadcastManager.getInstance(mActivity).sendBroadcast(errorIntent);
 
         Intent intent = mShadowActivity.getResultIntent();
         assertNull(intent);
-        assertFalse(mActivityController.get().isFinishing());
+        assertFalse(mActivity.isFinishing());
         assertEquals(View.GONE, mProgressBar.getVisibility());
         verify(alertMessageListener, times(1)).onAlertMessageDisplayed(errorMessage);
     }

--- a/stripe/src/test/java/com/stripe/android/view/BaseViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/BaseViewTest.java
@@ -1,0 +1,71 @@
+package com.stripe.android.view;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.junit.After;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+public abstract class BaseViewTest<T extends Activity> {
+    @NonNull private Class<T> mClazz;
+    @NonNull private final Map<Integer, ActivityController<T>> mActivityControllers =
+            new HashMap<>();
+
+    protected BaseViewTest(@NonNull Class<T> clazz) {
+        this.mClazz = clazz;
+    }
+
+    @NonNull
+    protected T createActivity() {
+        return createActivity(null);
+    }
+
+    @NonNull
+    protected T createActivity(@Nullable Intent intent) {
+        final ActivityController<T> activityController = Robolectric.buildActivity(mClazz, intent)
+                .create().start()
+                .postCreate(null).resume().visible();
+        final T activity = activityController.get();
+        mActivityControllers.put(activity.hashCode(), activityController);
+        return activityController.get();
+    }
+
+    @NonNull
+    protected T createStartedActivity() {
+        final ActivityController<T> activityController = Robolectric.buildActivity(mClazz)
+                .create().start();
+        final T activity = activityController.get();
+        mActivityControllers.put(activity.hashCode(), activityController);
+        return activity;
+    }
+
+    /**
+     * Call resume() and visible() on an Activity that was created with
+     * {@link #createStartedActivity()}.
+     */
+    protected void resumeStartedActivity(T activity) {
+        final ActivityController<T> activityController =
+                mActivityControllers.get(activity.hashCode());
+        if (activityController != null) {
+            activityController.resume().visible();
+        }
+    }
+
+    @CallSuper
+    @After
+    public void tearDown() {
+        for (ActivityController<T> activityController : mActivityControllers.values()) {
+            activityController.pause().stop().destroy();
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.java
@@ -11,14 +11,13 @@ import com.stripe.android.model.Card;
 import com.stripe.android.testharness.TestFocusChangeListener;
 import com.stripe.android.testharness.ViewTestUtils;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 import java.util.Calendar;
@@ -50,7 +49,7 @@ import static org.mockito.Mockito.verify;
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.O_MR1)
-public class CardInputWidgetTest {
+public class CardInputWidgetTest extends BaseViewTest<CardInputTestActivity> {
 
     // Every Card made by the CardInputView should have the card widget token.
     private static final String[] EXPECTED_LOGGING_ARRAY = {LOGGING_TOKEN};
@@ -60,15 +59,19 @@ public class CardInputWidgetTest {
     private StripeEditText mCvcEditText;
     private TestFocusChangeListener mOnGlobalFocusChangeListener;
 
-    @Mock
-    CardInputListener mCardInputListener;
+    private CardInputTestActivity mActivity;
+
+    @Mock private CardInputListener mCardInputListener;
+
+    public CardInputWidgetTest() {
+        super(CardInputTestActivity.class);
+    }
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class)
-                        .create().start();
+
+        mActivity = createStartedActivity();
 
         CardInputWidget.DimensionOverrideSettings dimensionOverrides =
                 new CardInputWidget.DimensionOverrideSettings() {
@@ -85,13 +88,13 @@ public class CardInputWidgetTest {
                     }
                 };
 
-        mCardInputWidget = activityController.get().getCardInputWidget();
+        mCardInputWidget = mActivity.getCardInputWidget();
         mCardInputWidget.setDimensionOverrideSettings(dimensionOverrides);
         mOnGlobalFocusChangeListener = new TestFocusChangeListener();
         mCardInputWidget.getViewTreeObserver()
                 .addOnGlobalFocusChangeListener(mOnGlobalFocusChangeListener);
 
-        mCardNumberEditText = activityController.get().getCardNumberEditText();
+        mCardNumberEditText = mActivity.getCardNumberEditText();
         mCardNumberEditText.setText("");
 
         mExpiryEditText = mCardInputWidget.findViewById(R.id.et_expiry_date);
@@ -104,7 +107,15 @@ public class CardInputWidgetTest {
         params.width = 48;
         params.rightMargin = 12;
         iconView.setLayoutParams(params);
-        activityController.visible().resume();
+
+        resumeStartedActivity(mActivity);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+//        mActivity.finish();
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.java
@@ -10,14 +10,13 @@ import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.ViewTestUtils;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.Calendar;
 
@@ -45,7 +44,7 @@ import static org.mockito.Mockito.verify;
  * Test class for {@link CardMultilineWidget}.
  */
 @RunWith(RobolectricTestRunner.class)
-public class CardMultilineWidgetTest {
+public class CardMultilineWidgetTest extends BaseViewTest<CardInputTestActivity> {
 
     // Every Card made by the CardInputView should have the card widget token.
     private static final String[] EXPECTED_LOGGING_ARRAY = {CARD_MULTILINE_TOKEN};
@@ -55,23 +54,31 @@ public class CardMultilineWidgetTest {
     private WidgetControlGroup mFullGroup;
     private WidgetControlGroup mNoZipGroup;
 
-    @Mock
-    CardInputListener mFullCardListener;
-    @Mock
-    CardInputListener mNoZipCardListener;
+    @Mock private CardInputListener mFullCardListener;
+    @Mock private CardInputListener mNoZipCardListener;
+
+    public CardMultilineWidgetTest() {
+        super(CardInputTestActivity.class);
+    }
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
-        mCardMultilineWidget = activityController.get().getCardMultilineWidget();
+
+        final CardInputTestActivity activity = createStartedActivity();
+        mCardMultilineWidget = activity.getCardMultilineWidget();
         mFullGroup = new WidgetControlGroup(mCardMultilineWidget);
 
-        mNoZipCardMultilineWidget = activityController.get().getNoZipCardMulitlineWidget();
+        mNoZipCardMultilineWidget = activity.getNoZipCardMulitlineWidget();
         mNoZipGroup = new WidgetControlGroup(mNoZipCardMultilineWidget);
 
         mFullGroup.cardNumberEditText.setText("");
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.stripe.android.model.Card;
 import com.stripe.android.testharness.ViewTestUtils;
 
@@ -8,9 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_NO_SPACES;
 import static com.stripe.android.view.CardInputTestActivity.VALID_AMEX_WITH_SPACES;
@@ -34,18 +34,15 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @RunWith(RobolectricTestRunner.class)
 public class CardNumberEditTextTest {
 
-    @Mock CardNumberEditText.CardNumberCompleteListener mCardNumberCompleteListener;
-    @Mock CardNumberEditText.CardBrandChangeListener mCardBrandChangeListener;
+    @Mock private CardNumberEditText.CardNumberCompleteListener mCardNumberCompleteListener;
+    @Mock private CardNumberEditText.CardBrandChangeListener mCardBrandChangeListener;
     private CardNumberEditText mCardNumberEditText;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
-        mCardNumberEditText =
-                activityController.get().getCardNumberEditText();
+        mCardNumberEditText = new CardNumberEditText(ApplicationProvider.getApplicationContext());
         mCardNumberEditText.setText("");
         mCardNumberEditText.setCardNumberCompleteListener(mCardNumberCompleteListener);
         mCardNumberEditText.setCardBrandChangeListener(mCardBrandChangeListener);

--- a/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.java
@@ -2,13 +2,13 @@ package com.stripe.android.view;
 
 import android.widget.Filter;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,10 +30,8 @@ public class CountryAdapterTest {
         MockitoAnnotations.initMocks(this);
         Locale.setDefault(Locale.US);
 
-        ActivityController<ShippingInfoTestActivity> activityController =
-                Robolectric.buildActivity(ShippingInfoTestActivity.class).create().start();
         List<String> countries = new ArrayList<>(CountryUtils.getCountryNameToCodeMap().keySet());
-        mCountryAdapter = new CountryAdapter(activityController.get(), countries);
+        mCountryAdapter = new CountryAdapter(ApplicationProvider.getApplicationContext(), countries);
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.java
@@ -9,9 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.Locale;
 
@@ -25,19 +23,23 @@ import static org.junit.Assert.assertTrue;
  * Test class for {@link CountryAutoCompleteTextView}
  */
 @RunWith(RobolectricTestRunner.class)
-public class CountryAutoCompleteTextViewTest {
+public class CountryAutoCompleteTextViewTest extends BaseViewTest<ShippingInfoTestActivity> {
 
     private CountryAutoCompleteTextView mCountryAutoCompleteTextView;
     private AutoCompleteTextView mAutoCompleteTextView;
+
+    public CountryAutoCompleteTextViewTest() {
+        super(ShippingInfoTestActivity.class);
+    }
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         Locale.setDefault(Locale.US);
-        ActivityController<ShippingInfoTestActivity> activityController =
-                Robolectric.buildActivity(ShippingInfoTestActivity.class).create().start();
-        mCountryAutoCompleteTextView = activityController.get().findViewById(R.id.country_autocomplete_aaw);
-        mAutoCompleteTextView = mCountryAutoCompleteTextView.findViewById(R.id.autocomplete_country_cat);
+        mCountryAutoCompleteTextView = createStartedActivity()
+                .findViewById(R.id.country_autocomplete_aaw);
+        mAutoCompleteTextView = mCountryAutoCompleteTextView
+                .findViewById(R.id.autocomplete_country_cat);
     }
 
     @Test
@@ -51,9 +53,11 @@ public class CountryAutoCompleteTextViewTest {
         String previousValidCountryCode = mCountryAutoCompleteTextView.getSelectedCountryCode();
         mCountryAutoCompleteTextView.setCountrySelected("FAKE COUNTRY CODE");
         assertNull(mAutoCompleteTextView.getError());
-        assertEquals(mAutoCompleteTextView.getText().toString(), new Locale("", previousValidCountryCode).getDisplayCountry());
+        assertEquals(mAutoCompleteTextView.getText().toString(),
+                new Locale("", previousValidCountryCode).getDisplayCountry());
         mCountryAutoCompleteTextView.setCountrySelected(Locale.UK.getCountry());
-        assertNotEquals(mAutoCompleteTextView.getText().toString(), new Locale("", previousValidCountryCode).getDisplayCountry());
+        assertNotEquals(mAutoCompleteTextView.getText().toString(),
+                new Locale("", previousValidCountryCode).getDisplayCountry());
         assertEquals(mAutoCompleteTextView.getText().toString(), Locale.UK.getDisplayCountry());
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.stripe.android.testharness.ViewTestUtils;
 
 import org.junit.Before;
@@ -7,9 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.Calendar;
 
@@ -29,16 +29,14 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @RunWith(RobolectricTestRunner.class)
 public class ExpiryDateEditTextTest {
 
-    @Mock ExpiryDateEditText.ExpiryDateEditListener mExpiryDateEditListener;
+    @Mock private ExpiryDateEditText.ExpiryDateEditListener mExpiryDateEditListener;
     private ExpiryDateEditText mExpiryDateEditText;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
 
-        mExpiryDateEditText = activityController.get().getExpiryDateEditText();
+        mExpiryDateEditText = new ExpiryDateEditText(ApplicationProvider.getApplicationContext());
         mExpiryDateEditText.setText("");
         mExpiryDateEditText.setExpiryDateEditListener(mExpiryDateEditListener);
     }

--- a/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.java
@@ -4,11 +4,10 @@ import android.support.design.widget.TextInputLayout;
 
 import com.stripe.android.R;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import static org.junit.Assert.assertTrue;
 
@@ -18,16 +17,23 @@ import static org.junit.Assert.assertTrue;
  * is no need to otherwise test the behavior.
  */
 @RunWith(RobolectricTestRunner.class)
-public class IconTextInputLayoutTest {
+public class IconTextInputLayoutTest extends BaseViewTest<CardInputTestActivity> {
+
+    public IconTextInputLayoutTest() {
+        super(CardInputTestActivity.class);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
 
     @Test
     public void init_successfullyFindsFields() {
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start();
-
-        IconTextInputLayout iconTextInputLayout =
-                activityController.get().getCardMultilineWidget()
-                        .findViewById(R.id.tl_add_source_card_number_ml);
+        final IconTextInputLayout iconTextInputLayout = createActivity()
+                .getCardMultilineWidget()
+                .findViewById(R.id.tl_add_source_card_number_ml);
 
         assertTrue(iconTextInputLayout.hasObtainedCollapsingTextHelper());
     }

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
@@ -4,6 +4,8 @@ import android.support.v4.graphics.ColorUtils;
 import android.support.v7.widget.AppCompatImageView;
 import android.view.View;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.stripe.android.R;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.CustomerSource;
@@ -14,9 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.Calendar;
 
@@ -40,9 +40,7 @@ public class MaskedCardViewTest {
 
     @Before
     public void setup() {
-        ActivityController<CardInputTestActivity> activityController =
-                Robolectric.buildActivity(CardInputTestActivity.class).create().start().resume();
-        mMaskedCardView = activityController.get().getMaskedCardView();
+        mMaskedCardView = new MaskedCardView(ApplicationProvider.getApplicationContext());
         mSelectedImageView = mMaskedCardView.findViewById(R.id.masked_check_icon);
 
         Calendar expirationCalendar = Calendar.getInstance();

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android.view;
 
-import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 import android.view.View;
@@ -16,13 +14,13 @@ import com.stripe.android.model.Customer;
 import com.stripe.android.model.CustomerSource;
 import com.stripe.android.model.Source;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.shadows.ShadowActivity;
@@ -47,7 +45,7 @@ import static org.mockito.Mockito.when;
  * Test class for {@link PaymentMethodsActivity}.
  */
 @RunWith(RobolectricTestRunner.class)
-public class PaymentMethodsActivityTest {
+public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActivity> {
 
     static final String TEST_CUSTOMER_OBJECT_WITH_SOURCES =
             "{\n" +
@@ -92,18 +90,28 @@ public class PaymentMethodsActivityTest {
     private View mAddCardView;
     private ShadowActivity mShadowActivity;
 
+    public PaymentMethodsActivityTest() {
+        super(PaymentMethodsActivity.class);
+    }
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
 
-        mPaymentMethodsActivity = createActivity(createIntent()
+        mPaymentMethodsActivity = createActivity(new Intent()
                 .putExtra(EXTRA_PROXY_DELAY, true));
         mShadowActivity = Shadows.shadowOf(mPaymentMethodsActivity);
 
         mProgressBar = mPaymentMethodsActivity.findViewById(R.id.payment_methods_progress_bar);
         mRecyclerView = mPaymentMethodsActivity.findViewById(R.id.payment_methods_recycler);
         mAddCardView = mPaymentMethodsActivity.findViewById(R.id.payment_methods_add_payment_container);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
     }
 
     @Test
@@ -165,7 +173,7 @@ public class PaymentMethodsActivityTest {
 
     @Test
     public void onClickAddSourceView_whenStartedFromPaymentSession_launchesActivityWithLog() {
-        final PaymentMethodsActivity paymentMethodsActivity = createActivity(createIntent()
+        final PaymentMethodsActivity paymentMethodsActivity = createActivity(new Intent()
                 .putExtra(EXTRA_PROXY_DELAY, true)
                 .putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true));
         mShadowActivity = Shadows.shadowOf(paymentMethodsActivity);
@@ -323,21 +331,5 @@ public class PaymentMethodsActivityTest {
         assertNotNull(customerSource);
         assertEquals(customerSource.toJson().toString(),
                 intent.getStringExtra(EXTRA_SELECTED_PAYMENT));
-    }
-
-    @NonNull
-    private PaymentMethodsActivity createActivity(@NonNull Intent intent) {
-        return Robolectric.buildActivity(PaymentMethodsActivity.class, intent)
-                .create()
-                .start()
-                .resume()
-                .visible()
-                .get();
-    }
-
-    @NonNull
-    private Intent createIntent() {
-        return new PaymentMethodsActivityStarter(Robolectric.buildActivity(Activity.class).get())
-                .newIntent();
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.java
@@ -1,13 +1,13 @@
 package com.stripe.android.view;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.stripe.android.model.ShippingMethod;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,23 +21,22 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class SelectShippingMethodWidgetTest {
 
-    private SelectShippingMethodWidget mSelectShippingMethodWidget;
     private ShippingMethodAdapter mShippingMethodAdapter;
     private List<ShippingMethod> mShippingMethods;
 
     @Before
     public void setup() {
         Locale.setDefault(Locale.US);
-        ActivityController<SelectShippingMethodTestActivity> activityController =
-                Robolectric.buildActivity(SelectShippingMethodTestActivity.class).create().start();
-        mSelectShippingMethodWidget = activityController.get().getSelectShippingMethodWidget();
         mShippingMethods = new ArrayList<>();
         ShippingMethod ups = new ShippingMethod("UPS Ground", "ups-ground", "Arrives in 3-5 days", 0, "USD");
         ShippingMethod fedEx = new ShippingMethod("FedEx", "fedex", "Arrives tomorrow", 599, "USD");
         mShippingMethods.add(ups);
         mShippingMethods.add(fedEx);
-        mSelectShippingMethodWidget.setShippingMethods(mShippingMethods, ups);
-        mShippingMethodAdapter = mSelectShippingMethodWidget.mShippingMethodAdapter;
+
+        final SelectShippingMethodWidget selectShippingMethodWidget =
+                new SelectShippingMethodWidget(ApplicationProvider.getApplicationContext());
+        selectShippingMethodWidget.setShippingMethods(mShippingMethods, ups);
+        mShippingMethodAdapter = selectShippingMethodWidget.mShippingMethodAdapter;
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.java
@@ -7,13 +7,12 @@ import com.stripe.android.R;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.ShippingInformation;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,7 @@ import static org.junit.Assert.assertTrue;
  * Test class for {@link ShippingInfoWidget}
  */
 @RunWith(RobolectricTestRunner.class)
-public class ShippingInfoWidgetTest {
+public class ShippingInfoWidgetTest extends BaseViewTest<ShippingInfoTestActivity> {
 
     private ShippingInfoWidget mShippingInfoWidget;
     private TextInputLayout mAddressLine1TextInputLayout;
@@ -47,16 +46,17 @@ public class ShippingInfoWidgetTest {
     private CountryAutoCompleteTextView mCountryAutoCompleteTextView;
 
     private String mNoPostalCodeCountry = "ZW"; // Zimbabwe
-    private Address mAddress;
     private ShippingInformation mShippingInfo;
+
+    public ShippingInfoWidgetTest() {
+        super(ShippingInfoTestActivity.class);
+    }
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         Locale.setDefault(Locale.US);
-        ActivityController<ShippingInfoTestActivity> activityController =
-                Robolectric.buildActivity(ShippingInfoTestActivity.class).create().start();
-        mShippingInfoWidget = activityController.get().getShippingInfoWidget();
+        mShippingInfoWidget = createStartedActivity().getShippingInfoWidget();
         mAddressLine1TextInputLayout = mShippingInfoWidget.findViewById(R.id.tl_address_line1_aaw);
         mAddressLine2TextInputLayout = mShippingInfoWidget.findViewById(R.id.tl_address_line2_aaw);
         mCityTextInputLayout = mShippingInfoWidget.findViewById(R.id.tl_city_aaw);
@@ -71,7 +71,7 @@ public class ShippingInfoWidgetTest {
         mStateEditText = mShippingInfoWidget.findViewById(R.id.et_state_aaw);
         mPhoneEditText = mShippingInfoWidget.findViewById(R.id.et_phone_number_aaw);
         mCountryAutoCompleteTextView = mShippingInfoWidget.findViewById(R.id.country_autocomplete_aaw);
-        mAddress = new Address.Builder()
+        final Address address = new Address.Builder()
                 .setCity("San Francisco")
                 .setState("CA")
                 .setCountry("US")
@@ -79,7 +79,13 @@ public class ShippingInfoWidgetTest {
                 .setLine2("10th Floor")
                 .setPostalCode("12345")
                 .build();
-        mShippingInfo = new ShippingInformation(mAddress, "Fake Name", "(123) 456 - 7890");
+        mShippingInfo = new ShippingInformation(address, "Fake Name", "(123) 456 - 7890");
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.java
@@ -6,14 +6,13 @@ import android.support.v4.content.ContextCompat;
 import com.stripe.android.R;
 import com.stripe.android.testharness.ViewTestUtils;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,21 +26,28 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  * Test class for {@link StripeEditText}.
  */
 @RunWith(RobolectricTestRunner.class)
-public class StripeEditTextTest {
+public class StripeEditTextTest extends BaseViewTest<CardInputTestActivity> {
 
     @Mock private StripeEditText.AfterTextChangedListener mAfterTextChangedListener;
     @Mock private StripeEditText.DeleteEmptyListener mDeleteEmptyListener;
-    private ActivityController<CardInputTestActivity> mActivityController;
     private StripeEditText mEditText;
+
+    public StripeEditTextTest() {
+        super(CardInputTestActivity.class);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mActivityController = Robolectric.buildActivity(CardInputTestActivity.class)
-                .create().start();
 
         // Note that the CVC EditText is a StripeEditText
-        mEditText =  mActivityController.get().getCvcEditText();
+        mEditText = new StripeEditText(createActivity());
         mEditText.setText("");
         mEditText.setDeleteEmptyListener(mDeleteEmptyListener);
         mEditText.setAfterTextChangedListener(mAfterTextChangedListener);
@@ -94,20 +100,20 @@ public class StripeEditTextTest {
 
     @Test
     public void getDefaultErrorColorInt_onDarkTheme_returnsDarkError() {
-        mEditText.setTextColor(mActivityController.get().getResources()
+        mEditText.setTextColor(mEditText.getContext().getResources()
                 .getColor(android.R.color.primary_text_dark));
         @ColorInt int colorInt = mEditText.getDefaultErrorColorInt();
-        @ColorInt int expectedErrorInt = ContextCompat.getColor(mActivityController.get(),
+        @ColorInt int expectedErrorInt = ContextCompat.getColor(mEditText.getContext(),
                 R.color.error_text_dark_theme);
         assertEquals(expectedErrorInt, colorInt);
     }
 
     @Test
     public void getDefaultErrorColorInt_onLightTheme_returnsLightError() {
-        mEditText.setTextColor(mActivityController.get().getResources()
+        mEditText.setTextColor(mEditText.getContext().getResources()
                 .getColor(android.R.color.primary_text_light));
         @ColorInt int colorInt = mEditText.getDefaultErrorColorInt();
-        @ColorInt int expectedErrorInt = ContextCompat.getColor(mActivityController.get(),
+        @ColorInt int expectedErrorInt = ContextCompat.getColor(mEditText.getContext(),
                 R.color.error_text_light_theme);
         assertEquals(expectedErrorInt, colorInt);
     }

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.java
@@ -6,12 +6,11 @@ import android.support.annotation.ColorInt;
 
 import com.stripe.android.model.Card;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -23,39 +22,45 @@ import static org.junit.Assert.assertTrue;
  * Test class for {@link ViewUtils}
  */
 @RunWith(RobolectricTestRunner.class)
-public class ViewUtilsTest {
+public class ViewUtilsTest extends BaseViewTest<CardInputTestActivity> {
 
-    private ActivityController<CardInputTestActivity> mActivityController;
+    public ViewUtilsTest() {
+        super(CardInputTestActivity.class);
+    }
 
     @Before
     public void setup() {
-        mActivityController = Robolectric.buildActivity(CardInputTestActivity.class)
-                .create().start();
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
     }
 
     @Test
     public void getThemeAccentColor_whenOnPostLollipopConfig_getsNonzeroColor() {
-        @ColorInt int color = ViewUtils.getThemeAccentColor(mActivityController.get()).data;
+        @ColorInt int color = ViewUtils.getThemeAccentColor(createActivity()).data;
         assertTrue(Color.alpha(color) > 0);
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.JELLY_BEAN)
     public void getThemeAccentColor_whenOnPreKitKatConfig_getsNonzeroColor() {
-        @ColorInt int color = ViewUtils.getThemeAccentColor(mActivityController.get()).data;
+        @ColorInt int color = ViewUtils.getThemeAccentColor(createActivity()).data;
         assertTrue(Color.alpha(color) > 0);
     }
 
     @Test
     public void getThemeColorControlNormal_whenOnPostLollipopConfig_getsNonzeroColor() {
-        @ColorInt int color = ViewUtils.getThemeColorControlNormal(mActivityController.get()).data;
+        @ColorInt int color = ViewUtils.getThemeColorControlNormal(createActivity()).data;
         assertTrue(Color.alpha(color) > 0);
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.JELLY_BEAN)
     public void getThemeColorControlNormal_whenOnPreKitKatConfig_getsNonzeroColor() {
-        @ColorInt int color = ViewUtils.getThemeColorControlNormal(mActivityController.get()).data;
+        @ColorInt int color = ViewUtils.getThemeColorControlNormal(createActivity()).data;
         assertTrue(Color.alpha(color) > 0);
     }
 


### PR DESCRIPTION
## Summary
Tests that rely on Robolectric's `ActivityController`
need to complete the Activity's lifecycle.

This PR introduces `BaseViewTest` that provides convenience
methods for managing `ActivityController`s.

See https://github.com/robolectric/robolectric/issues/2068 for more information

## Testing
Updated unit tests
