### PR TITLE
Fix issue in ConfirmSetupIntentParams#toBuilder()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
@@ -2,6 +2,7 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.ObjectBuilder;
 import com.stripe.android.utils.ObjectUtils;
@@ -402,7 +403,8 @@ public final class ConfirmPaymentIntentParams implements ConfirmStripeIntentPara
     }
 
     @NonNull
-    private Builder toBuilder() {
+    @VisibleForTesting
+    Builder toBuilder() {
         return new Builder(mClientSecret)
                 .setReturnUrl(mReturnUrl)
                 .setPaymentMethodId(mPaymentMethodId)
@@ -413,7 +415,8 @@ public final class ConfirmPaymentIntentParams implements ConfirmStripeIntentPara
                 .setExtraParams(mExtraParams);
     }
 
-    private static final class Builder implements ObjectBuilder<ConfirmPaymentIntentParams> {
+    @VisibleForTesting
+    static final class Builder implements ObjectBuilder<ConfirmPaymentIntentParams> {
         @NonNull private final String mClientSecret;
 
         @Nullable private PaymentMethodCreateParams mPaymentMethodCreateParams;

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
@@ -2,6 +2,7 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.stripe.android.ObjectBuilder;
 import com.stripe.android.utils.ObjectUtils;
@@ -59,6 +60,15 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
                 .build();
     }
 
+    /**
+     * Create the parameters necessary for confirming a SetupIntent with a new PaymentMethod
+     *
+     * @param paymentMethodCreateParams the params to create a new PaymentMethod that will be
+     *                                  attached to the SetupIntent being confirmed
+     * @param clientSecret client secret from the SetupIntent being confirmed
+     * @param returnUrl the URL the customer should be redirected to after the authorization process
+     * @return params that can be use to confirm a SetupIntent
+     */
     @NonNull
     public static ConfirmSetupIntentParams create(
             @NonNull PaymentMethodCreateParams paymentMethodCreateParams,
@@ -71,10 +81,10 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
     }
 
     /**
-     * See {@link #create(String, String, String)}
+     * See {@link #create(PaymentMethodCreateParams, String, String)}
      */
     @NonNull
-    public static ConfirmSetupIntentParams createWithPaymentMethodCreateParams(
+    public static ConfirmSetupIntentParams create(
             @NonNull PaymentMethodCreateParams paymentMethodCreateParams,
             @NonNull String clientSecret) {
         return create(paymentMethodCreateParams, clientSecret, null);
@@ -133,10 +143,12 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
     }
 
     @NonNull
-    private ConfirmSetupIntentParams.Builder toBuilder() {
+    @VisibleForTesting
+    ConfirmSetupIntentParams.Builder toBuilder() {
         return new ConfirmSetupIntentParams.Builder(mClientSecret)
                 .setReturnUrl(mReturnUrl)
                 .setPaymentMethodId(mPaymentMethodId)
+                .setPaymentMethodCreateParams(mPaymentMethodCreateParams)
                 .setShouldUseSdk(mUseStripeSdk);
     }
 
@@ -146,11 +158,12 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
                 typedEquals((ConfirmSetupIntentParams) obj));
     }
 
-    private boolean typedEquals(@NonNull ConfirmSetupIntentParams confirmSetupIntentParams) {
-        return ObjectUtils.equals(mReturnUrl, confirmSetupIntentParams.mReturnUrl)
-                && ObjectUtils.equals(mClientSecret, confirmSetupIntentParams.mClientSecret)
-                && ObjectUtils.equals(mPaymentMethodId, confirmSetupIntentParams.mPaymentMethodId)
-                && ObjectUtils.equals(mUseStripeSdk, confirmSetupIntentParams.mUseStripeSdk);
+    private boolean typedEquals(@NonNull ConfirmSetupIntentParams params) {
+        return ObjectUtils.equals(mReturnUrl, params.mReturnUrl)
+                && ObjectUtils.equals(mClientSecret, params.mClientSecret)
+                && ObjectUtils.equals(mPaymentMethodId, params.mPaymentMethodId)
+                && ObjectUtils.equals(mPaymentMethodCreateParams, params.mPaymentMethodCreateParams)
+                && ObjectUtils.equals(mUseStripeSdk, params.mUseStripeSdk);
     }
 
     @Override
@@ -159,7 +172,8 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
     }
 
 
-    private static final class Builder implements ObjectBuilder<ConfirmSetupIntentParams> {
+    @VisibleForTesting
+    static final class Builder implements ObjectBuilder<ConfirmSetupIntentParams> {
         @NonNull private final String mClientSecret;
         @Nullable private String mPaymentMethodId;
         @Nullable private PaymentMethodCreateParams mPaymentMethodCreateParams;

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
@@ -24,22 +24,33 @@ public class ConfirmPaymentIntentParamsTest {
                     .currency("usd")
                     .build();
 
-    private static final String TEST_CLIENT_SECRET =
+    private static final String CLIENT_SECRET =
             "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA";
 
-    private static final String TEST_RETURN_URL = "stripe://return_url";
-    private static final String TEST_SOURCE_ID = "src_123testsourceid";
-    private static final String TEST_PAYMENT_METHOD_ID = "pm_123456789";
+    private static final String RETURN_URL = "stripe://return_url";
+    private static final String SOURCE_ID = "src_123testsourceid";
+    private static final String PM_ID = "pm_123456789";
+
+    private static final PaymentMethodCreateParams PM_CREATE_PARAMS =
+            PaymentMethodCreateParams.create(
+                    new PaymentMethodCreateParams.Card.Builder()
+                            .setNumber("4242424242424242")
+                            .setExpiryMonth(1)
+                            .setExpiryYear(2024)
+                            .setCvc("111")
+                            .build(),
+                    null
+            );
 
     @Test
     public void createConfirmPaymentIntentWithSourceDataParams_withAllFields_hasExpectedFields() {
         final SourceParams sourceParams = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD);
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithSourceParams(
-                        sourceParams, TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                        sourceParams, CLIENT_SECRET, RETURN_URL);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
         assertEquals(sourceParams, params.getSourceParams());
         assertFalse(params.shouldSavePaymentMethod());
     }
@@ -48,11 +59,11 @@ public class ConfirmPaymentIntentParamsTest {
     public void createConfirmPaymentIntentWithSourceIdParams_withAllFields_hasExpectedFields() {
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithSourceId(
-                        TEST_SOURCE_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                        SOURCE_ID, CLIENT_SECRET, RETURN_URL);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
-        assertEquals(TEST_SOURCE_ID, params.getSourceId());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
+        assertEquals(SOURCE_ID, params.getSourceId());
         assertFalse(params.shouldSavePaymentMethod());
     }
 
@@ -60,11 +71,11 @@ public class ConfirmPaymentIntentParamsTest {
     public void createConfirmPaymentIntentWithSourceIdParams_withSavePaymentMethod_hasExpectedFields() {
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithSourceId(
-                        TEST_SOURCE_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+                        SOURCE_ID, CLIENT_SECRET, RETURN_URL, true);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
-        assertEquals(TEST_SOURCE_ID, params.getSourceId());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
+        assertEquals(SOURCE_ID, params.getSourceId());
         assertTrue(params.shouldSavePaymentMethod());
 
         assertEquals(Boolean.TRUE,
@@ -78,10 +89,10 @@ public class ConfirmPaymentIntentParamsTest {
                         .build(), null);
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodCreateParams(paymentMethodCreateParams,
-                        TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                        CLIENT_SECRET, RETURN_URL);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
         assertEquals(paymentMethodCreateParams, params.getPaymentMethodCreateParams());
         assertFalse(params.shouldSavePaymentMethod());
     }
@@ -90,11 +101,11 @@ public class ConfirmPaymentIntentParamsTest {
     public void createConfirmPaymentIntentWithPaymentMethodId_hasExpectedFields() {
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodId(
-                        TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                        PM_ID, CLIENT_SECRET, RETURN_URL);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
-        assertEquals(TEST_PAYMENT_METHOD_ID, params.getPaymentMethodId());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
+        assertEquals(PM_ID, params.getPaymentMethodId());
         assertFalse(params.shouldSavePaymentMethod());
     }
 
@@ -105,10 +116,10 @@ public class ConfirmPaymentIntentParamsTest {
                         .build(), null);
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodCreateParams(paymentMethodCreateParams,
-                        TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+                        CLIENT_SECRET, RETURN_URL, true);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
         assertEquals(paymentMethodCreateParams, params.getPaymentMethodCreateParams());
         assertTrue(params.shouldSavePaymentMethod());
     }
@@ -117,11 +128,11 @@ public class ConfirmPaymentIntentParamsTest {
     public void createConfirmPaymentIntentWithPaymentMethodId_withSavePaymentMethod_hasExpectedFields() {
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodId(
-                        TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL, true);
+                        PM_ID, CLIENT_SECRET, RETURN_URL, true);
 
-        assertEquals(TEST_CLIENT_SECRET, params.getClientSecret());
-        assertEquals(TEST_RETURN_URL, params.getReturnUrl());
-        assertEquals(TEST_PAYMENT_METHOD_ID, params.getPaymentMethodId());
+        assertEquals(CLIENT_SECRET, params.getClientSecret());
+        assertEquals(RETURN_URL, params.getReturnUrl());
+        assertEquals(PM_ID, params.getPaymentMethodId());
         assertTrue(params.shouldSavePaymentMethod());
 
         assertEquals(Boolean.TRUE,
@@ -132,29 +143,29 @@ public class ConfirmPaymentIntentParamsTest {
     public void createWithSourceId_toParamMap_createsExpectedMap() {
         final ConfirmPaymentIntentParams confirmPaymentIntentParams = ConfirmPaymentIntentParams
                 .createWithSourceId(
-                        TEST_SOURCE_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                        SOURCE_ID, CLIENT_SECRET, RETURN_URL);
 
         final Map<String, Object> paramMap = confirmPaymentIntentParams.toParamMap();
 
-        assertEquals(paramMap.get(ConfirmPaymentIntentParams.API_PARAM_SOURCE_ID), TEST_SOURCE_ID);
+        assertEquals(paramMap.get(ConfirmPaymentIntentParams.API_PARAM_SOURCE_ID), SOURCE_ID);
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), TEST_CLIENT_SECRET);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), CLIENT_SECRET);
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_RETURN_URL), TEST_RETURN_URL);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_RETURN_URL), RETURN_URL);
         assertFalse(paramMap.containsKey(ConfirmPaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 
     @Test
     public void createWithPaymentMethodId_withoutReturnUrl_toParamMap_createsExpectedMap() {
         final ConfirmPaymentIntentParams confirmPaymentIntentParams = ConfirmPaymentIntentParams
-                .createWithPaymentMethodId(TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET);
+                .createWithPaymentMethodId(PM_ID, CLIENT_SECRET);
 
         final Map<String, Object> paramMap = confirmPaymentIntentParams.toParamMap();
 
         assertEquals(paramMap.get(ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_ID),
-                TEST_PAYMENT_METHOD_ID);
+                PM_ID);
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), TEST_CLIENT_SECRET);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), CLIENT_SECRET);
         assertFalse(paramMap.containsKey(ConfirmPaymentIntentParams.API_PARAM_RETURN_URL));
         assertFalse(paramMap.containsKey(ConfirmPaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
@@ -162,16 +173,16 @@ public class ConfirmPaymentIntentParamsTest {
     @Test
     public void createWithPaymentMethodId_withReturnUrl_toParamMap_createsExpectedMap() {
         final ConfirmPaymentIntentParams confirmPaymentIntentParams = ConfirmPaymentIntentParams
-                .createWithPaymentMethodId(TEST_PAYMENT_METHOD_ID, TEST_CLIENT_SECRET, TEST_RETURN_URL);
+                .createWithPaymentMethodId(PM_ID, CLIENT_SECRET, RETURN_URL);
 
         final Map<String, Object> paramMap = confirmPaymentIntentParams.toParamMap();
 
         assertEquals(paramMap.get(ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_ID),
-                TEST_PAYMENT_METHOD_ID);
+                PM_ID);
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), TEST_CLIENT_SECRET);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), CLIENT_SECRET);
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_RETURN_URL), TEST_RETURN_URL);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_RETURN_URL), RETURN_URL);
         assertFalse(paramMap.containsKey(ConfirmPaymentIntentParams.API_PARAM_SAVE_PAYMENT_METHOD));
     }
 
@@ -186,13 +197,13 @@ public class ConfirmPaymentIntentParamsTest {
         extraParams.put(extraParamKey2, extraParamValue2);
 
         final ConfirmPaymentIntentParams confirmPaymentIntentParams = ConfirmPaymentIntentParams
-                .createWithPaymentMethodId("pm_123", TEST_CLIENT_SECRET,
-                        TEST_RETURN_URL, false, extraParams);
+                .createWithPaymentMethodId("pm_123", CLIENT_SECRET,
+                        RETURN_URL, false, extraParams);
 
         final Map<String, Object> paramMap = confirmPaymentIntentParams.toParamMap();
 
         assertEquals(
-                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), TEST_CLIENT_SECRET);
+                paramMap.get(ConfirmPaymentIntentParams.API_PARAM_CLIENT_SECRET), CLIENT_SECRET);
         assertEquals(
                 paramMap.get(extraParamKey1), extraParamValue1);
         assertEquals(
@@ -216,5 +227,17 @@ public class ConfirmPaymentIntentParamsTest {
         assertTrue(confirmPaymentIntentParams
                 .withShouldUseStripeSdk(true)
                 .shouldUseStripeSdk());
+    }
+
+    @Test
+    public void toBuilder_withPaymentMethodCreateParams_shouldCreateEqualObject() {
+        final Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("key", "value");
+        final ConfirmPaymentIntentParams params =
+                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                        PM_CREATE_PARAMS, CLIENT_SECRET, RETURN_URL, true, extraParams
+                );
+
+        assertEquals(params, params.toBuilder().build());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
@@ -13,8 +13,19 @@ import static org.junit.Assert.assertTrue;
 
 public class ConfirmSetupIntentParamsTest {
 
+    private static final PaymentMethodCreateParams PM_CREATE_PARAMS =
+            PaymentMethodCreateParams.create(
+                    new PaymentMethodCreateParams.Card.Builder()
+                            .setNumber("4242424242424242")
+                            .setExpiryMonth(1)
+                            .setExpiryYear(2024)
+                            .setCvc("111")
+                            .build(),
+                    null
+            );
+
     @Test
-    public void shouldUseStripeSdk() {
+    public void shouldUseStripeSdk_withPaymentMethodId() {
         final ConfirmSetupIntentParams confirmSetupIntentParams =
                 ConfirmSetupIntentParams.create(
                         "pm_123", "client_secret", "return_url");
@@ -23,6 +34,39 @@ public class ConfirmSetupIntentParamsTest {
         assertTrue(confirmSetupIntentParams
                 .withShouldUseStripeSdk(true)
                 .shouldUseStripeSdk());
+    }
+
+    @Test
+    public void shouldUseStripeSdk_withPaymentMethodCreateParams() {
+        final ConfirmSetupIntentParams confirmSetupIntentParams =
+                ConfirmSetupIntentParams.create(
+                        PM_CREATE_PARAMS,
+                        "client_secret",
+                        "return_url"
+                );
+        assertFalse(confirmSetupIntentParams.shouldUseStripeSdk());
+
+        assertTrue(confirmSetupIntentParams
+                .withShouldUseStripeSdk(true)
+                .shouldUseStripeSdk());
+    }
+
+    @Test
+    public void toBuilder_withPaymentMethodId_shouldCreateEqualObject() {
+        final ConfirmSetupIntentParams confirmSetupIntentParams =
+                ConfirmSetupIntentParams.create(
+                        "pm_123", "client_secret", "return_url");
+        assertEquals(confirmSetupIntentParams,
+                confirmSetupIntentParams.toBuilder().build());
+    }
+
+    @Test
+    public void toBuilder_withPaymentMethodCreateParams_shouldCreateEqualObject() {
+        final ConfirmSetupIntentParams confirmSetupIntentParams =
+                ConfirmSetupIntentParams.create(
+                        PM_CREATE_PARAMS, "client_secret", "return_url");
+        assertEquals(confirmSetupIntentParams,
+                confirmSetupIntentParams.toBuilder().build());
     }
 
     @Test
@@ -42,17 +86,9 @@ public class ConfirmSetupIntentParamsTest {
     @SuppressWarnings("unchecked")
     @Test
     public void create_withPaymentMethodCreateParams_shouldPopulateParamMapCorrectly() {
-        final PaymentMethodCreateParams.Card expectedCard =
-                new PaymentMethodCreateParams.Card.Builder()
-                        .setNumber("4242424242424242")
-                        .setCvc("123")
-                        .setExpiryMonth(8)
-                        .setExpiryYear(2019)
-                        .build();
-
         final ConfirmSetupIntentParams confirmSetupIntentParams =
                 ConfirmSetupIntentParams.create(
-                        PaymentMethodCreateParams.create(expectedCard, null),
+                        PM_CREATE_PARAMS,
                         "client_secret",
                         null
                 );


### PR DESCRIPTION
## Summary
This method was missing a call to `setPaymentMethodCreateParams()`.

## Motivation
Fixes #1311

## Testing
Added unit tests.
