### PR TITLE
Add Stripe#authenticateSetup()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -202,6 +202,26 @@ public class Stripe {
     }
 
     /**
+     * Authenticate a {@link SetupIntent}. Used for manual confirmation flow.
+     *
+     * @param activity     the {@link Activity} that is launching the payment authentication flow
+     * @param clientSecret the `client_secret` property of a confirmed {@link SetupIntent} object
+     */
+    public void authenticateSetup(@NonNull Activity activity,
+                                  @NonNull String clientSecret,
+                                  @NonNull String publishableKey) {
+        mPaymentController.startAuth(this, activity, clientSecret, publishableKey);
+    }
+
+    /**
+     * See {@link #authenticateSetup(Activity, String, String)}}
+     */
+    public void authenticateSetup(@NonNull Activity activity,
+                                  @NonNull String clientSecret) {
+        authenticateSetup(activity, clientSecret, mDefaultPublishableKey);
+    }
+
+    /**
      * Should be called via {@link Activity#onActivityResult(int, int, Intent)}} to handle the
      * result of a PaymentIntent automatic confirmation
      * (see {@link #confirmPayment(Activity, ConfirmPaymentIntentParams, String)}) or manual

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.stripe.android.model.ConfirmPaymentIntentParams;
 import com.stripe.android.model.ConfirmSetupIntentParams;
 import com.stripe.android.model.PaymentIntentFixtures;
+import com.stripe.android.model.SetupIntentFixtures;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -71,6 +72,19 @@ public class StripePaymentAuthTest {
         final Stripe stripe = createStripe();
         final String clientSecret = PaymentIntentFixtures.PI_REQUIRES_VISA_3DS2.getClientSecret();
         stripe.authenticatePayment(mActivity, Objects.requireNonNull(clientSecret));
+        verify(mPaymentController).startAuth(
+                eq(stripe),
+                eq(mActivity),
+                eq(clientSecret),
+                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        );
+    }
+
+    @Test
+    public void authenticateSetup_shouldAuth() {
+        final Stripe stripe = createStripe();
+        final String clientSecret = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret();
+        stripe.authenticateSetup(mActivity, Objects.requireNonNull(clientSecret));
         verify(mPaymentController).startAuth(
                 eq(stripe),
                 eq(mActivity),


### PR DESCRIPTION
This method is used for confirming SetupIntents that were confirmed on the user's backend.