### PR TITLE
Don't use Robolectric when unnecessary

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.26.0"
     testImplementation "org.robolectric:robolectric:4.2.1"
     testImplementation 'androidx.test:core:1.1.0'
+    testImplementation 'org.json:json:20180813'
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
@@ -3,7 +3,6 @@ package com.stripe.android;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
@@ -136,7 +135,7 @@ public class StripeNetworkUtils {
 
             if (mapToEdit.get(key) instanceof CharSequence) {
                 CharSequence sequence = (CharSequence) mapToEdit.get(key);
-                if (TextUtils.isEmpty(sequence)) {
+                if (StripeTextUtils.isEmpty(sequence)) {
                     mapToEdit.remove(key);
                 }
             }

--- a/stripe/src/main/java/com/stripe/android/StripeTextUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeTextUtils.java
@@ -45,6 +45,15 @@ public class StripeTextUtils {
     }
 
     /**
+     * Returns true if the string is null or 0-length.
+     * @param str the string to be examined
+     * @return true if str is null or zero length
+     */
+    public static boolean isEmpty(@Nullable CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+
+    /**
      * Converts a card number that may have spaces between the numbers into one without any spaces.
      * Note: method does not check that all characters are digits or spaces.
      *

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
-import android.text.TextUtils;
 
 import com.stripe.android.CardUtils;
 import com.stripe.android.R;
@@ -348,7 +347,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     @Nullable
     @CardBrand
     public static String asCardBrand(@Nullable String possibleCardType) {
-        if (possibleCardType == null || TextUtils.isEmpty(possibleCardType.trim())) {
+        if (possibleCardType == null || StripeTextUtils.isEmpty(possibleCardType.trim())) {
             return null;
         }
 
@@ -380,7 +379,7 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     @Nullable
     @FundingType
     public static String asFundingType(@Nullable String possibleFundingType) {
-        if (possibleFundingType == null || TextUtils.isEmpty(possibleFundingType.trim())) {
+        if (possibleFundingType == null || StripeTextUtils.isEmpty(possibleFundingType.trim())) {
             return null;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/ModelUtils.java
+++ b/stripe/src/main/java/com/stripe/android/model/ModelUtils.java
@@ -2,7 +2,6 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import java.util.Calendar;
 import java.util.Locale;
@@ -19,7 +18,21 @@ class ModelUtils {
      * @return {@code true} if the input value consists entirely of integers
      */
     static boolean isWholePositiveNumber(@Nullable String value) {
-        return value != null && TextUtils.isDigitsOnly(value);
+        return value != null && isDigitsOnly(value);
+    }
+
+    /**
+     * Returns whether the given CharSequence contains only digits.
+     */
+    private static boolean isDigitsOnly(@NonNull CharSequence str) {
+        final int len = str.length();
+        for (int cp, i = 0; i < len; i += Character.charCount(cp)) {
+            cp = Character.codePointAt(str, i);
+            if (!Character.isDigit(cp)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/Token.java
+++ b/stripe/src/main/java/com/stripe/android/model/Token.java
@@ -3,8 +3,8 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
-import android.text.TextUtils;
 
+import com.stripe.android.StripeTextUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
@@ -249,7 +249,7 @@ public class Token implements StripePaymentSource {
     @Nullable
     @TokenType
     private static String asTokenType(@Nullable String possibleTokenType) {
-        if (possibleTokenType == null || TextUtils.isEmpty(possibleTokenType.trim())) {
+        if (possibleTokenType == null || StripeTextUtils.isEmpty(possibleTokenType.trim())) {
             return null;
         }
 

--- a/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/CardUtilsTest.java
@@ -3,8 +3,6 @@ package com.stripe.android;
 import com.stripe.android.model.Card;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,7 +11,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test class for {@link CardUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class CardUtilsTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/ErrorParserTest.java
+++ b/stripe/src/test/java/com/stripe/android/ErrorParserTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -10,7 +8,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Test class for {@link ErrorParser}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class ErrorParserTest {
 
     private static final String RAW_INVALID_REQUEST_ERROR = "" +

--- a/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.java
@@ -2,8 +2,6 @@ package com.stripe.android;
 
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Currency;
 import java.util.Locale;
@@ -14,7 +12,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test class for {@link PayWithGoogleUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class PayWithGoogleUtilsTest {
 
     @After

--- a/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,7 +11,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test class for {@link StripeTextUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class StripeTextUtilsTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/AddressTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/AddressTest.java
@@ -3,8 +3,6 @@ package com.stripe.android.model;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +16,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link Address}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class AddressTest {
 
     static final String JSON_ADDRESS = "{" +

--- a/stripe/src/test/java/com/stripe/android/model/BankAccountTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/BankAccountTest.java
@@ -1,15 +1,12 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Test class for {@link BankAccount}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class BankAccountTest {
 
     private static final String RAW_BANK_ACCOUNT = "{\n" +

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -8,8 +8,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Calendar;
 import java.util.HashMap;
@@ -27,7 +25,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link Card}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class CardTest {
     private static final int YEAR_IN_FUTURE = 2100;
 

--- a/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
@@ -5,8 +5,6 @@ import com.stripe.android.testharness.JsonTestUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static com.stripe.android.model.CardTest.JSON_CARD;
 import static com.stripe.android.model.SourceTest.EXAMPLE_ALIPAY_SOURCE;
@@ -19,7 +17,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link CustomerSource} model class.
  */
-@RunWith(RobolectricTestRunner.class)
 public class CustomerSourceTest {
 
     static final String JSON_APPLE_PAY_CARD = "{\n" +

--- a/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
@@ -8,8 +8,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static com.stripe.android.model.CardTest.JSON_CARD;
 import static com.stripe.android.model.CustomerSourceTest.JSON_APPLE_PAY_CARD;
@@ -25,7 +23,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link Customer} model object.
  */
-@RunWith(RobolectricTestRunner.class)
 public class CustomerTest {
 
     private static final String NON_CUSTOMER_OBJECT =

--- a/stripe/src/test/java/com/stripe/android/model/ModelUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ModelUtilsTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Calendar;
 
@@ -14,7 +12,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test class for {@link ModelUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class ModelUtilsTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
@@ -3,8 +3,6 @@ package com.stripe.android.model;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +12,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class PaymentIntentParamsTest {
     private static final Card FULL_FIELDS_VISA_CARD =
             new Card(VALID_VISA_NO_SPACES,

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -3,15 +3,12 @@ package com.stripe.android.model;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class PaymentMethodTest {
     private static final String RAW_CARD_JSON = "{\n" +
             "\t\"id\": \"pm_123456789\",\n" +

--- a/stripe/src/test/java/com/stripe/android/model/ShippingInformationTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingInformationTest.java
@@ -3,12 +3,9 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class ShippingInformationTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +17,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link ShippingMethod}
  */
-@RunWith(RobolectricTestRunner.class)
 public class ShippingMethodTest {
 
     private static final String EXAMPLE_JSON_SHIPPING_ADDRESS = "{" +

--- a/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Map;
 
@@ -13,7 +11,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Test class for {@link SourceCardData}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceCardDataTest {
 
     static final String EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY =

--- a/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
@@ -4,8 +4,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +16,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link SourceCodeVerification}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceCodeVerificationTest {
 
     static final String EXAMPLE_JSON_CODE_VERIFICATION = "{" +

--- a/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link SourceOwner} model.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceOwnerTest {
 
     private static final String EXAMPLE_JSON_OWNER_WITH_NULLS = "{" +

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import com.stripe.android.testharness.JsonTestUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +19,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test class for {@link SourceParams}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceParamsTest {
 
     private static final Card FULL_FIELDS_VISA_CARD;

--- a/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
@@ -4,8 +4,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +16,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link SourceReceiver}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceReceiverTest {
 
     private static final String EXAMPLE_JSON_RECEIVER = "{" +

--- a/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
@@ -1,12 +1,9 @@
 package com.stripe.android.model;
 
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +15,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-@RunWith(RobolectricTestRunner.class)
 public class SourceRedirectTest {
 
     static final String EXAMPLE_JSON_REDIRECT = "  {" +

--- a/stripe/src/test/java/com/stripe/android/model/SourceSepaDebitDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceSepaDebitDataTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -11,7 +9,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Test class for {@link SourceSepaDebitData}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceSepaDebitDataTest {
 
     private static final String EXAMPLE_SEPA_JSON_DATA = "{\"bank_code\":\"37040044\"," +

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -4,8 +4,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +25,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link Source} model.
  */
-@RunWith(RobolectricTestRunner.class)
 public class SourceTest {
 
     static final String EXAMPLE_ALIPAY_SOURCE = "{\n" +

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -8,8 +8,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +25,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link StripeJsonModel}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class StripeJsonModelTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
@@ -6,8 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +20,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link StripeJsonUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class StripeJsonUtilsTest {
 
     private static final String SIMPLE_JSON_TEST_OBJECT =

--- a/stripe/src/test/java/com/stripe/android/model/StripeSourceTypeModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeSourceTypeModelTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for {@link StripeSourceTypeModel}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class StripeSourceTypeModelTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.java
@@ -1,8 +1,6 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -14,7 +12,6 @@ import static org.junit.Assert.assertNull;
 /**
  * Test class for {@link Token}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class TokenTest {
     private static final Card CARD = new Card.Builder(null, 8, 2017, null)
             .id("card_189fi32eZvKYlo2CHK8NPRME")

--- a/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
@@ -3,13 +3,10 @@ package com.stripe.android.model.wallets;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class WalletFactoryTest {
     private static final String VISA_WALLET_JSON = "{\n" +
             "\t\"type\": \"visa_checkout\",\n" +

--- a/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtilsTest.java
@@ -3,8 +3,6 @@ package com.stripe.android.testharness;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,7 +17,6 @@ import static org.junit.Assert.fail;
 /**
  * Test class for the test utils class {@link JsonTestUtils}.
  */
-@RunWith(RobolectricTestRunner.class)
 public class JsonTestUtilsTest {
 
     @Test


### PR DESCRIPTION
Robolectric was being as the test runner in many test classes, especially
model test classes, because it implements JSON parsing. Instead of loading
Robolectric for model tests, simply include `'org.json:json:20180813'`
as a test dependency.