### PR TITLE
Configure Gradle signing plugin to use gpg-agent

### DIFF
--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -81,7 +81,12 @@ afterEvaluate { project ->
 
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        useGpgCmd()
         sign configurations.archives
+    }
+
+    tasks.withType(Sign) {
+        onlyIf { isReleaseBuild() && project.hasProperty('signing.gnupg.keyName') }
     }
 
     task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
## Summary
See https://github.com/stripe/stripe-java/pull/665 for more details.

## Testing
Ran sign task and confirmed that aar and asc files are generated.
