### PR TITLE
Make AppInfo public

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AppInfo.java
+++ b/stripe/src/main/java/com/stripe/android/AppInfo.java
@@ -18,29 +18,29 @@ import java.util.Objects;
  * See <a href="https://stripe.com/docs/building-plugins#setappinfo">
  *     https://stripe.com/docs/building-plugins#setappinfo</a>.
  */
-final class AppInfo {
+public final class AppInfo {
     @NonNull private final String mName;
     @Nullable private final String mVersion;
     @Nullable private final String mUrl;
     @Nullable private final String mPartnerId;
 
     @NonNull
-    static AppInfo create(@NonNull String name) {
+    public static AppInfo create(@NonNull String name) {
         return new AppInfo(name, null, null, null);
     }
 
     @NonNull
-    static AppInfo create(@NonNull String name, @NonNull String version) {
+    public static AppInfo create(@NonNull String name, @NonNull String version) {
         return new AppInfo(name, version, null, null);
     }
 
     @NonNull
-    static AppInfo create(@NonNull String name, @NonNull String version, @NonNull String url) {
+    public static AppInfo create(@NonNull String name, @NonNull String version, @NonNull String url) {
         return new AppInfo(name, version, url, null);
     }
 
     @NonNull
-    static AppInfo create(@NonNull String name, @NonNull String version, @NonNull String url,
+    public static AppInfo create(@NonNull String name, @NonNull String version, @NonNull String url,
                           @NonNull String partnerId) {
         return new AppInfo(name, version, url, partnerId);
     }


### PR DESCRIPTION

## Summary
Making AppInfo & AppInfo create methods public to allow 3rd party plugins (e.g. tipsi-stripe) to be updated so that they can start providing plugin information.  Fixes #1131

## Motivation
We are working on upgrading [tipsi-stripe](https://github.com/tipsi/tipsi-stripe/) so that it will start providing plugin information to Stripe, and we need to be able to call `stripe.setAppInfo(AppInfo.create(...))`, which requires `AppInfo` to be public so that it can be imported and the `create` methods to be public so that they can be invoked.

## Testing
Build passed (if any additional testing beyond this is needed please let me know!)