### PR TITLE
Update PaymentAuthWebView logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization;
 import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.PaymentAuthWebViewActivity;
@@ -14,8 +13,9 @@ import com.stripe.android.view.PaymentAuthWebViewActivity;
  * A class that manages starting a {@link PaymentAuthWebViewActivity} instance with the correct
  * arguments.
  */
-public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentIntent.RedirectData> {
+public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentAuthWebViewStarter.Data> {
     public static final String EXTRA_AUTH_URL = "auth_url";
+    public static final String EXTRA_CLIENT_SECRET = "client_secret";
     public static final String EXTRA_RETURN_URL = "return_url";
     public static final String EXTRA_UI_CUSTOMIZATION = "ui_customization";
 
@@ -34,16 +34,27 @@ public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentIntent.
         mToolbarCustomization = toolbarCustomization;
     }
 
-    /**
-     * @param redirectData typically obtained through {@link PaymentIntent#getRedirectData()}
-     */
-    public void start(@NonNull PaymentIntent.RedirectData redirectData) {
+    public void start(@NonNull PaymentAuthWebViewStarter.Data data) {
         final Intent intent = new Intent(mActivity, PaymentAuthWebViewActivity.class)
-                .putExtra(EXTRA_AUTH_URL, redirectData.url.toString())
-                .putExtra(EXTRA_RETURN_URL, redirectData.returnUrl != null ?
-                        redirectData.returnUrl.toString() : null)
+                .putExtra(EXTRA_CLIENT_SECRET, data.mClientSecret)
+                .putExtra(EXTRA_AUTH_URL, data.mUrl)
+                .putExtra(EXTRA_RETURN_URL, data.mReturnUrl)
                 .putExtra(EXTRA_UI_CUSTOMIZATION, mToolbarCustomization);
 
         mActivity.startActivityForResult(intent, mRequestCode);
+    }
+
+    static final class Data {
+        @NonNull private final String mClientSecret;
+        @NonNull private final String mUrl;
+        @Nullable private final String mReturnUrl;
+
+        Data(@NonNull String clientSecret,
+             @NonNull String url,
+             @Nullable String returnUrl) {
+            mClientSecret = clientSecret;
+            mUrl = url;
+            mReturnUrl = returnUrl;
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
@@ -3,7 +3,6 @@ package com.stripe.android.model;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 
 import java.util.Map;
 import java.util.Objects;
@@ -189,7 +188,7 @@ public interface StripeIntent {
          * PaymentIntent.next_action.redirect_to_url.return_url
          * </a>
          */
-        @Nullable public final Uri returnUrl;
+        @Nullable public final String returnUrl;
 
         @Nullable
         static RedirectData create(@NonNull Map<?, ?> redirectToUrlHash) {
@@ -207,7 +206,7 @@ public interface StripeIntent {
 
         RedirectData(@NonNull String url, @Nullable String returnUrl) {
             this.url = Uri.parse(url);
-            this.returnUrl = returnUrl != null ? Uri.parse(returnUrl) : null;
+            this.returnUrl = returnUrl;
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -31,11 +31,13 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
                 getIntent().getParcelableExtra(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION);
         customizeToolbar(toolbar);
 
+        final String clientSecret = getIntent()
+                .getStringExtra(PaymentAuthWebViewStarter.EXTRA_CLIENT_SECRET);
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
 
         final PaymentAuthWebView webView = findViewById(R.id.auth_web_view);
-        webView.init(this, returnUrl);
+        webView.init(this, clientSecret, returnUrl);
         webView.loadUrl(getIntent().getStringExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL));
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import com.stripe.android.model.PaymentIntentFixtures;
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization;
 
 import org.junit.Before;
@@ -23,6 +22,15 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentAuthWebViewStarterTest {
+    private static final String CLIENT_SECRET =
+            "pi_1EceMnCRMbs6FrXfCXdF8dnx_secret_vew0L3IGaO0x9o0eyRMGzKr0k";
+    private static final PaymentAuthWebViewStarter.Data DATA =
+            new PaymentAuthWebViewStarter.Data(
+                    CLIENT_SECRET,
+                    "https://hooks.stripe.com/",
+                    "stripe://payment-auth"
+            );
+
     @Mock private Activity mActivity;
     @Captor private ArgumentCaptor<Intent> mIntentArgumentCaptor;
     @Captor private ArgumentCaptor<Integer> mRequestCodeCaptor;
@@ -34,8 +42,7 @@ public class PaymentAuthWebViewStarterTest {
 
     @Test
     public void start_startsWithCorrectIntentAndRequestCode() {
-        new PaymentAuthWebViewStarter(mActivity, 50000)
-                .start(PaymentIntentFixtures.REDIRECT_DATA);
+        new PaymentAuthWebViewStarter(mActivity, 50000).start(DATA);
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
                 mRequestCodeCaptor.capture());
 
@@ -43,13 +50,15 @@ public class PaymentAuthWebViewStarterTest {
         final Bundle extras = intent.getExtras();
         assertNotNull(extras);
         assertNull(extras.getParcelable(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION));
-        assertEquals(3, extras.size());
+        assertEquals(4, extras.size());
+        assertEquals(CLIENT_SECRET,
+                extras.getString(PaymentAuthWebViewStarter.EXTRA_CLIENT_SECRET));
     }
 
     @Test
     public void start_startsWithCorrectIntentAndRequestCodeAndCustomization() {
         new PaymentAuthWebViewStarter(mActivity, 50000,
-                new StripeToolbarCustomization()).start(PaymentIntentFixtures.REDIRECT_DATA);
+                new StripeToolbarCustomization()).start(DATA);
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
                 mRequestCodeCaptor.capture());
 
@@ -57,6 +66,8 @@ public class PaymentAuthWebViewStarterTest {
         final Bundle extras = intent.getExtras();
         assertNotNull(extras);
         assertNotNull(extras.getParcelable(PaymentAuthWebViewStarter.EXTRA_UI_CUSTOMIZATION));
-        assertEquals(3, extras.size());
+        assertEquals(4, extras.size());
+        assertEquals(CLIENT_SECRET,
+                extras.getString(PaymentAuthWebViewStarter.EXTRA_CLIENT_SECRET));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentRedirectDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentRedirectDataTest.java
@@ -28,7 +28,7 @@ public class PaymentIntentRedirectDataTest {
                 StripeIntent.RedirectData.create(redirectMap);
         assertNotNull(redirectData);
         assertEquals(Uri.parse(url), redirectData.url);
-        assertEquals(Uri.parse(returnUrl), redirectData.returnUrl);
+        assertEquals(returnUrl, redirectData.returnUrl);
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -36,6 +36,7 @@ public class PaymentAuthWebViewTest {
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
                 new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "pi_123_secret_456",
                         "stripe://payment_intent_return");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
         verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
@@ -53,6 +54,7 @@ public class PaymentAuthWebViewTest {
 
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
                 new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "seti_1234_secret_5678",
                         "stripe://payment_auth");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
         verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
@@ -64,12 +66,44 @@ public class PaymentAuthWebViewTest {
     }
 
     @Test
-    public void shouldOverrideUrlLoading_withoutReturnUrl_shouldNotAutoFinishActivity() {
+    public void shouldOverrideUrlLoading_withoutReturnUrl_onPaymentIntentImplicitReturnUrl_shouldSetResult() {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, null);
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
+        verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
+        verify(mActivity).finish();
+
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        assertEquals("pi_123_secret_456",
+                intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
+    }
+
+    @Test
+    public void shouldOverrideUrlLoading_withoutReturnUrl_onSetupIntentImplicitReturnUrl_shouldSetResult() {
+        final String deepLink = "stripe://payment_auth?setup_intent=seti_1234" +
+                "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
+        final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "seti_1234_secret_5678", null);
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
+        verify(mActivity).setResult(eq(Activity.RESULT_OK), mIntentArgumentCaptor.capture());
+        verify(mActivity).finish();
+
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        assertEquals("seti_1234_secret_5678",
+                intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
+    }
+
+    @Test
+    public void shouldOverrideUrlLoading_withoutReturnUrl_shouldNotAutoFinishActivity() {
+        final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "pi_123_secret_456", null);
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView,
+                "https://example.com");
         verify(mActivity, never()).finish();
     }
 }


### PR DESCRIPTION
## Summary
* Pass `clientSecret` to `PaymentAuthWebViewClient` instead
  of obtaining it from the query string. We know the
  `client_secret` ahead of time.
* Update `PaymentAuthWebViewClient#isReturnUrl()` logic to
  handle detecting the returnUrl when not explicitly
  specified.

## Motivation
Ensure that return url can be detected when one isn't available from the PaymentIntent

## Testing
Add unit tests
