### PR TITLE
Conditionally call useGpgCmd() when signing

### DIFF
--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -81,7 +81,9 @@ afterEvaluate { project ->
 
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        useGpgCmd()
+        if (isReleaseBuild() && project.hasProperty('signing.gnupg.keyName')) {
+            useGpgCmd()
+        }
         sign configurations.archives
     }
 


### PR DESCRIPTION
## Summary
`required {}` is a deferred callable so it won’t be called until the signing task is invoked. The rest of the method will be evaluated regardless of what required evaluates to.

https://github.com/gradle/gradle/issues/5064#issuecomment-425375453

## Motivation
Unblock jitpack

