### PR TITLE
Add support for launching PaymentSession from a Fragment

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -95,6 +95,9 @@
 
         <activity
             android:name=".activity.PaymentAuthActivity" />
+
+        <activity
+            android:name=".activity.PaymentSessionFromFragmentActivity" />
     </application>
 
 </manifest>

--- a/example/res/layout/launch_payment_session_fragment.xml
+++ b/example/res/layout/launch_payment_session_fragment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:id="@+id/root">
+
+    <Button
+        android:id="@+id/launch_payment_session"
+        android:enabled="false"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/example_vertical_spacing"
+        android:text="@string/payment_session_select_payment"
+        />
+
+</LinearLayout>

--- a/example/res/layout/payment_session_from_fragment_layout.xml
+++ b/example/res/layout/payment_session_from_fragment_layout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:id="@+id/root">
+
+
+</LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -20,9 +20,10 @@
     <string name="confirmPayment">Confirm payment details</string>
     <string name="changeDetails">Change payment details</string>
     <string name="customer_payment_data_example">Customer Payment Selection</string>
-    <string name="launch_customer_session">Launch Customer Session</string>
-    <string name="launch_pay_with_google">Launch Pay with Google</string>
-    <string name="launch_payment_session">Launch Payment Session</string>
+    <string name="launch_customer_session">Customer Session</string>
+    <string name="launch_pay_with_google">Pay with Google</string>
+    <string name="launch_payment_session">Payment Session</string>
+    <string name="launch_payment_session_from_fragment">Payment Session from Fragment</string>
     <string name="pollingSource">Polling for source changes&#8230;</string>
     <string name="save">Save</string>
     <string name="saverx">Save Rx</string>
@@ -61,7 +62,7 @@
         <item>USD</item>
     </string-array>
 
-    <string name="launch_payment_intent_example">Launch PaymentIntent Example</string>
+    <string name="launch_payment_intent_example">PaymentIntent Example</string>
     <string name="creating_payment_intent">Creating PaymentIntent&#8230;</string>
     <string name="confirming_payment_intent">Confirming PaymentIntent&#8230;</string>
     <string name="retrieving_payment_intent">Retrieving PaymentIntent&#8230;</string>
@@ -72,7 +73,7 @@
     <string name="retrieve_payment_intent">Retrieve PaymentIntent</string>
     <string name="error_while_retrieving_payment_intent">An error occurred while retrieving the PaymentIntent</string>
 
-    <string name="launch_setup_intent_example">Launch SetupIntent Example</string>
+    <string name="launch_setup_intent_example">SetupIntent Example</string>
     <string name="creating_setup_intent">Creating SetupIntent&#8230;</string>
     <string name="creating_payment_method">Creating Payment Method&#8230;</string>
     <string name="confirming_setup_intent">Confirming SetupIntent&#8230;</string>
@@ -90,7 +91,7 @@
     <string name="pay_with_google">Pay with Google</string>
 
     <!-- Payment Auth example -->
-    <string name="launch_payment_auth_example">Launch Payment Auth Example</string>
+    <string name="launch_payment_auth_example">Payment Auth Example</string>
     <string name="buy">Buy!</string>
     <string name="setup">Buy in the Future!</string>
     <string name="payment_intent_status">PaymentIntent status: %s</string>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.java
@@ -67,6 +67,8 @@ public class LauncherActivity extends AppCompatActivity {
                             CustomerSessionActivity.class),
                     new Item(activity.getString(R.string.launch_payment_session),
                             PaymentSessionActivity.class),
+                    new Item(activity.getString(R.string.launch_payment_session_from_fragment),
+                            PaymentSessionFromFragmentActivity.class),
                     new Item(activity.getString(R.string.launch_pay_with_google),
                             PayWithGoogleActivity.class)
             ));

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionFromFragmentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionFromFragmentActivity.java
@@ -1,0 +1,164 @@
+package com.stripe.example.activity;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.Toast;
+
+import com.stripe.android.CustomerSession;
+import com.stripe.android.PaymentSession;
+import com.stripe.android.PaymentSessionConfig;
+import com.stripe.android.PaymentSessionData;
+import com.stripe.android.StripeError;
+import com.stripe.android.model.Customer;
+import com.stripe.android.view.ShippingInfoWidget;
+import com.stripe.example.R;
+import com.stripe.example.service.ExampleEphemeralKeyProvider;
+
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+
+public class PaymentSessionFromFragmentActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.payment_session_from_fragment_layout);
+
+        setTitle(R.string.launch_payment_session_from_fragment);
+
+        final Fragment newFragment = new PaymentSessionLauncherFragment();
+
+        final FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.add(R.id.root, newFragment, PaymentSessionLauncherFragment.class.getSimpleName())
+                .commit();
+    }
+
+    public static class PaymentSessionLauncherFragment extends Fragment {
+
+        private PaymentSession mPaymentSession;
+        private Button mLaunchButton;
+
+        @Override
+        public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+            super.onActivityCreated(savedInstanceState);
+            mPaymentSession = createPaymentSession(createCustomerSession());
+
+            mLaunchButton = Objects.requireNonNull(getView())
+                    .findViewById(R.id.launch_payment_session);
+            mLaunchButton.setOnClickListener((l) ->
+                    mPaymentSession.presentPaymentMethodSelection());
+        }
+
+        @Nullable
+        @Override
+        public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                                 @Nullable Bundle savedInstanceState) {
+            return getLayoutInflater().inflate(R.layout.launch_payment_session_fragment, null);
+        }
+
+        @Override
+        public void onActivityResult(int requestCode, int resultCode, Intent data) {
+            super.onActivityResult(requestCode, resultCode, data);
+            mPaymentSession.handlePaymentData(requestCode, resultCode, data);
+        }
+
+        @NonNull
+        private PaymentSession createPaymentSession(
+                @NonNull final CustomerSession customerSession) {
+            final PaymentSession paymentSession = new PaymentSession(this);
+            final boolean paymentSessionInitialized = paymentSession.init(
+                    new PaymentSession.PaymentSessionListener() {
+                        @Override
+                        public void onCommunicatingStateChanged(boolean isCommunicating) {
+
+                        }
+
+                        @Override
+                        public void onError(int errorCode, @NonNull String errorMessage) {
+
+                        }
+
+                        @Override
+                        public void onPaymentSessionDataChanged(@NonNull PaymentSessionData data) {
+                            customerSession.retrieveCurrentCustomer(
+                                    new CustomerSession.CustomerRetrievalListener() {
+                                        @Override
+                                        public void onCustomerRetrieved(
+                                                @NonNull Customer customer) {
+                                            mLaunchButton.setEnabled(true);
+                                        }
+
+                                        @Override
+                                        public void onError(int errorCode,
+                                                            @NonNull String errorMessage,
+                                                            @Nullable StripeError stripeError) {
+
+                                        }
+                                    });
+                        }
+                    },
+                    new PaymentSessionConfig.Builder()
+                            .setHiddenShippingInfoFields(
+                                    ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD,
+                                    ShippingInfoWidget.CustomizableShippingField.CITY_FIELD
+                            )
+                            .build());
+            if (paymentSessionInitialized) {
+                paymentSession.setCartTotal(2000L);
+            }
+
+            return paymentSession;
+        }
+
+        @NonNull
+        private CustomerSession createCustomerSession() {
+            CustomerSession.initCustomerSession(requireContext(),
+                    new ExampleEphemeralKeyProvider(new ProgressListenerImpl(requireActivity())));
+            final CustomerSession customerSession = CustomerSession.getInstance();
+            customerSession.retrieveCurrentCustomer(
+                    new CustomerSession.CustomerRetrievalListener() {
+                        @Override
+                        public void onCustomerRetrieved(@NonNull Customer customer) {
+
+                        }
+
+                        @Override
+                        public void onError(int errorCode, @NonNull String errorMessage,
+                                            @Nullable StripeError stripeError) {
+
+                        }
+                    }
+            );
+            return customerSession;
+        }
+
+
+        private static final class ProgressListenerImpl
+                implements ExampleEphemeralKeyProvider.ProgressListener {
+            @NonNull private final WeakReference<Activity> mActivityRef;
+
+            private ProgressListenerImpl(@NonNull Activity activity) {
+                mActivityRef = new WeakReference<>(activity);
+            }
+
+            @Override
+            public void onStringResponse(@NonNull String response) {
+                final Activity activity = mActivityRef.get();
+                if (activity != null && response.startsWith("Error: ")) {
+                    Toast.makeText(activity, response, Toast.LENGTH_LONG).show();
+                }
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.java
@@ -6,14 +6,15 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization;
-import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.PaymentAuthWebViewActivity;
 
 /**
  * A class that manages starting a {@link PaymentAuthWebViewActivity} instance with the correct
  * arguments.
  */
-public class PaymentAuthWebViewStarter implements ActivityStarter<PaymentAuthWebViewStarter.Data> {
+public class PaymentAuthWebViewStarter
+        implements AuthActivityStarter<PaymentAuthWebViewStarter.Data> {
     public static final String EXTRA_AUTH_URL = "auth_url";
     public static final String EXTRA_CLIENT_SECRET = "client_secret";
     public static final String EXTRA_RETURN_URL = "return_url";

--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -31,7 +31,7 @@ import com.stripe.android.stripe3ds2.transaction.StripeChallengeParameters;
 import com.stripe.android.stripe3ds2.transaction.StripeChallengeStatusReceiver;
 import com.stripe.android.stripe3ds2.transaction.Transaction;
 import com.stripe.android.stripe3ds2.views.ChallengeProgressDialogActivity;
-import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.StripeIntentResultExtras;
 
 import java.lang.ref.WeakReference;
@@ -623,7 +623,7 @@ class PaymentController {
         private static final String VALUE_YES = "Y";
 
         @NonNull private final WeakReference<Activity> mActivityRef;
-        @NonNull private final ActivityStarter<Stripe3ds2CompletionStarter.StartData> mStarter;
+        @NonNull private final AuthActivityStarter<Stripe3ds2CompletionStarter.StartData> mStarter;
         @NonNull private final StripeApiHandler mApiHandler;
         @NonNull private final StripeIntent mStripeIntent;
         @NonNull private final String mSourceId;
@@ -656,7 +656,7 @@ class PaymentController {
 
         PaymentAuth3ds2ChallengeStatusReceiver(
                 @NonNull Activity activity,
-                @NonNull ActivityStarter<Stripe3ds2CompletionStarter.StartData> starter,
+                @NonNull AuthActivityStarter<Stripe3ds2CompletionStarter.StartData> starter,
                 @NonNull StripeApiHandler apiHandler,
                 @NonNull StripeIntent stripeIntent,
                 @NonNull String sourceId,

--- a/stripe/src/main/java/com/stripe/android/PaymentFlowActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentFlowActivityStarter.java
@@ -1,0 +1,18 @@
+package com.stripe.android;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+
+import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.PaymentFlowActivity;
+
+final class PaymentFlowActivityStarter extends ActivityStarter<PaymentFlowActivity> {
+    PaymentFlowActivityStarter(@NonNull Activity activity) {
+        super(activity, PaymentFlowActivity.class);
+    }
+
+    PaymentFlowActivityStarter(@NonNull Fragment fragment) {
+        super(fragment, PaymentFlowActivity.class);
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.java
@@ -7,7 +7,7 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.model.StripeIntent;
 import com.stripe.android.utils.ObjectUtils;
-import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.PaymentRelayActivity;
 import com.stripe.android.view.StripeIntentResultExtras;
 
@@ -15,7 +15,7 @@ import com.stripe.android.view.StripeIntentResultExtras;
  * Starts an instance of {@link PaymentRelayStarter}.
  * Should only be called from {@link PaymentController}.
  */
-class PaymentRelayStarter implements ActivityStarter<PaymentRelayStarter.Data> {
+class PaymentRelayStarter implements AuthActivityStarter<PaymentRelayStarter.Data> {
     @NonNull private final Activity mActivity;
     private final int mRequestCode;
 

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
@@ -8,7 +8,7 @@ import android.support.annotation.Nullable;
 
 import com.stripe.android.model.StripeIntent;
 import com.stripe.android.utils.ObjectUtils;
-import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.PaymentRelayActivity;
 import com.stripe.android.view.StripeIntentResultExtras;
 
@@ -17,7 +17,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.ref.WeakReference;
 
 class Stripe3ds2CompletionStarter
-        implements ActivityStarter<Stripe3ds2CompletionStarter.StartData> {
+        implements AuthActivityStarter<Stripe3ds2CompletionStarter.StartData> {
     @NonNull private final WeakReference<Activity> mActivityRef;
     private final int mRequestCode;
 

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
@@ -1,7 +1,48 @@
 package com.stripe.android.view;
 
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 
-public interface ActivityStarter<StartDataType> {
-    void start(@NonNull StartDataType data);
+import java.util.Objects;
+
+public abstract class ActivityStarter<T> {
+    @NonNull private final Activity mActivity;
+    @Nullable private final Fragment mFragment;
+    @NonNull private final Class<T> mTargetClass;
+
+    public ActivityStarter(@NonNull Activity activity, @NonNull Class<T> targetClass) {
+        mActivity = activity;
+        mFragment = null;
+        mTargetClass = targetClass;
+    }
+
+    public ActivityStarter(@NonNull Fragment fragment, @NonNull Class<T> targetClass) {
+        mActivity = fragment.requireActivity();
+        mFragment = fragment;
+        mTargetClass = targetClass;
+    }
+
+    public final void startForResult(final int requestCode) {
+        startForResult(requestCode, new Bundle());
+    }
+
+    public final void startForResult(int requestCode, @NonNull Bundle bundle) {
+        final Intent intent = newIntent();
+        intent.putExtras(bundle);
+
+        if (mFragment != null) {
+            Objects.requireNonNull(mFragment).startActivityForResult(intent, requestCode);
+        } else {
+            mActivity.startActivityForResult(intent, requestCode);
+        }
+    }
+
+    @NonNull
+    public final Intent newIntent() {
+        return new Intent(mActivity, mTargetClass);
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.java
@@ -1,0 +1,7 @@
+package com.stripe.android.view;
+
+import android.support.annotation.NonNull;
+
+public interface AuthActivityStarter<StartDataType> {
+    void start(@NonNull StartDataType data);
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -1,23 +1,16 @@
 package com.stripe.android.view;
 
 import android.app.Activity;
-import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 
-public class PaymentMethodsActivityStarter {
-
-    @NonNull private final Activity mActivity;
-
+public final class PaymentMethodsActivityStarter
+        extends ActivityStarter<PaymentMethodsActivity> {
     public PaymentMethodsActivityStarter(@NonNull Activity activity) {
-        mActivity = activity;
+        super(activity, PaymentMethodsActivity.class);
     }
 
-    public void startForResult(final int requestCode) {
-        mActivity.startActivityForResult(newIntent(), requestCode);
-    }
-
-    @NonNull
-    public Intent newIntent() {
-        return new Intent(mActivity, PaymentMethodsActivity.class);
+    public PaymentMethodsActivityStarter(@NonNull Fragment fragment) {
+        super(fragment, PaymentMethodsActivity.class);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -26,7 +26,7 @@ import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent;
 import com.stripe.android.stripe3ds2.transaction.RuntimeErrorEvent;
 import com.stripe.android.stripe3ds2.transaction.Transaction;
 import com.stripe.android.stripe3ds2.views.ChallengeProgressDialogActivity;
-import com.stripe.android.view.ActivityStarter;
+import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.StripeIntentResultExtras;
 
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class PaymentControllerTest {
     @Mock private Transaction mTransaction;
     @Mock private StripeApiHandler mApiHandler;
     @Mock private MessageVersionRegistry mMessageVersionRegistry;
-    @Mock private ActivityStarter<Stripe3ds2CompletionStarter.StartData> m3ds2Starter;
+    @Mock private AuthActivityStarter<Stripe3ds2CompletionStarter.StartData> m3ds2Starter;
     @Mock private ApiResultCallback<PaymentIntentResult> mPaymentAuthResultCallback;
     @Mock private ApiResultCallback<SetupIntentResult> mSetupAuthResultCallback;
     @Mock private PaymentRelayStarter mPaymentRelayStarter;

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -18,9 +18,10 @@ import com.stripe.android.model.PaymentMethodCreateParams;
 import com.stripe.android.model.PaymentMethodFixtures;
 import com.stripe.android.model.PaymentMethodTest;
 import com.stripe.android.testharness.TestEphemeralKeyProvider;
+import com.stripe.android.view.ActivityStarter;
 import com.stripe.android.view.AddPaymentMethodActivity;
+import com.stripe.android.view.PaymentFlowActivity;
 import com.stripe.android.view.PaymentMethodsActivity;
-import com.stripe.android.view.PaymentMethodsActivityStarter;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -80,7 +81,8 @@ public class PaymentSessionTest {
     @Mock private ThreadPoolExecutor mThreadPoolExecutor;
     @Mock private PaymentSession.PaymentSessionListener mPaymentSessionListener;
     @Mock private CustomerSession mCustomerSession;
-    @Mock private PaymentMethodsActivityStarter mPaymentMethodsActivityStarter;
+    @Mock private ActivityStarter<PaymentMethodsActivity> mPaymentMethodsActivityStarter;
+    @Mock private ActivityStarter<PaymentFlowActivity> mPaymentFlowActivityStarter;
     @Mock private PaymentSessionPrefs mPaymentSessionPrefs;
 
     @Captor private ArgumentCaptor<PaymentSessionData> mPaymentSessionDataArgumentCaptor;
@@ -372,8 +374,9 @@ public class PaymentSessionTest {
 
     @NonNull
     private PaymentSession createPaymentSesson() {
-        return new PaymentSession(mActivity, mCustomerSession,
-                mPaymentMethodsActivityStarter, mPaymentSessionData, mPaymentSessionPrefs);
+        return new PaymentSession(mCustomerSession, mPaymentMethodsActivityStarter,
+                mPaymentFlowActivityStarter, mPaymentSessionData,
+                mPaymentSessionPrefs);
     }
 
     @NonNull


### PR DESCRIPTION
## Summary
- Add a `PaymentSession(Fragment)` constructor
- Create ActivityStarter base class that supports starting
  an activity from an Activity or Fragment
- Add an example to the example app

## Motivation
Fixes #1273

## Testing
Created activity in example app to test integration
