### PR TITLE
Auth Web View Progress Default Visibility

### DIFF
--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -21,9 +21,10 @@
 
     <ProgressBar
         android:id="@+id/auth_web_view_progress_bar"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="match_parent"
+        style="@style/Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/payment_auth_web_view_toolbar"
+        android:layout_centerInParent="true"
+        android:indeterminate="true"
         android:visibility="gone" />
 </RelativeLayout>

--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -25,6 +25,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:indeterminate="true"
-        android:visibility="gone" />
+        android:indeterminate="true" />
 </RelativeLayout>

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -67,13 +67,6 @@ class PaymentAuthWebView extends WebView {
         }
 
         @Override
-        public void onPageStarted(@NonNull WebView view, @NonNull String url,
-                                  @Nullable Bitmap favicon) {
-            super.onPageStarted(view, url, favicon);
-            mProgressBar.setVisibility(VISIBLE);
-        }
-
-        @Override
         public void onPageCommitVisible(@NonNull WebView view, @NonNull String url) {
             super.onPageCommitVisible(view, url);
             mProgressBar.setVisibility(GONE);

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -5,7 +5,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -5,12 +5,12 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
-import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -45,7 +45,6 @@ class PaymentAuthWebView extends WebView {
 
     void init(@NonNull Activity activity, @NonNull String returnUrl) {
         setWebViewClient(new PaymentAuthWebViewClient(activity, returnUrl));
-        setWebChromeClient(new PaymentAuthWebViewChromeClient(activity));
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -54,36 +53,30 @@ class PaymentAuthWebView extends WebView {
         getSettings().setAllowContentAccess(false);
     }
 
-    static class PaymentAuthWebViewChromeClient extends WebChromeClient {
-        @NonNull private final ProgressBar mProgressBar;
-
-        PaymentAuthWebViewChromeClient(@NonNull Activity activity) {
-            mProgressBar = activity.findViewById(R.id.auth_web_view_progress_bar);
-        }
-
-        @Override
-        public void onProgressChanged(@NonNull WebView view, int progress) {
-            if (progress < 100) {
-                if (mProgressBar.getVisibility() == GONE) {
-                    mProgressBar.setVisibility(VISIBLE);
-                }
-                mProgressBar.setProgress(progress);
-            } else if (progress == 100) {
-                mProgressBar.setVisibility(GONE);
-                mProgressBar.setProgress(0);
-            }
-        }
-    }
-
     static class PaymentAuthWebViewClient extends WebViewClient {
         static final String PARAM_CLIENT_SECRET = "payment_intent_client_secret";
 
         @NonNull private final Activity mActivity;
         @NonNull private final Uri mReturnUrl;
+        @NonNull private final ProgressBar mProgressBar;
 
         PaymentAuthWebViewClient(@NonNull Activity activity, @NonNull String returnUrl) {
             mActivity = activity;
             mReturnUrl = Uri.parse(returnUrl);
+            mProgressBar = activity.findViewById(R.id.auth_web_view_progress_bar);
+        }
+
+        @Override
+        public void onPageStarted(@NonNull WebView view, @NonNull String url,
+                                  @Nullable Bitmap favicon) {
+            super.onPageStarted(view, url, favicon);
+            mProgressBar.setVisibility(VISIBLE);
+        }
+
+        @Override
+        public void onPageCommitVisible(@NonNull WebView view, @NonNull String url) {
+            super.onPageCommitVisible(view, url);
+            mProgressBar.setVisibility(GONE);
         }
 
         @Override


### PR DESCRIPTION
## Summary

Make the progress bar visible by default, only hiding it after the page stars showing.

## Motivation

MOBILE3DS2-371 Design feedback

## Testing

```
startActivity(new Intent(this, PaymentAuthWebViewActivity.class)
                .putExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL, "https://stripe.com")
                .putExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL, "https://google.com"));
```


