### PR TITLE
Add use_stripe_sdk param to confirm requests in PaymentController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
@@ -11,13 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public final class ConfirmPaymentIntentParams implements StripeIntentParams {
+public final class ConfirmPaymentIntentParams implements ConfirmStripeIntentParams {
 
     public static final String API_PARAM_SOURCE_DATA = "source_data";
     public static final String API_PARAM_PAYMENT_METHOD_DATA = "payment_method_data";
 
     static final String API_PARAM_SOURCE_ID = "source";
-
     static final String API_PARAM_SAVE_PAYMENT_METHOD = "save_payment_method";
 
     @Nullable private final PaymentMethodCreateParams mPaymentMethodCreateParams;
@@ -30,6 +29,7 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
     @Nullable private final String mReturnUrl;
 
     private final boolean mSavePaymentMethod;
+    private final boolean mUseStripeSdk;
 
     private ConfirmPaymentIntentParams(@NonNull Builder builder) {
         mClientSecret = builder.mClientSecret;
@@ -43,6 +43,7 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
         mSavePaymentMethod = builder.mSavePaymentMethod;
 
         mExtraParams = builder.mExtraParams;
+        mUseStripeSdk = builder.mShouldUseSdk;
     }
 
     /**
@@ -321,6 +322,19 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
         return mSavePaymentMethod;
     }
 
+    @Override
+    public boolean shouldUseStripeSdk() {
+        return mUseStripeSdk;
+    }
+
+    @NonNull
+    @Override
+    public ConfirmPaymentIntentParams withShouldUseStripeSdk(boolean shouldUseStripeSdk) {
+        return toBuilder()
+                .setShouldUseSdk(shouldUseStripeSdk)
+                .build();
+    }
+
     /**
      * Create a Map representing this object that is prepared for the Stripe API.
      */
@@ -351,7 +365,23 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
             networkReadyMap.put(API_PARAM_SAVE_PAYMENT_METHOD, true);
         }
 
+        if (mUseStripeSdk) {
+            networkReadyMap.put(API_PARAM_USE_STRIPE_SDK, true);
+        }
+
         return networkReadyMap;
+    }
+
+    @NonNull
+    private Builder toBuilder() {
+        return new Builder(mClientSecret)
+                .setReturnUrl(mReturnUrl)
+                .setPaymentMethodId(mPaymentMethodId)
+                .setPaymentMethodCreateParams(mPaymentMethodCreateParams)
+                .setSourceId(mSourceId)
+                .setSourceParams(mSourceParams)
+                .setSavePaymentMethod(mSavePaymentMethod)
+                .setExtraParams(mExtraParams);
     }
 
     private static final class Builder implements ObjectBuilder<ConfirmPaymentIntentParams> {
@@ -366,6 +396,7 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
         @Nullable private String mReturnUrl;
 
         private boolean mSavePaymentMethod;
+        private boolean mShouldUseSdk;
 
         /**
          * Sets the client secret that is used to authenticate actions on this PaymentIntent
@@ -454,12 +485,17 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
         }
 
         @NonNull
+        public Builder setShouldUseSdk(boolean shouldUseSdk) {
+            mShouldUseSdk = shouldUseSdk;
+            return this;
+        }
+
+        @NonNull
         @Override
         public ConfirmPaymentIntentParams build() {
             return new ConfirmPaymentIntentParams(this);
         }
     }
-
 
     @Override
     public boolean equals(@Nullable Object obj) {
@@ -469,17 +505,20 @@ public final class ConfirmPaymentIntentParams implements StripeIntentParams {
 
     private boolean typedEquals(@NonNull ConfirmPaymentIntentParams params) {
         return ObjectUtils.equals(mReturnUrl, params.mReturnUrl)
+                && ObjectUtils.equals(mClientSecret, params.mClientSecret)
+                && ObjectUtils.equals(mPaymentMethodId, params.mPaymentMethodId)
                 && ObjectUtils.equals(mPaymentMethodCreateParams, params.mPaymentMethodCreateParams)
-                && ObjectUtils.equals(mSourceParams, params.mSourceParams)
                 && ObjectUtils.equals(mSourceId, params.mSourceId)
+                && ObjectUtils.equals(mSourceParams, params.mSourceParams)
                 && ObjectUtils.equals(mExtraParams, params.mExtraParams)
                 && ObjectUtils.equals(mSavePaymentMethod, params.mSavePaymentMethod)
-                && ObjectUtils.equals(mPaymentMethodId, params.mPaymentMethodId);
+                && ObjectUtils.equals(mUseStripeSdk, params.mUseStripeSdk);
     }
 
     @Override
     public int hashCode() {
-        return ObjectUtils.hash(mPaymentMethodCreateParams, mSourceParams, mSourceId,
-                mExtraParams, mReturnUrl, mClientSecret, mPaymentMethodId, mSavePaymentMethod);
+        return ObjectUtils.hash(mReturnUrl, mClientSecret, mPaymentMethodId,
+                mPaymentMethodCreateParams, mSourceId, mSourceParams, mExtraParams,
+                mSavePaymentMethod, mUseStripeSdk);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
@@ -3,22 +3,25 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.stripe.android.ObjectBuilder;
 import com.stripe.android.utils.ObjectUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
-public final class ConfirmSetupIntentParams implements StripeIntentParams {
+public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams {
 
     @NonNull private final String mClientSecret;
     @Nullable private final String mReturnUrl;
     @NonNull private final String mPaymentMethodId;
+    private final boolean mUseStripeSdk;
 
-    private ConfirmSetupIntentParams(@NonNull String clientSecret, @Nullable String returnUrl,
-                                     @NonNull String paymentMethodId) {
-        this.mClientSecret = clientSecret;
-        this.mReturnUrl = returnUrl;
-        this.mPaymentMethodId = paymentMethodId;
+    private ConfirmSetupIntentParams(@NonNull Builder builder) {
+        this.mClientSecret = builder.mClientSecret;
+        this.mReturnUrl = builder.mReturnUrl;
+        this.mPaymentMethodId = Objects.requireNonNull(builder.mPaymentMethodId);
+        this.mUseStripeSdk = builder.mShouldUseSdk;
     }
 
     /**
@@ -36,12 +39,28 @@ public final class ConfirmSetupIntentParams implements StripeIntentParams {
             @NonNull String paymentMethodId,
             @NonNull String clientSecret,
             @NonNull String returnUrl) {
-        return new ConfirmSetupIntentParams(clientSecret, returnUrl, paymentMethodId);
+        return new ConfirmSetupIntentParams.Builder(clientSecret)
+                .setReturnUrl(returnUrl)
+                .setPaymentMethodId(paymentMethodId)
+                .build();
     }
 
     @NonNull
     public String getClientSecret() {
         return mClientSecret;
+    }
+
+    @Override
+    public boolean shouldUseStripeSdk() {
+        return mUseStripeSdk;
+    }
+
+    @NonNull
+    @Override
+    public ConfirmSetupIntentParams withShouldUseStripeSdk(boolean shouldUseStripeSdk) {
+        return toBuilder()
+                .setShouldUseSdk(shouldUseStripeSdk)
+                .build();
     }
 
     /**
@@ -59,7 +78,19 @@ public final class ConfirmSetupIntentParams implements StripeIntentParams {
             networkReadyMap.put(API_PARAM_RETURN_URL, mReturnUrl);
         }
 
+        if (mUseStripeSdk) {
+            networkReadyMap.put(API_PARAM_USE_STRIPE_SDK, true);
+        }
+
         return networkReadyMap;
+    }
+
+    @NonNull
+    private ConfirmSetupIntentParams.Builder toBuilder() {
+        return new ConfirmSetupIntentParams.Builder(mClientSecret)
+                .setReturnUrl(mReturnUrl)
+                .setPaymentMethodId(mPaymentMethodId)
+                .setShouldUseSdk(mUseStripeSdk);
     }
 
     @Override
@@ -78,4 +109,42 @@ public final class ConfirmSetupIntentParams implements StripeIntentParams {
     public int hashCode() {
         return ObjectUtils.hash(mReturnUrl, mClientSecret, mPaymentMethodId);
     }
+
+
+    private static final class Builder implements ObjectBuilder<ConfirmSetupIntentParams> {
+        @NonNull private final String mClientSecret;
+        @Nullable private String mPaymentMethodId;
+        @Nullable private String mReturnUrl;
+        private boolean mShouldUseSdk;
+
+        private Builder(@NonNull String clientSecret) {
+            mClientSecret = Objects.requireNonNull(clientSecret);
+        }
+
+        @NonNull
+        private ConfirmSetupIntentParams.Builder setPaymentMethodId(
+                @NonNull String paymentMethodId) {
+            mPaymentMethodId = paymentMethodId;
+            return this;
+        }
+
+        @NonNull
+        private ConfirmSetupIntentParams.Builder setReturnUrl(@NonNull String returnUrl) {
+            mReturnUrl = returnUrl;
+            return this;
+        }
+
+        @NonNull
+        public ConfirmSetupIntentParams.Builder setShouldUseSdk(boolean shouldUseSdk) {
+            mShouldUseSdk = shouldUseSdk;
+            return this;
+        }
+
+        @NonNull
+        @Override
+        public ConfirmSetupIntentParams build() {
+            return new ConfirmSetupIntentParams(this);
+        }
+    }
+
 }

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
@@ -102,12 +102,13 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
     private boolean typedEquals(@NonNull ConfirmSetupIntentParams confirmSetupIntentParams) {
         return ObjectUtils.equals(mReturnUrl, confirmSetupIntentParams.mReturnUrl)
                 && ObjectUtils.equals(mClientSecret, confirmSetupIntentParams.mClientSecret)
-                && ObjectUtils.equals(mPaymentMethodId, confirmSetupIntentParams.mPaymentMethodId);
+                && ObjectUtils.equals(mPaymentMethodId, confirmSetupIntentParams.mPaymentMethodId)
+                && ObjectUtils.equals(mUseStripeSdk, confirmSetupIntentParams.mUseStripeSdk);
     }
 
     @Override
     public int hashCode() {
-        return ObjectUtils.hash(mReturnUrl, mClientSecret, mPaymentMethodId);
+        return ObjectUtils.hash(mReturnUrl, mClientSecret, mPaymentMethodId, mUseStripeSdk);
     }
 
 

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.java
@@ -1,19 +1,24 @@
 package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import java.util.Map;
 
-public interface StripeIntentParams {
+public interface ConfirmStripeIntentParams {
 
     String API_PARAM_CLIENT_SECRET = "client_secret";
     String API_PARAM_RETURN_URL = "return_url";
     String API_PARAM_PAYMENT_METHOD_ID = "payment_method";
+    String API_PARAM_USE_STRIPE_SDK = "use_stripe_sdk";
 
     @NonNull
     Map<String, Object> toParamMap();
 
     @NonNull
     String getClientSecret();
+
+    boolean shouldUseStripeSdk();
+
+    @NonNull
+    ConfirmStripeIntentParams withShouldUseStripeSdk(boolean shouldUseStripeSdk);
 }

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
@@ -193,4 +193,15 @@ public class ConfirmPaymentIntentParamsTest {
                 ConfirmPaymentIntentParams.create("client_secret", "")
                         .getClientSecret());
     }
+
+    @Test
+    public void shouldUseStripeSdk() {
+        final ConfirmPaymentIntentParams confirmPaymentIntentParams =
+                ConfirmPaymentIntentParams.create("client_secret", "return_url");
+        assertFalse(confirmPaymentIntentParams.shouldUseStripeSdk());
+
+        assertTrue(confirmPaymentIntentParams
+                .withShouldUseStripeSdk(true)
+                .shouldUseStripeSdk());
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
@@ -1,0 +1,21 @@
+package com.stripe.android.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfirmSetupIntentParamsTest {
+
+    @Test
+    public void shouldUseStripeSdk() {
+        final ConfirmSetupIntentParams confirmSetupIntentParams =
+                ConfirmSetupIntentParams.create(
+                        "pm_123", "client_secret", "return_url");
+        assertFalse(confirmSetupIntentParams.shouldUseStripeSdk());
+
+        assertTrue(confirmSetupIntentParams
+                .withShouldUseStripeSdk(true)
+                .shouldUseStripeSdk());
+    }
+}


### PR DESCRIPTION
## Summary
Create methods to modify `ConfirmStripeIntentParams` to set `use_stripe_sdk` and use in `PaymentController`.

## Motivation
MOBILE3DS2-432

## Testing
Added unit tests.