### PR TITLE
Add support for /confirm_payment endpoint

### DIFF
--- a/samplestore/src/main/java/com/stripe/samplestore/service/StripeService.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/service/StripeService.java
@@ -17,6 +17,16 @@ public interface StripeService {
     @POST("capture_payment")
     Observable<ResponseBody> capturePayment(@Body Map<String, Object> params);
 
+    /**
+     * Used for Payment Intent Manual confirmation
+     *
+     * @see <a
+     * href="https://stripe.com/docs/payments/payment-intents/quickstart#manual-confirmation-flow">
+     * Manual Confirmation Flow</a>
+     */
+    @POST("confirm_payment")
+    Observable<ResponseBody> confirmPayment(@Body Map<String, Object> params);
+
     @FormUrlEncoded
     @POST("ephemeral_keys")
     Observable<ResponseBody> createEphemeralKey(@FieldMap Map<String, String> apiVersionMap);


### PR DESCRIPTION
## Summary
This endpoint already exists on the example backend:
https://github.com/stripe/example-ios-backend/blob/master/web.rb#L69

## Motivation
Support manual confirmation flow

## Testing
<!-- How was the code tested? Be as specific as possible. -->
