### PR TITLE
Improve EphemeralKey construction logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerEphemeralKey.java
@@ -3,12 +3,11 @@ package com.stripe.android;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-class CustomerEphemeralKey extends AbstractEphemeralKey {
+final class CustomerEphemeralKey extends EphemeralKey {
     public static final Parcelable.Creator<CustomerEphemeralKey> CREATOR
             = new Parcelable.Creator<CustomerEphemeralKey>() {
 
@@ -27,30 +26,10 @@ class CustomerEphemeralKey extends AbstractEphemeralKey {
         super(in);
     }
 
-    protected CustomerEphemeralKey(
-            long created,
-            @NonNull String customerId,
-            long expires,
-            @NonNull String id,
-            boolean liveMode,
-            @NonNull String object,
-            @NonNull String secret,
-            @NonNull String type
-    ) {
-        super(created,
-                customerId,
-                expires,
-                id,
-                liveMode,
-                object,
-                secret,
-                type);
-
-    }
-
-    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
-    public CustomerEphemeralKey(@Nullable JSONObject jsonObject) throws JSONException {
-        super(jsonObject);
+    private CustomerEphemeralKey(long created, @NonNull String customerId, long expires,
+                                 @NonNull String id, boolean liveMode, @NonNull String object,
+                                 @NonNull String secret, @NonNull String type) {
+        super(created, customerId, expires, id, liveMode, object, secret, type);
     }
 
     @NonNull
@@ -59,14 +38,18 @@ class CustomerEphemeralKey extends AbstractEphemeralKey {
     }
 
     @NonNull
-    static CustomerEphemeralKey fromString(@Nullable String rawJson) throws JSONException {
-        return AbstractEphemeralKey
-                .fromString(rawJson, CustomerEphemeralKey.class);
+    static CustomerEphemeralKey fromJson(@NonNull JSONObject jsonObject) throws JSONException {
+        return EphemeralKey.fromJson(jsonObject, new Factory());
     }
 
-    @NonNull
-    static CustomerEphemeralKey fromJson(@Nullable JSONObject jsonObject) {
-        return AbstractEphemeralKey
-                .fromJson(jsonObject, CustomerEphemeralKey.class);
+    static final class Factory extends EphemeralKey.Factory<CustomerEphemeralKey> {
+        @NonNull
+        @Override
+        CustomerEphemeralKey create(long created, @NonNull String objectId, long expires,
+                                       @NonNull String id, boolean liveMode, @NonNull String object,
+                                       @NonNull String secret, @NonNull String type) {
+            return new CustomerEphemeralKey(created, objectId, expires, id, liveMode, object,
+                    secret, type);
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -262,7 +262,7 @@ public class CustomerSession {
                 KEY_REFRESH_BUFFER_IN_SECONDS,
                 proxyNowCalendar,
                 mOperationIdFactory,
-                CustomerEphemeralKey.class);
+                new CustomerEphemeralKey.Factory());
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyProvider.java
@@ -5,13 +5,13 @@ import android.support.annotation.Size;
 
 /**
  * Represents an object that can call to a server and create
- * {@link AbstractEphemeralKey EphemeralKeys}.
+ * {@link EphemeralKey EphemeralKeys}.
  */
 public interface EphemeralKeyProvider {
 
     /**
      * When called, talks to a client server that then communicates with Stripe's servers to
-     * create an {@link AbstractEphemeralKey}.
+     * create an {@link EphemeralKey}.
      *
      * @param apiVersion the Stripe API Version being used
      * @param keyUpdateListener a callback object to notify about results

--- a/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardEphemeralKey.java
@@ -3,12 +3,8 @@ package com.stripe.android;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-class IssuingCardEphemeralKey extends AbstractEphemeralKey {
+final class IssuingCardEphemeralKey extends EphemeralKey {
     public static final Parcelable.Creator<IssuingCardEphemeralKey> CREATOR
             = new Parcelable.Creator<IssuingCardEphemeralKey>() {
 
@@ -27,30 +23,10 @@ class IssuingCardEphemeralKey extends AbstractEphemeralKey {
         super(in);
     }
 
-    protected IssuingCardEphemeralKey(
-            long created,
-            @NonNull String customerId,
-            long expires,
-            @NonNull String id,
-            boolean liveMode,
-            @NonNull String object,
-            @NonNull String secret,
-            @NonNull String type
-    ) {
-        super(created,
-                customerId,
-                expires,
-                id,
-                liveMode,
-                object,
-                secret,
-                type);
-
-    }
-
-    @SuppressWarnings("checkstyle:RedundantModifier") // Not actually redundant :|
-    public IssuingCardEphemeralKey(@Nullable JSONObject jsonObject) throws JSONException {
-        super(jsonObject);
+    private IssuingCardEphemeralKey(long created, @NonNull String customerId, long expires,
+                                    @NonNull String id, boolean liveMode, @NonNull String object,
+                                    @NonNull String secret, @NonNull String type) {
+        super(created, customerId, expires, id, liveMode, object, secret, type);
     }
 
     @NonNull
@@ -58,15 +34,14 @@ class IssuingCardEphemeralKey extends AbstractEphemeralKey {
         return mObjectId;
     }
 
-    @NonNull
-    static IssuingCardEphemeralKey fromString(@Nullable String rawJson) throws JSONException {
-        return AbstractEphemeralKey
-                .fromString(rawJson, IssuingCardEphemeralKey.class);
-    }
-
-    @NonNull
-    static IssuingCardEphemeralKey fromJson(@Nullable JSONObject jsonObject) {
-        return AbstractEphemeralKey
-                .fromJson(jsonObject, IssuingCardEphemeralKey.class);
+    static final class Factory extends EphemeralKey.Factory<IssuingCardEphemeralKey> {
+        @NonNull
+        @Override
+        IssuingCardEphemeralKey create(long created, @NonNull String objectId, long expires,
+                                       @NonNull String id, boolean liveMode, @NonNull String object,
+                                       @NonNull String secret, @NonNull String type) {
+            return new IssuingCardEphemeralKey(created, objectId, expires, id, liveMode, object,
+                    secret, type);
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -20,6 +20,7 @@ import java.util.Map;
 /**
  * Methods for retrieval / update of a Stripe Issuing card
  */
+@SuppressWarnings("WeakerAccess")
 public class IssuingCardPinService
         implements EphemeralKeyManager.KeyManagerListener<IssuingCardEphemeralKey> {
 
@@ -71,7 +72,7 @@ public class IssuingCardPinService
                 KEY_REFRESH_BUFFER_IN_SECONDS,
                 null,
                 operationIdFactory,
-                IssuingCardEphemeralKey.class);
+                new IssuingCardEphemeralKey.Factory());
         mApiHandler = apiHandler;
     }
 

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -29,6 +29,7 @@ import com.stripe.android.view.PaymentFlowActivity;
 import com.stripe.android.view.PaymentMethodsActivity;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,7 +99,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
             "            }]\n" +
             "}";
 
-    public static final String FIRST_TEST_CUSTOMER_OBJECT =
+    static final String FIRST_TEST_CUSTOMER_OBJECT =
             "{\n" +
                     "  \"id\": \"cus_AQsHpvKfKwJDrF\",\n" +
                     "  \"object\": \"customer\",\n" +
@@ -198,17 +199,12 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     }
 
     @NonNull
-    private CustomerEphemeralKey getCustomerEphemeralKey(@NonNull String key) {
-        try {
-            return CustomerEphemeralKey.fromString(key);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
+    private CustomerEphemeralKey getCustomerEphemeralKey(@NonNull String key) throws JSONException {
+        return CustomerEphemeralKey.fromJson(new JSONObject(key));
     }
 
     @Before
-    public void setup()
-            throws StripeException {
+    public void setup() throws StripeException {
         MockitoAnnotations.initMocks(this);
         PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
@@ -325,7 +321,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void create_withoutInvokingFunctions_fetchesKeyAndCustomer()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         final CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -341,7 +337,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void setCustomerShippingInfo_withValidInfo_callsWithExpectedArgs()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         final CustomerEphemeralKey firstKey = Objects.requireNonNull(
                 getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW));
         mEphemeralKeyProvider.setNextRawEphemeralKey(FIRST_SAMPLE_KEY_RAW);
@@ -368,7 +364,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void retrieveCustomer_withExpiredCache_updatesCustomer()
             throws CardException, APIException, InvalidRequestException,
-            AuthenticationException, APIConnectionException {
+            AuthenticationException, APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -419,7 +415,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void retrieveCustomer_withUnExpiredCache_returnsCustomerWithoutHittingApi()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         final CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -469,7 +465,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void addSourceToCustomer_withUnExpiredCustomer_returnsAddedSourceAndEmptiesLogs()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -525,7 +521,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void addSourceToCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -575,7 +571,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void removeSourceFromCustomer_withUnExpiredCustomer_returnsRemovedSourceAndEmptiesLogs()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -628,7 +624,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void removeSourceFromCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -675,7 +671,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void setDefaultSourceForCustomer_withUnExpiredCustomer_returnsCustomerAndClearsLog()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -730,7 +726,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void setDefaultSourceForCustomer_whenApiThrows_tellsListenerBroadcastsAndClearsLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -808,7 +804,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void attachPaymentMethodToCustomer_withUnExpiredCustomer_returnsAddedPaymentMethodAndEmptiesLogs()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -861,7 +857,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void attachPaymentMethodToCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -909,7 +905,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
     @Test
     public void detachPaymentMethodFromCustomer_withUnExpiredCustomer_returnsRemovedPaymentMethodAndEmptiesLogs()
             throws CardException, APIException, InvalidRequestException, AuthenticationException,
-            APIConnectionException {
+            APIConnectionException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -961,7 +957,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void detachPaymentMethodFromCustomer_whenApiThrowsError_tellsListenerBroadcastsAndEmptiesLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 
@@ -1007,7 +1003,7 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
 
     @Test
     public void getPaymentMethods_withUnExpiredCustomer_returnsAddedPaymentMethodAndEmptiesLogs()
-            throws StripeException {
+            throws StripeException, JSONException {
         CustomerEphemeralKey firstKey = getCustomerEphemeralKey(FIRST_SAMPLE_KEY_RAW);
         assertNotNull(firstKey);
 

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.stripe.android.testharness.TestEphemeralKeyProvider;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,7 +61,9 @@ public class EphemeralKeyManagerTest {
     @Captor private ArgumentCaptor<CustomerEphemeralKey> mEphemeralKeyArgumentCaptor;
     @Captor private ArgumentCaptor<String> mActionArgumentCaptor;
 
-    private final OperationIdFactory mOperationIdFactory = new OperationIdFactory();
+    @NonNull private final OperationIdFactory mOperationIdFactory = new OperationIdFactory();
+    @NonNull private final CustomerEphemeralKey.Factory mEphemeralKeyFactory =
+            new CustomerEphemeralKey.Factory();
 
     private CustomerEphemeralKey mCustomerEphemeralKey;
     private TestEphemeralKeyProvider mTestEphemeralKeyProvider;
@@ -68,7 +71,7 @@ public class EphemeralKeyManagerTest {
     @Before
     public void setup() throws JSONException {
         MockitoAnnotations.initMocks(this);
-        mCustomerEphemeralKey = CustomerEphemeralKey.fromString(FIRST_SAMPLE_KEY_RAW);
+        mCustomerEphemeralKey = CustomerEphemeralKey.fromJson(new JSONObject(FIRST_SAMPLE_KEY_RAW));
         mTestEphemeralKeyProvider = new TestEphemeralKeyProvider();
     }
 
@@ -148,7 +151,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 null,
                 mOperationIdFactory,
-                CustomerEphemeralKey.class);
+                mEphemeralKeyFactory);
 
         verify(mKeyManagerListener).onKeyUpdate(
                 mEphemeralKeyArgumentCaptor.capture(),
@@ -171,7 +174,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 fixedCalendar,
                 mOperationIdFactory,
-                CustomerEphemeralKey.class);
+                new CustomerEphemeralKey.Factory());
 
         final String operationId = mOperationIdFactory.create();
         final String actionString = "action";
@@ -211,7 +214,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 proxyCalendar,
                 mOperationIdFactory,
-                CustomerEphemeralKey.class);
+                mEphemeralKeyFactory);
 
         // Make sure we're in a good state
         verify(mKeyManagerListener).onKeyUpdate(
@@ -246,7 +249,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 null,
                 operationIdFactory,
-                CustomerEphemeralKey.class);
+                mEphemeralKeyFactory);
 
         verify(mKeyManagerListener, never()).onKeyUpdate(
                 ArgumentMatchers.<CustomerEphemeralKey>isNull(),
@@ -258,7 +261,7 @@ public class EphemeralKeyManagerTest {
                 "EphemeralKeyUpdateListener.onKeyUpdate was passed a value that " +
                         "could not be JSON parsed: [Value Not_a_JSON of type java.lang.String " +
                         "cannot be converted to JSONObject]. The raw body from Stripe's " +
-                        "response should be passed");
+                        "response should be passed.");
     }
 
     @Test
@@ -274,7 +277,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 null,
                 operationIdFactory,
-                CustomerEphemeralKey.class);
+                mEphemeralKeyFactory);
 
         verify(mKeyManagerListener, never()).onKeyUpdate(
                 ArgumentMatchers.<CustomerEphemeralKey>isNull(),
@@ -283,10 +286,10 @@ public class EphemeralKeyManagerTest {
                 ArgumentMatchers.<Map<String, Object>>isNull());
         verify(mKeyManagerListener).onKeyError(operationId,
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
-                "EphemeralKeyUpdateListener.onKeyUpdate was passed a JSON String " +
-                        "that was invalid: [Improperly formatted JSON for ephemeral " +
-                        "key CustomerEphemeralKey - No value for created]. The raw body " +
-                        "from Stripe's response should be passed");
+                "EphemeralKeyUpdateListener.onKeyUpdate was passed a value that " +
+                        "could not be JSON parsed: [No value for created]. The raw body from " +
+                        "Stripe's response should be passed."
+        );
     }
 
     @Test
@@ -303,7 +306,7 @@ public class EphemeralKeyManagerTest {
                 TEST_SECONDS_BUFFER,
                 null,
                 operationIdFactory,
-                CustomerEphemeralKey.class);
+                mEphemeralKeyFactory);
 
         verify(mKeyManagerListener, never()).onKeyUpdate(
                 ArgumentMatchers.<CustomerEphemeralKey>isNull(),
@@ -317,7 +320,7 @@ public class EphemeralKeyManagerTest {
 
     @NonNull
     private CustomerEphemeralKey createEphemeralKey(long expires) {
-        return new CustomerEphemeralKey(1501199335L, "cus_AQsHpvKfKwJDrF",
+        return mEphemeralKeyFactory.create(1501199335L, "cus_AQsHpvKfKwJDrF",
                 expires, "ephkey_123", false, "customer", "", "");
     }
 }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
@@ -40,17 +40,13 @@ public class EphemeralKeyTest {
             "}";
 
     @NonNull
-    private CustomerEphemeralKey getCustomerEphemeralKey(@NonNull String key) {
-        try {
-            return CustomerEphemeralKey.fromString(key);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
+    private CustomerEphemeralKey getCustomerEphemeralKey() throws JSONException {
+        return CustomerEphemeralKey.fromJson(new JSONObject(EphemeralKeyTest.SAMPLE_KEY_RAW));
     }
     
     @Test
-    public void fromJson_createsKeyWithExpectedValues() {
-        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
+    public void fromJson_createsKeyWithExpectedValues() throws JSONException {
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey();
         assertNotNull(ephemeralKey);
         assertEquals("ephkey_123", ephemeralKey.getId());
         assertEquals("ephemeral_key", ephemeralKey.getObject());
@@ -75,8 +71,8 @@ public class EphemeralKeyTest {
     }
 
     @Test
-    public void toMap_createsMapWithExpectedValues() {
-        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
+    public void toMap_createsMapWithExpectedValues() throws JSONException {
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey();
         assertNotNull(ephemeralKey);
         Map<String, Object> expectedMap = new HashMap<String, Object>() {{
             put(CustomerEphemeralKey.FIELD_ID, "ephkey_123");
@@ -98,8 +94,8 @@ public class EphemeralKeyTest {
     }
 
     @Test
-    public void toParcel_fromParcel_createsExpectedObject() {
-        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey(SAMPLE_KEY_RAW);
+    public void toParcel_fromParcel_createsExpectedObject() throws JSONException {
+        CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey();
         assertNotNull(ephemeralKey);
         Parcel parcel = Parcel.obtain();
         ephemeralKey.writeToParcel(parcel, 0);


### PR DESCRIPTION
Previously `EphemeralKeyManager#updateKey()` was using reflection to
create the `EphemeralKey` object. Now, pass in a `EphemeralKey.Factory`
to manage object creation.