### PR TITLE
Handle both challenge and frictionless flow in PaymentAuthenticationController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
@@ -169,6 +169,8 @@ public final class Stripe3ds2AuthResult {
         static final String FIELD_SDK_TRANS_ID = "sdkTransID";
         static final String FIELD_THREE_DS_SERVER_TRANS_ID = "threeDSServerTransID";
 
+        static final String VALUE_YES = "Y";
+
         @NonNull public final String threeDSServerTransId;
         @Nullable public final String acsChallengeMandated;
         @Nullable public final String acsSignedContent;
@@ -216,6 +218,10 @@ public final class Stripe3ds2AuthResult {
                     .setMessageExtension(MessageExtension.fromJson(
                             aresJson.optJSONArray(FIELD_MESSAGE_EXTENSION)))
                     .build();
+        }
+
+        public boolean shouldChallenge() {
+            return VALUE_YES.equals(acsChallengeMandated);
         }
 
         @Override

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.java
@@ -1,0 +1,20 @@
+package com.stripe.android.model;
+
+public final class Stripe3ds2AuthResultFixtures {
+
+    // TODO(mshafrir): fully hydrate fixtures
+
+    public static final Stripe3ds2AuthResult ARES_CHALLENGE_FLOW =
+            new Stripe3ds2AuthResult.Builder()
+                    .setAres(new Stripe3ds2AuthResult.Ares.Builder()
+                            .setAcsChallengeMandated(Stripe3ds2AuthResult.Ares.VALUE_YES)
+                            .build())
+                    .build();
+
+    public static final Stripe3ds2AuthResult ARES_FRICTIONLESS_FLOW =
+            new Stripe3ds2AuthResult.Builder()
+                    .setAres(new Stripe3ds2AuthResult.Ares.Builder()
+                            .setAcsChallengeMandated("N")
+                            .build())
+                    .build();
+}


### PR DESCRIPTION
## Motivation
Previously we were only supporting challenge flow

## Testing
Added tests
