### PR TITLE
Update Proguard rules

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -63,7 +63,7 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {

--- a/example/proguard-rules.pro
+++ b/example/proguard-rules.pro
@@ -35,6 +35,9 @@
 -keepattributes Exceptions
 
 
+# Stripe SDK rules
+-keep class com.stripe.android.** { *; }
+
 
 # OkHttp rules
 

--- a/samplestore/build.gradle
+++ b/samplestore/build.gradle
@@ -29,7 +29,7 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {

--- a/samplestore/proguard-rules.pro
+++ b/samplestore/proguard-rules.pro
@@ -35,6 +35,9 @@
 -keepattributes Exceptions
 
 
+# Stripe SDK rules
+-keep class com.stripe.android.** { *; }
+
 
 # OkHttp rules
 

--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -1,3 +1,5 @@
 -keep class android.support.design.widget.TextInputLayout { *; }
 -keep class android.support.design.widget.CollapsingTextHelper { *; }
+-keep class org.bouncycastle.** { *; }
+
 -dontwarn com.stripe.android.view.**


### PR DESCRIPTION
## Summary
- Add BouncyCastle to `:stripe` Proguard rules
- Enable `minifyEnabled` for samplestore + example apps
  to help expose integration issues
- Add Stripe SDK Proguard rules to apps

## Motivation
Fix integration issues with 3DS2 SDK

## Testing
Manually tested on various API versions