### PR TITLE
Make PaymentMethod Parcelable

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.java
@@ -63,9 +63,8 @@ public class CustomerSessionActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_SELECT_SOURCE && resultCode == RESULT_OK) {
-            final String selectedPaymentMethod =
-                    data.getStringExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT);
-            final PaymentMethod paymentMethod = PaymentMethod.fromString(selectedPaymentMethod);
+            final PaymentMethod paymentMethod =
+                    data.getParcelableExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT);
 
             if (paymentMethod != null && paymentMethod.card != null) {
                 mSelectedSourceTextView.setText(buildCardString(paymentMethod.card));

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -89,9 +89,8 @@ public class PaymentSession {
         } else if (resultCode == Activity.RESULT_OK) {
             switch (requestCode) {
                 case PAYMENT_METHOD_REQUEST: {
-                    final PaymentMethod paymentMethod = PaymentMethod.fromString(
-                                    data.getStringExtra(
-                                            PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT));
+                    final PaymentMethod paymentMethod =
+                            data.getParcelableExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT);
                     if (paymentMethod != null) {
                         mPaymentSessionData.setPaymentMethod(paymentMethod);
                         mPaymentSessionData.updateIsPaymentReadyToCharge(mPaymentSessionConfig);

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -250,7 +250,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
         }
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<PaymentMethod> CREATOR =
             new Parcelable.Creator<PaymentMethod>() {
                 @NonNull
@@ -382,7 +381,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             dest.writeString(phone);
         }
 
-        @SuppressWarnings("unused")
         public static final Parcelable.Creator<BillingDetails> CREATOR =
                 new Parcelable.Creator<BillingDetails>() {
                     @Override
@@ -598,7 +596,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             dest.writeParcelable(wallet, flags);
         }
 
-        @SuppressWarnings("unused")
         public static final Parcelable.Creator<Card> CREATOR = new Parcelable.Creator<Card>() {
             @Override
             public Card createFromParcel(@NonNull Parcel in) {
@@ -796,7 +793,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
                 dest.writeString(cvcCheck);
             }
 
-            @SuppressWarnings("unused")
             public static final Parcelable.Creator<Checks> CREATOR =
                     new Parcelable.Creator<Checks>() {
                         @Override
@@ -916,7 +912,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
                 dest.writeByte((byte) (isSupported ? 0x01 : 0x00));
             }
 
-            @SuppressWarnings("unused")
             public static final Parcelable.Creator<ThreeDSecureUsage> CREATOR =
                     new Parcelable.Creator<ThreeDSecureUsage>() {
                         @Override
@@ -1004,7 +999,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             super(in);
         }
 
-        @SuppressWarnings("unused")
         public static final Parcelable.Creator<CardPresent> CREATOR =
                 new Parcelable.Creator<CardPresent>() {
                     @Override
@@ -1071,7 +1065,6 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             dest.writeString(bankIdentifierCode);
         }
 
-        @SuppressWarnings("unused")
         public static final Parcelable.Creator<Ideal> CREATOR = new Parcelable.Creator<Ideal>() {
             @Override
             public Ideal createFromParcel(@NonNull Parcel in) {

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -251,18 +251,19 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
     }
 
     @SuppressWarnings("unused")
-    public static final Parcelable.Creator<PaymentMethod> CREATOR = new Parcelable.Creator<PaymentMethod>() {
-        @NonNull
-        @Override
-        public PaymentMethod createFromParcel(@NonNull Parcel in) {
-            return new PaymentMethod(in);
-        }
+    public static final Parcelable.Creator<PaymentMethod> CREATOR =
+            new Parcelable.Creator<PaymentMethod>() {
+                @NonNull
+                @Override
+                public PaymentMethod createFromParcel(@NonNull Parcel in) {
+                    return new PaymentMethod(in);
+                }
 
-        @Override
-        public PaymentMethod[] newArray(int size) {
-            return new PaymentMethod[size];
-        }
-    };
+                @Override
+                public PaymentMethod[] newArray(int size) {
+                    return new PaymentMethod[size];
+                }
+            };
 
 
     public static final class Builder {
@@ -382,17 +383,18 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
         }
 
         @SuppressWarnings("unused")
-        public static final Parcelable.Creator<BillingDetails> CREATOR = new Parcelable.Creator<BillingDetails>() {
-            @Override
-            public BillingDetails createFromParcel(@NonNull Parcel in) {
-                return new BillingDetails(in);
-            }
+        public static final Parcelable.Creator<BillingDetails> CREATOR =
+                new Parcelable.Creator<BillingDetails>() {
+                    @Override
+                    public BillingDetails createFromParcel(@NonNull Parcel in) {
+                        return new BillingDetails(in);
+                    }
 
-            @Override
-            public BillingDetails[] newArray(int size) {
-                return new BillingDetails[size];
-            }
-        };
+                    @Override
+                    public BillingDetails[] newArray(int size) {
+                        return new BillingDetails[size];
+                    }
+                };
 
         @NonNull
         @Override
@@ -795,17 +797,18 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             }
 
             @SuppressWarnings("unused")
-            public static final Parcelable.Creator<Checks> CREATOR = new Parcelable.Creator<Checks>() {
-                @Override
-                public Checks createFromParcel(@NonNull Parcel in) {
-                    return new Checks(in);
-                }
+            public static final Parcelable.Creator<Checks> CREATOR =
+                    new Parcelable.Creator<Checks>() {
+                        @Override
+                        public Checks createFromParcel(@NonNull Parcel in) {
+                            return new Checks(in);
+                        }
 
-                @Override
-                public Checks[] newArray(int size) {
-                    return new Checks[size];
-                }
-            };
+                        @Override
+                        public Checks[] newArray(int size) {
+                            return new Checks[size];
+                        }
+                    };
 
             @NonNull
             @Override
@@ -914,17 +917,18 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
             }
 
             @SuppressWarnings("unused")
-            public static final Parcelable.Creator<ThreeDSecureUsage> CREATOR = new Parcelable.Creator<ThreeDSecureUsage>() {
-                @Override
-                public ThreeDSecureUsage createFromParcel(@NonNull Parcel in) {
-                    return new ThreeDSecureUsage(in);
-                }
+            public static final Parcelable.Creator<ThreeDSecureUsage> CREATOR =
+                    new Parcelable.Creator<ThreeDSecureUsage>() {
+                        @Override
+                        public ThreeDSecureUsage createFromParcel(@NonNull Parcel in) {
+                            return new ThreeDSecureUsage(in);
+                        }
 
-                @Override
-                public ThreeDSecureUsage[] newArray(int size) {
-                    return new ThreeDSecureUsage[size];
-                }
-            };
+                        @Override
+                        public ThreeDSecureUsage[] newArray(int size) {
+                            return new ThreeDSecureUsage[size];
+                        }
+                    };
 
             @NonNull
             @Override
@@ -1001,17 +1005,18 @@ public class PaymentMethod extends StripeJsonModel implements Parcelable {
         }
 
         @SuppressWarnings("unused")
-        public static final Parcelable.Creator<CardPresent> CREATOR = new Parcelable.Creator<CardPresent>() {
-            @Override
-            public CardPresent createFromParcel(@NonNull Parcel in) {
-                return new CardPresent(in);
-            }
+        public static final Parcelable.Creator<CardPresent> CREATOR =
+                new Parcelable.Creator<CardPresent>() {
+                    @Override
+                    public CardPresent createFromParcel(@NonNull Parcel in) {
+                        return new CardPresent(in);
+                    }
 
-            @Override
-            public CardPresent[] newArray(int size) {
-                return new CardPresent[size];
-            }
-        };
+                    @Override
+                    public CardPresent[] newArray(int size) {
+                        return new CardPresent[size];
+                    }
+                };
 
         @NonNull
         @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
@@ -43,7 +43,6 @@ public final class AmexExpressCheckoutWallet extends Wallet {
         }
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<AmexExpressCheckoutWallet> CREATOR =
             new Parcelable.Creator<AmexExpressCheckoutWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import org.json.JSONObject;
@@ -10,6 +12,10 @@ import java.util.Map;
 public final class AmexExpressCheckoutWallet extends Wallet {
     private AmexExpressCheckoutWallet(@NonNull Builder builder) {
         super(Type.AmexExpressCheckout, builder);
+    }
+
+    private AmexExpressCheckoutWallet(@NonNull Parcel in) {
+        super(in);
     }
 
     @NonNull
@@ -36,4 +42,18 @@ public final class AmexExpressCheckoutWallet extends Wallet {
             return new AmexExpressCheckoutWallet(this);
         }
     }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<AmexExpressCheckoutWallet> CREATOR =
+            new Parcelable.Creator<AmexExpressCheckoutWallet>() {
+                @Override
+                public AmexExpressCheckoutWallet createFromParcel(@NonNull Parcel in) {
+                    return new AmexExpressCheckoutWallet(in);
+                }
+
+                @Override
+                public AmexExpressCheckoutWallet[] newArray(int size) {
+                    return new AmexExpressCheckoutWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import org.json.JSONObject;
@@ -10,6 +12,10 @@ import java.util.Map;
 public final class ApplePayWallet extends Wallet {
     private ApplePayWallet(@NonNull Builder builder) {
         super(Type.ApplePay, builder);
+    }
+
+    private ApplePayWallet(@NonNull Parcel in) {
+        super(in);
     }
 
     @NonNull
@@ -36,4 +42,18 @@ public final class ApplePayWallet extends Wallet {
             return new ApplePayWallet(this);
         }
     }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<ApplePayWallet> CREATOR =
+            new Parcelable.Creator<ApplePayWallet>() {
+                @Override
+                public ApplePayWallet createFromParcel(@NonNull Parcel in) {
+                    return new ApplePayWallet(in);
+                }
+
+                @Override
+                public ApplePayWallet[] newArray(int size) {
+                    return new ApplePayWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
@@ -43,7 +43,6 @@ public final class ApplePayWallet extends Wallet {
         }
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<ApplePayWallet> CREATOR =
             new Parcelable.Creator<ApplePayWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
@@ -43,7 +43,6 @@ public final class GooglePayWallet extends Wallet {
         }
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<GooglePayWallet> CREATOR =
             new Parcelable.Creator<GooglePayWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import org.json.JSONObject;
@@ -10,6 +12,10 @@ import java.util.Map;
 public final class GooglePayWallet extends Wallet {
     private GooglePayWallet(@NonNull Builder builder) {
         super(Type.GooglePay, builder);
+    }
+
+    private GooglePayWallet(@NonNull Parcel in) {
+        super(in);
     }
 
     @NonNull
@@ -36,4 +42,18 @@ public final class GooglePayWallet extends Wallet {
             return new GooglePayWallet(this);
         }
     }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<GooglePayWallet> CREATOR =
+            new Parcelable.Creator<GooglePayWallet>() {
+                @Override
+                public GooglePayWallet createFromParcel(@NonNull Parcel in) {
+                    return new GooglePayWallet(in);
+                }
+
+                @Override
+                public GooglePayWallet[] newArray(int size) {
+                    return new GooglePayWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
@@ -144,7 +144,6 @@ public final class MasterpassWallet extends Wallet {
         dest.writeParcelable(shippingAddress, flags);
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<MasterpassWallet> CREATOR =
             new Parcelable.Creator<MasterpassWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -57,7 +59,8 @@ public final class MasterpassWallet extends Wallet {
             wallet.put(FIELD_NAME, name);
             wallet.put(FIELD_SHIPPING_ADDRESS,
                     shippingAddress != null ? shippingAddress.toJson() : null);
-        } catch (JSONException ignore) {}
+        } catch (JSONException ignore) {
+        }
         return wallet;
     }
 
@@ -123,4 +126,35 @@ public final class MasterpassWallet extends Wallet {
             return new MasterpassWallet(this);
         }
     }
+
+    private MasterpassWallet(@NonNull Parcel in) {
+        super(in);
+        billingAddress = in.readParcelable(Address.class.getClassLoader());
+        email = in.readString();
+        name = in.readString();
+        shippingAddress = in.readParcelable(Address.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeParcelable(billingAddress, flags);
+        dest.writeString(email);
+        dest.writeString(name);
+        dest.writeParcelable(shippingAddress, flags);
+    }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<MasterpassWallet> CREATOR =
+            new Parcelable.Creator<MasterpassWallet>() {
+                @Override
+                public MasterpassWallet createFromParcel(@NonNull Parcel in) {
+                    return new MasterpassWallet(in);
+                }
+
+                @Override
+                public MasterpassWallet[] newArray(int size) {
+                    return new MasterpassWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
@@ -43,7 +43,6 @@ public final class SamsungPayWallet extends Wallet {
         }
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<SamsungPayWallet> CREATOR =
             new Parcelable.Creator<SamsungPayWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
@@ -17,6 +17,7 @@ public final class SamsungPayWallet extends Wallet {
     private SamsungPayWallet(@NonNull Parcel in) {
         super(in);
     }
+
     @NonNull
     @Override
     Map<String, Object> getWalletTypeMap() {

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import org.json.JSONObject;
@@ -12,6 +14,9 @@ public final class SamsungPayWallet extends Wallet {
         super(Type.SamsungPay, builder);
     }
 
+    private SamsungPayWallet(@NonNull Parcel in) {
+        super(in);
+    }
     @NonNull
     @Override
     Map<String, Object> getWalletTypeMap() {
@@ -36,4 +41,18 @@ public final class SamsungPayWallet extends Wallet {
             return new SamsungPayWallet(this);
         }
     }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<SamsungPayWallet> CREATOR =
+            new Parcelable.Creator<SamsungPayWallet>() {
+                @Override
+                public SamsungPayWallet createFromParcel(@NonNull Parcel in) {
+                    return new SamsungPayWallet(in);
+                }
+
+                @Override
+                public SamsungPayWallet[] newArray(int size) {
+                    return new SamsungPayWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
@@ -144,7 +144,6 @@ public final class VisaCheckoutWallet extends Wallet {
         dest.writeParcelable(shippingAddress, flags);
     }
 
-    @SuppressWarnings("unused")
     public static final Parcelable.Creator<VisaCheckoutWallet> CREATOR =
             new Parcelable.Creator<VisaCheckoutWallet>() {
                 @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -57,7 +59,8 @@ public final class VisaCheckoutWallet extends Wallet {
             wallet.put(FIELD_NAME, name);
             wallet.put(FIELD_SHIPPING_ADDRESS,
                     shippingAddress != null ? shippingAddress.toJson() : null);
-        } catch (JSONException ignore) {}
+        } catch (JSONException ignore) {
+        }
         return wallet;
     }
 
@@ -123,4 +126,35 @@ public final class VisaCheckoutWallet extends Wallet {
             return new VisaCheckoutWallet(this);
         }
     }
+
+    private VisaCheckoutWallet(@NonNull Parcel in) {
+        super(in);
+        billingAddress = in.readParcelable(Address.class.getClassLoader());
+        email = in.readString();
+        name = in.readString();
+        shippingAddress = in.readParcelable(Address.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeParcelable(billingAddress, flags);
+        dest.writeString(email);
+        dest.writeString(name);
+        dest.writeParcelable(shippingAddress, flags);
+    }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<VisaCheckoutWallet> CREATOR =
+            new Parcelable.Creator<VisaCheckoutWallet>() {
+                @Override
+                public VisaCheckoutWallet createFromParcel(@NonNull Parcel in) {
+                    return new VisaCheckoutWallet(in);
+                }
+
+                @Override
+                public VisaCheckoutWallet[] newArray(int size) {
+                    return new VisaCheckoutWallet[size];
+                }
+            };
 }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -176,7 +176,6 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
             dest.writeString(state);
         }
 
-        @SuppressWarnings("unused")
         public static final Parcelable.Creator<Address> CREATOR =
                 new Parcelable.Creator<Address>() {
                     @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -15,7 +17,7 @@ import java.util.Map;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
-public abstract class Wallet extends StripeJsonModel {
+public abstract class Wallet extends StripeJsonModel implements Parcelable {
     static final String FIELD_DYANMIC_LAST4 = "dynamic_last4";
     static final String FIELD_TYPE = "type";
 
@@ -25,6 +27,22 @@ public abstract class Wallet extends StripeJsonModel {
     Wallet(@NonNull Type walletType, @NonNull Builder builder) {
         this.walletType = walletType;
         dynamicLast4 = builder.mDynamicLast4;
+    }
+
+    Wallet(@NonNull Parcel in) {
+        dynamicLast4 = in.readString();
+        walletType = Type.fromCode(in.readString());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(dynamicLast4);
+        dest.writeString(walletType.code);
     }
 
     @NonNull
@@ -45,8 +63,24 @@ public abstract class Wallet extends StripeJsonModel {
             wallet.put(FIELD_TYPE, walletType.code);
             wallet.put(FIELD_DYANMIC_LAST4, dynamicLast4);
             wallet.put(walletType.code, getWalletTypeJson());
-        } catch (JSONException ignore) {}
+        } catch (JSONException ignore) {
+        }
         return wallet;
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(dynamicLast4, walletType);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof Wallet && typedEquals((Wallet) obj));
+    }
+
+    private boolean typedEquals(@NonNull Wallet wallet) {
+        return ObjectUtils.equals(dynamicLast4, wallet.dynamicLast4)
+                && ObjectUtils.equals(walletType, wallet.walletType);
     }
 
     @NonNull
@@ -94,14 +128,14 @@ public abstract class Wallet extends StripeJsonModel {
         }
     }
 
-    public static class Address extends StripeJsonModel {
+    public static class Address extends StripeJsonModel implements Parcelable {
         static final String FIELD_CITY = "city";
         static final String FIELD_COUNTRY = "country";
         static final String FIELD_LINE1 = "line1";
         static final String FIELD_LINE2 = "line2";
         static final String FIELD_POSTAL_CODE = "postal_code";
         static final String FIELD_STATE = "state";
-        
+
         @Nullable public final String city;
         @Nullable public final String country;
         @Nullable public final String line1;
@@ -117,6 +151,43 @@ public abstract class Wallet extends StripeJsonModel {
             postalCode = builder.mPostalCode;
             state = builder.mState;
         }
+
+        private Address(@NonNull Parcel in) {
+            city = in.readString();
+            country = in.readString();
+            line1 = in.readString();
+            line2 = in.readString();
+            postalCode = in.readString();
+            state = in.readString();
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            dest.writeString(city);
+            dest.writeString(country);
+            dest.writeString(line1);
+            dest.writeString(line2);
+            dest.writeString(postalCode);
+            dest.writeString(state);
+        }
+
+        @SuppressWarnings("unused")
+        public static final Parcelable.Creator<Address> CREATOR = new Parcelable.Creator<Address>() {
+            @Override
+            public Address createFromParcel(@NonNull Parcel in) {
+                return new Address(in);
+            }
+
+            @Override
+            public Address[] newArray(int size) {
+                return new Address[size];
+            }
+        };
 
         @NonNull
         @Override
@@ -142,7 +213,8 @@ public abstract class Wallet extends StripeJsonModel {
                 address.put(FIELD_LINE2, line2);
                 address.put(FIELD_POSTAL_CODE, postalCode);
                 address.put(FIELD_STATE, state);
-            } catch (JSONException ignore) {}
+            } catch (JSONException ignore) {
+            }
             return address;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 public abstract class Wallet extends StripeJsonModel implements Parcelable {
-    static final String FIELD_DYANMIC_LAST4 = "dynamic_last4";
+    static final String FIELD_DYNAMIC_LAST4 = "dynamic_last4";
     static final String FIELD_TYPE = "type";
 
     @Nullable private final String dynamicLast4;
@@ -50,7 +50,7 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
     public final Map<String, Object> toMap() {
         final AbstractMap<String, Object> wallet = new HashMap<>();
         wallet.put(FIELD_TYPE, walletType.code);
-        wallet.put(FIELD_DYANMIC_LAST4, dynamicLast4);
+        wallet.put(FIELD_DYNAMIC_LAST4, dynamicLast4);
         wallet.put(walletType.code, getWalletTypeMap());
         return wallet;
     }
@@ -61,7 +61,7 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
         final JSONObject wallet = new JSONObject();
         try {
             wallet.put(FIELD_TYPE, walletType.code);
-            wallet.put(FIELD_DYANMIC_LAST4, dynamicLast4);
+            wallet.put(FIELD_DYNAMIC_LAST4, dynamicLast4);
             wallet.put(walletType.code, getWalletTypeJson());
         } catch (JSONException ignore) {
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -177,17 +177,18 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
         }
 
         @SuppressWarnings("unused")
-        public static final Parcelable.Creator<Address> CREATOR = new Parcelable.Creator<Address>() {
-            @Override
-            public Address createFromParcel(@NonNull Parcel in) {
-                return new Address(in);
-            }
+        public static final Parcelable.Creator<Address> CREATOR =
+                new Parcelable.Creator<Address>() {
+                    @Override
+                    public Address createFromParcel(@NonNull Parcel in) {
+                        return new Address(in);
+                    }
 
-            @Override
-            public Address[] newArray(int size) {
-                return new Address[size];
-            }
-        };
+                    @Override
+                    public Address[] newArray(int size) {
+                        return new Address[size];
+                    }
+                };
 
         @NonNull
         @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/WalletFactory.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/WalletFactory.java
@@ -6,7 +6,7 @@ import android.support.annotation.Nullable;
 import org.json.JSONObject;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.wallets.Wallet.FIELD_DYANMIC_LAST4;
+import static com.stripe.android.model.wallets.Wallet.FIELD_DYNAMIC_LAST4;
 
 public class WalletFactory {
 
@@ -64,7 +64,7 @@ public class WalletFactory {
             }
         }
 
-        final String dynamicLast4 = optString(walletJson, FIELD_DYANMIC_LAST4);
+        final String dynamicLast4 = optString(walletJson, FIELD_DYNAMIC_LAST4);
         return walletBuilder
                 .setDynamicLast4(dynamicLast4)
                 .build();

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -220,8 +220,7 @@ public class PaymentMethodsActivity extends AppCompatActivity {
             return;
         }
 
-        final Intent intent = new Intent().putExtra(EXTRA_SELECTED_PAYMENT,
-                paymentMethod.toJson().toString());
+        final Intent intent = new Intent().putExtra(EXTRA_SELECTED_PAYMENT, paymentMethod);
         setResult(RESULT_OK, intent);
         finish();
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -168,7 +168,7 @@ public class PaymentSessionTest {
         boolean handled = paymentSession.handlePaymentData(
                 PaymentSession.PAYMENT_METHOD_REQUEST, RESULT_OK,
                 new Intent().putExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT,
-                        PaymentMethodTest.RAW_CARD_JSON));
+                        PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON)));
 
         assertTrue(handled);
 

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -1,8 +1,12 @@
 package com.stripe.android.model;
 
+import android.os.Parcel;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(RobolectricTestRunner.class)
 public class PaymentMethodTest {
     public static final String RAW_CARD_JSON = "{\n" +
             "\t\"id\": \"pm_123456789\",\n" +
@@ -178,5 +183,35 @@ public class PaymentMethodTest {
         assertEquals(1, billingDetails.size());
         assertFalse(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_ADDRESS));
         assertTrue(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_NAME));
+    }
+
+    @Test
+    public void testParcelable_shouldBeEqualAfterParcel() {
+        final Map<String, String> metadata = new HashMap<>(2);
+        metadata.put("meta", "data");
+        metadata.put("meta2", "data2");
+        final PaymentMethod paymentMethod = new PaymentMethod.Builder()
+                .setBillingDetails(BILLING_DETAILS)
+                .setCard(CARD)
+                .setCardPresent(PaymentMethod.CardPresent.EMPTY)
+                .setCreated(1550757934255L)
+                .setCustomerId("cus_AQsHpvKfKwJDrF")
+                .setId("pm_123456789")
+                .setType("card")
+                .setLiveMode(true)
+                .setMetadata(metadata)
+                .setIdeal(new PaymentMethod.Ideal.Builder()
+                        .setBank("my bank")
+                        .setBankIdentifierCode("bank id")
+                        .build())
+                .build();
+
+        final Parcel parcel = Parcel.obtain();
+        paymentMethod.writeToParcel(parcel, paymentMethod.describeContents());
+        parcel.setDataPosition(0);
+
+        final PaymentMethod parcelPaymentMethod = PaymentMethod.CREATOR.createFromParcel(parcel);
+
+        assertEquals(paymentMethod, parcelPaymentMethod);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
@@ -1,12 +1,18 @@
 package com.stripe.android.model.wallets;
 
+import android.os.Parcel;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(RobolectricTestRunner.class)
 public class WalletFactoryTest {
     private static final String VISA_WALLET_JSON = "{\n" +
             "\t\"type\": \"visa_checkout\",\n" +
@@ -130,5 +136,30 @@ public class WalletFactoryTest {
         assertTrue(wallet instanceof SamsungPayWallet);
         final SamsungPayWallet samsungPayWallet = (SamsungPayWallet) wallet;
         assertEquals(samsungPayWallet.toJson().toString(), walletJson.toString());
+    }
+
+    @Test
+    public void testParcelable_shouldBeEqualAfterParcel() throws JSONException {
+        final WalletFactory walletFactory = new WalletFactory();
+
+        final SamsungPayWallet samsungPayWallet =
+                (SamsungPayWallet) walletFactory.create(new JSONObject(SAMSUNG_PAY_WALLET_JSON));
+        assertNotNull(samsungPayWallet);
+        final Parcel samsungWalletParcel = Parcel.obtain();
+        samsungPayWallet.writeToParcel(samsungWalletParcel, samsungPayWallet.describeContents());
+        samsungWalletParcel.setDataPosition(0);
+        final SamsungPayWallet parcelSamsungWallet =
+                SamsungPayWallet.CREATOR.createFromParcel(samsungWalletParcel);
+        assertEquals(samsungPayWallet, parcelSamsungWallet);
+
+        final VisaCheckoutWallet visaWallet =
+                (VisaCheckoutWallet) walletFactory.create(new JSONObject(VISA_WALLET_JSON));
+        assertNotNull(visaWallet);
+        final Parcel visaParcel = Parcel.obtain();
+        visaWallet.writeToParcel(visaParcel, visaWallet.describeContents());
+        visaParcel.setDataPosition(0);
+        final VisaCheckoutWallet parcelVisaWallet =
+                VisaCheckoutWallet.CREATOR.createFromParcel(visaParcel);
+        assertEquals(visaWallet, parcelVisaWallet);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -229,7 +229,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         assertTrue(intent.hasExtra(EXTRA_SELECTED_PAYMENT));
 
         final PaymentMethod selectedPaymentMethod =
-                PaymentMethod.fromString(intent.getStringExtra(EXTRA_SELECTED_PAYMENT));
+                intent.getParcelableExtra(EXTRA_SELECTED_PAYMENT);
         assertNotNull(selectedPaymentMethod);
         assertEquals(mPaymentMethods.get(0), selectedPaymentMethod);
     }


### PR DESCRIPTION
## Summary

Make PaymentMethod and associated classes parcelable

## Motivation

Instead of returning payment method via JSON string in intent data, use a parcel

## Testing

Automated tests
