### PR TITLE
Correctly handle PaymentIntent in samplestore app

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -25,18 +25,17 @@
         </activity>
         <activity
             android:name=".activity.PaymentIntentActivity"
-            android:theme="@style/SampleTheme"
-            android:launchMode="singleInstance">
+            android:launchMode="singleInstance"
+            android:theme="@style/SampleTheme">
             <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-
-            <data
-                android:host="payment_intent_return"
-                android:scheme="stripe"/>
-        </intent-filter>
+                <data
+                    android:host="payment_intent_return"
+                    android:scheme="stripe" />
+            </intent-filter>
         </activity>
         <service
             android:name=".service.TokenIntentService"

--- a/samplestore/src/main/AndroidManifest.xml
+++ b/samplestore/src/main/AndroidManifest.xml
@@ -19,8 +19,15 @@
                   android:theme="@style/AppTheme.NoActionBar">
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="stripe"
+                    android:host="payment-auth-return"/>
             </intent-filter>
 
         </activity>

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.java
@@ -1,6 +1,7 @@
 package com.stripe.samplestore;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -12,10 +13,19 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.stripe.android.CustomerSession;
 import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.Stripe;
+import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.model.PaymentIntentParams;
 import com.stripe.samplestore.service.SampleStoreEphemeralKeyProvider;
+
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
 
 public class StoreActivity
         extends AppCompatActivity
@@ -32,6 +42,8 @@ public class StoreActivity
     static final int PURCHASE_REQUEST = 37;
 
     private static final String EXTRA_PRICE_PAID = "EXTRA_PRICE_PAID";
+
+    @NonNull private final CompositeDisposable mCompositeDisposable = new CompositeDisposable();
 
     private FloatingActionButton mGoToCartButton;
     private StoreAdapter mStoreAdapter;
@@ -62,10 +74,13 @@ public class StoreActivity
 
         mGoToCartButton.setOnClickListener(v -> mStoreAdapter.launchPurchaseActivityWithCart());
         setupCustomerSession();
+
+        handlePostAuthReturn();
     }
 
     @Override
     protected void onDestroy() {
+        mCompositeDisposable.dispose();
         mEphemeralKeyProvider.destroy();
         super.onDestroy();
     }
@@ -91,6 +106,57 @@ public class StoreActivity
             mGoToCartButton.show();
         } else {
             mGoToCartButton.hide();
+        }
+    }
+
+    /**
+     * If the intent URI matches the post auth deep-link URI, the user attempted to authenticate
+     * payment and was returned to the app. Retrieve the PaymentIntent and inform the user about
+     * the state of their payment.
+     */
+    private void handlePostAuthReturn() {
+        final Uri intentUri = getIntent().getData();
+        if (intentUri != null) {
+            if ("stripe".equals(intentUri.getScheme()) &&
+                    "payment-auth-return".equals(intentUri.getHost())) {
+                final String paymentIntentClientSecret =
+                        intentUri.getQueryParameter("payment_intent_client_secret");
+                if (paymentIntentClientSecret != null) {
+                    final Stripe stripe = new Stripe(getApplicationContext(),
+                            PaymentConfiguration.getInstance().getPublishableKey());
+                    final PaymentIntentParams paymentIntentParams = PaymentIntentParams
+                            .createRetrievePaymentIntentParams(paymentIntentClientSecret);
+                    mCompositeDisposable.add(Observable
+                            .fromCallable(() ->
+                                    stripe.retrievePaymentIntentSynchronous(paymentIntentParams,
+                                            PaymentConfiguration.getInstance().getPublishableKey()))
+                            .subscribeOn(Schedulers.io())
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribe((paymentIntent -> {
+                                if (paymentIntent != null) {
+                                    handleRetrievedPaymentIntent(paymentIntent);
+                                }
+                            }))
+                    );
+                }
+            }
+        }
+    }
+
+    private void handleRetrievedPaymentIntent(@NonNull PaymentIntent paymentIntent) {
+        final PaymentIntent.Status status =
+                PaymentIntent.Status.fromCode(paymentIntent.getStatus());
+        if (status == PaymentIntent.Status.Succeeded) {
+            if (paymentIntent.getAmount() != null) {
+                displayPurchase(paymentIntent.getAmount());
+            }
+        } else if (status == PaymentIntent.Status.RequiresPaymentMethod) {
+            Toast.makeText(this, "User failed authentication", Toast.LENGTH_SHORT)
+                    .show();
+        } else {
+            Toast.makeText(this, "PaymentIntent status: " + paymentIntent.getStatus(),
+                    Toast.LENGTH_SHORT)
+                    .show();
         }
     }
 


### PR DESCRIPTION

## Summary
A PaymentIntent may require user action to authenticate
the purchase before capture can happen.

Add logic to specify a return URL when confirming the
PaymentIntent, then handle the return deep link and
handle the result accordingly.

## Motivation
MOBILE3DS2-360

## Testing
Use "4000000000003220" during checkout
