### PR TITLE
Allow selecting an initial payment method

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -187,6 +187,11 @@ public class PaymentSession {
     public void presentPaymentMethodSelection() {
         final Intent paymentMethodsIntent = mPaymentMethodsActivityStarter.newIntent()
                 .putExtra(EXTRA_PAYMENT_SESSION_ACTIVE, true);
+        if (mPaymentSessionData.getPaymentMethod() != null) {
+            paymentMethodsIntent.putExtra(
+                    PaymentMethodsActivity.EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID,
+                    mPaymentSessionData.getPaymentMethod().id);
+        }
         mHostActivity.startActivityForResult(paymentMethodsIntent, PAYMENT_METHOD_REQUEST);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/MaskedCardAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/MaskedCardAdapter.java
@@ -99,6 +99,14 @@ class MaskedCardAdapter extends RecyclerView.Adapter<MaskedCardAdapter.ViewHolde
     }
 
     @Nullable
+    String getSelectedPaymentMethodId() {
+        if (mSelectedIndex == NO_SELECTION) {
+            return null;
+        }
+        return mPaymentMethods.get(mSelectedIndex).id;
+    }
+
+    @Nullable
     PaymentMethod getSelectedPaymentMethod() {
         if (mSelectedIndex == NO_SELECTION) {
             return null;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -36,6 +36,8 @@ import static com.stripe.android.view.AddPaymentMethodActivity.EXTRA_NEW_PAYMENT
 public class PaymentMethodsActivity extends AppCompatActivity {
 
     public static final String EXTRA_SELECTED_PAYMENT = "selected_payment";
+    public static final String EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID =
+            "initial_selected_payment_method_id";
     public static final String TOKEN_PAYMENT_METHODS_ACTIVITY = "PaymentMethodsActivity";
 
     static final int REQUEST_CODE_ADD_CARD = 700;
@@ -89,7 +91,8 @@ public class PaymentMethodsActivity extends AppCompatActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
-        getCustomerPaymentMethods(null);
+        getCustomerPaymentMethods(
+                getIntent().getStringExtra(EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID));
 
         // This prevents the first click from being eaten by the focus.
         addCardView.requestFocusFromTouch();

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -35,6 +35,8 @@ import static com.stripe.android.view.AddPaymentMethodActivity.EXTRA_NEW_PAYMENT
  */
 public class PaymentMethodsActivity extends AppCompatActivity {
 
+    private static final String STATE_SELECTED_PAYMENT_METHOD = "state_selected_payment_method";
+
     public static final String EXTRA_SELECTED_PAYMENT = "selected_payment";
     public static final String EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID =
             "initial_selected_payment_method_id";
@@ -91,8 +93,19 @@ public class PaymentMethodsActivity extends AppCompatActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
-        getCustomerPaymentMethods(
-                getIntent().getStringExtra(EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID));
+        final String selectedPaymentMethodId;
+
+        if (savedInstanceState != null &&
+                savedInstanceState.containsKey(STATE_SELECTED_PAYMENT_METHOD)) {
+            selectedPaymentMethodId = savedInstanceState.getString(STATE_SELECTED_PAYMENT_METHOD);
+        } else if (getIntent().hasExtra(EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID)) {
+            selectedPaymentMethodId =
+                    getIntent().getStringExtra(EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID);
+        } else {
+            selectedPaymentMethodId = null;
+        }
+
+        getCustomerPaymentMethods(selectedPaymentMethodId);
 
         // This prevents the first click from being eaten by the focus.
         addCardView.requestFocusFromTouch();
@@ -267,5 +280,12 @@ public class PaymentMethodsActivity extends AppCompatActivity {
             activity.showError(displayedError);
             activity.setCommunicatingProgress(false);
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(STATE_SELECTED_PAYMENT_METHOD,
+                mMaskedCardAdapter.getSelectedPaymentMethodId());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -36,7 +36,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -105,6 +108,32 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         listener.onPaymentMethodsRetrieved(mPaymentMethods);
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
+    }
+
+    @Test
+    public void onCreate_initialGivenPaymentMethodIsSelected() {
+        // reset the mock because the activity is being re-created again
+        reset(mCustomerSession);
+        final PaymentMethod paymentMethod =
+                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+        assertNotNull(paymentMethod);
+        mPaymentMethodsActivity = createActivity(new Intent().putExtra(
+                PaymentMethodsActivity.EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID, paymentMethod.id));
+        mRecyclerView = mPaymentMethodsActivity.findViewById(R.id.payment_methods_recycler);
+
+        verify(mCustomerSession).getPaymentMethods(eq(PaymentMethod.Type.Card),
+                mListenerArgumentCaptor.capture());
+
+        final CustomerSession.PaymentMethodsRetrievalListener listener =
+                mListenerArgumentCaptor.getValue();
+        assertNotNull(listener);
+
+        listener.onPaymentMethodsRetrieved(mPaymentMethods);
+
+        final MaskedCardAdapter maskedCardAdapter = (MaskedCardAdapter) mRecyclerView.getAdapter();
+        assertNotNull(maskedCardAdapter);
+        assertNotNull(maskedCardAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod.id, maskedCardAdapter.getSelectedPaymentMethod().id);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Set the initially selected payment method to be the previously selected payment method instead of always defaulting to the newest payment method.

## Motivation

ANDROID-365

## Testing

Unit tests and example app
