### PR TITLE
Refactor Stripe.java

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -25,6 +25,7 @@ import com.stripe.android.model.PaymentMethodCreateParams;
 import com.stripe.android.model.Source;
 
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 
 import static com.stripe.android.PaymentSession.EXTRA_PAYMENT_SESSION_ACTIVE;
 import static com.stripe.android.PaymentSession.TOKEN_PAYMENT_SESSION;
@@ -71,7 +72,8 @@ public class AddPaymentMethodActivity extends StripeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mStripe = new Stripe(getApplicationContext());
+        mStripe = new Stripe(getApplicationContext(),
+                PaymentConfiguration.getInstance().getPublishableKey());
         mViewStub.setLayoutResource(R.layout.activity_add_source);
         mViewStub.inflate();
         mCardMultilineWidget = findViewById(R.id.add_source_card_entry_widget);
@@ -115,12 +117,13 @@ public class AddPaymentMethodActivity extends StripeActivity {
             return;
         }
 
-        createPaymentMethod(mStripe);
+        createPaymentMethod(Objects.requireNonNull(mStripe));
     }
 
     @VisibleForTesting
     void createPaymentMethod(@NonNull Stripe stripe) {
-        final PaymentMethodCreateParams.Card card = mCardMultilineWidget.getPaymentMethodCard();
+        final PaymentMethodCreateParams.Card card =
+                Objects.requireNonNull(mCardMultilineWidget).getPaymentMethodCard();
         final PaymentMethod.BillingDetails billingDetails =
                 mCardMultilineWidget.getPaymentMethodBillingDetails();
 
@@ -132,7 +135,6 @@ public class AddPaymentMethodActivity extends StripeActivity {
         final PaymentMethodCreateParams paymentMethodCreateParams =
                 PaymentMethodCreateParams.create(card, billingDetails);
 
-        stripe.setDefaultPublishableKey(PaymentConfiguration.getInstance().getPublishableKey());
         setCommunicatingProgress(true);
         stripe.createPaymentMethod(paymentMethodCreateParams,
                 new PaymentMethodCallbackImpl(this, mUpdatesCustomer));
@@ -142,7 +144,8 @@ public class AddPaymentMethodActivity extends StripeActivity {
         final CustomerSession.PaymentMethodRetrievalListener listener =
                 new PaymentMethodRetrievalListenerImpl(this);
 
-        CustomerSession.getInstance().attachPaymentMethod(paymentMethod.id, listener);
+        CustomerSession.getInstance()
+                .attachPaymentMethod(Objects.requireNonNull(paymentMethod.id), listener);
     }
 
     private void logToCustomerSessionIf(@NonNull String logToken, boolean condition) {
@@ -160,7 +163,7 @@ public class AddPaymentMethodActivity extends StripeActivity {
     }
 
     boolean hasValidCard() {
-        return mCardMultilineWidget.getCard() != null;
+        return Objects.requireNonNull(mCardMultilineWidget).getCard() != null;
     }
 
     @Nullable

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -39,7 +39,6 @@ public class StripePaymentAuthTest {
     @Test
     public void startPaymentAuth_withConfirmParams_shouldConfirmAndAuth() {
         final Stripe stripe = createStripe();
-        stripe.setDefaultPublishableKey("pk_test");
         final PaymentIntentParams paymentIntentParams =
                 PaymentIntentParams.createConfirmPaymentIntentWithPaymentMethodId(
                         "pm_card_threeDSecure2Required",
@@ -57,7 +56,6 @@ public class StripePaymentAuthTest {
                 PaymentAuthenticationController.REQUEST_CODE, Activity.RESULT_OK, data))
                 .thenReturn(true);
         final Stripe stripe = createStripe();
-        stripe.setDefaultPublishableKey("pk_test");
         stripe.onPaymentAuthResult(PaymentAuthenticationController.REQUEST_CODE, Activity.RESULT_OK,
                 data, mCallback);
 
@@ -68,7 +66,6 @@ public class StripePaymentAuthTest {
     @Test
     public void startPaymentAuth_withConfirmedPaymentIntent_shouldAuth() {
         final Stripe stripe = createStripe();
-        stripe.setDefaultPublishableKey("pk_test");
         stripe.startPaymentAuth(mActivity, PaymentIntentFixtures.PI_REQUIRES_3DS2);
         verify(mPaymentAuthenticationController).startAuth(eq(mActivity),
                 eq(PaymentIntentFixtures.PI_REQUIRES_3DS2), eq("pk_test"));
@@ -81,8 +78,9 @@ public class StripePaymentAuthTest {
                         mContext,
                         new RequestExecutor(),
                         false),
-                new LoggingUtils(mContext),
                 new StripeNetworkUtils(mContext),
-                mPaymentAuthenticationController);
+                mPaymentAuthenticationController,
+                "pk_test"
+        );
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -91,6 +91,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
     public void setup() {
         // The input in this test class will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
+        PaymentConfiguration.init("pk_test_abc123");
         MockitoAnnotations.initMocks(this);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
     }
@@ -157,7 +158,6 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         mWidgetControlGroup.expiryDateEditText.append("50");
         mWidgetControlGroup.cvcEditText.append("12");
 
-        PaymentConfiguration.init("pk_test_abc123");
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
 
@@ -177,8 +177,6 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         mWidgetControlGroup.expiryDateEditText.append("50");
         mWidgetControlGroup.cvcEditText.append("1234");
 
-        PaymentConfiguration.init("pk_test_abc123");
-
         assertEquals(View.GONE, mProgressBar.getVisibility());
 
         mActivity.createPaymentMethod(mStripe);
@@ -195,8 +193,6 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         mWidgetControlGroup.expiryDateEditText.append("50");
         mWidgetControlGroup.cvcEditText.append("1234");
         mWidgetControlGroup.postalCodeEditText.append("90210");
-
-        PaymentConfiguration.init("pk_test_abc123");
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
         assertTrue(mCardMultilineWidget.isEnabled());
@@ -257,7 +253,6 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         mWidgetControlGroup.expiryDateEditText.append("50");
         mWidgetControlGroup.cvcEditText.append("1234");
 
-        PaymentConfiguration.init("pk_test_abc123");
         assertEquals(View.GONE, mProgressBar.getVisibility());
 
         mActivity.createPaymentMethod(mStripe);
@@ -295,8 +290,6 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         mWidgetControlGroup.expiryDateEditText.append("50");
         mWidgetControlGroup.cvcEditText.append("1234");
         mWidgetControlGroup.postalCodeEditText.append("90210");
-
-        PaymentConfiguration.init("pk_test_abc123");
 
         assertEquals(View.GONE, mProgressBar.getVisibility());
         assertTrue(mCardMultilineWidget.isEnabled());


### PR DESCRIPTION
## Summary
- Ensure that `mDefaultPublishableKey` is passed in to overloaded methods
- Deprecate `Stripe#setDefaultPublishableKey()` and replace most usages of
  method with constructor version
- Remove `Stripe#logEventSynchronous()` and `LoggingUtils` instance variable
- Add missing annotations
- Clean up `StripeTest`
  - Standard usage of publishable keys
  - Remove try/catch blocks with throws for cases when success is expected

## Motivation
Improve the `Stripe` interface and implementation

## Testing
Updated unit tests and manually tested
