### PR TITLE
Correctly pass Status.FAILED when 3DS2 auth fails

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -620,6 +620,8 @@ class PaymentController {
 
     static final class PaymentAuth3ds2ChallengeStatusReceiver
             extends StripeChallengeStatusReceiver {
+        private static final String VALUE_YES = "Y";
+
         @NonNull private final WeakReference<Activity> mActivityRef;
         @NonNull private final ActivityStarter<Stripe3ds2CompletionStarter.StartData> mStarter;
         @NonNull private final StripeApiHandler mApiHandler;
@@ -689,8 +691,11 @@ class PaymentController {
                             null
                     )
             );
-            notifyCompletion(Stripe3ds2CompletionStarter.StartData.createForComplete(mStripeIntent,
-                    completionEvent.getTransactionStatus()));
+            notifyCompletion(new Stripe3ds2CompletionStarter.StartData(mStripeIntent,
+                    VALUE_YES.equals(completionEvent.getTransactionStatus()) ?
+                            Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_SUCCESSFUL :
+                            Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL
+            ));
         }
 
         @Override

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
@@ -41,47 +41,35 @@ class Stripe3ds2CompletionStarter
         activity.startActivityForResult(intent, mRequestCode);
     }
 
-    @IntDef({ChallengeFlowOutcome.COMPLETE, ChallengeFlowOutcome.CANCEL,
-            ChallengeFlowOutcome.TIMEOUT, ChallengeFlowOutcome.PROTOCOL_ERROR,
-            ChallengeFlowOutcome.RUNTIME_ERROR})
+    @IntDef({ChallengeFlowOutcome.COMPLETE_SUCCESSFUL, ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL,
+            ChallengeFlowOutcome.CANCEL, ChallengeFlowOutcome.TIMEOUT,
+            ChallengeFlowOutcome.PROTOCOL_ERROR, ChallengeFlowOutcome.RUNTIME_ERROR})
     @Retention(RetentionPolicy.SOURCE)
     @interface ChallengeFlowOutcome {
-        int COMPLETE = 0;
-        int CANCEL = 1;
-        int TIMEOUT = 2;
-        int PROTOCOL_ERROR = 3;
-        int RUNTIME_ERROR = 4;
+        int COMPLETE_SUCCESSFUL = 0;
+        int COMPLETE_UNSUCCESSFUL = 1;
+        int CANCEL = 2;
+        int TIMEOUT = 3;
+        int PROTOCOL_ERROR = 4;
+        int RUNTIME_ERROR = 5;
     }
 
     static class StartData {
         @NonNull private final StripeIntent mStripeIntent;
         @ChallengeFlowOutcome private final int mChallengeFlowStatus;
-        @Nullable private final String mCompletionTransactionStatus;
-
-        @NonNull
-        static StartData createForComplete(@NonNull StripeIntent stripeIntent,
-                                           @NonNull String completionTransactionStatus) {
-            return new StartData(stripeIntent, ChallengeFlowOutcome.COMPLETE,
-                    completionTransactionStatus);
-        }
 
         StartData(@NonNull StripeIntent stripeIntent,
-                  @ChallengeFlowOutcome int status) {
-            this(stripeIntent, status, null);
-        }
-
-        private StartData(@NonNull StripeIntent stripeIntent,
-                          @ChallengeFlowOutcome int challengeFlowStatus,
-                          @Nullable String completionTransactionStatus) {
+                  @ChallengeFlowOutcome int challengeFlowStatus) {
             mStripeIntent = stripeIntent;
             mChallengeFlowStatus = challengeFlowStatus;
-            mCompletionTransactionStatus = completionTransactionStatus;
         }
 
         @StripeIntentResult.Status
         private int getAuthStatus() {
-            if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE) {
+            if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE_SUCCESSFUL) {
                 return StripeIntentResult.Status.SUCCEEDED;
+            } else if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL) {
+                return StripeIntentResult.Status.FAILED;
             } else if (mChallengeFlowStatus == ChallengeFlowOutcome.CANCEL) {
                 return StripeIntentResult.Status.CANCELED;
             } else {
@@ -91,8 +79,7 @@ class Stripe3ds2CompletionStarter
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(mStripeIntent, mChallengeFlowStatus,
-                    mCompletionTransactionStatus);
+            return ObjectUtils.hash(mStripeIntent, mChallengeFlowStatus);
         }
 
         @Override
@@ -102,9 +89,7 @@ class Stripe3ds2CompletionStarter
 
         private boolean typedEquals(@NonNull StartData startData) {
             return ObjectUtils.equals(mStripeIntent, startData.mStripeIntent) &&
-                    ObjectUtils.equals(mChallengeFlowStatus, startData.mChallengeFlowStatus) &&
-                    ObjectUtils.equals(mCompletionTransactionStatus,
-                            startData.mCompletionTransactionStatus);
+                    ObjectUtils.equals(mChallengeFlowStatus, startData.mChallengeFlowStatus);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.java
@@ -5,7 +5,6 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
 import com.stripe.android.model.ConfirmPaymentIntentParams;
-import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.StripeIntent;
 
 import java.lang.annotation.Retention;
@@ -14,7 +13,7 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * A model representing the result of a {@link StripeIntent} confirmation or authentication attempt
  * via {@link Stripe#confirmPayment(Activity, ConfirmPaymentIntentParams)} or
- * {@link Stripe#authenticatePayment(Activity, PaymentIntent)}}
+ * {@link Stripe#authenticatePayment(Activity, String)}}
  *
  * {@link #getIntent()} represents a {@link StripeIntent} retrieved after
  * confirmation/authentication succeeded or failed.

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
@@ -35,14 +35,29 @@ public class Stripe3ds2CompletionStarterTest {
     }
 
     @Test
-    public void start_withCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
-        mStarter.start(Stripe3ds2CompletionStarter.StartData.createForComplete(
-                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2, "Y"));
+    public void start_withSuccessfulCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
+        mStarter.start(new Stripe3ds2CompletionStarter.StartData(
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_SUCCESSFUL));
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
         assertEquals(StripeIntentResult.Status.SUCCEEDED,
+                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
+                        StripeIntentResult.Status.UNKNOWN));
+    }
+
+    @Test
+    public void start_withUnsuccessfulCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
+        mStarter.start(new Stripe3ds2CompletionStarter.StartData(
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL));
+        verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
+        final Intent intent = mIntentArgumentCaptor.getValue();
+        assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
+                intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
+        assertEquals(StripeIntentResult.Status.FAILED,
                 intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
                         StripeIntentResult.Status.UNKNOWN));
     }


### PR DESCRIPTION
Previously, `Status.SUCCEEDED` was passed in all completion cases

Fixes #1253
