### PR TITLE
increase padding to 16dp

### DIFF
--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -12,6 +12,12 @@
     <style name="StripeToolBarStyle" parent="@style/ThemeOverlay.AppCompat">
         <item name="colorControlNormal">?attr/titleTextColor</item>
         <item name="actionMenuTextColor">?attr/titleTextColor</item>
+        <item name="android:actionButtonStyle">@style/StripeActionButtonStyle</item>
+    </style>
+
+    <style name="StripeActionButtonStyle" parent="Widget.AppCompat.ActionButton">
+        <item name="android:paddingStart">16dp</item>
+        <item name="android:paddingEnd">16dp</item>
     </style>
 
     <style name="StripeErrorTextStyle">


### PR DESCRIPTION
## Summary

Increase the margins on the toolbar close menu item from 12dp to 16dp.

![Screenshot_1559155825](https://user-images.githubusercontent.com/48026502/58583145-513d1500-8221-11e9-8ec2-8d879fc164fd.png)


## Motivation

Design feedback MOBILE3DS2-371

## Testing

Ran example app
