### PR TITLE
Create RequestExecutor#executeAndForget

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -10,8 +10,6 @@ import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.model.ShippingMethod;
 import com.stripe.android.utils.ObjectUtils;
 
-import java.util.Objects;
-
 /**
  * A data class representing the state of the associated {@link PaymentSession}.
  */

--- a/stripe/src/main/java/com/stripe/android/utils/ObjectUtils.java
+++ b/stripe/src/main/java/com/stripe/android/utils/ObjectUtils.java
@@ -1,5 +1,6 @@
 package com.stripe.android.utils;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.Arrays;
@@ -12,5 +13,10 @@ public final class ObjectUtils {
 
     public static int hash(@Nullable Object... values) {
         return Arrays.hashCode(values);
+    }
+
+    @NonNull
+    public static <T> T getOrDefault(@Nullable T obj, @NonNull T defaultValue) {
+        return obj != null ? obj : defaultValue;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/RequestExecutorTest.java
+++ b/stripe/src/test/java/com/stripe/android/RequestExecutorTest.java
@@ -2,18 +2,38 @@ package com.stripe.android;
 
 import android.support.annotation.NonNull;
 
+import androidx.test.core.app.ApplicationProvider;
+
+import com.stripe.android.exception.APIConnectionException;
 import com.stripe.android.exception.InvalidRequestException;
 
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+@RunWith(RobolectricTestRunner.class)
 public class RequestExecutorTest {
+
+    // Test to verify fingerprint endpoint's success
+    @Test
+    public void executeAndForget_withFingerprintRequest_shouldReturnSuccessfully()
+            throws InvalidRequestException, APIConnectionException {
+        final TelemetryClientUtil telemetryClientUtil =
+                new TelemetryClientUtil(ApplicationProvider.getApplicationContext());
+        final int responseCode = new RequestExecutor().executeAndForget(
+                new FingerprintRequest(telemetryClientUtil.createTelemetryMap(),
+                        UUID.randomUUID().toString()));
+        assertEquals(200, responseCode);
+    }
 
     @Test
     public void getOutputBytes_shouldHandleUnsupportedEncodingException() {

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -224,9 +224,8 @@ public class StripeApiHandlerTest {
     public void logApiCall_shouldReturnSuccessful() {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.
-        final boolean isSuccessful = mApiHandler.logApiCall(new HashMap<String, Object>(),
+        mApiHandler.logApiCall(new HashMap<String, Object>(),
                 ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
-        assertTrue(isSuccessful);
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/utils/ObjectUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/utils/ObjectUtilsTest.java
@@ -1,0 +1,17 @@
+package com.stripe.android.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObjectUtilsTest {
+
+    @Test
+    public void getOrDefault() {
+        assertEquals("default",
+                ObjectUtils.getOrDefault(null, "default"));
+
+        assertEquals("value",
+                ObjectUtils.getOrDefault("value", "default"));
+    }
+}


### PR DESCRIPTION
This method better reflects a fire-and-forget request, because it does
not attempt to parse the response body