### PR TITLE
Rename PaymentAuthenticationController to PaymentController

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -1,5 +1,6 @@
 package com.stripe.example.activity;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -11,8 +12,8 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.stripe.android.ApiResultCallback;
-import com.stripe.android.PaymentAuthResult;
 import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.PaymentIntentResult;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentIntentParams;
@@ -34,7 +35,8 @@ import io.reactivex.schedulers.Schedulers;
 import okhttp3.ResponseBody;
 
 /**
- * An example of creating a PaymentIntent, then confirming it with PaymentAuthenticationController.
+ * An example of creating a PaymentIntent, then confirming it with
+ * {@link Stripe#confirmPayment(Activity, PaymentIntentParams)}}
  */
 public class PaymentAuthActivity extends AppCompatActivity {
 
@@ -78,7 +80,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
 
     private void confirmPaymentIntent(@NonNull String paymentIntentClientSecret) {
         mStatusTextView.append("\n\nStarting payment authentication");
-        mStripe.startPaymentAuth(this,
+        mStripe.confirmPayment(this,
                 PaymentIntentParams.createConfirmPaymentIntentWithPaymentMethodId(
                         PAYMENT_METHOD_3DS2_REQUIRED,
                         paymentIntentClientSecret,
@@ -91,7 +93,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
 
         mProgressBar.setVisibility(View.VISIBLE);
         mStatusTextView.append("\n\nPayment authentication completed, getting result");
-        mStripe.onPaymentAuthResult(requestCode, resultCode, data,
+        mStripe.onPaymentResult(requestCode, resultCode, data,
                 new AuthResultListener(this));
     }
 
@@ -153,7 +155,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
         return params;
     }
 
-    private static class AuthResultListener implements ApiResultCallback<PaymentAuthResult> {
+    private static class AuthResultListener implements ApiResultCallback<PaymentIntentResult> {
         @NonNull private final WeakReference<PaymentAuthActivity> mActivityRef;
 
         private AuthResultListener(@NonNull PaymentAuthActivity activity) {
@@ -161,13 +163,13 @@ public class PaymentAuthActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onSuccess(@NonNull PaymentAuthResult paymentAuthResult) {
+        public void onSuccess(@NonNull PaymentIntentResult paymentIntentResult) {
             final PaymentAuthActivity activity = mActivityRef.get();
             if (activity == null) {
                 return;
             }
 
-            final PaymentIntent paymentIntent = paymentAuthResult.paymentIntent;
+            final PaymentIntent paymentIntent = paymentIntentResult.paymentIntent;
             activity.mStatusTextView.append("\n\n" +
                     activity.getString(R.string.payment_intent_status, paymentIntent.getStatus()));
             activity.onAuthComplete();

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -22,8 +22,8 @@ import com.jakewharton.rxbinding2.view.RxView;
 import com.stripe.android.ApiResultCallback;
 import com.stripe.android.CustomerSession;
 import com.stripe.android.PayWithGoogleUtils;
-import com.stripe.android.PaymentAuthResult;
 import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.PaymentIntentResult;
 import com.stripe.android.PaymentSession;
 import com.stripe.android.PaymentSessionConfig;
 import com.stripe.android.PaymentSessionData;
@@ -164,11 +164,11 @@ public class PaymentActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        final boolean isPaymentAuthResult = mStripe.onPaymentAuthResult(
+        final boolean isHandled = mStripe.onPaymentResult(
                 requestCode, resultCode, data,
-                new ApiResultCallback<PaymentAuthResult>() {
+                new ApiResultCallback<PaymentIntentResult>() {
                     @Override
-                    public void onSuccess(@NonNull PaymentAuthResult result) {
+                    public void onSuccess(@NonNull PaymentIntentResult result) {
                         processPaymentIntent(result.paymentIntent);
                     }
 
@@ -178,7 +178,7 @@ public class PaymentActivity extends AppCompatActivity {
                     }
                 });
 
-        if (!isPaymentAuthResult) {
+        if (!isHandled) {
             mPaymentSession.handlePaymentData(requestCode, resultCode, data);
         }
     }
@@ -309,7 +309,7 @@ public class PaymentActivity extends AppCompatActivity {
 
     private void processPaymentIntent(@NonNull PaymentIntent paymentIntent) {
         if (paymentIntent.requiresAction()) {
-            mStripe.startPaymentAuth(this, paymentIntent);
+            mStripe.authenticatePayment(this, paymentIntent);
             return;
         } else if (paymentIntent.requiresConfirmation()) {
             confirmPaymentIntent(Objects.requireNonNull(paymentIntent.getId()));

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:theme="@style/StripeDefaultTheme" />
 
         <activity
-            android:name=".view.PaymentAuthRelayActivity"
+            android:name=".view.PaymentRelayActivity"
             android:theme="@style/StripeDefaultTheme" />
     </application>
 

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthConfig.java
@@ -7,8 +7,10 @@ import android.support.annotation.VisibleForTesting;
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization;
 import com.stripe.android.stripe3ds2.init.ui.UiCustomization;
 
+import java.util.Objects;
+
 /**
- * Configuration for {@link PaymentAuthenticationController}
+ * Configuration for authentication mechanisms via {@link PaymentController}
  */
 class PaymentAuthConfig {
 
@@ -64,7 +66,7 @@ class PaymentAuthConfig {
 
         private Stripe3ds2Config(@NonNull Builder builder) {
             timeout = builder.mTimeout;
-            uiCustomization = builder.mUiCustomization;
+            uiCustomization = Objects.requireNonNull(builder.mUiCustomization);
         }
 
         static final class Builder {

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
@@ -11,13 +11,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * A model representing the result of a payment authentication attempt via
- * {@link Stripe#startPaymentAuth(Activity, PaymentIntentParams)}.
+ * A model representing the result of a payment confirmation or authentication attempt via
+ * {@link Stripe#confirmPayment(Activity, PaymentIntentParams)} or
+ * {@link Stripe#authenticatePayment(Activity, PaymentIntent)}}
  *
- * {@link #paymentIntent} represents a {@link PaymentIntent} retrieved after payment authentication
- * succeeded or failed.
+ * {@link #paymentIntent} represents a {@link PaymentIntent} retrieved after payment
+ * confirmation/authentication succeeded or failed.
  */
-public final class PaymentAuthResult {
+public final class PaymentIntentResult {
     @NonNull public final PaymentIntent paymentIntent;
     @Status public final int status;
 
@@ -30,7 +31,7 @@ public final class PaymentAuthResult {
         int CANCELED = 3;
     }
 
-    private PaymentAuthResult(@NonNull Builder builder) {
+    private PaymentIntentResult(@NonNull Builder builder) {
         this.paymentIntent = builder.mPaymentIntent;
         this.status = builder.mStatus;
     }
@@ -52,8 +53,8 @@ public final class PaymentAuthResult {
         }
 
         @NonNull
-        public PaymentAuthResult build() {
-            return new PaymentAuthResult(this);
+        public PaymentIntentResult build() {
+            return new PaymentIntentResult(this);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
@@ -8,43 +8,43 @@ import android.support.annotation.Nullable;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.utils.ObjectUtils;
 import com.stripe.android.view.ActivityStarter;
-import com.stripe.android.view.PaymentAuthRelayActivity;
-import com.stripe.android.view.PaymentAuthenticationExtras;
+import com.stripe.android.view.PaymentRelayActivity;
+import com.stripe.android.view.PaymentResultExtras;
 
 /**
- * Starts an instance of {@link PaymentAuthRelayStarter}.
- * Should only be called from {@link com.stripe.android.PaymentAuthenticationController}.
+ * Starts an instance of {@link PaymentRelayStarter}.
+ * Should only be called from {@link PaymentController}.
  */
-class PaymentAuthRelayStarter implements ActivityStarter<PaymentAuthRelayStarter.Data> {
+class PaymentRelayStarter implements ActivityStarter<PaymentRelayStarter.Data> {
     @NonNull private final Activity mActivity;
     private final int mRequestCode;
 
-    PaymentAuthRelayStarter(@NonNull Activity activity, int requestCode) {
+    PaymentRelayStarter(@NonNull Activity activity, int requestCode) {
         mActivity = activity;
         mRequestCode = requestCode;
     }
 
     @Override
     public void start(@NonNull Data data) {
-        final Intent intent = new Intent(mActivity, PaymentAuthRelayActivity.class)
-                .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET,
+        final Intent intent = new Intent(mActivity, PaymentRelayActivity.class)
+                .putExtra(PaymentResultExtras.CLIENT_SECRET,
                         data.paymentIntent != null ? data.paymentIntent.getClientSecret() : null)
-                .putExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION, data.exception)
-                .putExtra(PaymentAuthenticationExtras.AUTH_STATUS, data.authStatus);
+                .putExtra(PaymentResultExtras.AUTH_EXCEPTION, data.exception)
+                .putExtra(PaymentResultExtras.AUTH_STATUS, data.status);
         mActivity.startActivityForResult(intent, mRequestCode);
     }
 
     public static final class Data {
         @Nullable final PaymentIntent paymentIntent;
         @Nullable final Exception exception;
-        @PaymentAuthResult.Status final int authStatus;
+        @PaymentIntentResult.Status final int status;
 
         /**
          * Use when payment authentication completed or can be bypassed.
          */
         Data(@NonNull PaymentIntent paymentIntent) {
             this.paymentIntent = paymentIntent;
-            this.authStatus = PaymentAuthResult.Status.SUCCEEDED;
+            this.status = PaymentIntentResult.Status.SUCCEEDED;
             this.exception = null;
         }
 
@@ -53,13 +53,13 @@ class PaymentAuthRelayStarter implements ActivityStarter<PaymentAuthRelayStarter
          */
         Data(@NonNull Exception exception) {
             this.paymentIntent = null;
-            this.authStatus = PaymentAuthResult.Status.FAILED;
+            this.status = PaymentIntentResult.Status.FAILED;
             this.exception = exception;
         }
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(paymentIntent, exception, authStatus);
+            return ObjectUtils.hash(paymentIntent, exception, status);
         }
 
         @Override
@@ -70,7 +70,7 @@ class PaymentAuthRelayStarter implements ActivityStarter<PaymentAuthRelayStarter
         private boolean typedEquals(@NonNull Data data) {
             return ObjectUtils.equals(paymentIntent, data.paymentIntent) &&
                     ObjectUtils.equals(exception, data.exception) &&
-                    ObjectUtils.equals(authStatus, data.authStatus);
+                    ObjectUtils.equals(status, data.status);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
@@ -9,8 +9,8 @@ import android.support.annotation.Nullable;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.utils.ObjectUtils;
 import com.stripe.android.view.ActivityStarter;
-import com.stripe.android.view.PaymentAuthRelayActivity;
-import com.stripe.android.view.PaymentAuthenticationExtras;
+import com.stripe.android.view.PaymentRelayActivity;
+import com.stripe.android.view.PaymentResultExtras;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -33,10 +33,10 @@ class Stripe3ds2CompletionStarter
             return;
         }
 
-        final Intent intent = new Intent(activity, PaymentAuthRelayActivity.class)
-                .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET,
+        final Intent intent = new Intent(activity, PaymentRelayActivity.class)
+                .putExtra(PaymentResultExtras.CLIENT_SECRET,
                         data.mPaymentIntent.getClientSecret())
-                .putExtra(PaymentAuthenticationExtras.AUTH_STATUS,
+                .putExtra(PaymentResultExtras.AUTH_STATUS,
                         data.getAuthStatus());
         activity.startActivityForResult(intent, mRequestCode);
     }
@@ -78,14 +78,14 @@ class Stripe3ds2CompletionStarter
             mCompletionTransactionStatus = completionTransactionStatus;
         }
 
-        @PaymentAuthResult.Status
+        @PaymentIntentResult.Status
         private int getAuthStatus() {
             if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE) {
-                return PaymentAuthResult.Status.SUCCEEDED;
+                return PaymentIntentResult.Status.SUCCEEDED;
             } else if (mChallengeFlowStatus == ChallengeFlowOutcome.CANCEL) {
-                return PaymentAuthResult.Status.CANCELED;
+                return PaymentIntentResult.Status.CANCELED;
             } else {
-                return PaymentAuthResult.Status.FAILED;
+                return PaymentIntentResult.Status.FAILED;
             }
         }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -79,7 +79,7 @@ class PaymentAuthWebView extends WebView {
                         .getQueryParameter(PARAM_CLIENT_SECRET);
                 mActivity.setResult(Activity.RESULT_OK,
                         new Intent()
-                                .putExtra(PaymentAuthenticationExtras.CLIENT_SECRET, clientSecret));
+                                .putExtra(PaymentResultExtras.CLIENT_SECRET, clientSecret));
                 mActivity.finish();
                 return true;
             }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
@@ -9,7 +9,7 @@ import android.support.v7.app.AppCompatActivity;
 /**
  * An {@link Activity} that relays the intent extras that it received as a result and finishes.
  */
-public class PaymentAuthRelayActivity extends AppCompatActivity {
+public class PaymentRelayActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/stripe/src/main/java/com/stripe/android/view/PaymentResultExtras.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentResultExtras.java
@@ -1,8 +1,9 @@
 package com.stripe.android.view;
 
+import com.stripe.android.PaymentIntentResult;
 import com.stripe.android.model.PaymentIntent;
 
-public final class PaymentAuthenticationExtras {
+public final class PaymentResultExtras {
     /**
      * Should be a {@link PaymentIntent#getClientSecret()}
      */
@@ -11,10 +12,10 @@ public final class PaymentAuthenticationExtras {
     public static final String AUTH_EXCEPTION = "exception";
 
     /**
-     * See {@link com.stripe.android.PaymentAuthResult.Status} for possible values
+     * See {@link PaymentIntentResult.Status} for possible values
      */
     public static final String AUTH_STATUS = "status";
 
-    private PaymentAuthenticationExtras() {
+    private PaymentResultExtras() {
     }
 }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.java
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.java
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.io.UnsupportedEncodingException;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -23,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.java
@@ -1,5 +1,8 @@
 package com.stripe.android;
 
+import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization;
+import com.stripe.android.stripe3ds2.init.ui.UiCustomization;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,5 +32,18 @@ public class PaymentAuthConfigTest {
                         .build())
                 .build());
         assertEquals(20, PaymentAuthConfig.get().stripe3ds2Config.timeout);
+    }
+
+    @Test
+    public void testStripe3ds2ConfigBuilder() {
+        final UiCustomization uiCustomization = new StripeUiCustomization();
+        PaymentAuthConfig.init(new PaymentAuthConfig.Builder()
+                .set3ds2Config(new PaymentAuthConfig.Stripe3ds2Config.Builder()
+                        .setTimeout(20)
+                        .setUiCustomization(uiCustomization)
+                        .build())
+                .build());
+        assertEquals(uiCustomization,
+                PaymentAuthConfig.get().stripe3ds2Config.uiCustomization);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.java
@@ -9,12 +9,12 @@ import org.robolectric.RobolectricTestRunner;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
-public class PaymentAuthResultTest {
+public class PaymentIntentResultTest {
 
     @Test
     public void testBuilder() {
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2,
-                new PaymentAuthResult.Builder()
+                new PaymentIntentResult.Builder()
                         .setPaymentIntent(PaymentIntentFixtures.PI_REQUIRES_3DS2)
                         .build()
                         .paymentIntent);

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 
 import com.stripe.android.model.PaymentIntentFixtures;
-import com.stripe.android.view.PaymentAuthenticationExtras;
+import com.stripe.android.view.PaymentResultExtras;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,42 +21,42 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-public class PaymentAuthRelayStarterTest {
+public class PaymentRelayStarterTest {
     @Mock private Activity mActivity;
     @Captor private ArgumentCaptor<Intent> mIntentArgumentCaptor;
 
-    private PaymentAuthRelayStarter mStarter;
+    private PaymentRelayStarter mStarter;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mStarter = new PaymentAuthRelayStarter(mActivity, 500);
+        mStarter = new PaymentRelayStarter(mActivity, 500);
     }
 
     @Test
     public void start_withPaymentIntent_shouldSetCorrectIntentExtras() {
-        mStarter.start(new PaymentAuthRelayStarter.Data(PaymentIntentFixtures.PI_REQUIRES_3DS2));
+        mStarter.start(new PaymentRelayStarter.Data(PaymentIntentFixtures.PI_REQUIRES_3DS2));
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
-                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
-        assertEquals(PaymentAuthResult.Status.SUCCEEDED,
-                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
-                        PaymentAuthResult.Status.UNKNOWN));
-        assertNull(intent.getSerializableExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION));
+                intent.getStringExtra(PaymentResultExtras.CLIENT_SECRET));
+        assertEquals(PaymentIntentResult.Status.SUCCEEDED,
+                intent.getIntExtra(PaymentResultExtras.AUTH_STATUS,
+                        PaymentIntentResult.Status.UNKNOWN));
+        assertNull(intent.getSerializableExtra(PaymentResultExtras.AUTH_EXCEPTION));
     }
 
     @Test
     public void start_withException_shouldSetCorrectIntentExtras() {
         final Exception exception = new RuntimeException();
-        mStarter.start(new PaymentAuthRelayStarter.Data(exception));
+        mStarter.start(new PaymentRelayStarter.Data(exception));
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
-        assertNull(intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
-        assertEquals(PaymentAuthResult.Status.FAILED,
-                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
-                        PaymentAuthResult.Status.UNKNOWN));
+        assertNull(intent.getStringExtra(PaymentResultExtras.CLIENT_SECRET));
+        assertEquals(PaymentIntentResult.Status.FAILED,
+                intent.getIntExtra(PaymentResultExtras.AUTH_STATUS,
+                        PaymentIntentResult.Status.UNKNOWN));
         assertEquals(exception,
-                intent.getSerializableExtra(PaymentAuthenticationExtras.AUTH_EXCEPTION));
+                intent.getSerializableExtra(PaymentResultExtras.AUTH_EXCEPTION));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 
 import com.stripe.android.model.PaymentIntentFixtures;
-import com.stripe.android.view.PaymentAuthenticationExtras;
+import com.stripe.android.view.PaymentResultExtras;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -41,10 +41,10 @@ public class Stripe3ds2CompletionStarterTest {
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
-                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
-        assertEquals(PaymentAuthResult.Status.SUCCEEDED,
-                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
-                        PaymentAuthResult.Status.UNKNOWN));
+                intent.getStringExtra(PaymentResultExtras.CLIENT_SECRET));
+        assertEquals(PaymentIntentResult.Status.SUCCEEDED,
+                intent.getIntExtra(PaymentResultExtras.AUTH_STATUS,
+                        PaymentIntentResult.Status.UNKNOWN));
     }
 
     @Test
@@ -55,9 +55,9 @@ public class Stripe3ds2CompletionStarterTest {
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_3DS2.getClientSecret(),
-                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
-        assertEquals(PaymentAuthResult.Status.FAILED,
-                intent.getIntExtra(PaymentAuthenticationExtras.AUTH_STATUS,
-                        PaymentAuthResult.Status.UNKNOWN));
+                intent.getStringExtra(PaymentResultExtras.CLIENT_SECRET));
+        assertEquals(PaymentIntentResult.Status.FAILED,
+                intent.getIntExtra(PaymentResultExtras.AUTH_STATUS,
+                        PaymentIntentResult.Status.UNKNOWN));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1269,7 +1269,7 @@ public class StripeTest {
         return new Stripe(
                 apiHandler,
                 new StripeNetworkUtils(mContext),
-                new PaymentAuthenticationController(mContext, apiHandler),
+                new PaymentController(mContext, apiHandler),
                 publishableKey);
     }
 
@@ -1280,7 +1280,7 @@ public class StripeTest {
         return new Stripe(
                 apiHandler,
                 new StripeNetworkUtils(mContext),
-                new PaymentAuthenticationController(mContext, apiHandler),
+                new PaymentController(mContext, apiHandler),
                 NON_LOGGING_PK,
                 tokenCreator
         );

--- a/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
@@ -13,7 +13,6 @@ import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 public class SourceRedirectTest {
 

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -42,6 +42,6 @@ public class PaymentAuthWebViewTest {
 
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals("pi_123_secret_456",
-                intent.getStringExtra(PaymentAuthenticationExtras.CLIENT_SECRET));
+                intent.getStringExtra(PaymentResultExtras.CLIENT_SECRET));
     }
 }


### PR DESCRIPTION
This better reflects its usage for non-authentication scenarios.
Also rename related classes and methods.
