### PR TITLE
Make Card model fields immutable

### DIFF
--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.java
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.java
@@ -57,7 +57,7 @@ public class TokenIntentService extends IntentService {
             final Integer year = (Integer) intent.getExtras().get(EXTRA_YEAR);
             final String cvc = intent.getStringExtra(EXTRA_CVC);
 
-            final Card card = new Card(cardNumber, month, year, cvc);
+            final Card card = Card.create(cardNumber, month, year, cvc);
 
             final Stripe stripe = new Stripe(getApplicationContext());
             try {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -134,36 +134,36 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
                 put(Card.UNKNOWN, R.drawable.ic_unknown);
             }};
 
-    @Nullable private String number;
-    @Nullable private String cvc;
-    @Nullable private Integer expMonth;
-    @Nullable private Integer expYear;
-    @Nullable private String name;
-    @Nullable private String addressLine1;
-    @Nullable private String addressLine1Check;
-    @Nullable private String addressLine2;
-    @Nullable private String addressCity;
-    @Nullable private String addressState;
-    @Nullable private String addressZip;
-    @Nullable private String addressZipCheck;
-    @Nullable private String addressCountry;
-    @Nullable @Size(4) private String last4;
-    @Nullable @CardBrand private String brand;
-    @Nullable @FundingType private String funding;
-    @Nullable private String fingerprint;
-    @Nullable private String country;
-    @Nullable private String currency;
-    @Nullable private String customerId;
-    @Nullable private String cvcCheck;
-    @Nullable private String id;
+    @Nullable private final String number;
+    @Nullable private final String cvc;
+    @Nullable private final Integer expMonth;
+    @Nullable private final Integer expYear;
+    @Nullable private final String name;
+    @Nullable private final String addressLine1;
+    @Nullable private final String addressLine1Check;
+    @Nullable private final String addressLine2;
+    @Nullable private final String addressCity;
+    @Nullable private final String addressState;
+    @Nullable private final String addressZip;
+    @Nullable private final String addressZipCheck;
+    @Nullable private final String addressCountry;
+    @Nullable @Size(4) private final String last4;
+    @Nullable @CardBrand private final String brand;
+    @Nullable @FundingType private final String funding;
+    @Nullable private final String fingerprint;
+    @Nullable private final String country;
+    @Nullable private final String currency;
+    @Nullable private final String customerId;
+    @Nullable private final String cvcCheck;
+    @Nullable private final String id;
     @NonNull private final List<String> loggingTokens = new ArrayList<>();
-    @Nullable private String tokenizationMethod;
-    @Nullable private Map<String, String> metadata;
+    @Nullable private final String tokenizationMethod;
+    @Nullable private final Map<String, String> metadata;
 
     /**
      * Builder class for a {@link Card} model.
      */
-    public static class Builder {
+    public static final class Builder {
         @Nullable private final String number;
         @Nullable private final String cvc;
         private final Integer expMonth;
@@ -199,8 +199,8 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
          */
         public Builder(
                 @Nullable String number,
-                @IntRange(from = 1, to = 12) Integer expMonth,
-                @IntRange(from = 0) Integer expYear,
+                @IntRange(from = 1, to = 12) @Nullable Integer expMonth,
+                @IntRange(from = 0) @Nullable Integer expYear,
                 @Nullable String cvc) {
             this.number = number;
             this.expMonth = expMonth;
@@ -464,120 +464,6 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * Card constructor with all available fields.
-     * @param number the credit card number
-     * @param expMonth the expiry month
-     * @param expYear the expiry year
-     * @param cvc the CVC number
-     * @param name the card name
-     * @param addressLine1 first line of the billing address
-     * @param addressLine2 second line of the billing address
-     * @param addressCity city of the billing address
-     * @param addressState state of the billing address
-     * @param addressZip zip code of the billing address
-     * @param addressCountry country for the billing address
-     * @param brand brand of this card
-     * @param last4 last 4 digits of the card
-     * @param fingerprint the card fingerprint
-     * @param funding the funding type of the card
-     * @param country ISO country code of the card itself
-     * @param currency currency used by the card
-     * @param id the cardId
-     * @param metadata metadata to associate with the Card model
-     */
-    public Card(
-            String number,
-            @Nullable Integer expMonth,
-            @Nullable Integer expYear,
-            String cvc,
-            String name,
-            String addressLine1,
-            String addressLine2,
-            String addressCity,
-            String addressState,
-            String addressZip,
-            String addressCountry,
-            String brand,
-            @Size(4) String last4,
-            String fingerprint,
-            String funding,
-            String country,
-            String currency,
-            String id,
-            @Nullable Map<String, String> metadata) {
-        this.number = StripeTextUtils.nullIfBlank(normalizeCardNumber(number));
-        this.expMonth = expMonth;
-        this.expYear = expYear;
-        this.cvc = StripeTextUtils.nullIfBlank(cvc);
-        this.name = StripeTextUtils.nullIfBlank(name);
-        this.addressLine1 = StripeTextUtils.nullIfBlank(addressLine1);
-        this.addressLine2 = StripeTextUtils.nullIfBlank(addressLine2);
-        this.addressCity = StripeTextUtils.nullIfBlank(addressCity);
-        this.addressState = StripeTextUtils.nullIfBlank(addressState);
-        this.addressZip = StripeTextUtils.nullIfBlank(addressZip);
-        this.addressCountry = StripeTextUtils.nullIfBlank(addressCountry);
-        this.brand = asCardBrand(brand) == null ? getBrand() : brand;
-        this.last4 = StripeTextUtils.nullIfBlank(last4) == null ? getLast4() : last4;
-        this.fingerprint = StripeTextUtils.nullIfBlank(fingerprint);
-        this.funding = asFundingType(funding);
-        this.country = StripeTextUtils.nullIfBlank(country);
-        this.currency = StripeTextUtils.nullIfBlank(currency);
-        this.id = StripeTextUtils.nullIfBlank(id);
-        this.metadata = metadata;
-    }
-
-    /**
-     * Convenience constructor with address and currency.
-     * @param number the card number
-     * @param expMonth the expiry month
-     * @param expYear the expiry year
-     * @param cvc the CVC code
-     * @param name the cardholder name
-     * @param addressLine1 the first line of the billing address
-     * @param addressLine2 the second line of the billing address
-     * @param addressCity the city of the billing address
-     * @param addressState the state of the billing address
-     * @param addressZip the zip code of the billing address
-     * @param addressCountry the country of the billing address
-     * @param currency the currency of the card
-     */
-    public Card(
-            String number,
-            Integer expMonth,
-            Integer expYear,
-            String cvc,
-            String name,
-            String addressLine1,
-            String addressLine2,
-            String addressCity,
-            String addressState,
-            String addressZip,
-            String addressCountry,
-            String currency,
-            @Nullable Map<String, String> metadata) {
-        this(
-                number,
-                expMonth,
-                expYear,
-                cvc,
-                name,
-                addressLine1,
-                addressLine2,
-                addressCity,
-                addressState,
-                addressZip,
-                addressCountry,
-                null,
-                null,
-                null,
-                null,
-                null,
-                currency,
-                null,
-                metadata);
-    }
-
-    /**
      * Convenience constructor for a Card object with a minimum number of inputs.
      *
      * @param number the card number
@@ -585,31 +471,14 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
      * @param expYear the expiry year
      * @param cvc the CVC code
      */
-    public Card(
+    @NonNull
+    public static Card create(
             String number,
             Integer expMonth,
             Integer expYear,
             String cvc) {
-        this(
-                number,
-                expMonth,
-                expYear,
-                cvc,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
+        return new Builder(number, expMonth, expYear, cvc)
+                .build();
     }
 
     @NonNull
@@ -716,32 +585,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * Setter for the card number. Note that mutating the number of this card object
-     * invalidates the {@link #brand} and {@link #last4}.
-     *
-     * @param number the new {@link #number}
-     */
-    @Deprecated
-    public void setNumber(@Nullable String number) {
-        this.number = number;
-        this.brand = null;
-        this.last4 = null;
-    }
-
-    /**
      * @return the {@link #cvc} for this card
      */
     @Nullable
     public String getCVC() {
         return cvc;
-    }
-
-    /**
-     * @param cvc the new {@link #cvc} code for this card
-     */
-    @Deprecated
-    public void setCVC(@Nullable String cvc) {
-        this.cvc = cvc;
     }
 
     /**
@@ -754,27 +602,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param expMonth sets the {@link #expMonth} for this card
-     */
-    @Deprecated
-    public void setExpMonth(@Nullable @IntRange(from = 1, to = 12) Integer expMonth) {
-        this.expMonth = expMonth;
-    }
-
-    /**
      * @return the {@link #expYear} for this card
      */
     @Nullable
     public Integer getExpYear() {
         return expYear;
-    }
-
-    /**
-     * @param expYear sets the {@link #expYear} for this card
-     */
-    @Deprecated
-    public void setExpYear(@Nullable Integer expYear) {
-        this.expYear = expYear;
     }
 
     /**
@@ -786,25 +618,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param name sets the cardholder {@link #name} for this card
-     */
-    public void setName(@Nullable String name) {
-        this.name = name;
-    }
-
-    /**
      * @return the {@link #addressLine1} of this card
      */
     @Nullable
     public String getAddressLine1() {
         return addressLine1;
-    }
-
-    /**
-     * @param addressLine1 sets the {@link #addressLine1} for this card
-     */
-    public void setAddressLine1(@Nullable String addressLine1) {
-        this.addressLine1 = addressLine1;
     }
 
     /**
@@ -816,25 +634,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param addressLine2 sets the {@link #addressLine2} for this card
-     */
-    public void setAddressLine2(@Nullable String addressLine2) {
-        this.addressLine2 = addressLine2;
-    }
-
-    /**
      * @return the {@link #addressCity} for this card
      */
     @Nullable
     public String getAddressCity() {
         return addressCity;
-    }
-
-    /**
-     * @param addressCity sets the {@link #addressCity} for this card
-     */
-    public void setAddressCity(@Nullable String addressCity) {
-        this.addressCity = addressCity;
     }
 
     /**
@@ -846,25 +650,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param addressZip sets the {@link #addressZip} for this card
-     */
-    public void setAddressZip(@Nullable String addressZip) {
-        this.addressZip = addressZip;
-    }
-
-    /**
      * @return the {@link #addressState} of this card
      */
     @Nullable
     public String getAddressState() {
         return addressState;
-    }
-
-    /**
-     * @param addressState sets the {@link #addressState} for this card
-     */
-    public void setAddressState(@Nullable String addressState) {
-        this.addressState = addressState;
     }
 
     /**
@@ -876,25 +666,11 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param addressCountry sets the {@link #addressCountry} for this card
-     */
-    public void setAddressCountry(@Nullable String addressCountry) {
-        this.addressCountry = addressCountry;
-    }
-
-    /**
      * @return the {@link #currency} of this card. Only supported for Managed accounts.
      */
     @Nullable
     public String getCurrency() {
         return currency;
-    }
-
-    /**
-     * @param currency sets the {@link #currency} of this card. Only supported for Managed accounts.
-     */
-    public void setCurrency(@Nullable String currency) {
-        this.currency = currency;
     }
 
     /**
@@ -906,40 +682,22 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
     }
 
     /**
-     * @param metadata {@link #metadata} for this card
-     */
-    public void setMetadata(@Nullable Map<String, String> metadata) {
-        this.metadata = metadata;
-    }
-
-    /**
-     * @return the {@link #last4} digits of this card. Sets the value based on the {@link #number}
-     * if it has not already been set.
+     * @return the {@link #last4} digits of this card.
      */
     @Nullable
     public String getLast4() {
-        if (!StripeTextUtils.isBlank(last4)) {
-            return last4;
-        }
-
-        if (number != null && number.length() > 4) {
-            last4 = number.substring(number.length() - 4);
-            return last4;
-        }
-
-        return null;
+        return last4;
     }
 
-    /**
-     * Gets the {@link #brand} of this card, changed from the "type" field. Use {@link #getBrand()}
-     * instead.
-     *
-     * @return the {@link #brand} of this card
-     */
-    @Deprecated
-    @CardBrand
-    public String getType() {
-        return getBrand();
+    @Nullable
+    private String calculateLast4(@Nullable String number, @Nullable String last4) {
+        if (!StripeTextUtils.isBlank(last4)) {
+            return last4;
+        } else if (number != null && number.length() > 4) {
+            return number.substring(number.length() - 4);
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -948,13 +706,19 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
      *
      * @return the {@link #brand} of this card
      */
+    @Nullable
     @CardBrand
     public String getBrand() {
-        if (StripeTextUtils.isBlank(brand) && !StripeTextUtils.isBlank(number)) {
-            brand = CardUtils.getPossibleCardType(number);
-        }
-
         return brand;
+    }
+
+    @Nullable
+    private String calculateBrand(@Nullable String brand) {
+        if (StripeTextUtils.isBlank(brand) && !StripeTextUtils.isBlank(number)) {
+            return CardUtils.getPossibleCardType(number);
+        } else {
+            return brand;
+        }
     }
 
     /**
@@ -1125,10 +889,10 @@ public class Card extends StripeJsonModel implements StripePaymentSource {
         this.addressZipCheck = StripeTextUtils.nullIfBlank(builder.addressZipCheck);
         this.addressCountry = StripeTextUtils.nullIfBlank(builder.addressCountry);
         this.last4 = StripeTextUtils.nullIfBlank(builder.last4) == null
-                ? getLast4()
+                ? calculateLast4(number, builder.last4)
                 : builder.last4;
         this.brand = asCardBrand(builder.brand) == null
-                ? getBrand()
+                ? calculateBrand(builder.brand)
                 : builder.brand;
         this.fingerprint = StripeTextUtils.nullIfBlank(builder.fingerprint);
         this.funding = asFundingType(builder.funding);

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -153,7 +153,7 @@ public class CardInputWidget extends LinearLayout {
             return null;
         }
 
-        return new Card(cardNumber, cardDate[0], cardDate[1], cvcValue)
+        return Card.create(cardNumber, cardDate[0], cardDate[1], cvcValue)
                 .addLoggingToken(LOGGING_TOKEN);
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -32,6 +32,7 @@ import com.stripe.android.model.PaymentMethodCreateParams;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Objects;
 
 import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CARD;
 import static com.stripe.android.view.CardInputListener.FocusField.FOCUS_CVC;
@@ -164,14 +165,14 @@ public class CardMultilineWidget extends LinearLayout {
     @Nullable
     public Card getCard() {
         if (validateAllFields()) {
-            String cardNumber = mCardNumberEditText.getCardNumber();
-            int[] cardDate = mExpiryDateEditText.getValidDateFields();
-            String cvcValue = mCvcEditText.getText().toString();
+            final String cardNumber = mCardNumberEditText.getCardNumber();
+            final int[] cardDate = Objects.requireNonNull(mExpiryDateEditText.getValidDateFields());
+            final String cvcValue = mCvcEditText.getText().toString();
 
-            Card card = new Card(cardNumber, cardDate[0], cardDate[1], cvcValue);
-            if (mShouldShowPostalCode) {
-                card.setAddressZip(mPostalCodeEditText.getText().toString());
-            }
+            final Card card = new Card.Builder(cardNumber, cardDate[0], cardDate[1], cvcValue)
+                    .addressZip(mShouldShowPostalCode ?
+                            mPostalCodeEditText.getText().toString() : null)
+                    .build();
             return card.addLoggingToken(CARD_MULTILINE_TOKEN);
         }
 

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -53,8 +53,7 @@ public class StripeApiHandlerTest {
 
     private static final String STRIPE_ACCOUNT_RESPONSE_HEADER = "Stripe-Account";
 
-    private static final Card CARD =
-            new Card("4242424242424242", 1, 2050, "123");
+    private static final Card CARD = Card.create("4242424242424242", 1, 2050, "123");
 
     @NonNull private final StripeApiHandler mApiHandler =
             new StripeApiHandler(ApplicationProvider.getApplicationContext());

--- a/stripe/src/test/java/com/stripe/android/StripeRequestTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeRequestTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class StripeRequestTest {
     private static final Card CARD =
-            new Card("4242424242424242", 1, 2050, "123");
+            Card.create("4242424242424242", 1, 2050, "123");
 
     @Test
     public void getHeaders_withAllRequestOptions_properlyMapsRequestOptions() {

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -52,7 +52,7 @@ public class StripeTest {
     private static final String NON_LOGGING_PK = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
     private static final String DEFAULT_SECRET_KEY = "sk_default";
 
-    private static final Card DEFAULT_CARD = new Card(null, null, null, null);
+    private static final Card DEFAULT_CARD = Card.create(null, null, null, null);
     private static final TokenCallback DEFAULT_TOKEN_CALLBACK = new TokenCallback() {
         @Override
         public void onError(@NonNull Exception error) {
@@ -67,7 +67,7 @@ public class StripeTest {
     private static final String TEST_BANK_ROUTING_NUMBER = "110000000";
 
     private static final int YEAR = Calendar.getInstance().get(Calendar.YEAR) + 1;
-    private static final Card CARD = new Card(TEST_CARD_NUMBER, 12, YEAR, "123");
+    private static final Card CARD = Card.create(TEST_CARD_NUMBER, 12, YEAR, "123");
     private static final BankAccount BANK_ACCOUNT = new BankAccount(
             TEST_BANK_ACCOUNT_NUMBER,
             "US",
@@ -456,14 +456,15 @@ public class StripeTest {
         final Stripe stripe = createNonLoggingStripe(CONNECT_ACCOUNT_PK);
         stripe.setStripeAccount("acct_28DT589O8KAxCGbLmxyZ");
 
-        final Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
-        card.setAddressCity("Sheboygan");
-        card.setAddressCountry("US");
-        card.setAddressLine1("123 Main St");
-        card.setAddressLine2("#456");
-        card.setAddressZip("53081");
-        card.setAddressState("WI");
-        card.setName("Winnie Hoop");
+        final Card card = new Card.Builder(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123")
+                .addressCity("Sheboygan")
+                .addressCountry("US")
+                .addressLine1("123 Main St")
+                .addressLine2("#456")
+                .addressZip("53081")
+                .addressState("WI")
+                .name("Winnie Hoop")
+                .build();
         final SourceParams params = SourceParams.createCardParams(card);
         final Map<String, String> metamap = new HashMap<String, String>() {{
             put("addons", "cream");
@@ -495,7 +496,7 @@ public class StripeTest {
     public void createSourceSynchronous_with3DSParams_passesIntegrationTest()
             throws StripeException {
         final Stripe stripe = createNonLoggingStripe();
-        Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
+        Card card = Card.create(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         SourceParams params = SourceParams.createCardParams(card);
 
         final Source cardSource = stripe.createSourceSynchronous(params);
@@ -859,7 +860,7 @@ public class StripeTest {
     public void retrieveSourceSynchronous_withValidData_passesIntegrationTest()
             throws StripeException {
         final Stripe stripe = createNonLoggingStripe();
-        Card card = new Card(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
+        Card card = Card.create(CardInputTestActivity.VALID_VISA_NO_SPACES, 12, 2050, "123");
         SourceParams params = SourceParams.createCardParams(card);
 
         final Source cardSource = stripe.createSourceSynchronous(params);
@@ -1049,7 +1050,7 @@ public class StripeTest {
     public void createTokenSynchronous_withInvalidCardNumber_throwsCardException() {
         try {
             // This card is missing quite a few numbers.
-            Card card = new Card("42424242", 12, YEAR, "123");
+            Card card = Card.create("42424242", 12, YEAR, "123");
             Stripe stripe = createNonLoggingStripe();
             Token token = stripe.createTokenSynchronous(card);
             fail("Expecting an exception, but created a token instead: " + token.toString());
@@ -1066,7 +1067,7 @@ public class StripeTest {
     public void createTokenSynchronous_withExpiredCard_throwsCardException() {
         try {
             // This card is missing quite a few numbers.
-            Card card = new Card("4242424242424242", 11, 2015, "123");
+            Card card = Card.create("4242424242424242", 11, 2015, "123");
             Stripe stripe = createNonLoggingStripe();
             Token token = stripe.createTokenSynchronous(card);
             fail("Expecting an exception, but created a token instead: " + token.toString());

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.fail;
 public class CardTest {
     private static final int YEAR_IN_FUTURE = 2100;
 
-    static final String JSON_CARD = "{\n" +
+    static final String JSON_CARD_USD = "{\n" +
             "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
             "    \"object\": \"card\",\n" +
             "    \"address_city\": \"Des Moines\",\n" +
@@ -42,6 +42,34 @@ public class CardTest {
             "    \"brand\": \"Visa\",\n" +
             "    \"country\": \"US\",\n" +
             "    \"currency\": \"usd\",\n" +
+            "    \"customer\": \"customer77\",\n" +
+            "    \"cvc_check\": \"unavailable\",\n" +
+            "    \"exp_month\": 8,\n" +
+            "    \"exp_year\": 2017,\n" +
+            "    \"funding\": \"credit\",\n" +
+            "    \"fingerprint\": \"abc123\",\n" +
+            "    \"last4\": \"4242\",\n" +
+            "    \"name\": \"John Cardholder\",\n" +
+            "    \"metadata\": {\n" +
+            "      \"color\": \"blue\",\n" +
+            "      \"animal\": \"dog\"\n" +
+            "    }\n" +
+            "  }";
+
+    static final String JSON_CARD_EUR = "{\n" +
+            "    \"id\": \"card_189fi32eZvKYlo2CHK8NPRME\",\n" +
+            "    \"object\": \"card\",\n" +
+            "    \"address_city\": \"Des Moines\",\n" +
+            "    \"address_country\": \"US\",\n" +
+            "    \"address_line1\": \"123 Any Street\",\n" +
+            "    \"address_line1_check\": \"unavailable\",\n" +
+            "    \"address_line2\": \"456\",\n" +
+            "    \"address_state\": \"IA\",\n" +
+            "    \"address_zip\": \"50305\",\n" +
+            "    \"address_zip_check\": \"unavailable\",\n" +
+            "    \"brand\": \"Visa\",\n" +
+            "    \"country\": \"US\",\n" +
+            "    \"currency\": \"eur\",\n" +
             "    \"customer\": \"customer77\",\n" +
             "    \"cvc_check\": \"unavailable\",\n" +
             "    \"exp_month\": 8,\n" +
@@ -155,141 +183,141 @@ public class CardTest {
 
     @Test
     public void canInitializeWithMinimalArguments() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, "123");
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, "123");
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForAmexCard() {
-        Card card = new Card("3412123412341234", null, null, null);
+        Card card = Card.create("3412123412341234", null, null, null);
         assertEquals(Card.AMERICAN_EXPRESS, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForDiscoverCard() {
-        Card card = new Card("6452123412341234", null, null, null);
+        Card card = Card.create("6452123412341234", null, null, null);
         assertEquals(Card.DISCOVER, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForJCBCard() {
-        Card card = new Card("3512123412341234", null, null, null);
+        Card card = Card.create("3512123412341234", null, null, null);
         assertEquals(Card.JCB, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForDinersClubCard() {
-        Card card = new Card("3612123412341234", null, null, null);
+        Card card = Card.create("3612123412341234", null, null, null);
         assertEquals(Card.DINERS_CLUB, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForVisaCard() {
-        Card card = new Card("4112123412341234", null, null, null);
+        Card card = Card.create("4112123412341234", null, null, null);
         assertEquals(Card.VISA, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForMasterCard() {
-        Card card = new Card("5112123412341234", null, null, null);
+        Card card = Card.create("5112123412341234", null, null, null);
         assertEquals(Card.MASTERCARD, card.getBrand());
     }
 
     @Test
     public void testTypeReturnsCorrectlyForUnionPay() {
-        Card card = new Card("6200000000000005", null, null, null);
+        Card card = Card.create("6200000000000005", null, null, null);
         assertEquals(Card.UNIONPAY, card.getBrand());
     }
 
     @Test
     public void shouldPassValidateNumberIfLuhnNumber() {
-        Card card = new Card("4242-4242-4242-4242", null, null, null);
+        Card card = Card.create("4242-4242-4242-4242", null, null, null);
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfNotLuhnNumber() {
-        Card card = new Card("4242-4242-4242-4241", null, null, null);
+        Card card = Card.create("4242-4242-4242-4241", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldPassValidateNumberIfLuhnNumberAmex() {
-        Card card = new Card("378282246310005", null, null, null);
+        Card card = Card.create("378282246310005", null, null, null);
         assertEquals(Card.AMERICAN_EXPRESS, card.getBrand());
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfNull() {
-        Card card = new Card(null, null, null, null);
+        Card card = Card.create(null, null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfBlank() {
-        Card card = new Card("", null, null, null);
+        Card card = Card.create("", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfJustSpaces() {
-        Card card = new Card("    ", null, null, null);
+        Card card = Card.create("    ", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfTooShort() {
-        Card card = new Card("0", null, null, null);
+        Card card = Card.create("0", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfContainsLetters() {
-        Card card = new Card("424242424242a4242", null, null, null);
+        Card card = Card.create("424242424242a4242", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfTooLong() {
-        Card card = new Card("4242 4242 4242 4242 6", null, null, null);
+        Card card = Card.create("4242 4242 4242 4242 6", null, null, null);
         assertEquals(Card.VISA, card.getBrand());
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldPassValidateNumber() {
-        Card card = new Card("4242424242424242", null, null, null);
+        Card card = Card.create("4242424242424242", null, null, null);
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldPassValidateNumberSpaces() {
-        Card card = new Card("4242 4242 4242 4242", null, null, null);
+        Card card = Card.create("4242 4242 4242 4242", null, null, null);
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldPassValidateNumberDashes() {
-        Card card = new Card("4242-4242-4242-4242", null, null, null);
+        Card card = Card.create("4242-4242-4242-4242", null, null, null);
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldPassValidateNumberWithMixedSeparators() {
-        Card card = new Card("4242-4   242 424-24 242", null, null, null);
+        Card card = Card.create("4242-4   242 424-24 242", null, null, null);
         assertTrue(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateNumberIfWithDot() {
-        Card card = new Card("4242.4242.4242.4242", null, null, null);
+        Card card = Card.create("4242.4242.4242.4242", null, null, null);
         assertFalse(card.validateNumber());
     }
 
     @Test
     public void shouldFailValidateExpiryDateIfNull() {
-        Card card = new Card(null, null, null, null);
+        Card card = Card.create(null, null, null, null);
         assertFalse(card.validateExpMonth());
         assertFalse(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -297,7 +325,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfNullMonth() {
-        Card card = new Card(null, null, YEAR_IN_FUTURE, null);
+        Card card = Card.create(null, null, YEAR_IN_FUTURE, null);
         assertFalse(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -305,7 +333,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfZeroMonth() {
-        Card card = new Card(null, 0, YEAR_IN_FUTURE, null);
+        Card card = Card.create(null, 0, YEAR_IN_FUTURE, null);
         assertFalse(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -313,7 +341,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfNegativeMonth() {
-        Card card = new Card(null, -1, YEAR_IN_FUTURE, null);
+        Card card = Card.create(null, -1, YEAR_IN_FUTURE, null);
         assertFalse(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -321,7 +349,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfMonthToLarge() {
-        Card card = new Card(null, 13, YEAR_IN_FUTURE, null);
+        Card card = Card.create(null, 13, YEAR_IN_FUTURE, null);
         assertFalse(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -329,13 +357,13 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfNullYear() {
-        Card card = new Card(null, 1, null, null);
+        Card card = Card.create(null, 1, null, null);
         assertFalse(card.validateExpiryDate(calendar));
     }
 
     @Test
     public void shouldFailValidateExpiryDateIfZeroYear() {
-        Card card = new Card(null, 12, 0, null);
+        Card card = Card.create(null, 12, 0, null);
         assertTrue(card.validateExpMonth());
         assertFalse(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -343,7 +371,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfNegativeYear() {
-        Card card = new Card(null, 12, -1, null);
+        Card card = Card.create(null, 12, -1, null);
         assertTrue(card.validateExpMonth());
         assertFalse(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -351,7 +379,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateForDecemberOfThisYear() {
-        Card card = new Card(null, 12, 1997, null);
+        Card card = Card.create(null, 12, 1997, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertTrue(card.validateExpiryDate(calendar));
@@ -359,7 +387,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateIfCurrentMonth() {
-        Card card = new Card(null, 8, 1997, null);
+        Card card = Card.create(null, 8, 1997, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertTrue(card.validateExpiryDate(calendar));
@@ -367,7 +395,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateIfCurrentMonthTwoDigitYear() {
-        Card card = new Card(null, 8, 97, null);
+        Card card = Card.create(null, 8, 97, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertTrue(card.validateExpiryDate(calendar));
@@ -375,7 +403,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateExpiryDateIfLastMonth() {
-        Card card = new Card(null, 7, 1997, null);
+        Card card = Card.create(null, 7, 1997, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -383,7 +411,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateIfNextMonth() {
-        Card card = new Card(null, 9, 1997, null);
+        Card card = Card.create(null, 9, 1997, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertTrue(card.validateExpiryDate(calendar));
@@ -391,7 +419,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateForJanuary00() {
-        Card card = new Card(null, 1, 0, null);
+        Card card = Card.create(null, 1, 0, null);
         assertTrue(card.validateExpMonth());
         assertFalse(card.validateExpYear(calendar));
         assertFalse(card.validateExpiryDate(calendar));
@@ -399,7 +427,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateExpiryDateForDecember99() {
-        Card card = new Card(null, 12, 99, null);
+        Card card = Card.create(null, 12, 99, null);
         assertTrue(card.validateExpMonth());
         assertTrue(card.validateExpYear(calendar));
         assertTrue(card.validateExpiryDate(calendar));
@@ -407,103 +435,103 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCVCIfNull() {
-        Card card = new Card(null, null, null, null);
+        Card card = Card.create(null, null, null, null);
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfBlank() {
-        Card card = new Card(null, null, null, "");
+        Card card = Card.create(null, null, null, "");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfUnknownTypeAndLength2() {
-        Card card = new Card(null, null, null, "12");
+        Card card = Card.create(null, null, null, "12");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfUnknownTypeAndLength3() {
-        Card card = new Card(null, null, null, "123");
+        Card card = Card.create(null, null, null, "123");
         assertTrue(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfUnknownTypeAndLength4() {
-        Card card = new Card(null, null, null, "1234");
+        Card card = Card.create(null, null, null, "1234");
         assertTrue(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfUnknownTypeAndLength5() {
-        Card card = new Card(null, null, null, "12345");
+        Card card = Card.create(null, null, null, "12345");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfVisaAndLength2() {
-        Card card = new Card("4242 4242 4242 4242", null, null, "12");
+        Card card = Card.create("4242 4242 4242 4242", null, null, "12");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfVisaAndLength3() {
-        Card card = new Card("4242 4242 4242 4242", null, null, "123");
+        Card card = Card.create("4242 4242 4242 4242", null, null, "123");
         assertTrue(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfVisaAndLength4() {
-        Card card = new Card("4242 4242 4242 4242", null, null, "1234");
+        Card card = Card.create("4242 4242 4242 4242", null, null, "1234");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfVisaAndLength5() {
-        Card card = new Card("4242 4242 4242 4242", null, null, "12345");
+        Card card = Card.create("4242 4242 4242 4242", null, null, "12345");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfVisaAndNotNumeric() {
-        Card card = new Card("4242 4242 4242 4242", null, null, "12a");
+        Card card = Card.create("4242 4242 4242 4242", null, null, "12a");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfAmexAndLength2() {
-        Card card = new Card("378282246310005", null, null, "12");
+        Card card = Card.create("378282246310005", null, null, "12");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfAmexAndLength3() {
-        Card card = new Card("378282246310005", null, null, "123");
+        Card card = Card.create("378282246310005", null, null, "123");
         assertTrue(card.validateCVC());
     }
 
     @Test
     public void shouldPassValidateCVCIfAmexAndLength4() {
-        Card card = new Card("378282246310005", null, null, "1234");
+        Card card = Card.create("378282246310005", null, null, "1234");
         assertTrue(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfAmexAndLength5() {
-        Card card = new Card("378282246310005", null, null, "12345");
+        Card card = Card.create("378282246310005", null, null, "12345");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCVCIfAmexAndNotNumeric() {
-        Card card = new Card("378282246310005", null, null, "123d");
+        Card card = Card.create("378282246310005", null, null, "123d");
         assertFalse(card.validateCVC());
     }
 
     @Test
     public void shouldFailValidateCardIfNotLuhnNumber() {
-        Card card = new Card("4242-4242-4242-4241", 12, 2050, "123");
+        Card card = Card.create("4242-4242-4242-4241", 12, 2050, "123");
         assertFalse(card.validateCard());
         assertFalse(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -512,7 +540,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardInvalidMonth() {
-        Card card = new Card("4242-4242-4242-4242", 13, 2050, "123");
+        Card card = Card.create("4242-4242-4242-4242", 13, 2050, "123");
         assertFalse(card.validateCard());
         assertTrue(card.validateNumber());
         assertFalse(card.validateExpiryDate(calendar));
@@ -521,7 +549,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardInvalidYear() {
-        Card card = new Card("4242-4242-4242-4242", 1, 1990, "123");
+        Card card = Card.create("4242-4242-4242-4242", 1, 1990, "123");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertFalse(card.validateExpiryDate(calendar));
@@ -530,7 +558,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateCardWithNullCVC() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, null);
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, null);
         assertTrue(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -539,7 +567,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateCardVisa() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, "123");
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, "123");
         assertTrue(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -548,7 +576,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardVisaWithShortCVC() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, "12");
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, "12");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -557,7 +585,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardVisaWithLongCVC() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, "1234");
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, "1234");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -566,7 +594,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardVisaWithBadCVC() {
-        Card card = new Card("4242-4242-4242-4242", 12, 2050, "bad");
+        Card card = Card.create("4242-4242-4242-4242", 12, 2050, "bad");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -575,7 +603,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateCardAmex() {
-        Card card = new Card("378282246310005", 12, 2050, "1234");
+        Card card = Card.create("378282246310005", 12, 2050, "1234");
         assertTrue(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -584,7 +612,7 @@ public class CardTest {
 
     @Test
     public void shouldPassValidateCardAmexWithNullCVC() {
-        Card card = new Card("378282246310005", 12, 2050, null);
+        Card card = Card.create("378282246310005", 12, 2050, null);
         assertTrue(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -593,7 +621,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardAmexWithShortCVC() {
-        Card card = new Card("378282246310005", 12, 2050, "12");
+        Card card = Card.create("378282246310005", 12, 2050, "12");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -602,7 +630,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardAmexWithLongCVC() {
-        Card card = new Card("378282246310005", 12, 2050, "12345");
+        Card card = Card.create("378282246310005", 12, 2050, "12345");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -611,7 +639,7 @@ public class CardTest {
 
     @Test
     public void shouldFailValidateCardAmexWithBadCVC() {
-        Card card = new Card("378282246310005", 12, 2050, "bad");
+        Card card = Card.create("378282246310005", 12, 2050, "bad");
         assertFalse(card.validateCard(calendar));
         assertTrue(card.validateNumber());
         assertTrue(card.validateExpiryDate(calendar));
@@ -620,83 +648,31 @@ public class CardTest {
 
     @Test
     public void testLast4() {
-        Card card = new Card("42 42 42 42 42 42 42 42", null, null, null);
+        Card card = Card.create("42 42 42 42 42 42 42 42", null, null, null);
         assertEquals("4242", card.getLast4());
     }
 
     @Test
     public void last4ShouldBeNullWhenNumberIsNull() {
-        Card card = new Card(null, null, null, null);
+        Card card = Card.create(null, null, null, null);
         assertNull(card.getLast4());
-    }
-
-    @Test
-    public void getLast4_whenNumberIsNullButLast4IsSet_returnsCorrectValue() {
-        Card card = new Card(
-                null,
-                2,
-                2020,
-                "123",
-                "John Q Public",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "1234",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
-        assertEquals("1234", card.getLast4());
-    }
-
-    @Test
-    public void getBrand_whenNumberIsNullButBrandIsSet_returnsCorrectValue() {
-        Card card = new Card(
-                null,
-                2,
-                2020,
-                "123",
-                "John Q Public",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                Card.AMERICAN_EXPRESS,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
-        assertEquals(Card.AMERICAN_EXPRESS, card.getBrand());
-        //noinspection deprecation
-        assertEquals(Card.AMERICAN_EXPRESS, card.getType());
     }
 
     @Test
     public void fromString_whenStringIsValidJson_returnsExpectedCard() {
         final Card expectedCard = buildEquivalentJsonCard();
-        final Card actualCard = Card.fromString(JSON_CARD);
+        final Card actualCard = Card.fromString(JSON_CARD_USD);
         assertEquals(expectedCard, actualCard);
     }
 
     @Test
     public void fromString_toJson_yieldsSameObject() {
-        Card cardFromJson = Card.fromString(JSON_CARD);
+        Card cardFromJson = Card.fromString(JSON_CARD_USD);
         assertNotNull(cardFromJson);
 
         JSONObject cycledCardObject = cardFromJson.toJson();
         try {
-            JSONObject rawJsonObject = new JSONObject(JSON_CARD);
+            JSONObject rawJsonObject = new JSONObject(JSON_CARD_USD);
             JsonTestUtils.assertJsonEquals(cycledCardObject, rawJsonObject);
         } catch (JSONException unexpected) {
             fail();
@@ -706,7 +682,7 @@ public class CardTest {
     @Test
     public void toMap_catchesAllFields_fromRawJson() {
         try {
-            final JSONObject rawJsonObject = new JSONObject(JSON_CARD);
+            final JSONObject rawJsonObject = new JSONObject(JSON_CARD_USD);
             final Map<String, Object> rawMap = StripeJsonUtils.jsonObjectToMap(rawJsonObject);
             final Card expectedCard = buildEquivalentJsonCard();
             JsonTestUtils.assertMapEquals(rawMap, expectedCard.toMap());

--- a/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
@@ -6,7 +6,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static com.stripe.android.model.CardTest.JSON_CARD;
+import static com.stripe.android.model.CardTest.JSON_CARD_USD;
 import static com.stripe.android.model.SourceTest.EXAMPLE_ALIPAY_SOURCE;
 import static com.stripe.android.model.SourceTest.EXAMPLE_JSON_SOURCE_WITHOUT_NULLS;
 import static org.junit.Assert.assertEquals;
@@ -47,7 +47,7 @@ public class CustomerSourceTest {
     @Test
     public void fromJson_whenCard_createsCustomerSourceData() {
         try {
-            JSONObject jsonCard = new JSONObject(JSON_CARD);
+            JSONObject jsonCard = new JSONObject(JSON_CARD_USD);
             CustomerSource sourceData = CustomerSource.fromJson(jsonCard);
             assertNotNull(sourceData);
             assertNotNull(sourceData.asCard());
@@ -96,7 +96,7 @@ public class CustomerSourceTest {
     @Test
     public void getSourceType_whenCard_returnsCard() {
         try {
-            JSONObject jsonCard = new JSONObject(JSON_CARD);
+            JSONObject jsonCard = new JSONObject(JSON_CARD_USD);
             CustomerSource sourceData = CustomerSource.fromJson(jsonCard);
             assertNotNull(sourceData);
             assertEquals(Source.CARD, sourceData.getSourceType());

--- a/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
@@ -9,7 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static com.stripe.android.model.CardTest.JSON_CARD;
+import static com.stripe.android.model.CardTest.JSON_CARD_USD;
 import static com.stripe.android.model.CustomerSourceTest.JSON_APPLE_PAY_CARD;
 import static com.stripe.android.model.SourceTest.EXAMPLE_ALIPAY_SOURCE;
 import static com.stripe.android.model.SourceTest.EXAMPLE_JSON_SOURCE_WITHOUT_NULLS;
@@ -108,10 +108,10 @@ public class CustomerTest {
             assertNotNull(applePayCard);
             sourcesArray.put(applePayCard.toJson());
 
-            Card testCard = Card.fromString(JSON_CARD);
+            Card testCard = Card.fromString(JSON_CARD_USD);
             assertNotNull(testCard);
 
-            JSONObject manipulatedCard = new JSONObject(JSON_CARD);
+            JSONObject manipulatedCard = new JSONObject(JSON_CARD_USD);
             manipulatedCard.put("id", "card_id55555");
             manipulatedCard.put("tokenization_method", "apple_pay");
             Card manipulatedApplePayCard = Card.fromJson(manipulatedCard);

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentParamsTest.java
@@ -14,19 +14,16 @@ import static org.junit.Assert.assertTrue;
 
 public class PaymentIntentParamsTest {
     private static final Card FULL_FIELDS_VISA_CARD =
-            new Card(VALID_VISA_NO_SPACES,
-                    12,
-                    2050,
-                    "123",
-                    "Captain Cardholder",
-                    "1 ABC Street",
-                    "Apt. 123",
-                    "San Francisco",
-                    "CA",
-                    "94107",
-                    "US",
-                    "usd",
-                    null);
+            new Card.Builder(VALID_VISA_NO_SPACES, 12, 2050, "123")
+                    .name("Captain Cardholder")
+                    .addressLine1("1 ABC Street")
+                    .addressLine2("Apt. 123")
+                    .addressCity("San Francisco")
+                    .addressState("CA")
+                    .addressZip("94107")
+                    .addressState("US")
+                    .currency("usd")
+                    .build();
 
     private static final String TEST_CLIENT_SECRET =
             "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA";

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -28,19 +28,17 @@ public class SourceParamsTest {
         metadata.put("color", "blue");
         metadata.put("animal", "dog");
 
-        FULL_FIELDS_VISA_CARD = new Card(VALID_VISA_NO_SPACES,
-                12,
-                2050,
-                "123",
-                "Captain Cardholder",
-                "1 ABC Street",
-                "Apt. 123",
-                "San Francisco",
-                "CA",
-                "94107",
-                "US",
-                "usd",
-                metadata);
+        FULL_FIELDS_VISA_CARD = new Card.Builder(VALID_VISA_NO_SPACES, 12, 2050, "123")
+                .name("Captain Cardholder")
+                .addressLine1("1 ABC Street")
+                .addressLine2("Apt. 123")
+                .addressCity("San Francisco")
+                .addressState("CA")
+                .addressZip("94107")
+                .addressCountry("US")
+                .currency("usd")
+                .metadata(metadata)
+                .build();
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -31,8 +31,8 @@ public class StripeJsonModelTest {
     public void equals_whenEquals_returnsTrue() {
         assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
 
-        Card firstCard = Card.fromString(CardTest.JSON_CARD);
-        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+        Card firstCard = Card.fromString(CardTest.JSON_CARD_USD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD_USD);
 
         assertEquals(firstCard, secondCard);
         // Just confirming for sanity
@@ -42,17 +42,8 @@ public class StripeJsonModelTest {
     @Test
     public void equals_whenNotEquals_returnsFalse() {
         assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
-
-        Card firstCard = Card.fromString(CardTest.JSON_CARD);
-        Card secondCard = Card.fromString(CardTest.JSON_CARD);
-
-        assertNotNull(firstCard);
-        assertNotNull(secondCard);
-
-        String firstName = firstCard.getName();
-        String secondName = firstName == null ? "a non-null value" : firstName + "a change";
-        secondCard.setName(secondName);
-
+        final Card firstCard = Card.create("4242", null, null, null);
+        final Card secondCard = Card.create("4343", null, null, null);
         assertNotEquals(firstCard, secondCard);
     }
 
@@ -60,8 +51,8 @@ public class StripeJsonModelTest {
     public void hashCode_whenEquals_returnsSameValue() {
         assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
 
-        Card firstCard = Card.fromString(CardTest.JSON_CARD);
-        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+        Card firstCard = Card.fromString(CardTest.JSON_CARD_USD);
+        Card secondCard = Card.fromString(CardTest.JSON_CARD_USD);
         assertNotNull(firstCard);
         assertNotNull(secondCard);
 
@@ -72,17 +63,13 @@ public class StripeJsonModelTest {
     public void hashCode_whenNotEquals_returnsDifferentValues() {
         assertTrue(StripeJsonModel.class.isAssignableFrom(Card.class));
 
-        Card firstCard = Card.fromString(CardTest.JSON_CARD);
-        Card secondCard = Card.fromString(CardTest.JSON_CARD);
+        Card usdCard = Card.fromString(CardTest.JSON_CARD_USD);
+        Card eurCard = Card.fromString(CardTest.JSON_CARD_EUR);
 
-        assertNotNull(firstCard);
-        assertNotNull(secondCard);
+        assertNotNull(usdCard);
+        assertNotNull(eurCard);
 
-        String firstCurrency = firstCard.getCurrency();
-        String secondCurrency = "USD".equals(firstCurrency) ? "EUR" : "USD";
-        secondCard.setCurrency(secondCurrency);
-
-        assertNotEquals(firstCard.hashCode(), secondCard.hashCode());
+        assertNotEquals(usdCard.hashCode(), eurCard.hashCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Make `Card` model fields immutable
Remove `@Deprecated` methods in `Card`, including `Card#getType()`

## Motivation
We prefer immutable models for consistency and reliability

