### PR TITLE
Add API key validation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiKeyValidator.java
+++ b/stripe/src/main/java/com/stripe/android/ApiKeyValidator.java
@@ -1,0 +1,30 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+final class ApiKeyValidator {
+    private static final ApiKeyValidator DEFAULT = new ApiKeyValidator();
+
+    @NonNull
+    static ApiKeyValidator get() {
+        return DEFAULT;
+    }
+
+    @NonNull
+    String requireValid(@Nullable String apiKey) {
+        if (apiKey == null || apiKey.trim().length() == 0) {
+            throw new IllegalArgumentException("Invalid Publishable Key: " +
+                    "You must use a valid publishable key to create a token. " +
+                    "For more info, see https://stripe.com/docs/keys");
+        }
+
+        if (apiKey.startsWith("sk_")) {
+            throw new IllegalArgumentException("Invalid Publishable Key: " +
+                    "You are using a secret key, instead of the publishable one. " +
+                    "For more info, see https://stripe.com/docs/keys");
+        }
+
+        return apiKey;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
@@ -44,6 +44,7 @@ class PaymentAuthenticationController {
     @NonNull private final MessageVersionRegistry mMessageVersionRegistry;
     @NonNull private final String mDirectoryServerId;
     @NonNull private final PaymentAuthConfig mConfig;
+    @NonNull private final ApiKeyValidator mApiKeyValidator;
 
     PaymentAuthenticationController(@NonNull Context context,
                                     @NonNull StripeApiHandler apiHandler) {
@@ -67,6 +68,7 @@ class PaymentAuthenticationController {
         mApiHandler = apiHandler;
         mMessageVersionRegistry = messageVersionRegistry;
         mDirectoryServerId = directoryServerId;
+        mApiKeyValidator = new ApiKeyValidator();
     }
 
     /**
@@ -76,6 +78,7 @@ class PaymentAuthenticationController {
                              @NonNull Activity activity,
                              @NonNull PaymentIntentParams paymentIntentParams,
                              @NonNull String publishableKey) {
+        mApiKeyValidator.requireValid(publishableKey);
         new ConfirmPaymentIntentTask(stripe, paymentIntentParams, publishableKey,
                 new ConfirmPaymentIntentCallback(activity, publishableKey, this))
                 .execute();
@@ -84,7 +87,8 @@ class PaymentAuthenticationController {
     void startAuth(@NonNull Activity activity,
                    @NonNull PaymentIntent paymentIntent,
                    @NonNull String publishableKey) {
-        handleNextAction(activity, paymentIntent, publishableKey);
+        handleNextAction(activity, paymentIntent,
+                mApiKeyValidator.requireValid(publishableKey));
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/RequestOptions.java
+++ b/stripe/src/main/java/com/stripe/android/RequestOptions.java
@@ -19,36 +19,47 @@ final class RequestOptions {
     }
 
     @Nullable private final String mGuid;
-    @Nullable private final String mPublishableApiKey;
+    @Nullable private final String mApiKey;
     @RequestType private final int mRequestType;
     @Nullable private final String mStripeAccount;
 
     @NonNull
     static RequestOptions createForFingerprinting(@NonNull String guid) {
-        return new RequestOptions(RequestType.FINGERPRINTING, null, null, guid);
+        return new RequestOptions(guid);
     }
 
     @NonNull
-    static RequestOptions createForApi(@NonNull String publishableApiKey) {
-        return new RequestOptions(RequestType.API, publishableApiKey, null, null);
+    static RequestOptions createForApi(@NonNull String apiKey) {
+        return new RequestOptions(apiKey, null);
     }
 
     @NonNull
     static RequestOptions createForApi(
-            @NonNull String publishableApiKey,
+            @NonNull String apiKey,
             @Nullable String stripeAccount) {
-        return new RequestOptions(RequestType.API, publishableApiKey, stripeAccount, null);
+        return new RequestOptions(apiKey, stripeAccount);
     }
 
+    /**
+     * Constructor for {@link RequestType#API}
+     */
     private RequestOptions(
-            @RequestType int requestType,
-            @Nullable String publishableApiKey,
-            @Nullable String stripeAccount,
-            @Nullable String guid) {
-        mGuid = guid;
-        mPublishableApiKey = publishableApiKey;
-        mRequestType = requestType;
+            @NonNull String apiKey,
+            @Nullable String stripeAccount) {
+        mRequestType = RequestType.API;
+        mApiKey = new ApiKeyValidator().requireValid(apiKey);
         mStripeAccount = stripeAccount;
+        mGuid = null;
+    }
+
+    /**
+     * Constructor for {@link RequestType#FINGERPRINTING}
+     */
+    private RequestOptions(@NonNull String guid) {
+        mRequestType = RequestType.FINGERPRINTING;
+        mGuid = guid;
+        mApiKey = null;
+        mStripeAccount = null;
     }
 
     /**
@@ -63,8 +74,8 @@ final class RequestOptions {
      * @return the publishable API key for this request
      */
     @Nullable
-    String getPublishableApiKey() {
-        return mPublishableApiKey;
+    String getApiKey() {
+        return mApiKey;
     }
 
     @RequestType

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Handler for calls to the Stripe API.
@@ -73,7 +74,7 @@ class StripeApiHandler {
             return false;
         }
 
-        final String apiKey = options.getPublishableApiKey();
+        final String apiKey = options.getApiKey();
         if (apiKey == null || apiKey.trim().isEmpty()) {
             // if there is no apiKey associated with the request, we don't need to react here.
             return false;
@@ -106,20 +107,16 @@ class StripeApiHandler {
         final RequestOptions options = RequestOptions.createForApi(publishableKey, stripeAccount);
 
         try {
-            final String apiKey = options.getPublishableApiKey();
-            if (StripeTextUtils.isBlank(apiKey)) {
-                return null;
-            }
-
             logTelemetryData();
             final SourceParams sourceParams = paymentIntentParams.getSourceParams();
             final String sourceType = sourceParams != null ? sourceParams.getType() : null;
             logApiCall(
-                    mLoggingUtils.getPaymentIntentConfirmationParams(null, apiKey, sourceType),
+                    mLoggingUtils.getPaymentIntentConfirmationParams(null,
+                            Objects.requireNonNull(options.getApiKey()), sourceType),
                     RequestOptions.createForApi(publishableKey)
             );
             final String paymentIntentId = PaymentIntent.parseIdFromClientSecret(
-                    paymentIntentParams.getClientSecret());
+                    Objects.requireNonNull(paymentIntentParams.getClientSecret()));
             final StripeResponse response = requestData(StripeRequest.createPost(
                     getConfirmPaymentIntentUrl(paymentIntentId), paramMap, options));
             return PaymentIntent.fromString(response.getResponseBody());
@@ -149,18 +146,14 @@ class StripeApiHandler {
         final RequestOptions options = RequestOptions.createForApi(publishableKey, stripeAccount);
 
         try {
-            final String apiKey = options.getPublishableApiKey();
-            if (StripeTextUtils.isBlank(apiKey)) {
-                return null;
-            }
-
             logTelemetryData();
             logApiCall(
-                    mLoggingUtils.getPaymentIntentRetrieveParams(null, apiKey),
+                    mLoggingUtils.getPaymentIntentRetrieveParams(null,
+                            Objects.requireNonNull(options.getApiKey())),
                     RequestOptions.createForApi(publishableKey)
             );
             final String paymentIntentId = PaymentIntent.parseIdFromClientSecret(
-                    paymentIntentParams.getClientSecret());
+                    Objects.requireNonNull(paymentIntentParams.getClientSecret()));
             final StripeResponse response = requestData(StripeRequest.createGet(
                     getRetrievePaymentIntentUrl(paymentIntentId), paramMap, options));
             return PaymentIntent.fromString(response.getResponseBody());
@@ -198,14 +191,10 @@ class StripeApiHandler {
         final RequestOptions options = RequestOptions.createForApi(publishableKey, stripeAccount);
 
         try {
-            final String apiKey = options.getPublishableApiKey();
-            if (StripeTextUtils.isBlank(apiKey)) {
-                return null;
-            }
-
             logTelemetryData();
             logApiCall(
-                    mLoggingUtils.getSourceCreationParams(null, apiKey, sourceParams.getType()),
+                    mLoggingUtils.getSourceCreationParams(null,
+                            Objects.requireNonNull(options.getApiKey()), sourceParams.getType()),
                     RequestOptions.createForApi(publishableKey)
             );
             final StripeResponse response = requestData(
@@ -275,14 +264,10 @@ class StripeApiHandler {
 
         mNetworkUtils.addUidParams(params);
         final RequestOptions options = RequestOptions.createForApi(publishableKey, stripeAccount);
-        final String apiKey = options.getPublishableApiKey();
-        if (StripeTextUtils.isBlank(apiKey)) {
-            return null;
-        }
-
         logTelemetryData();
         logApiCall(
-                mLoggingUtils.getPaymentMethodCreationParams(null, apiKey),
+                mLoggingUtils.getPaymentMethodCreationParams(null,
+                        Objects.requireNonNull(options.getApiKey())),
                 RequestOptions.createForApi(publishableKey)
         );
 
@@ -324,11 +309,6 @@ class StripeApiHandler {
             APIException {
 
         try {
-            final String apiKey = options.getPublishableApiKey();
-            if (StripeTextUtils.isBlank(apiKey)) {
-                return null;
-            }
-
             final List<String> loggingTokens =
                     (List<String>) tokenParams.get(LoggingUtils.FIELD_PRODUCT_USAGE);
             tokenParams.remove(LoggingUtils.FIELD_PRODUCT_USAGE);
@@ -336,7 +316,8 @@ class StripeApiHandler {
             logTelemetryData();
 
             logApiCall(
-                    mLoggingUtils.getTokenCreationParams(loggingTokens, apiKey, tokenType),
+                    mLoggingUtils.getTokenCreationParams(loggingTokens,
+                            Objects.requireNonNull(options.getApiKey()), tokenType),
                     options
             );
         } catch (ClassCastException classCastEx) {
@@ -1014,7 +995,7 @@ class StripeApiHandler {
             allowedToSetTTL = false;
         }
 
-        final String apiKey = request.options.getPublishableApiKey();
+        final String apiKey = request.options.getApiKey();
         if (StripeTextUtils.isBlank(apiKey)) {
             throw new AuthenticationException("No API key provided. (HINT: set your API key using" +
                     " 'Stripe.apiKey = <API-KEY>'. You can generate API keys from the Stripe" +

--- a/stripe/src/main/java/com/stripe/android/StripeRequest.java
+++ b/stripe/src/main/java/com/stripe/android/StripeRequest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-class StripeRequest {
+final class StripeRequest {
     private static final String CHARSET = "UTF-8";
 
     @NonNull final Method method;
@@ -100,7 +100,7 @@ class StripeRequest {
                         BuildConfig.VERSION_NAME));
 
         headers.put("Authorization", String.format(Locale.ENGLISH,
-                "Bearer %s", options.getPublishableApiKey()));
+                "Bearer %s", options.getApiKey()));
 
         // debug headers
         final AbstractMap<String, String> propertyMap = new HashMap<>();

--- a/stripe/src/test/java/com/stripe/android/ApiKeyValidatorTest.java
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyValidatorTest.java
@@ -1,0 +1,56 @@
+package com.stripe.android;
+
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class ApiKeyValidatorTest {
+
+    @Test
+    public void testPublishableKey() {
+        assertEquals("pk_test_123",
+                ApiKeyValidator.get().requireValid("pk_test_123"));
+    }
+
+    @Test
+    public void testEphemeralKey() {
+        assertEquals("ek_test_123",
+                ApiKeyValidator.get().requireValid("ek_test_123"));
+    }
+
+    @Test
+    public void testSecretKey_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() {
+                        ApiKeyValidator.get().requireValid("sk_test_123");
+                    }
+                });
+    }
+
+    @Test
+    public void testEmpty_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() {
+                        ApiKeyValidator.get().requireValid("   ");
+                    }
+                });
+    }
+
+    @Test
+    public void testNull_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
+                    @SuppressWarnings("ConstantConditions")
+                    @Override
+                    public void run() {
+                        ApiKeyValidator.get().requireValid(null);
+                    }
+                });
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/RequestOptionsTest.java
+++ b/stripe/src/test/java/com/stripe/android/RequestOptionsTest.java
@@ -1,9 +1,11 @@
 package com.stripe.android;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class RequestOptionsTest {
 
@@ -11,7 +13,7 @@ public class RequestOptionsTest {
     public void testCreateForApi() {
         final RequestOptions opts = RequestOptions.createForApi("key", "account");
         assertEquals(RequestOptions.RequestType.API, opts.getRequestType());
-        assertEquals("key", opts.getPublishableApiKey());
+        assertEquals("key", opts.getApiKey());
         assertEquals("account", opts.getStripeAccount());
         assertNull(opts.getGuid());
     }
@@ -20,8 +22,19 @@ public class RequestOptionsTest {
     public void testCreateForFingerprinting() {
         final RequestOptions opts = RequestOptions.createForFingerprinting("guid");
         assertEquals(RequestOptions.RequestType.FINGERPRINTING, opts.getRequestType());
-        assertNull(opts.getPublishableApiKey());
+        assertNull(opts.getApiKey());
         assertNull(opts.getStripeAccount());
         assertEquals("guid", opts.getGuid());
+    }
+
+    @Test
+    public void testCreateForApi_withSecretKey_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() {
+                        RequestOptions.createForApi("sk_test");
+                    }
+                });
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -183,7 +183,7 @@ public class StripeTest {
                                        @Nullable Executor executor,
                                        @NonNull TokenCallback callback) {
                         assertEquals(expectedExecutor, executor);
-                        assertEquals(NON_LOGGING_PK, requestOptions.getPublishableApiKey());
+                        assertEquals(NON_LOGGING_PK, requestOptions.getApiKey());
                         assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
                     }
                 });
@@ -200,7 +200,7 @@ public class StripeTest {
                                        @NonNull @Token.TokenType String tokenType,
                                        @Nullable Executor executor,
                                        @NonNull TokenCallback callback) {
-                        assertEquals(NON_LOGGING_PK, requestOptions.getPublishableApiKey());
+                        assertEquals(NON_LOGGING_PK, requestOptions.getApiKey());
                         assertNull(executor);
                         assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
                     }


### PR DESCRIPTION
## Summary
Add API key validation to `RequestOptions`, so that API keys
passed in via `Stripe` instance methods (as opposed to
`Stripe` constructor) are correctly validated.

## Motivation
Consolidate validation

## Testing
Add unit tests
