### PR TITLE
Don't check for resultCode in PaymentController

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -122,9 +122,13 @@ public class PaymentAuthActivity extends AppCompatActivity {
         mProgressBar.setVisibility(View.VISIBLE);
         mStatusTextView.append("\n\nPayment authentication completed, getting result");
 
-        mStripe.onPaymentResult(requestCode, resultCode, data, new AuthResultListener(this));
+        final boolean isPaymentResult =
+                mStripe.onPaymentResult(requestCode, data, new AuthResultListener(this));
 
-        mStripe.onSetupResult(requestCode, resultCode, data, new SetupAuthResultListener(this));
+        if (!isPaymentResult) {
+            final boolean isSetupResult =
+                    mStripe.onSetupResult(requestCode, data, new SetupAuthResultListener(this));
+        }
     }
 
     @Override

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -182,7 +182,7 @@ public class PaymentActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
 
         final boolean isHandled = mStripe.onPaymentResult(
-                requestCode, resultCode, data,
+                requestCode, data,
                 new ApiResultCallback<PaymentIntentResult>() {
                     @Override
                     public void onSuccess(@NonNull PaymentIntentResult result) {

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -116,20 +116,16 @@ class PaymentController {
      * Decide whether {@link #handlePaymentResult(Stripe, Intent, String, ApiResultCallback)}
      * should be called.
      */
-    boolean shouldHandlePaymentResult(int requestCode, int resultCode, @Nullable Intent data) {
-        return requestCode == PAYMENT_REQUEST_CODE &&
-                resultCode == Activity.RESULT_OK &&
-                data != null;
+    boolean shouldHandlePaymentResult(int requestCode, @Nullable Intent data) {
+        return requestCode == PAYMENT_REQUEST_CODE && data != null;
     }
 
     /**
      * Decide whether {@link #handleSetupResult(Stripe, Intent, String, ApiResultCallback)}
      * should be called.
      */
-    boolean shouldHandleSetupResult(int requestCode, int resultCode, @Nullable Intent data) {
-        return requestCode == SETUP_REQUEST_CODE &&
-                resultCode == Activity.RESULT_OK &&
-                data != null;
+    boolean shouldHandleSetupResult(int requestCode, @Nullable Intent data) {
+        return requestCode == SETUP_REQUEST_CODE && data != null;
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -207,11 +207,11 @@ public class Stripe {
      * (see {@link #confirmPayment(Activity, ConfirmPaymentIntentParams, String)}) or manual
      * confirmation (see {@link #authenticatePayment(Activity, String, String)}})
      */
-    public boolean onPaymentResult(int requestCode, int resultCode, @Nullable Intent data,
+    public boolean onPaymentResult(int requestCode, @Nullable Intent data,
                                    @NonNull String publishableKey,
                                    @NonNull ApiResultCallback<PaymentIntentResult> callback) {
         if (data != null &&
-                mPaymentController.shouldHandlePaymentResult(requestCode, resultCode, data)) {
+                mPaymentController.shouldHandlePaymentResult(requestCode, data)) {
             mPaymentController.handlePaymentResult(this, data, publishableKey, callback);
             return true;
         }
@@ -220,12 +220,11 @@ public class Stripe {
     }
 
     /**
-     * See {@link #onPaymentResult(int, int, Intent, String, ApiResultCallback)}
+     * See {@link #onPaymentResult(int, Intent, String, ApiResultCallback)}
      */
-    public boolean onPaymentResult(
-            int requestCode, int resultCode, @Nullable Intent data,
-            @NonNull ApiResultCallback<PaymentIntentResult> callback) {
-        return onPaymentResult(requestCode, resultCode, data, mDefaultPublishableKey, callback);
+    public boolean onPaymentResult(int requestCode, @Nullable Intent data,
+                                   @NonNull ApiResultCallback<PaymentIntentResult> callback) {
+        return onPaymentResult(requestCode, data, mDefaultPublishableKey, callback);
     }
 
     /**
@@ -233,11 +232,11 @@ public class Stripe {
      * result of a SetupIntent confirmation
      * (see {@link #confirmSetupIntent(Activity, ConfirmSetupIntentParams)})
      */
-    public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
-                                   @NonNull String publishableKey,
-                                   @NonNull ApiResultCallback<SetupIntentResult> callback) {
+    public boolean onSetupResult(int requestCode, @Nullable Intent data,
+                                 @NonNull String publishableKey,
+                                 @NonNull ApiResultCallback<SetupIntentResult> callback) {
         if (data != null &&
-                mPaymentController.shouldHandleSetupResult(requestCode, resultCode, data)) {
+                mPaymentController.shouldHandleSetupResult(requestCode, data)) {
             mPaymentController.handleSetupResult(this, data, publishableKey, callback);
             return true;
         }
@@ -246,11 +245,11 @@ public class Stripe {
     }
 
     /**
-     * See {@link #onSetupResult(int, int, Intent, String, ApiResultCallback)}
+     * See {@link #onSetupResult(int, Intent, String, ApiResultCallback)}
      */
-    public boolean onSetupResult(int requestCode, int resultCode, @Nullable Intent data,
-            @NonNull ApiResultCallback<SetupIntentResult> callback) {
-        return onSetupResult(requestCode, resultCode, data, mDefaultPublishableKey, callback);
+    public boolean onSetupResult(int requestCode, @Nullable Intent data,
+                                 @NonNull ApiResultCallback<SetupIntentResult> callback) {
+        return onSetupResult(requestCode, data, mDefaultPublishableKey, callback);
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -189,8 +189,8 @@ public class PaymentControllerTest {
 
     @Test
     public void shouldHandleResult_withInvalidResultCode() {
-        assertFalse(mController.shouldHandlePaymentResult(500, Activity.RESULT_OK, new Intent()));
-        assertFalse(mController.shouldHandleSetupResult(500, Activity.RESULT_OK, new Intent()));
+        assertFalse(mController.shouldHandlePaymentResult(500, new Intent()));
+        assertFalse(mController.shouldHandleSetupResult(500, new Intent()));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -83,11 +83,10 @@ public class StripePaymentAuthTest {
     public void onPaymentResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
         final Intent data = new Intent();
         when(mPaymentController.shouldHandlePaymentResult(
-                PaymentController.PAYMENT_REQUEST_CODE, Activity.RESULT_OK, data))
+                PaymentController.PAYMENT_REQUEST_CODE, data))
                 .thenReturn(true);
         final Stripe stripe = createStripe();
-        stripe.onPaymentResult(PaymentController.PAYMENT_REQUEST_CODE, Activity.RESULT_OK,
-                data, mPaymentCallback);
+        stripe.onPaymentResult(PaymentController.PAYMENT_REQUEST_CODE, data, mPaymentCallback);
 
         verify(mPaymentController).handlePaymentResult(stripe, data,
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mPaymentCallback);
@@ -97,11 +96,10 @@ public class StripePaymentAuthTest {
     public void onSetupResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
         final Intent data = new Intent();
         when(mPaymentController.shouldHandleSetupResult(
-                PaymentController.SETUP_REQUEST_CODE, Activity.RESULT_OK, data))
+                PaymentController.SETUP_REQUEST_CODE, data))
                 .thenReturn(true);
         final Stripe stripe = createStripe();
-        stripe.onSetupResult(PaymentController.SETUP_REQUEST_CODE, Activity.RESULT_OK,
-                data, mSetupCallback);
+        stripe.onSetupResult(PaymentController.SETUP_REQUEST_CODE, data, mSetupCallback);
 
         verify(mPaymentController).handleSetupResult(stripe, data,
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mSetupCallback);


### PR DESCRIPTION
In some cases we pass values other than `Activity.RESULT_OK`, so
don't check the resultCode.