### PR TITLE
Update example app to reflect backend change

### DIFF
--- a/example/res/layout/activity_payment_intent_demo.xml
+++ b/example/res/layout/activity_payment_intent_demo.xml
@@ -11,6 +11,7 @@
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:layout_margin="10dp"
+        android:paddingBottom="40dp"
         >
 
         <TextView

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -35,6 +35,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+import okhttp3.ResponseBody;
 import retrofit2.Retrofit;
 
 public class PaymentIntentActivity extends AppCompatActivity {
@@ -125,22 +126,24 @@ public class PaymentIntentActivity extends AppCompatActivity {
 
                 // Because we've made the mapping above, we're now subscribing
                 // to the result of creating a 3DS Source
-                .subscribe(
-                        responseBody -> {
-                            try {
-                                JSONObject jsonObject = new JSONObject(responseBody.string());
-                                mPaymentIntentValue.setText(jsonObject.toString());
-                                mClientSecret = jsonObject.optString("secret");
-                                mConfirmPaymentIntent.setEnabled(mClientSecret != null);
-                                mRetrievePaymentIntent.setEnabled(mClientSecret != null);
-
-                            } catch (IOException | JSONException exception) {
-                                Log.e(TAG, exception.toString());
-                            }
-                        },
+                .subscribe(this::onCreatedPaymentIntent,
                         throwable -> mErrorDialogHandler.show(throwable.getLocalizedMessage())
                 );
         mCompositeDisposable.add(disposable);
+    }
+
+    private void onCreatedPaymentIntent(@NonNull ResponseBody responseBody) {
+        try {
+            final JSONObject jsonObject = new JSONObject(responseBody.string());
+            final PaymentIntent paymentIntent = PaymentIntent.fromJson(jsonObject);
+            mPaymentIntentValue.setText(jsonObject.toString());
+            mClientSecret = paymentIntent.getClientSecret();
+            mConfirmPaymentIntent.setEnabled(mClientSecret != null);
+            mRetrievePaymentIntent.setEnabled(mClientSecret != null);
+
+        } catch (IOException | JSONException exception) {
+            Log.e(TAG, exception.toString());
+        }
     }
 
     private void retrievePaymentIntent() {


### PR DESCRIPTION
## Summary
`/create_intent` now returns the entire PaymentIntent object

## Motivation
https://github.com/stripe/example-ios-backend/pull/53

## Testing
Manually confirmed
