### PR TITLE
Customize Payment auth web view toolbar

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api "com.android.support:design:28.0.0"
 
-    implementation "com.stripe:stripe-3ds2-android:0.0.10"
+    implementation "com.stripe:stripe-3ds2-android:0.0.11"
 
     javadocDeps "com.android.support:support-annotations:28.0.0"
     javadocDeps "com.android.support:appcompat-v7:28.0.0"

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
@@ -3,8 +3,10 @@ package com.stripe.android;
 import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization;
 import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.PaymentAuthWebViewActivity;
 
@@ -15,24 +17,33 @@ import com.stripe.android.view.PaymentAuthWebViewActivity;
 public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentIntent.RedirectData> {
     public static final String EXTRA_AUTH_URL = "auth_url";
     public static final String EXTRA_RETURN_URL = "return_url";
+    public static final String EXTRA_UI_CUSTOMIZATION = "ui_customization";
 
     @NonNull private final Activity mActivity;
     private final int mRequestCode;
+    @Nullable private final StripeToolbarCustomization mToolbarCustomization;
 
     PaymentAuthWebViewStarter(@NonNull Activity activity, int requestCode) {
+        this(activity, requestCode, null);
+    }
+
+    PaymentAuthWebViewStarter(@NonNull Activity activity, int requestCode,
+                              @Nullable StripeToolbarCustomization toolbarCustomization) {
         mActivity = activity;
         mRequestCode = requestCode;
+        mToolbarCustomization = toolbarCustomization;
     }
 
     /**
      * @param redirectData typically obtained through {@link PaymentIntent#getRedirectData()}
-     *
      */
     public void start(@NonNull PaymentIntent.RedirectData redirectData) {
         final Intent intent = new Intent(mActivity, PaymentAuthWebViewActivity.class)
                 .putExtra(EXTRA_AUTH_URL, redirectData.url.toString())
                 .putExtra(EXTRA_RETURN_URL, redirectData.returnUrl != null ?
-                        redirectData.returnUrl.toString() : null);
+                        redirectData.returnUrl.toString() : null)
+                .putExtra(EXTRA_UI_CUSTOMIZATION, mToolbarCustomization);
+
         mActivity.startActivityForResult(intent, mRequestCode);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -28,13 +28,10 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
 
         final Toolbar toolbar = findViewById(R.id.payment_auth_web_view_toolbar);
         setSupportActionBar(toolbar);
-
         mToolbarCustomization =
                 getIntent().getParcelableExtra(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION);
+        customizeToolbar(toolbar);
 
-        if (mToolbarCustomization != null) {
-            customizeToolbar(toolbar);
-        }
 
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -32,7 +32,6 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
                 getIntent().getParcelableExtra(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION);
         customizeToolbar(toolbar);
 
-
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -1,6 +1,10 @@
 package com.stripe.android.view;
 
+import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -9,8 +13,13 @@ import android.view.MenuItem;
 
 import com.stripe.android.PaymentAuthWebViewStarter;
 import com.stripe.android.R;
+import com.stripe.android.StripeTextUtils;
+import com.stripe.android.stripe3ds2.init.ui.ToolbarCustomization;
+import com.stripe.android.stripe3ds2.utils.CustomizeUtils;
 
 public class PaymentAuthWebViewActivity extends AppCompatActivity {
+
+    @Nullable private ToolbarCustomization mToolbarCustomization;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -19,6 +28,13 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
 
         final Toolbar toolbar = findViewById(R.id.payment_auth_web_view_toolbar);
         setSupportActionBar(toolbar);
+
+        mToolbarCustomization =
+                getIntent().getParcelableExtra(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION);
+
+        if (mToolbarCustomization != null) {
+            customizeToolbar(toolbar);
+        }
 
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
@@ -37,6 +53,13 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.payment_auth_web_view_menu, menu);
+
+        if (mToolbarCustomization != null &&
+                !StripeTextUtils.isBlank(mToolbarCustomization.getButtonText())) {
+            final MenuItem closeMenuItem = menu.findItem(R.id.action_close);
+            closeMenuItem.setTitle(mToolbarCustomization.getButtonText());
+        }
+
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -48,5 +71,24 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    void customizeToolbar(@NonNull Toolbar toolbar) {
+        if (mToolbarCustomization != null) {
+            if (!StripeTextUtils.isBlank(mToolbarCustomization.getHeaderText())) {
+                toolbar.setTitle(CustomizeUtils.buildStyledText(this,
+                        mToolbarCustomization.getHeaderText(), mToolbarCustomization));
+            }
+
+            if (mToolbarCustomization.getBackgroundColor() != null) {
+                @ColorInt final int backgroundColor =
+                        Color.parseColor(mToolbarCustomization.getBackgroundColor());
+                toolbar.setBackgroundColor(backgroundColor);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    getWindow().setStatusBarColor(CustomizeUtils.darken(backgroundColor));
+                }
+            }
+        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import com.stripe.android.model.PaymentIntentFixtures;
+import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
@@ -40,6 +42,21 @@ public class PaymentAuthWebViewStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         final Bundle extras = intent.getExtras();
         assertNotNull(extras);
-        assertEquals(2, extras.size());
+        assertNull(extras.getParcelable(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION));
+        assertEquals(3, extras.size());
+    }
+
+    @Test
+    public void start_startsWithCorrectIntentAndRequestCodeAndCustomization() {
+        new PaymentAuthWebViewStarter(mActivity, 50000,
+                new StripeToolbarCustomization()).start(PaymentIntentFixtures.REDIRECT_DATA);
+        verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
+                mRequestCodeCaptor.capture());
+
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        final Bundle extras = intent.getExtras();
+        assertNotNull(extras);
+        assertNotNull(extras.getParcelable(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION));
+        assertEquals(3, extras.size());
     }
 }


### PR DESCRIPTION
## Summary

WIP until Stripe 3DS2 SDK library is updated.

Allow the usage of `ToolbarCustomization` for `PaymentAuthWebViewActivity` `Toolbar`.

## Motivation

Allow 3DS toolbar to match 3DS2 toolbar.

## Testing

Update Example app's `PaymentAuthActivity` to use `PAYMENT_METHOD_3DS_REQUIRED` in `confirmPaymentIntent`.

Insert the following code to customize in `begin3ds1Auth` in `PaymentAuthenticationController`.

``` java
        final StripeToolbarCustomization toolbarCustomization = new StripeToolbarCustomization();
        toolbarCustomization.setBackgroundColor("#FF0000");
        toolbarCustomization.setButtonText("ABORT!");
        toolbarCustomization.setHeaderText("IS THIS SECURE?");
```
