### PR TITLE
Refactor returnUrl handling in PaymentController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.java
@@ -98,12 +98,6 @@ public final class Stripe3ds2AuthResult {
                 && Objects.equals(error, obj.error);
     }
 
-    @Nullable
-    public StripeIntent.RedirectData getFallbackRedirectData() {
-        return fallbackRedirectUrl != null ?
-                new StripeIntent.RedirectData(fallbackRedirectUrl, null) : null;
-    }
-
     static class Builder implements ObjectBuilder<Stripe3ds2AuthResult> {
         private String mId;
         private String mObjectType;

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3dsRedirect.java
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3dsRedirect.java
@@ -26,7 +26,7 @@ public final class Stripe3dsRedirect {
     }
 
     @NonNull
-    public StripeIntent.RedirectData getRedirectData() {
-        return new StripeIntent.RedirectData(mUrl, null);
+    public String getUrl() {
+        return mUrl;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.java
@@ -290,7 +290,6 @@ public class Stripe3ds2AuthResultTest {
                 new JSONObject(AUTH_RESULT_ERROR_INVALID_ELEMENT_FORMAT_JSON));
         assertNull(result.ares);
         assertNull(result.fallbackRedirectUrl);
-        assertNull(result.getFallbackRedirectData());
         assertNotNull(result.error);
         assertEquals(
                 "sdkMaxTimeout",
@@ -307,12 +306,9 @@ public class Stripe3ds2AuthResultTest {
         assertNull(result.ares);
         assertNull(result.error);
 
-        final StripeIntent.RedirectData redirectData = result.getFallbackRedirectData();
-        assertNotNull(redirectData);
         assertEquals(
                 "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW",
-                redirectData.url.toString()
+                result.fallbackRedirectUrl
         );
-        assertNull(redirectData.returnUrl);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3dsRedirectTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3dsRedirectTest.java
@@ -17,7 +17,7 @@ public class Stripe3dsRedirectTest {
                 Objects.requireNonNull(PaymentIntentFixtures.PI_REQUIRES_3DS1.getStripeSdkData()));
         assertEquals(
                 "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW",
-                redirect.getRedirectData().url.toString()
+                redirect.getUrl()
         );
     }
 }


### PR DESCRIPTION
In some cases `returnUrl` is not available from the
immediate model, so refactor the code to allow for
passing the `returnUrl` param from the StripeIntent
confirmation request, which will be done in a
follow-up PR.