### PR TITLE
Create PaymentIntent.RedirectData

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -141,6 +141,16 @@ public class PaymentIntent extends StripeJsonModel {
 
     @Nullable
     public Uri getRedirectUrl() {
+        final RedirectData redirectData = getRedirectData();
+        if (redirectData == null) {
+            return null;
+        }
+
+        return redirectData.url;
+    }
+
+    @Nullable
+    public RedirectData getRedirectData() {
         final Map<String, Object> nextAction;
 
         final Status status = Status.fromCode(mStatus);
@@ -162,10 +172,7 @@ public class PaymentIntent extends StripeJsonModel {
                 NextActionType.AuthorizeWithUrl == nextActionType) {
             final Object redirectToUrl = nextAction.get(nextActionType.code);
             if (redirectToUrl instanceof Map) {
-                final Object url = ((Map) redirectToUrl).get("url");
-                if (url instanceof String) {
-                    return Uri.parse((String) url);
-                }
+                return RedirectData.create((Map) redirectToUrl);
             }
         }
 
@@ -460,6 +467,46 @@ public class PaymentIntent extends StripeJsonModel {
             }
 
             return null;
+        }
+    }
+
+    static class RedirectData {
+        static final String FIELD_URL = "url";
+        static final String FIELD_RETURN_URL = "return_url";
+
+        /**
+         * See <a href="https://stripe.com/docs/api
+         * /payment_intents/object#payment_intent_object-next_action-redirect_to_url-url">
+         * PaymentIntent.next_action.redirect_to_url.url
+         * </a>
+         */
+        @NonNull public final Uri url;
+
+        /**
+         * See <a href="https://stripe.com/docs/api
+         * /payment_intents/object#payment_intent_object-next_action-redirect_to_url-return_url">
+         * PaymentIntent.next_action.redirect_to_url.return_url
+         * </a>
+         */
+        @Nullable public final Uri returnUrl;
+
+        @Nullable
+        static RedirectData create(@NonNull Map<?, ?> redirectToUrlHash) {
+            final Object urlObj = redirectToUrlHash.get(FIELD_URL);
+            final Object returnUrlObj = redirectToUrlHash.get(FIELD_RETURN_URL);
+            final String url = (urlObj instanceof String) ? urlObj.toString() : null;
+            final String returnUrl = (returnUrlObj instanceof String) ?
+                    returnUrlObj.toString() : null;
+            if (url == null) {
+                return null;
+            }
+
+            return new RedirectData(url, returnUrl);
+        }
+
+        private RedirectData(@NonNull String url, @Nullable String returnUrl) {
+            this.url = Uri.parse(url);
+            this.returnUrl = returnUrl != null ? Uri.parse(returnUrl) : null;
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentRedirectDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentRedirectDataTest.java
@@ -1,0 +1,50 @@
+package com.stripe.android.model;
+
+import android.net.Uri;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(RobolectricTestRunner.class)
+public class PaymentIntentRedirectDataTest {
+
+    @Test
+    public void create_withBothFieldsPopulated_shouldReturnCorrectObject() {
+        final String url = "https://example.com";
+        final String returnUrl = "yourapp://post-authentication-return-url";
+        final Map<String, String> redirectMap = new HashMap<>();
+        redirectMap.put(PaymentIntent.RedirectData.FIELD_URL, url);
+        redirectMap.put(PaymentIntent.RedirectData.FIELD_RETURN_URL, returnUrl);
+
+        final PaymentIntent.RedirectData redirectData = PaymentIntent.RedirectData.create(redirectMap);
+        assertNotNull(redirectData);
+        assertEquals(Uri.parse(url), redirectData.url);
+        assertEquals(Uri.parse(returnUrl), redirectData.returnUrl);
+    }
+
+    @Test
+    public void create_withOnlyUrlFieldPopulated_shouldReturnCorrectObject() {
+        final String url = "https://example.com";
+        final Map<String, String> redirectMap = new HashMap<>();
+        redirectMap.put(PaymentIntent.RedirectData.FIELD_URL, url);
+
+        final PaymentIntent.RedirectData redirectData =
+                PaymentIntent.RedirectData.create(redirectMap);
+        assertNotNull(redirectData);
+        assertEquals(Uri.parse(url), redirectData.url);
+        assertNull(redirectData.returnUrl);
+    }
+
+    @Test
+    public void create_withInvalidData_shouldReturnNull() {
+        assertNull(PaymentIntent.RedirectData.create(new HashMap<>()));
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -59,8 +59,10 @@ public class PaymentIntentTest {
             "  \"livemode\": false,\n" +
             "  \"next_source_action\": {" +
             "       \"type\": \"authorize_with_url\"," +
-            "           authorize_with_url: {" +
-            "           url: \""+ BAD_URL +"\" } " +
+            "           \"authorize_with_url\": {" +
+            "             \"url\": \""+ BAD_URL +"\"," +
+            "             \"return_url\": \"yourapp://post-authentication-return-url\"" +
+            "           } " +
             "       },\n" +
             "  \"receipt_email\": null,\n" +
             "  \"shipping\": null,\n" +
@@ -133,7 +135,8 @@ public class PaymentIntentTest {
             "\t\"next_action\": {\n" +
             "\t\t\"type\": \"redirect_to_url\",\n" +
             "\t\t\"redirect_to_url\": {\n" +
-            "\t\t\t\"url\": \"https://example.com/redirect\"\n" +
+            "\t\t\t\"url\": \"https://example.com/redirect\",\n" +
+            "\t\t\t\"return_url\": \"yourapp://post-authentication-return-url\"\n" +
             "\t\t}\n" +
             "\t}\n" +
             "}";
@@ -145,7 +148,8 @@ public class PaymentIntentTest {
             "\t\"next_action\": {\n" +
             "\t\t\"type\": \"authorize_with_url\",\n" +
             "\t\t\"authorize_with_url\": {\n" +
-            "\t\t\t\"url\": \"https://example.com/redirect\"\n" +
+            "\t\t\t\"url\": \"https://example.com/redirect\",\n" +
+            "\t\t\t\"return_url\": \"yourapp://post-authentication-return-url\"\n" +
             "\t\t}\n" +
             "\t}\n" +
             "}";


### PR DESCRIPTION
## Summary
PaymentIntent's `next_action.redirect_to_url` hash includes both
`url` and `return_url`. Capture both of these fields in `RedirectData`.

## Motivation
MOBILE3DS2-357

## Testing
Add unit tests
