### PR TITLE
Add overloaded Stripe#startPaymentAuth for manual confirmation flow

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
@@ -72,13 +72,19 @@ class PaymentAuthenticationController {
     /**
      * Confirm the PaymentIntent and resolve any next actions
      */
-    void confirmAndAuth(@NonNull Stripe stripe,
-                        @NonNull Activity activity,
-                        @NonNull PaymentIntentParams paymentIntentParams,
-                        @NonNull String publishableKey) {
+    void startConfirmAndAuth(@NonNull Stripe stripe,
+                             @NonNull Activity activity,
+                             @NonNull PaymentIntentParams paymentIntentParams,
+                             @NonNull String publishableKey) {
         new ConfirmPaymentIntentTask(stripe, paymentIntentParams, publishableKey,
                 new ConfirmPaymentIntentCallback(activity, publishableKey, this))
                 .execute();
+    }
+
+    void startAuth(@NonNull Activity activity,
+                   @NonNull PaymentIntent paymentIntent,
+                   @NonNull String publishableKey) {
+        handleNextAction(activity, paymentIntent, publishableKey);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -105,6 +105,9 @@ public class Stripe {
     }
 
     /**
+     * Confirm and, if necessary, authenticate a {@link PaymentIntent}. Used for <a href=
+     * "https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow">
+     * automatic confirmation</a> flow.
      *
      * @param activity the {@link Activity} that is launching the payment authentication flow
      * @param confirmPaymentIntentParams {@link PaymentIntentParams} used to confirm the
@@ -113,13 +116,32 @@ public class Stripe {
     private void startPaymentAuth(@NonNull Activity activity,
                                   @NonNull PaymentIntentParams confirmPaymentIntentParams,
                                   @NonNull String publishableKey) {
-        mPaymentAuthenticationController.confirmAndAuth(this, activity,
+        mPaymentAuthenticationController.startConfirmAndAuth(this, activity,
                 confirmPaymentIntentParams, publishableKey);
     }
 
     public void startPaymentAuth(@NonNull Activity activity,
-                          @NonNull PaymentIntentParams paymentIntentParams) {
-        startPaymentAuth(activity, paymentIntentParams, mDefaultPublishableKey);
+                                 @NonNull PaymentIntentParams confirmPaymentIntentParams) {
+        startPaymentAuth(activity, confirmPaymentIntentParams, mDefaultPublishableKey);
+    }
+
+    /**
+     * Authenticate a {@link PaymentIntent}. Used for <a href=
+     * "https://stripe.com/docs/payments/payment-intents/quickstart#manual-confirmation-flow">
+     * manual confirmation</a> flow.
+     *
+     * @param activity the {@link Activity} that is launching the payment authentication flow
+     * @param paymentIntent a confirmed {@link PaymentIntent} object
+     */
+    private void startPaymentAuth(@NonNull Activity activity,
+                                  @NonNull PaymentIntent paymentIntent,
+                                  @NonNull String publishableKey) {
+        mPaymentAuthenticationController.startAuth(activity, paymentIntent, publishableKey);
+    }
+
+    void startPaymentAuth(@NonNull Activity activity,
+                          @NonNull PaymentIntent paymentIntent) {
+        startPaymentAuth(activity, paymentIntent, mDefaultPublishableKey);
     }
 
     private boolean onPaymentAuthResult(

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -31,6 +31,14 @@ import static com.stripe.android.model.StripeJsonUtils.putLongIfNotNull;
 import static com.stripe.android.model.StripeJsonUtils.putMapIfNotNull;
 import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
+/**
+ * A PaymentIntent tracks the process of collecting a payment from your customer.
+ *
+ * <ul>
+ * <li><a href="https://stripe.com/docs/payments/payment-intents">Payment Intents Overview</a></li>
+ * <li><a href="https://stripe.com/docs/api/payment_intents">PaymentIntents API</a></li>
+ * </ul>
+ */
 public class PaymentIntent extends StripeJsonModel {
     private static final String VALUE_PAYMENT_INTENT = "payment_intent";
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.stripe.android.model.PaymentIntentFixtures;
 import com.stripe.android.model.PaymentIntentParams;
 
 import org.junit.Before;
@@ -36,7 +37,7 @@ public class StripePaymentAuthTest {
     }
 
     @Test
-    public void startPaymentAuth_shouldCallControllerConfirmAndAuth() {
+    public void startPaymentAuth_withConfirmParams_shouldConfirmAndAuth() {
         final Stripe stripe = createStripe();
         stripe.setDefaultPublishableKey("pk_test");
         final PaymentIntentParams paymentIntentParams =
@@ -45,7 +46,7 @@ public class StripePaymentAuthTest {
                         "client_secret",
                         "yourapp://post-authentication-return-url");
         stripe.startPaymentAuth(mActivity, paymentIntentParams);
-        verify(mPaymentAuthenticationController).confirmAndAuth(eq(stripe), eq(mActivity),
+        verify(mPaymentAuthenticationController).startConfirmAndAuth(eq(stripe), eq(mActivity),
                 eq(paymentIntentParams), eq("pk_test"));
     }
 
@@ -62,6 +63,15 @@ public class StripePaymentAuthTest {
 
         verify(mPaymentAuthenticationController).handleResult(stripe, data,
                 "pk_test", mCallback);
+    }
+
+    @Test
+    public void startPaymentAuth_withConfirmedPaymentIntent_shouldAuth() {
+        final Stripe stripe = createStripe();
+        stripe.setDefaultPublishableKey("pk_test");
+        stripe.startPaymentAuth(mActivity, PaymentIntentFixtures.PI_REQUIRES_3DS2);
+        verify(mPaymentAuthenticationController).startAuth(eq(mActivity),
+                eq(PaymentIntentFixtures.PI_REQUIRES_3DS2), eq("pk_test"));
     }
 
     @NonNull


### PR DESCRIPTION
## Summary
`Stripe#startPaymentAuth(Activity, PaymentIntent)` is required
to support PaymentIntent objects that have already been confirmed
on the user's server (i.e. manual confirmation flow).

## Testing
Added unit tests
