### PR TITLE
Payment Auth Web View Focusable

### DIFF
--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -17,7 +17,9 @@
         android:id="@+id/auth_web_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/payment_auth_web_view_toolbar" />
+        android:layout_below="@id/payment_auth_web_view_toolbar"
+        android:focusable="true"
+        android:focusableInTouchMode="true" />
 
     <ProgressBar
         android:id="@+id/auth_web_view_progress_bar"


### PR DESCRIPTION
## Summary

Make payment auth web view focusable

## Motivation

Fixing focus issues in the 3DS2 SDK web view.

## Testing

Example app payment auth with buy in future setup intent.
