### PR TITLE
Fix 3DS2 issues

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2AuthParams.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2AuthParams.java
@@ -6,6 +6,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +27,8 @@ class Stripe3ds2AuthParams {
 
     private static final String FIELD_SDK_INTERFACE = "sdkInterface";
     private static final String FIELD_SDK_UI_TYPE = "sdkUiType";
+
+    private static final DecimalFormat MAX_TIMEOUT_FORMATTER = new DecimalFormat("00");
 
     @NonNull private final String mSourceId;
     @NonNull private final String mDeviceData;
@@ -70,7 +73,7 @@ class Stripe3ds2AuthParams {
             appParams.put(FIELD_SDK_TRANS_ID, mSdkTransactionId);
             appParams.put(FIELD_SDK_ENC_DATA, mDeviceData);
             appParams.put(FIELD_SDK_EPHEM_PUB_KEY, new JSONObject(mSdkEphemeralPublicKey));
-            appParams.put(FIELD_SDK_MAX_TIMEOUT, mMaxTimeout);
+            appParams.put(FIELD_SDK_MAX_TIMEOUT, MAX_TIMEOUT_FORMATTER.format(mMaxTimeout));
             appParams.put(FIELD_SDK_REFERENCE_NUMBER, mSdkReferenceNumber);
             appParams.put(FIELD_MESSAGE_VERSION, mMessageVersion);
             appParams.put(FIELD_DEVICE_RENDER_OPTIONS, createDeviceRenderOptions());

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
@@ -63,7 +63,8 @@ public final class Stripe3ds2AuthResult {
                 .setLiveMode(authResultJson.getBoolean(FIELD_LIVEMODE))
                 .setSource(authResultJson.getString(FIELD_SOURCE))
                 .setState(authResultJson.optString(FIELD_STATE))
-                .setAres(Ares.fromJson(authResultJson.optJSONObject(FIELD_ARES)))
+                .setAres(authResultJson.isNull(FIELD_ARES) ? null :
+                        Ares.fromJson(authResultJson.optJSONObject(FIELD_ARES)))
                 .setError(authResultJson.isNull(FIELD_ERROR) ? null :
                         ThreeDS2Error.fromJson(authResultJson.optJSONObject(FIELD_ERROR)))
                 .build();
@@ -203,8 +204,12 @@ public final class Stripe3ds2AuthResult {
             this.sdkTransId = sdkTransId;
         }
 
-        @NonNull
-        static Ares fromJson(@NonNull JSONObject aresJson) throws JSONException {
+        @Nullable
+        static Ares fromJson(@Nullable JSONObject aresJson) throws JSONException {
+            if (aresJson == null) {
+                return null;
+            }
+
             return new Ares.Builder()
                     .setThreeDSServerTransId(aresJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID))
                     .setAcsChallengeMandated(optString(aresJson, FIELD_ACS_CHALLENGE_MANDATED))

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2AuthParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2AuthParamsTest.java
@@ -21,7 +21,7 @@ public class Stripe3ds2AuthParamsTest {
         final String deviceData = "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew";
         final String sdkEphemeralPublicKey = "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"b23da28b-d611-46a8-93af-44ad57ce9c9d\",\"x\":\"hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg\",\"y\":\"OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A\"}";
         final String messageVersion = "2.1.0";
-        final int timeout = 10;
+        final int timeout = 5;
 
         final Stripe3ds2AuthParams authParams = new Stripe3ds2AuthParams(sourceId, appId,
                 sdkReferenceNumber, sdkTransactionId, deviceData, sdkEphemeralPublicKey,
@@ -37,7 +37,7 @@ public class Stripe3ds2AuthParamsTest {
                 "\"sdkTransID\":\"26a3ef80-f09c-4954-94f4-66c7fe9409ba\"," +
                 "\"sdkEncData\":\"" + deviceData + "\"," +
                 "\"sdkEphemPubKey\":" + sdkEphemeralPublicKey + "," +
-                "\"sdkMaxTimeout\":10," +
+                "\"sdkMaxTimeout\":\"05\"," +
                 "\"sdkReferenceNumber\":\"3DS_LOA_SDK_STIN_12345\"," +
                 "\"messageVersion\":\"2.1.0\"," +
                 "\"deviceRenderOptions\":" +

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class Stripe3ds2AuthResultTest {
     private static final String AUTH_RESULT_JSON = "{\n" +
@@ -117,6 +119,29 @@ public class Stripe3ds2AuthResultTest {
             "\t\"livemode\": false,\n" +
             "\t\"source\": \"src_1Ecwz1CRMbs6FrXfUwt98lxf\",\n" +
             "\t\"state\": \"challenge_required\"\n" +
+            "}";
+
+    private static final String AUTH_RESULT_ERROR_INVALID_ELEMENT_FORMAT_JSON = "{\n" +
+            "\t\"ares\": null,\n" +
+            "\t\"livemode\": true,\n" +
+            "\t\"created\": 1562711486,\n" +
+            "\t\"id\": \"threeds2_1EuRqMAWhjPjYwPi83sPpdVY\",\n" +
+            "\t\"source\": \"src_1EuRqGAWhjPjYwPid0T5ZrrF\",\n" +
+            "\t\"state\": \"failed\",\n" +
+            "\t\"error\": {\n" +
+            "\t\t\"errorComponent\": \"D\",\n" +
+            "\t\t\"acsTransID\": null,\n" +
+            "\t\t\"errorDescription\": \"Format or value of one or more Data Elements is Invalid according to the Specification\",\n" +
+            "\t\t\"messageType\": \"Erro\",\n" +
+            "\t\t\"dsTransID\": \"3fa2e398-4146-42f0-b905-a52c06b5caa2\",\n" +
+            "\t\t\"errorCode\": \"203\",\n" +
+            "\t\t\"errorDetail\": \"sdkMaxTimeout\",\n" +
+            "\t\t\"errorMessageType\": \"AReq\",\n" +
+            "\t\t\"messageVersion\": \"2.1.0\",\n" +
+            "\t\t\"sdkTransID\": \"a9e7db5d-e95c-4cc6-a8b7-df1cee092879\",\n" +
+            "\t\t\"threeDSServerTransID\": \"161d5143-340c-4e40-8ee1-a272be64aecc\"\n" +
+            "\t},\n" +
+            "\t\"object\": \"three_d_secure_2\"\n" +
             "}";
 
     @Test
@@ -243,5 +268,19 @@ public class Stripe3ds2AuthResultTest {
                 .build();
 
         assertEquals(expectedResult, jsonResult);
+    }
+
+    @Test
+    public void fromJson_invalidElementFormatJson_shouldPopulateErrorField() throws JSONException {
+        final Stripe3ds2AuthResult result = Stripe3ds2AuthResult.fromJson(
+                new JSONObject(AUTH_RESULT_ERROR_INVALID_ELEMENT_FORMAT_JSON));
+        assertNull(result.ares);
+        assertNotNull(result.error);
+        assertEquals(
+                "sdkMaxTimeout",
+                result.error.errorDetail);
+        assertEquals(
+                "Format or value of one or more Data Elements is Invalid according to the Specification",
+                result.error.errorDescription);
     }
 }


### PR DESCRIPTION
- Max timeout format must be a two digit string
- Fix handling of no `ares` field in `Stripe3ds2AuthResult`