### PR TITLE
Create PaymentAuthenticationController

### DIFF
--- a/docs/com/stripe/android/view/AuthWebViewStarter.html
+++ b/docs/com/stripe/android/view/AuthWebViewStarter.html
@@ -99,7 +99,7 @@ var activeTableTab = "activeTableTab";
 <li>java.lang.Object</li>
 <li>
 <ul class="inheritance">
-<li>com.stripe.android.view.PaymentAuthWebViewStarter</li>
+<li>com.stripe.android.PaymentAuthWebViewStarter</li>
 </ul>
 </li>
 </ul>

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -22,6 +22,10 @@
         <activity
             android:name=".view.PaymentAuthWebViewActivity"
             android:theme="@style/StripeDefaultTheme" />
+
+        <activity
+            android:name=".view.PaymentAuthBypassActivity"
+            android:theme="@style/StripeDefaultTheme" />
     </application>
 
 </manifest>

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthBypassStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthBypassStarter.java
@@ -1,0 +1,32 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.PaymentAuthBypassActivity;
+import com.stripe.android.view.PaymentAuthenticationExtras;
+
+/**
+ * Starts an instance of {@link PaymentAuthBypassStarter}.
+ * Should only be called from {@link com.stripe.android.PaymentAuthenticationController}.
+ */
+class PaymentAuthBypassStarter implements ActivityStarter<PaymentIntent> {
+    @NonNull private final Activity mActivity;
+    private final int mRequestCode;
+
+    PaymentAuthBypassStarter(@NonNull Activity activity, int requestCode) {
+        mActivity = activity;
+        mRequestCode = requestCode;
+    }
+
+    @Override
+    public void start(@NonNull PaymentIntent paymentIntent) {
+        final Intent intent = new Intent(mActivity, PaymentAuthBypassActivity.class)
+                .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET,
+                        paymentIntent.getClientSecret());
+        mActivity.startActivityForResult(intent, mRequestCode);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
@@ -1,25 +1,27 @@
-package com.stripe.android.view;
+package com.stripe.android;
 
 import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.PaymentAuthWebViewActivity;
 
 /**
  * A class that manages starting a {@link PaymentAuthWebViewActivity} instance with the correct
  * arguments.
  */
-public class PaymentAuthWebViewStarter {
-    static final String EXTRA_AUTH_URL = "auth_url";
-    static final String EXTRA_RETURN_URL = "return_url";
-
-    private static final int REQUEST_CODE = 50000;
+public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentIntent.RedirectData> {
+    public static final String EXTRA_AUTH_URL = "auth_url";
+    public static final String EXTRA_RETURN_URL = "return_url";
 
     @NonNull private final Activity mActivity;
+    private final int mRequestCode;
 
-    PaymentAuthWebViewStarter(@NonNull Activity activity) {
+    PaymentAuthWebViewStarter(@NonNull Activity activity, int requestCode) {
         mActivity = activity;
+        mRequestCode = requestCode;
     }
 
     /**
@@ -31,10 +33,6 @@ public class PaymentAuthWebViewStarter {
                 .putExtra(EXTRA_AUTH_URL, redirectData.url.toString())
                 .putExtra(EXTRA_RETURN_URL, redirectData.returnUrl != null ?
                         redirectData.returnUrl.toString() : null);
-        mActivity.startActivityForResult(intent, REQUEST_CODE);
-    }
-
-    static boolean isAuthWebViewResult(int requestCode) {
-        return requestCode == REQUEST_CODE;
+        mActivity.startActivityForResult(intent, mRequestCode);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
@@ -1,0 +1,202 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
+
+import com.stripe.android.exception.StripeException;
+import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.model.PaymentIntentParams;
+import com.stripe.android.view.PaymentAuthenticationExtras;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A controller responsible for authenticating payment (typically through resolving any required
+ * customer action). The payment authentication mechanism (e.g. 3DS) will be determined by the
+ * {@link PaymentIntent} object.
+ */
+class PaymentAuthenticationController {
+    static final int REQUEST_CODE = 50000;
+    private static final String TAG = "PaymentAuthentication";
+
+    /**
+     * Confirm the PaymentIntent and resolve any next actions
+     */
+    void confirmAndAuth(@NonNull Stripe stripe,
+                        @NonNull Activity activity,
+                        @NonNull PaymentIntentParams paymentIntentParams,
+                        @NonNull String publishableKey) {
+        final WeakReference<Activity> activityRef = new WeakReference<>(activity);
+        new ConfirmPaymentIntentTask(stripe, activity, paymentIntentParams, publishableKey,
+                new ApiResultCallback<PaymentIntent>() {
+                    @Override
+                    public void onSuccess(@NonNull PaymentIntent paymentIntent) {
+                        handleNextAction(activityRef.get(), paymentIntent);
+                    }
+
+                    @Override
+                    public void onError(@NonNull Exception e) {
+                        Log.e(TAG, "Exception thrown while confirming PaymentIntent", e);
+                    }
+                })
+                .execute();
+    }
+
+    /**
+     * Decide whether {@link #handleResult(Stripe, Intent, String, ApiResultCallback)} should be
+     * called.
+     */
+    boolean shouldHandleResult(int requestCode, int resultCode, @Nullable Intent data) {
+        return requestCode == REQUEST_CODE &&
+                resultCode == Activity.RESULT_OK &&
+                data != null;
+    }
+
+    /**
+     * Get the PaymentIntent's client_secret from {@param data} and use to retrieve the
+     * PaymentIntent object with updated status
+     *
+     * @param data the result Intent
+     */
+    void handleResult(@NonNull Stripe stripe, @NonNull Intent data, @NonNull String publishableKey,
+                      @NonNull final ApiResultCallback<PaymentIntent> listener) {
+        final String clientSecret = data.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET);
+        final PaymentIntentParams paymentIntentParams = PaymentIntentParams
+                .createRetrievePaymentIntentParams(clientSecret);
+        new RetrievePaymentIntentTask(stripe, paymentIntentParams, publishableKey,
+                new ApiResultCallback<PaymentIntent>() {
+                    @Override
+                    public void onSuccess(@NonNull PaymentIntent paymentIntent) {
+                        listener.onSuccess(paymentIntent);
+                    }
+
+                    @Override
+                    public void onError(@NonNull Exception e) {
+                        listener.onError(e);
+                    }
+                })
+                .execute();
+    }
+
+    /**
+     * Determine which payment authentication mechanism should be used, or bypass authentication
+     * if it is not needed.
+     */
+    @VisibleForTesting
+    void handleNextAction(@NonNull Activity activity,
+                          @NonNull PaymentIntent paymentIntent) {
+        if (paymentIntent.requiresAction()) {
+            begin3ds1Auth(activity, paymentIntent.getRedirectData());
+        } else {
+            new PaymentAuthBypassStarter(activity, REQUEST_CODE).start(paymentIntent);
+        }
+    }
+
+    /**
+     * Start in-app WebView activity.
+     *
+     * @param activity the payment authentication result will be returned as a result to this
+     *                 {@link Activity}
+     */
+    private void begin3ds1Auth(@NonNull Activity activity,
+                               @NonNull PaymentIntent.RedirectData redirectData) {
+        new PaymentAuthWebViewStarter(activity, REQUEST_CODE).start(redirectData);
+    }
+
+    private static final class RetrievePaymentIntentTask
+            extends AsyncTask<Void, Void, ResultWrapper<PaymentIntent>> {
+        @NonNull private final Stripe mStripe;
+        @NonNull private final PaymentIntentParams mParams;
+        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiResultCallback<PaymentIntent> mListener;
+
+        private RetrievePaymentIntentTask(@NonNull Stripe stripe,
+                                          @NonNull PaymentIntentParams params,
+                                          @NonNull String publishableKey,
+                                          @NonNull ApiResultCallback<PaymentIntent> listener) {
+            mStripe = stripe;
+            mParams = params;
+            mPublishableKey = publishableKey;
+            mListener = listener;
+        }
+
+        @Override
+        protected ResultWrapper<PaymentIntent> doInBackground(Void... voids) {
+            try {
+                final PaymentIntent paymentIntent =
+                        mStripe.retrievePaymentIntentSynchronous(mParams, mPublishableKey);
+                return new ResultWrapper<>(paymentIntent);
+            } catch (StripeException e) {
+                return new ResultWrapper<>(e);
+            }
+        }
+
+        @Override
+        protected void onPostExecute(@NonNull ResultWrapper<PaymentIntent> resultWrapper) {
+            final PaymentIntent paymentIntent = resultWrapper.result;
+            if (paymentIntent != null) {
+                mListener.onSuccess(paymentIntent);
+            } else if (resultWrapper.error != null) {
+                mListener.onError(resultWrapper.error);
+            } else {
+                mListener.onError(new RuntimeException(
+                        "Somehow got neither a PaymentIntent response or an error response"));
+            }
+        }
+    }
+
+    private static final class ConfirmPaymentIntentTask
+            extends AsyncTask<Void, Void, ResultWrapper<PaymentIntent>> {
+        @NonNull private final Stripe mStripe;
+        @NonNull private final WeakReference<Activity> mActivityRef;
+        @NonNull private final PaymentIntentParams mParams;
+        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiResultCallback<PaymentIntent> mListener;
+
+        private ConfirmPaymentIntentTask(@NonNull Stripe stripe,
+                                         @NonNull Activity activity,
+                                         @NonNull PaymentIntentParams params,
+                                         @NonNull String publishableKey,
+                                         @NonNull ApiResultCallback<PaymentIntent> listener) {
+            mStripe = stripe;
+            mActivityRef = new WeakReference<>(activity);
+            mParams = params;
+            mPublishableKey = publishableKey;
+            mListener = listener;
+        }
+
+        @Override
+        protected ResultWrapper<PaymentIntent> doInBackground(Void... voids) {
+            try {
+                final PaymentIntent paymentIntent =
+                        mStripe.confirmPaymentIntentSynchronous(mParams, mPublishableKey);
+                return new ResultWrapper<>(paymentIntent);
+            } catch (StripeException stripeException) {
+                return new ResultWrapper<>(stripeException);
+            }
+        }
+
+        @Override
+        protected void onPostExecute(@NonNull ResultWrapper<PaymentIntent> resultWrapper) {
+            final PaymentIntent paymentIntent = resultWrapper.result;
+            if (paymentIntent != null) {
+                final Activity activity = mActivityRef.get();
+                if (activity != null) {
+                    mListener.onSuccess(paymentIntent);
+                } else {
+                    mListener.onError(new RuntimeException("Activity has been GCed"));
+                }
+            } else if (resultWrapper.error != null) {
+                mListener.onError(resultWrapper.error);
+            } else {
+                mListener.onError(new RuntimeException(
+                        "Somehow got neither a PaymentIntent response or an error response"));
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
@@ -1,0 +1,7 @@
+package com.stripe.android.view;
+
+import android.support.annotation.NonNull;
+
+public interface ActivityStarter<StartDataType> {
+    void start(@NonNull StartDataType data);
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthBypassActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthBypassActivity.java
@@ -1,0 +1,21 @@
+package com.stripe.android.view;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * An {@link Activity} that is used when payment authentication can be bypassed.
+ *
+ * It sets a result and immediately finishes in order to pass the result back.
+ */
+public class PaymentAuthBypassActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setResult(Activity.RESULT_OK, new Intent().putExtras(getIntent().getExtras()));
+        finish();
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -76,6 +76,8 @@ class PaymentAuthWebView extends WebView {
     }
 
     static class PaymentAuthWebViewClient extends WebViewClient {
+        static final String PARAM_CLIENT_SECRET = "payment_intent_client_secret";
+
         @NonNull private final Activity mActivity;
         @NonNull private final Uri mReturnUrl;
 
@@ -88,9 +90,11 @@ class PaymentAuthWebView extends WebView {
         public boolean shouldOverrideUrlLoading(@NonNull WebView view,
                                                 @NonNull String urlString) {
             if (isReturnUrl(urlString)) {
+                final String clientSecret = Uri.parse(urlString)
+                        .getQueryParameter(PARAM_CLIENT_SECRET);
                 mActivity.setResult(Activity.RESULT_OK,
                         new Intent()
-                                .setData(Uri.parse(urlString)));
+                                .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET, clientSecret));
                 mActivity.finish();
                 return true;
             }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.stripe.android.PaymentAuthWebViewStarter;
 import com.stripe.android.R;
 
 public class PaymentAuthWebViewActivity extends AppCompatActivity {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthenticationExtras.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthenticationExtras.java
@@ -1,0 +1,8 @@
+package com.stripe.android.view;
+
+public final class PaymentAuthenticationExtras {
+    public static final String CLIENT_SECRET = "client_secret";
+
+    private PaymentAuthenticationExtras() {
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
@@ -1,4 +1,4 @@
-package com.stripe.android.view;
+package com.stripe.android;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -17,11 +17,10 @@ import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-public class PaymentPaymentAuthWebViewStarterTest {
+public class PaymentAuthWebViewStarterTest {
     @Mock private Activity mActivity;
     @Captor private ArgumentCaptor<Intent> mIntentArgumentCaptor;
     @Captor private ArgumentCaptor<Integer> mRequestCodeCaptor;
@@ -33,7 +32,7 @@ public class PaymentPaymentAuthWebViewStarterTest {
 
     @Test
     public void start_startsWithCorrectIntentAndRequestCode() {
-        new PaymentAuthWebViewStarter(mActivity)
+        new PaymentAuthWebViewStarter(mActivity, 50000)
                 .start(PaymentIntentFixtures.REDIRECT_DATA);
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
                 mRequestCodeCaptor.capture());
@@ -42,7 +41,5 @@ public class PaymentPaymentAuthWebViewStarterTest {
         final Bundle extras = intent.getExtras();
         assertNotNull(extras);
         assertEquals(2, extras.size());
-
-        assertTrue(PaymentAuthWebViewStarter.isAuthWebViewResult(mRequestCodeCaptor.getValue()));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
@@ -1,0 +1,44 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import com.stripe.android.model.PaymentIntentFixtures;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+public class PaymentAuthenticationControllerTest {
+
+    private PaymentAuthenticationController mController;
+
+    @Mock private Activity mActivity;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        mController = new PaymentAuthenticationController();
+    }
+
+    @Test
+    public void handleNextAction_whenAuthRequired() {
+        mController.handleNextAction(mActivity, PaymentIntentFixtures.PI_REQUIRES_ACTION);
+        verify(mActivity).startActivityForResult(any(Intent.class),
+                eq(PaymentAuthenticationController.REQUEST_CODE));
+    }
+
+    @Test
+    public void shouldHandleResult_withInvalidResultCode() {
+        assertFalse(mController.shouldHandleResult(500, Activity.RESULT_OK, new Intent()));
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -1,0 +1,79 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.model.PaymentIntentParams;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class StripePaymentAuthTest {
+
+    private Context mContext;
+
+    @Mock private Activity mActivity;
+    @Mock private PaymentAuthenticationController mPaymentAuthenticationController;
+    @Mock private ApiResultCallback<PaymentIntent> mCallback;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        mContext = ApplicationProvider.getApplicationContext();
+    }
+
+    @Test
+    public void startPaymentAuth_shouldCallControllerConfirmAndAuth() {
+        final Stripe stripe = createStripe();
+        stripe.setDefaultPublishableKey("pk_test");
+        final PaymentIntentParams paymentIntentParams =
+                PaymentIntentParams.createConfirmPaymentIntentWithPaymentMethodId(
+                        "pm_card_threeDSecure2Required",
+                        "client_secret",
+                        "yourapp://post-authentication-return-url");
+        stripe.startPaymentAuth(mActivity, paymentIntentParams);
+        verify(mPaymentAuthenticationController).confirmAndAuth(eq(stripe), eq(mActivity),
+                eq(paymentIntentParams), eq("pk_test"));
+    }
+
+    @Test
+    public void onPaymentAuthResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
+        final Intent data = new Intent();
+        when(mPaymentAuthenticationController.shouldHandleResult(
+                PaymentAuthenticationController.REQUEST_CODE, Activity.RESULT_OK, data))
+                .thenReturn(true);
+        final Stripe stripe = createStripe();
+        stripe.setDefaultPublishableKey("pk_test");
+        stripe.onPaymentAuthResult(PaymentAuthenticationController.REQUEST_CODE, Activity.RESULT_OK,
+                data, mCallback);
+
+        verify(mPaymentAuthenticationController).handleResult(stripe, data,
+                "pk_test", mCallback);
+    }
+
+    @NonNull
+    private Stripe createStripe() {
+        return new Stripe(
+                new StripeApiHandler(
+                        mContext,
+                        new RequestExecutor(),
+                        false),
+                new LoggingUtils(mContext),
+                new StripeNetworkUtils(mContext),
+                mPaymentAuthenticationController);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -153,7 +153,7 @@ public class StripeTest {
     @Test
     public void createTokenShouldCallTokenCreator() {
         final boolean[] tokenCreatorCalled = { false };
-        Stripe stripe = getNonLoggingStripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        Stripe stripe = getNonLoggingStripe(DEFAULT_PUBLISHABLE_KEY);
         stripe.mTokenCreator = new Stripe.TokenCreator() {
             @Override
             public void create(@NonNull Map<String, Object> tokenParams,
@@ -176,7 +176,7 @@ public class StripeTest {
             public void execute(@NonNull Runnable command) {
             }
         };
-        Stripe stripe = getNonLoggingStripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        Stripe stripe = getNonLoggingStripe(DEFAULT_PUBLISHABLE_KEY);
         stripe.mTokenCreator = new Stripe.TokenCreator() {
             @Override
             public void create(@NonNull Map<String, Object> tokenParams,
@@ -196,7 +196,7 @@ public class StripeTest {
     @Test
     public void createTokenShouldUseProvidedKey() {
         final String expectedPublishableKey = "pk_this_one";
-        Stripe stripe = getNonLoggingStripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+        Stripe stripe = getNonLoggingStripe(DEFAULT_PUBLISHABLE_KEY);
         stripe.mTokenCreator = new Stripe.TokenCreator() {
             @Override
             public void create(@NonNull Map<String, Object> tokenParams,
@@ -289,7 +289,7 @@ public class StripeTest {
     public void createBankAccountTokenSynchronous_withValidBankAccount_returnsToken()
             throws CardException, APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
-        Stripe stripe = getNonLoggingStripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+        Stripe stripe = getNonLoggingStripe(FUNCTIONAL_PUBLISHABLE_KEY);
 
         Token token = stripe.createBankAccountTokenSynchronous(BANK_ACCOUNT);
         assertNotNull(token);
@@ -309,7 +309,7 @@ public class StripeTest {
     @Test
     public void createSourceSynchronous_withAlipayReusableParams_passesIntegrationTest()
             throws APIException, AuthenticationException, InvalidRequestException, APIConnectionException {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams alipayParams = SourceParams.createAlipayReusableParams(
                 "usd",
                 "Example Payer",
@@ -334,7 +334,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withAlipaySingleUseParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams alipayParams = SourceParams.createAlipaySingleUseParams(
                 1000L,
                 "usd",
@@ -366,7 +366,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withBancontactParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams bancontactParams = SourceParams.createBancontactParams(
                 1000L,
                 "John Doe",
@@ -403,7 +403,7 @@ public class StripeTest {
     public void createSourceSynchronous_withCardParams_passesIntegrationTest()
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
-        final Stripe stripe = getNonLoggingStripe(mContext);
+        final Stripe stripe = getNonLoggingStripe();
         stripe.setDefaultPublishableKey("pk_test_dCyfhfyeO2CZkcvT5xyIDdJj");
         stripe.setStripeAccount("acct_28DT589O8KAxCGbLmxyZ");
 
@@ -444,7 +444,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_with3DSParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         SourceParams params = SourceParams.createCardParams(card);
         try {
@@ -517,7 +517,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withP24Params_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams p24Params = SourceParams.createP24Params(
                 100,
                 "eur",
@@ -547,7 +547,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withSepaDebitParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
@@ -590,7 +590,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withSepaDebitParamsWithMinimalValues_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
@@ -621,7 +621,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withNoEmail_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
@@ -662,7 +662,7 @@ public class StripeTest {
 
     @Test
     public void createSepaDebitSource_withNoAddress_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String validIban = "DE89370400440532013000";
         SourceParams params = SourceParams.createSepaDebitParams(
                 "Sepa Account Holder",
@@ -697,7 +697,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withiDEALParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams params = SourceParams.createIdealParams(
                 5500L,
                 "Bond",
@@ -734,7 +734,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withiDEALParamsNoStatement_doesNotIgnoreBank() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String bankName = "rabobank";
         SourceParams params = SourceParams.createIdealParams(
                 5500L,
@@ -774,7 +774,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withiDEALParamsNoName_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         String bankName = "rabobank";
         SourceParams params = SourceParams.createIdealParams(
                 5500L,
@@ -814,7 +814,7 @@ public class StripeTest {
 
     @Test
     public void createSourceSynchronous_withSofortParams_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         SourceParams params = SourceParams.createSofortParams(
                 70000L,
                 "example://return",
@@ -847,7 +847,7 @@ public class StripeTest {
 
     @Test
     public void retrieveSourceSynchronous_withValidData_passesIntegrationTest() {
-        Stripe stripe = getNonLoggingStripe(mContext);
+        Stripe stripe = getNonLoggingStripe();
         Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         SourceParams params = SourceParams.createCardParams(card);
         try {
@@ -1031,7 +1031,7 @@ public class StripeTest {
     public void createTokenSynchronous_withValidDataAndBadKey_throwsAuthenticationException() {
         try {
             // This key won't work for a real connection to the api.
-            Stripe stripe = getNonLoggingStripe(mContext, DEFAULT_PUBLISHABLE_KEY);
+            Stripe stripe = getNonLoggingStripe(DEFAULT_PUBLISHABLE_KEY);
             stripe.createTokenSynchronous(CARD);
             fail("Expecting an error, but did not get one.");
         } catch (AuthenticationException authEx) {
@@ -1056,7 +1056,7 @@ public class StripeTest {
         try {
             // This card is missing quite a few numbers.
             Card card = new Card("42424242", 12, YEAR, "123");
-            Stripe stripe = getNonLoggingStripe(mContext, FUNCTIONAL_PUBLISHABLE_KEY);
+            Stripe stripe = getNonLoggingStripe(FUNCTIONAL_PUBLISHABLE_KEY);
             Token token = stripe.createTokenSynchronous(card);
             fail("Expecting an exception, but created a token instead: " + token.toString());
         } catch (AuthenticationException authEx) {
@@ -1073,7 +1073,7 @@ public class StripeTest {
         try {
             // This card is missing quite a few numbers.
             Card card = new Card("4242424242424242", 11, 2015, "123");
-            Stripe stripe = getNonLoggingStripe(mContext);
+            Stripe stripe = getNonLoggingStripe();
             Token token = stripe.createTokenSynchronous(card, FUNCTIONAL_PUBLISHABLE_KEY);
             fail("Expecting an exception, but created a token instead: " + token.toString());
         } catch (AuthenticationException authEx) {
@@ -1129,7 +1129,7 @@ public class StripeTest {
                                 .setCvc("123")
                                 .build(),
                         expectedBillingDetails);
-        final Stripe stripe = getNonLoggingStripe(mContext);
+        final Stripe stripe = getNonLoggingStripe();
         final PaymentMethod createdPaymentMethod = stripe.createPaymentMethodSynchronous(
                 paymentMethodCreateParams, FUNCTIONAL_PUBLISHABLE_KEY);
         assertNotNull(createdPaymentMethod);
@@ -1216,7 +1216,7 @@ public class StripeTest {
                                 .build(),
                         expectedBillingDetails,
                         metadata);
-        final Stripe stripe = getNonLoggingStripe(mContext);
+        final Stripe stripe = getNonLoggingStripe();
         final PaymentMethod createdPaymentMethod = stripe.createPaymentMethodSynchronous(
                 paymentMethodCreateParams, FUNCTIONAL_PUBLISHABLE_KEY);
         assertNotNull(createdPaymentMethod);
@@ -1248,7 +1248,7 @@ public class StripeTest {
                                 .setBank("ing")
                                 .build(),
                         expectedBillingDetails);
-        final Stripe stripe = getNonLoggingStripe(mContext);
+        final Stripe stripe = getNonLoggingStripe();
         final PaymentMethod createdPaymentMethod = stripe.createPaymentMethodSynchronous(
                 paymentMethodCreateParams, FUNCTIONAL_PUBLISHABLE_KEY);
         assertNotNull(createdPaymentMethod);
@@ -1262,26 +1262,24 @@ public class StripeTest {
     }
 
     @NonNull
-    private static Stripe getNonLoggingStripe(@NonNull Context context) {
-        return createNonLoggingStripe(context, null);
+    private Stripe getNonLoggingStripe() {
+        return createNonLoggingStripe(null);
     }
 
     @NonNull
-    private static Stripe getNonLoggingStripe(@NonNull Context context,
-                                              @NonNull String publishableKey) {
-        return createNonLoggingStripe(context, publishableKey);
+    private Stripe getNonLoggingStripe(@NonNull String publishableKey) {
+        return createNonLoggingStripe(publishableKey);
     }
 
     @NonNull
-    private static Stripe createNonLoggingStripe(@NonNull Context context,
-                                                 @Nullable String publishableKey) {
+    private Stripe createNonLoggingStripe(@Nullable String publishableKey) {
         final Stripe stripe = new Stripe(
                 new StripeApiHandler(
-                        context,
+                        mContext,
                         new RequestExecutor(),
                         false),
-                new LoggingUtils(context),
-                new StripeNetworkUtils(context));
+                new LoggingUtils(mContext),
+                new StripeNetworkUtils(mContext));
         if (publishableKey != null) {
             stripe.setDefaultPublishableKey(publishableKey);
         }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
@@ -1,6 +1,62 @@
 package com.stripe.android.model;
 
+import android.support.annotation.NonNull;
+
+import java.util.Objects;
+
 public final class PaymentIntentFixtures {
+    @NonNull public static final PaymentIntent PI_REQUIRES_ACTION =
+            Objects.requireNonNull(PaymentIntent.fromString("{\n" +
+                    "\t\"id\": \"pi_1EZlvVCRMbs6FrXfKpq2xMmy\",\n" +
+                    "\t\"object\": \"payment_intent\",\n" +
+                    "\t\"amount\": 1000,\n" +
+                    "\t\"amount_capturable\": 0,\n" +
+                    "\t\"amount_received\": 0,\n" +
+                    "\t\"application\": null,\n" +
+                    "\t\"application_fee_amount\": null,\n" +
+                    "\t\"canceled_at\": null,\n" +
+                    "\t\"cancellation_reason\": null,\n" +
+                    "\t\"capture_method\": \"automatic\",\n" +
+                    "\t\"charges\": {\n" +
+                    "\t\t\"object\": \"list\",\n" +
+                    "\t\t\"data\": [],\n" +
+                    "\t\t\"has_more\": false,\n" +
+                    "\t\t\"total_count\": 0,\n" +
+                    "\t\t\"url\": \"/v1/charges?payment_intent=pi_1EZlvVCRMbs6FrXfKpq2xMmy\"\n" +
+                    "\t},\n" +
+                    "\t\"client_secret\": \"pi_1EZlvVCRMbs6FrXfKpq2xMmy_secret_cmhLfbSA54n4\",\n" +
+                    "\t\"confirmation_method\": \"automatic\",\n" +
+                    "\t\"created\": 1557783797,\n" +
+                    "\t\"currency\": \"usd\",\n" +
+                    "\t\"customer\": null,\n" +
+                    "\t\"description\": null,\n" +
+                    "\t\"invoice\": null,\n" +
+                    "\t\"last_payment_error\": null,\n" +
+                    "\t\"livemode\": false,\n" +
+                    "\t\"metadata\": {},\n" +
+                    "\t\"next_action\": {\n" +
+                    "\t\t\"redirect_to_url\": {\n" +
+                    "\t\t\t\"return_url\": \"stripe://deeplink\",\n" +
+                    "\t\t\t\"url\": \"https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecaz6CRMbs6FrXfuYKBRSUG/src_client_secret_F6octeOshkgxT47dr0ZxSZiv\"\n" +
+                    "\t\t},\n" +
+                    "\t\t\"type\": \"redirect_to_url\"\n" +
+                    "\t},\n" +
+                    "\t\"on_behalf_of\": null,\n" +
+                    "\t\"payment_method\": \"pm_1Ecaz6CRMbs6FrXfQs3wNGwB\",\n" +
+                    "\t\"payment_method_types\": [\n" +
+                    "\t\t\"card\"\n" +
+                    "\t],\n" +
+                    "\t\"receipt_email\": null,\n" +
+                    "\t\"review\": null,\n" +
+                    "\t\"shipping\": null,\n" +
+                    "\t\"source\": null,\n" +
+                    "\t\"statement_descriptor\": null,\n" +
+                    "\t\"status\": \"requires_action\",\n" +
+                    "\t\"transfer_data\": null,\n" +
+                    "\t\"transfer_group\": null\n" +
+                    "}"
+            ));
+
     public static final PaymentIntent.RedirectData REDIRECT_DATA =
             new PaymentIntent.RedirectData("https://example.com",
                     "yourapp://post-authentication-return-url");

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -32,7 +32,7 @@ public class PaymentAuthWebViewTest {
     @Test
     public void shouldOverrideUrlLoading_shouldSetResult() {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
-                        "payment_intent_client_secret=pi_123_secret_456&source_type=card";
+                "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
                 new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
                         "stripe://payment_intent_return");
@@ -41,6 +41,7 @@ public class PaymentAuthWebViewTest {
         verify(mActivity).finish();
 
         final Intent intent = mIntentArgumentCaptor.getValue();
-        assertEquals(deepLink, intent.getDataString());
+        assertEquals("pi_123_secret_456",
+                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
     }
 }


### PR DESCRIPTION
## Summary
`PaymentAuthenticationController` is responsibile for generally
handling any payment authentication required by the PaymentIntent.

Currently, the controller will (1) confirm the PaymentIntent and
(2) handle payment authentication via 3DS1 if required, else
bypass payment authentication.

The controller is accessed indirectly through `Stripe#startPaymentAuth`
and `Stripe#onPaymentAuthResult`.

In a follow-up PR, usage example will be added to the examples app.

## Motivation
MOBILE3DS2-372

## Testing
Wrote unit tests
