### PR TITLE
Add Status flag to PaymentAuthWebViewActivity result

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -244,6 +244,7 @@ public class PaymentAuthActivity extends AppCompatActivity {
 
             final PaymentIntent paymentIntent = paymentIntentResult.getIntent();
             activity.mStatusTextView.append("\n\n" +
+                    "Auth status: " + paymentIntentResult.getStatus() + "\n\n" +
                     activity.getString(R.string.payment_intent_status, paymentIntent.getStatus()));
             activity.onAuthComplete();
         }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -1,7 +1,9 @@
 package com.stripe.android.view;
 
-import android.app.Activity;
 import android.webkit.WebView;
+import android.widget.ProgressBar;
+
+import com.stripe.android.StripeIntentResult;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,13 +12,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentAuthWebViewTest {
 
-    @Mock private Activity mActivity;
+    @Mock private PaymentAuthWebView.PaymentAuthWebViewClient.Listener mListener;
+    @Mock private ProgressBar mProgressBar;
     @Mock private WebView mWebView;
 
     @Before
@@ -29,11 +33,11 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456",
                         "stripe://payment_intent_return");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
@@ -42,11 +46,11 @@ public class PaymentAuthWebViewTest {
                 "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
 
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "seti_1234_secret_5678",
                         "stripe://payment_auth");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
@@ -54,10 +58,10 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
@@ -65,49 +69,49 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_auth?setup_intent=seti_1234" +
                 "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "seti_1234_secret_5678", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
     public void shouldOverrideUrlLoading_withoutReturnUrl_shouldNotAutoFinishActivity() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView,
                 "https://example.com");
-        verify(mActivity, never()).finish();
+        verify(mListener, never()).onAuthCompleted(anyInt());
     }
 
     @Test
     public void shouldOverrideUrlLoading_witKnownReturnUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView,
                 "stripejs://use_stripe_sdk/return_url");
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
     public void onPageFinished_wit3DSecureCompleteUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.onPageFinished(mWebView,
                 "https://hooks.stripe.com/3d_secure/complete/tdsrc_1ExLWoCRMbs6FrXfjPJRYtng");
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 
     @Test
     public void onPageFinished_witRedirectCompleteUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.onPageFinished(mWebView,
                 "https://hooks.stripe.com/redirect/complete/src_1ExLWoCRMbs6FrXfjPJRYtng");
-        verify(mActivity).finish();
+        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
     }
 }


### PR DESCRIPTION
Browser-based auth was previously not returning a
`StripeIntentResult.Status`.

Fixes #1253
