### PR TITLE
Move fire-and-forget requests to separate thread

### DIFF
--- a/stripe/src/main/java/com/stripe/android/FireAndForgetRequestExecutor.java
+++ b/stripe/src/main/java/com/stripe/android/FireAndForgetRequestExecutor.java
@@ -2,18 +2,9 @@ package com.stripe.android;
 
 import android.support.annotation.NonNull;
 
-import com.stripe.android.exception.APIConnectionException;
-import com.stripe.android.exception.InvalidRequestException;
-
 interface FireAndForgetRequestExecutor {
     /**
-     * @return the response status code. Used for testing purposes.
-     */
-    int execute(@NonNull StripeRequest request)
-            throws APIConnectionException, InvalidRequestException;
-
-    /**
-     * Call {@link #execute(StripeRequest)} asynchronously.
+     * Execute the fire-and-forget request asynchronously.
      */
     void executeAsync(@NonNull StripeRequest request);
 }

--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -1067,15 +1067,7 @@ class StripeApiHandler {
     }
 
     private void makeFireAndForgetRequest(@NonNull StripeRequest request) {
-        final Pair<Boolean, String> dnsCacheData = disableDnsCache();
-
-        try {
-            mFireAndForgetRequestExecutor.execute(request);
-        } catch (StripeException ignore) {
-            // We're just logging. No need to crash here or attempt to re-log things.
-        } finally {
-            resetDnsCacheTtl(dnsCacheData);
-        }
+        mFireAndForgetRequestExecutor.executeAsync(request);
     }
 
     @NonNull

--- a/stripe/src/test/java/com/stripe/android/FakeFireAndForgetRequestExecutor.java
+++ b/stripe/src/test/java/com/stripe/android/FakeFireAndForgetRequestExecutor.java
@@ -4,11 +4,6 @@ import android.support.annotation.NonNull;
 
 final class FakeFireAndForgetRequestExecutor implements FireAndForgetRequestExecutor {
     @Override
-    public int execute(@NonNull StripeRequest request) {
-        return 200;
-    }
-
-    @Override
     public void executeAsync(@NonNull StripeRequest request) {
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -96,7 +96,7 @@ public class StripeTest {
 
     @Test
     public void testVersion() {
-        assertEquals("AndroidBindings/9.3.8", Stripe.VERSION);
+        assertEquals("AndroidBindings/10.0.0", Stripe.VERSION);
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1285,7 +1285,7 @@ public class StripeTest {
         assertEquals(metadata, createdPaymentMethod.metadata);
 
         verify(fireAndForgetRequestExecutor, times(2))
-                .execute(mStripeRequestArgumentCaptor.capture());
+                .executeAsync(mStripeRequestArgumentCaptor.capture());
         final List<StripeRequest> fireAndForgetRequests =
                 mStripeRequestArgumentCaptor.getAllValues();
         final StripeRequest analyticsRequest = fireAndForgetRequests.get(1);
@@ -1332,7 +1332,7 @@ public class StripeTest {
                 createdPaymentMethod.ideal);
 
         verify(fireAndForgetRequestExecutor, times(2))
-                .execute(mStripeRequestArgumentCaptor.capture());
+                .executeAsync(mStripeRequestArgumentCaptor.capture());
         final List<StripeRequest> fireAndForgetRequests =
                 mStripeRequestArgumentCaptor.getAllValues();
         final StripeRequest analyticsRequest = fireAndForgetRequests.get(1);


### PR DESCRIPTION
## Summary
Move non-critical fire-and-forget requests to a separate thread

## Motivation
Analytics requests should not block API requests and should be moved off of the critical path

## Testing
Manually tested