### PR TITLE
Don't expose CustomerSession's EphemeralKeyManager.KeyManagerListener implementation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -15,15 +15,16 @@ import java.util.concurrent.TimeUnit;
 class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
 
     @NonNull private final Class<TEphemeralKey> mEphemeralKeyClass;
-    private @Nullable TEphemeralKey mEphemeralKey;
-    private @NonNull EphemeralKeyProvider mEphemeralKeyProvider;
-    private @Nullable Calendar mOverrideCalendar;
-    private @NonNull KeyManagerListener mListener;
+    @NonNull private final EphemeralKeyProvider mEphemeralKeyProvider;
+    @Nullable private final Calendar mOverrideCalendar;
+    @NonNull private final KeyManagerListener<TEphemeralKey> mListener;
     private final long mTimeBufferInSeconds;
+
+    @Nullable private TEphemeralKey mEphemeralKey;
 
     EphemeralKeyManager(
             @NonNull EphemeralKeyProvider ephemeralKeyProvider,
-            @NonNull KeyManagerListener keyManagerListener,
+            @NonNull KeyManagerListener<TEphemeralKey> keyManagerListener,
             long timeBufferInSeconds,
             @Nullable Calendar overrideCalendar,
             @NonNull Class<TEphemeralKey> ephemeralKeyClass) {


### PR DESCRIPTION
## Summary & Motivation
Previously, `CustomerSession` implemented `EphemeralKeyManager.KeyManagerListener`,
which meant that the methods of that interface were exposed in `CustomerSession`'s
public API. We don't want users calling these methods directly, so instead implement
as an anonymous class.

## Testing
Ran unit tests
