### PR TITLE
Rename StripeIntentResult#getStatus() to StripeIntentResult#getOutcome()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.java
@@ -150,8 +150,9 @@ class PaymentController {
             return;
         }
 
-        @StripeIntentResult.Status final int authStatus = data.getIntExtra(
-                StripeIntentResultExtras.AUTH_STATUS, StripeIntentResult.Status.UNKNOWN);
+        @StripeIntentResult.Outcome final int flowOutcome =
+                data.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN);
         new RetrieveIntentTask(mApiHandler, getClientSecret(data), requestOptions,
                 new ApiResultCallback<StripeIntent>() {
                     @Override
@@ -159,7 +160,7 @@ class PaymentController {
                         if (stripeIntent instanceof PaymentIntent) {
                             callback.onSuccess(new PaymentIntentResult.Builder()
                                     .setPaymentIntent((PaymentIntent) stripeIntent)
-                                    .setStatus(authStatus)
+                                    .setOutcome(flowOutcome)
                                     .build());
                         }
                     }
@@ -191,8 +192,9 @@ class PaymentController {
             return;
         }
 
-        @StripeIntentResult.Status final int authStatus = data.getIntExtra(
-                StripeIntentResultExtras.AUTH_STATUS, StripeIntentResult.Status.UNKNOWN);
+        @StripeIntentResult.Outcome final int flowOutcome =
+                data.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN);
 
         new RetrieveIntentTask(mApiHandler, getClientSecret(data), requestOptions,
                 new ApiResultCallback<StripeIntent>() {
@@ -201,7 +203,7 @@ class PaymentController {
                         if (stripeIntent instanceof SetupIntent) {
                             callback.onSuccess(new SetupIntentResult.Builder()
                                     .setSetupIntent((SetupIntent) stripeIntent)
-                                    .setStatus(authStatus)
+                                    .setOutcome(flowOutcome)
                                     .build());
                         }
                     }

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.java
@@ -7,12 +7,12 @@ import com.stripe.android.model.PaymentIntent;
 public final class PaymentIntentResult extends StripeIntentResult<PaymentIntent> {
 
     private PaymentIntentResult(@NonNull Builder builder) {
-        super(builder.mPaymentIntent, builder.mStatus);
+        super(builder.mPaymentIntent, builder.mOutcome);
     }
 
     static final class Builder implements ObjectBuilder<PaymentIntentResult> {
         private PaymentIntent mPaymentIntent;
-        @Status private int mStatus;
+        @Outcome private int mOutcome;
 
         @NonNull
         Builder setPaymentIntent(@NonNull PaymentIntent paymentIntent) {
@@ -21,8 +21,8 @@ public final class PaymentIntentResult extends StripeIntentResult<PaymentIntent>
         }
 
         @NonNull
-        Builder setStatus(@Status int status) {
-            mStatus = status;
+        Builder setOutcome(@Outcome int outcome) {
+            mOutcome = outcome;
             return this;
         }
 

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.java
@@ -7,12 +7,12 @@ import com.stripe.android.model.SetupIntent;
 public class SetupIntentResult extends StripeIntentResult<SetupIntent> {
 
     private SetupIntentResult(@NonNull Builder builder) {
-        super(builder.mSetupIntent, builder.mStatus);
+        super(builder.mSetupIntent, builder.mOutcome);
     }
 
     static final class Builder implements ObjectBuilder<SetupIntentResult> {
         private SetupIntent mSetupIntent;
-        @Status private int mStatus;
+        @Outcome private int mOutcome;
 
         @NonNull
         Builder setSetupIntent(@NonNull SetupIntent setupIntent) {
@@ -21,8 +21,8 @@ public class SetupIntentResult extends StripeIntentResult<SetupIntent> {
         }
 
         @NonNull
-        Builder setStatus(@Status int status) {
-            mStatus = status;
+        Builder setOutcome(@Outcome int outcome) {
+            mOutcome = outcome;
             return this;
         }
 

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.java
@@ -29,7 +29,7 @@ class Stripe3ds2CompletionStarter
         final Bundle extras = new Bundle();
         extras.putString(StripeIntentResultExtras.CLIENT_SECRET,
                 data.mStripeIntent.getClientSecret());
-        extras.putInt(StripeIntentResultExtras.AUTH_STATUS, data.getAuthStatus());
+        extras.putInt(StripeIntentResultExtras.FLOW_OUTCOME, data.getOutcome());
         mHost.startActivityForResult(PaymentRelayActivity.class, extras, mRequestCode);
     }
 
@@ -48,32 +48,32 @@ class Stripe3ds2CompletionStarter
 
     static class StartData {
         @NonNull private final StripeIntent mStripeIntent;
-        @ChallengeFlowOutcome private final int mChallengeFlowStatus;
+        @ChallengeFlowOutcome private final int mChallengeFlowOutcome;
 
         StartData(@NonNull StripeIntent stripeIntent,
-                  @ChallengeFlowOutcome int challengeFlowStatus) {
+                  @ChallengeFlowOutcome int challengeFlowOutcome) {
             mStripeIntent = stripeIntent;
-            mChallengeFlowStatus = challengeFlowStatus;
+            mChallengeFlowOutcome = challengeFlowOutcome;
         }
 
-        @StripeIntentResult.Status
-        private int getAuthStatus() {
-            if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE_SUCCESSFUL) {
-                return StripeIntentResult.Status.SUCCEEDED;
-            } else if (mChallengeFlowStatus == ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL) {
-                return StripeIntentResult.Status.FAILED;
-            } else if (mChallengeFlowStatus == ChallengeFlowOutcome.CANCEL) {
-                return StripeIntentResult.Status.CANCELED;
-            } else if (mChallengeFlowStatus == ChallengeFlowOutcome.TIMEOUT) {
-                return StripeIntentResult.Status.TIMEDOUT;
+        @StripeIntentResult.Outcome
+        private int getOutcome() {
+            if (mChallengeFlowOutcome == ChallengeFlowOutcome.COMPLETE_SUCCESSFUL) {
+                return StripeIntentResult.Outcome.SUCCEEDED;
+            } else if (mChallengeFlowOutcome == ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL) {
+                return StripeIntentResult.Outcome.FAILED;
+            } else if (mChallengeFlowOutcome == ChallengeFlowOutcome.CANCEL) {
+                return StripeIntentResult.Outcome.CANCELED;
+            } else if (mChallengeFlowOutcome == ChallengeFlowOutcome.TIMEOUT) {
+                return StripeIntentResult.Outcome.TIMEDOUT;
             } else {
-                return StripeIntentResult.Status.FAILED;
+                return StripeIntentResult.Outcome.FAILED;
             }
         }
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(mStripeIntent, mChallengeFlowStatus);
+            return ObjectUtils.hash(mStripeIntent, mChallengeFlowOutcome);
         }
 
         @Override
@@ -83,7 +83,7 @@ class Stripe3ds2CompletionStarter
 
         private boolean typedEquals(@NonNull StartData startData) {
             return ObjectUtils.equals(mStripeIntent, startData.mStripeIntent) &&
-                    ObjectUtils.equals(mChallengeFlowStatus, startData.mChallengeFlowStatus);
+                    ObjectUtils.equals(mChallengeFlowOutcome, startData.mChallengeFlowOutcome);
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeIntentResultExtras.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeIntentResultExtras.java
@@ -12,9 +12,9 @@ public final class StripeIntentResultExtras {
     public static final String AUTH_EXCEPTION = "exception";
 
     /**
-     * See {@link StripeIntentResult.Status} for possible values
+     * See {@link StripeIntentResult.Outcome} for possible values
      */
-    public static final String AUTH_STATUS = "status";
+    public static final String FLOW_OUTCOME = "flow_outcome";
 
     private StripeIntentResultExtras() {
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -504,8 +504,8 @@ public class PaymentControllerTest {
         assertNotNull(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
 
         final Intent intent = new Intent()
-                .putExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.SUCCEEDED)
+                .putExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.SUCCEEDED)
                 .putExtra(StripeIntentResultExtras.CLIENT_SECRET,
                         SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.getClientSecret());
 
@@ -520,7 +520,7 @@ public class PaymentControllerTest {
                 ArgumentCaptor.forClass(SetupIntentResult.class);
         verify(mSetupAuthResultCallback).onSuccess(resultCaptor.capture());
         final SetupIntentResult result = resultCaptor.getValue();
-        assertEquals(StripeIntentResult.Status.SUCCEEDED, result.getStatus());
+        assertEquals(StripeIntentResult.Outcome.SUCCEEDED, result.getOutcome());
         assertEquals(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT, result.getIntent());
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.java
@@ -43,7 +43,7 @@ public class PaymentRelayStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertFalse(intent.hasExtra(StripeIntentResultExtras.AUTH_STATUS));
+        assertFalse(intent.hasExtra(StripeIntentResultExtras.FLOW_OUTCOME));
         assertNull(intent.getSerializableExtra(StripeIntentResultExtras.AUTH_EXCEPTION));
     }
 
@@ -54,7 +54,7 @@ public class PaymentRelayStarterTest {
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(), eq(500));
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertNull(intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertFalse(intent.hasExtra(StripeIntentResultExtras.AUTH_STATUS));
+        assertFalse(intent.hasExtra(StripeIntentResultExtras.FLOW_OUTCOME));
         assertEquals(exception,
                 intent.getSerializableExtra(StripeIntentResultExtras.AUTH_EXCEPTION));
     }

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.java
@@ -37,7 +37,7 @@ public class Stripe3ds2CompletionStarterTest {
     }
 
     @Test
-    public void start_withSuccessfulCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
+    public void start_withSuccessfulCompletion_shouldAddClientSecretAndOutcomeToIntent() {
         mStarter.start(new Stripe3ds2CompletionStarter.StartData(
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                 Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_SUCCESSFUL));
@@ -45,13 +45,13 @@ public class Stripe3ds2CompletionStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.SUCCEEDED,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertEquals(StripeIntentResult.Outcome.SUCCEEDED,
+                intent.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN));
     }
 
     @Test
-    public void start_withUnsuccessfulCompletion_shouldAddClientSecretAndAuthStatusToIntent() {
+    public void start_withUnsuccessfulCompletion_shouldAddClientSecretAndOutcomeToIntent() {
         mStarter.start(new Stripe3ds2CompletionStarter.StartData(
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                 Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL));
@@ -59,13 +59,13 @@ public class Stripe3ds2CompletionStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.FAILED,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertEquals(StripeIntentResult.Outcome.FAILED,
+                intent.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN));
     }
 
     @Test
-    public void start_withTimeout_shouldAddClientSecretAndAuthStatusToIntent() {
+    public void start_withTimeout_shouldAddClientSecretAndOutcomeToIntent() {
         mStarter.start(new Stripe3ds2CompletionStarter.StartData(
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                 Stripe3ds2CompletionStarter.ChallengeFlowOutcome.TIMEOUT));
@@ -73,13 +73,13 @@ public class Stripe3ds2CompletionStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.TIMEDOUT,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertEquals(StripeIntentResult.Outcome.TIMEDOUT,
+                intent.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN));
     }
 
     @Test
-    public void start_withProtocolError_shouldAddClientSecretAndAuthStatusToIntent() {
+    public void start_withProtocolError_shouldAddClientSecretAndOutcomeToIntent() {
         mStarter.start(new Stripe3ds2CompletionStarter.StartData(
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                 Stripe3ds2CompletionStarter.ChallengeFlowOutcome.PROTOCOL_ERROR));
@@ -87,8 +87,8 @@ public class Stripe3ds2CompletionStarterTest {
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.getClientSecret(),
                 intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET));
-        assertEquals(StripeIntentResult.Status.FAILED,
-                intent.getIntExtra(StripeIntentResultExtras.AUTH_STATUS,
-                        StripeIntentResult.Status.UNKNOWN));
+        assertEquals(StripeIntentResult.Outcome.FAILED,
+                intent.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME,
+                        StripeIntentResult.Outcome.UNKNOWN));
     }
 }


### PR DESCRIPTION
StripeIntent has a `getStatus()` method, so it's confusing to users
that there's both a `PaymentIntentResult#getStatus()` and
`PaymentIntent#getStatus()`. Renaming to avoid confusion and better
reflect what the field describes.