### PR TITLE
Fix Nexus staging plugin configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,15 +8,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.0'
     }
-}
-
-plugins {
-    id 'io.codearte.nexus-staging' version '0.20.0'
-}
-
-nexusStaging {
-    packageGroup = GROUP
 }
 
 allprojects {
@@ -54,4 +47,12 @@ if (JavaVersion.current().isJava8Compatible()) {
             options.addStringOption('Xdoclint:none', '-quiet')
         }
     }
+}
+
+apply plugin: "io.codearte.nexus-staging"
+
+nexusStaging {
+    username = project.hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+    password = project.hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+    packageGroup = GROUP
 }


### PR DESCRIPTION
r? @mshafrir-stripe 
cc @stripe/api-libraries 

## Summary
Fix the configuration of the Nexus staging plugin so that the `closeAndRelease` task works with our automated release tooling.

## Motivation
Making stuff work.

## Testing
Tested locally with `GRADLE_OPTS="-Dorg.gradle.project.NEXUS_USERNAME=stripe -Dorg.gradle.project.NEXUS_PASSWORD=<redacted>" ./gradlew closeRepository`.