### PR TITLE
Remove null values in PaymentMethod.BillingDetails#toMap()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -6,6 +6,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
@@ -136,6 +137,7 @@ public class Address extends StripeJsonModel implements Parcelable {
         if (mState != null) {
             map.put(FIELD_STATE, mState);
         }
+        StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -118,12 +118,24 @@ public class Address extends StripeJsonModel implements Parcelable {
     @Override
     public Map<String, Object> toMap() {
         final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_CITY, mCity);
-        map.put(FIELD_COUNTRY, mCountry);
-        map.put(FIELD_LINE_1, mLine1);
-        map.put(FIELD_LINE_2, mLine2);
-        map.put(FIELD_POSTAL_CODE, mPostalCode);
-        map.put(FIELD_STATE, mState);
+        if (mCity != null) {
+            map.put(FIELD_CITY, mCity);
+        }
+        if (mCountry != null) {
+            map.put(FIELD_COUNTRY, mCountry);
+        }
+        if (mLine1 != null) {
+            map.put(FIELD_LINE_1, mLine1);
+        }
+        if (mLine2 != null) {
+            map.put(FIELD_LINE_2, mLine2);
+        }
+        if (mPostalCode != null) {
+            map.put(FIELD_POSTAL_CODE, mPostalCode);
+        }
+        if (mState != null) {
+            map.put(FIELD_STATE, mState);
+        }
         return map;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -275,12 +275,12 @@ public class PaymentMethod extends StripeJsonModel {
     }
 
     public static final class BillingDetails extends StripeJsonModel {
-        private static final String FIELD_ADDRESS = "address";
-        private static final String FIELD_EMAIL = "email";
-        private static final String FIELD_NAME = "name";
-        private static final String FIELD_PHONE = "phone";
+        static final String FIELD_ADDRESS = "address";
+        static final String FIELD_EMAIL = "email";
+        static final String FIELD_NAME = "name";
+        static final String FIELD_PHONE = "phone";
 
-        @NonNull public final Address address;
+        @Nullable public final Address address;
         public final String email;
         public final String name;
         public final String phone;
@@ -296,10 +296,18 @@ public class PaymentMethod extends StripeJsonModel {
         @Override
         public Map<String, Object> toMap() {
             final Map<String, Object> billingDetails = new HashMap<>();
-            billingDetails.put(FIELD_ADDRESS, address.toMap());
-            billingDetails.put(FIELD_EMAIL, email);
-            billingDetails.put(FIELD_NAME, name);
-            billingDetails.put(FIELD_PHONE, phone);
+            if (address != null) {
+                billingDetails.put(FIELD_ADDRESS, address.toMap());
+            }
+            if (email != null) {
+                billingDetails.put(FIELD_EMAIL, email);
+            }
+            if (name != null) {
+                billingDetails.put(FIELD_NAME, name);
+            }
+            if (phone != null) {
+                billingDetails.put(FIELD_PHONE, phone);
+            }
             return billingDetails;
         }
 
@@ -308,7 +316,7 @@ public class PaymentMethod extends StripeJsonModel {
         public JSONObject toJson() {
             final JSONObject billingDetails = new JSONObject();
             try {
-                billingDetails.put(FIELD_ADDRESS, address.toJson());
+                billingDetails.put(FIELD_ADDRESS, address != null ? address.toJson() : null);
                 billingDetails.put(FIELD_EMAIL, email);
                 billingDetails.put(FIELD_NAME, name);
                 billingDetails.put(FIELD_PHONE, phone);

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 
+import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.model.wallets.Wallet;
 import com.stripe.android.model.wallets.WalletFactory;
 import com.stripe.android.utils.ObjectUtils;
@@ -308,6 +309,7 @@ public class PaymentMethod extends StripeJsonModel {
             if (phone != null) {
                 billingDetails.put(FIELD_PHONE, phone);
             }
+            StripeNetworkUtils.removeNullAndEmptyParams(billingDetails);
             return billingDetails;
         }
 

--- a/stripe/src/test/java/com/stripe/android/model/AddressTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/AddressTest.java
@@ -11,7 +11,6 @@ import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link Address}.
@@ -39,14 +38,10 @@ public class AddressTest {
     private static final Address ADDRESS = Address.fromString(JSON_ADDRESS);
 
     @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() {
+    public void fromJsonString_backToJson_createsIdenticalElement() throws JSONException {
         assertNotNull(ADDRESS);
-        try {
-            JSONObject rawConversion = new JSONObject(JSON_ADDRESS);
-            assertJsonEquals(rawConversion, ADDRESS.toJson());
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
+        JSONObject rawConversion = new JSONObject(JSON_ADDRESS);
+        assertJsonEquals(rawConversion, ADDRESS.toJson());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PaymentMethodTest {
     public static final String RAW_CARD_JSON = "{\n" +
@@ -164,5 +166,17 @@ public class PaymentMethodTest {
     @Test
     public void fromString_shouldReturnExpectedPaymentMethod() {
         assertEquals(CARD_PAYMENT_METHOD, PaymentMethod.fromString(RAW_CARD_JSON));
+    }
+
+    @Test
+    public void billingDetailsToMap_removesNullValues() {
+        final Map<String, Object> billingDetails =
+                new PaymentMethod.BillingDetails.Builder()
+                        .setName("name")
+                        .build()
+                        .toMap();
+        assertEquals(1, billingDetails.size());
+        assertFalse(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_ADDRESS));
+        assertTrue(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_NAME));
     }
 }


### PR DESCRIPTION
Null values are required to be removed by the API