### PR TITLE
Add support for Connect Account to CustomerSession

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
+++ b/stripe/src/main/java/com/stripe/android/StripeApiHandler.java
@@ -393,7 +393,7 @@ class StripeApiHandler {
             @NonNull List<String> productUsageTokens,
             @NonNull String sourceId,
             @NonNull @Source.SourceType String sourceType,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -410,10 +410,8 @@ class StripeApiHandler {
         );
 
         final StripeResponse response = fireStripeApiRequest(
-                ApiRequest.createPost(
-                        getAddCustomerSourceUrl(customerId),
-                        params,
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                ApiRequest.createPost(getAddCustomerSourceUrl(customerId),
+                        params, requestOptions, mAppInfo)
         );
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -426,7 +424,7 @@ class StripeApiHandler {
             @NonNull String publishableKey,
             @NonNull List<String> productUsageTokens,
             @NonNull String sourceId,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -441,7 +439,7 @@ class StripeApiHandler {
         final StripeResponse response = fireStripeApiRequest(
                 ApiRequest.createDelete(
                         getDeleteCustomerSourceUrl(customerId, sourceId),
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
 
         // Method throws if errors are found, so no return value occurs.
@@ -455,7 +453,7 @@ class StripeApiHandler {
             @NonNull String publishableKey,
             @NonNull List<String> productUsageTokens,
             @NonNull String paymentMethodId,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -475,7 +473,7 @@ class StripeApiHandler {
                 ApiRequest.createPost(
                         getAttachPaymentMethodUrl(paymentMethodId),
                         params,
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -487,7 +485,7 @@ class StripeApiHandler {
             @NonNull String publishableKey,
             @NonNull List<String> productUsageTokens,
             @NonNull String paymentMethodId,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -503,7 +501,7 @@ class StripeApiHandler {
         final StripeResponse response = fireStripeApiRequest(
                 ApiRequest.createPost(
                         getDetachPaymentMethodUrl(paymentMethodId),
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -519,7 +517,7 @@ class StripeApiHandler {
             @NonNull String paymentMethodType,
             @NonNull String publishableKey,
             @NonNull List<String> productUsageTokens,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -540,7 +538,7 @@ class StripeApiHandler {
                 ApiRequest.createGet(
                         getPaymentMethodsUrl(),
                         queryParams,
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -566,7 +564,7 @@ class StripeApiHandler {
             @NonNull List<String> productUsageTokens,
             @NonNull String sourceId,
             @NonNull @Source.SourceType String sourceType,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -578,14 +576,14 @@ class StripeApiHandler {
         fireAnalyticsRequest(
                 mAnalyticsDataFactory.getEventLoggingParams(productUsageTokens, sourceType,
                         null, publishableKey, AnalyticsDataFactory.EventName.DEFAULT_SOURCE),
-                ephemeralKey
+                publishableKey
         );
 
         final StripeResponse response = fireStripeApiRequest(
                 ApiRequest.createPost(
                         getRetrieveCustomerUrl(customerId),
                         params,
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
 
         // Method throws if errors are found, so no return value occurs.
@@ -599,7 +597,7 @@ class StripeApiHandler {
             @NonNull String publishableKey,
             @NonNull List<String> productUsageTokens,
             @NonNull ShippingInformation shippingInformation,
-            @NonNull String ephemeralKey)
+            @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -618,7 +616,7 @@ class StripeApiHandler {
                 ApiRequest.createPost(
                         getRetrieveCustomerUrl(customerId),
                         params,
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response);
@@ -627,7 +625,8 @@ class StripeApiHandler {
 
 
     @Nullable
-    Customer retrieveCustomer(@NonNull String customerId, @NonNull String ephemeralKey)
+    Customer retrieveCustomer(@NonNull String customerId,
+                              @NonNull ApiRequest.Options requestOptions)
             throws InvalidRequestException,
             APIConnectionException,
             APIException,
@@ -635,7 +634,7 @@ class StripeApiHandler {
             CardException {
         final StripeResponse response = fireStripeApiRequest(
                 ApiRequest.createGet(getRetrieveCustomerUrl(customerId),
-                        ApiRequest.Options.create(ephemeralKey), mAppInfo)
+                        requestOptions, mAppInfo)
         );
         convertErrorsToExceptionsAndThrowIfNecessary(response);
         return Customer.fromString(response.getResponseBody());

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -93,7 +93,7 @@ public class PaymentSessionTest {
                 PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
         assertNotNull(paymentMethod);
 
-        when(mApiHandler.retrieveCustomer(anyString(), anyString()))
+        when(mApiHandler.retrieveCustomer(anyString(), ArgumentMatchers.<ApiRequest.Options>any()))
                 .thenReturn(firstCustomer, secondCustomer);
         when(mApiHandler.createPaymentMethod(
                 ArgumentMatchers.<PaymentMethodCreateParams>any(),
@@ -105,7 +105,7 @@ public class PaymentSessionTest {
                 ArgumentMatchers.<String>anyList(),
                 anyString(),
                 anyString(),
-                anyString()))
+                ArgumentMatchers.<ApiRequest.Options>any()))
                 .thenReturn(secondCustomer);
 
         doAnswer(new Answer() {
@@ -335,6 +335,7 @@ public class PaymentSessionTest {
     @NonNull
     private CustomerSession createCustomerSession() {
         return new CustomerSession(ApplicationProvider.getApplicationContext(),
-                mEphemeralKeyProvider, null, mThreadPoolExecutor, mApiHandler);
+                mEphemeralKeyProvider, null, mThreadPoolExecutor, mApiHandler,
+                "acct_abc123");
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeApiHandlerTest.java
@@ -510,7 +510,7 @@ public class StripeApiHandlerTest {
         final List<PaymentMethod> paymentMethods = apiHandler
                 .getPaymentMethods("cus_123", PaymentMethod.Type.Card.code,
                         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, new ArrayList<String>(),
-                        ApiKeyFixtures.FAKE_EPHEMERAL_KEY);
+                        ApiRequest.Options.create(ApiKeyFixtures.FAKE_EPHEMERAL_KEY));
         assertEquals(3, paymentMethods.size());
         assertEquals("pm_1EVNYJCRMbs6FrXfG8n52JaK", paymentMethods.get(0).id);
         assertEquals("pm_1EVNXtCRMbs6FrXfTlZGIdGq", paymentMethods.get(1).id);
@@ -558,7 +558,7 @@ public class StripeApiHandlerTest {
         final List<PaymentMethod> paymentMethods = apiHandler
                 .getPaymentMethods("cus_123", PaymentMethod.Type.Card.code,
                         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, new ArrayList<String>(),
-                        ApiKeyFixtures.FAKE_EPHEMERAL_KEY);
+                        ApiRequest.Options.create(ApiKeyFixtures.FAKE_EPHEMERAL_KEY));
         assertTrue(paymentMethods.isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
Specifying `stripeAccountId` will set a `Stripe-Account`
header on API requests made by `CustomerSession`

## Motivation
MOBILE3DS2-452

## Testing
Updated tests and manually verified
