### PR TITLE
Add 3DS2 support to PaymentAuthenticationController

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api "com.android.support:design:28.0.0"
 
+    implementation "com.stripe:stripe-3ds2-android:0.0.4"
+
     javadocDeps "com.android.support:support-annotations:28.0.0"
     javadocDeps "com.android.support:appcompat-v7:28.0.0"
     javadocDeps "com.android.support:design:28.0.0"

--- a/stripe/src/main/java/com/stripe/android/ApiOperation.java
+++ b/stripe/src/main/java/com/stripe/android/ApiOperation.java
@@ -6,6 +6,8 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.exception.StripeException;
 
+import org.json.JSONException;
+
 abstract class ApiOperation<ResultType>
         extends AsyncTask<Void, Void, ResultWrapper<ResultType>> {
     @NonNull private final ApiResultCallback<ResultType> mCallback;
@@ -18,7 +20,7 @@ abstract class ApiOperation<ResultType>
     protected final ResultWrapper<ResultType> doInBackground(Void... voids) {
         try {
             return new ResultWrapper<>(getResult());
-        } catch (StripeException e) {
+        } catch (StripeException | JSONException e) {
             return new ResultWrapper<>(e);
         }
     }
@@ -37,5 +39,5 @@ abstract class ApiOperation<ResultType>
     }
 
     @Nullable
-    abstract ResultType getResult() throws StripeException;
+    abstract ResultType getResult() throws StripeException, JSONException;
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -70,7 +70,7 @@ public class Stripe {
      * @param context {@link Context} for resolving resources
      */
     public Stripe(@NonNull Context context) {
-        this(new StripeApiHandler(context), new LoggingUtils(context),
+        this(context, new StripeApiHandler(context), new LoggingUtils(context),
                 new StripeNetworkUtils(context));
     }
 
@@ -81,16 +81,17 @@ public class Stripe {
      * @param publishableKey the client's publishable key
      */
     public Stripe(@NonNull Context context, @NonNull String publishableKey) {
-        this(new StripeApiHandler(context), new LoggingUtils(context),
+        this(context, new StripeApiHandler(context), new LoggingUtils(context),
                 new StripeNetworkUtils(context));
         setDefaultPublishableKey(publishableKey);
     }
 
     @VisibleForTesting
-    Stripe(@NonNull StripeApiHandler apiHandler, @NonNull LoggingUtils loggingUtils,
+    Stripe(@NonNull Context context, @NonNull StripeApiHandler apiHandler,
+           @NonNull LoggingUtils loggingUtils,
            @NonNull StripeNetworkUtils stripeNetworkUtils) {
         this(apiHandler, loggingUtils, stripeNetworkUtils,
-                new PaymentAuthenticationController(apiHandler));
+                new PaymentAuthenticationController(context, apiHandler));
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -21,7 +21,6 @@ import com.stripe.android.model.PaymentMethodCreateParams;
 import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Stripe3ds2AuthResult;
 import com.stripe.android.model.Token;
 
 import org.json.JSONArray;
@@ -666,11 +665,12 @@ class StripeApiHandler {
         convertErrorsToExceptionsAndThrowIfNecessary(response);
     }
 
+    @NonNull
     @VisibleForTesting
-    Stripe3ds2AuthResult start3ds2Auth(@NonNull Stripe3ds2AuthParams authParams,
+    JSONObject start3ds2Auth(@NonNull Stripe3ds2AuthParams authParams,
                                        @NonNull String publishableKey)
             throws InvalidRequestException, APIConnectionException, APIException, CardException,
-            AuthenticationException {
+            AuthenticationException, JSONException {
         final StripeResponse response = getStripeResponse(
                 StripeRequest.createPost(
                         getApiUrl("3ds2/authenticate"),
@@ -678,12 +678,12 @@ class StripeApiHandler {
                         RequestOptions.builder(publishableKey).build())
         );
         convertErrorsToExceptionsAndThrowIfNecessary(response);
-        return new Stripe3ds2AuthResult();
+        return new JSONObject(response.getResponseBody());
     }
 
     void start3ds2Auth(@NonNull Stripe3ds2AuthParams authParams,
                        @NonNull String publishableKey,
-                       @NonNull ApiResultCallback<Stripe3ds2AuthResult> callback) {
+                       @NonNull ApiResultCallback<JSONObject> callback) {
         new Start3ds2AuthTask(this, authParams, publishableKey, callback)
                 .execute();
     }
@@ -1074,7 +1074,7 @@ class StripeApiHandler {
                 StripeRequest.createPost(RequestExecutor.LOGGING_ENDPOINT, params, options));
     }
 
-    private static final class Start3ds2AuthTask extends ApiOperation<Stripe3ds2AuthResult> {
+    private static final class Start3ds2AuthTask extends ApiOperation<JSONObject> {
         @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final Stripe3ds2AuthParams mParams;
         @NonNull private final String mPublishableKey;
@@ -1082,16 +1082,16 @@ class StripeApiHandler {
         private Start3ds2AuthTask(@NonNull StripeApiHandler apiHandler,
                                   @NonNull Stripe3ds2AuthParams params,
                                   @NonNull String publishableKey,
-                                  @NonNull ApiResultCallback<Stripe3ds2AuthResult> callback) {
+                                  @NonNull ApiResultCallback<JSONObject> callback) {
             super(callback);
             mApiHandler = apiHandler;
             mParams = params;
             mPublishableKey = publishableKey;
         }
 
-        @Nullable
+        @NonNull
         @Override
-        Stripe3ds2AuthResult getResult() throws StripeException {
+        JSONObject getResult() throws StripeException, JSONException {
             return mApiHandler.start3ds2Auth(mParams, mPublishableKey);
         }
     }

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2Fixtures.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2Fixtures.java
@@ -1,0 +1,54 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.stripe3ds2.transaction.AuthenticationRequestParameters;
+
+import java.util.UUID;
+
+public class Stripe3ds2Fixtures {
+
+    private static final String DEVICE_DATA = "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew";
+    private static final String SDK_TRANSACTION_ID = UUID.randomUUID().toString();
+    private static final String SDK_APP_ID = "1.0.0";
+    private static final String SDK_REFERENCE_NUMBER = "3DS_LOA_SDK_STIN_12345";
+    private static final String SDK_EPHEMERAL_PUBLIC_KEY = "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"b23da28b-d611-46a8-93af-44ad57ce9c9d\",\"x\":\"hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg\",\"y\":\"OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A\"}";;
+    private static final String MESSAGE_VERSION = "2.1.0";
+
+    @NonNull
+    public static final AuthenticationRequestParameters AREQ_PARAMS =
+            new AuthenticationRequestParameters() {
+                @Override
+                public String getDeviceData() {
+                    return DEVICE_DATA;
+                }
+
+                @Override
+                public String getSDKTransactionID() {
+                    return SDK_TRANSACTION_ID;
+                }
+
+                @Override
+                public String getSDKAppID() {
+                    return SDK_APP_ID;
+                }
+
+                @Override
+                public String getSDKReferenceNumber() {
+                    return SDK_REFERENCE_NUMBER;
+                }
+
+                @Override
+                public String getSDKEphemeralPublicKey() {
+                    return SDK_EPHEMERAL_PUBLIC_KEY;
+                }
+
+                @Override
+                public String getMessageVersion() {
+                    return MESSAGE_VERSION;
+                }
+            };
+
+    private Stripe3ds2Fixtures() {
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -186,11 +187,10 @@ public class StripeApiHandlerTest {
         assertNotNull(source);
     }
 
-    @Ignore("test needs to be updated for backend change")
     @Test
     public void start3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException()
             throws APIConnectionException, APIException, CardException,
-            AuthenticationException {
+            AuthenticationException, JSONException {
         final Stripe3ds2AuthParams authParams = new Stripe3ds2AuthParams(
                 "src_invalid",
                 "1.0.0",

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1273,7 +1273,7 @@ public class StripeTest {
 
     @NonNull
     private Stripe createNonLoggingStripe(@Nullable String publishableKey) {
-        final Stripe stripe = new Stripe(
+        final Stripe stripe = new Stripe(mContext,
                 new StripeApiHandler(
                         mContext,
                         new RequestExecutor(),

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public final class PaymentIntentFixtures {
     @NonNull
-    static final PaymentIntent PI_REQUIRES_3DS2 = Objects.requireNonNull(
+    public static final PaymentIntent PI_REQUIRES_3DS2 = Objects.requireNonNull(
             PaymentIntent.fromString("{\n" +
                     "    \"id\": \"pi_1EceMnCRMbs6FrXfCXdF8dnx\",\n" +
                     "    \"object\": \"payment_intent\",\n" +
@@ -114,7 +114,7 @@ public final class PaymentIntentFixtures {
     );
 
     @NonNull
-    public static final PaymentIntent PI_REQUIRES_ACTION =
+    public static final PaymentIntent PI_REQUIRES_REDIRECT =
             Objects.requireNonNull(PaymentIntent.fromString("{\n" +
                     "\t\"id\": \"pi_1EZlvVCRMbs6FrXfKpq2xMmy\",\n" +
                     "\t\"object\": \"payment_intent\",\n" +

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -271,7 +271,7 @@ public class PaymentIntentTest {
     @Test
     public void getNextActionTypeAndStripeSdkData_whenRedirectToUrl() {
         assertEquals(PaymentIntent.NextActionType.RedirectToUrl,
-                PaymentIntentFixtures.PI_REQUIRES_ACTION.getNextActionType());
-        assertNull(PaymentIntentFixtures.PI_REQUIRES_ACTION.getStripeSdkData());
+                PaymentIntentFixtures.PI_REQUIRES_REDIRECT.getNextActionType());
+        assertNull(PaymentIntentFixtures.PI_REQUIRES_REDIRECT.getStripeSdkData());
     }
 }


### PR DESCRIPTION
## Summary
Integrate the 3DS2 SDK and use it to authenticate and initiate challenge flow

## Motivation
MOBILE3DS2-374

## Testing
Add unit tests