### PR TITLE
Update AuthWebView logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -3,6 +3,7 @@ package com.stripe.android.model;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
@@ -480,7 +481,8 @@ public class PaymentIntent extends StripeJsonModel {
             return new RedirectData(url, returnUrl);
         }
 
-        private RedirectData(@NonNull String url, @Nullable String returnUrl) {
+        @VisibleForTesting
+        RedirectData(@NonNull String url, @Nullable String returnUrl) {
             this.url = Uri.parse(url);
             this.returnUrl = returnUrl != null ? Uri.parse(returnUrl) : null;
         }

--- a/stripe/src/main/java/com/stripe/android/view/AuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/AuthWebView.java
@@ -5,7 +5,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -88,8 +87,9 @@ class AuthWebView extends WebView {
         public boolean shouldOverrideUrlLoading(@NonNull WebView view,
                                                 @NonNull String urlString) {
             if (isReturnUrl(urlString)) {
-                mActivity.startActivity(new Intent(Intent.ACTION_VIEW)
-                        .setData(Uri.parse(urlString)));
+                mActivity.setResult(Activity.RESULT_OK,
+                        new Intent()
+                                .setData(Uri.parse(urlString)));
                 mActivity.finish();
                 return true;
             }

--- a/stripe/src/main/java/com/stripe/android/view/AuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AuthWebViewActivity.java
@@ -19,4 +19,10 @@ public class AuthWebViewActivity extends AppCompatActivity {
         webView.init(this, returnUrl);
         webView.loadUrl(getIntent().getStringExtra(AuthWebViewStarter.EXTRA_AUTH_URL));
     }
+
+    @Override
+    public void onBackPressed() {
+        setResult(RESULT_CANCELED);
+        super.onBackPressed();
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/view/AuthWebViewStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AuthWebViewStarter.java
@@ -13,6 +13,8 @@ public class AuthWebViewStarter {
     static final String EXTRA_AUTH_URL = "auth_url";
     static final String EXTRA_RETURN_URL = "return_url";
 
+    private static final int REQUEST_CODE = 50000;
+
     @NonNull private final Activity mActivity;
 
     public AuthWebViewStarter(@NonNull Activity activity) {
@@ -21,10 +23,17 @@ public class AuthWebViewStarter {
 
     /**
      * @param redirectData typically obtained through {@link PaymentIntent#getRedirectData()}
+     *
      */
     public void start(@NonNull PaymentIntent.RedirectData redirectData) {
-        mActivity.startActivity(new Intent(mActivity, AuthWebViewActivity.class)
+        final Intent intent = new Intent(mActivity, AuthWebViewActivity.class)
                 .putExtra(EXTRA_AUTH_URL, redirectData.url.toString())
-                .putExtra(EXTRA_RETURN_URL, redirectData.returnUrl.toString()));
+                .putExtra(EXTRA_RETURN_URL, redirectData.returnUrl != null ?
+                        redirectData.returnUrl.toString() : null);
+        mActivity.startActivityForResult(intent, REQUEST_CODE);
+    }
+
+    static boolean isAuthWebViewResult(int requestCode) {
+        return requestCode == REQUEST_CODE;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
@@ -1,0 +1,7 @@
+package com.stripe.android.model;
+
+public final class PaymentIntentFixtures {
+    public static final PaymentIntent.RedirectData REDIRECT_DATA =
+            new PaymentIntent.RedirectData("https://example.com",
+                    "yourapp://post-authentication-return-url");
+}

--- a/stripe/src/test/java/com/stripe/android/view/AuthWebViewStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AuthWebViewStarterTest.java
@@ -1,0 +1,48 @@
+package com.stripe.android.view;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.stripe.android.model.PaymentIntentFixtures;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+public class AuthWebViewStarterTest {
+    @Mock private Activity mActivity;
+    @Captor private ArgumentCaptor<Intent> mIntentArgumentCaptor;
+    @Captor private ArgumentCaptor<Integer> mRequestCodeCaptor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void start_startsWithCorrectIntentAndRequestCode() {
+        new AuthWebViewStarter(mActivity)
+                .start(PaymentIntentFixtures.REDIRECT_DATA);
+        verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
+                mRequestCodeCaptor.capture());
+
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        final Bundle extras = intent.getExtras();
+        assertNotNull(extras);
+        assertEquals(2, extras.size());
+
+        assertTrue(AuthWebViewStarter.isAuthWebViewResult(mRequestCodeCaptor.getValue()));
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/AuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AuthWebViewTest.java
@@ -14,6 +14,7 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
@@ -29,14 +30,14 @@ public class AuthWebViewTest {
     }
 
     @Test
-    public void shouldOverrideUrlLoading_withDeepLink_shouldStartDeepLink() {
+    public void shouldOverrideUrlLoading_shouldSetResult() {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                         "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final AuthWebView.AuthWebViewClient authWebViewClient =
                 new AuthWebView.AuthWebViewClient(mActivity,
                         "stripe://payment_intent_return");
         authWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mActivity).startActivity(mIntentArgumentCaptor.capture());
+        verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
         verify(mActivity).finish();
 
         final Intent intent = mIntentArgumentCaptor.getValue();


### PR DESCRIPTION
## Summary
Use activity result instead of deep links to pass intent data

- Set ok result if button is clicked
- Set canceled result in AuthWebViewActivity when back button is pressed

