### PR TITLE
Setup Intents

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -39,6 +39,22 @@
                     android:scheme="stripe" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".activity.SetupIntentActivity"
+            android:launchMode="singleInstance"
+            android:theme="@style/AppTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="setup_intent_return"
+                    android:scheme="stripe" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".service.TokenIntentService"
             android:exported="false"/>

--- a/example/res/layout/activity_payment_auth.xml
+++ b/example/res/layout/activity_payment_auth.xml
@@ -17,6 +17,18 @@
         android:layout_marginBottom="40dp"
         android:text="@string/buy" />
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/setup_auth_intro" />
+
+    <Button
+        android:id="@+id/setup_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="40dp"
+        android:text="@string/setup" />
+
     <ProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="match_parent"

--- a/example/res/layout/activity_setup_intent_demo.xml
+++ b/example/res/layout/activity_setup_intent_demo.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:stripe="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:layout_margin="10dp"
+        android:paddingBottom="40dp"
+        >
+
+        <TextView
+            android:id="@+id/create_setup_intent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/create_setup_intent_backend"
+            />
+
+        <Button
+            android:id="@+id/btn_create_setup_intent"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/create_setup_intent"
+            />
+
+        <TextView
+            android:id="@+id/confirm_setup_intent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/create_payment_method_and_confirm_setup_intent"
+            android:layout_marginTop="20dp"
+            />
+
+        <com.stripe.android.view.CardInputWidget
+            android:id="@+id/card_input_widget"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            stripe:cardHintText="@string/sample_card_requiring_auth"
+            />
+
+        <Button
+            android:id="@+id/btn_create_payment_method"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:enabled="false"
+            android:text="@string/create_payment_method"
+            />
+
+        <Button
+            android:id="@+id/btn_confirm_setup_intent"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:enabled="false"
+            android:text="@string/confirm_setup_intent"
+            />
+
+        <Button
+            android:id="@+id/btn_retrieve_setup_intent"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:enabled="false"
+            android:text="@string/retrieve_setup_intent"
+            />
+
+        <TextView
+            android:id="@+id/setup_intent_value"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:typeface="monospace"
+            />
+
+    </LinearLayout>
+</ScrollView>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="label_source_id">ID Last 6</string>
 
     <string name="sample_card_requiring_3ds">4000 0000 0000 3063</string>
+    <string name="sample_card_requiring_auth">4000 0025 0000 3155</string>
 
     <string name="pay_with_google_content_description">Pay with Google</string>
 
@@ -71,6 +72,19 @@
     <string name="retrieve_payment_intent">Retrieve PaymentIntent</string>
     <string name="error_while_retrieving_payment_intent">An error occurred while retrieving the PaymentIntent</string>
 
+    <string name="launch_setup_intent_example">Launch SetupIntent Example</string>
+    <string name="creating_setup_intent">Creating SetupIntent&#8230;</string>
+    <string name="creating_payment_method">Creating Payment Method&#8230;</string>
+    <string name="confirming_setup_intent">Confirming SetupIntent&#8230;</string>
+    <string name="retrieving_setup_intent">Retrieving SetupIntent&#8230;</string>
+    <string name="create_setup_intent_backend">First, create a SetupIntent on your backend.</string>
+    <string name="create_setup_intent">Create SetupIntent</string>
+    <string name="create_payment_method_and_confirm_setup_intent">Second, create a payment method and confirm the SetupIntent</string>
+    <string name="create_payment_method">Create Payment Method</string>
+    <string name="confirm_setup_intent">Confirm SetupIntent</string>
+    <string name="retrieve_setup_intent">Retrieve SetupIntent</string>
+    <string name="error_while_retrieving_setup_intent">An error occurred while retrieving the SetupIntent</string>
+
     <string name="authentication_dialog_title">Authentication required</string>
     <string name="authentication_dialog_message">Authenticate %1$s ending in %2$s?</string>
     <string name="pay_with_google">Pay with Google</string>
@@ -78,6 +92,9 @@
     <!-- Payment Auth example -->
     <string name="launch_payment_auth_example">Launch Payment Auth Example</string>
     <string name="buy">Buy!</string>
+    <string name="setup">Buy in the Future!</string>
     <string name="payment_intent_status">PaymentIntent status: %s</string>
+    <string name="setup_intent_status">SetupIntent status: %s</string>
     <string name="payment_auth_intro">Tapping the button below will create a PaymentIntent then attempt to confirm it.</string>
+    <string name="setup_auth_intro">Tapping the button below will create a SetupIntent then attempt to confirm it.</string>
 </resources>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -53,6 +53,8 @@ public class LauncherActivity extends AppCompatActivity {
             this.mItems = new ArrayList<>(Arrays.asList(
                     new Item(activity.getString(R.string.launch_payment_intent_example),
                             PaymentIntentActivity.class),
+                    new Item(activity.getString(R.string.launch_setup_intent_example),
+                            SetupIntentActivity.class),
                     new Item(activity.getString(R.string.launch_payment_auth_example),
                             PaymentAuthActivity.class),
                     new Item(activity.getString(R.string.create_card_tokens),

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -109,7 +109,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
     private void confirmSetupIntent(@NonNull String setupIntentClientSecret) {
         mStatusTextView.append("\n\nStarting setup intent authentication");
         mStripe.confirmSetupIntent(this,
-                SetupIntentParams.createConfirmSetupIntenParamsWithPaymentMethodId(
+                SetupIntentParams.createConfirmSetupIntentParamsWithPaymentMethodId(
                         PAYMENT_METHOD_AUTH_REQUIRED_ON_SETUP,
                         setupIntentClientSecret,
                         RETURN_URL));

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -116,7 +116,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         mProgressBar.setVisibility(View.VISIBLE);

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -15,9 +15,12 @@ import com.stripe.android.ApiResultCallback;
 import com.stripe.android.PaymentAuthConfig;
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.PaymentIntentResult;
+import com.stripe.android.SetupIntentResult;
 import com.stripe.android.Stripe;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentIntentParams;
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.SetupIntentParams;
 import com.stripe.example.R;
 import com.stripe.example.module.RetrofitFactory;
 import com.stripe.example.service.StripeService;
@@ -46,6 +49,8 @@ public class PaymentAuthActivity extends AppCompatActivity {
      */
     private static final String PAYMENT_METHOD_3DS2_REQUIRED = "pm_card_threeDSecure2Required";
     private static final String PAYMENT_METHOD_3DS_REQUIRED = "pm_card_threeDSecureRequired";
+    private static final String PAYMENT_METHOD_AUTH_REQUIRED_ON_SETUP =
+            "pm_card_authenticationRequiredOnSetup";
 
     private static final String RETURN_URL = "stripe://payment_auth";
 
@@ -58,6 +63,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
     private StripeService mStripeService;
     private TextView mStatusTextView;
     private Button mBuyButton;
+    private Button mSetupButton;
     private ProgressBar mProgressBar;
 
     @Override
@@ -85,6 +91,9 @@ public class PaymentAuthActivity extends AppCompatActivity {
         mBuyButton = findViewById(R.id.buy_button);
         mBuyButton.setOnClickListener((v) -> createPaymentIntent());
 
+        mSetupButton = findViewById(R.id.setup_button);
+        mSetupButton.setOnClickListener((v) -> createSetupIntent());
+
         mProgressBar = findViewById(R.id.progress_bar);
     }
 
@@ -97,14 +106,25 @@ public class PaymentAuthActivity extends AppCompatActivity {
                         RETURN_URL));
     }
 
+    private void confirmSetupIntent(@NonNull String setupIntentClientSecret) {
+        mStatusTextView.append("\n\nStarting setup intent authentication");
+        mStripe.confirmSetupIntent(this,
+                SetupIntentParams.createConfirmSetupIntenParamsWithPaymentMethodId(
+                        PAYMENT_METHOD_AUTH_REQUIRED_ON_SETUP,
+                        setupIntentClientSecret,
+                        RETURN_URL));
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         mProgressBar.setVisibility(View.VISIBLE);
         mStatusTextView.append("\n\nPayment authentication completed, getting result");
-        mStripe.onPaymentResult(requestCode, resultCode, data,
-                new AuthResultListener(this));
+
+        mStripe.onPaymentResult(requestCode, resultCode, data, new AuthResultListener(this));
+
+        mStripe.onSetupResult(requestCode, resultCode, data, new SetupAuthResultListener(this));
     }
 
     @Override
@@ -133,9 +153,24 @@ public class PaymentAuthActivity extends AppCompatActivity {
                         .doOnSubscribe((d) -> {
                             mProgressBar.setVisibility(View.VISIBLE);
                             mBuyButton.setEnabled(false);
+                            mSetupButton.setEnabled(false);
                             mStatusTextView.setText(R.string.creating_payment_intent);
                         })
                         .subscribe(this::handleCreatePaymentIntentResponse));
+    }
+
+    private void createSetupIntent() {
+        mCompositeSubscription.add(
+                mStripeService.createSetupIntent(new HashMap<>(0))
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .doOnSubscribe((d) -> {
+                            mProgressBar.setVisibility(View.VISIBLE);
+                            mBuyButton.setEnabled(false);
+                            mSetupButton.setEnabled(false);
+                            mStatusTextView.setText(R.string.creating_setup_intent);
+                        })
+                        .subscribe(this::handleCreateSetupIntentResponse));
     }
 
     private void handleCreatePaymentIntentResponse(@NonNull ResponseBody responseBody) {
@@ -151,8 +186,22 @@ public class PaymentAuthActivity extends AppCompatActivity {
         }
     }
 
+    private void handleCreateSetupIntentResponse(@NonNull ResponseBody responseBody) {
+        try {
+            final JSONObject responseData = new JSONObject(responseBody.string());
+            mStatusTextView.append("\n\n" +
+                    getString(R.string.setup_intent_status,
+                            responseData.getString("status")));
+            final String secret = responseData.getString("secret");
+            confirmSetupIntent(secret);
+        } catch (IOException | JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
     private void onAuthComplete() {
         mBuyButton.setEnabled(true);
+        mSetupButton.setEnabled(true);
         mProgressBar.setVisibility(View.INVISIBLE);
     }
 
@@ -182,6 +231,38 @@ public class PaymentAuthActivity extends AppCompatActivity {
             final PaymentIntent paymentIntent = paymentIntentResult.getIntent();
             activity.mStatusTextView.append("\n\n" +
                     activity.getString(R.string.payment_intent_status, paymentIntent.getStatus()));
+            activity.onAuthComplete();
+        }
+
+        @Override
+        public void onError(@NonNull Exception e) {
+            final PaymentAuthActivity activity = mActivityRef.get();
+            if (activity == null) {
+                return;
+            }
+
+            activity.mStatusTextView.append("\n\nException: " + e.getMessage());
+            activity.onAuthComplete();
+        }
+    }
+
+    private static class SetupAuthResultListener implements ApiResultCallback<SetupIntentResult> {
+        @NonNull private final WeakReference<PaymentAuthActivity> mActivityRef;
+
+        private SetupAuthResultListener(@NonNull PaymentAuthActivity activity) {
+            this.mActivityRef = new WeakReference<>(activity);
+        }
+
+        @Override
+        public void onSuccess(@NonNull SetupIntentResult setupIntentResult) {
+            final PaymentAuthActivity activity = mActivityRef.get();
+            if (activity == null) {
+                return;
+            }
+
+            final SetupIntent setupIntent = setupIntentResult.getIntent();
+            activity.mStatusTextView.append("\n\n" +
+                    activity.getString(R.string.setup_intent_status, setupIntent.getStatus()));
             activity.onAuthComplete();
         }
 

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.java
@@ -71,7 +71,7 @@ public class PaymentIntentActivity extends AppCompatActivity {
         mErrorDialogHandler = new ErrorDialogHandler(this);
         mStripe = new Stripe(getApplicationContext(),
                 PaymentConfiguration.getInstance().getPublishableKey());
-        Retrofit retrofit = RetrofitFactory.getInstance();
+        final Retrofit retrofit = RetrofitFactory.getInstance();
         mStripeService = retrofit.create(StripeService.class);
 
         createPaymentIntent.setOnClickListener(v -> createPaymentIntent());

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
@@ -195,7 +195,7 @@ public class SetupIntentActivity extends AppCompatActivity {
         final Observable<SetupIntent> setupIntentObservable = Observable.fromCallable(
                 () -> {
                     final SetupIntentParams setupIntentParams = SetupIntentParams
-                            .createConfirmSetupIntenParamsWithPaymentMethodId(
+                            .createConfirmSetupIntentParamsWithPaymentMethodId(
                                     mPaymentMethod.id, mClientSecret, RETURN_URL);
                     return mStripe.confirmSetupIntentSynchronous(setupIntentParams,
                             PaymentConfiguration.getInstance().getPublishableKey());

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
@@ -85,9 +85,7 @@ public class SetupIntentActivity extends AppCompatActivity {
             }
         });
         mRetrieveSetupIntent.setOnClickListener(v -> retrieveSetupIntent());
-        mConfirmSetupIntent.setOnClickListener(v -> {
-            confirmSetupIntent();
-        });
+        mConfirmSetupIntent.setOnClickListener(v -> confirmSetupIntent());
     }
 
     @Override
@@ -111,7 +109,7 @@ public class SetupIntentActivity extends AppCompatActivity {
         }
     }
 
-    void createSetupIntent() {
+    private void createSetupIntent() {
         final Disposable disposable = mStripeService.createSetupIntent(new HashMap<>())
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
@@ -1,0 +1,231 @@
+package com.stripe.example.activity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.stripe.android.PaymentConfiguration;
+import com.stripe.android.Stripe;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.PaymentMethod;
+import com.stripe.android.model.PaymentMethodCreateParams;
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.SetupIntentParams;
+import com.stripe.android.view.CardInputWidget;
+import com.stripe.example.R;
+import com.stripe.example.controller.ErrorDialogHandler;
+import com.stripe.example.controller.ProgressDialogController;
+import com.stripe.example.module.RetrofitFactory;
+import com.stripe.example.service.StripeService;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+import okhttp3.ResponseBody;
+import retrofit2.Retrofit;
+
+public class SetupIntentActivity extends AppCompatActivity {
+    private static final String TAG = SetupIntentActivity.class.getName();
+
+    private static final String RETURN_URL = "stripe://setup_intent_return";
+
+    @NonNull
+    private final CompositeDisposable mCompositeDisposable = new CompositeDisposable();
+
+    private ProgressDialogController mProgressDialogController;
+    private ErrorDialogHandler mErrorDialogHandler;
+    private Stripe mStripe;
+    private StripeService mStripeService;
+    private String mClientSecret;
+    private Button mCreatePaymentMethod;
+    private Button mConfirmSetupIntent;
+    private Button mRetrieveSetupIntent;
+    private CardInputWidget mCardInputWidget;
+    private TextView mSetupIntentValue;
+    private PaymentMethod mPaymentMethod;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_setup_intent_demo);
+        final Button createSetupIntent = findViewById(R.id.btn_create_setup_intent);
+        mCreatePaymentMethod = findViewById(R.id.btn_create_payment_method);
+        mRetrieveSetupIntent = findViewById(R.id.btn_retrieve_setup_intent);
+        mConfirmSetupIntent = findViewById(R.id.btn_confirm_setup_intent);
+        mSetupIntentValue = findViewById(R.id.setup_intent_value);
+        mCardInputWidget = findViewById(R.id.card_input_widget);
+
+        mProgressDialogController = new ProgressDialogController(getSupportFragmentManager(),
+                getResources());
+        mErrorDialogHandler = new ErrorDialogHandler(this);
+        mStripe = new Stripe(getApplicationContext(),
+                PaymentConfiguration.getInstance().getPublishableKey());
+        final Retrofit retrofit = RetrofitFactory.getInstance();
+        mStripeService = retrofit.create(StripeService.class);
+
+        createSetupIntent.setOnClickListener(v -> createSetupIntent());
+        mCreatePaymentMethod.setOnClickListener(v -> {
+            final Card card = mCardInputWidget.getCard();
+            if (card != null) {
+                createPaymentMethod(card);
+            }
+        });
+        mRetrieveSetupIntent.setOnClickListener(v -> retrieveSetupIntent());
+        mConfirmSetupIntent.setOnClickListener(v -> {
+            confirmSetupIntent();
+        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        mCompositeDisposable.dispose();
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onNewIntent(@NonNull Intent intent) {
+        super.onNewIntent(intent);
+
+        if (intent.getData() != null && intent.getData().getQuery() != null) {
+            Toast.makeText(SetupIntentActivity.this,
+                    "Retrieving SetupIntent after authorizing",
+                    Toast.LENGTH_SHORT)
+                    .show();
+            mClientSecret = intent.getData().getQueryParameter(
+                    "setup_intent_client_secret");
+            retrieveSetupIntent();
+        }
+    }
+
+    void createSetupIntent() {
+        final Disposable disposable = mStripeService.createSetupIntent(new HashMap<>())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe((d) ->
+                        mProgressDialogController.show(R.string.creating_setup_intent))
+                .doOnComplete(() ->
+                        mProgressDialogController.dismiss())
+
+                // Because we've made the mapping above, we're now subscribing
+                // to the result of creating a 3DS Source
+                .subscribe(this::onCreatedSetupIntent,
+                        throwable -> mErrorDialogHandler.show(throwable.getLocalizedMessage())
+                );
+        mCompositeDisposable.add(disposable);
+    }
+
+    private void onCreatedSetupIntent(@NonNull ResponseBody responseBody) {
+        try {
+            final JSONObject jsonObject = new JSONObject(responseBody.string());
+            mSetupIntentValue.setText(jsonObject.toString());
+            mClientSecret = jsonObject.getString("secret");
+            mCreatePaymentMethod.setEnabled(mClientSecret != null);
+        } catch (IOException | JSONException exception) {
+            Log.e(TAG, exception.toString());
+        }
+    }
+
+    private void retrieveSetupIntent() {
+        final Observable<SetupIntent> setupIntentObservable = Observable.fromCallable(
+                () -> mStripe.retrieveSetupIntentSynchronous(
+                        SetupIntentParams.createRetrieveSetupIntentParams(mClientSecret)));
+
+        final Disposable disposable = setupIntentObservable
+                .subscribeOn(Schedulers.io())
+                .doOnSubscribe((d) ->
+                        mProgressDialogController.show(R.string.retrieving_setup_intent))
+                .doOnComplete(() -> mProgressDialogController.dismiss())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        setupIntent -> mSetupIntentValue.setText(setupIntent != null ?
+                                new JSONObject(setupIntent.toMap()).toString() :
+                                getString(R.string.error_while_retrieving_setup_intent)),
+                        throwable -> Log.e(TAG, throwable.toString())
+                );
+        mCompositeDisposable.add(disposable);
+    }
+
+    private void createPaymentMethod(@NonNull final Card card) {
+        final PaymentMethodCreateParams paymentMethodCreateParams =
+                PaymentMethodCreateParams.create(card.toPaymentMethodParamsCard(), null);
+
+        final Observable<PaymentMethod> paymentMethodObservable = Observable.fromCallable(
+                () -> mStripe.createPaymentMethodSynchronous(paymentMethodCreateParams,
+                        PaymentConfiguration.getInstance().getPublishableKey()));
+
+        final Disposable disposable = paymentMethodObservable
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe((d) ->
+                        mProgressDialogController.show(R.string.creating_payment_method))
+                .doOnComplete(() ->
+                        mProgressDialogController.dismiss())
+                .subscribe(
+                        paymentMethod -> {
+                            if (paymentMethod != null) {
+                                mSetupIntentValue
+                                        .setText(paymentMethod.id);
+
+                                mPaymentMethod = paymentMethod;
+                                mConfirmSetupIntent.setEnabled(mPaymentMethod != null);
+                                mRetrieveSetupIntent.setEnabled(mPaymentMethod != null);
+                            }
+                        },
+                        throwable -> Log.e(TAG, throwable.toString())
+                );
+        mCompositeDisposable.add(disposable);
+    }
+
+    private void confirmSetupIntent() {
+
+        final Observable<SetupIntent> setupIntentObservable = Observable.fromCallable(
+                () -> {
+                    final SetupIntentParams setupIntentParams = SetupIntentParams
+                            .createConfirmSetupIntenParamsWithPaymentMethodId(
+                                    mPaymentMethod.id, mClientSecret, RETURN_URL);
+                    return mStripe.confirmSetupIntentSynchronous(setupIntentParams,
+                            PaymentConfiguration.getInstance().getPublishableKey());
+                });
+
+        final Disposable disposable = setupIntentObservable
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe((d) ->
+                        mProgressDialogController.show(R.string.confirm_setup_intent))
+                .doOnComplete(() ->
+                        mProgressDialogController.dismiss())
+                .subscribe(
+                        setupIntent -> {
+                            if (setupIntent != null) {
+                                mSetupIntentValue
+                                        .setText(new JSONObject(setupIntent.toMap()).toString());
+
+                                if (setupIntent.requiresAction()) {
+                                    Toast.makeText(SetupIntentActivity.this,
+                                            "Redirecting to redirect URL",
+                                            Toast.LENGTH_SHORT)
+                                            .show();
+                                    startActivity(new Intent(Intent.ACTION_VIEW,
+                                            setupIntent.getRedirectUrl()));
+                                }
+                            }
+                        },
+                        throwable -> Log.e(TAG, throwable.toString())
+                );
+        mCompositeDisposable.add(disposable);
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.java
@@ -177,12 +177,10 @@ public class SetupIntentActivity extends AppCompatActivity {
                 .subscribe(
                         paymentMethod -> {
                             if (paymentMethod != null) {
-                                mSetupIntentValue
-                                        .setText(paymentMethod.id);
-
+                                mSetupIntentValue.setText(paymentMethod.id);
                                 mPaymentMethod = paymentMethod;
-                                mConfirmSetupIntent.setEnabled(mPaymentMethod != null);
-                                mRetrieveSetupIntent.setEnabled(mPaymentMethod != null);
+                                mConfirmSetupIntent.setEnabled(true);
+                                mRetrieveSetupIntent.setEnabled(true);
                             }
                         },
                         throwable -> Log.e(TAG, throwable.toString())

--- a/example/src/main/java/com/stripe/example/service/StripeService.java
+++ b/example/src/main/java/com/stripe/example/service/StripeService.java
@@ -21,4 +21,8 @@ public interface StripeService {
     @FormUrlEncoded
     @POST("create_intent")
     Observable<ResponseBody> createPaymentIntent(@FieldMap Map<String, Object> params);
+
+    @FormUrlEncoded
+    @POST("create_setup_intent")
+    Observable<ResponseBody> createSetupIntent(@FieldMap Map<String, Object> params);
 }

--- a/stripe/src/main/java/com/stripe/android/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/LoggingUtils.java
@@ -41,7 +41,9 @@ class LoggingUtils {
             EVENT_DELETE_SOURCE,
             EVENT_SET_SHIPPING_INFO,
             EVENT_CONFIRM_PAYMENT_INTENT,
-            EVENT_RETRIEVE_PAYMENT_INTENT})
+            EVENT_RETRIEVE_PAYMENT_INTENT,
+            EVENT_CONFIRM_SETUP_INTENT,
+            EVENT_RETRIEVE_SETUP_INTENT})
     @interface LoggingEventName {
     }
 

--- a/stripe/src/main/java/com/stripe/android/LoggingUtils.java
+++ b/stripe/src/main/java/com/stripe/android/LoggingUtils.java
@@ -56,6 +56,8 @@ class LoggingUtils {
     static final String EVENT_SET_SHIPPING_INFO = "set_shipping_info";
     static final String EVENT_CONFIRM_PAYMENT_INTENT = "payment_intent_confirmation";
     static final String EVENT_RETRIEVE_PAYMENT_INTENT = "payment_intent_retrieval";
+    static final String EVENT_CONFIRM_SETUP_INTENT = "setup_intent_confirmation";
+    static final String EVENT_RETRIEVE_SETUP_INTENT = "setup_intent_retrieval";
 
     static final String FIELD_PRODUCT_USAGE = "product_usage";
     static final String FIELD_ANALYTICS_UA = "analytics_ua";
@@ -206,6 +208,28 @@ class LoggingUtils {
                 null,
                 null,
                 publishableApiKey, EVENT_RETRIEVE_PAYMENT_INTENT);
+    }
+
+    @NonNull
+    Map<String, Object> getSetupIntentConfirmationParams(
+            @Nullable List<String> productUsageTokens,
+            @NonNull String publishableApiKey) {
+        return getEventLoggingParams(
+                productUsageTokens,
+                null,
+                null,
+                publishableApiKey, EVENT_CONFIRM_SETUP_INTENT);
+    }
+
+    @NonNull
+    Map<String, Object> getSetupIntentRetrieveParams(
+            @Nullable List<String> productUsageTokens,
+            @NonNull String publishableApiKey) {
+        return getEventLoggingParams(
+                productUsageTokens,
+                null,
+                null,
+                publishableApiKey, EVENT_RETRIEVE_SETUP_INTENT);
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -198,14 +198,16 @@ class PaymentController {
                 .execute();
     }
 
+    @VisibleForTesting
     @NonNull
-    private PaymentIntentParams createPaymentIntentParams(@NonNull Intent data) {
+    PaymentIntentParams createPaymentIntentParams(@NonNull Intent data) {
         final String clientSecret = data.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET);
         return PaymentIntentParams.createRetrievePaymentIntentParams(clientSecret);
     }
 
+    @VisibleForTesting
     @NonNull
-    private SetupIntentParams createSetupIntentParams(@NonNull Intent data) {
+    SetupIntentParams createSetupIntentParams(@NonNull Intent data) {
         final String clientSecret = data.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET);
         return SetupIntentParams.createRetrieveSetupIntentParams(clientSecret);
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -12,9 +12,12 @@ import android.support.annotation.VisibleForTesting;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentIntentParams;
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.SetupIntentParams;
 import com.stripe.android.model.Stripe3ds2AuthResult;
 import com.stripe.android.model.Stripe3ds2Fingerprint;
 import com.stripe.android.model.StripeIntent;
+import com.stripe.android.model.StripeIntentParams;
 import com.stripe.android.stripe3ds2.init.StripeConfigParameters;
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service;
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl;
@@ -37,10 +40,12 @@ import java.util.concurrent.TimeUnit;
 /**
  * A controller responsible for confirming and authenticating payment (typically through resolving
  * any required customer action). The payment authentication mechanism (e.g. 3DS) will be determined
- * by the {@link PaymentIntent} object.
+ * by the {@link PaymentIntent} or {@link SetupIntent} object.
  */
 class PaymentController {
-    static final int REQUEST_CODE = 50000;
+    static final int PAYMENT_REQUEST_CODE = 50000;
+    static final int SETUP_REQUEST_CODE = 50001;
+
 
     @NonNull private final StripeThreeDs2Service mThreeDs2Service;
     @NonNull private final StripeApiHandler mApiHandler;
@@ -71,15 +76,16 @@ class PaymentController {
     }
 
     /**
-     * Confirm the PaymentIntent and resolve any next actions
+     * Confirm the Stripe Intent and resolve any next actions
      */
     void startConfirmAndAuth(@NonNull Stripe stripe,
                              @NonNull Activity activity,
-                             @NonNull PaymentIntentParams paymentIntentParams,
+                             @NonNull StripeIntentParams stripeIntentParams,
                              @NonNull String publishableKey) {
         mApiKeyValidator.requireValid(publishableKey);
-        new ConfirmStripeIntentTask(stripe, paymentIntentParams, publishableKey,
-                new ConfirmPaymentIntentCallback(activity, publishableKey, this))
+        new ConfirmStripeIntentTask(stripe, stripeIntentParams, publishableKey,
+                new ConfirmStripeIntentCallback(activity, publishableKey, this,
+                        getRequestCode(stripeIntentParams)))
                 .execute();
     }
 
@@ -90,11 +96,21 @@ class PaymentController {
     }
 
     /**
-     * Decide whether {@link #handleResult(Stripe, Intent, String, ApiResultCallback)} should be
-     * called.
+     * Decide whether {@link #handlePaymentResult(Stripe, Intent, String, ApiResultCallback)}
+     * should be called.
      */
-    boolean shouldHandleResult(int requestCode, int resultCode, @Nullable Intent data) {
-        return requestCode == REQUEST_CODE &&
+    boolean shouldHandlePaymentResult(int requestCode, int resultCode, @Nullable Intent data) {
+        return requestCode == PAYMENT_REQUEST_CODE &&
+                resultCode == Activity.RESULT_OK &&
+                data != null;
+    }
+
+    /**
+     * Decide whether {@link #handleSetupResult(Stripe, Intent, String, ApiResultCallback)}
+     * should be called.
+     */
+    boolean shouldHandleSetupResult(int requestCode, int resultCode, @Nullable Intent data) {
+        return requestCode == SETUP_REQUEST_CODE &&
                 resultCode == Activity.RESULT_OK &&
                 data != null;
     }
@@ -103,13 +119,14 @@ class PaymentController {
      * If payment authentication triggered an exception, get the exception object and pass to
      * {@link ApiResultCallback#onError(Exception)}.
      *
-     * Otherwise, get the PaymentIntent's client_secret from {@param data} and use to retrieve the
-     * PaymentIntent object with updated status.
+     * Otherwise, get the PaymentIntent's client_secret from {@param data} and use to retrieve
+     * the PaymentIntent object with updated status.
      *
      * @param data the result Intent
      */
-    void handleResult(@NonNull Stripe stripe, @NonNull Intent data, @NonNull String publishableKey,
-                      @NonNull final ApiResultCallback<PaymentIntentResult> callback) {
+    void handlePaymentResult(@NonNull Stripe stripe, @NonNull Intent data,
+                             @NonNull String publishableKey,
+                             @NonNull final ApiResultCallback<PaymentIntentResult> callback) {
         final Exception authException = (Exception) data.getSerializableExtra(
                 StripeIntentResultExtras.AUTH_EXCEPTION);
         if (authException != null) {
@@ -139,10 +156,58 @@ class PaymentController {
                 .execute();
     }
 
+    /**
+     * If setup authentication triggered an exception, get the exception object and pass to
+     * {@link ApiResultCallback#onError(Exception)}.
+     *
+     * Otherwise, get the SetupIntent's client_secret from {@param data} and use to retrieve the
+     * SetupIntent object with updated status.
+     *
+     * @param data the result Intent
+     */
+    void handleSetupResult(@NonNull Stripe stripe, @NonNull Intent data,
+                           @NonNull String publishableKey,
+                           @NonNull final ApiResultCallback<SetupIntentResult> callback) {
+        final Exception authException = (Exception) data.getSerializableExtra(
+                StripeIntentResultExtras.AUTH_EXCEPTION);
+        if (authException != null) {
+            callback.onError(authException);
+            return;
+        }
+
+        @StripeIntentResult.Status final int authStatus = data.getIntExtra(
+                StripeIntentResultExtras.AUTH_STATUS, StripeIntentResult.Status.UNKNOWN);
+
+        new RetrieveIntentTask(stripe, createSetupIntentParams(data), publishableKey,
+                new ApiResultCallback<StripeIntent>() {
+                    @Override
+                    public void onSuccess(@NonNull StripeIntent stripeIntent) {
+                        if (stripeIntent instanceof SetupIntent) {
+                            callback.onSuccess(new SetupIntentResult.Builder<>()
+                                    .setSetupIntent((SetupIntent) stripeIntent)
+                                    .setStatus(authStatus)
+                                    .build());
+                        }
+                    }
+
+                    @Override
+                    public void onError(@NonNull Exception e) {
+                        callback.onError(e);
+                    }
+                })
+                .execute();
+    }
+
     @NonNull
     private PaymentIntentParams createPaymentIntentParams(@NonNull Intent data) {
         final String clientSecret = data.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET);
         return PaymentIntentParams.createRetrievePaymentIntentParams(clientSecret);
+    }
+
+    @NonNull
+    private SetupIntentParams createSetupIntentParams(@NonNull Intent data) {
+        final String clientSecret = data.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET);
+        return SetupIntentParams.createRetrieveSetupIntentParams(clientSecret);
     }
 
     /**
@@ -166,7 +231,7 @@ class PaymentController {
                     bypassAuth(activity, stripeIntent);
                 }
             } else if (StripeIntent.NextActionType.RedirectToUrl == nextActionType) {
-                begin3ds1Auth(activity,
+                begin3ds1Auth(activity, getRequestCode(stripeIntent),
                         Objects.requireNonNull(stripeIntent.getRedirectData()));
             } else {
                 // next action type is not supported, so bypass authentication
@@ -178,8 +243,34 @@ class PaymentController {
         }
     }
 
+    /**
+     * Get the appropriate request code for the given stripe intent type
+     *
+     * @param intent the {@link StripeIntent} to get the request code for
+     * @return PAYMENT_REQUEST_CODE or SETUP_REQUEST_CODE
+     */
+    static int getRequestCode(@NonNull StripeIntent intent) {
+        if (intent instanceof PaymentIntent) {
+            return PAYMENT_REQUEST_CODE;
+        }
+        return SETUP_REQUEST_CODE;
+    }
+
+    /**
+     * Get the appropriate request code for the given stripe intent params type
+     *
+     * @param params the {@link StripeIntentParams} to get the request code for
+     * @return PAYMENT_REQUEST_CODE or SETUP_REQUEST_CODE
+     */
+    static int getRequestCode(@NonNull StripeIntentParams params) {
+        if (params instanceof PaymentIntentParams) {
+            return PAYMENT_REQUEST_CODE;
+        }
+        return SETUP_REQUEST_CODE;
+    }
+
     private void bypassAuth(@NonNull Activity activity, @NonNull StripeIntent stripeIntent) {
-        new PaymentRelayStarter(activity, REQUEST_CODE)
+        new PaymentRelayStarter(activity, getRequestCode(stripeIntent))
                 .start(new PaymentRelayStarter.Data(stripeIntent));
     }
 
@@ -219,23 +310,25 @@ class PaymentController {
      *         {@link Activity}
      */
     private void begin3ds1Auth(@NonNull Activity activity,
+                               int requestCode,
                                @NonNull StripeIntent.RedirectData redirectData) {
-        new PaymentAuthWebViewStarter(activity, REQUEST_CODE).start(redirectData);
+        new PaymentAuthWebViewStarter(activity, requestCode).start(redirectData);
     }
 
     private static void handleError(@NonNull Activity activity,
+                                    int requestCode,
                                     @NonNull Exception exception) {
-        new PaymentRelayStarter(activity, REQUEST_CODE)
+        new PaymentRelayStarter(activity, requestCode)
                 .start(new PaymentRelayStarter.Data(exception));
     }
 
     private static final class RetrieveIntentTask extends ApiOperation<StripeIntent> {
         @NonNull private final Stripe mStripe;
-        @NonNull private final PaymentIntentParams mParams;
+        @NonNull private final StripeIntentParams mParams;
         @NonNull private final String mPublishableKey;
 
         private RetrieveIntentTask(@NonNull Stripe stripe,
-                                   @NonNull PaymentIntentParams params,
+                                   @NonNull StripeIntentParams params,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<StripeIntent> callback) {
             super(callback);
@@ -246,18 +339,25 @@ class PaymentController {
 
         @Nullable
         @Override
-        PaymentIntent getResult() throws StripeException {
-            return mStripe.retrievePaymentIntentSynchronous(mParams, mPublishableKey);
+        StripeIntent getResult() throws StripeException {
+            if (mParams instanceof PaymentIntentParams) {
+                return mStripe.retrievePaymentIntentSynchronous(
+                        (PaymentIntentParams) mParams, mPublishableKey);
+            } else if (mParams instanceof SetupIntentParams) {
+                return mStripe.retrieveSetupIntentSynchronous(
+                        (SetupIntentParams) mParams, mPublishableKey);
+            }
+            return null;
         }
     }
 
     private static final class ConfirmStripeIntentTask extends ApiOperation<StripeIntent> {
         @NonNull private final Stripe mStripe;
-        @NonNull private final PaymentIntentParams mParams;
+        @NonNull private final StripeIntentParams mParams;
         @NonNull private final String mPublishableKey;
 
         private ConfirmStripeIntentTask(@NonNull Stripe stripe,
-                                        @NonNull PaymentIntentParams params,
+                                        @NonNull StripeIntentParams params,
                                         @NonNull String publishableKey,
                                         @NonNull ApiResultCallback<StripeIntent> callback) {
             super(callback);
@@ -268,24 +368,34 @@ class PaymentController {
 
         @Nullable
         @Override
-        PaymentIntent getResult() throws StripeException {
-            return mStripe.confirmPaymentIntentSynchronous(mParams, mPublishableKey);
+        StripeIntent getResult() throws StripeException {
+            if (mParams instanceof PaymentIntentParams) {
+                return mStripe.confirmPaymentIntentSynchronous(
+                        (PaymentIntentParams) mParams, mPublishableKey);
+            } else if (mParams instanceof SetupIntentParams) {
+                return mStripe.confirmSetupIntentSynchronous(
+                        (SetupIntentParams) mParams, mPublishableKey);
+            }
+            return null;
         }
     }
 
-    private static final class ConfirmPaymentIntentCallback
+    private static final class ConfirmStripeIntentCallback
             implements ApiResultCallback<StripeIntent> {
         @NonNull private final WeakReference<Activity> mActivityRef;
         @NonNull private final String mPublishableKey;
         @NonNull private final PaymentController mPaymentController;
+        private final int mRequestCode;
 
-        private ConfirmPaymentIntentCallback(
+        private ConfirmStripeIntentCallback(
                 @NonNull Activity activity,
                 @NonNull String publishableKey,
-                @NonNull PaymentController paymentController) {
+                @NonNull PaymentController paymentController,
+                int requestCode) {
             mActivityRef = new WeakReference<>(activity);
             mPublishableKey = publishableKey;
             mPaymentController = paymentController;
+            mRequestCode = requestCode;
         }
 
         @Override
@@ -300,7 +410,7 @@ class PaymentController {
         public void onError(@NonNull Exception e) {
             final Activity activity = mActivityRef.get();
             if (activity != null) {
-                handleError(activity, e);
+                handleError(activity, mRequestCode, e);
             }
         }
     }
@@ -326,7 +436,8 @@ class PaymentController {
                 @NonNull String sourceId,
                 @NonNull String publishableKey) {
             this(activity, apiHandler, transaction, maxTimeout, stripeIntent,
-                    sourceId, publishableKey, new PaymentRelayStarter(activity, REQUEST_CODE));
+                    sourceId, publishableKey, new PaymentRelayStarter(activity,
+                            getRequestCode(stripeIntent)));
         }
 
         @VisibleForTesting
@@ -437,7 +548,7 @@ class PaymentController {
                 @NonNull String publishableKey) {
             return new PaymentAuth3ds2ChallengeStatusReceiver(
                     activity,
-                    new Stripe3ds2CompletionStarter(activity, REQUEST_CODE),
+                    new Stripe3ds2CompletionStarter(activity, getRequestCode(stripeIntent)),
                     apiHandler,
                     stripeIntent,
                     sourceId,
@@ -507,7 +618,7 @@ class PaymentController {
                         public void onError(@NonNull Exception e) {
                             final Activity activity = mActivityRef.get();
                             if (activity != null) {
-                                handleError(activity, e);
+                                handleError(activity, getRequestCode(mStripeIntent), e);
                             }
                         }
                     });

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -141,7 +141,7 @@ class PaymentController {
                     @Override
                     public void onSuccess(@NonNull StripeIntent stripeIntent) {
                         if (stripeIntent instanceof PaymentIntent) {
-                            callback.onSuccess(new PaymentIntentResult.Builder<>()
+                            callback.onSuccess(new PaymentIntentResult.Builder()
                                     .setPaymentIntent((PaymentIntent) stripeIntent)
                                     .setStatus(authStatus)
                                     .build());
@@ -183,7 +183,7 @@ class PaymentController {
                     @Override
                     public void onSuccess(@NonNull StripeIntent stripeIntent) {
                         if (stripeIntent instanceof SetupIntent) {
-                            callback.onSuccess(new SetupIntentResult.Builder<>()
+                            callback.onSuccess(new SetupIntentResult.Builder()
                                     .setSetupIntent((SetupIntent) stripeIntent)
                                     .setStatus(authStatus)
                                     .build());

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
@@ -3,7 +3,6 @@ package com.stripe.android;
 import android.support.annotation.NonNull;
 
 import com.stripe.android.model.PaymentIntent;
-import com.stripe.android.model.StripeIntent;
 
 public final class PaymentIntentResult implements StripeIntentResult<PaymentIntent> {
     @NonNull private final PaymentIntent paymentIntent;
@@ -25,8 +24,7 @@ public final class PaymentIntentResult implements StripeIntentResult<PaymentInte
         return status;
     }
 
-    static final class Builder<T extends StripeIntent>
-            implements ObjectBuilder<PaymentIntentResult> {
+    static final class Builder implements ObjectBuilder<PaymentIntentResult> {
         private PaymentIntent mPaymentIntent;
         @Status private int mStatus;
 

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
@@ -4,7 +4,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.model.SetupIntent;
-import com.stripe.android.model.StripeIntent;
 import com.stripe.android.utils.ObjectUtils;
 
 public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
@@ -27,8 +26,7 @@ public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
         return mStatus;
     }
 
-    static final class Builder<T extends StripeIntent>
-            implements ObjectBuilder<SetupIntentResult> {
+    static final class Builder implements ObjectBuilder<SetupIntentResult> {
         private SetupIntent mSetupIntent;
         @Status private int mStatus;
 

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
@@ -1,0 +1,50 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.StripeIntent;
+
+public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
+    @NonNull private final SetupIntent mSetupIntent;
+    @Status private final int mStatus;
+
+    private SetupIntentResult(@NonNull Builder builder) {
+        mSetupIntent = builder.mSetupIntent;
+        mStatus = builder.mStatus;
+    }
+
+    @NonNull
+    @Override
+    public SetupIntent getIntent() {
+        return mSetupIntent;
+    }
+
+    @Override
+    public int getStatus() {
+        return mStatus;
+    }
+
+    static final class Builder<T extends StripeIntent>
+            implements ObjectBuilder<SetupIntentResult> {
+        private SetupIntent mSetupIntent;
+        @Status private int mStatus;
+
+        @NonNull
+        public Builder setSetupIntent(@NonNull SetupIntent setupIntent) {
+            mSetupIntent = setupIntent;
+            return this;
+        }
+
+        @NonNull
+        public Builder setStatus(@Status int status) {
+            mStatus = status;
+            return this;
+        }
+
+        @NonNull
+        public SetupIntentResult build() {
+            return new SetupIntentResult(this);
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
@@ -1,9 +1,11 @@
 package com.stripe.android;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.stripe.android.model.SetupIntent;
 import com.stripe.android.model.StripeIntent;
+import com.stripe.android.utils.ObjectUtils;
 
 public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
     @NonNull private final SetupIntent mSetupIntent;
@@ -46,5 +48,22 @@ public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
         public SetupIntentResult build() {
             return new SetupIntentResult(this);
         }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof SetupIntentResult &&
+                typedEquals((SetupIntentResult) obj));
+    }
+
+    private boolean typedEquals(@NonNull SetupIntentResult setupIntentResult) {
+        return ObjectUtils.equals(mSetupIntent, setupIntentResult.mSetupIntent)
+                && ObjectUtils.equals(mStatus, setupIntentResult.mStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mSetupIntent, mStatus);
+
     }
 }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -207,7 +207,8 @@ public class Stripe {
     public boolean onPaymentResult(int requestCode, int resultCode, @Nullable Intent data,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<PaymentIntentResult> callback) {
-        if (mPaymentController.shouldHandlePaymentResult(requestCode, resultCode, data)) {
+        if (data != null &&
+                mPaymentController.shouldHandlePaymentResult(requestCode, resultCode, data)) {
             mPaymentController.handlePaymentResult(this, data, publishableKey, callback);
             return true;
         }
@@ -232,7 +233,8 @@ public class Stripe {
     public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<SetupIntentResult> callback) {
-        if (mPaymentController.shouldHandleSetupResult(requestCode, resultCode, data)) {
+        if (data!= null &&
+                mPaymentController.shouldHandleSetupResult(requestCode, resultCode, data)) {
             mPaymentController.handleSetupResult(this, data, publishableKey, callback);
             return true;
         }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -233,7 +233,7 @@ public class Stripe {
     public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<SetupIntentResult> callback) {
-        if (data!= null &&
+        if (data != null &&
                 mPaymentController.shouldHandleSetupResult(requestCode, resultCode, data)) {
             mPaymentController.handleSetupResult(this, data, publishableKey, callback);
             return true;

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -22,6 +22,8 @@ import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentIntentParams;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.PaymentMethodCreateParams;
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.SetupIntentParams;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
@@ -591,6 +593,59 @@ public class Stripe {
             APIException {
         return mApiHandler.confirmPaymentIntent(
                 paymentIntentParams,
+                ApiRequest.Options.create(publishableKey, mStripeAccount)
+        );
+    }
+
+    /**
+     * Blocking method to retrieve a {@link SetupIntent} object.
+     * Do not call this on the UI thread or your app will crash.
+     *
+     * @param setupIntentParams a set of params with which to retrieve the Setup Intent
+     * @param publishableKey a publishable API key to use
+     * @return a {@link SetupIntent} or {@code null} if a problem occurred
+     */
+    @Nullable
+    public SetupIntent retrieveSetupIntentSynchronous(
+            @NonNull SetupIntentParams setupIntentParams,
+            @NonNull String publishableKey) throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            APIException {
+        return mApiHandler.retrieveSetupIntent(
+                setupIntentParams,
+                ApiRequest.Options.create(publishableKey, mStripeAccount)
+        );
+    }
+
+    /**
+     * See {@link #retrieveSetupIntentSynchronous(SetupIntentParams, String)}
+     */
+    @Nullable
+    public SetupIntent retrieveSetupIntentSynchronous(
+            @NonNull SetupIntentParams setupIntentParams)
+            throws APIException, AuthenticationException, InvalidRequestException,
+            APIConnectionException {
+        return retrieveSetupIntentSynchronous(setupIntentParams, mDefaultPublishableKey);
+    }
+
+    /**
+     * Blocking method to confirm a {@link SetupIntent} object.
+     * Do not call this on the UI thread or your app will crash.
+     *
+     * @param setupIntentParams a set of params with which to confirm the Setup Intent
+     * @param publishableKey a publishable API key to use
+     * @return a {@link SetupIntent} or {@code null} if a problem occurred
+     */
+    @Nullable
+    public SetupIntent confirmSetupIntentSynchronous(
+            @NonNull SetupIntentParams setupIntentParams,
+            @NonNull String publishableKey) throws AuthenticationException,
+            InvalidRequestException,
+            APIConnectionException,
+            APIException {
+        return mApiHandler.confirmSetupIntent(
+                setupIntentParams,
                 ApiRequest.Options.create(publishableKey, mStripeAccount)
         );
     }

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -132,6 +132,27 @@ public class Stripe {
     }
 
     /**
+     * Confirm and, if necessary, authenticate a {@link SetupIntent}.
+     *
+     * @param activity the {@link Activity} that is launching the payment authentication flow
+     * @param setupIntentParams {@link SetupIntentParams} used to confirm the {@link SetupIntent}
+     */
+    public void confirmSetupIntent(@NonNull Activity activity,
+                                   @NonNull SetupIntentParams setupIntentParams,
+                                   @NonNull String publishableKey) {
+        mPaymentController.startConfirmAndAuth(this, activity,
+                setupIntentParams, publishableKey);
+    }
+
+    /**
+     * See {@link #confirmSetupIntent(Activity, SetupIntentParams, String)}}
+     */
+    public void confirmSetupIntent(@NonNull Activity activity,
+                                   @NonNull SetupIntentParams setupIntentParams) {
+        confirmSetupIntent(activity, setupIntentParams, mDefaultPublishableKey);
+    }
+
+    /**
      * Confirm and, if necessary, authenticate a {@link PaymentIntent}. Used for <a href=
      * "https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow">
      * automatic confirmation</a> flow.
@@ -186,8 +207,8 @@ public class Stripe {
     public boolean onPaymentResult(int requestCode, int resultCode, @Nullable Intent data,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<PaymentIntentResult> callback) {
-        if (data != null && mPaymentController.shouldHandleResult(requestCode, resultCode, data)) {
-            mPaymentController.handleResult(this, data, publishableKey, callback);
+        if (mPaymentController.shouldHandlePaymentResult(requestCode, resultCode, data)) {
+            mPaymentController.handlePaymentResult(this, data, publishableKey, callback);
             return true;
         }
 
@@ -201,6 +222,30 @@ public class Stripe {
             int requestCode, int resultCode, @Nullable Intent data,
             @NonNull ApiResultCallback<PaymentIntentResult> callback) {
         return onPaymentResult(requestCode, resultCode, data, mDefaultPublishableKey, callback);
+    }
+
+    /**
+     * Should be called via {@link Activity#onActivityResult(int, int, Intent)}} to handle the
+     * result of a SetupIntent confirmation
+     * (see {@link #confirmSetupIntent(Activity, SetupIntentParams)})
+     */
+    public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
+                                   @NonNull String publishableKey,
+                                   @NonNull ApiResultCallback<SetupIntentResult> callback) {
+        if (mPaymentController.shouldHandleSetupResult(requestCode, resultCode, data)) {
+            mPaymentController.handleSetupResult(this, data, publishableKey, callback);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * See {@link #onSetupResult(int, int, Intent, String, ApiResultCallback)}
+     */
+    public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
+            @NonNull ApiResultCallback<SetupIntentResult> callback) {
+        return onSetupResult(requestCode, resultCode, data, mDefaultPublishableKey, callback);
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -50,6 +50,7 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
     static final String FIELD_RECEIPT_EMAIL = "receipt_email";
     static final String FIELD_SOURCE = "source";
     static final String FIELD_STATUS = "status";
+    static final String FIELD_SETUP_FUTURE_USAGE = "setup_future_usage";
 
     private static final String FIELD_NEXT_ACTION_TYPE = "type";
 
@@ -70,6 +71,7 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
     @Nullable private final String mReceiptEmail;
     @Nullable private final String mSource;
     @Nullable private final Status mStatus;
+    @Nullable private final Usage mSetupFutureUsage;
 
     @Nullable
     public String getId() {
@@ -226,8 +228,8 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
             @Nullable Map<String, Object> nextAction,
             @Nullable String receiptEmail,
             @Nullable String source,
-            @Nullable Status status
-    ) {
+            @Nullable Status status,
+            @Nullable Usage setupFutureUsage) {
         mId = id;
         mObjectType = objectType;
         mPaymentMethodTypes = paymentMethodTypes;
@@ -244,6 +246,7 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
         mReceiptEmail = receiptEmail;
         mSource = source;
         mStatus = status;
+        mSetupFutureUsage = setupFutureUsage;
         mNextActionType = mNextAction != null ?
                 NextActionType.fromCode((String) mNextAction.get(FIELD_NEXT_ACTION_TYPE)) : null;
     }
@@ -284,6 +287,8 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
         final Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
         final String receiptEmail = optString(jsonObject, FIELD_RECEIPT_EMAIL);
         final Status status = Status.fromCode(optString(jsonObject, FIELD_STATUS));
+        final Usage setupFutureUsage =
+                Usage.fromCode(optString(jsonObject, FIELD_SETUP_FUTURE_USAGE));
         final Map<String, Object> nextAction = optMap(jsonObject, FIELD_NEXT_ACTION);
         final String source = optString(jsonObject, FIELD_SOURCE);
 
@@ -303,22 +308,8 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
                 nextAction,
                 receiptEmail,
                 source,
-                status);
-    }
-
-    @NonNull
-    private static List<String> jsonArrayToList(@Nullable JSONArray jsonArray) {
-        final List<String> list = new ArrayList<>();
-        if (jsonArray != null) {
-            for (int i = 0; i < jsonArray.length(); i++) {
-                try {
-                    list.add(jsonArray.getString(i));
-                } catch (JSONException ignored) {
-                }
-            }
-        }
-
-        return list;
+                status,
+                setupFutureUsage);
     }
 
     @NonNull
@@ -340,6 +331,8 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
         map.put(FIELD_NEXT_ACTION, mNextAction);
         map.put(FIELD_RECEIPT_EMAIL, mReceiptEmail);
         map.put(FIELD_STATUS, mStatus != null ? mStatus.code : null);
+        map.put(FIELD_SETUP_FUTURE_USAGE,
+                mSetupFutureUsage != null ? mSetupFutureUsage.code : null);
         map.put(FIELD_SOURCE, mSource);
         StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
@@ -365,6 +358,7 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
                 && ObjectUtils.equals(mReceiptEmail, paymentIntent.mReceiptEmail)
                 && ObjectUtils.equals(mSource, paymentIntent.mSource)
                 && ObjectUtils.equals(mStatus, paymentIntent.mStatus)
+                && ObjectUtils.equals(mSetupFutureUsage, paymentIntent.mSetupFutureUsage)
                 && ObjectUtils.equals(mPaymentMethodTypes, paymentIntent.mPaymentMethodTypes)
                 && ObjectUtils.equals(mNextAction, paymentIntent.mNextAction)
                 && ObjectUtils.equals(mNextActionType, paymentIntent.mNextActionType);
@@ -374,7 +368,8 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
     public int hashCode() {
         return ObjectUtils.hash(mId, mObjectType, mAmount, mCanceledAt, mCaptureMethod,
                 mClientSecret, mConfirmationMethod, mCreated, mCurrency, mDescription, mLiveMode,
-                mReceiptEmail, mSource, mStatus, mPaymentMethodTypes, mNextAction, mNextActionType);
+                mReceiptEmail, mSource, mStatus, mPaymentMethodTypes, mNextAction,
+                mNextActionType, mSetupFutureUsage);
     }
 
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
@@ -7,7 +7,7 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class PaymentIntentParams {
+public final class PaymentIntentParams implements StripeIntentParams {
 
     public static final String API_PARAM_SOURCE_DATA = "source_data";
     public static final String API_PARAM_PAYMENT_METHOD_DATA = "payment_method_data";

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
@@ -3,6 +3,8 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.stripe.android.utils.ObjectUtils;
+
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -399,5 +401,28 @@ public final class PaymentIntentParams implements StripeIntentParams {
 
     public boolean shouldSavePaymentMethod() {
         return mSavePaymentMethod;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof PaymentIntentParams &&
+                typedEquals((PaymentIntentParams) obj));
+    }
+
+    private boolean typedEquals(@NonNull PaymentIntentParams paymentIntentParams) {
+        return ObjectUtils.equals(mReturnUrl, paymentIntentParams.mReturnUrl)
+                && ObjectUtils.equals(mPaymentMethodCreateParams,
+                paymentIntentParams.mPaymentMethodCreateParams)
+                && ObjectUtils.equals(mSourceParams, paymentIntentParams.mSourceParams)
+                && ObjectUtils.equals(mSourceId, paymentIntentParams.mSourceId)
+                && ObjectUtils.equals(mExtraParams, paymentIntentParams.mExtraParams)
+                && ObjectUtils.equals(mSavePaymentMethod, paymentIntentParams.mSavePaymentMethod)
+                && ObjectUtils.equals(mPaymentMethodId, paymentIntentParams.mPaymentMethodId);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mPaymentMethodCreateParams, mSourceParams, mSourceId,
+                mExtraParams, mReturnUrl, mClientSecret, mPaymentMethodId, mSavePaymentMethod);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntentParams.java
@@ -14,11 +14,7 @@ public final class PaymentIntentParams implements StripeIntentParams {
     public static final String API_PARAM_SOURCE_DATA = "source_data";
     public static final String API_PARAM_PAYMENT_METHOD_DATA = "payment_method_data";
 
-    static final String API_PARAM_PAYMENT_METHOD_ID = "payment_method";
     static final String API_PARAM_SOURCE_ID = "source";
-
-    static final String API_PARAM_RETURN_URL = "return_url";
-    static final String API_PARAM_CLIENT_SECRET = "client_secret";
 
     static final String API_PARAM_SAVE_PAYMENT_METHOD = "save_payment_method";
 

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
@@ -84,6 +84,46 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
         return clientSecret.split("_secret")[0];
     }
 
+    @Nullable
+    public String getId() {
+        return mId;
+    }
+
+    @Nullable
+    public Long getCreated() {
+        return mCreated;
+    }
+
+    @Nullable
+    public String getCustomerId() {
+        return mCustomerId;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return mDescription;
+    }
+
+    @Nullable
+    public Boolean getLiveMode() {
+        return mLiveMode;
+    }
+
+    @Nullable
+    public String getPaymentMethodId() {
+        return mPaymentMethodId;
+    }
+
+    @NonNull
+    public List<String> getPaymentMethodTypes() {
+        return mPaymentMethodTypes;
+    }
+
+    @Nullable
+    public Usage getUsage() {
+        return mUsage;
+    }
+
     @Override
     public boolean requiresAction() {
         return mStatus == Status.RequiresAction;

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
@@ -1,0 +1,247 @@
+package com.stripe.android.model;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.stripe.android.StripeNetworkUtils;
+import com.stripe.android.utils.ObjectUtils;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static com.stripe.android.model.StripeJsonUtils.optBoolean;
+import static com.stripe.android.model.StripeJsonUtils.optLong;
+import static com.stripe.android.model.StripeJsonUtils.optMap;
+import static com.stripe.android.model.StripeJsonUtils.optString;
+
+
+/**
+ * A SetupIntent guides you through the process of setting up a customer's payment credentials for
+ * future payments.
+ */
+public final class SetupIntent extends StripeModel implements StripeIntent {
+    private static final String VALUE_SETUP_INTENT = "setup_intent";
+
+    static final String FIELD_ID = "id";
+    static final String FIELD_OBJECT = "object";
+    static final String FIELD_CREATED = "created";
+    static final String FIELD_CLIENT_SECRET = "client_secret";
+    static final String FIELD_CUSTOMER = "customer";
+    static final String FIELD_DESCRIPTION = "description";
+    static final String FIELD_LIVEMODE = "livemode";
+    static final String FIELD_NEXT_ACTION = "next_action";
+    static final String FIELD_PAYMENT_METHOD_TYPES = "payment_method_types";
+    static final String FIELD_STATUS = "status";
+    static final String FIELD_USAGE = "usage";
+    static final String FIELD_PAYMENT_METHOD = "payment_method";
+
+    private static final String FIELD_NEXT_ACTION_TYPE = "type";
+
+    @Nullable private final String mId;
+    @Nullable private final String mObjectType;
+    @Nullable private final Long mCreated;
+    @Nullable private final String mClientSecret;
+    @Nullable private final String mCustomerId;
+    @Nullable private final String mDescription;
+    @Nullable private final Boolean mLiveMode;
+    @Nullable private final Map<String, Object> mNextAction;
+    @Nullable private final NextActionType mNextActionType;
+    @Nullable private final String mPaymentMethodId;
+    @NonNull private final List<String> mPaymentMethodTypes;
+    @Nullable private final Status mStatus;
+    @Nullable private final Usage mUsage;
+
+    private SetupIntent(@Nullable String id, @Nullable String objectType,
+                        @Nullable Long created, @Nullable String clientSecret,
+                        @Nullable String customerId, @Nullable String description,
+                        @Nullable Boolean liveMode, @Nullable Map<String, Object> nextAction,
+                        @Nullable String paymentMethodId, @NonNull List<String> paymentMethodTypes,
+                        @Nullable Status status, @Nullable Usage usage) {
+        mId = id;
+        mObjectType = objectType;
+        mCreated = created;
+        mClientSecret = clientSecret;
+        mCustomerId = customerId;
+        mDescription = description;
+        mLiveMode = liveMode;
+        mNextAction = nextAction;
+        mNextActionType = mNextAction != null ?
+                NextActionType.fromCode((String) mNextAction.get(FIELD_NEXT_ACTION_TYPE)) : null;
+        mPaymentMethodId = paymentMethodId;
+        mPaymentMethodTypes = paymentMethodTypes;
+        mStatus = status;
+        mUsage = usage;
+    }
+
+    @NonNull
+    public static String parseIdFromClientSecret(@NonNull String clientSecret) {
+        return clientSecret.split("_secret")[0];
+    }
+
+    @Override
+    public boolean requiresAction() {
+        return mStatus == Status.RequiresAction;
+    }
+
+    @Override
+    public boolean requiresConfirmation() {
+        return mStatus == Status.RequiresConfirmation;
+    }
+
+    @Nullable
+    @Override
+    public NextActionType getNextActionType() {
+        return mNextActionType;
+    }
+
+    @Nullable
+    @Override
+    public RedirectData getRedirectData() {
+        if (NextActionType.RedirectToUrl != mNextActionType) {
+            return null;
+        }
+
+        final Map<String, Object> nextAction;
+
+        if (Status.RequiresAction == mStatus) {
+            nextAction = mNextAction;
+        } else {
+            nextAction = null;
+        }
+
+        if (nextAction == null) {
+            return null;
+        }
+
+        final NextActionType nextActionType = NextActionType
+                .fromCode((String) nextAction.get(FIELD_NEXT_ACTION_TYPE));
+        if (NextActionType.RedirectToUrl == nextActionType) {
+            final Object redirectToUrl = nextAction.get(nextActionType.code);
+            if (redirectToUrl instanceof Map) {
+                return RedirectData.create((Map) redirectToUrl);
+            }
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getClientSecret() {
+        return mClientSecret;
+    }
+
+    @Nullable
+    public Uri getRedirectUrl() {
+        final RedirectData redirectData = getRedirectData();
+        if (redirectData == null) {
+            return null;
+        }
+
+        return redirectData.url;
+    }
+
+    @Nullable
+    @Override
+    public SdkData getStripeSdkData() {
+        if (mNextAction == null || NextActionType.UseStripeSdk != mNextActionType) {
+            return null;
+        }
+
+        //noinspection ConstantConditions,unchecked
+        return new SdkData((Map<String, ?>) mNextAction.get(NextActionType.UseStripeSdk.code));
+    }
+
+    @Nullable
+    @Override
+    public Status getStatus() {
+        return mStatus;
+    }
+
+    @Nullable
+    public static SetupIntent fromString(@Nullable String jsonString) {
+        try {
+            return fromJson(new JSONObject(jsonString));
+        } catch (JSONException ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
+    public static SetupIntent fromJson(@Nullable JSONObject jsonObject) {
+        if (jsonObject == null ||
+                !VALUE_SETUP_INTENT.equals(jsonObject.optString(FIELD_OBJECT))) {
+            return null;
+        }
+
+        final String id = optString(jsonObject, FIELD_ID);
+        final String objectType = optString(jsonObject, FIELD_OBJECT);
+        final Long created = optLong(jsonObject, FIELD_CREATED);
+        final String clientSecret = optString(jsonObject, FIELD_CLIENT_SECRET);
+        final String customerId = optString(jsonObject, FIELD_CUSTOMER);
+        final String description = optString(jsonObject, FIELD_DESCRIPTION);
+        final Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
+        final String paymentMethodId = optString(jsonObject, FIELD_PAYMENT_METHOD);
+        final List<String> paymentMethodTypes = jsonArrayToList(
+                jsonObject.optJSONArray(FIELD_PAYMENT_METHOD_TYPES));
+        final Status status = Status.fromCode(optString(jsonObject, FIELD_STATUS));
+        final Map<String, Object> nextAction = optMap(jsonObject, FIELD_NEXT_ACTION);
+        final Usage usage = Usage.fromCode(optString(jsonObject, FIELD_USAGE));
+        return new SetupIntent(id, objectType, created, clientSecret, customerId, description,
+                livemode, nextAction, paymentMethodId, paymentMethodTypes, status, usage);
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> toMap() {
+        final AbstractMap<String, Object> map = new HashMap<>();
+        map.put(FIELD_ID, mId);
+        map.put(FIELD_OBJECT, mObjectType);
+        map.put(FIELD_PAYMENT_METHOD, mPaymentMethodId);
+        map.put(FIELD_PAYMENT_METHOD_TYPES, mPaymentMethodTypes);
+        map.put(FIELD_CLIENT_SECRET, mClientSecret);
+        map.put(FIELD_CREATED, mCreated);
+        map.put(FIELD_CUSTOMER, mCustomerId);
+        map.put(FIELD_DESCRIPTION, mDescription);
+        map.put(FIELD_LIVEMODE, mLiveMode);
+        map.put(FIELD_NEXT_ACTION, mNextAction);
+        map.put(FIELD_STATUS, mStatus != null ? mStatus.code : null);
+        map.put(FIELD_USAGE, mUsage != null ? mUsage.code : null);
+        StripeNetworkUtils.removeNullAndEmptyParams(map);
+        return map;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof SetupIntent && typedEquals((SetupIntent) obj));
+    }
+
+    private boolean typedEquals(@NonNull SetupIntent setupIntent) {
+        return ObjectUtils.equals(mId, setupIntent.mId)
+                && ObjectUtils.equals(mObjectType, setupIntent.mObjectType)
+                && ObjectUtils.equals(mClientSecret, setupIntent.mClientSecret)
+                && ObjectUtils.equals(mCreated, setupIntent.mCreated)
+                && ObjectUtils.equals(mCustomerId, setupIntent.mCustomerId)
+                && ObjectUtils.equals(mDescription, setupIntent.mDescription)
+                && ObjectUtils.equals(mLiveMode, setupIntent.mLiveMode)
+                && ObjectUtils.equals(mStatus, setupIntent.mStatus)
+                && ObjectUtils.equals(mUsage, setupIntent.mUsage)
+                && ObjectUtils.equals(mPaymentMethodId, setupIntent.mPaymentMethodId)
+                && ObjectUtils.equals(mPaymentMethodTypes, setupIntent.mPaymentMethodTypes)
+                && ObjectUtils.equals(mNextAction, setupIntent.mNextAction)
+                && ObjectUtils.equals(mNextActionType, setupIntent.mNextActionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mId, mObjectType, mCustomerId, mClientSecret, mCreated,
+                mDescription, mLiveMode, mStatus, mPaymentMethodId, mPaymentMethodTypes,
+                mNextAction, mNextActionType, mUsage);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.stripe.android.ObjectBuilder;
 import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
@@ -45,39 +46,36 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
 
     @Nullable private final String mId;
     @Nullable private final String mObjectType;
-    @Nullable private final Long mCreated;
+    private final long mCreated;
     @Nullable private final String mClientSecret;
     @Nullable private final String mCustomerId;
     @Nullable private final String mDescription;
-    @Nullable private final Boolean mLiveMode;
+    private final boolean mLiveMode;
     @Nullable private final Map<String, Object> mNextAction;
     @Nullable private final NextActionType mNextActionType;
     @Nullable private final String mPaymentMethodId;
-    @NonNull private final List<String> mPaymentMethodTypes;
+    @Nullable private final List<String> mPaymentMethodTypes;
     @Nullable private final Status mStatus;
     @Nullable private final Usage mUsage;
 
-    private SetupIntent(@Nullable String id, @Nullable String objectType,
-                        @Nullable Long created, @Nullable String clientSecret,
-                        @Nullable String customerId, @Nullable String description,
-                        @Nullable Boolean liveMode, @Nullable Map<String, Object> nextAction,
-                        @Nullable String paymentMethodId, @NonNull List<String> paymentMethodTypes,
-                        @Nullable Status status, @Nullable Usage usage) {
-        mId = id;
-        mObjectType = objectType;
-        mCreated = created;
-        mClientSecret = clientSecret;
-        mCustomerId = customerId;
-        mDescription = description;
-        mLiveMode = liveMode;
-        mNextAction = nextAction;
+    private SetupIntent(@NonNull Builder builder) {
+        mId = builder.mId;
+        mObjectType = builder.mObjectType;
+        mCreated = builder.mCreated;
+        mClientSecret = builder.mClientSecret;
+        mCustomerId = builder.mCustomerId;
+        mDescription = builder.mDescription;
+        mLiveMode = builder.mLiveMode;
+        mNextAction = builder.mNextAction;
         mNextActionType = mNextAction != null ?
                 NextActionType.fromCode((String) mNextAction.get(FIELD_NEXT_ACTION_TYPE)) : null;
-        mPaymentMethodId = paymentMethodId;
-        mPaymentMethodTypes = paymentMethodTypes;
-        mStatus = status;
-        mUsage = usage;
+        mPaymentMethodId = builder.mPaymentMethodId;
+        mPaymentMethodTypes = builder.mPaymentMethodTypes;
+        mStatus = builder.mStatus;
+        mUsage = builder.mUsage;
     }
+
+
 
     @NonNull
     public static String parseIdFromClientSecret(@NonNull String clientSecret) {
@@ -89,8 +87,7 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
         return mId;
     }
 
-    @Nullable
-    public Long getCreated() {
+    public long getCreated() {
         return mCreated;
     }
 
@@ -104,8 +101,7 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
         return mDescription;
     }
 
-    @Nullable
-    public Boolean getLiveMode() {
+    public boolean getLiveMode() {
         return mLiveMode;
     }
 
@@ -220,21 +216,21 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
             return null;
         }
 
-        final String id = optString(jsonObject, FIELD_ID);
-        final String objectType = optString(jsonObject, FIELD_OBJECT);
-        final Long created = optLong(jsonObject, FIELD_CREATED);
-        final String clientSecret = optString(jsonObject, FIELD_CLIENT_SECRET);
-        final String customerId = optString(jsonObject, FIELD_CUSTOMER);
-        final String description = optString(jsonObject, FIELD_DESCRIPTION);
-        final Boolean livemode = optBoolean(jsonObject, FIELD_LIVEMODE);
-        final String paymentMethodId = optString(jsonObject, FIELD_PAYMENT_METHOD);
-        final List<String> paymentMethodTypes = jsonArrayToList(
-                jsonObject.optJSONArray(FIELD_PAYMENT_METHOD_TYPES));
-        final Status status = Status.fromCode(optString(jsonObject, FIELD_STATUS));
-        final Map<String, Object> nextAction = optMap(jsonObject, FIELD_NEXT_ACTION);
-        final Usage usage = Usage.fromCode(optString(jsonObject, FIELD_USAGE));
-        return new SetupIntent(id, objectType, created, clientSecret, customerId, description,
-                livemode, nextAction, paymentMethodId, paymentMethodTypes, status, usage);
+        return new Builder()
+                .setId(optString(jsonObject, FIELD_ID))
+                .setObjectType(optString(jsonObject, FIELD_OBJECT))
+                .setCreated(jsonObject.optLong(FIELD_CREATED))
+                .setClientSecret(optString(jsonObject, FIELD_CLIENT_SECRET))
+                .setCustomerId(optString(jsonObject, FIELD_CUSTOMER))
+                .setDescription(optString(jsonObject, FIELD_DESCRIPTION))
+                .setLiveMode(jsonObject.optBoolean(FIELD_LIVEMODE))
+                .setPaymentMethodId(optString(jsonObject, FIELD_PAYMENT_METHOD))
+                .setPaymentMethodTypes(jsonArrayToList(
+                        jsonObject.optJSONArray(FIELD_PAYMENT_METHOD_TYPES)))
+                .setStatus(Status.fromCode(optString(jsonObject, FIELD_STATUS)))
+                .setUsage(Usage.fromCode(optString(jsonObject, FIELD_USAGE)))
+                .setNextAction(optMap(jsonObject, FIELD_NEXT_ACTION))
+                .build();
     }
 
     @NonNull
@@ -283,5 +279,98 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
         return ObjectUtils.hash(mId, mObjectType, mCustomerId, mClientSecret, mCreated,
                 mDescription, mLiveMode, mStatus, mPaymentMethodId, mPaymentMethodTypes,
                 mNextAction, mNextActionType, mUsage);
+    }
+
+    static final class Builder implements ObjectBuilder<SetupIntent> {
+        @Nullable String mId;
+        @Nullable String mObjectType;
+        long mCreated;
+        @Nullable String mClientSecret;
+        @Nullable String mCustomerId;
+        @Nullable String mDescription;
+        boolean mLiveMode;
+        @Nullable Map<String, Object> mNextAction;
+        @Nullable String mPaymentMethodId;
+        @Nullable List<String> mPaymentMethodTypes;
+        @Nullable Status mStatus;
+        @Nullable Usage mUsage;
+
+        @NonNull
+        Builder setId(@Nullable String id) {
+            mId = id;
+            return this;
+        }
+
+        @NonNull
+        Builder setObjectType(@Nullable String objectType) {
+            mObjectType = objectType;
+            return this;
+        }
+
+        @NonNull
+        Builder setCreated(long created) {
+            mCreated = created;
+            return this;
+        }
+
+        @NonNull
+        Builder setClientSecret(@Nullable String clientSecret) {
+            mClientSecret = clientSecret;
+            return this;
+        }
+
+        @NonNull
+        Builder setCustomerId(@Nullable String customerId) {
+            mCustomerId = customerId;
+            return this;
+        }
+
+        @NonNull
+        Builder setDescription(@Nullable String description) {
+            mDescription = description;
+            return this;
+        }
+
+        @NonNull
+        Builder setLiveMode(boolean liveMode) {
+            mLiveMode = liveMode;
+            return this;
+        }
+
+        @NonNull
+        Builder setNextAction(@Nullable Map<String, Object> nextAction) {
+            mNextAction = nextAction;
+            return this;
+        }
+
+        @NonNull
+        Builder setPaymentMethodId(@Nullable String paymentMethodId) {
+            mPaymentMethodId = paymentMethodId;
+            return this;
+        }
+
+        @NonNull
+        Builder setPaymentMethodTypes(@Nullable List<String> paymentMethodTypes) {
+            mPaymentMethodTypes = paymentMethodTypes;
+            return this;
+        }
+
+        @NonNull
+        Builder setStatus(@Nullable Status status) {
+            mStatus = status;
+            return this;
+        }
+
+        @NonNull
+        Builder setUsage(@Nullable Usage usage) {
+            mUsage = usage;
+            return this;
+        }
+
+        @NonNull
+        @Override
+        public SetupIntent build() {
+            return new SetupIntent(this);
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
@@ -7,13 +7,13 @@ import android.support.annotation.Nullable;
 import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import static com.stripe.android.model.StripeJsonUtils.optBoolean;
 import static com.stripe.android.model.StripeJsonUtils.optLong;

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -7,7 +7,7 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class SetupIntentParams {
+public final class SetupIntentParams implements StripeIntentParams {
 
     static final String API_PARAM_CLIENT_SECRET = "client_secret";
     static final String API_PARAM_RETURN_URL = "return_url";

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -3,6 +3,8 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.stripe.android.utils.ObjectUtils;
+
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -136,5 +138,22 @@ public final class SetupIntentParams implements StripeIntentParams {
         networkReadyMap.put(API_PARAM_CLIENT_SECRET, mClientSecret);
 
         return networkReadyMap;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof SetupIntentParams &&
+                typedEquals((SetupIntentParams) obj));
+    }
+
+    private boolean typedEquals(@NonNull SetupIntentParams setupIntentParams) {
+        return ObjectUtils.equals(mReturnUrl, setupIntentParams.mReturnUrl)
+                && ObjectUtils.equals(mClientSecret, setupIntentParams.mClientSecret)
+                && ObjectUtils.equals(mPaymentMethodId, setupIntentParams.mPaymentMethodId);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mReturnUrl, mClientSecret, mPaymentMethodId);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -1,0 +1,127 @@
+package com.stripe.android.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SetupIntentParams {
+
+    static final String API_PARAM_CLIENT_SECRET = "client_secret";
+    static final String API_PARAM_RETURN_URL = "return_url";
+    static final String API_PARAM_PAYMENT_METHOD_ID = "payment_method";
+
+    @Nullable private String mClientSecret;
+    @Nullable private String mPaymentMethodId;
+    @Nullable private String mReturnUrl;
+
+    private SetupIntentParams() {
+
+    }
+
+    /**
+     * Create the parameters necessary for confirming a PaymentIntent while attaching a
+     * PaymentMethod that already exits.
+     *
+     * @param paymentMethodId the ID of the PaymentMethod that is being attached to the
+     *                        PaymentIntent being confirmed
+     * @param clientSecret client secret from the PaymentIntent being confirmed
+     * @param returnUrl the URL the customer should be redirected to after the authorization
+     *                  process
+     * @return params that can be use to confirm a PaymentIntent
+     */
+    @NonNull
+    public static SetupIntentParams createConfirmSetupIntenParamsWithPaymentMethodId(
+            @Nullable String paymentMethodId,
+            @NonNull String clientSecret,
+            @NonNull String returnUrl) {
+        return new SetupIntentParams()
+                .setPaymentMethodId(paymentMethodId)
+                .setClientSecret(clientSecret)
+                .setReturnUrl(returnUrl);
+    }
+
+    /**
+     * Sets the client secret that is used to authenticate actions on this SetupIntent
+     * @param clientSecret client secret associated with this SetupIntent
+     * @return {@code this}, for chaining purposes
+     */
+    public SetupIntentParams setClientSecret(@NonNull String clientSecret) {
+        mClientSecret = clientSecret;
+        return this;
+    }
+
+    /**
+     * @return client secret associated with the SetupIntent, used to identify the SetupIntent
+     * and authenticate actions.
+     */
+    @Nullable
+    public String getClientSecret() {
+        return mClientSecret;
+    }
+
+    /**
+     * Sets a pre-existing PaymentMethod that will be attached to this SetupIntent
+     *
+     * @param paymentMethodId The ID of the PaymentMethod that is being attached to this
+     *                        SetupIntent.
+     * @return {@code this}, for chaining purposes
+     */
+    @NonNull
+    public SetupIntentParams setPaymentMethodId(@Nullable String paymentMethodId) {
+        mPaymentMethodId = paymentMethodId;
+        return this;
+    }
+
+    /**
+     * @return the ID of the existing PaymentMethod that is being attached to this SetupIntent.
+     */
+    @Nullable
+    public String getPaymentMethodId() {
+        return mPaymentMethodId;
+    }
+
+    /**
+     * @param returnUrl the URL the customer should be redirected to after the authorization
+     *                  process
+     * @return {@code this}, for chaining purposes
+     */
+    @NonNull
+    public SetupIntentParams setReturnUrl(@NonNull String returnUrl) {
+        mReturnUrl = returnUrl;
+        return this;
+    }
+
+    /**
+     * @return  the URL the customer should be redirected to after the authorization process
+     */
+    @Nullable
+    public String getReturnUrl() {
+        return mReturnUrl;
+    }
+
+    /**
+     * Create a string-keyed map representing this object that is
+     * ready to be sent over the network.
+     *
+     * @return a String-keyed map
+     */
+    @NonNull
+    public Map<String, Object> toParamMap() {
+        final AbstractMap<String, Object> networkReadyMap = new HashMap<>();
+
+        if (mPaymentMethodId != null) {
+            networkReadyMap.put(API_PARAM_PAYMENT_METHOD_ID, mPaymentMethodId);
+        }
+
+        if (mReturnUrl != null) {
+            networkReadyMap.put(API_PARAM_RETURN_URL, mReturnUrl);
+        }
+
+        networkReadyMap.put(API_PARAM_CLIENT_SECRET, mClientSecret);
+
+        return networkReadyMap;
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -47,7 +47,7 @@ public final class SetupIntentParams implements StripeIntentParams {
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
-    public static SetupIntentParams createConfirmSetupIntenParamsWithPaymentMethodId(
+    public static SetupIntentParams createConfirmSetupIntentParamsWithPaymentMethodId(
             @Nullable String paymentMethodId,
             @NonNull String clientSecret,
             @NonNull String returnUrl) {

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -26,10 +26,10 @@ public final class SetupIntentParams implements StripeIntentParams {
      * PaymentMethod that already exits.
      *
      * @param paymentMethodId the ID of the PaymentMethod that is being attached to the
-     *                        PaymentIntent being confirmed
+     *         PaymentIntent being confirmed
      * @param clientSecret client secret from the PaymentIntent being confirmed
      * @param returnUrl the URL the customer should be redirected to after the authorization
-     *                  process
+     *         process
      * @return params that can be use to confirm a PaymentIntent
      */
     @NonNull
@@ -44,7 +44,20 @@ public final class SetupIntentParams implements StripeIntentParams {
     }
 
     /**
+     * Create the parameters necessary for retrieving the details of SetupIntent
+     *
+     * @param clientSecret client secret from the SetupIntent that is being retrieved
+     * @return params that can be used to retrieve a SetupIntent
+     */
+    @NonNull
+    public static SetupIntentParams createRetrieveSetupIntentParams(
+            @NonNull String clientSecret) {
+        return new SetupIntentParams().setClientSecret(clientSecret);
+    }
+
+    /**
      * Sets the client secret that is used to authenticate actions on this SetupIntent
+     *
      * @param clientSecret client secret associated with this SetupIntent
      * @return {@code this}, for chaining purposes
      */
@@ -55,7 +68,7 @@ public final class SetupIntentParams implements StripeIntentParams {
 
     /**
      * @return client secret associated with the SetupIntent, used to identify the SetupIntent
-     * and authenticate actions.
+     *         and authenticate actions.
      */
     @Nullable
     public String getClientSecret() {
@@ -66,7 +79,7 @@ public final class SetupIntentParams implements StripeIntentParams {
      * Sets a pre-existing PaymentMethod that will be attached to this SetupIntent
      *
      * @param paymentMethodId The ID of the PaymentMethod that is being attached to this
-     *                        SetupIntent.
+     *         SetupIntent.
      * @return {@code this}, for chaining purposes
      */
     @NonNull
@@ -85,7 +98,7 @@ public final class SetupIntentParams implements StripeIntentParams {
 
     /**
      * @param returnUrl the URL the customer should be redirected to after the authorization
-     *                  process
+     *         process
      * @return {@code this}, for chaining purposes
      */
     @NonNull
@@ -95,7 +108,7 @@ public final class SetupIntentParams implements StripeIntentParams {
     }
 
     /**
-     * @return  the URL the customer should be redirected to after the authorization process
+     * @return the URL the customer should be redirected to after the authorization process
      */
     @Nullable
     public String getReturnUrl() {

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -11,10 +11,6 @@ import java.util.Map;
 
 public final class SetupIntentParams implements StripeIntentParams {
 
-    static final String API_PARAM_CLIENT_SECRET = "client_secret";
-    static final String API_PARAM_RETURN_URL = "return_url";
-    static final String API_PARAM_PAYMENT_METHOD_ID = "payment_method";
-
     @Nullable private String mClientSecret;
     @Nullable private String mPaymentMethodId;
     @Nullable private String mReturnUrl;

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntentParams.java
@@ -24,6 +24,18 @@ public final class SetupIntentParams implements StripeIntentParams {
     }
 
     /**
+     * Create a custom {@link SetupIntentParams}. Incorrect attributes may result in errors
+     * when connecting to Stripe's API.
+     *
+     * @return an empty Params object. Call the setter methods on this class to specific values on
+     *         the params
+     */
+    @NonNull
+    public static SetupIntentParams createCustomParams() {
+        return new SetupIntentParams();
+    }
+
+    /**
      * Create the parameters necessary for confirming a PaymentIntent while attaching a
      * PaymentMethod that already exits.
      *

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
@@ -108,6 +108,44 @@ public interface StripeIntent {
         }
     }
 
+    /**
+     * See https://stripe.com/docs/api/setup_intents/object#setup_intent_object-usage and
+     * https://stripe.com/docs/payments/payment-intents/off-session
+     */
+    enum Usage {
+        OnSession("on_session"),
+        OffSession("off_session"),
+        OneTime("one_time");
+
+        @NonNull
+        public final String code;
+
+        Usage(@NonNull String code) {
+            this.code = code;
+        }
+
+        @Nullable
+        public static Usage fromCode(@Nullable String code) {
+            if (code == null) {
+                return null;
+            }
+
+            for (Usage usage : values()) {
+                if (usage.code.equals(code)) {
+                    return usage;
+                }
+            }
+
+            return null;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
+
     final class SdkData {
         private static final String FIELD_TYPE = "type";
 

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntentParams.java
@@ -7,6 +7,10 @@ import java.util.Map;
 
 public interface StripeIntentParams {
 
+    String API_PARAM_CLIENT_SECRET = "client_secret";
+    String API_PARAM_RETURN_URL = "return_url";
+    String API_PARAM_PAYMENT_METHOD_ID = "payment_method";
+
     @NonNull
     Map<String, Object> toParamMap();
 

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntentParams.java
@@ -1,0 +1,15 @@
+package com.stripe.android.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.Map;
+
+public interface StripeIntentParams {
+
+    @NonNull
+    Map<String, Object> toParamMap();
+
+    @Nullable
+    String getClientSecret();
+}

--- a/stripe/src/main/java/com/stripe/android/model/StripeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeModel.java
@@ -3,7 +3,12 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONException;
 
 /**
  * Represents a JSON model used in the Stripe Api.
@@ -18,4 +23,19 @@ public abstract class StripeModel {
 
     @Override
     public abstract boolean equals(@Nullable Object obj);
+
+    @NonNull
+    static List<String> jsonArrayToList(@Nullable JSONArray jsonArray) {
+        final List<String> list = new ArrayList<>();
+        if (jsonArray != null) {
+            for (int i = 0; i < jsonArray.length(); i++) {
+                try {
+                    list.add(jsonArray.getString(i));
+                } catch (JSONException ignored) {
+                }
+            }
+        }
+
+        return list;
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/model/StripeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeModel.java
@@ -3,12 +3,12 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.json.JSONArray;
-import org.json.JSONException;
 
 /**
  * Represents a JSON model used in the Stripe Api.

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -37,6 +37,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -186,6 +187,32 @@ public class PaymentControllerTest {
         verify(mApiHandler).complete3ds2Auth(eq("src_123"),
                 eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
                 ArgumentMatchers.<ApiResultCallback<Boolean>>any());
+    }
+
+    @Test
+    public void createPaymentIntentParams_shouldCreateParams() {
+        final Intent data = new Intent()
+                .putExtra(StripeIntentResultExtras.CLIENT_SECRET,
+                        PaymentIntentFixtures.PI_REQUIRES_VISA_3DS2.getClientSecret());
+
+        assertNotNull(PaymentIntentFixtures.PI_REQUIRES_VISA_3DS2.getClientSecret());
+        final PaymentIntentParams expectedPaymentParams = PaymentIntentParams.createCustomParams()
+                .setClientSecret(PaymentIntentFixtures.PI_REQUIRES_VISA_3DS2.getClientSecret());
+
+        assertEquals(expectedPaymentParams, mController.createPaymentIntentParams(data));
+    }
+
+    @Test
+    public void createSetupIntentParams_shouldCreateParams() {
+        final Intent data = new Intent()
+                .putExtra(StripeIntentResultExtras.CLIENT_SECRET,
+                        SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
+
+        assertNotNull(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
+        final SetupIntentParams expectedSetupParams = SetupIntentParams.createCustomParams()
+                .setClientSecret(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
+
+        assertEquals(expectedSetupParams, mController.createSetupIntentParams(data));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -245,6 +245,8 @@ public class PaymentControllerTest {
     public void handleSetupResult_shouldCallbackOnSuccess()
             throws APIException, AuthenticationException, InvalidRequestException,
             APIConnectionException {
+        assertNotNull(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
+        
         final Intent intent = new Intent()
                 .putExtra(StripeIntentResultExtras.AUTH_STATUS,
                         StripeIntentResult.Status.SUCCEEDED)

--- a/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.java
+++ b/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.java
@@ -1,6 +1,5 @@
 package com.stripe.android;
 
-import com.stripe.android.model.SetupIntent;
 import com.stripe.android.model.SetupIntentFixtures;
 
 import org.junit.Test;

--- a/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.java
+++ b/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.java
@@ -1,0 +1,20 @@
+package com.stripe.android;
+
+import com.stripe.android.model.SetupIntent;
+import com.stripe.android.model.SetupIntentFixtures;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SetupIntentResultTest {
+
+    @Test
+    public void testBuilder() {
+        assertEquals(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
+                new SetupIntentResult.Builder()
+                        .setSetupIntent(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
+                        .build()
+                        .getIntent());
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -55,7 +55,7 @@ public class StripePaymentAuthTest {
     public void confirmSetupIntent_shouldConfirmAndAuth() {
         final Stripe stripe = createStripe();
         final SetupIntentParams setupIntentParams =
-                SetupIntentParams.createConfirmSetupIntenParamsWithPaymentMethodId(
+                SetupIntentParams.createConfirmSetupIntentParamsWithPaymentMethodId(
                         "pm_card_threeDSecure2Required",
                         "client_secret",
                         "yourapp://post-authentication-return-url");

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.stripe.android.model.PaymentIntentFixtures;
 import com.stripe.android.model.PaymentIntentParams;
+import com.stripe.android.model.SetupIntentParams;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +29,8 @@ public class StripePaymentAuthTest {
 
     @Mock private Activity mActivity;
     @Mock private PaymentController mPaymentController;
-    @Mock private ApiResultCallback<PaymentIntentResult> mCallback;
+    @Mock private ApiResultCallback<PaymentIntentResult> mPaymentCallback;
+    @Mock private ApiResultCallback<SetupIntentResult> mSetupCallback;
 
     @Before
     public void setup() {
@@ -50,6 +52,19 @@ public class StripePaymentAuthTest {
     }
 
     @Test
+    public void confirmSetupIntent_shouldConfirmAndAuth() {
+        final Stripe stripe = createStripe();
+        final SetupIntentParams setupIntentParams =
+                SetupIntentParams.createConfirmSetupIntenParamsWithPaymentMethodId(
+                        "pm_card_threeDSecure2Required",
+                        "client_secret",
+                        "yourapp://post-authentication-return-url");
+        stripe.confirmSetupIntent(mActivity, setupIntentParams);
+        verify(mPaymentController).startConfirmAndAuth(eq(stripe), eq(mActivity),
+                eq(setupIntentParams), eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY));
+    }
+
+    @Test
     public void authenticatePayment_shouldAuth() {
         final Stripe stripe = createStripe();
         stripe.authenticatePayment(mActivity, PaymentIntentFixtures.PI_REQUIRES_VISA_3DS2);
@@ -63,15 +78,29 @@ public class StripePaymentAuthTest {
     @Test
     public void onPaymentResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
         final Intent data = new Intent();
-        when(mPaymentController.shouldHandleResult(
-                PaymentController.REQUEST_CODE, Activity.RESULT_OK, data))
+        when(mPaymentController.shouldHandlePaymentResult(
+                PaymentController.PAYMENT_REQUEST_CODE, Activity.RESULT_OK, data))
                 .thenReturn(true);
         final Stripe stripe = createStripe();
-        stripe.onPaymentResult(PaymentController.REQUEST_CODE, Activity.RESULT_OK,
-                data, mCallback);
+        stripe.onPaymentResult(PaymentController.PAYMENT_REQUEST_CODE, Activity.RESULT_OK,
+                data, mPaymentCallback);
 
-        verify(mPaymentController).handleResult(stripe, data,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mCallback);
+        verify(mPaymentController).handlePaymentResult(stripe, data,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mPaymentCallback);
+    }
+
+    @Test
+    public void onSetupResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
+        final Intent data = new Intent();
+        when(mPaymentController.shouldHandleSetupResult(
+                PaymentController.SETUP_REQUEST_CODE, Activity.RESULT_OK, data))
+                .thenReturn(true);
+        final Stripe stripe = createStripe();
+        stripe.onSetupResult(PaymentController.SETUP_REQUEST_CODE, Activity.RESULT_OK,
+                data, mSetupCallback);
+
+        verify(mPaymentController).handleSetupResult(stripe, data,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mSetupCallback);
     }
 
     @NonNull

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentFixtures.java
@@ -1,0 +1,37 @@
+package com.stripe.android.model;
+
+import android.support.annotation.NonNull;
+
+import java.util.Objects;
+
+public class SetupIntentFixtures {
+
+    @NonNull
+    public static final String SI_NEXT_ACTION_REDIRECT_JSON = "{\n" +
+            "  \"id\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV\",\n" +
+            "  \"object\": \"setup_intent\",\n" +
+            "  \"cancellation_reason\": null,\n" +
+            "  \"client_secret\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y\",\n" +
+            "  \"created\": 1561677666,\n" +
+            "  \"description\": \"a description\",\n" +
+            "  \"last_setup_error\": null,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"next_action\": {\n" +
+            "    \"redirect_to_url\": {\n" +
+            "      \"return_url\": \"stripe://setup_intent_return\",\n" +
+            "      \"url\": \"https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02\"\n" +
+            "    },\n" +
+            "    \"type\": \"redirect_to_url\"\n" +
+            "  },\n" +
+            "  \"payment_method\": \"pm_1EqTSoGMT9dGPIDG7dgafX1H\",\n" +
+            "  \"payment_method_types\": [\n" +
+            "    \"card\"\n" +
+            "  ],\n" +
+            "  \"status\": \"requires_action\",\n" +
+            "  \"usage\": \"off_session\"\n" +
+            "}";
+
+    @NonNull
+    public static final SetupIntent SI_NEXT_ACTION_REDIRECT =
+            Objects.requireNonNull(SetupIntent.fromString(SI_NEXT_ACTION_REDIRECT_JSON));
+}

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
@@ -37,6 +37,8 @@ public class SetupIntentTest {
 
         final StripeIntent.RedirectData redirectData = setupIntent.getRedirectData();
         assertNotNull(redirectData);
+        assertNotNull(redirectData.returnUrl);
+        assertNotNull(setupIntent.getRedirectUrl());
         assertEquals("stripe://setup_intent_return", redirectData.returnUrl.toString());
         assertEquals("https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B" +
                 "?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02", redirectData.url.toString());

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
@@ -1,0 +1,63 @@
+package com.stripe.android.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SetupIntentTest {
+
+    private static final String SETUP_INTENT_NEXT_ACTION_REDIRECT = "{\n" +
+            "  \"id\": \"seti_1Eq6tqGMT9dGPIDGhdilBKsu\",\n" +
+            "  \"object\": \"setup_intent\",\n" +
+            "  \"cancellation_reason\": null,\n" +
+            "  \"client_secret\": \"seti_1Eq6tqGMT9dGPIDGhdilBKsu_secret_FKmSUxflgdu2gMlMLNzj89t90SRIZTn\",\n" +
+            "  \"created\": 1561677666,\n" +
+            "  \"description\": \"a description\",\n" +
+            "  \"last_setup_error\": null,\n" +
+            "  \"livemode\": false,\n" +
+            "  \"next_action\": {\n" +
+            "    \"type\": \"use_stripe_sdk\",\n" +
+            "    \"use_stripe_sdk\": {\n" +
+            "      \"type\": \"three_d_secure_redirect\",\n" +
+            "      \"stripe_js\": \"https://hooks.stripe.com/redirect/authenticate/src_1Eq6tzGMT9dGPIDGL26pAgjJ?client_secret=src_client_secret_FKmSF6ewY3iTFmfdIT5784LI\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"payment_method\": \"pm_1Eq6tlGMT9dGPIDGFkaLeB0v\",\n" +
+            "  \"payment_method_types\": [\n" +
+            "    \"card\"\n" +
+            "  ],\n" +
+            "  \"status\": \"requires_action\",\n" +
+            "  \"usage\": \"off_session\"\n" +
+            "}";
+
+
+    @Test
+    public void parseIdFromClientSecret_correctIdParsed() {
+        final String id = SetupIntent.parseIdFromClientSecret(
+                "seti_1Eq5kyGMT9dGPIDGxiSp4cce_secret_FKlHb3yTI0YZWe4iqghS8ZXqwwMoMmy");
+        assertEquals("seti_1Eq5kyGMT9dGPIDGxiSp4cce", id);
+    }
+
+    @Test
+    public void fromJsonStringWithNextAction_createsSetupIntentWithNextAction() {
+        final SetupIntent setupIntent = SetupIntent.fromString(SETUP_INTENT_NEXT_ACTION_REDIRECT);
+        assertNotNull(setupIntent);
+        assertEquals("seti_1Eq6tqGMT9dGPIDGhdilBKsu", setupIntent.getId());
+        assertEquals("seti_1Eq6tqGMT9dGPIDGhdilBKsu_secret_FKmSUxflgdu2gMlMLNzj89t90SRIZTn",
+                setupIntent.getClientSecret());
+        assertEquals(1561677666, (long)setupIntent.getCreated());
+        assertEquals("a description", setupIntent.getDescription());
+        assertFalse(setupIntent.getLiveMode());
+        assertTrue(setupIntent.requiresAction());
+        assertEquals(StripeIntent.Status.RequiresAction, setupIntent.getStatus());
+        assertEquals(StripeIntent.Usage.OffSession, setupIntent.getUsage());
+
+        final StripeIntent.SdkData sdkData = setupIntent.getStripeSdkData();
+        assertNotNull(sdkData);
+        assertTrue(sdkData.is3ds1());
+    }
+
+}

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
@@ -1,38 +1,40 @@
 package com.stripe.android.model;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(RobolectricTestRunner.class)
 public class SetupIntentTest {
 
     private static final String SETUP_INTENT_NEXT_ACTION_REDIRECT = "{\n" +
-            "  \"id\": \"seti_1Eq6tqGMT9dGPIDGhdilBKsu\",\n" +
+            "  \"id\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV\",\n" +
             "  \"object\": \"setup_intent\",\n" +
             "  \"cancellation_reason\": null,\n" +
-            "  \"client_secret\": \"seti_1Eq6tqGMT9dGPIDGhdilBKsu_secret_FKmSUxflgdu2gMlMLNzj89t90SRIZTn\",\n" +
+            "  \"client_secret\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y\",\n" +
             "  \"created\": 1561677666,\n" +
             "  \"description\": \"a description\",\n" +
             "  \"last_setup_error\": null,\n" +
             "  \"livemode\": false,\n" +
             "  \"next_action\": {\n" +
-            "    \"type\": \"use_stripe_sdk\",\n" +
-            "    \"use_stripe_sdk\": {\n" +
-            "      \"type\": \"three_d_secure_redirect\",\n" +
-            "      \"stripe_js\": \"https://hooks.stripe.com/redirect/authenticate/src_1Eq6tzGMT9dGPIDGL26pAgjJ?client_secret=src_client_secret_FKmSF6ewY3iTFmfdIT5784LI\"\n" +
-            "    }\n" +
+            "    \"redirect_to_url\": {\n" +
+            "      \"return_url\": \"stripe://setup_intent_return\",\n" +
+            "      \"url\": \"https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02\"\n" +
+            "    },\n" +
+            "    \"type\": \"redirect_to_url\"\n" +
             "  },\n" +
-            "  \"payment_method\": \"pm_1Eq6tlGMT9dGPIDGFkaLeB0v\",\n" +
+            "  \"payment_method\": \"pm_1EqTSoGMT9dGPIDG7dgafX1H\",\n" +
             "  \"payment_method_types\": [\n" +
             "    \"card\"\n" +
             "  ],\n" +
             "  \"status\": \"requires_action\",\n" +
             "  \"usage\": \"off_session\"\n" +
             "}";
-
 
     @Test
     public void parseIdFromClientSecret_correctIdParsed() {
@@ -45,19 +47,25 @@ public class SetupIntentTest {
     public void fromJsonStringWithNextAction_createsSetupIntentWithNextAction() {
         final SetupIntent setupIntent = SetupIntent.fromString(SETUP_INTENT_NEXT_ACTION_REDIRECT);
         assertNotNull(setupIntent);
-        assertEquals("seti_1Eq6tqGMT9dGPIDGhdilBKsu", setupIntent.getId());
-        assertEquals("seti_1Eq6tqGMT9dGPIDGhdilBKsu_secret_FKmSUxflgdu2gMlMLNzj89t90SRIZTn",
+        assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV", setupIntent.getId());
+        assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y",
                 setupIntent.getClientSecret());
         assertEquals(1561677666, (long)setupIntent.getCreated());
         assertEquals("a description", setupIntent.getDescription());
+        assertEquals("pm_1EqTSoGMT9dGPIDG7dgafX1H", setupIntent.getPaymentMethodId());
         assertFalse(setupIntent.getLiveMode());
         assertTrue(setupIntent.requiresAction());
         assertEquals(StripeIntent.Status.RequiresAction, setupIntent.getStatus());
         assertEquals(StripeIntent.Usage.OffSession, setupIntent.getUsage());
 
-        final StripeIntent.SdkData sdkData = setupIntent.getStripeSdkData();
-        assertNotNull(sdkData);
-        assertTrue(sdkData.is3ds1());
+        final StripeIntent.RedirectData redirectData = setupIntent.getRedirectData();
+        assertNotNull(redirectData);
+        assertEquals("stripe://setup_intent_return", redirectData.returnUrl.toString());
+        assertEquals("https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B" +
+                "?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02", redirectData.url.toString());
+        assertEquals("https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B" +
+                "?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02",
+                setupIntent.getRedirectUrl().toString());
     }
 
 }

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import static com.stripe.android.model.SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -11,30 +12,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class SetupIntentTest {
-
-    private static final String SETUP_INTENT_NEXT_ACTION_REDIRECT = "{\n" +
-            "  \"id\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV\",\n" +
-            "  \"object\": \"setup_intent\",\n" +
-            "  \"cancellation_reason\": null,\n" +
-            "  \"client_secret\": \"seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y\",\n" +
-            "  \"created\": 1561677666,\n" +
-            "  \"description\": \"a description\",\n" +
-            "  \"last_setup_error\": null,\n" +
-            "  \"livemode\": false,\n" +
-            "  \"next_action\": {\n" +
-            "    \"redirect_to_url\": {\n" +
-            "      \"return_url\": \"stripe://setup_intent_return\",\n" +
-            "      \"url\": \"https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02\"\n" +
-            "    },\n" +
-            "    \"type\": \"redirect_to_url\"\n" +
-            "  },\n" +
-            "  \"payment_method\": \"pm_1EqTSoGMT9dGPIDG7dgafX1H\",\n" +
-            "  \"payment_method_types\": [\n" +
-            "    \"card\"\n" +
-            "  ],\n" +
-            "  \"status\": \"requires_action\",\n" +
-            "  \"usage\": \"off_session\"\n" +
-            "}";
 
     @Test
     public void parseIdFromClientSecret_correctIdParsed() {
@@ -45,7 +22,7 @@ public class SetupIntentTest {
 
     @Test
     public void fromJsonStringWithNextAction_createsSetupIntentWithNextAction() {
-        final SetupIntent setupIntent = SetupIntent.fromString(SETUP_INTENT_NEXT_ACTION_REDIRECT);
+        final SetupIntent setupIntent = SetupIntent.fromString(SI_NEXT_ACTION_REDIRECT_JSON);
         assertNotNull(setupIntent);
         assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV", setupIntent.getId());
         assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y",

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -30,7 +30,7 @@ public class PaymentAuthWebViewTest {
     }
 
     @Test
-    public void shouldOverrideUrlLoading_shouldSetResult() {
+    public void shouldOverrideUrlLoading_paymentIntent_shouldSetResult() {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
@@ -42,6 +42,23 @@ public class PaymentAuthWebViewTest {
 
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals("pi_123_secret_456",
+                intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
+    }
+
+    @Test
+    public void shouldOverrideUrlLoading_setupIntent_shouldSetResult() {
+        final String deepLink = "stripe://payment_auth?setup_intent=seti_1234" +
+                "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
+
+        final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "stripe://payment_auth");
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
+        verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
+        verify(mActivity).finish();
+
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        assertEquals("seti_1234_secret_5678",
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
     }
 }


### PR DESCRIPTION
## Summary

Add support for Setup Intents 

## Testing

Added automated tests and through the example app's SetupIntent example and the `Buy in the Future!` option in the Payment Auth example.


