### PR TITLE
Call complete3ds2() after challenge flow is completed

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
@@ -41,10 +41,11 @@ class Stripe3ds2CompletionStarter
         activity.startActivityForResult(intent, mRequestCode);
     }
 
-    @IntDef({ChallengeFlowStatus.COMPLETE, ChallengeFlowStatus.CANCEL, ChallengeFlowStatus.TIMEOUT,
-            ChallengeFlowStatus.PROTOCOL_ERROR, ChallengeFlowStatus.RUNTIME_ERROR})
+    @IntDef({ChallengeFlowOutcome.COMPLETE, ChallengeFlowOutcome.CANCEL,
+            ChallengeFlowOutcome.TIMEOUT, ChallengeFlowOutcome.PROTOCOL_ERROR,
+            ChallengeFlowOutcome.RUNTIME_ERROR})
     @Retention(RetentionPolicy.SOURCE)
-    @interface ChallengeFlowStatus {
+    @interface ChallengeFlowOutcome {
         int COMPLETE = 0;
         int CANCEL = 1;
         int TIMEOUT = 2;
@@ -54,23 +55,23 @@ class Stripe3ds2CompletionStarter
 
     static class StartData {
         @NonNull private final PaymentIntent mPaymentIntent;
-        @ChallengeFlowStatus private final int mChallengeFlowStatus;
+        @ChallengeFlowOutcome private final int mChallengeFlowStatus;
         @Nullable private final String mCompletionTransactionStatus;
 
         @NonNull
         static StartData createForComplete(@NonNull PaymentIntent paymentIntent,
                                            @NonNull String completionTransactionStatus) {
-            return new StartData(paymentIntent, ChallengeFlowStatus.COMPLETE,
+            return new StartData(paymentIntent, ChallengeFlowOutcome.COMPLETE,
                     completionTransactionStatus);
         }
 
         StartData(@NonNull PaymentIntent paymentIntent,
-                  @ChallengeFlowStatus int status) {
+                  @ChallengeFlowOutcome int status) {
             this(paymentIntent, status, null);
         }
 
         private StartData(@NonNull PaymentIntent paymentIntent,
-                          @ChallengeFlowStatus int challengeFlowStatus,
+                          @ChallengeFlowOutcome int challengeFlowStatus,
                           @Nullable String completionTransactionStatus) {
             mPaymentIntent = paymentIntent;
             mChallengeFlowStatus = challengeFlowStatus;
@@ -79,9 +80,9 @@ class Stripe3ds2CompletionStarter
 
         @PaymentAuthResult.Status
         private int getAuthStatus() {
-            if (mChallengeFlowStatus == ChallengeFlowStatus.COMPLETE) {
+            if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE) {
                 return PaymentAuthResult.Status.SUCCEEDED;
-            } else if (mChallengeFlowStatus == ChallengeFlowStatus.CANCEL) {
+            } else if (mChallengeFlowStatus == ChallengeFlowOutcome.CANCEL) {
                 return PaymentAuthResult.Status.CANCELED;
             } else {
                 return PaymentAuthResult.Status.FAILED;

--- a/stripe/src/main/java/com/stripe/android/StripeError.java
+++ b/stripe/src/main/java/com/stripe/android/StripeError.java
@@ -2,12 +2,14 @@ package com.stripe.android;
 
 import android.support.annotation.Nullable;
 
+import java.io.Serializable;
+
 /**
  * A model for error objects sent from the Stripe API.
  *
  * https://stripe.com/docs/api/errors
  */
-public class StripeError {
+public final class StripeError implements Serializable {
 
     // https://stripe.com/docs/api/errors (e.g. "invalid_request_error")
     @Nullable public final String type;

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
@@ -51,7 +51,7 @@ public class Stripe3ds2CompletionStarterTest {
     public void start_withProtocolError_shouldAddClientSecretAndAuthStatusToIntent() {
         mStarter.start(new Stripe3ds2CompletionStarter.StartData(
                 PaymentIntentFixtures.PI_REQUIRES_3DS2,
-                Stripe3ds2CompletionStarter.ChallengeFlowStatus.PROTOCOL_ERROR));
+                Stripe3ds2CompletionStarter.ChallengeFlowOutcome.PROTOCOL_ERROR));
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),


### PR DESCRIPTION
## Summary
In this case, any outcome of the challenge flow is considered
"completed".

Note that the `complete3ds2()` call currently returns an error
due to a backend issue.

## Testing
Manually tested
