### PR TITLE
Refactor CustomerSession

### DIFF
--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -27,16 +27,17 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
             @NonNull KeyManagerListener<TEphemeralKey> keyManagerListener,
             long timeBufferInSeconds,
             @Nullable Calendar overrideCalendar,
+            @NonNull OperationIdFactory operationIdFactory,
             @NonNull Class<TEphemeralKey> ephemeralKeyClass) {
         mEphemeralKeyClass = ephemeralKeyClass;
         mEphemeralKeyProvider = ephemeralKeyProvider;
         mListener = keyManagerListener;
         mTimeBufferInSeconds = timeBufferInSeconds;
         mOverrideCalendar = overrideCalendar;
-        retrieveEphemeralKey(null, null, null);
+        retrieveEphemeralKey(operationIdFactory.create(), null, null);
     }
 
-    void retrieveEphemeralKey(@Nullable String operationId,
+    void retrieveEphemeralKey(@NonNull String operationId,
                               @Nullable String actionString,
                               @Nullable Map<String, Object> arguments) {
         if (shouldRefreshKey(
@@ -58,7 +59,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
 
     @SuppressWarnings("checkstyle:IllegalCatch")
     private void updateKey(
-            @Nullable String operationId,
+            @NonNull String operationId,
             @NonNull String key,
             @Nullable String actionString,
             @Nullable Map<String, Object> arguments) {
@@ -90,7 +91,7 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
         }
     }
 
-    private void updateKeyError(@Nullable String operationId, int errorCode,
+    private void updateKeyError(@NonNull String operationId, int errorCode,
                                 @Nullable String errorMessage) {
         mEphemeralKey = null;
         mListener.onKeyError(operationId, errorCode, errorMessage);
@@ -112,22 +113,22 @@ class EphemeralKeyManager<TEphemeralKey extends AbstractEphemeralKey> {
     }
 
     interface KeyManagerListener<TEphemeralKey extends AbstractEphemeralKey> {
-        void onKeyUpdate(@NonNull TEphemeralKey ephemeralKey, @Nullable String operationId,
+        void onKeyUpdate(@NonNull TEphemeralKey ephemeralKey, @NonNull String operationId,
                          @Nullable String action, @Nullable Map<String, Object> arguments);
 
-        void onKeyError(@Nullable String operationId, int errorCode, @Nullable String errorMessage);
+        void onKeyError(@NonNull String operationId, int errorCode, @Nullable String errorMessage);
     }
 
     private static class ClientKeyUpdateListener implements EphemeralKeyUpdateListener {
 
         @Nullable private final String mActionString;
-        @Nullable private final String mOperationId;
+        @NonNull private final String mOperationId;
         @Nullable private final Map<String, Object> mArguments;
         @NonNull private final WeakReference<EphemeralKeyManager> mEphemeralKeyManagerRef;
 
         ClientKeyUpdateListener(
                 @NonNull EphemeralKeyManager keyManager,
-                @Nullable String operationId,
+                @NonNull String operationId,
                 @Nullable String actionString,
                 @Nullable Map<String, Object> arguments) {
             mEphemeralKeyManagerRef = new WeakReference<>(keyManager);

--- a/stripe/src/main/java/com/stripe/android/OperationIdFactory.java
+++ b/stripe/src/main/java/com/stripe/android/OperationIdFactory.java
@@ -1,0 +1,12 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+
+import java.util.UUID;
+
+class OperationIdFactory {
+    @NonNull
+    String create() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -39,12 +39,9 @@ public class IssuingCardPinServiceTest {
             "            }]\n" +
             "}";
 
-    @Mock
-    private RequestExecutor mRequestExecutor;
-    @Mock
-    IssuingCardPinService.IssuingCardPinRetrievalListener mockRetrievalListener;
-    @Mock
-    IssuingCardPinService.IssuingCardPinUpdateListener mockUpdateListener;
+    @Mock private RequestExecutor mRequestExecutor;
+    @Mock private IssuingCardPinService.IssuingCardPinRetrievalListener mockRetrievalListener;
+    @Mock private IssuingCardPinService.IssuingCardPinUpdateListener mockUpdateListener;
 
     private IssuingCardPinService service;
 
@@ -58,10 +55,10 @@ public class IssuingCardPinServiceTest {
         final StripeApiHandler apiHandler = new StripeApiHandler(
                 ApplicationProvider.getApplicationContext(),
                 mRequestExecutor,
-                false
-        );
+                false);
 
-        service = new IssuingCardPinService(ephemeralKeyProvider, apiHandler);
+        service = new IssuingCardPinService(ephemeralKeyProvider, apiHandler,
+                new OperationIdFactory());
     }
 
     @Test


### PR DESCRIPTION
## Summary
* Create convenience classes in `CustomerSession` for
  abstracting common logic for `Runnable`s and `MessageData`
* Consolidate `CustomerSession`'s listener maps to a single map
* Create `OperationIdFactory`
* Require non-null `operationId`

## Motivation
These changes will simplify adding future methods to `CustomerSession`

## Testing
Add unit tests and manually test in apps