### PR TITLE
Use directory server ID based on 3ds2 fingerprint result

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -45,19 +45,17 @@ import static com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTIO
  */
 class PaymentController {
     static final int REQUEST_CODE = 50000;
-    private static final String DIRECTORY_SERVER_ID = "F000000000";
 
     @NonNull private final StripeThreeDs2Service mThreeDs2Service;
     @NonNull private final StripeApiHandler mApiHandler;
     @NonNull private final MessageVersionRegistry mMessageVersionRegistry;
-    @NonNull private final String mDirectoryServerId;
     @NonNull private final PaymentAuthConfig mConfig;
     @NonNull private final ApiKeyValidator mApiKeyValidator;
 
     PaymentController(@NonNull Context context,
                       @NonNull StripeApiHandler apiHandler) {
         this(context, new StripeThreeDs2ServiceImpl(context), apiHandler,
-                new MessageVersionRegistry(), DIRECTORY_SERVER_ID,
+                new MessageVersionRegistry(),
                 PaymentAuthConfig.get());
     }
 
@@ -66,16 +64,13 @@ class PaymentController {
                       @NonNull StripeThreeDs2Service threeDs2Service,
                       @NonNull StripeApiHandler apiHandler,
                       @NonNull MessageVersionRegistry messageVersionRegistry,
-                      @NonNull String directoryServerId,
                       @NonNull PaymentAuthConfig config) {
-
         mConfig = config;
         mThreeDs2Service = threeDs2Service;
         mThreeDs2Service.initialize(context, new StripeConfigParameters(), null,
                 config.stripe3ds2Config.uiCustomization.getUiCustomization());
         mApiHandler = apiHandler;
         mMessageVersionRegistry = messageVersionRegistry;
-        mDirectoryServerId = directoryServerId;
         mApiKeyValidator = new ApiKeyValidator();
     }
 
@@ -193,9 +188,9 @@ class PaymentController {
                                @NonNull Stripe3ds2Fingerprint stripe3ds2Fingerprint,
                                @NonNull String publishableKey) {
         final Transaction transaction =
-                mThreeDs2Service.createTransaction(mDirectoryServerId,
+                mThreeDs2Service.createTransaction(stripe3ds2Fingerprint.directoryServer.id,
                         mMessageVersionRegistry.getCurrent(), false,
-                        stripe3ds2Fingerprint.directoryServerName);
+                        stripe3ds2Fingerprint.directoryServer.name);
         final ProgressDialog dialog = transaction.getProgressView(activity);
         dialog.show();
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
@@ -5,7 +5,6 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.model.Address;
 import com.stripe.android.model.ShippingInformation;
 import com.stripe.android.utils.ObjectUtils;
 import com.stripe.android.view.ShippingInfoWidget;

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.java
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.java
@@ -1,14 +1,9 @@
 package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 public final class Stripe3ds2Fingerprint {
     private static final String FIELD_TYPE = "type";
@@ -19,7 +14,7 @@ public final class Stripe3ds2Fingerprint {
     private static final String TYPE = "stripe_3ds2_fingerprint";
 
     @NonNull public final String source;
-    @NonNull @DirectoryServerName public final String directoryServerName;
+    @NonNull public final DirectoryServer directoryServer;
     @NonNull public final String serverTransactionId;
 
     @NonNull
@@ -31,7 +26,7 @@ public final class Stripe3ds2Fingerprint {
 
         return new Stripe3ds2Fingerprint(
                 (String) sdkData.data.get(FIELD_THREE_D_SECURE_2_SOURCE),
-                toDirectoryServerName((String) sdkData.data.get(FIELD_DIRECTORY_SERVER_NAME)),
+                DirectoryServer.lookup((String) sdkData.data.get(FIELD_DIRECTORY_SERVER_NAME)),
                 (String) sdkData.data.get(FIELD_SERVER_TRANSACTION_ID)
         );
     }
@@ -46,44 +41,43 @@ public final class Stripe3ds2Fingerprint {
         }
 
         final String source = json.getString(FIELD_THREE_D_SECURE_2_SOURCE);
-        @DirectoryServerName final String directoryServerName =
-                toDirectoryServerName(json.getString(FIELD_DIRECTORY_SERVER_NAME));
+        final DirectoryServer directoryServer =
+                DirectoryServer.lookup(json.getString(FIELD_DIRECTORY_SERVER_NAME));
         final String serverTransactionId = json.getString(FIELD_SERVER_TRANSACTION_ID);
-        return new Stripe3ds2Fingerprint(source, directoryServerName, serverTransactionId);
-    }
-
-    @NonNull
-    @DirectoryServerName
-    private static String toDirectoryServerName(@Nullable String code)
-            throws IllegalArgumentException {
-        if (DirectoryServerName.AMERICAN_EXPRESS.equals(code)) {
-            return DirectoryServerName.AMERICAN_EXPRESS;
-        } else if (DirectoryServerName.MASTERCARD.equals(code)) {
-            return DirectoryServerName.MASTERCARD;
-        } else if (DirectoryServerName.VISA.equals(code)) {
-            return DirectoryServerName.VISA;
-        } else {
-            throw new IllegalArgumentException("Invalid directory_server_name: " + code);
-        }
+        return new Stripe3ds2Fingerprint(source, directoryServer, serverTransactionId);
     }
 
     private Stripe3ds2Fingerprint(@NonNull String source,
-                                  @NonNull @DirectoryServerName String directoryServerName,
+                                  @NonNull DirectoryServer directoryServer,
                                   @NonNull String serverTransactionId) {
         this.source = source;
-        this.directoryServerName = directoryServerName;
+        this.directoryServer = directoryServer;
         this.serverTransactionId = serverTransactionId;
     }
 
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({
-            DirectoryServerName.AMERICAN_EXPRESS,
-            DirectoryServerName.MASTERCARD,
-            DirectoryServerName.VISA
-    })
-    @interface DirectoryServerName {
-        String AMERICAN_EXPRESS = "american_express";
-        String MASTERCARD = "mastercard";
-        String VISA = "visa";
+    // TODO(mshafrir): update ids
+    public enum DirectoryServer {
+        Visa("visa", "F000000000"),
+        Mastercard("mastercard", "F000000000"),
+        Amex("american_express", "F000000000");
+
+        @NonNull public final String name;
+        @NonNull public final String id;
+
+        DirectoryServer(@NonNull String name, @NonNull String id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        @NonNull
+        static DirectoryServer lookup(@NonNull String name) {
+            for (DirectoryServer directoryServer : values()) {
+                if (directoryServer.name.equals(name)) {
+                    return directoryServer;
+                }
+            }
+
+            throw new IllegalArgumentException("Invalid directory server name: '" + name + "'");
+        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -9,13 +9,12 @@ import androidx.test.core.app.ApplicationProvider;
 import com.stripe.android.model.PaymentIntentFixtures;
 import com.stripe.android.model.Stripe3ds2AuthResult;
 import com.stripe.android.model.Stripe3ds2AuthResultFixtures;
+import com.stripe.android.model.Stripe3ds2Fingerprint;
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service;
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry;
 import com.stripe.android.stripe3ds2.transaction.Transaction;
 import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.PaymentResultExtras;
-
-import java.util.Objects;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +25,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,7 +39,6 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class PaymentControllerTest {
 
-    private static final String DIRECTORY_SERVER_ID = "F000000000";
     private static final String MESSAGE_VERSION = "2.1.0";
     private static final String PUBLISHABLE_KEY = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY;
     private static final int MAX_TIMEOUT = 5;
@@ -70,8 +70,11 @@ public class PaymentControllerTest {
         MockitoAnnotations.initMocks(this);
         when(mTransaction.getAuthenticationRequestParameters())
                 .thenReturn(Stripe3ds2Fixtures.AREQ_PARAMS);
-        when(mThreeDs2Service
-                .createTransaction(DIRECTORY_SERVER_ID, MESSAGE_VERSION, false, "visa"))
+        when(mThreeDs2Service.createTransaction(
+                Stripe3ds2Fingerprint.DirectoryServer.Visa.id,
+                MESSAGE_VERSION,
+                false,
+                Stripe3ds2Fingerprint.DirectoryServer.Visa.name))
                 .thenReturn(mTransaction);
         when(mMessageVersionRegistry.getCurrent()).thenReturn(MESSAGE_VERSION);
         when(mActivity.getApplicationContext())
@@ -81,7 +84,6 @@ public class PaymentControllerTest {
                 mThreeDs2Service,
                 mApiHandler,
                 mMessageVersionRegistry,
-                DIRECTORY_SERVER_ID,
                 CONFIG);
     }
 
@@ -90,8 +92,11 @@ public class PaymentControllerTest {
         when(mTransaction.getProgressView(mActivity)).thenReturn(mProgressDialog);
         mController.handleNextAction(mActivity, PaymentIntentFixtures.PI_REQUIRES_3DS2,
                 PUBLISHABLE_KEY);
-        verify(mThreeDs2Service).createTransaction(DIRECTORY_SERVER_ID, MESSAGE_VERSION, false,
-                "visa");
+        verify(mThreeDs2Service).createTransaction(
+                Stripe3ds2Fingerprint.DirectoryServer.Visa.id,
+                MESSAGE_VERSION,
+                false,
+                Stripe3ds2Fingerprint.DirectoryServer.Visa.name);
         verify(mApiHandler).start3ds2Auth(ArgumentMatchers.<Stripe3ds2AuthParams>any(),
                 eq(PUBLISHABLE_KEY),
                 ArgumentMatchers.<ApiResultCallback<Stripe3ds2AuthResult>>any());

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.java
@@ -36,8 +36,8 @@ public class Stripe3ds2FingerprintTest {
         final Stripe3ds2Fingerprint stripe3ds2Fingerprint = Stripe3ds2Fingerprint.create(sdkData);
         assertEquals("src_1EceOlCRMbs6FrXf2hqrI1g5",
                 stripe3ds2Fingerprint.source);
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServerName.VISA,
-                stripe3ds2Fingerprint.directoryServerName);
+        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Visa,
+                stripe3ds2Fingerprint.directoryServer);
         assertEquals("e64bb72f-60ac-4845-b8b6-47cfdb0f73aa",
                 stripe3ds2Fingerprint.serverTransactionId);
     }
@@ -56,8 +56,8 @@ public class Stripe3ds2FingerprintTest {
                 Stripe3ds2Fingerprint.create(new JSONObject(VISA_DS_JSON));
         assertEquals("src_1EZl3YCRMbs6FrXfYgJXF46w",
                 stripe3ds2Fingerprint.source);
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServerName.VISA,
-                stripe3ds2Fingerprint.directoryServerName);
+        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Visa,
+                stripe3ds2Fingerprint.directoryServer);
         assertEquals("b31807ca-e7d6-4685-a7e3-53fbd2962135",
                 stripe3ds2Fingerprint.serverTransactionId);
     }


### PR DESCRIPTION
## Summary
Create transaction with directory server id derived from directory server name

## Motivation
We shouldn't hardcode DS ID

## Testing
Updated tests
