### PR TITLE
Add PaymentMethod support to CustomerSession

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -15,6 +15,7 @@ import android.support.v4.content.LocalBroadcastManager;
 
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.Customer;
+import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.Source;
 
@@ -43,8 +44,11 @@ public class CustomerSession {
 
     private static final String ACTION_ADD_SOURCE = "add_source";
     private static final String ACTION_DELETE_SOURCE = "delete_source";
+    private static final String ACTION_ATTACH_PAYMENT_METHOD = "attach_payment_method";
+    private static final String ACTION_DETACH_PAYMENT_METHOD = "detach_payment_method";
     private static final String ACTION_SET_DEFAULT_SOURCE = "default_source";
     private static final String ACTION_SET_CUSTOMER_SHIPPING_INFO = "set_shipping_info";
+    private static final String KEY_PAYMENT_METHOD = "payment_method";
     private static final String KEY_SOURCE = "source";
     private static final String KEY_SOURCE_TYPE = "source_type";
     private static final String KEY_SHIPPING_INFO = "shipping_info";
@@ -60,7 +64,9 @@ public class CustomerSession {
     private static final int CUSTOMER_RETRIEVED = 7;
     private static final int CUSTOMER_ERROR = 11;
     private static final int SOURCE_RETRIEVED = 13;
+    private static final int PAYMENT_METHOD_RETRIEVED = 15;
     private static final int SOURCE_ERROR = 17;
+    private static final int PAYMENT_METHOD_ERROR = 21;
     private static final int CUSTOMER_SHIPPING_INFO_SAVED = 19;
 
     // The maximum number of active threads we support
@@ -82,6 +88,8 @@ public class CustomerSession {
             new HashMap<>();
     @NonNull private final Map<String, SourceRetrievalListener> mSourceRetrievalListeners =
             new HashMap<>();
+    @NonNull private final Map<String, PaymentMethodRetrievalListener>
+            mPaymentMethodRetrievalListeners = new HashMap<>();
 
     @NonNull private final EphemeralKeyManager mEphemeralKeyManager;
     @NonNull private final Handler mUiThreadHandler;
@@ -324,6 +332,48 @@ public class CustomerSession {
     }
 
     /**
+     * Attaches a PaymentMethod to a Customer.
+     *
+     * @param paymentMethodId the ID of the payment method to be attached
+     * @param listener        a {@link PaymentMethodRetrievalListener} to be notified when the
+     *                        api call is complete
+     */
+    public void attachPaymentMethod(
+            @NonNull String paymentMethodId,
+            @Nullable PaymentMethodRetrievalListener listener) {
+        final Map<String, Object> arguments = new HashMap<>();
+        arguments.put(KEY_PAYMENT_METHOD, paymentMethodId);
+
+        final String operationId = UUID.randomUUID().toString();
+        if (listener != null) {
+            mPaymentMethodRetrievalListeners.put(operationId, listener);
+        }
+        mEphemeralKeyManager
+                .retrieveEphemeralKey(operationId, ACTION_ATTACH_PAYMENT_METHOD, arguments);
+    }
+
+    /**
+     * Detaches a PaymentMethod from a Customer.
+     *
+     * @param paymentMethodId the ID of the payment method to be detached
+     * @param listener        a {@link PaymentMethodRetrievalListener} to be notified when the
+     *                        api call is complete. The api call will return the removed source.
+     */
+    public void detachPaymentMethod(
+            @NonNull String paymentMethodId,
+            @Nullable PaymentMethodRetrievalListener listener) {
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put(KEY_PAYMENT_METHOD, paymentMethodId);
+
+        final String operationId = UUID.randomUUID().toString();
+        if (listener != null) {
+            mPaymentMethodRetrievalListeners.put(operationId, listener);
+        }
+        mEphemeralKeyManager
+                .retrieveEphemeralKey(operationId, ACTION_DETACH_PAYMENT_METHOD, arguments);
+    }
+
+    /**
      * Set the shipping information on the current customer object.
      *
      * @param shippingInformation the data to be set
@@ -430,6 +480,58 @@ public class CustomerSession {
                 } catch (StripeException stripeEx) {
                     mUiThreadHandler.sendMessage(
                             mUiThreadHandler.obtainMessage(SOURCE_ERROR,
+                                    new ExceptionMessage(operationId, stripeEx)));
+                    sendErrorIntent(stripeEx);
+                }
+            }
+        };
+        executeRunnable(fetchCustomerRunnable);
+    }
+
+    private void attachPaymentMethod(
+            @NonNull final CustomerEphemeralKey key,
+            @NonNull final String paymentMethodId,
+            @Nullable final String operationId) {
+        final Runnable fetchCustomerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final PaymentMethodMessage paymentMethodMessage = new PaymentMethodMessage(
+                            operationId,
+                            attachCustomerPaymentMethodWithKey(key, paymentMethodId)
+                    );
+                    mUiThreadHandler.sendMessage(mUiThreadHandler
+                            .obtainMessage(PAYMENT_METHOD_RETRIEVED, paymentMethodMessage));
+                } catch (StripeException stripeEx) {
+                    mUiThreadHandler
+                            .sendMessage(mUiThreadHandler.obtainMessage(PAYMENT_METHOD_ERROR,
+                                    new ExceptionMessage(operationId, stripeEx)));
+                    sendErrorIntent(stripeEx);
+                }
+            }
+        };
+
+        executeRunnable(fetchCustomerRunnable);
+    }
+
+    private void detachPaymentMethod(
+            @NonNull final CustomerEphemeralKey key,
+            @NonNull final String paymentMethodId,
+            @Nullable final String operationId) {
+        final Runnable fetchCustomerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final PaymentMethodMessage paymentMethodMessage = new PaymentMethodMessage(
+                            operationId,
+                            detachCustomerPaymentMethodWithKey(key, paymentMethodId)
+                    );
+                    mUiThreadHandler.sendMessage(mUiThreadHandler
+                            .obtainMessage(PAYMENT_METHOD_RETRIEVED, paymentMethodMessage));
+
+                } catch (StripeException stripeEx) {
+                    mUiThreadHandler.sendMessage(mUiThreadHandler
+                            .obtainMessage(PAYMENT_METHOD_ERROR,
                                     new ExceptionMessage(operationId, stripeEx)));
                     sendErrorIntent(stripeEx);
                 }
@@ -551,6 +653,21 @@ public class CustomerSession {
                             (String) arguments.get(KEY_SOURCE),
                             operationId);
                     resetUsageTokens();
+                } else if (ACTION_ATTACH_PAYMENT_METHOD.equals(actionString) &&
+                        arguments.containsKey(KEY_PAYMENT_METHOD)) {
+                    attachPaymentMethod(
+                            ephemeralKey,
+                            (String) arguments.get(KEY_PAYMENT_METHOD),
+                            operationId
+                    );
+                    resetUsageTokens();
+                } else if (ACTION_DETACH_PAYMENT_METHOD.equals(actionString) &&
+                        arguments.containsKey(KEY_PAYMENT_METHOD)) {
+                    detachPaymentMethod(
+                            ephemeralKey,
+                            (String) arguments.get(KEY_PAYMENT_METHOD),
+                            operationId);
+                    resetUsageTokens();
                 } else if (ACTION_SET_DEFAULT_SOURCE.equals(actionString) &&
                         arguments.containsKey(KEY_SOURCE) &&
                         arguments.containsKey(KEY_SOURCE_TYPE)) {
@@ -657,6 +774,31 @@ public class CustomerSession {
     }
 
     @Nullable
+    private PaymentMethod attachCustomerPaymentMethodWithKey(
+            @NonNull CustomerEphemeralKey key,
+            @NonNull String paymentMethodId) throws StripeException {
+        return mApiHandler.attachPaymentMethod(
+                key.getCustomerId(),
+                PaymentConfiguration.getInstance().getPublishableKey(),
+                new ArrayList<>(mProductUsageTokens),
+                paymentMethodId,
+                key.getSecret()
+        );
+    }
+
+    @Nullable
+    private PaymentMethod detachCustomerPaymentMethodWithKey(
+            @NonNull CustomerEphemeralKey key,
+            @NonNull String paymentMethodId) throws StripeException {
+        return mApiHandler.detachPaymentMethod(
+                PaymentConfiguration.getInstance().getPublishableKey(),
+                new ArrayList<>(mProductUsageTokens),
+                paymentMethodId,
+                key.getSecret()
+        );
+    }
+
+    @Nullable
     private Customer setCustomerShippingInfoWithKey(
             @NonNull CustomerEphemeralKey key,
             @NonNull ShippingInformation shippingInformation) throws StripeException {
@@ -717,6 +859,12 @@ public class CustomerSession {
         return mSourceRetrievalListeners.remove(operationId);
     }
 
+    @Nullable
+    private PaymentMethodRetrievalListener getPaymentMethodRetrievalListener(
+            @Nullable String operationId) {
+        return mPaymentMethodRetrievalListeners.remove(operationId);
+    }
+
     public abstract static class ActivityCustomerRetrievalListener<A extends Activity>
             implements CustomerRetrievalListener {
 
@@ -740,6 +888,10 @@ public class CustomerSession {
         void onSourceRetrieved(@NonNull Source source);
     }
 
+    public interface PaymentMethodRetrievalListener extends RetrievalListener {
+        void onPaymentMethodRetrieved(@NonNull PaymentMethod paymentMethod);
+    }
+
     interface RetrievalListener {
         void onError(int errorCode, @Nullable String errorMessage,
                      @Nullable StripeError stripeError);
@@ -754,6 +906,24 @@ public class CustomerSession {
         @NonNull private final WeakReference<A> mActivityRef;
 
         public ActivitySourceRetrievalListener(@NonNull A activity) {
+            this.mActivityRef = new WeakReference<>(activity);
+        }
+
+        @Nullable
+        protected A getActivity() {
+            return mActivityRef.get();
+        }
+    }
+
+    /**
+     * Abstract implementation of {@link PaymentMethodRetrievalListener} that holds a
+     * {@link WeakReference} to an {@link Activity} object.
+     */
+    public abstract static class ActivityPaymentMethodRetrievalListener<A extends Activity>
+            implements PaymentMethodRetrievalListener {
+        @NonNull private final WeakReference<A> mActivityRef;
+
+        public ActivityPaymentMethodRetrievalListener(@NonNull A activity) {
             this.mActivityRef = new WeakReference<>(activity);
         }
 
@@ -780,6 +950,17 @@ public class CustomerSession {
         private SourceMessage(@Nullable String operationId, @Nullable Source source) {
             this.operationId = operationId;
             this.source = source;
+        }
+    }
+
+    private static class PaymentMethodMessage {
+        @Nullable private final String operationId;
+        @Nullable private final PaymentMethod paymentMethod;
+
+        private PaymentMethodMessage(@Nullable String operationId,
+                                     @Nullable PaymentMethod paymentMethod) {
+            this.operationId = operationId;
+            this.paymentMethod = paymentMethod;
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/LoggingUtils.java
@@ -33,6 +33,8 @@ class LoggingUtils {
     @StringDef({
             EVENT_TOKEN_CREATION,
             EVENT_ADD_PAYMENT_METHOD,
+            EVENT_ATTACH_PAYMENT_METHOD,
+            EVENT_DETACH_PAYMENT_METHOD,
             EVENT_SOURCE_CREATION,
             EVENT_ADD_SOURCE,
             EVENT_DEFAULT_SOURCE,
@@ -45,6 +47,8 @@ class LoggingUtils {
 
     static final String EVENT_TOKEN_CREATION = "token_creation";
     static final String EVENT_ADD_PAYMENT_METHOD = "add_payment_method";
+    static final String EVENT_ATTACH_PAYMENT_METHOD = "attach_payment_method";
+    static final String EVENT_DETACH_PAYMENT_METHOD = "detach_payment_method";
     static final String EVENT_SOURCE_CREATION = "source_creation";
     static final String EVENT_ADD_SOURCE = "add_source";
     static final String EVENT_DEFAULT_SOURCE = "default_source";
@@ -157,6 +161,28 @@ class LoggingUtils {
                 null,
                 null,
                 publishableKey, EVENT_DELETE_SOURCE);
+    }
+
+    @NonNull
+    Map<String, Object> getAttachPaymentMethodParams(
+            @Nullable List<String> productUsageTokens,
+            @NonNull String publishableKey) {
+        return getEventLoggingParams(
+                productUsageTokens,
+                null,
+                null,
+                publishableKey, EVENT_ATTACH_PAYMENT_METHOD);
+    }
+
+    @NonNull
+    Map<String, Object> getDetachPaymentMethodParams(
+            @Nullable List<String> productUsageTokens,
+            @NonNull String publishableKey) {
+        return getEventLoggingParams(
+                productUsageTokens,
+                null,
+                null,
+                publishableKey, EVENT_DETACH_PAYMENT_METHOD);
     }
 
     @NonNull

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -114,6 +114,24 @@ public class StripeApiHandlerTest {
     }
 
     @Test
+    public void getAttachPaymentMethodUrl() {
+        final String paymentMethodId = "pm_1ETDEa2eZvKYlo2CN5828c52";
+        final String attachUrl = mApiHandler.getAttachPaymentMethodUrl(paymentMethodId);
+        final String expectedUrl = String.join("", "https://api.stripe.com/v1/payment_methods/",
+                paymentMethodId, "/attach");
+        assertEquals(expectedUrl, attachUrl);
+    }
+
+    @Test
+    public void getDetachPaymentMethodUrl() {
+        final String paymentMethodId = "pm_1ETDEa2eZvKYlo2CN5828c52";
+        final String detachUrl = mApiHandler.getDetachPaymentMethodUrl(paymentMethodId);
+        final String expectedUrl = String.join("", "https://api.stripe.com/v1/payment_methods/",
+                paymentMethodId, "/detach");
+        assertEquals(expectedUrl, detachUrl);
+    }
+
+    @Test
     public void getHeaders_withAllRequestOptions_properlyMapsRequestOptions() {
         String fakePublicKey = "fake_public_key";
         String idempotencyKey = "idempotency_rules";


### PR DESCRIPTION
## Summary
Add PaymentMethod support to CustomerSession to attach and detach payment methods to customers.

## Motivation
ANDROID-353

## Testing
Automated tests
