### PR TITLE
Remove StripeJsonModel#toJson()

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -158,7 +158,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         paymentIntent -> mPaymentIntentValue.setText(paymentIntent != null ?
-                                paymentIntent.toJson().toString() :
+                                new JSONObject(paymentIntent.toMap()).toString() :
                                 getString(R.string.error_while_retrieving_payment_intent)),
                         throwable -> Log.e(TAG, throwable.toString())
                 );
@@ -188,7 +188,8 @@ public class PaymentIntentActivity extends AppCompatActivity {
                 .subscribe(
                         paymentIntent -> {
                             if (paymentIntent != null) {
-                                mPaymentIntentValue.setText(paymentIntent.toJson().toString());
+                                mPaymentIntentValue
+                                        .setText(new JSONObject(paymentIntent.toMap()).toString());
 
                                 if (paymentIntent.requiresAction()) {
                                     Toast.makeText(PaymentIntentActivity.this,

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.java
@@ -86,35 +86,6 @@ abstract class EphemeralKey extends StripeJsonModel implements Parcelable {
 
     @NonNull
     @Override
-    public JSONObject toJson() {
-        JSONObject jsonObject = new JSONObject();
-        JSONArray associatedObjectsArray = new JSONArray();
-        JSONObject associatedObject = new JSONObject();
-
-        try {
-            jsonObject.put(FIELD_CREATED, mCreated);
-            jsonObject.put(FIELD_EXPIRES, mExpires);
-            jsonObject.put(FIELD_OBJECT, mObject);
-            jsonObject.put(FIELD_ID, mId);
-            jsonObject.put(FIELD_SECRET, mSecret);
-            jsonObject.put(FIELD_LIVEMODE, mLiveMode);
-
-            associatedObject.put(FIELD_TYPE, mType);
-            associatedObject.put(FIELD_ID, mObjectId);
-            associatedObjectsArray.put(associatedObject);
-
-            jsonObject.put(FIELD_ASSOCIATED_OBJECTS, associatedObjectsArray);
-        } catch (JSONException impossible) {
-            // An exception can only be thrown from put operations if the key is null
-            // or the value is a non-finite number.
-            throw new IllegalArgumentException("JSONObject creation exception thrown.");
-        }
-
-        return jsonObject;
-    }
-
-    @NonNull
-    @Override
     public Map<String, Object> toMap() {
         final AbstractMap<String, Object> map = new HashMap<>();
         map.put(FIELD_CREATED, mCreated);

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyUpdateListener.java
@@ -1,7 +1,6 @@
 package com.stripe.android;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * Represents a listener for Ephemeral Key Update events.

--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -20,7 +20,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for an owner <a href="https://stripe.com/docs/api#source_object-owner-address">address</a>
@@ -139,19 +138,6 @@ public final class Address extends StripeJsonModel implements Parcelable {
         }
         StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putStringIfNotNull(jsonObject, FIELD_CITY, mCity);
-        putStringIfNotNull(jsonObject, FIELD_COUNTRY, mCountry);
-        putStringIfNotNull(jsonObject, FIELD_LINE_1, mLine1);
-        putStringIfNotNull(jsonObject, FIELD_LINE_2, mLine2);
-        putStringIfNotNull(jsonObject, FIELD_POSTAL_CODE, mPostalCode);
-        putStringIfNotNull(jsonObject, FIELD_STATE, mState);
-        return jsonObject;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -30,9 +30,6 @@ import static com.stripe.android.model.StripeJsonUtils.optCurrency;
 import static com.stripe.android.model.StripeJsonUtils.optHash;
 import static com.stripe.android.model.StripeJsonUtils.optInteger;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putIntegerIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringHashIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * A model object representing a Card in the Android SDK.
@@ -788,36 +785,6 @@ public final class Card extends StripeJsonModel implements StripePaymentSource {
     @Nullable
     public String getCvcCheck() {
         return cvcCheck;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject object = new JSONObject();
-        putStringIfNotNull(object, FIELD_NAME, name);
-        putStringIfNotNull(object, FIELD_ADDRESS_CITY, addressCity);
-        putStringIfNotNull(object, FIELD_ADDRESS_COUNTRY, addressCountry);
-        putStringIfNotNull(object, FIELD_ADDRESS_LINE1, addressLine1);
-        putStringIfNotNull(object, FIELD_ADDRESS_LINE1_CHECK, addressLine1Check);
-        putStringIfNotNull(object, FIELD_ADDRESS_LINE2, addressLine2);
-        putStringIfNotNull(object, FIELD_ADDRESS_STATE, addressState);
-        putStringIfNotNull(object, FIELD_ADDRESS_ZIP, addressZip);
-        putStringIfNotNull(object, FIELD_ADDRESS_ZIP_CHECK, addressZipCheck);
-        putStringIfNotNull(object, FIELD_BRAND, brand);
-        putStringIfNotNull(object, FIELD_CURRENCY, currency);
-        putStringIfNotNull(object, FIELD_COUNTRY, country);
-        putStringIfNotNull(object, FIELD_CUSTOMER, customerId);
-        putIntegerIfNotNull(object, FIELD_EXP_MONTH, expMonth);
-        putIntegerIfNotNull(object, FIELD_EXP_YEAR, expYear);
-        putStringIfNotNull(object, FIELD_FINGERPRINT, fingerprint);
-        putStringIfNotNull(object, FIELD_FUNDING, funding);
-        putStringIfNotNull(object, FIELD_CVC_CHECK, cvcCheck);
-        putStringIfNotNull(object, FIELD_LAST4, last4);
-        putStringIfNotNull(object, FIELD_ID, id);
-        putStringIfNotNull(object, FIELD_TOKENIZATION_METHOD, tokenizationMethod);
-        putStringHashIfNotNull(object, FIELD_METADATA, metadata);
-        putStringIfNotNull(object, FIELD_OBJECT, VALUE_CARD);
-        return object;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -19,10 +19,6 @@ import java.util.Map;
 import static com.stripe.android.model.StripeJsonUtils.optBoolean;
 import static com.stripe.android.model.StripeJsonUtils.optInteger;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putBooleanIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putIntegerIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putObjectIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for a Stripe Customer object
@@ -103,28 +99,6 @@ public final class Customer extends StripeJsonModel {
             }
         }
         return null;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        JSONObject jsonObject = new JSONObject();
-        putStringIfNotNull(jsonObject, FIELD_ID, mId);
-        putStringIfNotNull(jsonObject, FIELD_OBJECT, VALUE_CUSTOMER);
-        putStringIfNotNull(jsonObject, FIELD_DEFAULT_SOURCE, mDefaultSource);
-        StripeJsonModel.putStripeJsonModelIfNotNull(jsonObject,
-                FIELD_SHIPPING,
-                mShippingInformation);
-        JSONObject sourcesObject = new JSONObject();
-        putStringIfNotNull(sourcesObject, FIELD_OBJECT, VALUE_LIST);
-        putBooleanIfNotNull(sourcesObject, FIELD_HAS_MORE, mHasMore);
-        putIntegerIfNotNull(sourcesObject, FIELD_TOTAL_COUNT, mTotalCount);
-        putStripeJsonModelListIfNotNull(sourcesObject, FIELD_DATA, mSources);
-        putStringIfNotNull(sourcesObject, FIELD_URL, mUrl);
-
-        putObjectIfNotNull(jsonObject, FIELD_SOURCES, sourcesObject);
-
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
+++ b/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
@@ -121,17 +121,6 @@ public final class CustomerSource extends StripeJsonModel implements StripePayme
         return new HashMap<>();
     }
 
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        if (mStripePaymentSource instanceof Source) {
-            return ((Source) mStripePaymentSource).toJson();
-        } else if (mStripePaymentSource instanceof Card) {
-            return ((Card) mStripePaymentSource).toJson();
-        }
-        return new JSONObject();
-    }
-
     @Override
     public boolean equals(@Nullable Object obj) {
         return this == obj || (obj instanceof CustomerSource && typedEquals((CustomerSource) obj));

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -19,17 +19,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.stripe.android.model.StripeJsonUtils.listToJsonArray;
 import static com.stripe.android.model.StripeJsonUtils.optBoolean;
 import static com.stripe.android.model.StripeJsonUtils.optCurrency;
 import static com.stripe.android.model.StripeJsonUtils.optLong;
 import static com.stripe.android.model.StripeJsonUtils.optMap;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putArrayIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putBooleanIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putLongIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putMapIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * A PaymentIntent tracks the process of collecting a payment from your customer.
@@ -326,30 +320,6 @@ public final class PaymentIntent extends StripeJsonModel {
         }
 
         return list;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putStringIfNotNull(jsonObject, FIELD_ID, mId);
-        putStringIfNotNull(jsonObject, FIELD_OBJECT, mObjectType);
-        putArrayIfNotNull(jsonObject, FIELD_PAYMENT_METHOD_TYPES,
-                listToJsonArray(mPaymentMethodTypes));
-        putLongIfNotNull(jsonObject, FIELD_AMOUNT, mAmount);
-        putLongIfNotNull(jsonObject, FIELD_CANCELED, mCanceledAt);
-        putStringIfNotNull(jsonObject, FIELD_CAPTURE_METHOD, mCaptureMethod);
-        putStringIfNotNull(jsonObject, FIELD_CLIENT_SECRET, mClientSecret);
-        putStringIfNotNull(jsonObject, FIELD_CONFIRMATION_METHOD, mConfirmationMethod);
-        putLongIfNotNull(jsonObject, FIELD_CREATED, mCreated);
-        putStringIfNotNull(jsonObject, FIELD_CURRENCY, mCurrency);
-        putStringIfNotNull(jsonObject, FIELD_DESCRIPTION, mDescription);
-        putBooleanIfNotNull(jsonObject, FIELD_LIVEMODE, mLiveMode);
-        putMapIfNotNull(jsonObject, FIELD_NEXT_ACTION, mNextAction);
-        putStringIfNotNull(jsonObject, FIELD_RECEIPT_EMAIL, mReceiptEmail);
-        putStringIfNotNull(jsonObject, FIELD_SOURCE, mSource);
-        putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus != null ? mStatus.code : null);
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -110,31 +110,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
         return paymentMethod;
     }
 
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject paymentMethod = new JSONObject();
-        try {
-            paymentMethod.put(FIELD_ID, id);
-            paymentMethod.put(FIELD_CREATED, created);
-            paymentMethod.put(FIELD_CUSTOMER, customerId);
-            paymentMethod.put(FIELD_LIVEMODE, liveMode);
-            paymentMethod.put(FIELD_METADATA, metadata != null ? new JSONObject(metadata) : null);
-            paymentMethod.put(FIELD_TYPE, type);
-            paymentMethod.put(FIELD_BILLING_DETAILS,
-                    billingDetails != null ? billingDetails.toJson() : null);
-            paymentMethod.put(FIELD_CARD,
-                    card != null ? card.toJson() : null);
-            paymentMethod.put(FIELD_CARD_PRESENT,
-                    cardPresent != null ? cardPresent.toJson() : null);
-            paymentMethod.put(FIELD_IDEAL,
-                    ideal != null ? ideal.toJson() : null);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-        return paymentMethod;
-    }
-
     @Nullable
     public static PaymentMethod fromString(@Nullable String jsonString) {
         if (jsonString == null) {
@@ -414,21 +389,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
             return billingDetails;
         }
 
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            final JSONObject billingDetails = new JSONObject();
-            try {
-                billingDetails.put(FIELD_ADDRESS, address != null ? address.toJson() : null);
-                billingDetails.put(FIELD_EMAIL, email);
-                billingDetails.put(FIELD_NAME, name);
-                billingDetails.put(FIELD_PHONE, phone);
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
-            return billingDetails;
-        }
-
         @Nullable
         public static BillingDetails fromJson(@Nullable JSONObject billingDetails) {
             if (billingDetails == null) {
@@ -625,26 +585,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
             return map;
         }
 
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            final JSONObject json = new JSONObject();
-            try {
-                json.put(FIELD_BRAND, brand);
-                json.put(FIELD_CHECKS, checks != null ? checks.toJson() : null);
-                json.put(FIELD_COUNTRY, country);
-                json.put(FIELD_EXP_MONTH, expiryMonth);
-                json.put(FIELD_EXP_YEAR, expiryYear);
-                json.put(FIELD_FUNDING, funding);
-                json.put(FIELD_LAST4, last4);
-                json.put(FIELD_THREE_D_SECURE_USAGE, threeDSecureUsage != null ?
-                        threeDSecureUsage.toJson() : null);
-                json.put(FIELD_WALLET, wallet);
-            } catch (JSONException ignore) {
-            }
-            return json;
-        }
-
         @Nullable
         public static Card fromJson(@Nullable JSONObject cardJson) {
             if (cardJson == null) {
@@ -816,19 +756,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
                 return map;
             }
 
-            @NonNull
-            @Override
-            public JSONObject toJson() {
-                final JSONObject json = new JSONObject();
-                try {
-                    json.put(FIELD_ADDRESS_LINE1_CHECK, addressLine1Check);
-                    json.put(FIELD_ADDRESS_POSTAL_CODE_CHECK, addressPostalCodeCheck);
-                    json.put(FIELD_CVC_CHECK, cvcCheck);
-                } catch (JSONException ignore) {
-                }
-                return json;
-            }
-
             @Nullable
             public static Checks fromJson(@Nullable JSONObject checksJson) {
                 if (checksJson == null) {
@@ -933,17 +860,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
                 return map;
             }
 
-            @NonNull
-            @Override
-            public JSONObject toJson() {
-                final JSONObject json = new JSONObject();
-                try {
-                    json.put(FIELD_IS_SUPPORTED, isSupported);
-                } catch (JSONException ignore) {
-                }
-                return json;
-            }
-
             @Nullable
             public static ThreeDSecureUsage fromJson(@Nullable JSONObject threeDSecureUsage) {
                 if (threeDSecureUsage == null) {
@@ -1018,12 +934,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
             return new HashMap<>();
         }
 
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            return new JSONObject();
-        }
-
         @Override
         public int hashCode() {
             return ObjectUtils.hash(type);
@@ -1083,19 +993,6 @@ public final class PaymentMethod extends StripeJsonModel implements Parcelable {
             final AbstractMap<String, Object> ideal = new HashMap<>();
             ideal.put(FIELD_BANK, bank);
             ideal.put(FIELD_BIC, bankIdentifierCode);
-            return ideal;
-        }
-
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            final JSONObject ideal = new JSONObject();
-            try {
-                ideal.put(FIELD_BANK, bank);
-                ideal.put(FIELD_BIC, bankIdentifierCode);
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
             return ideal;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model representing a shipping address object
@@ -83,16 +82,6 @@ public final class ShippingInformation extends StripeJsonModel implements Parcel
                 Address.fromJson(jsonObject.optJSONObject(FIELD_ADDRESS)),
                 optString(jsonObject, FIELD_NAME),
                 optString(jsonObject, FIELD_PHONE));
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putStringIfNotNull(jsonObject, FIELD_NAME, mName);
-        putStringIfNotNull(jsonObject, FIELD_PHONE, mPhone);
-        putStripeJsonModelIfNotNull(jsonObject, FIELD_ADDRESS, mAddress);
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
@@ -8,15 +8,10 @@ import android.support.annotation.Size;
 
 import com.stripe.android.utils.ObjectUtils;
 
-import org.json.JSONObject;
-
 import java.util.AbstractMap;
 import java.util.Currency;
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.stripe.android.model.StripeJsonUtils.putLongIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model representing a shipping method in the Android SDK.
@@ -114,18 +109,6 @@ public final class ShippingMethod extends StripeJsonModel implements Parcelable 
     @NonNull
     public String getIdentifier() {
         return mIdentifier;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putLongIfNotNull(jsonObject, FIELD_AMOUNT, mAmount);
-        putStringIfNotNull(jsonObject, FIELD_CURRENCY_CODE, mCurrencyCode);
-        putStringIfNotNull(jsonObject, FIELD_DETAIL, mDetail);
-        putStringIfNotNull(jsonObject, FIELD_IDENTIFIER, mIdentifier);
-        putStringIfNotNull(jsonObject, FIELD_LABEL, mLabel);
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -19,10 +19,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
-import static com.stripe.android.model.StripeJsonUtils.mapToJsonObject;
 import static com.stripe.android.model.StripeJsonUtils.optLong;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * A model class representing a source in the Android SDK. More detailed information and interaction
@@ -358,6 +356,7 @@ public final class Source extends StripeJsonModel implements StripePaymentSource
     public Map<String, Object> toMap() {
         final AbstractMap<String, Object> map = new HashMap<>();
         map.put(FIELD_ID, mId);
+        map.put(FIELD_OBJECT, VALUE_SOURCE);
         map.put(FIELD_AMOUNT, mAmount);
         map.put(FIELD_CLIENT_SECRET, mClientSecret);
 
@@ -380,43 +379,6 @@ public final class Source extends StripeJsonModel implements StripePaymentSource
         map.put(FIELD_USAGE, mUsage);
         removeNullAndEmptyParams(map);
         return map;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        try {
-            putStringIfNotNull(jsonObject, FIELD_ID, mId);
-            jsonObject.put(FIELD_OBJECT, VALUE_SOURCE);
-            jsonObject.put(FIELD_AMOUNT, mAmount);
-            putStringIfNotNull(jsonObject, FIELD_CLIENT_SECRET, mClientSecret);
-            putStripeJsonModelIfNotNull(jsonObject, FIELD_CODE_VERIFICATION, mCodeVerification);
-            jsonObject.put(FIELD_CREATED, mCreated);
-            putStringIfNotNull(jsonObject, FIELD_CURRENCY, mCurrency);
-            putStringIfNotNull(jsonObject, FIELD_FLOW, mFlow);
-            jsonObject.put(FIELD_LIVEMODE, mLiveMode);
-
-            JSONObject metaDataObject = mapToJsonObject(mMetaData);
-            if (metaDataObject != null) {
-                jsonObject.put(FIELD_METADATA, metaDataObject);
-            }
-
-            JSONObject sourceTypeJsonObject = mapToJsonObject(mSourceTypeData);
-
-            if (sourceTypeJsonObject != null) {
-                jsonObject.put(mTypeRaw, sourceTypeJsonObject);
-            }
-
-            putStripeJsonModelIfNotNull(jsonObject, FIELD_OWNER, mOwner);
-            putStripeJsonModelIfNotNull(jsonObject, FIELD_RECEIVER, mReceiver);
-            putStripeJsonModelIfNotNull(jsonObject, FIELD_REDIRECT, mRedirect);
-            putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
-            putStringIfNotNull(jsonObject, FIELD_TYPE, mTypeRaw);
-            putStringIfNotNull(jsonObject, FIELD_USAGE, mUsage);
-
-        } catch (JSONException ignored) { }
-        return jsonObject;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
@@ -22,8 +22,6 @@ import java.util.Set;
 
 import static com.stripe.android.model.StripeJsonUtils.optInteger;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putIntegerIfNotNull;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for data contained in the SourceTypeData of a Card Source.
@@ -163,24 +161,6 @@ public final class SourceCardData extends StripeSourceTypeModel {
     @Nullable
     public String getTokenizationMethod() {
         return mTokenizationMethod;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = super.toJson();
-        putStringIfNotNull(jsonObject, FIELD_ADDRESS_LINE1_CHECK, mAddressLine1Check);
-        putStringIfNotNull(jsonObject, FIELD_ADDRESS_ZIP_CHECK, mAddressZipCheck);
-        putStringIfNotNull(jsonObject, FIELD_BRAND, mBrand);
-        putStringIfNotNull(jsonObject, FIELD_COUNTRY, mCountry);
-        putStringIfNotNull(jsonObject, FIELD_DYNAMIC_LAST4, mDynamicLast4);
-        putIntegerIfNotNull(jsonObject, FIELD_EXP_MONTH, mExpiryMonth);
-        putIntegerIfNotNull(jsonObject, FIELD_EXP_YEAR, mExpiryYear);
-        putStringIfNotNull(jsonObject, FIELD_FUNDING, mFunding);
-        putStringIfNotNull(jsonObject, FIELD_LAST4, mLast4);
-        putStringIfNotNull(jsonObject, FIELD_THREE_D_SECURE, mThreeDSecureStatus);
-        putStringIfNotNull(jsonObject, FIELD_TOKENIZATION_METHOD, mTokenizationMethod);
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
@@ -69,19 +69,6 @@ public final class SourceCodeVerification extends StripeJsonModel {
         return map;
     }
 
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-
-        try {
-            jsonObject.put(FIELD_ATTEMPTS_REMAINING, mAttemptsRemaining);
-            StripeJsonUtils.putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
-        } catch (JSONException ignored) { }
-
-        return jsonObject;
-    }
-
     @Nullable
     public static SourceCodeVerification fromString(@Nullable String jsonString) {
         try {

--- a/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
@@ -14,7 +14,6 @@ import java.util.Map;
 
 import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for a <a href="https://stripe.com/docs/api#source_object-owner">owner</a> object
@@ -118,32 +117,6 @@ public final class SourceOwner extends StripeJsonModel {
         map.put(FIELD_VERIFIED_PHONE, mVerifiedPhone);
         removeNullAndEmptyParams(map);
         return map;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        final JSONObject jsonAddressObject = mAddress == null ? null : mAddress.toJson();
-        final JSONObject jsonVerifiedAddressObject = mVerifiedAddress == null
-                ? null
-                : mVerifiedAddress.toJson();
-        try {
-            if (jsonAddressObject != null && jsonAddressObject.length() > 0) {
-                jsonObject.put(FIELD_ADDRESS, jsonAddressObject);
-            }
-            putStringIfNotNull(jsonObject, FIELD_EMAIL, mEmail);
-            putStringIfNotNull(jsonObject, FIELD_NAME, mName);
-            putStringIfNotNull(jsonObject, FIELD_PHONE, mPhone);
-            if (jsonVerifiedAddressObject != null && jsonVerifiedAddressObject.length() > 0) {
-                jsonObject.put(FIELD_VERIFIED_ADDRESS, jsonVerifiedAddressObject);
-            }
-            putStringIfNotNull(jsonObject, FIELD_VERIFIED_EMAIL, mVerifiedEmail);
-            putStringIfNotNull(jsonObject, FIELD_VERIFIED_NAME, mVerifiedName);
-            putStringIfNotNull(jsonObject, FIELD_VERIFIED_PHONE, mVerifiedPhone);
-        } catch (JSONException ignored) { }
-
-        return jsonObject;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceReceiver.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceReceiver.java
@@ -72,21 +72,6 @@ public final class SourceReceiver extends StripeJsonModel {
         return map;
     }
 
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        StripeJsonUtils.putStringIfNotNull(jsonObject, FIELD_ADDRESS, mAddress);
-        try {
-            jsonObject.put(FIELD_AMOUNT_CHARGED, mAmountCharged);
-            jsonObject.put(FIELD_AMOUNT_RECEIVED, mAmountReceived);
-            jsonObject.put(FIELD_AMOUNT_RETURNED, mAmountReturned);
-        } catch (JSONException jsonException) {
-            return jsonObject;
-        }
-        return jsonObject;
-    }
-
     @Nullable
     public static SourceReceiver fromString(@Nullable String jsonString) {
         try {

--- a/stripe/src/main/java/com/stripe/android/model/SourceRedirect.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceRedirect.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for a <a href="https://stripe.com/docs/api/sources/object#source_object-redirect">
@@ -79,16 +78,6 @@ public final class SourceRedirect extends StripeJsonModel {
         map.put(FIELD_URL, mUrl);
         removeNullAndEmptyParams(map);
         return map;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putStringIfNotNull(jsonObject, FIELD_RETURN_URL, mReturnUrl);
-        putStringIfNotNull(jsonObject, FIELD_STATUS, mStatus);
-        putStringIfNotNull(jsonObject, FIELD_URL, mUrl);
-        return jsonObject;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
-import static com.stripe.android.model.StripeJsonUtils.putStringIfNotNull;
 
 /**
  * Model for the SourceTypeData contained in a SEPA Debit Source object.
@@ -117,20 +116,6 @@ public final class SourceSepaDebitData extends StripeSourceTypeModel {
     @Nullable
     public String getMandateUrl() {
         return mMandateUrl;
-    }
-
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = super.toJson();
-        putStringIfNotNull(jsonObject, FIELD_BANK_CODE, mBankCode);
-        putStringIfNotNull(jsonObject, FIELD_BRANCH_CODE, mBranchCode);
-        putStringIfNotNull(jsonObject, FIELD_COUNTRY, mCountry);
-        putStringIfNotNull(jsonObject, FIELD_FINGERPRINT, mFingerPrint);
-        putStringIfNotNull(jsonObject, FIELD_LAST4, mLast4);
-        putStringIfNotNull(jsonObject, FIELD_MANDATE_REFERENCE, mMandateReference);
-        putStringIfNotNull(jsonObject, FIELD_MANDATE_URL, mMandateUrl);
-        return jsonObject;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/StripeJsonModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeJsonModel.java
@@ -4,10 +4,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,9 +15,6 @@ public abstract class StripeJsonModel {
 
     @NonNull
     public abstract Map<String, Object> toMap();
-
-    @NonNull
-    public abstract JSONObject toJson();
 
     @Override
     public abstract int hashCode();
@@ -39,51 +32,14 @@ public abstract class StripeJsonModel {
         upperLevelMap.put(key, jsonModel.toMap());
     }
 
-
-    static void putStripeJsonModelIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String key,
-            @Nullable StripeJsonModel jsonModel) {
-        if (jsonModel == null) {
-            return;
-        }
-
-        try {
-            jsonObject.put(key, jsonModel.toJson());
-        } catch (JSONException ignored) {
-        }
-    }
-
     static void putStripeJsonModelListIfNotNull(
             @NonNull Map<String, Object> upperLevelMap,
             @NonNull @Size(min = 1) String key,
-            @Nullable List<? extends StripeJsonModel> jsonModelList) {
-        if (jsonModelList == null) {
-            return;
-        }
-
-        List<Map<String, Object>> mapList = new ArrayList<>();
-        for (int i = 0; i < jsonModelList.size(); i++) {
-            mapList.add(jsonModelList.get(i).toMap());
+            @NonNull List<? extends StripeJsonModel> models) {
+        final List<Map<String, Object>> mapList = new ArrayList<>();
+        for (int i = 0; i < models.size(); i++) {
+            mapList.add(models.get(i).toMap());
         }
         upperLevelMap.put(key, mapList);
-    }
-
-    static void putStripeJsonModelListIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String key,
-            @Nullable List<? extends StripeJsonModel> jsonModelList) {
-        if (jsonModelList == null) {
-            return;
-        }
-
-        try {
-            JSONArray array = new JSONArray();
-            for (StripeJsonModel model : jsonModelList) {
-                array.put(model.toJson());
-            }
-            jsonObject.put(key, array);
-        } catch (JSONException ignored) {
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/StripeJsonUtils.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeJsonUtils.java
@@ -4,12 +4,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 
-import com.stripe.android.StripeTextUtils;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -201,8 +200,8 @@ public class StripeJsonUtils {
         if (jsonObject == null) {
             return null;
         }
-        Map<String, Object> map = new HashMap<>();
-        Iterator<String> keyIterator = jsonObject.keys();
+        final AbstractMap<String, Object> map = new HashMap<>();
+        final Iterator<String> keyIterator = jsonObject.keys();
         while (keyIterator.hasNext()) {
             String key = keyIterator.next();
             Object value = jsonObject.opt(key);
@@ -295,7 +294,7 @@ public class StripeJsonUtils {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    static JSONObject mapToJsonObject(@Nullable Map<String, ? extends Object> mapObject) {
+    static JSONObject mapToJsonObject(@Nullable Map<String, ?> mapObject) {
         if (mapObject == null) {
             return null;
         }
@@ -384,211 +383,6 @@ public class StripeJsonUtils {
             }
         }
         return jsonArray;
-    }
-
-    /**
-     * Util function for putting a string value into a {@link JSONObject} if that
-     * string is not null or empty. This ignores any {@link JSONException} that may be thrown
-     * due to insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putStringIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable String value) {
-        if (!StripeTextUtils.isBlank(value)) {
-            try {
-                jsonObject.put(fieldName, value);
-            } catch (JSONException ignored) { }
-        }
-    }
-
-    /**
-     * Util function for putting an integer value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown
-     * due to insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putIntegerIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Integer value) {
-        if (value == null) {
-            return;
-        }
-        try {
-            jsonObject.put(fieldName, value.intValue());
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting an long value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown
-     * due to insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putLongIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Long value) {
-        if (value == null) {
-            return;
-        }
-        try {
-            jsonObject.put(fieldName, value.longValue());
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting a double value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown
-     * due to insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putDoubleIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Double value) {
-        if (value == null) {
-            return;
-        }
-        try {
-            jsonObject.put(fieldName, value.doubleValue());
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting a {@link Boolean} value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown due to
-     * insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putBooleanIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Boolean value) {
-        if (value == null) {
-            return;
-        }
-        try {
-            jsonObject.put(fieldName, value.booleanValue());
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting a String-String map value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown due to
-     * insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putStringHashIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Map<String, String> value) {
-        if (value == null) {
-            return;
-        }
-        JSONObject jsonHash = stringHashToJsonObject(value);
-        if (jsonHash == null) {
-            return;
-        }
-
-        try {
-            jsonObject.put(fieldName, jsonHash);
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting a String-Object map value into a {@link JSONObject} if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown due to
-     * insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putMapIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable Map<String, Object> value
-    ) {
-        if (value == null) {
-            return;
-        }
-
-        JSONObject mapObject = mapToJsonObject(value);
-        if (mapObject == null) {
-            return;
-        }
-
-        try {
-            jsonObject.put(fieldName, mapObject);
-        } catch (JSONException ignored) { }
-
-    }
-
-    /**
-     * Util function for putting a {@link JSONObject} value into another JSONOBject if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown due to
-     * insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putObjectIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable JSONObject value
-    ) {
-        if (value == null) {
-            return;
-        }
-
-        try {
-            jsonObject.put(fieldName, value);
-        } catch (JSONException ignored) { }
-    }
-
-    /**
-     * Util function for putting a {@link JSONArray} value into another JSONOBject if that
-     * value is not null. This ignores any {@link JSONException} that may be thrown due to
-     * insertion.
-     *
-     * @param jsonObject the {@link JSONObject} into which to put the field
-     * @param fieldName the field name
-     * @param value the potential field value
-     */
-    static void putArrayIfNotNull(
-            @NonNull JSONObject jsonObject,
-            @NonNull @Size(min = 1) String fieldName,
-            @Nullable JSONArray value
-    ) {
-        if (value == null) {
-            return;
-        }
-
-        try {
-            jsonObject.put(fieldName, value);
-        } catch (JSONException ignored) { }
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
@@ -35,14 +35,6 @@ public abstract class StripeSourceTypeModel extends StripeJsonModel {
         return new HashMap<>(mAdditionalFields);
     }
 
-    @NonNull
-    @Override
-    public JSONObject toJson() {
-        final JSONObject jsonObject = new JSONObject();
-        putAdditionalFieldsIntoJsonObject(jsonObject, mAdditionalFields);
-        return jsonObject;
-    }
-
     /**
      * Convert a {@link JSONObject} to a flat, string-keyed map.
      *

--- a/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
@@ -4,8 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,13 +23,7 @@ public final class AmexExpressCheckoutWallet extends Wallet {
     }
 
     @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        return new JSONObject();
-    }
-
-    @NonNull
-    static AmexExpressCheckoutWallet.Builder fromJson(@NonNull JSONObject walletJson) {
+    static AmexExpressCheckoutWallet.Builder fromJson() {
         return new Builder();
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
@@ -4,8 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,13 +23,7 @@ public final class ApplePayWallet extends Wallet {
     }
 
     @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        return new JSONObject();
-    }
-
-    @NonNull
-    static ApplePayWallet.Builder fromJson(@NonNull JSONObject walletJson) {
+    static ApplePayWallet.Builder fromJson() {
         return new Builder();
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
@@ -4,8 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,13 +23,7 @@ public final class GooglePayWallet extends Wallet {
     }
 
     @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        return new JSONObject();
-    }
-
-    @NonNull
-    static GooglePayWallet.Builder fromJson(@NonNull JSONObject walletJson) {
+    static GooglePayWallet.Builder fromJson() {
         return new Builder();
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
@@ -7,7 +7,6 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.utils.ObjectUtils;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.AbstractMap;
@@ -45,22 +44,6 @@ public final class MasterpassWallet extends Wallet {
         wallet.put(FIELD_NAME, name);
         wallet.put(FIELD_SHIPPING_ADDRESS,
                 shippingAddress != null ? shippingAddress.toMap() : null);
-        return wallet;
-    }
-
-    @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        final JSONObject wallet = new JSONObject();
-        try {
-            wallet.put(FIELD_BILLING_ADDRESS,
-                    billingAddress != null ? billingAddress.toJson() : null);
-            wallet.put(FIELD_EMAIL, email);
-            wallet.put(FIELD_NAME, name);
-            wallet.put(FIELD_SHIPPING_ADDRESS,
-                    shippingAddress != null ? shippingAddress.toJson() : null);
-        } catch (JSONException ignore) {
-        }
         return wallet;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
@@ -4,8 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,13 +23,7 @@ public final class SamsungPayWallet extends Wallet {
     }
 
     @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        return new JSONObject();
-    }
-
-    @NonNull
-    static SamsungPayWallet.Builder fromJson(@NonNull JSONObject walletJson) {
+    static SamsungPayWallet.Builder fromJson() {
         return new Builder();
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
@@ -7,7 +7,6 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.utils.ObjectUtils;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.AbstractMap;
@@ -45,22 +44,6 @@ public final class VisaCheckoutWallet extends Wallet {
         wallet.put(FIELD_NAME, name);
         wallet.put(FIELD_SHIPPING_ADDRESS,
                 shippingAddress != null ? shippingAddress.toMap() : null);
-        return wallet;
-    }
-
-    @NonNull
-    @Override
-    JSONObject getWalletTypeJson() {
-        final JSONObject wallet = new JSONObject();
-        try {
-            wallet.put(FIELD_BILLING_ADDRESS,
-                    billingAddress != null ? billingAddress.toJson() : null);
-            wallet.put(FIELD_EMAIL, email);
-            wallet.put(FIELD_NAME, name);
-            wallet.put(FIELD_SHIPPING_ADDRESS,
-                    shippingAddress != null ? shippingAddress.toJson() : null);
-        } catch (JSONException ignore) {
-        }
         return wallet;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -8,7 +8,6 @@ import android.support.annotation.Nullable;
 import com.stripe.android.model.StripeJsonModel;
 import com.stripe.android.utils.ObjectUtils;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.AbstractMap;
@@ -56,19 +55,6 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
         return wallet;
     }
 
-    @NonNull
-    @Override
-    public final JSONObject toJson() {
-        final JSONObject wallet = new JSONObject();
-        try {
-            wallet.put(FIELD_TYPE, walletType.code);
-            wallet.put(FIELD_DYNAMIC_LAST4, dynamicLast4);
-            wallet.put(walletType.code, getWalletTypeJson());
-        } catch (JSONException ignore) {
-        }
-        return wallet;
-    }
-
     @Override
     public int hashCode() {
         return ObjectUtils.hash(dynamicLast4, walletType);
@@ -86,9 +72,6 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
 
     @NonNull
     abstract Map<String, Object> getWalletTypeMap();
-
-    @NonNull
-    abstract JSONObject getWalletTypeJson();
 
     abstract static class Builder<W extends Wallet> {
         @Nullable private String mDynamicLast4;
@@ -200,22 +183,6 @@ public abstract class Wallet extends StripeJsonModel implements Parcelable {
             address.put(FIELD_LINE2, line2);
             address.put(FIELD_POSTAL_CODE, postalCode);
             address.put(FIELD_STATE, state);
-            return address;
-        }
-
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            final JSONObject address = new JSONObject();
-            try {
-                address.put(FIELD_CITY, city);
-                address.put(FIELD_COUNTRY, country);
-                address.put(FIELD_LINE1, line1);
-                address.put(FIELD_LINE2, line2);
-                address.put(FIELD_POSTAL_CODE, postalCode);
-                address.put(FIELD_STATE, state);
-            } catch (JSONException ignore) {
-            }
             return address;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/wallets/WalletFactory.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/WalletFactory.java
@@ -36,15 +36,15 @@ public final class WalletFactory {
 
         switch (walletType) {
             case AmexExpressCheckout: {
-                walletBuilder = AmexExpressCheckoutWallet.fromJson(walletTypeJson);
+                walletBuilder = AmexExpressCheckoutWallet.fromJson();
                 break;
             }
             case ApplePay: {
-                walletBuilder = ApplePayWallet.fromJson(walletTypeJson);
+                walletBuilder = ApplePayWallet.fromJson();
                 break;
             }
             case GooglePay: {
-                walletBuilder = GooglePayWallet.fromJson(walletTypeJson);
+                walletBuilder = GooglePayWallet.fromJson();
                 break;
             }
             case Masterpass: {
@@ -52,7 +52,7 @@ public final class WalletFactory {
                 break;
             }
             case SamsungPay: {
-                walletBuilder = SamsungPayWallet.fromJson(walletTypeJson);
+                walletBuilder = SamsungPayWallet.fromJson();
                 break;
             }
             case VisaCheckout: {

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
@@ -61,10 +61,7 @@ public class EphemeralKeyTest {
     @Test
     public void fromJson_toJson_createsEqualObject() {
         try {
-            JSONObject originalObject = new JSONObject(SAMPLE_KEY_RAW);
-            CustomerEphemeralKey key = CustomerEphemeralKey.fromJson(originalObject);
-            assertNotNull(key);
-            JsonTestUtils.assertJsonEquals(originalObject, key.toJson());
+            assertNotNull(CustomerEphemeralKey.fromJson(new JSONObject(SAMPLE_KEY_RAW)));
         } catch (JSONException unexpected) {
             fail("Failure to parse test JSON");
         }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.java
@@ -9,7 +9,6 @@ import com.stripe.android.model.ShippingMethod;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;

--- a/stripe/src/test/java/com/stripe/android/model/AddressTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/AddressTest.java
@@ -1,13 +1,10 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -36,13 +33,6 @@ public class AddressTest {
     }};
 
     private static final Address ADDRESS = Address.fromString(JSON_ADDRESS);
-
-    @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() throws JSONException {
-        assertNotNull(ADDRESS);
-        JSONObject rawConversion = new JSONObject(JSON_ADDRESS);
-        assertJsonEquals(rawConversion, ADDRESS.toJson());
-    }
 
     @Test
     public void fromJsonString_toMap_createsExpectedMap() {

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -17,7 +17,6 @@ import static com.stripe.android.model.Card.asCardBrand;
 import static com.stripe.android.model.Card.asFundingType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -663,20 +662,6 @@ public class CardTest {
         final Card expectedCard = buildEquivalentJsonCard();
         final Card actualCard = Card.fromString(JSON_CARD_USD);
         assertEquals(expectedCard, actualCard);
-    }
-
-    @Test
-    public void fromString_toJson_yieldsSameObject() {
-        Card cardFromJson = Card.fromString(JSON_CARD_USD);
-        assertNotNull(cardFromJson);
-
-        JSONObject cycledCardObject = cardFromJson.toJson();
-        try {
-            JSONObject rawJsonObject = new JSONObject(JSON_CARD_USD);
-            JsonTestUtils.assertJsonEquals(cycledCardObject, rawJsonObject);
-        } catch (JSONException unexpected) {
-            fail();
-        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerSourceTest.java
@@ -1,7 +1,5 @@
 package com.stripe.android.model;
 
-import com.stripe.android.testharness.JsonTestUtils;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -83,14 +81,7 @@ public class CustomerSourceTest {
 
     @Test
     public void fromExampleJsonSource_toJson_createsSameObject() {
-        try {
-            JSONObject original = new JSONObject(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS);
-            CustomerSource sourceData = CustomerSource.fromJson(original);
-            assertNotNull(sourceData);
-            JsonTestUtils.assertJsonEquals(original, sourceData.toJson());
-        } catch (JSONException exception) {
-            fail("Test data failure: " + exception.getMessage());
-        }
+        assertNotNull(CustomerSource.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerTest.java
@@ -2,8 +2,6 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 
-import com.stripe.android.testharness.JsonTestUtils;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -84,16 +82,10 @@ public class CustomerTest {
 
     @Test
     public void fromJson_toJson_createsSameObject() {
-        try {
-            JSONObject rawJsonCustomer = new JSONObject(TEST_CUSTOMER_OBJECT);
-            Customer customer = Customer.fromString(TEST_CUSTOMER_OBJECT);
-            assertNotNull(customer);
-            JsonTestUtils.assertJsonEquals(rawJsonCustomer, customer.toJson());
-            assertEquals(Customer.fromString(TEST_CUSTOMER_OBJECT),
-                    Customer.fromString(TEST_CUSTOMER_OBJECT));
-        } catch (JSONException testDataException) {
-            fail("Test data failure: " + testDataException.getMessage());
-        }
+        Customer customer = Customer.fromString(TEST_CUSTOMER_OBJECT);
+        assertNotNull(customer);
+        assertEquals(Customer.fromString(TEST_CUSTOMER_OBJECT),
+                Customer.fromString(TEST_CUSTOMER_OBJECT));
     }
 
     @NonNull
@@ -106,7 +98,7 @@ public class CustomerTest {
             sourcesObject.put("total_count", 5);
             CustomerSource applePayCard = CustomerSource.fromString(JSON_APPLE_PAY_CARD);
             assertNotNull(applePayCard);
-            sourcesArray.put(applePayCard.toJson());
+            sourcesArray.put(new JSONObject(applePayCard.toMap()));
 
             Card testCard = Card.fromString(JSON_CARD_USD);
             assertNotNull(testCard);
@@ -123,11 +115,11 @@ public class CustomerTest {
             Source alipaySource = Source.fromString(EXAMPLE_ALIPAY_SOURCE);
             assertNotNull(sourceCardWithApplePay);
             assertNotNull(alipaySource);
-            sourcesArray.put(sourceCardWithApplePay.toJson());
-            sourcesArray.put(alipaySource.toJson());
+            sourcesArray.put(new JSONObject(sourceCardWithApplePay.toMap()));
+            sourcesArray.put(new JSONObject(alipaySource.toMap()));
 
-            sourcesArray.put(testCard.toJson());
-            sourcesArray.put(manipulatedApplePayCard.toJson());
+            sourcesArray.put(new JSONObject(testCard.toMap()));
+            sourcesArray.put(new JSONObject(manipulatedApplePayCard.toMap()));
             sourcesObject.put("data", sourcesArray);
 
             rawJsonCustomer.put("sources", sourcesObject);

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -2,8 +2,6 @@ package com.stripe.android.model;
 
 import android.net.Uri;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -13,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEqualsExcludingNulls;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -182,14 +179,6 @@ public class PaymentIntentTest {
 
     private static final PaymentIntent PAYMENT_INTENT_WITH_SOURCE = PaymentIntent
             .fromString(PAYMENT_INTENT_WITH_SOURCE_JSON);
-
-    @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() throws JSONException {
-        assertNotNull(PAYMENT_INTENT_WITH_SOURCE);
-        JSONObject rawConversion = new JSONObject(PAYMENT_INTENT_WITH_SOURCE_JSON);
-        JSONObject actualObject = PAYMENT_INTENT_WITH_SOURCE.toJson();
-        assertJsonEqualsExcludingNulls(rawConversion, actualObject);
-    }
 
     @Test
     public void fromJsonString_toMap_createsExpectedMap() {

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -2,7 +2,6 @@ package com.stripe.android.model;
 
 import android.os.Parcel;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -130,8 +129,8 @@ public class PaymentMethodTest {
     }
 
     @Test
-    public void toJson_withIdeal_shouldReturnExpectedJson() throws JSONException {
-        final JSONObject paymentMethod = new PaymentMethod.Builder()
+    public void toJson_withIdeal_shouldReturnExpectedJson() {
+        final JSONObject paymentMethod = new JSONObject(new PaymentMethod.Builder()
                 .setId("pm_123456789")
                 .setCreated(1550757934255L)
                 .setLiveMode(true)
@@ -143,17 +142,11 @@ public class PaymentMethodTest {
                         .setBankIdentifierCode("bank id")
                         .build())
                 .build()
-                .toJson();
+                .toMap());
 
-        assertEquals(new JSONObject(RAW_IDEAL_JSON).toString(), paymentMethod.toString());
+        assertEquals(PaymentMethod.fromJson(paymentMethod),
+                PaymentMethod.fromString(RAW_IDEAL_JSON));
     }
-
-    @Test
-    public void toJson_withCard_shouldReturnExpectedJson() throws JSONException {
-        assertEquals(new JSONObject(RAW_CARD_JSON).toString(),
-                CARD_PAYMENT_METHOD.toJson().toString());
-    }
-
 
     @Test
     public void equals_withEqualPaymentMethods_shouldReturnTrue() {

--- a/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
@@ -41,7 +41,7 @@ public class ShippingMethodTest {
     public void testJSONConversion() {
         try {
             JSONObject rawConversion = new JSONObject(EXAMPLE_JSON_SHIPPING_ADDRESS);
-            assertJsonEquals(SHIPPING_METHOD.toJson(), rawConversion);
+            assertJsonEquals(new JSONObject(SHIPPING_METHOD.toMap()), rawConversion);
         } catch (JSONException jsonException) {
             fail("Test Data failure: " + jsonException.getLocalizedMessage());
         }

--- a/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
@@ -1,17 +1,13 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link SourceCodeVerification}.
@@ -35,16 +31,6 @@ public class SourceCodeVerificationTest {
     public void setup() {
         mCodeVerification = SourceCodeVerification.fromString(EXAMPLE_JSON_CODE_VERIFICATION);
         assertNotNull(mCodeVerification);
-    }
-
-    @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() {
-        try {
-            JSONObject rawConversion = new JSONObject(EXAMPLE_JSON_CODE_VERIFICATION);
-            assertJsonEquals(rawConversion, mCodeVerification.toJson());
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
@@ -1,18 +1,13 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.stripe.android.model.AddressTest.JSON_ADDRESS;
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link SourceOwner} model.
@@ -47,22 +42,9 @@ public class SourceOwnerTest {
         put("phone", "4158675309");
     }};
 
-    private SourceOwner mSourceOwner;
-
-    @Before
-    public void setup() {
-        mSourceOwner = SourceOwner.fromString(EXAMPLE_JSON_OWNER_WITHOUT_NULLS);
-        assertNotNull(mSourceOwner);
-    }
-
     @Test
-    public void fromJsonStringWithoutNulls_backToJson_createsIdenticalElement() {
-        try {
-            JSONObject rawConversion = new JSONObject(EXAMPLE_JSON_OWNER_WITHOUT_NULLS);
-            assertJsonEquals(rawConversion, mSourceOwner.toJson());
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
+    public void fromJsonStringWithoutNulls() {
+        assertNotNull(SourceOwner.fromString(EXAMPLE_JSON_OWNER_WITHOUT_NULLS));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
@@ -1,17 +1,13 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link SourceReceiver}.
@@ -39,16 +35,6 @@ public class SourceReceiverTest {
     public void setup() {
         mSourceReceiver = SourceReceiver.fromString(EXAMPLE_JSON_RECEIVER);
         assertNotNull(mSourceReceiver);
-    }
-
-    @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() {
-        try {
-            JSONObject rawConversion = new JSONObject(EXAMPLE_JSON_RECEIVER);
-            assertJsonEquals(rawConversion, mSourceReceiver.toJson());
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
@@ -1,14 +1,11 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -35,11 +32,6 @@ public class SourceRedirectTest {
     public void setup() {
         mSourceRedirect = SourceRedirect.fromString(EXAMPLE_JSON_REDIRECT);
         assertNotNull(mSourceRedirect);
-    }
-
-    @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() throws JSONException {
-        assertJsonEquals(new JSONObject(EXAMPLE_JSON_REDIRECT), mSourceRedirect.toJson());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -1,8 +1,5 @@
 package com.stripe.android.model;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -14,13 +11,11 @@ import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_JSON_OWNER_WITHOU
 import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_MAP_OWNER;
 import static com.stripe.android.model.SourceReceiverTest.EXAMPLE_MAP_RECEIVER;
 import static com.stripe.android.model.SourceRedirectTest.EXAMPLE_JSON_REDIRECT;
-import static com.stripe.android.testharness.JsonTestUtils.assertJsonEquals;
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link Source} model.
@@ -124,6 +119,7 @@ public class SourceTest {
 
     private static final Map<String, Object> EXAMPLE_SOURCE_MAP = new HashMap<String, Object>() {{
         put("id", "src_19t3xKBZqEXluyI4uz2dxAfQ");
+        put("object", "source");
         put("amount", 1000L);
         put("client_secret", "src_client_secret_of43INi1HteJwXVe3djAUosN");
         put("created", 1488499654L);
@@ -203,30 +199,15 @@ public class SourceTest {
             "  \"tokenization_method\": null\n" +
             "}\n";
 
-    private Source mSource;
-
-    @Before
-    public void setup() {
-        mSource = Source.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS);
-        assertNotNull(mSource);
-    }
-
     @Test
-    public void fromJsonString_backToJson_createsIdenticalElement() {
-        try {
-            JSONObject rawConversion = new JSONObject(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS);
-            JSONObject actualObject = mSource.toJson();
-            assertJsonEquals(rawConversion, actualObject);
-            assertEquals(mSource, Source.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS));
-        } catch (JSONException jsonException) {
-            fail("Test Data failure: " + jsonException.getLocalizedMessage());
-        }
+    public void fromStringWithoutNulls() {
+        assertNotNull(Source.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS));
     }
 
     @Test
     public void fromJsonStringWithNulls_toMap_createsExpectedMap() {
         Source sourceWithNulls = Source.fromString(EXAMPLE_JSON_SOURCE_WITH_NULLS);
-        assertNotNull("Test Data failure during parsing", sourceWithNulls);
+        assertNotNull(sourceWithNulls);
         assertMapEquals(EXAMPLE_SOURCE_MAP, sourceWithNulls.toMap());
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonModelTest.java
@@ -4,9 +4,6 @@ import android.support.annotation.NonNull;
 
 import com.stripe.android.testharness.JsonTestUtils;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -20,7 +17,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test class for {@link StripeJsonModel}.
@@ -73,22 +69,6 @@ public class StripeJsonModelTest {
     }
 
     @Test
-    public void putStripeJsonModelListIfNotNull_forMapsWhenNull_doesNothing() {
-        Map<String, Object> sampleMap = new HashMap<>();
-        StripeJsonModel.putStripeJsonModelListIfNotNull(sampleMap, "mapkey", null);
-
-        assertTrue(sampleMap.isEmpty());
-    }
-
-    @Test
-    public void putStripeJsonModelListIfNotNull_forJsonWhenNull_doesNothing() {
-        JSONObject jsonObject = new JSONObject();
-        StripeJsonModel.putStripeJsonModelListIfNotNull(jsonObject, "jsonkey", null);
-
-        assertFalse(jsonObject.has("jsonkey"));
-    }
-
-    @Test
     @SuppressWarnings("unchecked")
     public void putStripeJsonModelListIfNotNull_forMapsWhenNotNull_addsExpectedList() {
         List<ExampleJsonModel> exampleJsonModels = new ArrayList<>();
@@ -109,27 +89,6 @@ public class StripeJsonModelTest {
         JsonTestUtils.assertListEquals(expectedList, modelList);
     }
 
-    @Test
-    public void putStripeJsonModelListIfNotNull_forJsonWhenNotNull_addsExpectedList() {
-        List<ExampleJsonModel> exampleJsonModels = new ArrayList<>();
-        exampleJsonModels.add(new ExampleJsonModel());
-        exampleJsonModels.add(new ExampleJsonModel());
-
-        JSONObject jsonObject = new JSONObject();
-        StripeJsonModel.putStripeJsonModelListIfNotNull(jsonObject, "listkey", exampleJsonModels);
-
-        assertEquals(1, jsonObject.length());
-        JSONArray jsonArray = jsonObject.optJSONArray("listkey");
-        assertNotNull(jsonArray);
-        assertEquals(2, jsonArray.length());
-
-        JSONArray expectedArray = new JSONArray();
-        expectedArray.put(new ExampleJsonModel().toJson());
-        expectedArray.put(new ExampleJsonModel().toJson());
-
-        JsonTestUtils.assertJsonArrayEquals(expectedArray, jsonArray);
-    }
-
     private static class ExampleJsonModel extends StripeJsonModel {
 
         @NonNull
@@ -139,19 +98,6 @@ public class StripeJsonModelTest {
             map.put("akey", "avalue");
             map.put("bkey", "bvalue");
             return map;
-        }
-
-        @NonNull
-        @Override
-        public JSONObject toJson() {
-            JSONObject jsonObject = new JSONObject();
-            try {
-                jsonObject.put("akey", "avalue");
-                jsonObject.put("bkey", "bvalue");
-            } catch (JSONException unexpected) {
-                fail("Test data failure: " + unexpected.getMessage());
-            }
-            return jsonObject;
         }
 
         @Override

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -227,7 +228,7 @@ public class StripeJsonUtilsTest {
         itemsList.add("a string item");
         itemsList.add(256);
         itemsList.add(Arrays.asList(1, 2, "C", 4));
-        itemsList.add(Arrays.asList(new HashMap<String, Object>() {{
+        itemsList.add(Collections.singletonList(new HashMap<String, Object>() {{
             put("deep", "deepValue");
         }}));
         testMap.put("outer_key",
@@ -356,7 +357,7 @@ public class StripeJsonUtilsTest {
         itemsList.add("a string item");
         itemsList.add(256);
         itemsList.add(Arrays.asList(1, 2, "C", 4));
-        itemsList.add(Arrays.asList(new HashMap<String, Object>() {{
+        itemsList.add(Collections.singletonList(new HashMap<String, Object>() {{
             put("deep", "deepValue");
         }}));
         expectedMap.put("outer_key",

--- a/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.java
@@ -89,8 +89,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(VISA_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof VisaCheckoutWallet);
-        final VisaCheckoutWallet visaCheckoutWallet = (VisaCheckoutWallet) wallet;
-        assertEquals(visaCheckoutWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test
@@ -98,8 +96,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(MASTERPASS_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof MasterpassWallet);
-        final MasterpassWallet masterpassWallet = (MasterpassWallet) wallet;
-        assertEquals(masterpassWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test
@@ -107,8 +103,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(AMEX_EXPRESS_CHECKOUT_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof AmexExpressCheckoutWallet);
-        final AmexExpressCheckoutWallet amexCheckoutWallet = (AmexExpressCheckoutWallet) wallet;
-        assertEquals(amexCheckoutWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test
@@ -116,8 +110,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(APPLE_PAY_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof ApplePayWallet);
-        final ApplePayWallet applePayWallet = (ApplePayWallet) wallet;
-        assertEquals(applePayWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test
@@ -125,8 +117,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(GOOGLE_PAY_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof GooglePayWallet);
-        final GooglePayWallet googlePayWallet = (GooglePayWallet) wallet;
-        assertEquals(googlePayWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test
@@ -134,8 +124,6 @@ public class WalletFactoryTest {
         final JSONObject walletJson = new JSONObject(SAMSUNG_PAY_WALLET_JSON);
         final Wallet wallet = new WalletFactory().create(walletJson);
         assertTrue(wallet instanceof SamsungPayWallet);
-        final SamsungPayWallet samsungPayWallet = (SamsungPayWallet) wallet;
-        assertEquals(samsungPayWallet.toJson().toString(), walletJson.toString());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtils.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/JsonTestUtils.java
@@ -1,5 +1,6 @@
 package com.stripe.android.testharness;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.json.JSONArray;
@@ -52,42 +53,6 @@ public class JsonTestUtils {
         }
     }
 
-    /**
-     * Assert that two {@link JSONObject JSONObjects} are equal, comparing key by key recursively.
-     * Ignores nulls.
-     *
-     * @param first the first object
-     * @param second the second object
-     */
-    public static void assertJsonEqualsExcludingNulls(JSONObject first, JSONObject second) {
-        if (assertSameNullity(first, second)) {
-            return;
-        }
-
-        Iterator<String> keyIterator = first.keys();
-        while(keyIterator.hasNext()) {
-            String key = keyIterator.next();
-            String errorMessage = getKeyErrorMessage(key);
-            if (first.opt(key) != JSONObject.NULL) {
-                assertTrue(errorMessage, second.has(key));
-            }
-            if (first.opt(key) instanceof JSONObject) {
-                assertTrue(errorMessage, second.opt(key) instanceof JSONObject);
-                assertJsonEqualsExcludingNulls(first.optJSONObject(key), second.optJSONObject(key));
-            } else if (first.opt(key) instanceof JSONArray) {
-                assertTrue(errorMessage, second.opt(key) instanceof JSONArray);
-                assertJsonArrayEquals(first.optJSONArray(key), second.optJSONArray(key));
-            } else if (first.opt(key) instanceof Number) {
-                assertTrue(errorMessage, second.opt(key) instanceof Number);
-                assertEquals(errorMessage,
-                        ((Number) first.opt(key)).longValue(),
-                        ((Number) second.opt(key)).longValue());
-            } else {
-                assertEquals(errorMessage, first.opt(key), second.opt(key));
-            }
-        }
-    }
-
 
     /**
      * Assert that two {@link JSONArray JSONArrays} are equal, comparing index by index recursively.
@@ -123,8 +88,7 @@ public class JsonTestUtils {
      * @param first the first map
      * @param second the second map
      */
-    public static void assertMapEquals(Map<String, ? extends Object> first,
-                                       Map<String, ? extends Object> second) {
+    public static void assertMapEquals(Map<String, ?> first, Map<String, ?> second) {
         if (assertSameNullity(first, second)) {
             return;
         }
@@ -164,8 +128,7 @@ public class JsonTestUtils {
                     castMapWithGenerics((Map) secondObject));
         } else if (firstObject instanceof List) {
             assertTrue(secondObject instanceof List);
-            assertListEquals((List) firstObject,
-                    (List) secondObject);
+            assertListEquals((List) firstObject, (List) secondObject);
         } else {
             assertEquals(firstObject, secondObject);
         }
@@ -191,13 +154,12 @@ public class JsonTestUtils {
      * @return {@code false} if both objects are non-null, {@code true} if they are {@code null}
      */
     private static boolean assertSameNullity(@Nullable Object first, @Nullable Object second) {
-        boolean sameNullity = first == null
-                ? second == null
-                : second != null;
+        boolean sameNullity = (first == null) == (second == null);
         assertTrue(sameNullity);
         return first == null;
     }
 
+    @NonNull
     private static String getKeyErrorMessage(String key) {
         return String.format(Locale.ENGLISH, "Matching error at key %s", key);
     }

--- a/stripe/src/test/java/com/stripe/android/testharness/TestFocusChangeListener.java
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestFocusChangeListener.java
@@ -26,12 +26,4 @@ public class TestFocusChangeListener implements ViewTreeObserver.OnGlobalFocusCh
     public int getNewFocusId() {
         return mNewFocus.getId();
     }
-
-    public boolean hasOldFocus() {
-        return mOldFocus != null;
-    }
-
-    public boolean hasNewFocus() {
-        return mNewFocus != null;
-    }
 }


### PR DESCRIPTION
`toJson()` was previously used in the implementation of `equals()`
(see #813). Now that it is no longer used in `equals()`, it is
no longer needed.