### PR TITLE
Persist customer's selected payment method from standard integration

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.java
@@ -1,0 +1,39 @@
+package com.stripe.android;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.Locale;
+
+class PaymentSessionPrefs {
+    private static final String PREF_FILE = "PaymentSessionPrefs";
+
+    @NonNull private final SharedPreferences mPrefs;
+
+    PaymentSessionPrefs(@NonNull Context context) {
+        this(context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE));
+    }
+
+    private PaymentSessionPrefs(@NonNull SharedPreferences prefs) {
+        mPrefs = prefs;
+    }
+
+    @Nullable
+    String getSelectedPaymentMethodId(@NonNull String customerId) {
+        return mPrefs.getString(getPaymentMethodKey(customerId), null);
+    }
+
+    void saveSelectedPaymentMethodId(@NonNull String customerId,
+                                     @NonNull String paymentMethodId) {
+        mPrefs.edit()
+                .putString(getPaymentMethodKey(customerId), paymentMethodId)
+                .apply();
+    }
+
+    @NonNull
+    private static String getPaymentMethodKey(@NonNull String customerId) {
+        return String.format(Locale.US, "customer[%s].payment_method", customerId);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -156,8 +156,7 @@ public class AddPaymentMethodActivity extends StripeActivity {
 
     private void finishWithPaymentMethod(@NonNull PaymentMethod paymentMethod) {
         setCommunicatingProgress(false);
-        final Intent intent = new Intent().putExtra(EXTRA_NEW_PAYMENT_METHOD, paymentMethod);
-        setResult(RESULT_OK, intent);
+        setResult(RESULT_OK, new Intent().putExtra(EXTRA_NEW_PAYMENT_METHOD, paymentMethod));
         finish();
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -234,18 +234,18 @@ public class PaymentSessionTest {
     public void getSelectedPaymentMethodId_whenPrefsNotSet_returnsNull() {
         when(mCustomerSession.getCachedCustomer()).thenReturn(FIRST_CUSTOMER);
         CustomerSession.setInstance(mCustomerSession);
-        assertNull(createPaymentSesson().getSelectedPaymentMethodId());
+        assertNull(createPaymentSesson().getSelectedPaymentMethodId(null));
     }
 
     @Test
-    public void getSelectedPaymentMethodId_whenHasPaymentSessionData_hasId() {
+    public void getSelectedPaymentMethodId_whenHasPaymentSessionData_returnsExpectedId() {
         mPaymentSessionData.setPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD);
         assertEquals("pm_123456789",
-                createPaymentSesson().getSelectedPaymentMethodId());
+                createPaymentSesson().getSelectedPaymentMethodId(null));
     }
 
     @Test
-    public void getSelectedPaymentMethodId_whenHasPrefsSet_hasId() {
+    public void getSelectedPaymentMethodId_whenHasPrefsSet_returnsExpectedId() {
         final String customerId = Objects.requireNonNull(FIRST_CUSTOMER.getId());
         when(mPaymentSessionPrefs.getSelectedPaymentMethodId(customerId)).thenReturn("pm_12345");
 
@@ -253,7 +253,14 @@ public class PaymentSessionTest {
         CustomerSession.setInstance(mCustomerSession);
 
         assertEquals("pm_12345",
-                createPaymentSesson().getSelectedPaymentMethodId());
+                createPaymentSesson().getSelectedPaymentMethodId(null));
+    }
+
+    @Test
+    public void getSelectedPaymentMethodId_whenHasUserSpecifiedPaymentMethod_returnsExpectedId() {
+        mPaymentSessionData.setPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD);
+        assertEquals("pm_987",
+                createPaymentSesson().getSelectedPaymentMethodId("pm_987"));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodFixtures.java
@@ -1,0 +1,56 @@
+package com.stripe.android.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PaymentMethodFixtures {
+    public static final PaymentMethod.Card CARD = new PaymentMethod.Card.Builder()
+            .setBrand(PaymentMethod.Card.Brand.VISA)
+            .setChecks(new PaymentMethod.Card.Checks.Builder()
+                    .setAddressLine1Check("unchecked")
+                    .setAddressPostalCodeCheck(null)
+                    .setCvcCheck("unchecked")
+                    .build())
+            .setCountry("US")
+            .setExpiryMonth(8)
+            .setExpiryYear(2022)
+            .setFunding("credit")
+            .setLast4("4242")
+            .setThreeDSecureUsage(new PaymentMethod.Card.ThreeDSecureUsage.Builder()
+                    .setSupported(true)
+                    .build())
+            .setWallet(null)
+            .build();
+
+    public static final PaymentMethod.BillingDetails BILLING_DETAILS =
+            new PaymentMethod.BillingDetails.Builder()
+                    .setAddress(new Address.Builder()
+                            .setLine1("510 Townsend St")
+                            .setCity("San Francisco")
+                            .setState("CA")
+                            .setPostalCode("94103")
+                            .setCountry("USA")
+                            .build())
+                    .setEmail("patrick@example.com")
+                    .setName("Patrick")
+                    .setPhone("123-456-7890")
+                    .build();
+
+    public static final PaymentMethod CARD_PAYMENT_METHOD;
+
+    static {
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("order_id", "123456789");
+
+        CARD_PAYMENT_METHOD = new PaymentMethod.Builder()
+                .setId("pm_123456789")
+                .setCreated(1550757934255L)
+                .setLiveMode(true)
+                .setType("card")
+                .setCustomerId("cus_AQsHpvKfKwJDrF")
+                .setBillingDetails(BILLING_DETAILS)
+                .setCard(PaymentMethodFixtures.CARD)
+                .setMetadata(metadata)
+                .build();
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -79,56 +79,6 @@ public class PaymentMethodTest {
             "\t}\n" +
             "}";
 
-    private static final PaymentMethod.Card CARD = new PaymentMethod.Card.Builder()
-            .setBrand(PaymentMethod.Card.Brand.VISA)
-            .setChecks(new PaymentMethod.Card.Checks.Builder()
-                    .setAddressLine1Check("unchecked")
-                    .setAddressPostalCodeCheck(null)
-                    .setCvcCheck("unchecked")
-                    .build())
-            .setCountry("US")
-            .setExpiryMonth(8)
-            .setExpiryYear(2022)
-            .setFunding("credit")
-            .setLast4("4242")
-            .setThreeDSecureUsage(new PaymentMethod.Card.ThreeDSecureUsage.Builder()
-                    .setSupported(true)
-                    .build())
-            .setWallet(null)
-            .build();
-
-    private static final PaymentMethod.BillingDetails BILLING_DETAILS =
-            new PaymentMethod.BillingDetails.Builder()
-                    .setAddress(new Address.Builder()
-                            .setLine1("510 Townsend St")
-                            .setCity("San Francisco")
-                            .setState("CA")
-                            .setPostalCode("94103")
-                            .setCountry("USA")
-                            .build())
-                    .setEmail("patrick@example.com")
-                    .setName("Patrick")
-                    .setPhone("123-456-7890")
-                    .build();
-
-    private static final PaymentMethod CARD_PAYMENT_METHOD;
-
-    static {
-        final Map<String, String> metadata = new HashMap<>();
-        metadata.put("order_id", "123456789");
-
-        CARD_PAYMENT_METHOD = new PaymentMethod.Builder()
-                .setId("pm_123456789")
-                .setCreated(1550757934255L)
-                .setLiveMode(true)
-                .setType("card")
-                .setCustomerId("cus_AQsHpvKfKwJDrF")
-                .setBillingDetails(BILLING_DETAILS)
-                .setCard(CARD)
-                .setMetadata(metadata)
-                .build();
-    }
-
     @Test
     public void toJson_withIdeal_shouldReturnExpectedJson() {
         final JSONObject paymentMethod = new JSONObject(new PaymentMethod.Builder()
@@ -137,7 +87,7 @@ public class PaymentMethodTest {
                 .setLiveMode(true)
                 .setType("ideal")
                 .setCustomerId("cus_AQsHpvKfKwJDrF")
-                .setBillingDetails(BILLING_DETAILS)
+                .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
                 .setIdeal(new PaymentMethod.Ideal.Builder()
                         .setBank("my bank")
                         .setBankIdentifierCode("bank id")
@@ -151,20 +101,22 @@ public class PaymentMethodTest {
 
     @Test
     public void equals_withEqualPaymentMethods_shouldReturnTrue() {
-        assertEquals(CARD_PAYMENT_METHOD, new PaymentMethod.Builder()
-                .setId("pm_123456789")
-                .setCreated(1550757934255L)
-                .setLiveMode(true)
-                .setType("card")
-                .setCustomerId("cus_AQsHpvKfKwJDrF")
-                .setBillingDetails(BILLING_DETAILS)
-                .setCard(CARD)
-                .build());
+        assertEquals(PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                new PaymentMethod.Builder()
+                        .setId("pm_123456789")
+                        .setCreated(1550757934255L)
+                        .setLiveMode(true)
+                        .setType("card")
+                        .setCustomerId("cus_AQsHpvKfKwJDrF")
+                        .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
+                        .setCard(PaymentMethodFixtures.CARD)
+                        .build());
     }
 
     @Test
     public void fromString_shouldReturnExpectedPaymentMethod() {
-        assertEquals(CARD_PAYMENT_METHOD, PaymentMethod.fromString(RAW_CARD_JSON));
+        assertEquals(PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                PaymentMethod.fromString(RAW_CARD_JSON));
     }
 
     @Test
@@ -192,8 +144,8 @@ public class PaymentMethodTest {
         metadata.put("meta", "data");
         metadata.put("meta2", "data2");
         final PaymentMethod paymentMethod = new PaymentMethod.Builder()
-                .setBillingDetails(BILLING_DETAILS)
-                .setCard(CARD)
+                .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
+                .setCard(PaymentMethodFixtures.CARD)
                 .setCardPresent(PaymentMethod.CardPresent.EMPTY)
                 .setCreated(1550757934255L)
                 .setCustomerId("cus_AQsHpvKfKwJDrF")


### PR DESCRIPTION
##  Motivation
This allows a customer's preferences to be set across payment sessions

## Testing
Add unit tests and manually tested
