### PR TITLE
Update StripeIntentResult's Status logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
@@ -4,24 +4,10 @@ import android.support.annotation.NonNull;
 
 import com.stripe.android.model.PaymentIntent;
 
-public final class PaymentIntentResult implements StripeIntentResult<PaymentIntent> {
-    @NonNull private final PaymentIntent paymentIntent;
-    @Status private final int status;
+public final class PaymentIntentResult extends StripeIntentResult<PaymentIntent> {
 
     private PaymentIntentResult(@NonNull Builder builder) {
-        this.paymentIntent = builder.mPaymentIntent;
-        this.status = builder.mStatus;
-    }
-
-    @NonNull
-    @Override
-    public PaymentIntent getIntent() {
-        return paymentIntent;
-    }
-
-    @Override
-    public int getStatus() {
-        return status;
+        super(builder.mPaymentIntent, builder.mStatus);
     }
 
     static final class Builder implements ObjectBuilder<PaymentIntentResult> {
@@ -29,13 +15,13 @@ public final class PaymentIntentResult implements StripeIntentResult<PaymentInte
         @Status private int mStatus;
 
         @NonNull
-        public Builder setPaymentIntent(@NonNull PaymentIntent paymentIntent) {
+        Builder setPaymentIntent(@NonNull PaymentIntent paymentIntent) {
             mPaymentIntent = paymentIntent;
             return this;
         }
 
         @NonNull
-        public Builder setStatus(@Status int status) {
+        Builder setStatus(@Status int status) {
             mStatus = status;
             return this;
         }

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
@@ -29,22 +29,19 @@ class PaymentRelayStarter implements ActivityStarter<PaymentRelayStarter.Data> {
         final Intent intent = new Intent(mActivity, PaymentRelayActivity.class)
                 .putExtra(StripeIntentResultExtras.CLIENT_SECRET,
                         data.stripeIntent != null ? data.stripeIntent.getClientSecret() : null)
-                .putExtra(StripeIntentResultExtras.AUTH_EXCEPTION, data.exception)
-                .putExtra(StripeIntentResultExtras.AUTH_STATUS, data.status);
+                .putExtra(StripeIntentResultExtras.AUTH_EXCEPTION, data.exception);
         mActivity.startActivityForResult(intent, mRequestCode);
     }
 
     public static final class Data {
         @Nullable final StripeIntent stripeIntent;
         @Nullable final Exception exception;
-        @StripeIntentResult.Status final int status;
 
         /**
          * Use when payment authentication completed or can be bypassed.
          */
         Data(@NonNull StripeIntent stripeIntent) {
             this.stripeIntent = stripeIntent;
-            this.status = StripeIntentResult.Status.SUCCEEDED;
             this.exception = null;
         }
 
@@ -53,13 +50,12 @@ class PaymentRelayStarter implements ActivityStarter<PaymentRelayStarter.Data> {
          */
         Data(@NonNull Exception exception) {
             this.stripeIntent = null;
-            this.status = StripeIntentResult.Status.FAILED;
             this.exception = exception;
         }
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(stripeIntent, exception, status);
+            return ObjectUtils.hash(stripeIntent, exception);
         }
 
         @Override
@@ -69,8 +65,7 @@ class PaymentRelayStarter implements ActivityStarter<PaymentRelayStarter.Data> {
 
         private boolean typedEquals(@NonNull Data data) {
             return ObjectUtils.equals(stripeIntent, data.stripeIntent) &&
-                    ObjectUtils.equals(exception, data.exception) &&
-                    ObjectUtils.equals(status, data.status);
+                    ObjectUtils.equals(exception, data.exception);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
@@ -1,29 +1,13 @@
 package com.stripe.android;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.stripe.android.model.SetupIntent;
-import com.stripe.android.utils.ObjectUtils;
 
-public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
-    @NonNull private final SetupIntent mSetupIntent;
-    @Status private final int mStatus;
+public class SetupIntentResult extends StripeIntentResult<SetupIntent> {
 
     private SetupIntentResult(@NonNull Builder builder) {
-        mSetupIntent = builder.mSetupIntent;
-        mStatus = builder.mStatus;
-    }
-
-    @NonNull
-    @Override
-    public SetupIntent getIntent() {
-        return mSetupIntent;
-    }
-
-    @Override
-    public int getStatus() {
-        return mStatus;
+        super(builder.mSetupIntent, builder.mStatus);
     }
 
     static final class Builder implements ObjectBuilder<SetupIntentResult> {
@@ -31,13 +15,13 @@ public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
         @Status private int mStatus;
 
         @NonNull
-        public Builder setSetupIntent(@NonNull SetupIntent setupIntent) {
+        Builder setSetupIntent(@NonNull SetupIntent setupIntent) {
             mSetupIntent = setupIntent;
             return this;
         }
 
         @NonNull
-        public Builder setStatus(@Status int status) {
+        Builder setStatus(@Status int status) {
             mStatus = status;
             return this;
         }
@@ -46,22 +30,5 @@ public class SetupIntentResult implements StripeIntentResult<SetupIntent> {
         public SetupIntentResult build() {
             return new SetupIntentResult(this);
         }
-    }
-
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        return this == obj || (obj instanceof SetupIntentResult &&
-                typedEquals((SetupIntentResult) obj));
-    }
-
-    private boolean typedEquals(@NonNull SetupIntentResult setupIntentResult) {
-        return ObjectUtils.equals(mSetupIntent, setupIntentResult.mSetupIntent)
-                && ObjectUtils.equals(mStatus, setupIntentResult.mStatus);
-    }
-
-    @Override
-    public int hashCode() {
-        return ObjectUtils.hash(mSetupIntent, mStatus);
-
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.java
@@ -3,12 +3,15 @@ package com.stripe.android;
 import android.app.Activity;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.stripe.android.model.ConfirmPaymentIntentParams;
 import com.stripe.android.model.StripeIntent;
+import com.stripe.android.utils.ObjectUtils;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Objects;
 
 /**
  * A model representing the result of a {@link StripeIntent} confirmation or authentication attempt
@@ -18,18 +21,73 @@ import java.lang.annotation.RetentionPolicy;
  * {@link #getIntent()} represents a {@link StripeIntent} retrieved after
  * confirmation/authentication succeeded or failed.
  */
-public interface StripeIntentResult<T extends StripeIntent> {
+public abstract class StripeIntentResult<T extends StripeIntent> {
+    @NonNull private final T mStripeIntent;
+    @Status private final int mStatus;
 
-    @NonNull T getIntent();
+    public StripeIntentResult(@NonNull T stripeIntent, @Status int status) {
+        mStripeIntent = stripeIntent;
+        mStatus = calculateStatus(Objects.requireNonNull(stripeIntent.getStatus()), status);
+    }
 
-    @Status int getStatus();
+    @StripeIntentResult.Status
+    private static int calculateStatus(@NonNull StripeIntent.Status stripeIntentStatus,
+                                       @StripeIntentResult.Status int authStatus) {
+        if (authStatus != StripeIntentResult.Status.UNKNOWN) {
+            return authStatus;
+        }
+
+        switch (stripeIntentStatus) {
+            case RequiresAction:
+            case Canceled: {
+                return StripeIntentResult.Status.CANCELED;
+            }
+            case RequiresPaymentMethod: {
+                return StripeIntentResult.Status.FAILED;
+            }
+            case Succeeded:
+            case RequiresCapture:
+            case RequiresConfirmation: {
+                return StripeIntentResult.Status.SUCCEEDED;
+            }
+            case Processing:
+            default: {
+                return StripeIntentResult.Status.UNKNOWN;
+            }
+        }
+    }
+
+    @NonNull
+    public final T getIntent() {
+        return mStripeIntent;
+    }
+
+    public final int getStatus() {
+        return mStatus;
+    }
+
+    @Override
+    public final boolean equals(@Nullable Object obj) {
+        return this == obj || (obj instanceof StripeIntentResult &&
+                typedEquals((StripeIntentResult) obj));
+    }
+
+    private boolean typedEquals(@NonNull StripeIntentResult setupIntentResult) {
+        return ObjectUtils.equals(mStripeIntent, setupIntentResult.mStripeIntent)
+                && ObjectUtils.equals(mStatus, setupIntentResult.mStatus);
+    }
+
+    @Override
+    public final int hashCode() {
+        return ObjectUtils.hash(mStripeIntent, mStatus);
+    }
 
     /**
      * Values that indicate the outcome of confirmation and payment authentication.
      */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({Status.UNKNOWN, Status.SUCCEEDED, Status.FAILED, Status.CANCELED, Status.TIMEDOUT})
-    @interface Status {
+    public @interface Status {
         int UNKNOWN = 0;
 
         /**

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.java
@@ -71,17 +71,33 @@ public interface StripeIntent {
     }
 
     /**
-     * See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
+     * <ul>
+     * <li>
+     * <a href="https://stripe.com/docs/payments/intents#intent-statuses">
+     *     The Intent State Machine - Intent statuses</a>
+     * </li>
+     *
+     * <li>
+     * <a href="https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status">
+     *     PaymentIntent.status API reference</a>
+     * </li>
+     *
+     * <li>
+     * <a href="https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status">
+     *     SetupIntent.status API reference</a>
+     * </li>
+     * </ul>
      */
     enum Status {
         Canceled("canceled"),
         Processing("processing"),
         RequiresAction("requires_action"),
-        RequiresAuthorization("requires_authorization"),
-        RequiresCapture("requires_capture"),
         RequiresConfirmation("requires_confirmation"),
         RequiresPaymentMethod("requires_payment_method"),
-        Succeeded("succeeded");
+        Succeeded("succeeded"),
+
+        // only applies to Payment Intents
+        RequiresCapture("requires_capture");
 
         @NonNull
         public final String code;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -2,6 +2,7 @@ package com.stripe.android.view;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
@@ -12,8 +13,6 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
-
-import com.stripe.android.StripeIntentResult;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -41,9 +40,9 @@ class PaymentAuthWebView extends WebView {
         configureSettings();
     }
 
-    void init(@NonNull PaymentAuthWebViewClient.Listener listener, @NonNull ProgressBar progressBar,
+    void init(@NonNull Activity activity, @NonNull ProgressBar progressBar,
               @NonNull String clientSecret, @NonNull String returnUrl) {
-        setWebViewClient(new PaymentAuthWebViewClient(listener, progressBar, clientSecret,
+        setWebViewClient(new PaymentAuthWebViewClient(activity, progressBar, clientSecret,
                 returnUrl));
     }
 
@@ -66,11 +65,11 @@ class PaymentAuthWebView extends WebView {
         @NonNull private final String mClientSecret;
         @Nullable private final Uri mReturnUrl;
         @NonNull private final ProgressBar mProgressBar;
-        @NonNull private final Listener mListener;
+        @NonNull private final Activity mActivity;
 
-        PaymentAuthWebViewClient(@NonNull Listener listener, @NonNull ProgressBar progressBar,
+        PaymentAuthWebViewClient(@NonNull Activity activity, @NonNull ProgressBar progressBar,
                                  @NonNull String clientSecret, @Nullable String returnUrl) {
-            mListener = listener;
+            mActivity = activity;
             mClientSecret = clientSecret;
             mReturnUrl = returnUrl != null ? Uri.parse(returnUrl) : null;
             mProgressBar = progressBar;
@@ -154,11 +153,7 @@ class PaymentAuthWebView extends WebView {
         }
 
         private void onAuthCompleted() {
-            mListener.onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
-        }
-
-        interface Listener {
-            void onAuthCompleted(@StripeIntentResult.Status int status);
+            mActivity.finish();
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -16,7 +16,6 @@ import android.widget.ProgressBar;
 
 import com.stripe.android.PaymentAuthWebViewStarter;
 import com.stripe.android.R;
-import com.stripe.android.StripeIntentResult;
 import com.stripe.android.StripeTextUtils;
 import com.stripe.android.stripe3ds2.init.ui.ToolbarCustomization;
 import com.stripe.android.stripe3ds2.utils.CustomizeUtils;
@@ -24,11 +23,9 @@ import com.stripe.android.stripe3ds2.utils.CustomizeUtils;
 import static com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION;
 
 public class PaymentAuthWebViewActivity
-        extends AppCompatActivity
-        implements PaymentAuthWebView.PaymentAuthWebViewClient.Listener {
+        extends AppCompatActivity {
 
     @Nullable private ToolbarCustomization mToolbarCustomization;
-    private Intent mResultIntent;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -49,8 +46,8 @@ public class PaymentAuthWebViewActivity
         final String returnUrl = getIntent()
                 .getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL);
 
-        mResultIntent = new Intent()
-                .putExtra(StripeIntentResultExtras.CLIENT_SECRET, clientSecret);
+        setResult(Activity.RESULT_OK, new Intent()
+                .putExtra(StripeIntentResultExtras.CLIENT_SECRET, clientSecret));
 
         final PaymentAuthWebView webView = findViewById(R.id.auth_web_view);
         final ProgressBar progressBar = findViewById(R.id.auth_web_view_progress_bar);
@@ -72,14 +69,9 @@ public class PaymentAuthWebViewActivity
     }
 
     @Override
-    public void onBackPressed() {
-        onAuthCompleted(StripeIntentResult.Status.CANCELED);
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.action_close) {
-            onAuthCompleted(StripeIntentResult.Status.CANCELED);
+            finish();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -100,12 +92,5 @@ public class PaymentAuthWebViewActivity
                 CustomizeUtils.setStatusBarColor(this, backgroundColor);
             }
         }
-    }
-
-    @Override
-    public void onAuthCompleted(@StripeIntentResult.Status int status) {
-        setResult(Activity.RESULT_OK,
-                mResultIntent.putExtra(StripeIntentResultExtras.AUTH_STATUS, status));
-        finish();
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -40,9 +41,7 @@ public class PaymentRelayStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.SUCCEEDED,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertFalse(intent.hasExtra(StripeIntentResultExtras.AUTH_STATUS));
         assertNull(intent.getSerializableExtra(StripeIntentResultExtras.AUTH_EXCEPTION));
     }
 
@@ -53,9 +52,7 @@ public class PaymentRelayStarterTest {
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertNull(intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.FAILED,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertFalse(intent.hasExtra(StripeIntentResultExtras.AUTH_STATUS));
         assertEquals(exception,
                 intent.getSerializableExtra(StripeIntentResultExtras.AUTH_EXCEPTION));
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -1,9 +1,8 @@
 package com.stripe.android.view;
 
+import android.app.Activity;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
-
-import com.stripe.android.StripeIntentResult;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,14 +11,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentAuthWebViewTest {
 
-    @Mock private PaymentAuthWebView.PaymentAuthWebViewClient.Listener mListener;
+    @Mock private Activity mActivity;
     @Mock private ProgressBar mProgressBar;
     @Mock private WebView mWebView;
 
@@ -33,11 +31,11 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456",
                         "stripe://payment_intent_return");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
@@ -46,11 +44,11 @@ public class PaymentAuthWebViewTest {
                 "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
 
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "seti_1234_secret_5678",
                         "stripe://payment_auth");
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
@@ -58,10 +56,10 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_intent_return?payment_intent=pi_123&" +
                 "payment_intent_client_secret=pi_123_secret_456&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
@@ -69,49 +67,49 @@ public class PaymentAuthWebViewTest {
         final String deepLink = "stripe://payment_auth?setup_intent=seti_1234" +
                 "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card";
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "seti_1234_secret_5678", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
     public void shouldOverrideUrlLoading_withoutReturnUrl_shouldNotAutoFinishActivity() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView,
                 "https://example.com");
-        verify(mListener, never()).onAuthCompleted(anyInt());
+        verify(mActivity, never()).finish();
     }
 
     @Test
     public void shouldOverrideUrlLoading_witKnownReturnUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView,
                 "stripejs://use_stripe_sdk/return_url");
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
     public void onPageFinished_wit3DSecureCompleteUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.onPageFinished(mWebView,
                 "https://hooks.stripe.com/3d_secure/complete/tdsrc_1ExLWoCRMbs6FrXfjPJRYtng");
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 
     @Test
     public void onPageFinished_witRedirectCompleteUrl_shouldFinish() {
         final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
-                new PaymentAuthWebView.PaymentAuthWebViewClient(mListener, mProgressBar,
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
                         "pi_123_secret_456", null);
         paymentAuthWebViewClient.onPageFinished(mWebView,
                 "https://hooks.stripe.com/redirect/complete/src_1ExLWoCRMbs6FrXfjPJRYtng");
-        verify(mListener).onAuthCompleted(StripeIntentResult.Status.SUCCEEDED);
+        verify(mActivity).finish();
     }
 }


### PR DESCRIPTION
## Summary
- Only explicitly set status for 3DS2 result, remove elsewhere
  (i.e. `PaymentAuthWebViewActivity`, `PaymentRelayStarter`)
- When status is `UNKNOWN` or not explicitly set,
  determine the status based on the StripeIntent's state

## Motivation
Fixes #1271

## Testing
Tested manually on both 3DS2 & 3DS1
