### PR TITLE
Add support for known 3DS auth completion URL

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -77,6 +77,14 @@ class PaymentAuthWebView extends WebView {
         }
 
         @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
+            if (url.startsWith("https://hooks.stripe.com/3d_secure/complete/")) {
+                mActivity.finish();
+            }
+        }
+
+        @Override
         public boolean shouldOverrideUrlLoading(@NonNull WebView view,
                                                 @NonNull String urlString) {
             final Uri uri = Uri.parse(urlString);

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -90,4 +90,14 @@ public class PaymentAuthWebViewTest {
                 "stripejs://use_stripe_sdk/return_url");
         verify(mActivity).finish();
     }
+
+    @Test
+    public void onPageFinished_wit3DSecureCompleteUrl_shouldFinish() {
+        final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                        "pi_123_secret_456", null);
+        paymentAuthWebViewClient.onPageFinished(mWebView,
+                "https://hooks.stripe.com/3d_secure/complete/tdsrc_1ExLWoCRMbs6FrXfjPJRYtng");
+        verify(mActivity).finish();
+    }
 }


### PR DESCRIPTION
We should not intercept this URL, because the request to
this endpoint needs to be made. Instead, wait for the page
to finish loading before auto-closing the auth webview.