### PR TITLE
Update PaymentController and related classes to take ApiRequest.Options

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiRequest.java
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.java
@@ -78,10 +78,9 @@ final class ApiRequest extends StripeRequest {
 
     @NonNull
     static ApiRequest createAnalyticsRequest(@NonNull Map<String, ?> params,
-                                             @NonNull String apiKey,
+                                             @NonNull ApiRequest.Options requestOptions,
                                              @Nullable AppInfo appInfo) {
-        return new ApiRequest(Method.GET, ANALYTICS_HOST, params,
-                ApiRequest.Options.create(apiKey), appInfo);
+        return new ApiRequest(Method.GET, ANALYTICS_HOST, params, requestOptions, appInfo);
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -52,7 +52,6 @@ class PaymentController {
     @NonNull private final StripeApiHandler mApiHandler;
     @NonNull private final MessageVersionRegistry mMessageVersionRegistry;
     @NonNull private final PaymentAuthConfig mConfig;
-    @NonNull private final ApiKeyValidator mApiKeyValidator;
     @NonNull private final FireAndForgetRequestExecutor mAnalyticsRequestExecutor;
     @NonNull private final AnalyticsDataFactory mAnalyticsDataFactory;
 
@@ -81,7 +80,6 @@ class PaymentController {
                 config.stripe3ds2Config.uiCustomization.getUiCustomization());
         mApiHandler = apiHandler;
         mMessageVersionRegistry = messageVersionRegistry;
-        mApiKeyValidator = new ApiKeyValidator();
         mAnalyticsRequestExecutor = analyticsRequestExecutor;
         mAnalyticsDataFactory = analyticsDataFactory;
     }
@@ -92,7 +90,6 @@ class PaymentController {
     void startConfirmAndAuth(@NonNull Activity activity,
                              @NonNull ConfirmStripeIntentParams confirmStripeIntentParams,
                              @NonNull ApiRequest.Options requestOptions) {
-        mApiKeyValidator.requireValid(requestOptions.apiKey);
         new ConfirmStripeIntentTask(mApiHandler, confirmStripeIntentParams, requestOptions,
                 new ConfirmStripeIntentCallback(activity, requestOptions, this,
                         getRequestCode(confirmStripeIntentParams)))
@@ -102,7 +99,6 @@ class PaymentController {
     void startAuth(@NonNull final Activity activity,
                    @NonNull String clientSecret,
                    @NonNull final ApiRequest.Options requestOptions) {
-        mApiKeyValidator.requireValid(requestOptions.apiKey);
         new RetrieveIntentTask(mApiHandler,
                 clientSecret,
                 requestOptions,
@@ -121,7 +117,7 @@ class PaymentController {
     }
 
     /**
-     * Decide whether {@link #handlePaymentResult(Stripe, Intent, String, ApiResultCallback)}
+     * Decide whether {@link #handlePaymentResult(Intent, ApiRequest.Options, ApiResultCallback)}
      * should be called.
      */
     boolean shouldHandlePaymentResult(int requestCode, @Nullable Intent data) {
@@ -129,7 +125,7 @@ class PaymentController {
     }
 
     /**
-     * Decide whether {@link #handleSetupResult(Stripe, Intent, String, ApiResultCallback)}
+     * Decide whether {@link #handleSetupResult(Intent, ApiRequest.Options, ApiResultCallback)}
      * should be called.
      */
     boolean shouldHandleSetupResult(int requestCode, @Nullable Intent data) {

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -89,29 +89,27 @@ class PaymentController {
     /**
      * Confirm the Stripe Intent and resolve any next actions
      */
-    void startConfirmAndAuth(@NonNull Stripe stripe,
-                             @NonNull Activity activity,
+    void startConfirmAndAuth(@NonNull Activity activity,
                              @NonNull ConfirmStripeIntentParams confirmStripeIntentParams,
-                             @NonNull String publishableKey) {
-        mApiKeyValidator.requireValid(publishableKey);
-        new ConfirmStripeIntentTask(stripe, confirmStripeIntentParams, publishableKey,
-                new ConfirmStripeIntentCallback(activity, publishableKey, this,
+                             @NonNull ApiRequest.Options requestOptions) {
+        mApiKeyValidator.requireValid(requestOptions.apiKey);
+        new ConfirmStripeIntentTask(mApiHandler, confirmStripeIntentParams, requestOptions,
+                new ConfirmStripeIntentCallback(activity, requestOptions, this,
                         getRequestCode(confirmStripeIntentParams)))
                 .execute();
     }
 
-    void startAuth(@NonNull Stripe stripe,
-                   @NonNull final Activity activity,
+    void startAuth(@NonNull final Activity activity,
                    @NonNull String clientSecret,
-                   @NonNull final String publishableKey) {
-        mApiKeyValidator.requireValid(publishableKey);
-        new RetrieveIntentTask(stripe,
+                   @NonNull final ApiRequest.Options requestOptions) {
+        mApiKeyValidator.requireValid(requestOptions.apiKey);
+        new RetrieveIntentTask(mApiHandler,
                 clientSecret,
-                publishableKey,
+                requestOptions,
                 new ApiResultCallback<StripeIntent>() {
                     @Override
                     public void onSuccess(@NonNull StripeIntent stripeIntent) {
-                        handleNextAction(activity, stripeIntent, publishableKey);
+                        handleNextAction(activity, stripeIntent, requestOptions);
                     }
 
                     @Override
@@ -147,8 +145,8 @@ class PaymentController {
      *
      * @param data the result Intent
      */
-    void handlePaymentResult(@NonNull Stripe stripe, @NonNull Intent data,
-                             @NonNull String publishableKey,
+    void handlePaymentResult(@NonNull Intent data,
+                             @NonNull ApiRequest.Options requestOptions,
                              @NonNull final ApiResultCallback<PaymentIntentResult> callback) {
         final Exception authException = (Exception) data.getSerializableExtra(
                 StripeIntentResultExtras.AUTH_EXCEPTION);
@@ -159,7 +157,7 @@ class PaymentController {
 
         @StripeIntentResult.Status final int authStatus = data.getIntExtra(
                 StripeIntentResultExtras.AUTH_STATUS, StripeIntentResult.Status.UNKNOWN);
-        new RetrieveIntentTask(stripe, getClientSecret(data), publishableKey,
+        new RetrieveIntentTask(mApiHandler, getClientSecret(data), requestOptions,
                 new ApiResultCallback<StripeIntent>() {
                     @Override
                     public void onSuccess(@NonNull StripeIntent stripeIntent) {
@@ -188,8 +186,8 @@ class PaymentController {
      *
      * @param data the result Intent
      */
-    void handleSetupResult(@NonNull Stripe stripe, @NonNull Intent data,
-                           @NonNull String publishableKey,
+    void handleSetupResult(@NonNull Intent data,
+                           @NonNull ApiRequest.Options requestOptions,
                            @NonNull final ApiResultCallback<SetupIntentResult> callback) {
         final Exception authException = (Exception) data.getSerializableExtra(
                 StripeIntentResultExtras.AUTH_EXCEPTION);
@@ -201,7 +199,7 @@ class PaymentController {
         @StripeIntentResult.Status final int authStatus = data.getIntExtra(
                 StripeIntentResultExtras.AUTH_STATUS, StripeIntentResult.Status.UNKNOWN);
 
-        new RetrieveIntentTask(stripe, getClientSecret(data), publishableKey,
+        new RetrieveIntentTask(mApiHandler, getClientSecret(data), requestOptions,
                 new ApiResultCallback<StripeIntent>() {
                     @Override
                     public void onSuccess(@NonNull StripeIntent stripeIntent) {
@@ -234,7 +232,7 @@ class PaymentController {
     @VisibleForTesting
     void handleNextAction(@NonNull Activity activity,
                           @NonNull StripeIntent stripeIntent,
-                          @NonNull String publishableKey) {
+                          @NonNull ApiRequest.Options requestOptions) {
         if (stripeIntent.requiresAction()) {
             final StripeIntent.NextActionType nextActionType = stripeIntent.getNextActionType();
             if (StripeIntent.NextActionType.UseStripeSdk == nextActionType) {
@@ -243,7 +241,8 @@ class PaymentController {
                 if (sdkData.is3ds2()) {
                     try {
                         begin3ds2Auth(activity, stripeIntent,
-                                Stripe3ds2Fingerprint.create(sdkData), publishableKey);
+                                Stripe3ds2Fingerprint.create(sdkData),
+                                requestOptions);
                     } catch (CertificateException e) {
                         handleError(activity, getRequestCode(stripeIntent), e);
                     }
@@ -261,8 +260,8 @@ class PaymentController {
                                 mAnalyticsDataFactory.createAuthParams(
                                         AnalyticsDataFactory.EventName.AUTH_REDIRECT,
                                         StripeTextUtils.emptyIfNull(stripeIntent.getId()),
-                                        publishableKey),
-                                publishableKey,
+                                        requestOptions.apiKey),
+                                requestOptions,
                                 null
                         )
                 );
@@ -317,7 +316,7 @@ class PaymentController {
     private void begin3ds2Auth(@NonNull Activity activity,
                                @NonNull StripeIntent stripeIntent,
                                @NonNull Stripe3ds2Fingerprint stripe3ds2Fingerprint,
-                               @NonNull String publishableKey) {
+                               @NonNull ApiRequest.Options requestOptions) {
         final Transaction transaction =
                 mThreeDs2Service.createTransaction(stripe3ds2Fingerprint.directoryServer.id,
                         mMessageVersionRegistry.getCurrent(), stripeIntent.isLiveMode(),
@@ -346,9 +345,9 @@ class PaymentController {
                 returnUrl
         );
         mApiHandler.start3ds2Auth(authParams, StripeTextUtils.emptyIfNull(stripeIntent.getId()),
-                publishableKey,
+                requestOptions,
                 new Stripe3ds2AuthCallback(activity, mApiHandler, transaction, timeout,
-                        stripeIntent, stripe3ds2Fingerprint.source, publishableKey,
+                        stripeIntent, stripe3ds2Fingerprint.source, requestOptions,
                         mAnalyticsRequestExecutor, mAnalyticsDataFactory));
     }
 
@@ -375,45 +374,44 @@ class PaymentController {
     }
 
     private static final class RetrieveIntentTask extends ApiOperation<StripeIntent> {
-        @NonNull private final Stripe mStripe;
+        @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final String mClientSecret;
-        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiRequest.Options mRequestOptions;
 
-        private RetrieveIntentTask(@NonNull Stripe stripe,
+        private RetrieveIntentTask(@NonNull StripeApiHandler apiHandler,
                                    @NonNull String clientSecret,
-                                   @NonNull String publishableKey,
+                                   @NonNull ApiRequest.Options requestOptions,
                                    @NonNull ApiResultCallback<StripeIntent> callback) {
             super(callback);
-            mStripe = stripe;
+            mApiHandler = apiHandler;
             mClientSecret = clientSecret;
-            mPublishableKey = publishableKey;
+            mRequestOptions = requestOptions;
         }
 
         @Nullable
         @Override
         StripeIntent getResult() throws StripeException {
             if (mClientSecret.startsWith("pi_")) {
-                return mStripe.retrievePaymentIntentSynchronous(
-                        mClientSecret, mPublishableKey);
+                return mApiHandler.retrievePaymentIntent(mClientSecret, mRequestOptions);
             } else if (mClientSecret.startsWith("seti_")) {
-                return mStripe.retrieveSetupIntentSynchronous(mClientSecret, mPublishableKey);
+                return mApiHandler.retrieveSetupIntent(mClientSecret, mRequestOptions);
             }
             return null;
         }
     }
 
     private static final class ConfirmStripeIntentTask extends ApiOperation<StripeIntent> {
-        @NonNull private final Stripe mStripe;
+        @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final ConfirmStripeIntentParams mParams;
-        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiRequest.Options mRequestOptions;
 
-        private ConfirmStripeIntentTask(@NonNull Stripe stripe,
+        private ConfirmStripeIntentTask(@NonNull StripeApiHandler apiHandler,
                                         @NonNull ConfirmStripeIntentParams params,
-                                        @NonNull String publishableKey,
+                                        @NonNull ApiRequest.Options requestOptions,
                                         @NonNull ApiResultCallback<StripeIntent> callback) {
             super(callback);
-            mStripe = stripe;
-            mPublishableKey = publishableKey;
+            mApiHandler = apiHandler;
+            mRequestOptions = requestOptions;
 
             // mark this request as `use_stripe_sdk=true`
             mParams = params.withShouldUseStripeSdk(true);
@@ -423,11 +421,15 @@ class PaymentController {
         @Override
         StripeIntent getResult() throws StripeException {
             if (mParams instanceof ConfirmPaymentIntentParams) {
-                return mStripe.confirmPaymentIntentSynchronous(
-                        (ConfirmPaymentIntentParams) mParams, mPublishableKey);
+                return mApiHandler.confirmPaymentIntent(
+                        (ConfirmPaymentIntentParams) mParams,
+                        mRequestOptions
+                );
             } else if (mParams instanceof ConfirmSetupIntentParams) {
-                return mStripe.confirmSetupIntentSynchronous(
-                        (ConfirmSetupIntentParams) mParams, mPublishableKey);
+                return mApiHandler.confirmSetupIntent(
+                        (ConfirmSetupIntentParams) mParams,
+                        mRequestOptions
+                );
             }
             return null;
         }
@@ -436,17 +438,17 @@ class PaymentController {
     private static final class ConfirmStripeIntentCallback
             implements ApiResultCallback<StripeIntent> {
         @NonNull private final WeakReference<Activity> mActivityRef;
-        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiRequest.Options mRequestOptions;
         @NonNull private final PaymentController mPaymentController;
         private final int mRequestCode;
 
         private ConfirmStripeIntentCallback(
                 @NonNull Activity activity,
-                @NonNull String publishableKey,
+                @NonNull ApiRequest.Options requestOptions,
                 @NonNull PaymentController paymentController,
                 int requestCode) {
             mActivityRef = new WeakReference<>(activity);
-            mPublishableKey = publishableKey;
+            mRequestOptions = requestOptions;
             mPaymentController = paymentController;
             mRequestCode = requestCode;
         }
@@ -455,7 +457,7 @@ class PaymentController {
         public void onSuccess(@NonNull StripeIntent stripeIntent) {
             final Activity activity = mActivityRef.get();
             if (activity != null) {
-                mPaymentController.handleNextAction(activity, stripeIntent, mPublishableKey);
+                mPaymentController.handleNextAction(activity, stripeIntent, mRequestOptions);
             }
         }
 
@@ -476,7 +478,7 @@ class PaymentController {
         private final int mMaxTimeout;
         @NonNull private final StripeIntent mStripeIntent;
         @NonNull private final String mSourceId;
-        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiRequest.Options mRequestOptions;
         @NonNull private final PaymentRelayStarter mPaymentRelayStarter;
         @NonNull private final Handler mBackgroundHandler;
         @NonNull private final FireAndForgetRequestExecutor mAnalyticsRequestExecutor;
@@ -489,11 +491,11 @@ class PaymentController {
                 int maxTimeout,
                 @NonNull StripeIntent stripeIntent,
                 @NonNull String sourceId,
-                @NonNull String publishableKey,
+                @NonNull ApiRequest.Options requestOptions,
                 @NonNull FireAndForgetRequestExecutor analyticsRequestExecutor,
                 @NonNull AnalyticsDataFactory analyticsDataFactory) {
             this(activity, apiHandler, transaction, maxTimeout, stripeIntent,
-                    sourceId, publishableKey,
+                    sourceId, requestOptions,
                     new PaymentRelayStarter(activity, getRequestCode(stripeIntent)),
                     analyticsRequestExecutor,
                     analyticsDataFactory);
@@ -507,7 +509,7 @@ class PaymentController {
                 int maxTimeout,
                 @NonNull StripeIntent stripeIntent,
                 @NonNull String sourceId,
-                @NonNull String publishableKey,
+                @NonNull ApiRequest.Options requestOptions,
                 @NonNull PaymentRelayStarter paymentRelayStarter,
                 @NonNull FireAndForgetRequestExecutor analyticsRequestExecutor,
                 @NonNull AnalyticsDataFactory analyticsDataFactory) {
@@ -517,7 +519,7 @@ class PaymentController {
             mMaxTimeout = maxTimeout;
             mStripeIntent = stripeIntent;
             mSourceId = sourceId;
-            mPublishableKey = publishableKey;
+            mRequestOptions = requestOptions;
             mPaymentRelayStarter = paymentRelayStarter;
             mAnalyticsRequestExecutor = analyticsRequestExecutor;
             mAnalyticsDataFactory = analyticsDataFactory;
@@ -578,8 +580,8 @@ class PaymentController {
                             mAnalyticsDataFactory.createAuthParams(
                                     AnalyticsDataFactory.EventName.AUTH_3DS2_FRICTIONLESS,
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
-                                    mPublishableKey),
-                            mPublishableKey,
+                                    mRequestOptions.apiKey),
+                            mRequestOptions,
                             null
                     )
             );
@@ -600,7 +602,7 @@ class PaymentController {
                     mTransaction.doChallenge(activity,
                             challengeParameters,
                             PaymentAuth3ds2ChallengeStatusReceiver.create(activity, mApiHandler,
-                                    mStripeIntent, mSourceId, mPublishableKey,
+                                    mStripeIntent, mSourceId, mRequestOptions,
                                     mAnalyticsRequestExecutor, mAnalyticsDataFactory,
                                     mTransaction),
                             mMaxTimeout);
@@ -616,7 +618,7 @@ class PaymentController {
         @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final StripeIntent mStripeIntent;
         @NonNull private final String mSourceId;
-        @NonNull private final String mPublishableKey;
+        @NonNull private final ApiRequest.Options mRequestOptions;
         @NonNull private final FireAndForgetRequestExecutor mAnalyticsRequestExecutor;
         @NonNull private final AnalyticsDataFactory mAnalyticsDataFactory;
         @NonNull private final Transaction mTransaction;
@@ -627,7 +629,7 @@ class PaymentController {
                 @NonNull StripeApiHandler apiHandler,
                 @NonNull StripeIntent stripeIntent,
                 @NonNull String sourceId,
-                @NonNull String publishableKey,
+                @NonNull ApiRequest.Options requestOptions,
                 @NonNull FireAndForgetRequestExecutor analyticsRequestExecutor,
                 @NonNull AnalyticsDataFactory analyticsDataFactory,
                 @NonNull Transaction transaction) {
@@ -637,7 +639,7 @@ class PaymentController {
                     apiHandler,
                     stripeIntent,
                     sourceId,
-                    publishableKey,
+                    requestOptions,
                     analyticsRequestExecutor,
                     analyticsDataFactory,
                     transaction);
@@ -649,7 +651,7 @@ class PaymentController {
                 @NonNull StripeApiHandler apiHandler,
                 @NonNull StripeIntent stripeIntent,
                 @NonNull String sourceId,
-                @NonNull String publishableKey,
+                @NonNull ApiRequest.Options requestOptions,
                 @NonNull FireAndForgetRequestExecutor analyticsRequestExecutor,
                 @NonNull AnalyticsDataFactory analyticsDataFactory,
                 @NonNull Transaction transaction) {
@@ -658,7 +660,7 @@ class PaymentController {
             mApiHandler = apiHandler;
             mStripeIntent = stripeIntent;
             mSourceId = sourceId;
-            mPublishableKey = publishableKey;
+            mRequestOptions = requestOptions;
             mAnalyticsRequestExecutor = analyticsRequestExecutor;
             mAnalyticsDataFactory = analyticsDataFactory;
             mTransaction = transaction;
@@ -674,9 +676,9 @@ class PaymentController {
                                     AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_COMPLETED,
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     uiTypeCode,
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
@@ -693,9 +695,9 @@ class PaymentController {
                                     AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_CANCELED,
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     uiTypeCode,
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
@@ -712,9 +714,9 @@ class PaymentController {
                                     AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_TIMEDOUT,
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     uiTypeCode,
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
@@ -730,9 +732,9 @@ class PaymentController {
                             mAnalyticsDataFactory.create3ds2ChallengeErrorParams(
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     protocolErrorEvent,
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
@@ -748,9 +750,9 @@ class PaymentController {
                             mAnalyticsDataFactory.create3ds2ChallengeErrorParams(
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     runtimeErrorEvent,
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
@@ -767,14 +769,14 @@ class PaymentController {
                                     StripeTextUtils.emptyIfNull(mStripeIntent.getId()),
                                     StripeTextUtils.emptyIfNull(
                                             mTransaction.getInitialChallengeUiType()),
-                                    mPublishableKey
+                                    mRequestOptions.apiKey
                             ),
-                            mPublishableKey,
+                            mRequestOptions,
                             null
                     )
             );
 
-            mApiHandler.complete3ds2Auth(mSourceId, mPublishableKey,
+            mApiHandler.complete3ds2Auth(mSourceId, mRequestOptions,
                     new ApiResultCallback<Boolean>() {
                         @Override
                         public void onSuccess(@NonNull Boolean result) {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -143,8 +143,8 @@ public class Stripe {
     public void confirmSetupIntent(@NonNull Activity activity,
                                    @NonNull ConfirmSetupIntentParams confirmSetupIntentParams,
                                    @NonNull String publishableKey) {
-        mPaymentController.startConfirmAndAuth(this, activity,
-                confirmSetupIntentParams, publishableKey);
+        mPaymentController.startConfirmAndAuth(activity, confirmSetupIntentParams,
+                ApiRequest.Options.create(publishableKey, mStripeAccount));
     }
 
     /**
@@ -167,8 +167,8 @@ public class Stripe {
     public void confirmPayment(@NonNull Activity activity,
                                @NonNull ConfirmPaymentIntentParams confirmPaymentIntentParams,
                                @NonNull String publishableKey) {
-        mPaymentController.startConfirmAndAuth(this, activity,
-                confirmPaymentIntentParams, publishableKey);
+        mPaymentController.startConfirmAndAuth(activity, confirmPaymentIntentParams,
+                ApiRequest.Options.create(publishableKey, mStripeAccount));
     }
 
     /**
@@ -190,7 +190,8 @@ public class Stripe {
     public void authenticatePayment(@NonNull Activity activity,
                                     @NonNull String clientSecret,
                                     @NonNull String publishableKey) {
-        mPaymentController.startAuth(this, activity, clientSecret, publishableKey);
+        mPaymentController.startAuth(activity, clientSecret,
+                ApiRequest.Options.create(publishableKey, mStripeAccount));
     }
 
     /**
@@ -210,7 +211,8 @@ public class Stripe {
     public void authenticateSetup(@NonNull Activity activity,
                                   @NonNull String clientSecret,
                                   @NonNull String publishableKey) {
-        mPaymentController.startAuth(this, activity, clientSecret, publishableKey);
+        mPaymentController.startAuth(activity, clientSecret,
+                ApiRequest.Options.create(publishableKey, mStripeAccount));
     }
 
     /**
@@ -232,7 +234,10 @@ public class Stripe {
                                    @NonNull ApiResultCallback<PaymentIntentResult> callback) {
         if (data != null &&
                 mPaymentController.shouldHandlePaymentResult(requestCode, data)) {
-            mPaymentController.handlePaymentResult(this, data, publishableKey, callback);
+            mPaymentController.handlePaymentResult(
+                    data,
+                    ApiRequest.Options.create(publishableKey, mStripeAccount),
+                    callback);
             return true;
         }
 
@@ -257,7 +262,11 @@ public class Stripe {
                                  @NonNull ApiResultCallback<SetupIntentResult> callback) {
         if (data != null &&
                 mPaymentController.shouldHandleSetupResult(requestCode, data)) {
-            mPaymentController.handleSetupResult(this, data, publishableKey, callback);
+            mPaymentController.handleSetupResult(
+                    data,
+                    ApiRequest.Options.create(publishableKey, mStripeAccount),
+                    callback
+            );
             return true;
         }
 

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2Fixtures.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2Fixtures.java
@@ -6,17 +6,17 @@ import com.stripe.android.stripe3ds2.transaction.AuthenticationRequestParameters
 
 import java.util.UUID;
 
-public class Stripe3ds2Fixtures {
+final class Stripe3ds2Fixtures {
+    static final String MESSAGE_VERSION = "2.1.0";
 
     private static final String DEVICE_DATA = "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew";
     private static final String SDK_TRANSACTION_ID = UUID.randomUUID().toString();
     private static final String SDK_APP_ID = "1.0.0";
     private static final String SDK_REFERENCE_NUMBER = "3DS_LOA_SDK_STIN_12345";
-    private static final String SDK_EPHEMERAL_PUBLIC_KEY = "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"b23da28b-d611-46a8-93af-44ad57ce9c9d\",\"x\":\"hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg\",\"y\":\"OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A\"}";;
-    private static final String MESSAGE_VERSION = "2.1.0";
+    private static final String SDK_EPHEMERAL_PUBLIC_KEY = "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"b23da28b-d611-46a8-93af-44ad57ce9c9d\",\"x\":\"hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg\",\"y\":\"OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A\"}";
 
     @NonNull
-    public static final AuthenticationRequestParameters AREQ_PARAMS =
+    static final AuthenticationRequestParameters AREQ_PARAMS =
             new AuthenticationRequestParameters() {
                 @Override
                 public String getDeviceData() {

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -188,7 +188,7 @@ public class StripeApiHandlerTest {
                 UUID.randomUUID().toString(),
                 "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew",
                 "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"b23da28b-d611-46a8-93af-44ad57ce9c9d\",\"x\":\"hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg\",\"y\":\"OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A\"}",
-                "2.1.0",
+                Stripe3ds2Fixtures.MESSAGE_VERSION,
                 10,
                 "stripe://payment-auth-return"
         );
@@ -199,7 +199,7 @@ public class StripeApiHandlerTest {
                     @Override
                     public void run() throws Throwable {
                         mApiHandler.start3ds2Auth(authParams, "pi_12345",
-                                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
+                                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY));
                     }
                 });
 
@@ -215,7 +215,7 @@ public class StripeApiHandlerTest {
                     @Override
                     public void run() throws Throwable {
                         mApiHandler.complete3ds2Auth("src_123",
-                                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY);
+                                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY));
                     }
                 });
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND, invalidRequestException.getStatusCode());

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -28,6 +28,9 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class StripePaymentAuthTest {
 
+    private static final ApiRequest.Options REQUEST_OPTIONS =
+            ApiRequest.Options.create(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+
     private Context mContext;
 
     @Mock private Activity mActivity;
@@ -50,8 +53,8 @@ public class StripePaymentAuthTest {
                         "client_secret",
                         "yourapp://post-authentication-return-url");
         stripe.confirmPayment(mActivity, confirmPaymentIntentParams);
-        verify(mPaymentController).startConfirmAndAuth(eq(stripe), eq(mActivity),
-                eq(confirmPaymentIntentParams), eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY));
+        verify(mPaymentController).startConfirmAndAuth(eq(mActivity),
+                eq(confirmPaymentIntentParams), eq(REQUEST_OPTIONS));
     }
 
     @Test
@@ -63,8 +66,8 @@ public class StripePaymentAuthTest {
                         "client_secret",
                         "yourapp://post-authentication-return-url");
         stripe.confirmSetupIntent(mActivity, confirmSetupIntentParams);
-        verify(mPaymentController).startConfirmAndAuth(eq(stripe), eq(mActivity),
-                eq(confirmSetupIntentParams), eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY));
+        verify(mPaymentController).startConfirmAndAuth(eq(mActivity),
+                eq(confirmSetupIntentParams), eq(REQUEST_OPTIONS));
     }
 
     @Test
@@ -73,10 +76,9 @@ public class StripePaymentAuthTest {
         final String clientSecret = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret();
         stripe.authenticatePayment(mActivity, Objects.requireNonNull(clientSecret));
         verify(mPaymentController).startAuth(
-                eq(stripe),
                 eq(mActivity),
                 eq(clientSecret),
-                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+                eq(REQUEST_OPTIONS)
         );
     }
 
@@ -86,10 +88,9 @@ public class StripePaymentAuthTest {
         final String clientSecret = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret();
         stripe.authenticateSetup(mActivity, Objects.requireNonNull(clientSecret));
         verify(mPaymentController).startAuth(
-                eq(stripe),
                 eq(mActivity),
                 eq(clientSecret),
-                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+                eq(REQUEST_OPTIONS)
         );
     }
 
@@ -102,8 +103,9 @@ public class StripePaymentAuthTest {
         final Stripe stripe = createStripe();
         stripe.onPaymentResult(PaymentController.PAYMENT_REQUEST_CODE, data, mPaymentCallback);
 
-        verify(mPaymentController).handlePaymentResult(stripe, data,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mPaymentCallback);
+        verify(mPaymentController).handlePaymentResult(data,
+                ApiRequest.Options.create(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
+                mPaymentCallback);
     }
 
     @Test
@@ -115,8 +117,9 @@ public class StripePaymentAuthTest {
         final Stripe stripe = createStripe();
         stripe.onSetupResult(PaymentController.SETUP_REQUEST_CODE, data, mSetupCallback);
 
-        verify(mPaymentController).handleSetupResult(stripe, data,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, mSetupCallback);
+        verify(mPaymentController).handleSetupResult(data,
+                ApiRequest.Options.create(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
+                mSetupCallback);
     }
 
     @NonNull


### PR DESCRIPTION
## Summary
Instead of passing a publishable key, pass `ApiRequest.Options` so that
a user-specified Connected account (see `Stripe#setAccount()`) is
included in requests.

## Motivation
MOBILE3DS2-451

## Testing
Updated tests and manually verified