### PR TITLE
Ensure withShouldUseStripeSdk does not drop paymentMethodCreateParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.java
@@ -137,6 +137,7 @@ public final class ConfirmSetupIntentParams implements ConfirmStripeIntentParams
         return new ConfirmSetupIntentParams.Builder(mClientSecret)
                 .setReturnUrl(mReturnUrl)
                 .setPaymentMethodId(mPaymentMethodId)
+                .setPaymentMethodCreateParams(mPaymentMethodCreateParams)
                 .setShouldUseSdk(mUseStripeSdk);
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.java
@@ -64,4 +64,36 @@ public class ConfirmSetupIntentParamsTest {
         assertEquals("card", paymentMethodData.get("type"));
         assertNotNull(paymentMethodData.get("card"));
     }
+
+    @Test
+    public void create_withShouldUseStripeSdk_shouldKeepPaymentMethodData() {
+        final PaymentMethodCreateParams.Card expectedCard =
+                new PaymentMethodCreateParams.Card.Builder()
+                        .setNumber("4242424242424242")
+                        .setCvc("123")
+                        .setExpiryMonth(8)
+                        .setExpiryYear(2019)
+                        .build();
+
+        ConfirmSetupIntentParams confirmSetupIntentParams =
+                ConfirmSetupIntentParams.create(
+                        PaymentMethodCreateParams.create(expectedCard, null),
+                        "client_secret",
+                        null
+                );
+
+        assertEquals(false, confirmSetupIntentParams.shouldUseStripeSdk());
+        confirmSetupIntentParams = confirmSetupIntentParams.withShouldUseStripeSdk(true);
+        assertEquals(true, confirmSetupIntentParams.shouldUseStripeSdk());
+
+
+        // Ensures that payment method data is still present after the withShouldUseStripeSdk call
+        final Map<String, Object> params = confirmSetupIntentParams.toParamMap();
+        assertNull(params.get(ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_ID));
+        final Map<String, Object> paymentMethodData = (Map<String, Object>)
+                Objects.requireNonNull(
+                        params.get(ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_DATA));
+        assertEquals("card", paymentMethodData.get("type"));
+        assertNotNull(paymentMethodData.get("card"));
+    }
 }


### PR DESCRIPTION

## Summary
When confirming a SetupIntent, prevent `.withShouldUseStripeSdk(boolean)` from unexpectedly dropping the attached `PaymentMethodCreateParams`.  This only happens for SetupIntents, not for PaymentIntents.

## Motivation
We need to be able to confirm SetupIntent objects while also attaching new payment method data (vs referencing an existing payment method id) via `stripe.confirmSetupIntent(activity, confirmSetupIntentParams)`.  This should be supported by `ConfirmSetupIntentParams`, like it is with `ConfirmPaymentIntentParams`, since they both carry support for `CreatePaymentMethodParams`, however this property is unexpectedly dropped if `.withShouldUseStripeSdk(boolean)` is called.  This issue does not occur if `.withShouldUseStripeSdk(boolean)` is called on a `ConfirmPaymentIntentParams`, but does occur if called on a `ConfirmSetupIntentParams`.

## Testing
- Unit test included (only)

## Long explanation
When confirming a SetupIntent or a PaymentIntent, the `paymentController.startConfirmAndAuth(...)` method is called which creates a `ConfirmStripeIntentTask`.  During creation, the given `ConfirmStripeIntentParams` object is transformed via its `.withShouldUseStripeSdk(true)` interface method.  There are two implementations of this method, one for `ConfirmSetupIntentParams` and one for `ConfirmPaymentIntentParams`.

The one for `ConfirmPaymentIntentParams` faithfully carries forward all of the properties, while `ConfirmSetupIntentParams` has an unexpected side effect of dropping the `mPaymentMethodCreateParams` if they are present.

The result of this makes it impossible to confirm a SetupIntent using a new payment method.  The workaround would require a user to create a payment method separately, obtain the payment method ID and then use that to confirm the SetupIntent (We shouldn't require users to do this, since, like a PaymentIntent, we should be able to specify the payment method using the `PaymentMethodCreateParams` during the confirm step.

If a user attempts to confirm a SetupIntent via `stripe.confirmSetupIntent(..)` after providing it with a new payment method (using `PaymentMethodCreateParams`), they will see an error like this:

```
com.stripe.android.exception.InvalidRequestException: You cannot confirm this SetupIntent because it's missing a payment method. Update the SetupIntent with a payment method and then confirm it again.; request-id: req_DRwGpA9WfR3mhw
```

Gist of logs:
https://gist.github.com/mindlapse/e4a4c2246e6e138af6e9acf646e04109
