### PR TITLE
Update dismissing the 3DS2 progress view

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -529,14 +529,14 @@ class PaymentController {
         @NonNull private final LocalBroadcastManager mLocalBroadcastManager;
         @NonNull private final WeakReference<ProgressDialog> mProgressDialogRef;
 
-        public DialogBroadcastReceiver(@NonNull LocalBroadcastManager localBroadcastManager,
+        DialogBroadcastReceiver(@NonNull LocalBroadcastManager localBroadcastManager,
                                        @NonNull ProgressDialog progressDialog) {
             mProgressDialogRef = new WeakReference<>(progressDialog);
             mLocalBroadcastManager = localBroadcastManager;
         }
 
         @Override
-        public void onReceive(Context context, Intent intent) {
+        public void onReceive(@NonNull Context context, @NonNull Intent intent) {
             final ProgressDialog dialog = mProgressDialogRef.get();
             if (dialog != null) {
                 dialog.dismiss();

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -406,11 +406,6 @@ class PaymentController {
 
         private void startFrictionlessFlow() {
             mPaymentRelayStarter.start(new PaymentRelayStarter.Data(mPaymentIntent));
-            final Activity activity = mActivityRef.get();
-            if (activity != null) {
-                LocalBroadcastManager.getInstance(activity)
-                        .sendBroadcast(new Intent().setAction(UL_HANDLE_CHALLENGE_ACTION));
-            }
         }
 
         private void startChallengeFlow(@NonNull final Activity activity,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
@@ -4,7 +4,10 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
+
+import static com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION;
 
 /**
  * An {@link Activity} that relays the intent extras that it received as a result and finishes.
@@ -13,6 +16,8 @@ public class PaymentRelayActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        LocalBroadcastManager.getInstance(this)
+                .sendBroadcast(new Intent().setAction(UL_HANDLE_CHALLENGE_ACTION));
         setResult(Activity.RESULT_OK, new Intent().putExtras(getIntent().getExtras()));
         finish();
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -15,6 +15,8 @@ import com.stripe.android.stripe3ds2.transaction.Transaction;
 import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.PaymentResultExtras;
 
+import java.util.Objects;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,8 +26,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-
-import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,9 +70,12 @@ public class PaymentControllerTest {
         MockitoAnnotations.initMocks(this);
         when(mTransaction.getAuthenticationRequestParameters())
                 .thenReturn(Stripe3ds2Fixtures.AREQ_PARAMS);
-        when(mThreeDs2Service.createTransaction(DIRECTORY_SERVER_ID, MESSAGE_VERSION, false, "visa"))
+        when(mThreeDs2Service
+                .createTransaction(DIRECTORY_SERVER_ID, MESSAGE_VERSION, false, "visa"))
                 .thenReturn(mTransaction);
         when(mMessageVersionRegistry.getCurrent()).thenReturn(MESSAGE_VERSION);
+        when(mActivity.getApplicationContext())
+                .thenReturn(ApplicationProvider.getApplicationContext());
         mController = new PaymentController(
                 ApplicationProvider.getApplicationContext(),
                 mThreeDs2Service,
@@ -135,7 +138,7 @@ public class PaymentControllerTest {
     public void authCallback_withChallengeFlow_shouldNotStartRelayActivity() {
         final PaymentController.Stripe3ds2AuthCallback authCallback =
                 new PaymentController.Stripe3ds2AuthCallback(mActivity, mApiHandler,
-                        mTransaction, mProgressDialog, MAX_TIMEOUT,
+                        mTransaction, MAX_TIMEOUT,
                         PaymentIntentFixtures.PI_REQUIRES_3DS2, SOURCE_ID,
                         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mPaymentRelayStarter);
         authCallback.onSuccess(Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW);
@@ -147,7 +150,7 @@ public class PaymentControllerTest {
     public void authCallback_withFrictionlessFlow_shouldStartRelayActivityWithPaymentIntent() {
         final PaymentController.Stripe3ds2AuthCallback authCallback =
                 new PaymentController.Stripe3ds2AuthCallback(mActivity, mApiHandler,
-                        mTransaction, mProgressDialog, MAX_TIMEOUT,
+                        mTransaction, MAX_TIMEOUT,
                         PaymentIntentFixtures.PI_REQUIRES_3DS2, SOURCE_ID,
                         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                         mPaymentRelayStarter);
@@ -162,7 +165,7 @@ public class PaymentControllerTest {
     public void authCallback_withError_shouldStartRelayActivityWithException() {
         final PaymentController.Stripe3ds2AuthCallback authCallback =
                 new PaymentController.Stripe3ds2AuthCallback(mActivity, mApiHandler,
-                        mTransaction, mProgressDialog, MAX_TIMEOUT,
+                        mTransaction, MAX_TIMEOUT,
                         PaymentIntentFixtures.PI_REQUIRES_3DS2, SOURCE_ID,
                         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mPaymentRelayStarter);
         authCallback.onSuccess(Stripe3ds2AuthResultFixtures.ERROR);


### PR DESCRIPTION
## Summary

Utilize local broadcast receiver to handle dismissing the dialog.

## Motivation

Reduce the lag between the dialog dismissing and the challenge activity starting

## Testing

Example app payment auth and sample store.
