### PR TITLE
Fix for PIN management

### DIFF
--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -48,7 +48,7 @@ public class IssuingCardPinService
      * Create a IssuingCardPinService with the provided {@link EphemeralKeyProvider}.
      *
      * @param keyProvider an {@link EphemeralKeyProvider} used to get
-     *                    {@link CustomerEphemeralKey EphemeralKeys} as needed
+     *                    {@link IssuingCardEphemeralKey EphemeralKeys} as needed
      */
     @NonNull
     public static IssuingCardPinService create(
@@ -168,16 +168,22 @@ public class IssuingCardPinService
                             "The one-time code has expired",
                             null);
                 }
-                if ("incorrect_code".equals(e.getErrorCode())) {
+                else if ("incorrect_code".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_INCORRECT,
                             "The one-time code was incorrect",
                             null);
                 }
-                if ("too_many_attempts".equals(e.getErrorCode())) {
+                else if ("too_many_attempts".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
                             "The verification challenge was attempted too many times",
+                            null);
+                }
+                else if ("already_redeemed".equals(e.getErrorCode())) {
+                    listener.onError(
+                            CardPinActionError.ONE_TIME_CODE_ALREADY_REDEEMED,
+                            "The verification challenge was already redeemed",
                             null);
                 } else {
                     listener.onError(
@@ -237,18 +243,24 @@ public class IssuingCardPinService
                             "The one-time code has expired",
                             null);
                 }
-                if ("incorrect_code".equals(e.getErrorCode())) {
+                else if ("incorrect_code".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_INCORRECT,
                             "The one-time code was incorrect",
                             null);
                 }
-                if ("too_many_attempts".equals(e.getErrorCode())) {
+                else if ("too_many_attempts".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
                             "The verification challenge was attempted too many times",
                             null);
-                } else {
+                }
+                else if ("already_redeemed".equals(e.getErrorCode())) {
+                    listener.onError(
+                            CardPinActionError.ONE_TIME_CODE_ALREADY_REDEEMED,
+                            "The verification challenge was already redeemed",
+                            null);
+                }  else {
                     listener.onError(
                             CardPinActionError.UNKNOWN_ERROR,
                             "The call to update the PIN failed, possibly an error " +
@@ -294,6 +306,7 @@ public class IssuingCardPinService
         ONE_TIME_CODE_INCORRECT,
         ONE_TIME_CODE_EXPIRED,
         ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
+        ONE_TIME_CODE_ALREADY_REDEEMED,
     }
 
     public interface IssuingCardPinRetrievalListener {

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -167,20 +167,17 @@ public class IssuingCardPinService
                             CardPinActionError.ONE_TIME_CODE_EXPIRED,
                             "The one-time code has expired",
                             null);
-                }
-                else if ("incorrect_code".equals(e.getErrorCode())) {
+                } else if ("incorrect_code".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_INCORRECT,
                             "The one-time code was incorrect",
                             null);
-                }
-                else if ("too_many_attempts".equals(e.getErrorCode())) {
+                } else if ("too_many_attempts".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
                             "The verification challenge was attempted too many times",
                             null);
-                }
-                else if ("already_redeemed".equals(e.getErrorCode())) {
+                } else if ("already_redeemed".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_ALREADY_REDEEMED,
                             "The verification challenge was already redeemed",
@@ -242,25 +239,22 @@ public class IssuingCardPinService
                             CardPinActionError.ONE_TIME_CODE_EXPIRED,
                             "The one-time code has expired",
                             null);
-                }
-                else if ("incorrect_code".equals(e.getErrorCode())) {
+                } else if ("incorrect_code".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_INCORRECT,
                             "The one-time code was incorrect",
                             null);
-                }
-                else if ("too_many_attempts".equals(e.getErrorCode())) {
+                } else if ("too_many_attempts".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_TOO_MANY_ATTEMPTS,
                             "The verification challenge was attempted too many times",
                             null);
-                }
-                else if ("already_redeemed".equals(e.getErrorCode())) {
+                } else if ("already_redeemed".equals(e.getErrorCode())) {
                     listener.onError(
                             CardPinActionError.ONE_TIME_CODE_ALREADY_REDEEMED,
                             "The verification challenge was already redeemed",
                             null);
-                }  else {
+                } else {
                     listener.onError(
                             CardPinActionError.UNKNOWN_ERROR,
                             "The call to update the PIN failed, possibly an error " +


### PR DESCRIPTION
## Summary
Fixed a couple things:
- Wrong naming in a comment
- was using `if / if / if` instead of `if / else if / else if`
- error `already_redeemed` was not handled, and it can be quite important

## Motivation
Bug fixes 

## Testing
Existing tests will apply