### PR TITLE
Set PaymentAuthWebViewActivity result in one place

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -82,9 +81,6 @@ class PaymentAuthWebView extends WebView {
                                                 @NonNull String urlString) {
             final Uri uri = Uri.parse(urlString);
             if (isReturnUrl(uri)) {
-                mActivity.setResult(Activity.RESULT_OK,
-                        new Intent()
-                                .putExtra(StripeIntentResultExtras.CLIENT_SECRET, mClientSecret));
                 mActivity.finish();
                 return true;
             }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -1,5 +1,6 @@
 package com.stripe.android.view;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -43,15 +44,12 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
 
+        setResult(Activity.RESULT_OK,
+                new Intent().putExtra(StripeIntentResultExtras.CLIENT_SECRET, clientSecret));
+
         final PaymentAuthWebView webView = findViewById(R.id.auth_web_view);
         webView.init(this, clientSecret, returnUrl);
         webView.loadUrl(getIntent().getStringExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL));
-    }
-
-    @Override
-    public void onBackPressed() {
-        setResult(RESULT_CANCELED);
-        super.onBackPressed();
     }
 
     @Override
@@ -70,7 +68,6 @@ public class PaymentAuthWebViewActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.action_close) {
-            setResult(RESULT_CANCELED);
             finish();
             return true;
         }


### PR DESCRIPTION
We always want to return a result, so set it in onCreate().
Result code is not used downstream so we can always use "OK"