### PR TITLE
Add business_type param to Account tokenization when available

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
@@ -3,7 +3,6 @@ package com.stripe.android;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
@@ -136,14 +135,17 @@ public class StripeNetworkUtils {
 
             if (mapToEdit.get(key) instanceof CharSequence) {
                 CharSequence sequence = (CharSequence) mapToEdit.get(key);
-                if (TextUtils.isEmpty(sequence)) {
+                if (StripeTextUtils.isEmpty(sequence)) {
                     mapToEdit.remove(key);
                 }
             }
 
             if (mapToEdit.get(key) instanceof Map) {
-                Map<String, Object> stringObjectMap = (Map<String, Object>) mapToEdit.get(key);
-                removeNullAndEmptyParams(stringObjectMap);
+                final Map<String, Object> stringObjectMap =
+                        (Map<String, Object>) mapToEdit.get(key);
+                if (stringObjectMap != null) {
+                    removeNullAndEmptyParams(stringObjectMap);
+                }
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeTextUtils.java
@@ -45,6 +45,15 @@ public class StripeTextUtils {
     }
 
     /**
+     * Returns true if the string is null or 0-length.
+     * @param str the string to be examined
+     * @return true if str is null or zero length
+     */
+    public static boolean isEmpty(@Nullable CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+
+    /**
      * Converts a card number that may have spaces between the numbers into one without any spaces.
      * Note: method does not check that all characters are digits or spaces.
      *

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -15,10 +15,11 @@ import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
  */
 public class AccountParams {
 
-    private static final String API_TOS_SHOWN_AND_ACCEPTED = "tos_shown_and_accepted";
+    static final String API_BUSINESS_TYPE = "business_type";
+    static final String API_TOS_SHOWN_AND_ACCEPTED = "tos_shown_and_accepted";
 
     private final boolean mTosShownAndAccepted;
-    @NonNull private final BusinessType mBusinessType;
+    @Nullable private final BusinessType mBusinessType;
     @Nullable private final Map<String, Object> mBusinessData;
 
     /**
@@ -49,12 +50,12 @@ public class AccountParams {
     @NonNull
     public static AccountParams createAccountParams(
             boolean tosShownAndAccepted,
-            @NonNull BusinessType businessType,
+            @Nullable BusinessType businessType,
             @Nullable Map<String, Object> businessData) {
         return new AccountParams(businessType, businessData, tosShownAndAccepted);
     }
 
-    private AccountParams(@NonNull BusinessType businessType,
+    private AccountParams(@Nullable BusinessType businessType,
                           @Nullable Map<String, Object> businessData,
                           boolean tosShownAndAccepted) {
         mBusinessType = businessType;
@@ -69,17 +70,20 @@ public class AccountParams {
      */
     @NonNull
     public Map<String, Object> toParamMap() {
-        final Map<String, Object> networkReadyMap = new HashMap<>();
-        final Map<String, Object> tokenMap = new HashMap<>();
-        tokenMap.put(API_TOS_SHOWN_AND_ACCEPTED, mTosShownAndAccepted);
+        final Map<String, Object> accountData = new HashMap<>();
+        if (mBusinessType != null) {
+            accountData.put(API_BUSINESS_TYPE, mBusinessType.code);
 
-        if (mBusinessData != null) {
-            tokenMap.put(mBusinessType.code, mBusinessData);
+            if (mBusinessData != null) {
+                accountData.put(mBusinessType.code, mBusinessData);
+            }
         }
+        accountData.put(API_TOS_SHOWN_AND_ACCEPTED, mTosShownAndAccepted);
 
-        networkReadyMap.put("account", tokenMap);
-        removeNullAndEmptyParams(networkReadyMap);
-        return networkReadyMap;
+        final Map<String, Object> params = new HashMap<>();
+        params.put("account", accountData);
+        removeNullAndEmptyParams(params);
+        return params;
     }
 
     @Override

--- a/stripe/src/test/java/com/stripe/android/model/AccountParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/AccountParamsTest.java
@@ -1,0 +1,43 @@
+package com.stripe.android.model;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AccountParamsTest {
+
+    @Test
+    public void toParamMap_withBusinessData() {
+        final Map<String, Object> businessData = new HashMap<>();
+        businessData.put("name", "Stripe");
+        final Map<String, Object> params =
+                AccountParams.createAccountParams(true,
+                        AccountParams.BusinessType.Company, businessData)
+                        .toParamMap();
+
+        final Map<String, ?> accountData = (Map<String, ?>) params.get("account");
+        assertNotNull(accountData);
+        assertEquals(3, accountData.size());
+        assertEquals(Boolean.TRUE, accountData.get(AccountParams.API_TOS_SHOWN_AND_ACCEPTED));
+        assertEquals(AccountParams.BusinessType.Company.code,
+                accountData.get(AccountParams.API_BUSINESS_TYPE));
+        assertEquals(businessData,
+                accountData.get(AccountParams.BusinessType.Company.code));
+    }
+
+    @Test
+    public void toParamMap_withNoBusinessData() {
+        final Map<String, Object> params =
+                AccountParams.createAccountParams(true, null, null)
+                        .toParamMap();
+
+        final Map<String, ?> accountData = (Map<String, ?>) params.get("account");
+        assertNotNull(accountData);
+        assertEquals(1, accountData.size());
+        assertEquals(Boolean.TRUE, accountData.get(AccountParams.API_TOS_SHOWN_AND_ACCEPTED));
+    }
+}


### PR DESCRIPTION
## Summary
If `BusinessType` is populated in `AccountParams`, include it with the `business_type` param.

## Motivation
Fixes #943

## Testing
Wrote unit tests
