### PR TITLE
Create RequestOptions before starting async tasks

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -509,7 +509,8 @@ public class Stripe {
             InvalidRequestException,
             APIConnectionException,
             APIException {
-        return mApiHandler.createSource(params, publishableKey, mStripeAccount);
+        return mApiHandler.createSource(params,
+                RequestOptions.createForApi(publishableKey, mStripeAccount));
     }
 
     /**
@@ -529,8 +530,7 @@ public class Stripe {
             APIException {
         return mApiHandler.retrievePaymentIntent(
                 paymentIntentParams,
-                publishableKey,
-                mStripeAccount
+                RequestOptions.createForApi(publishableKey, mStripeAccount)
         );
     }
 
@@ -551,8 +551,7 @@ public class Stripe {
             APIException {
         return mApiHandler.confirmPaymentIntent(
                 paymentIntentParams,
-                publishableKey,
-                mStripeAccount
+                RequestOptions.createForApi(publishableKey, mStripeAccount)
         );
     }
 
@@ -571,7 +570,7 @@ public class Stripe {
             throws AuthenticationException, InvalidRequestException, APIConnectionException,
             APIException {
         return mApiHandler.createPaymentMethod(paymentMethodCreateParams,
-                publishableKey, mStripeAccount);
+                RequestOptions.createForApi(publishableKey, mStripeAccount));
     }
 
     /**
@@ -842,7 +841,8 @@ public class Stripe {
             InvalidRequestException,
             APIConnectionException,
             APIException {
-        return mApiHandler.retrieveSource(sourceId, clientSecret, publishableKey, mStripeAccount);
+        return mApiHandler.retrieveSource(sourceId, clientSecret,
+                RequestOptions.createForApi(publishableKey, mStripeAccount));
     }
 
     /**
@@ -905,8 +905,7 @@ public class Stripe {
     private static class CreateSourceTask extends ApiOperation<Source> {
         @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final SourceParams mSourceParams;
-        @NonNull private final String mPublishableKey;
-        @Nullable private final String mStripeAccount;
+        @NonNull private final RequestOptions mRequestOptions;
 
         CreateSourceTask(@NonNull StripeApiHandler apiHandler,
                          @NonNull SourceParams sourceParams,
@@ -916,26 +915,20 @@ public class Stripe {
             super(callback);
             mApiHandler = apiHandler;
             mSourceParams = sourceParams;
-            mPublishableKey = publishableKey;
-            mStripeAccount = stripeAccount;
+            mRequestOptions = RequestOptions.createForApi(publishableKey, stripeAccount);
         }
 
         @Nullable
         @Override
         Source getResult() throws StripeException {
-                return mApiHandler.createSource(
-                        mSourceParams,
-                        mPublishableKey,
-                        mStripeAccount
-                );
+                return mApiHandler.createSource(mSourceParams, mRequestOptions);
         }
     }
 
     private static class CreatePaymentMethodTask extends ApiOperation<PaymentMethod> {
         @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final PaymentMethodCreateParams mPaymentMethodCreateParams;
-        @NonNull private final String mPublishableKey;
-        @Nullable private final String mStripeAccount;
+        @NonNull private final RequestOptions mRequestOptions;
 
         CreatePaymentMethodTask(@NonNull StripeApiHandler apiHandler,
                                 @NonNull PaymentMethodCreateParams paymentMethodCreateParams,
@@ -945,18 +938,13 @@ public class Stripe {
             super(callback);
             mApiHandler = apiHandler;
             mPaymentMethodCreateParams = paymentMethodCreateParams;
-            mPublishableKey = publishableKey;
-            mStripeAccount = stripeAccount;
+            mRequestOptions = RequestOptions.createForApi(publishableKey, stripeAccount);
         }
 
         @Nullable
         @Override
         PaymentMethod getResult() throws StripeException {
-            return mApiHandler.createPaymentMethod(
-                    mPaymentMethodCreateParams,
-                    mPublishableKey,
-                    mStripeAccount
-            );
+            return mApiHandler.createPaymentMethod(mPaymentMethodCreateParams, mRequestOptions);
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.java
@@ -1,0 +1,8 @@
+package com.stripe.android;
+
+public final class ApiKeyFixtures {
+    static final String DEFAULT_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
+    static final String CONNECTED_ACCOUNT_PUBLISHABLE_KEY = "pk_test_fdjfCYpGSwAX24KUEiuaAAWX";
+
+    public static final String FAKE_PUBLISHABLE_KEY = "pk_test_123";
+}

--- a/stripe/src/test/java/com/stripe/android/ApiKeyValidatorTest.java
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyValidatorTest.java
@@ -10,8 +10,8 @@ public class ApiKeyValidatorTest {
 
     @Test
     public void testPublishableKey() {
-        assertEquals("pk_test_123",
-                ApiKeyValidator.get().requireValid("pk_test_123"));
+        assertEquals(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ApiKeyValidator.get().requireValid(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -210,7 +210,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     public void setup()
             throws StripeException {
         MockitoAnnotations.initMocks(this);
-        PaymentConfiguration.init("pk_test_abc123");
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         LocalBroadcastManager.getInstance(ApplicationProvider.getApplicationContext())
                 .registerReceiver(mBroadcastReceiver,
@@ -358,7 +358,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).setCustomerShippingInfo(
                 eq(FIRST_CUSTOMER.getId()),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq(shippingInformation),
                 eq(firstKey.getSecret()));
@@ -506,7 +506,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).addCustomerSource(
                 eq(FIRST_CUSTOMER.getId()),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
                 eq(Source.CARD),
@@ -611,7 +611,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).deleteCustomerSource(
                 eq(FIRST_CUSTOMER.getId()),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
                 eq(firstKey.getSecret()));
@@ -711,7 +711,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).setDefaultCustomerSource(
                 eq(FIRST_CUSTOMER.getId()),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq("abc123"),
                 eq(Source.CARD),
@@ -842,7 +842,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).attachPaymentMethod(
                 eq(FIRST_CUSTOMER.getId()),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq("pm_abc123"),
                 eq(firstKey.getSecret())
@@ -944,7 +944,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         assertNotNull(FIRST_CUSTOMER);
         assertNotNull(FIRST_CUSTOMER.getId());
         verify(mApiHandler).detachPaymentMethod(
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq("pm_abc123"),
                 eq(firstKey.getSecret()));
@@ -1042,7 +1042,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         verify(mApiHandler).getPaymentMethods(
                 eq(FIRST_CUSTOMER.getId()),
                 eq("card"),
-                eq("pk_test_abc123"),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 mListArgumentCaptor.capture(),
                 eq(firstKey.getSecret())
         );

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
@@ -40,7 +40,7 @@ public class PaymentAuthenticationControllerTest {
 
     private static final String DIRECTORY_SERVER_ID = "F000000000";
     private static final String MESSAGE_VERSION = "2.1.0";
-    private static final String PUBLISHABLE_KEY = "pk_test";
+    private static final String PUBLISHABLE_KEY = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY;
     private static final int MAX_TIMEOUT = 5;
 
     private static final PaymentAuthConfig CONFIG = new PaymentAuthConfig.Builder()

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
@@ -28,8 +28,8 @@ public class PaymentConfigurationTest {
 
     @Test
     public void getInstance_withPublicKey_returnsDefaultInstance() {
-        PaymentConfiguration.init("pk_test_key");
-        assertEquals("pk_test_key",
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        assertEquals(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                 PaymentConfiguration.getInstance().getPublishableKey());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -80,7 +80,7 @@ public class PaymentSessionTest {
             APIConnectionException {
         MockitoAnnotations.initMocks(this);
 
-        PaymentConfiguration.init("pk_test_abc123");
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         mEphemeralKeyProvider = new TestEphemeralKeyProvider();
 
@@ -96,9 +96,8 @@ public class PaymentSessionTest {
         when(mApiHandler.retrieveCustomer(anyString(), anyString()))
                 .thenReturn(firstCustomer, secondCustomer);
         when(mApiHandler.createPaymentMethod(
-                any(PaymentMethodCreateParams.class),
-                anyString(),
-                anyString()
+                ArgumentMatchers.<PaymentMethodCreateParams>any(),
+                ArgumentMatchers.<RequestOptions>any()
         )).thenReturn(paymentMethod);
         when(mApiHandler.setDefaultCustomerSource(
                 anyString(),

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -48,9 +48,6 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class StripeApiHandlerTest {
 
-    private static final String FUNCTIONAL_SOURCE_PUBLISHABLE_KEY =
-            "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
-
     private static final String STRIPE_ACCOUNT_RESPONSE_HEADER = "Stripe-Account";
 
     private static final Card CARD = Card.create("4242424242424242", 1, 2050, "123");
@@ -161,11 +158,8 @@ public class StripeApiHandlerTest {
     public void createSource_shouldLogSourceCreation_andReturnSource()
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
-        final Source source = mApiHandler.createSource(
-                SourceParams.createCardParams(CARD),
-                FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
-                null
-        );
+        final Source source = mApiHandler.createSource(SourceParams.createCardParams(CARD),
+                RequestOptions.createForApi(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY));
 
         // Check that we get a token back; we don't care about its fields for this test.
         assertNotNull(source);
@@ -176,11 +170,8 @@ public class StripeApiHandlerTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         final String connectAccountId = "acct_1Acj2PBUgO3KuWzz";
-        final Source source = mApiHandler.createSource(
-                SourceParams.createCardParams(CARD),
-                "pk_test_fdjfCYpGSwAX24KUEiuaAAWX",
-                connectAccountId
-        );
+        final Source source = mApiHandler.createSource(SourceParams.createCardParams(CARD),
+                RequestOptions.createForApi(ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY, connectAccountId));
 
         // Check that we get a source back; we don't care about its fields for this test.
         assertNotNull(source);
@@ -201,7 +192,7 @@ public class StripeApiHandlerTest {
                 10);
 
         try {
-            mApiHandler.start3ds2Auth(authParams, "pk_test_fdjfCYpGSwAX24KUEiuaAAWX");
+            mApiHandler.start3ds2Auth(authParams, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
             fail("Expected InvalidRequestException");
         } catch (InvalidRequestException e) {
             assertEquals("source", e.getParam());
@@ -213,10 +204,8 @@ public class StripeApiHandlerTest {
     public void logApiCall_shouldReturnSuccessful() {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.
-        final boolean isSuccessful = mApiHandler.logApiCall(
-                new HashMap<String, Object>(),
-                RequestOptions.createForApi("pk_test_fdjfCYpGSwAX24KUEiuaAAWX")
-        );
+        final boolean isSuccessful = mApiHandler.logApiCall(new HashMap<String, Object>(),
+                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
         assertTrue(isSuccessful);
     }
 
@@ -229,8 +218,10 @@ public class StripeApiHandlerTest {
                 StripeRequest.createPost(
                         StripeApiHandler.getSourcesUrl(),
                         SourceParams.createCardParams(CARD).toParamMap(),
-                        RequestOptions.createForApi("pk_test_fdjfCYpGSwAX24KUEiuaAAWX",
-                                connectAccountId))
+                        RequestOptions.createForApi(
+                                ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY,
+                                connectAccountId
+                        ))
         );
         assertNotNull(response);
 
@@ -261,7 +252,7 @@ public class StripeApiHandlerTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         String clientSecret = "temporarily put a private key here simulate the backend";
-        String publicKey = "put a public key that matches the private key here";
+        String publishableKey = "put a public key that matches the private key here";
 
         final PaymentIntentParams paymentIntentParams =
                 PaymentIntentParams.createConfirmPaymentIntentWithSourceDataParams(
@@ -270,10 +261,7 @@ public class StripeApiHandlerTest {
                         "yourapp://post-authentication-return-url"
                 );
         final PaymentIntent paymentIntent = mApiHandler.confirmPaymentIntent(
-                paymentIntentParams,
-                publicKey,
-                null
-        );
+                paymentIntentParams, RequestOptions.createForApi(publishableKey));
 
         assertNotNull(paymentIntent);
     }
@@ -283,7 +271,7 @@ public class StripeApiHandlerTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         String clientSecret = "temporarily put a private key here simulate the backend";
-        String publicKey = "put a public key that matches the private key here";
+        String publishableKey = "put a public key that matches the private key here";
         String sourceId = "id of the source created on the backend";
 
         final PaymentIntentParams paymentIntentParams =
@@ -293,10 +281,7 @@ public class StripeApiHandlerTest {
                         "yourapp://post-authentication-return-url"
                 );
         final PaymentIntent paymentIntent = mApiHandler.confirmPaymentIntent(
-                paymentIntentParams,
-                publicKey,
-                null
-        );
+                paymentIntentParams, RequestOptions.createForApi(publishableKey));
         assertNotNull(paymentIntent);
     }
 
@@ -305,12 +290,11 @@ public class StripeApiHandlerTest {
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
         String clientSecret = "temporarily put a private key here simulate the backend";
-        String publicKey = "put a public key that matches the private key here";
+        String publishableKey = "put a public key that matches the private key here";
 
         final PaymentIntent paymentIntent = mApiHandler.retrievePaymentIntent(
                 PaymentIntentParams.createRetrievePaymentIntentParams(clientSecret),
-                publicKey,
-                null
+                RequestOptions.createForApi(publishableKey)
         );
         assertNotNull(paymentIntent);
     }
@@ -324,11 +308,8 @@ public class StripeApiHandlerTest {
                 new RequestExecutor(),
                 false
         );
-        final Source source = apiHandler.createSource(
-                SourceParams.createCardParams(CARD),
-                FUNCTIONAL_SOURCE_PUBLISHABLE_KEY,
-                null
-        );
+        final Source source = apiHandler.createSource(SourceParams.createCardParams(CARD),
+                RequestOptions.createForApi(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY));
 
         // Check that we get a token back; we don't care about its fields for this test.
         assertNotNull(source);
@@ -341,8 +322,7 @@ public class StripeApiHandlerTest {
                 mRequestExecutor,
                 false
         );
-        apiHandler.logApiCall(new HashMap<String, Object>(),
-                RequestOptions.createForApi("some_key"));
+        apiHandler.logApiCall(new HashMap<String, Object>(), ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
         verifyNoMoreInteractions(mRequestExecutor);
     }
 
@@ -505,7 +485,7 @@ public class StripeApiHandlerTest {
         );
         final List<PaymentMethod> paymentMethods = apiHandler
                 .getPaymentMethods("cus_123", PaymentMethod.Type.Card.code,
-                        FUNCTIONAL_SOURCE_PUBLISHABLE_KEY, new ArrayList<String>(),
+                        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, new ArrayList<String>(),
                         "secret");
         assertEquals(3, paymentMethods.size());
         assertEquals("pm_1EVNYJCRMbs6FrXfG8n52JaK", paymentMethods.get(0).id);
@@ -549,7 +529,7 @@ public class StripeApiHandlerTest {
         );
         final List<PaymentMethod> paymentMethods = apiHandler
                 .getPaymentMethods("cus_123", PaymentMethod.Type.Card.code,
-                        FUNCTIONAL_SOURCE_PUBLISHABLE_KEY, new ArrayList<String>(),
+                        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, new ArrayList<String>(),
                         "secret");
         assertTrue(paymentMethods.isEmpty());
     }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -46,7 +46,7 @@ public class StripePaymentAuthTest {
                         "yourapp://post-authentication-return-url");
         stripe.startPaymentAuth(mActivity, paymentIntentParams);
         verify(mPaymentAuthenticationController).startConfirmAndAuth(eq(stripe), eq(mActivity),
-                eq(paymentIntentParams), eq("pk_test"));
+                eq(paymentIntentParams), eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY));
     }
 
     @Test
@@ -60,15 +60,18 @@ public class StripePaymentAuthTest {
                 data, mCallback);
 
         verify(mPaymentAuthenticationController).handleResult(stripe, data,
-                "pk_test", mCallback);
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mCallback);
     }
 
     @Test
     public void startPaymentAuth_withConfirmedPaymentIntent_shouldAuth() {
         final Stripe stripe = createStripe();
         stripe.startPaymentAuth(mActivity, PaymentIntentFixtures.PI_REQUIRES_3DS2);
-        verify(mPaymentAuthenticationController).startAuth(eq(mActivity),
-                eq(PaymentIntentFixtures.PI_REQUIRES_3DS2), eq("pk_test"));
+        verify(mPaymentAuthenticationController).startAuth(
+                eq(mActivity),
+                eq(PaymentIntentFixtures.PI_REQUIRES_3DS2),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        );
     }
 
     @NonNull
@@ -80,7 +83,7 @@ public class StripePaymentAuthTest {
                         false),
                 new StripeNetworkUtils(mContext),
                 mPaymentAuthenticationController,
-                "pk_test"
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         );
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -49,7 +49,7 @@ public class StripeTest {
     // publishable keys
     private static final String CONNECT_ACCOUNT_PK = "pk_test_dCyfhfyeO2CZkcvT5xyIDdJj";
     private static final String LOGGING_PK = "pk_test_6pRNASCoBOKtIshFeQd4XMUh";
-    private static final String NON_LOGGING_PK = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
+    private static final String NON_LOGGING_PK = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY;
     private static final String DEFAULT_SECRET_KEY = "sk_default";
 
     private static final Card DEFAULT_CARD = Card.create(null, null, null, null);
@@ -229,7 +229,8 @@ public class StripeTest {
     @Test
     public void createCardTokenSynchronous_withValidDataAndConnectAccount_returnsToken()
             throws StripeException {
-        final Stripe stripe = new Stripe(mContext, "pk_test_fdjfCYpGSwAX24KUEiuaAAWX");
+        final Stripe stripe = new Stripe(mContext,
+                ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY);
         stripe.setStripeAccount("acct_1Acj2PBUgO3KuWzz");
 
         final Token token = stripe.createTokenSynchronous(CARD);
@@ -1027,7 +1028,7 @@ public class StripeTest {
     public void createTokenSynchronous_withValidDataAndBadKey_throwsAuthenticationException() {
         try {
             // This key won't work for a real connection to the api.
-            Stripe stripe = createNonLoggingStripe("pk_test");
+            Stripe stripe = createNonLoggingStripe(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
             stripe.createTokenSynchronous(CARD);
             fail("Expecting an error, but did not get one.");
         } catch (AuthenticationException authEx) {

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -10,6 +10,7 @@ import android.widget.ProgressBar;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.stripe.android.ApiKeyFixtures;
 import com.stripe.android.ApiResultCallback;
 import com.stripe.android.CustomerSession;
 import com.stripe.android.CustomerSessionTestHelper;
@@ -91,7 +92,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
     public void setup() {
         // The input in this test class will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
-        PaymentConfiguration.init("pk_test_abc123");
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
         MockitoAnnotations.initMocks(this);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
     }


### PR DESCRIPTION
## Motivation
Creating the `RequestOptions` first ensures that the API key being used is valid

## Testing
Added tests