### PR TITLE
Update Stripe3ds2UiCustomization

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/appName"
         android:name=".ExampleApplication"
+        android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
 
         <!-- Enables the Google Payment API -->
@@ -19,21 +20,17 @@
             android:value="true"/>
 
         <activity
-            android:name=".activity.PaymentActivity"
-            android:theme="@style/AppTheme">
+            android:name=".activity.PaymentActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
         <activity
-            android:name=".activity.PaymentIntentActivity"
-            android:theme="@style/AppTheme">
-        </activity>
+            android:name=".activity.PaymentIntentActivity" />
 
         <activity
             android:name=".activity.SetupIntentActivity"
-            android:launchMode="singleInstance"
-            android:theme="@style/AppTheme">
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -51,8 +48,7 @@
 
         <activity
             android:name=".activity.RedirectActivity"
-            android:launchMode="singleTask"
-            android:theme="@style/AppTheme">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -76,8 +72,7 @@
         </activity>
         <activity
             android:name=".activity.LauncherActivity"
-            android:launchMode="singleTask"
-            android:theme="@style/AppTheme">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
@@ -85,36 +80,31 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".activity.CustomerSessionActivity"
-            android:theme="@style/AppTheme">
+            android:name=".activity.CustomerSessionActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
         <activity
-            android:name=".activity.PaymentMultilineActivity"
-            android:theme="@style/AppTheme">
+            android:name=".activity.PaymentMultilineActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
         <activity
-            android:name=".activity.PaymentSessionActivity"
-            android:theme="@style/AppTheme">
+            android:name=".activity.PaymentSessionActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
-        <activity android:name=".activity.PayWithGoogleActivity"
-                  android:theme="@style/AppTheme">
+        <activity android:name=".activity.PayWithGoogleActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>
         </activity>
 
         <activity
-            android:name=".activity.PaymentAuthActivity"
-            android:theme="@style/AppTheme" />
+            android:name=".activity.PaymentAuthActivity" />
     </application>
 
 </manifest>

--- a/example/res/values/colors.xml
+++ b/example/res/values/colors.xml
@@ -1,2 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="primary">#5F65D4</color>
+    <color name="primaryDark">#392996</color>
+    <color name="accent">#9cdbff</color>
+    <color name="textPrimary">#FFFFFF</color>
+    <color name="text">#000000</color>
+    <color name="background">#0000FF</color>
 </resources>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="@style/Theme.AppCompat.DayNight">
-        <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight">
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primaryDark</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="colorControlActivated">@color/accent</item>
+        <item name="android:textColorPrimary">@color/textPrimary</item>
+        <item name="android:textColor">@color/text</item>
     </style>
 </resources>

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.java
@@ -74,7 +74,8 @@ public class PaymentAuthActivity extends AppCompatActivity {
         setContentView(R.layout.activity_payment_auth);
 
         final PaymentAuthConfig.Stripe3ds2UiCustomization uiCustomization =
-                new PaymentAuthConfig.Stripe3ds2UiCustomization.Builder().build();
+                PaymentAuthConfig.Stripe3ds2UiCustomization.Builder.createWithAppTheme(this)
+                        .build();
         PaymentAuthConfig.init(new PaymentAuthConfig.Builder()
                 .set3ds2Config(new PaymentAuthConfig.Stripe3ds2Config.Builder()
                         .setTimeout(6)

--- a/samplestore/src/main/AndroidManifest.xml
+++ b/samplestore/src/main/AndroidManifest.xml
@@ -28,8 +28,7 @@
         </activity>
 
         <activity
-            android:name=".PaymentActivity"
-            android:launchMode="singleTask">
+            android:name=".PaymentActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
             </intent-filter>

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.java
@@ -22,6 +22,7 @@ import com.jakewharton.rxbinding2.view.RxView;
 import com.stripe.android.ApiResultCallback;
 import com.stripe.android.CustomerSession;
 import com.stripe.android.PayWithGoogleUtils;
+import com.stripe.android.PaymentAuthConfig;
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.PaymentIntentResult;
 import com.stripe.android.PaymentSession;
@@ -101,6 +102,22 @@ public class PaymentActivity extends AppCompatActivity {
         if (Settings.STRIPE_ACCOUNT_ID != null) {
             mStripe.setStripeAccount(Settings.STRIPE_ACCOUNT_ID);
         }
+
+        final PaymentAuthConfig.Stripe3ds2ButtonCustomization selectCustomization =
+                new PaymentAuthConfig.Stripe3ds2ButtonCustomization.Builder()
+                        .setBackgroundColor("#EC4847")
+                        .setTextColor("#000000")
+                        .build();
+        final PaymentAuthConfig.Stripe3ds2UiCustomization uiCustomization =
+                PaymentAuthConfig.Stripe3ds2UiCustomization.Builder.createWithAppTheme(this)
+                        .setButtonCustomization(selectCustomization,
+                                PaymentAuthConfig.Stripe3ds2UiCustomization.ButtonType.SELECT)
+                        .build();
+        PaymentAuthConfig.init(new PaymentAuthConfig.Builder()
+                .set3ds2Config(new PaymentAuthConfig.Stripe3ds2Config.Builder()
+                        .setUiCustomization(uiCustomization)
+                        .build())
+                .build());
 
         mService = RetrofitFactory.getInstance().create(StripeService.class);
 

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api "com.android.support:design:28.0.0"
 
-    implementation "com.stripe:stripe-3ds2-android:1.1.2"
+    implementation "com.stripe:stripe-3ds2-android:1.1.3"
 
     javadocDeps "com.android.support:support-annotations:28.0.0"
     javadocDeps "com.android.support:appcompat-v7:28.0.0"

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthConfig.java
@@ -1,11 +1,11 @@
 package com.stripe.android;
 
+import android.app.Activity;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
-import com.stripe.android.stripe3ds2.exceptions.InvalidInputException;
 import com.stripe.android.stripe3ds2.init.ui.ButtonCustomization;
 import com.stripe.android.stripe3ds2.init.ui.LabelCustomization;
 import com.stripe.android.stripe3ds2.init.ui.StripeButtonCustomization;
@@ -133,11 +133,11 @@ public final class PaymentAuthConfig {
              * Set the button's background color
              *
              * @param hexColor The button's background color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
             public Builder setBackgroundColor(@NonNull String hexColor)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mButtonCustomization.setBackgroundColor(hexColor);
                 return this;
             }
@@ -146,10 +146,10 @@ public final class PaymentAuthConfig {
              * Set the corner radius of the button
              *
              * @param cornerRadius The radius of the button in pixels
-             * @throws InvalidInputException If the corner radius is less than 0
+             * @throws RuntimeException If the corner radius is less than 0
              */
             @NonNull
-            public Builder setCornerRadius(int cornerRadius) throws InvalidInputException {
+            public Builder setCornerRadius(int cornerRadius) throws RuntimeException {
                 mButtonCustomization.setCornerRadius(cornerRadius);
                 return this;
             }
@@ -158,10 +158,10 @@ public final class PaymentAuthConfig {
              * Set the button's text font
              *
              * @param fontName The name of the font. If not found, default system font used
-             * @throws InvalidInputException If font name is null or empty
+             * @throws RuntimeException If font name is null or empty
              */
             @NonNull
-            public Builder setTextFontName(@NonNull String fontName) throws InvalidInputException {
+            public Builder setTextFontName(@NonNull String fontName) throws RuntimeException {
                 mButtonCustomization.setTextFontName(fontName);
                 return this;
             }
@@ -170,10 +170,10 @@ public final class PaymentAuthConfig {
              * Set the button's text color
              *
              * @param hexColor The button's text color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
-            public Builder setTextColor(@NonNull String hexColor) throws InvalidInputException {
+            public Builder setTextColor(@NonNull String hexColor) throws RuntimeException {
                 mButtonCustomization.setTextColor(hexColor);
                 return this;
             }
@@ -182,10 +182,10 @@ public final class PaymentAuthConfig {
              * Set the button's text size
              *
              * @param fontSize The size of the font in scaled-pixels (sp)
-             * @throws InvalidInputException If the font size is 0 or less
+             * @throws RuntimeException If the font size is 0 or less
              */
             @NonNull
-            public Builder setTextFontSize(int fontSize) throws InvalidInputException {
+            public Builder setTextFontSize(int fontSize) throws RuntimeException {
                 mButtonCustomization.setTextFontSize(fontSize);
                 return this;
             }
@@ -240,11 +240,11 @@ public final class PaymentAuthConfig {
              * Set the text color for heading labels
              *
              * @param hexColor The heading labels's text color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
             public Builder setHeadingTextColor(@NonNull String hexColor)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mLabelCustomization.setHeadingTextColor(hexColor);
                 return this;
             }
@@ -253,11 +253,11 @@ public final class PaymentAuthConfig {
              * Set the heading label's font
              *
              * @param fontName The name of the font. Defaults to system font if not found
-             * @throws InvalidInputException If the font name is null or empty
+             * @throws RuntimeException If the font name is null or empty
              */
             @NonNull
             public Builder setHeadingTextFontName(@NonNull String fontName)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mLabelCustomization.setHeadingTextFontName(fontName);
                 return this;
             }
@@ -266,10 +266,10 @@ public final class PaymentAuthConfig {
              * Set the heading label's text size
              *
              * @param fontSize The size of the heading label in scaled-pixels (sp).
-             * @throws InvalidInputException If the font size is 0 or less
+             * @throws RuntimeException If the font size is 0 or less
              */
             @NonNull
-            public Builder setHeadingTextFontSize(int fontSize) throws InvalidInputException {
+            public Builder setHeadingTextFontSize(int fontSize) throws RuntimeException {
                 mLabelCustomization.setHeadingTextFontSize(fontSize);
                 return this;
             }
@@ -278,10 +278,10 @@ public final class PaymentAuthConfig {
              * Set the label's font
              *
              * @param fontName The name of the font. Defaults to system font if not found
-             * @throws InvalidInputException If the font name is null or empty
+             * @throws RuntimeException If the font name is null or empty
              */
             @NonNull
-            public Builder setTextFontName(@NonNull String fontName) throws InvalidInputException {
+            public Builder setTextFontName(@NonNull String fontName) throws RuntimeException {
                 mLabelCustomization.setTextFontName(fontName);
                 return this;
             }
@@ -290,10 +290,10 @@ public final class PaymentAuthConfig {
              * Set the label's text color
              *
              * @param hexColor The labels's text color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
-            public Builder setTextColor(@NonNull String hexColor) throws InvalidInputException {
+            public Builder setTextColor(@NonNull String hexColor) throws RuntimeException {
                 mLabelCustomization.setTextColor(hexColor);
                 return this;
             }
@@ -302,10 +302,10 @@ public final class PaymentAuthConfig {
              * Set the label's text size
              *
              * @param fontSize The label's font size in scaled-pixels (sp)
-             * @throws InvalidInputException If the font size is 0 or less
+             * @throws RuntimeException If the font size is 0 or less
              */
             @NonNull
-            public Builder setTextFontSize(int fontSize) throws InvalidInputException {
+            public Builder setTextFontSize(int fontSize) throws RuntimeException {
                 mLabelCustomization.setTextFontSize(fontSize);
                 return this;
             }
@@ -359,10 +359,10 @@ public final class PaymentAuthConfig {
              * Set the width of the border around the text entry box
              *
              * @param borderWidth Width of the border in pixels
-             * @throws InvalidInputException If the border width is less than 0
+             * @throws RuntimeException If the border width is less than 0
              */
             @NonNull
-            public Builder setBorderWidth(int borderWidth) throws InvalidInputException {
+            public Builder setBorderWidth(int borderWidth) throws RuntimeException {
                 mTextBoxCustomization.setBorderWidth(borderWidth);
                 return this;
             }
@@ -371,10 +371,10 @@ public final class PaymentAuthConfig {
              * Set the color of the border around the text entry box
              *
              * @param hexColor The border's color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
-            public Builder setBorderColor(@NonNull String hexColor) throws InvalidInputException {
+            public Builder setBorderColor(@NonNull String hexColor) throws RuntimeException {
                 mTextBoxCustomization.setBorderColor(hexColor);
                 return this;
             }
@@ -383,10 +383,10 @@ public final class PaymentAuthConfig {
              * Set the corner radius of the text entry box
              *
              * @param cornerRadius The corner radius in pixels
-             * @throws InvalidInputException If the corner radius is less than 0
+             * @throws RuntimeException If the corner radius is less than 0
              */
             @NonNull
-            public Builder setCornerRadius(int cornerRadius) throws InvalidInputException {
+            public Builder setCornerRadius(int cornerRadius) throws RuntimeException {
                 mTextBoxCustomization.setCornerRadius(cornerRadius);
                 return this;
             }
@@ -395,10 +395,10 @@ public final class PaymentAuthConfig {
              * Set the font for text entry
              *
              * @param fontName The name of the font. The system default is used if not found.
-             * @throws InvalidInputException If the font name is null or empty.
+             * @throws RuntimeException If the font name is null or empty.
              */
             @NonNull
-            public Builder setTextFontName(@NonNull String fontName) throws InvalidInputException {
+            public Builder setTextFontName(@NonNull String fontName) throws RuntimeException {
                 mTextBoxCustomization.setTextFontName(fontName);
                 return this;
             }
@@ -407,10 +407,10 @@ public final class PaymentAuthConfig {
              * Set the text color for text entry
              *
              * @param hexColor The text color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
-            public Builder setTextColor(@NonNull String hexColor) throws InvalidInputException {
+            public Builder setTextColor(@NonNull String hexColor) throws RuntimeException {
                 mTextBoxCustomization.setTextColor(hexColor);
                 return this;
             }
@@ -419,10 +419,10 @@ public final class PaymentAuthConfig {
              * Set the text entry font size
              *
              * @param fontSize The font size in scaled-pixels (sp)
-             * @throws InvalidInputException If the font size is 0 or less
+             * @throws RuntimeException If the font size is 0 or less
              */
             @NonNull
-            public Builder setTextFontSize(int fontSize) throws InvalidInputException {
+            public Builder setTextFontSize(int fontSize) throws RuntimeException {
                 mTextBoxCustomization.setTextFontSize(fontSize);
                 return this;
             }
@@ -476,11 +476,11 @@ public final class PaymentAuthConfig {
              * Set the toolbar's background color
              *
              * @param hexColor The background color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
             public Builder setBackgroundColor(@NonNull String hexColor)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mToolbarCustomization.setBackgroundColor(hexColor);
                 return this;
             }
@@ -489,10 +489,10 @@ public final class PaymentAuthConfig {
              * Set the toolbar's title
              *
              * @param headerText The toolbar's title text
-             * @throws InvalidInputException if the title is null or empty
+             * @throws RuntimeException if the title is null or empty
              */
             @NonNull
-            public Builder setHeaderText(@NonNull String headerText) throws InvalidInputException {
+            public Builder setHeaderText(@NonNull String headerText) throws RuntimeException {
                 mToolbarCustomization.setHeaderText(headerText);
                 return this;
             }
@@ -501,10 +501,10 @@ public final class PaymentAuthConfig {
              * Set the toolbar's cancel button text
              *
              * @param buttonText The cancel button's text
-             * @throws InvalidInputException If the button text is null or empty
+             * @throws RuntimeException If the button text is null or empty
              */
             @NonNull
-            public Builder setButtonText(@NonNull String buttonText) throws InvalidInputException {
+            public Builder setButtonText(@NonNull String buttonText) throws RuntimeException {
                 mToolbarCustomization.setButtonText(buttonText);
                 return this;
             }
@@ -513,10 +513,10 @@ public final class PaymentAuthConfig {
              * Set the font for the title text
              *
              * @param fontName The name of the font. System default is used if not found
-             * @throws InvalidInputException If the font name is null or empty
+             * @throws RuntimeException If the font name is null or empty
              */
             @NonNull
-            public Builder setTextFontName(@NonNull String fontName) throws InvalidInputException {
+            public Builder setTextFontName(@NonNull String fontName) throws RuntimeException {
                 mToolbarCustomization.setTextFontName(fontName);
                 return this;
             }
@@ -525,10 +525,10 @@ public final class PaymentAuthConfig {
              * Set the color of the title text
              *
              * @param hexColor The title's text color in the format #RRGGBB or #AARRGGBB
-             * @throws InvalidInputException If the color cannot be parsed
+             * @throws RuntimeException If the color cannot be parsed
              */
             @NonNull
-            public Builder setTextColor(@NonNull String hexColor) throws InvalidInputException {
+            public Builder setTextColor(@NonNull String hexColor) throws RuntimeException {
                 mToolbarCustomization.setTextColor(hexColor);
                 return this;
             }
@@ -537,10 +537,10 @@ public final class PaymentAuthConfig {
              * Set the title text's font size
              *
              * @param fontSize The size of the title text in scaled-pixels (sp)
-             * @throws InvalidInputException If the font size is 0 or less
+             * @throws RuntimeException If the font size is 0 or less
              */
             @NonNull
-            public Builder setTextFontSize(int fontSize) throws InvalidInputException {
+            public Builder setTextFontSize(int fontSize) throws RuntimeException {
                 mToolbarCustomization.setTextFontSize(fontSize);
                 return this;
             }
@@ -582,7 +582,14 @@ public final class PaymentAuthConfig {
         /**
          * The type of button for which customization can be set
          */
-        public enum ButtonType {SUBMIT, CONTINUE, NEXT, CANCEL, RESEND}
+        public enum ButtonType {
+            SUBMIT,
+            CONTINUE,
+            NEXT,
+            CANCEL,
+            RESEND,
+            SELECT
+        }
 
         private Stripe3ds2UiCustomization(@NonNull UiCustomization uiCustomization) {
             mUiCustomization = uiCustomization;
@@ -596,25 +603,44 @@ public final class PaymentAuthConfig {
         public static final class Builder implements ObjectBuilder<Stripe3ds2UiCustomization> {
             @NonNull private final UiCustomization mUiCustomization;
 
+            @NonNull
+            public static Builder createWithAppTheme(@NonNull Activity activity) {
+                return new Builder(activity);
+            }
+
             public Builder() {
                 mUiCustomization = new StripeUiCustomization();
             }
 
+            private Builder(@NonNull Activity activity) {
+                mUiCustomization = StripeUiCustomization.createWithAppTheme(activity);
+            }
+
             @NonNull
             private UiCustomization.ButtonType getUiButtonType(@NonNull ButtonType buttonType)
-                    throws InvalidInputException {
-                if (buttonType == ButtonType.NEXT) {
-                    return UiCustomization.ButtonType.NEXT;
-                } else if (buttonType == ButtonType.CANCEL) {
-                    return UiCustomization.ButtonType.CANCEL;
-                } else if (buttonType == ButtonType.SUBMIT) {
-                    return UiCustomization.ButtonType.SUBMIT;
-                } else if (buttonType == ButtonType.RESEND) {
-                    return UiCustomization.ButtonType.RESEND;
-                } else if (buttonType == ButtonType.CONTINUE) {
-                    return UiCustomization.ButtonType.CONTINUE;
-                } else {
-                    throw new InvalidInputException(new RuntimeException("Invalid Button Type"));
+                    throws RuntimeException {
+                switch (buttonType) {
+                    case SUBMIT: {
+                        return UiCustomization.ButtonType.SUBMIT;
+                    }
+                    case CONTINUE: {
+                        return UiCustomization.ButtonType.CONTINUE;
+                    }
+                    case NEXT: {
+                        return UiCustomization.ButtonType.NEXT;
+                    }
+                    case CANCEL: {
+                        return UiCustomization.ButtonType.CANCEL;
+                    }
+                    case RESEND: {
+                        return UiCustomization.ButtonType.RESEND;
+                    }
+                    case SELECT: {
+                        return UiCustomization.ButtonType.SELECT;
+                    }
+                    default: {
+                        throw new IllegalArgumentException("Invalid Button Type");
+                    }
                 }
             }
 
@@ -623,13 +649,13 @@ public final class PaymentAuthConfig {
              *
              * @param buttonCustomization The button customization data
              * @param buttonType The type of button to customize
-             * @throws InvalidInputException If any customization data is invalid
+             * @throws RuntimeException If any customization data is invalid
              */
             @NonNull
             public Builder setButtonCustomization(
                     @NonNull Stripe3ds2ButtonCustomization buttonCustomization,
                     @NonNull ButtonType buttonType)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mUiCustomization.setButtonCustomization(buttonCustomization.mButtonCustomization,
                         getUiButtonType(buttonType));
                 return this;
@@ -639,12 +665,12 @@ public final class PaymentAuthConfig {
              * Set the customization data for the 3DS2 toolbar
              *
              * @param toolbarCustomization Toolbar customization data
-             * @throws InvalidInputException If any customization data is invalid
+             * @throws RuntimeException If any customization data is invalid
              */
             @NonNull
             public Builder setToolbarCustomization(
                     @NonNull Stripe3ds2ToolbarCustomization toolbarCustomization)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mUiCustomization
                         .setToolbarCustomization(toolbarCustomization.mToolbarCustomization);
                 return this;
@@ -654,12 +680,12 @@ public final class PaymentAuthConfig {
              * Set the 3DS2 label customization
              *
              * @param labelCustomization Label customization data
-             * @throws InvalidInputException If any customization data is invalid
+             * @throws RuntimeException If any customization data is invalid
              */
             @NonNull
             public Builder setLabelCustomization(
                     @NonNull Stripe3ds2LabelCustomization labelCustomization)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mUiCustomization.setLabelCustomization(labelCustomization.mLabelCustomization);
                 return this;
             }
@@ -668,12 +694,12 @@ public final class PaymentAuthConfig {
              * Set the 3DS2 text box customization
              *
              * @param textBoxCustomization Text box customization data
-             * @throws InvalidInputException If any customization data is invalid
+             * @throws RuntimeException If any customization data is invalid
              */
             @NonNull
             public Builder setTextBoxCustomization(
                     @NonNull Stripe3ds2TextBoxCustomization textBoxCustomization)
-                    throws InvalidInputException {
+                    throws RuntimeException {
                 mUiCustomization
                         .setTextBoxCustomization(textBoxCustomization.mTextBoxCustomization);
                 return this;

--- a/stripe/src/test/java/com/stripe/android/Fake3ds2ChallengeActivity.java
+++ b/stripe/src/test/java/com/stripe/android/Fake3ds2ChallengeActivity.java
@@ -1,0 +1,15 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+public class Fake3ds2ChallengeActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        setTheme(android.R.style.Theme);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.java
@@ -10,7 +10,9 @@ import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization;
 import com.stripe.android.stripe3ds2.init.ui.TextBoxCustomization;
 import com.stripe.android.stripe3ds2.init.ui.ToolbarCustomization;
 import com.stripe.android.stripe3ds2.init.ui.UiCustomization;
+import com.stripe.android.view.BaseViewTest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -22,11 +24,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 @RunWith(RobolectricTestRunner.class)
-public class PaymentAuthConfigTest {
+public class PaymentAuthConfigTest extends BaseViewTest<Fake3ds2ChallengeActivity> {
+
+    public PaymentAuthConfigTest() {
+        super(Fake3ds2ChallengeActivity.class);
+    }
 
     @Before
     public void setup() {
         PaymentAuthConfig.reset();
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
     }
 
     @Test
@@ -182,6 +194,10 @@ public class PaymentAuthConfigTest {
                 new PaymentAuthConfig.Stripe3ds2ButtonCustomization.Builder()
                         .setTextColor("#000011").build();
 
+        final PaymentAuthConfig.Stripe3ds2ButtonCustomization selectStripe3ds2ButtonCustomization =
+                new PaymentAuthConfig.Stripe3ds2ButtonCustomization.Builder()
+                        .setBackgroundColor("#000066").build();
+
         final PaymentAuthConfig.Stripe3ds2LabelCustomization stripe3ds2LabelCustomization =
                 new PaymentAuthConfig.Stripe3ds2LabelCustomization.Builder()
                         .setTextColor("#000002").build();
@@ -200,6 +216,8 @@ public class PaymentAuthConfigTest {
                                 PaymentAuthConfig.Stripe3ds2UiCustomization.ButtonType.NEXT)
                         .setButtonCustomization(cancelStripe3ds2ButtonCustomization,
                                 PaymentAuthConfig.Stripe3ds2UiCustomization.ButtonType.CANCEL)
+                        .setButtonCustomization(selectStripe3ds2ButtonCustomization,
+                                PaymentAuthConfig.Stripe3ds2UiCustomization.ButtonType.SELECT)
                         .setLabelCustomization(stripe3ds2LabelCustomization)
                         .setTextBoxCustomization(stripe3ds2TextBoxCustomization)
                         .setToolbarCustomization(stripe3ds2ToolbarCustomization)
@@ -210,6 +228,9 @@ public class PaymentAuthConfigTest {
 
         final ButtonCustomization cancelButtonCustomization = new StripeButtonCustomization();
         cancelButtonCustomization.setTextColor("#000011");
+
+        final ButtonCustomization selectButtonCustomization = new StripeButtonCustomization();
+        selectButtonCustomization.setBackgroundColor("#000066");
 
         final LabelCustomization labelCustomization = new StripeLabelCustomization();
         labelCustomization.setTextColor("#000002");
@@ -225,10 +246,25 @@ public class PaymentAuthConfigTest {
                 UiCustomization.ButtonType.NEXT);
         expectedUiCustomization.setButtonCustomization(cancelButtonCustomization,
                 UiCustomization.ButtonType.CANCEL);
+        expectedUiCustomization.setButtonCustomization(selectButtonCustomization,
+                UiCustomization.ButtonType.SELECT);
         expectedUiCustomization.setLabelCustomization(labelCustomization);
         expectedUiCustomization.setTextBoxCustomization(textBoxCustomization);
         expectedUiCustomization.setToolbarCustomization(toolbarCustomization);
 
         assertEquals(expectedUiCustomization, uiCustomization.getUiCustomization());
+    }
+
+    @Test
+    public void createWithAppTheme_shouldCreateExpectedToolbarCustomization() {
+        final PaymentAuthConfig.Stripe3ds2UiCustomization uiCustomizationFromTheme =
+                PaymentAuthConfig.Stripe3ds2UiCustomization.Builder
+                        .createWithAppTheme(createActivity())
+                        .build();
+        final ToolbarCustomization toolbarCustomization = new StripeToolbarCustomization();
+        toolbarCustomization.setBackgroundColor("#FF222222");
+        toolbarCustomization.setTextColor("#00000621");
+        assertEquals(toolbarCustomization,
+                uiCustomizationFromTheme.getUiCustomization().getToolbarCustomization());
     }
 }


### PR DESCRIPTION
## Summary
- Add `Stripe3ds2UiCustomization.Builder.createWithAppTheme(Activity)`
  to allow to default `Stripe3ds2UiCustomization` to app's theme
- Add `Stripe3ds2UiCustomization.ButtonType.SELECT` to allow customizing
  of select buttons (i.e. radio buttons and checkboxes)
- Update apps for changes

## Motivation
Allow users to more easily customize 3DS2 challenge screen

## Testing
Added unit tests and manually verified