### PR TITLE
Add toolbar to payment auth web view activity

### DIFF
--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -11,7 +11,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="@dimen/toolbar_elevation"
         android:theme="@style/StripeToolBarStyle"
-        app:title="@string/title_payment_auth_web_view" />
+        app:title="Secure Checkout" />
 
     <com.stripe.android.view.PaymentAuthWebView
         android:id="@+id/auth_web_view"

--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/payment_auth_web_view_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="@dimen/toolbar_elevation"
+        android:theme="@style/StripeToolBarStyle"
+        app:title="@string/title_payment_auth_web_view" />
 
     <com.stripe.android.view.PaymentAuthWebView
         android:id="@+id/auth_web_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_below="@id/payment_auth_web_view_toolbar" />
 
     <ProgressBar
         android:id="@+id/auth_web_view_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@id/payment_auth_web_view_toolbar"
         android:visibility="gone" />
-</FrameLayout>
+</RelativeLayout>

--- a/stripe/res/menu/payment_auth_web_view_menu.xml
+++ b/stripe/res/menu/payment_auth_web_view_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_close"
+        android:title="@string/action_close"
+        app:showAsAction="always" />
+
+</menu>

--- a/stripe/res/menu/payment_auth_web_view_menu.xml
+++ b/stripe/res/menu/payment_auth_web_view_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_close"
-        android:title="@string/action_close"
+        android:title="Close"
         app:showAsAction="always" />
 
 </menu>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -107,6 +107,8 @@
     <string name="payment_method_add_new_card">Add new card&#8230;</string>
     <!--Human-friendly label for something with $0 price-->
     <string name="price_free">Free</string>
+    <string name="title_payment_auth_web_view">Secure Checkout</string>
+    <string name="action_close">Close</string>
     <string name="title_add_a_card">Add a Card</string>
     <string name="title_payment_method">Payment Method</string>
     <!--Screen title telling users they should add an address-->

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -107,8 +107,6 @@
     <string name="payment_method_add_new_card">Add new card&#8230;</string>
     <!--Human-friendly label for something with $0 price-->
     <string name="price_free">Free</string>
-    <string name="title_payment_auth_web_view">Secure Checkout</string>
-    <string name="action_close">Close</string>
     <string name="title_add_a_card">Add a Card</string>
     <string name="title_payment_method">Payment Method</string>
     <!--Screen title telling users they should add an address-->

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -10,6 +10,7 @@
 
     <style name="StripeToolBarStyle" parent="@style/ThemeOverlay.AppCompat">
         <item name="colorControlNormal">?attr/titleTextColor</item>
+        <item name="actionMenuTextColor">?attr/titleTextColor</item>
     </style>
 
     <style name="StripeErrorTextStyle">

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -3,6 +3,9 @@ package com.stripe.android.view;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import com.stripe.android.R;
 
@@ -12,6 +15,9 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.payment_auth_web_view_layout);
+
+        final Toolbar toolbar = findViewById(R.id.payment_auth_web_view_toolbar);
+        setSupportActionBar(toolbar);
 
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
@@ -25,5 +31,21 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
     public void onBackPressed() {
         setResult(RESULT_CANCELED);
         super.onBackPressed();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.payment_auth_web_view_menu, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_close) {
+            setResult(RESULT_CANCELED);
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }


### PR DESCRIPTION
## Summary

Adds the toolbar to the payment auth web view activity.

![Screenshot_1558454661](https://user-images.githubusercontent.com/48026502/58112144-df315400-7bc0-11e9-89c7-81c641be63e1.png)

## Motivation

MOBILE3DS2-369

## Testing

Manually started the `PaymentAuthWebViewActivity` with `PaymentAuthWebViewStarter`.