### PR TITLE
Update PaymentIntent model for API 2019-02-11

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -38,8 +38,15 @@
    CustomerSession.getInstance().setCustomerShippingInformation(listener);
    ```
 
+- `PaymentIntent` has been updated to reflect [API version 2019-02-11](https://stripe.com/docs/upgrades#2019-02-11)
+    - `PaymentIntent.Status.RequiresSource` is now `PaymentIntent.Status.RequiresPaymentMethod`
+    - `PaymentIntent.Status.RequiresSourceAction` is now `PaymentIntent.Status.RequiresAction`
+    - `PaymentIntent#getNextSourceAction()` is now `PaymentIntent#getNextAction()`
+    - `PaymentIntent#getAuthorizationUrl()` is now `PaymentIntent#getRedirectUrl()`
+    - `PaymentIntent#requiresAction()` has been added as a convenience
+
 ### Migrating from versions < 7.0.0
-- Remove Bitcoin source support because Stripe no longer processes Bitcoin payments: https://stripe.com/blog/ending-bitcoin-support
+- Remove Bitcoin source support because Stripe [no longer processes Bitcoin payments](https://stripe.com/blog/ending-bitcoin-support)
     - Sources can no longer have a "BITCOIN" source type. These sources will now be interpreted as "UNKNOWN".
     - You can no longer `createBitcoinParams`. Please use a different payment method.
 

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -256,11 +256,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
                                 if (paymentIntent != null) {
                                     mPaymentIntentValue.setText(paymentIntent.toJson().toString());
 
-                                    final PaymentIntent.Status status = PaymentIntent.Status
-                                            .fromCode(paymentIntent.getStatus());
-
-                                    if (PaymentIntent.Status.RequiresAction == status ||
-                                            PaymentIntent.Status.RequiresSourceAction == status) {
+                                    if (paymentIntent.requiresAction()) {
                                         Toast.makeText(PaymentIntentActivity.this,
                                                 "Redirecting to redirect URL",
                                                 Toast.LENGTH_SHORT)

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -44,7 +44,6 @@ public class PaymentIntent extends StripeJsonModel {
     static final String FIELD_DESCRIPTION = "description";
     static final String FIELD_LIVEMODE = "livemode";
     static final String FIELD_NEXT_ACTION = "next_action";
-    static final String FIELD_NEXT_SOURCE_ACTION = "next_source_action";
     static final String FIELD_PAYMENT_METHOD_TYPES = "payment_method_types";
     static final String FIELD_RECEIPT_EMAIL = "receipt_email";
     static final String FIELD_SOURCE = "source";
@@ -63,7 +62,6 @@ public class PaymentIntent extends StripeJsonModel {
     @Nullable private final String mCurrency;
     @Nullable private final String mDescription;
     @Nullable private final Boolean mLiveMode;
-    @Nullable private final Map<String, Object> mNextSourceAction;
     @Nullable private final Map<String, Object> mNextAction;
 
     @Nullable private final String mReceiptEmail;
@@ -125,13 +123,8 @@ public class PaymentIntent extends StripeJsonModel {
         return mLiveMode;
     }
 
-    /**
-     * @deprecated use {@link #getNextAction()}
-     */
-    @Deprecated
-    @Nullable
-    public Map<String, Object> getNextSourceAction() {
-        return mNextSourceAction;
+    public boolean requiresAction() {
+        return Status.fromCode(mStatus) == Status.RequiresAction;
     }
 
     @Nullable
@@ -146,8 +139,6 @@ public class PaymentIntent extends StripeJsonModel {
         final Status status = Status.fromCode(mStatus);
         if (Status.RequiresAction == status) {
             nextAction = mNextAction;
-        } else if (Status.RequiresSourceAction == status) {
-            nextAction = mNextSourceAction;
         } else {
             nextAction = null;
         }
@@ -170,15 +161,6 @@ public class PaymentIntent extends StripeJsonModel {
         }
 
         return null;
-    }
-
-    /**
-     * @deprecated use {@link #getRedirectUrl()}
-     */
-    @Deprecated
-    @Nullable
-    public Uri getAuthorizationUrl() {
-        return getRedirectUrl();
     }
 
     @Nullable
@@ -209,7 +191,6 @@ public class PaymentIntent extends StripeJsonModel {
             @Nullable String currency,
             @Nullable String description,
             @Nullable Boolean liveMode,
-            @Nullable Map<String, Object> nextSourceAction,
             @Nullable Map<String, Object> nextAction,
             @Nullable String receiptEmail,
             @Nullable String source,
@@ -227,7 +208,6 @@ public class PaymentIntent extends StripeJsonModel {
         mCurrency = currency;
         mDescription = description;
         mLiveMode = liveMode;
-        mNextSourceAction = nextSourceAction;
         mNextAction = nextAction;
         mReceiptEmail = receiptEmail;
         mSource = source;
@@ -270,7 +250,6 @@ public class PaymentIntent extends StripeJsonModel {
         final Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
         final String receiptEmail = optString(jsonObject, FIELD_RECEIPT_EMAIL);
         final String status = optString(jsonObject, FIELD_STATUS);
-        final Map<String, Object> nextSourceAction = optMap(jsonObject, FIELD_NEXT_SOURCE_ACTION);
         final Map<String, Object> nextAction = optMap(jsonObject, FIELD_NEXT_ACTION);
         final String source = optString(jsonObject, FIELD_SOURCE);
 
@@ -287,7 +266,6 @@ public class PaymentIntent extends StripeJsonModel {
                 currency,
                 description,
                 livemode,
-                nextSourceAction,
                 nextAction,
                 receiptEmail,
                 source,
@@ -326,7 +304,6 @@ public class PaymentIntent extends StripeJsonModel {
         putStringIfNotNull(jsonObject, FIELD_CURRENCY, mCurrency);
         putStringIfNotNull(jsonObject, FIELD_DESCRIPTION, mDescription);
         putBooleanIfNotNull(jsonObject, FIELD_LIVEMODE, mLiveMode);
-        putMapIfNotNull(jsonObject, FIELD_NEXT_SOURCE_ACTION, mNextSourceAction);
         putMapIfNotNull(jsonObject, FIELD_NEXT_ACTION, mNextAction);
         putStringIfNotNull(jsonObject, FIELD_RECEIPT_EMAIL, mReceiptEmail);
         putStringIfNotNull(jsonObject, FIELD_SOURCE, mSource);
@@ -350,7 +327,6 @@ public class PaymentIntent extends StripeJsonModel {
         map.put(FIELD_CURRENCY, mCurrency);
         map.put(FIELD_DESCRIPTION, mDescription);
         map.put(FIELD_LIVEMODE, mLiveMode);
-        map.put(FIELD_NEXT_SOURCE_ACTION, mNextSourceAction);
         map.put(FIELD_NEXT_ACTION, mNextAction);
         map.put(FIELD_RECEIPT_EMAIL, mReceiptEmail);
         map.put(FIELD_STATUS, mStatus);
@@ -376,7 +352,6 @@ public class PaymentIntent extends StripeJsonModel {
                 && ObjectUtils.equals(mCurrency, paymentIntent.mCurrency)
                 && ObjectUtils.equals(mDescription, paymentIntent.mDescription)
                 && ObjectUtils.equals(mLiveMode, paymentIntent.mLiveMode)
-                && ObjectUtils.equals(mNextSourceAction, paymentIntent.mNextSourceAction)
                 && ObjectUtils.equals(mReceiptEmail, paymentIntent.mReceiptEmail)
                 && ObjectUtils.equals(mSource, paymentIntent.mSource)
                 && ObjectUtils.equals(mStatus, paymentIntent.mStatus);
@@ -386,7 +361,7 @@ public class PaymentIntent extends StripeJsonModel {
     public int hashCode() {
         return ObjectUtils.hash(mId, mObjectType, mAmount, mCanceledAt,
                 mCaptureMethod, mClientSecret, mConfirmationMethod, mCreated, mCurrency,
-                mDescription, mLiveMode, mNextSourceAction, mReceiptEmail, mSource, mStatus);
+                mDescription, mLiveMode, mReceiptEmail, mSource, mStatus);
     }
 
     public enum NextActionType {
@@ -426,19 +401,7 @@ public class PaymentIntent extends StripeJsonModel {
         RequiresCapture("requires_capture"),
         RequiresConfirmation("requires_confirmation"),
         RequiresPaymentMethod("requires_payment_method"),
-        Succeeded("succeeded"),
-
-        /**
-         * @deprecated use {@link #RequiresPaymentMethod}
-         */
-        @Deprecated
-        RequiresSource("requires_source"),
-
-        /**
-         * @deprecated use {@link #RequiresAction}
-         */
-        @Deprecated
-        RequiresSourceAction("requires_source_action");
+        Succeeded("succeeded");
 
         @NonNull
         public final String code;

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -16,7 +16,9 @@ import java.util.Map;
 import static com.stripe.android.testharness.JsonTestUtils.assertJsonEqualsExcludingNulls;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentIntentTest {
@@ -36,7 +38,7 @@ public class PaymentIntentTest {
             "  \"currency\": \"usd\",\n" +
             "  \"description\": \"Example PaymentIntent charge\",\n" +
             "  \"livemode\": false,\n" +
-            "  \"next_source_action\": null,\n" +
+            "  \"next_action\": null,\n" +
             "  \"receipt_email\": null,\n" +
             "  \"shipping\": null,\n" +
             "  \"source\": \"src_1CkiC3LENEVhOs7YMSa4yx4G\",\n" +
@@ -57,7 +59,7 @@ public class PaymentIntentTest {
             "  \"currency\": \"usd\",\n" +
             "  \"description\": \"Example PaymentIntent charge\",\n" +
             "  \"livemode\": false,\n" +
-            "  \"next_source_action\": {" +
+            "  \"next_action\": {" +
             "       \"type\": \"authorize_with_url\"," +
             "           authorize_with_url: {" +
             "           url: \""+ BAD_URL +"\" } " +
@@ -65,7 +67,7 @@ public class PaymentIntentTest {
             "  \"receipt_email\": null,\n" +
             "  \"shipping\": null,\n" +
             "  \"source\": \"src_1CkiC3LENEVhOs7YMSa4yx4G\",\n" +
-            "  \"status\": \"requires_source_action\"\n" +
+            "  \"status\": \"requires_action\"\n" +
             "}\n";
 
     private static final String PAYMENT_INTENT_WITH_PAYMENT_METHODS_JSON = "{\n" +
@@ -197,9 +199,8 @@ public class PaymentIntentTest {
                 PAYMENT_INTENT_WITH_SOURCE_WITH_BAD_AUTH_URL_JSON);
         assertNotNull(paymentIntent);
 
-        final Uri authUrl = paymentIntent.getAuthorizationUrl();
+        final Uri authUrl = paymentIntent.getRedirectUrl();
         assertNotNull(authUrl);
-
         assertEquals(BAD_URL, authUrl.getEncodedPath());
     }
 
@@ -208,6 +209,7 @@ public class PaymentIntentTest {
         final PaymentIntent paymentIntent = PaymentIntent
                 .fromString(PARTIAL_PAYMENT_INTENT_WITH_REDIRECT_URL_JSON);
         assertNotNull(paymentIntent);
+        assertTrue(paymentIntent.requiresAction());
         final Uri redirectUrl = paymentIntent.getRedirectUrl();
         assertNotNull(redirectUrl);
         assertEquals("https://example.com/redirect", redirectUrl.toString());
@@ -235,6 +237,7 @@ public class PaymentIntentTest {
         final PaymentIntent paymentIntent =
                 PaymentIntent.fromString(PAYMENT_INTENT_WITH_PAYMENT_METHODS_JSON);
         assertNotNull(paymentIntent);
+        assertFalse(paymentIntent.requiresAction());
         assertEquals("card", paymentIntent.getPaymentMethodTypes().get(0));
     }
 }


### PR DESCRIPTION
## Summary
- Add `requiresAction()` to simplify checking if `status` is `"requires_action"`
- Replace `"next_source_action"` with `"next_action"`
- Remove deprecated fields and methods
- Update MIGRATING.md

https://stripe.com/docs/upgrades#2019-02-11

## Motivation
ANDROID-354

## Testing
Updated tests
