### PR TITLE
Add support for 3DS2 completion endpoint

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -652,7 +652,7 @@ class StripeApiHandler {
                         RequestOptions.createForApi(publishableKey))
         );
         convertErrorsToExceptionsAndThrowIfNecessary(response);
-        return response.isSuccessful();
+        return response.isOk();
     }
 
     void complete3ds2Auth(@NonNull String sourceId,

--- a/stripe/src/main/java/com/stripe/android/StripeResponse.java
+++ b/stripe/src/main/java/com/stripe/android/StripeResponse.java
@@ -2,6 +2,7 @@ package com.stripe.android;
 
 import android.support.annotation.Nullable;
 
+import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,10 @@ class StripeResponse {
      */
     int getResponseCode() {
         return mResponseCode;
+    }
+
+    boolean isSuccessful() {
+        return mResponseCode == HttpURLConnection.HTTP_OK;
     }
 
     boolean hasErrorCode() {

--- a/stripe/src/main/java/com/stripe/android/StripeResponse.java
+++ b/stripe/src/main/java/com/stripe/android/StripeResponse.java
@@ -38,7 +38,7 @@ class StripeResponse {
         return mResponseCode;
     }
 
-    boolean isSuccessful() {
+    boolean isOk() {
         return mResponseCode == HttpURLConnection.HTTP_OK;
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -204,6 +204,19 @@ public class StripeApiHandlerTest {
     }
 
     @Test
+    public void complete3ds2Auth_shouldThrowInvalidRequestException() {
+        assertThrows(
+                InvalidRequestException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        mApiHandler.complete3ds2Auth("src_123",
+                                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
+                    }
+                });
+    }
+
+    @Test
     public void logApiCall_shouldReturnSuccessful() {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.


### PR DESCRIPTION
## Summary
This endpoint must be called after 3DS2 flow completes

Integrate in a follow-up PR

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
