### PR TITLE
Create PaymentAuthResult.Status to signal information about auth result

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentAuthRelayStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthRelayStarter.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.model.PaymentIntent;
+import com.stripe.android.utils.ObjectUtils;
 import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.PaymentAuthRelayActivity;
 import com.stripe.android.view.PaymentAuthenticationExtras;
@@ -28,20 +29,22 @@ class PaymentAuthRelayStarter implements ActivityStarter<PaymentAuthRelayStarter
         final Intent intent = new Intent(mActivity, PaymentAuthRelayActivity.class)
                 .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET,
                         data.paymentIntent != null ? data.paymentIntent.getClientSecret() : null)
-                .putExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION,
-                        data.exception);
+                .putExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION, data.exception)
+                .putExtra(PaymentAuthenticationExtras.AUTH_STATUS, data.authStatus);
         mActivity.startActivityForResult(intent, mRequestCode);
     }
 
     public static final class Data {
         @Nullable final PaymentIntent paymentIntent;
         @Nullable final Exception exception;
+        @PaymentAuthResult.Status final int authStatus;
 
         /**
          * Use when payment authentication completed or can be bypassed.
          */
         Data(@NonNull PaymentIntent paymentIntent) {
             this.paymentIntent = paymentIntent;
+            this.authStatus = PaymentAuthResult.Status.SUCCEEDED;
             this.exception = null;
         }
 
@@ -50,7 +53,24 @@ class PaymentAuthRelayStarter implements ActivityStarter<PaymentAuthRelayStarter
          */
         Data(@NonNull Exception exception) {
             this.paymentIntent = null;
+            this.authStatus = PaymentAuthResult.Status.FAILED;
             this.exception = exception;
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectUtils.hash(paymentIntent, exception, authStatus);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return super.equals(obj) || (obj instanceof Data && typedEquals((Data) obj));
+        }
+
+        private boolean typedEquals(@NonNull Data data) {
+            return ObjectUtils.equals(paymentIntent, data.paymentIntent) &&
+                    ObjectUtils.equals(exception, data.exception) &&
+                    ObjectUtils.equals(authStatus, data.authStatus);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthResult.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthResult.java
@@ -1,10 +1,14 @@
 package com.stripe.android;
 
 import android.app.Activity;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentIntentParams;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * A model representing the result of a payment authentication attempt via
@@ -15,17 +19,35 @@ import com.stripe.android.model.PaymentIntentParams;
  */
 public final class PaymentAuthResult {
     @NonNull public final PaymentIntent paymentIntent;
+    @Status public final int status;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({Status.UNKNOWN, Status.SUCCEEDED, Status.FAILED, Status.CANCELED})
+    public @interface Status {
+        int UNKNOWN = 0;
+        int SUCCEEDED = 1;
+        int FAILED = 2;
+        int CANCELED = 3;
+    }
 
     private PaymentAuthResult(@NonNull Builder builder) {
         this.paymentIntent = builder.mPaymentIntent;
+        this.status = builder.mStatus;
     }
 
     static final class Builder {
         private PaymentIntent mPaymentIntent;
+        @Status private int mStatus;
 
         @NonNull
         public Builder setPaymentIntent(@NonNull PaymentIntent paymentIntent) {
             mPaymentIntent = paymentIntent;
+            return this;
+        }
+
+        @NonNull
+        public Builder setStatus(@Status int status) {
+            mStatus = status;
             return this;
         }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthenticationController.java
@@ -125,12 +125,15 @@ class PaymentAuthenticationController {
         final String clientSecret = data.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET);
         final PaymentIntentParams paymentIntentParams = PaymentIntentParams
                 .createRetrievePaymentIntentParams(clientSecret);
+        @PaymentAuthResult.Status final int authStatus = data.getIntExtra(
+                PaymentAuthenticationExtras.AUTH_STATUS, PaymentAuthResult.Status.UNKNOWN);
         new RetrievePaymentIntentTask(stripe, paymentIntentParams, publishableKey,
                 new ApiResultCallback<PaymentIntent>() {
                     @Override
                     public void onSuccess(@NonNull PaymentIntent paymentIntent) {
                         callback.onSuccess(new PaymentAuthResult.Builder()
                                 .setPaymentIntent(paymentIntent)
+                                .setStatus(authStatus)
                                 .build());
                     }
 
@@ -447,28 +450,28 @@ class PaymentAuthenticationController {
         public void cancelled() {
             super.cancelled();
             start(new Stripe3ds2CompletionStarter.StartData(mPaymentIntent,
-                    Stripe3ds2CompletionStarter.Status.CANCEL));
+                    Stripe3ds2CompletionStarter.ChallengeFlowStatus.CANCEL));
         }
 
         @Override
         public void timedout() {
             super.timedout();
             start(new Stripe3ds2CompletionStarter.StartData(mPaymentIntent,
-                    Stripe3ds2CompletionStarter.Status.TIMEOUT));
+                    Stripe3ds2CompletionStarter.ChallengeFlowStatus.TIMEOUT));
         }
 
         @Override
         public void protocolError(@NonNull ProtocolErrorEvent protocolErrorEvent) {
             super.protocolError(protocolErrorEvent);
             start(new Stripe3ds2CompletionStarter.StartData(mPaymentIntent,
-                    Stripe3ds2CompletionStarter.Status.PROTOCOL_ERROR));
+                    Stripe3ds2CompletionStarter.ChallengeFlowStatus.PROTOCOL_ERROR));
         }
 
         @Override
         public void runtimeError(@NonNull RuntimeErrorEvent runtimeErrorEvent) {
             super.runtimeError(runtimeErrorEvent);
             start(new Stripe3ds2CompletionStarter.StartData(mPaymentIntent,
-                    Stripe3ds2CompletionStarter.Status.RUNTIME_ERROR));
+                    Stripe3ds2CompletionStarter.ChallengeFlowStatus.RUNTIME_ERROR));
         }
 
         private void start(@NonNull Stripe3ds2CompletionStarter.StartData startData) {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthenticationExtras.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthenticationExtras.java
@@ -1,8 +1,19 @@
 package com.stripe.android.view;
 
+import com.stripe.android.model.PaymentIntent;
+
 public final class PaymentAuthenticationExtras {
+    /**
+     * Should be a {@link PaymentIntent#getClientSecret()}
+     */
     public static final String CLIENT_SECRET = "client_secret";
+
     public static final String AUTH_EXCEPTION = "exception";
+
+    /**
+     * See {@link com.stripe.android.PaymentAuthResult.Status} for possible values
+     */
+    public static final String AUTH_STATUS = "status";
 
     private PaymentAuthenticationExtras() {
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthRelayStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthRelayStarterTest.java
@@ -40,6 +40,9 @@ public class PaymentAuthRelayStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
                 intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
+        assertEquals(PaymentAuthResult.Status.SUCCEEDED,
+                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
+                        PaymentAuthResult.Status.UNKNOWN));
         assertNull(intent.getSerializableExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION));
     }
 
@@ -50,6 +53,9 @@ public class PaymentAuthRelayStarterTest {
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertNull(intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
+        assertEquals(PaymentAuthResult.Status.FAILED,
+                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
+                        PaymentAuthResult.Status.UNKNOWN));
         assertEquals(exception,
                 intent.getSerializableExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION));
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthenticationControllerTest.java
@@ -113,7 +113,7 @@ public class PaymentAuthenticationControllerTest {
                 .cancelled();
         verify(m3ds2Starter).start(
                 new Stripe3ds2CompletionStarter.StartData(PaymentIntentFixtures.PI_REQUIRES_3DS2,
-                        Stripe3ds2CompletionStarter.Status.CANCEL));
+                        Stripe3ds2CompletionStarter.ChallengeFlowStatus.CANCEL));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
@@ -35,12 +35,29 @@ public class Stripe3ds2CompletionStarterTest {
     }
 
     @Test
-    public void start_shouldAddPaymentIntentClientSecretToIntent() {
+    public void start_withCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
         mStarter.start(Stripe3ds2CompletionStarter.StartData.createForComplete(
                 PaymentIntentFixtures.PI_REQUIRES_3DS2, "Y"));
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
                 intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
+        assertEquals(PaymentAuthResult.Status.SUCCEEDED,
+                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
+                        PaymentAuthResult.Status.UNKNOWN));
+    }
+
+    @Test
+    public void start_withProtocolError_shouldAddClientSecretAndAuthStatusToIntent() {
+        mStarter.start(new Stripe3ds2CompletionStarter.StartData(
+                PaymentIntentFixtures.PI_REQUIRES_3DS2,
+                Stripe3ds2CompletionStarter.ChallengeFlowStatus.PROTOCOL_ERROR));
+        verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
+                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
+        assertEquals(PaymentAuthResult.Status.FAILED,
+                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
+                        PaymentAuthResult.Status.UNKNOWN));
     }
 }


### PR DESCRIPTION
## Summary
A user can inspect the value of this field in `PaymentAuthResult` to
make a better determination of how to react to the state of the
PaymentIntent.

## Testing
Added tests