### PR TITLE
Remove unused StripeModel.toMap()

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
@@ -149,7 +149,8 @@ class PaymentIntentActivity : AppCompatActivity() {
     }
 
     private fun displayPaymentIntent(paymentIntent: PaymentIntent) {
-        paymentIntentValue.text = JSONObject(paymentIntent.toMap()).toString()
+        val displayText = "Payment Intent status: ${paymentIntent.status?.code}"
+        paymentIntentValue.text = displayText
     }
 
     private fun confirmPaymentIntent(card: Card) {

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.kt
@@ -171,7 +171,8 @@ class SetupIntentActivity : AppCompatActivity() {
     }
 
     private fun displaySetupIntent(setupIntent: SetupIntent) {
-        setupIntentValue.text = JSONObject(setupIntent.toMap()).toString()
+        val displayText = "Setup Intent status: ${setupIntent.status?.code}"
+        setupIntentValue.text = displayText
     }
 
     private fun confirmSetupIntent() {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.java
@@ -12,11 +12,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -28,14 +23,14 @@ import java.util.Objects;
  */
 abstract class EphemeralKey extends StripeModel implements Parcelable {
 
-    static final String FIELD_CREATED = "created";
-    static final String FIELD_EXPIRES = "expires";
-    static final String FIELD_SECRET = "secret";
-    static final String FIELD_LIVEMODE = "livemode";
-    static final String FIELD_OBJECT = "object";
-    static final String FIELD_ID = "id";
-    static final String FIELD_ASSOCIATED_OBJECTS = "associated_objects";
-    static final String FIELD_TYPE = "type";
+    private static final String FIELD_CREATED = "created";
+    private static final String FIELD_EXPIRES = "expires";
+    private static final String FIELD_SECRET = "secret";
+    private static final String FIELD_LIVEMODE = "livemode";
+    private static final String FIELD_OBJECT = "object";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_ASSOCIATED_OBJECTS = "associated_objects";
+    private static final String FIELD_TYPE = "type";
 
     @NonNull final String mObjectId;
     private final long mCreated;
@@ -82,27 +77,6 @@ abstract class EphemeralKey extends StripeModel implements Parcelable {
         mObject = object;
         mSecret = secret;
         mType = type;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_CREATED, mCreated);
-        map.put(FIELD_EXPIRES, mExpires);
-        map.put(FIELD_OBJECT, mObject);
-        map.put(FIELD_ID, mId);
-        map.put(FIELD_SECRET, mSecret);
-        map.put(FIELD_LIVEMODE, mLiveMode);
-
-        final List<Object> associatedObjectsList = new ArrayList<>();
-        final Map<String, String> associatedObjectMap = new HashMap<>();
-        associatedObjectMap.put(FIELD_ID, mObjectId);
-        associatedObjectMap.put(FIELD_TYPE, mType);
-        associatedObjectsList.add(associatedObjectMap);
-
-        map.put(FIELD_ASSOCIATED_OBJECTS, associatedObjectsList);
-        return map;
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -115,16 +115,6 @@ public final class Address extends StripeModel implements StripeParamsModel, Par
         return mState;
     }
 
-    /**
-     * @deprecated use {@link #toParamMap()}
-     */
-    @Deprecated
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        return toParamMap();
-    }
-
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -10,7 +10,6 @@ import android.support.annotation.StringDef;
 import com.stripe.android.CardUtils;
 import com.stripe.android.ObjectBuilder;
 import com.stripe.android.R;
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.StripeTextUtils;
 import com.stripe.android.utils.ObjectUtils;
 
@@ -19,7 +18,6 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -626,37 +624,6 @@ public final class Card extends StripeModel implements StripePaymentSource {
     @Nullable
     public String getCvcCheck() {
         return cvcCheck;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_NAME, name);
-        map.put(FIELD_ADDRESS_CITY, addressCity);
-        map.put(FIELD_ADDRESS_COUNTRY, addressCountry);
-        map.put(FIELD_ADDRESS_LINE1, addressLine1);
-        map.put(FIELD_ADDRESS_LINE1_CHECK, addressLine1Check);
-        map.put(FIELD_ADDRESS_LINE2, addressLine2);
-        map.put(FIELD_ADDRESS_STATE, addressState);
-        map.put(FIELD_ADDRESS_ZIP, addressZip);
-        map.put(FIELD_ADDRESS_ZIP_CHECK, addressZipCheck);
-        map.put(FIELD_BRAND, brand);
-        map.put(FIELD_CURRENCY, currency);
-        map.put(FIELD_COUNTRY, country);
-        map.put(FIELD_CUSTOMER, customerId);
-        map.put(FIELD_CVC_CHECK, cvcCheck);
-        map.put(FIELD_EXP_MONTH, expMonth);
-        map.put(FIELD_EXP_YEAR, expYear);
-        map.put(FIELD_FINGERPRINT, fingerprint);
-        map.put(FIELD_FUNDING, funding);
-        map.put(FIELD_ID, id);
-        map.put(FIELD_LAST4, last4);
-        map.put(FIELD_TOKENIZATION_METHOD, tokenizationMethod);
-        map.put(FIELD_METADATA, metadata);
-        map.put(FIELD_OBJECT, VALUE_CARD);
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -3,18 +3,14 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.stripe.android.model.StripeJsonUtils.optBoolean;
 import static com.stripe.android.model.StripeJsonUtils.optInteger;
@@ -100,35 +96,6 @@ public final class Customer extends StripeModel {
             }
         }
         return null;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_ID, mId);
-        map.put(FIELD_OBJECT, VALUE_CUSTOMER);
-        map.put(FIELD_DEFAULT_SOURCE, mDefaultSource);
-        if (mShippingInformation != null) {
-            map.put(FIELD_SHIPPING, mShippingInformation.toMap());
-        }
-
-        final AbstractMap<String, Object> sourcesObject = new HashMap<>();
-        sourcesObject.put(FIELD_HAS_MORE, mHasMore);
-        sourcesObject.put(FIELD_TOTAL_COUNT, mTotalCount);
-        sourcesObject.put(FIELD_OBJECT, VALUE_LIST);
-        sourcesObject.put(FIELD_URL, mUrl);
-        final List<Map<String, Object>> sourcesMaps = new ArrayList<>(mSources.size());
-        for (int i = 0; i < mSources.size(); i++) {
-            sourcesMaps.add(mSources.get(i).toMap());
-        }
-        sourcesObject.put(FIELD_DATA, sourcesMaps);
-        StripeNetworkUtils.removeNullAndEmptyParams(sourcesObject);
-
-        map.put(FIELD_SOURCES, sourcesObject);
-
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
+++ b/stripe/src/main/java/com/stripe/android/model/CustomerSource.java
@@ -8,9 +8,6 @@ import com.stripe.android.utils.ObjectUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 /**
@@ -108,17 +105,6 @@ public final class CustomerSource extends StripeModel implements StripePaymentSo
         } else {
             return new CustomerSource(sourceObject);
         }
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        if (mStripePaymentSource instanceof Source) {
-            return ((Source) mStripePaymentSource).toMap();
-        } else if (mStripePaymentSource instanceof Card) {
-            return ((Card) mStripePaymentSource).toMap();
-        }
-        return new HashMap<>();
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.java
@@ -4,14 +4,11 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,23 +29,23 @@ import static com.stripe.android.model.StripeJsonUtils.optString;
 public final class PaymentIntent extends StripeModel implements StripeIntent {
     private static final String VALUE_PAYMENT_INTENT = "payment_intent";
 
-    static final String FIELD_ID = "id";
-    static final String FIELD_OBJECT = "object";
-    static final String FIELD_AMOUNT = "amount";
-    static final String FIELD_CREATED = "created";
-    static final String FIELD_CANCELED = "canceled_at";
-    static final String FIELD_CAPTURE_METHOD = "capture_method";
-    static final String FIELD_CLIENT_SECRET = "client_secret";
-    static final String FIELD_CONFIRMATION_METHOD = "confirmation_method";
-    static final String FIELD_CURRENCY = "currency";
-    static final String FIELD_DESCRIPTION = "description";
-    static final String FIELD_LIVEMODE = "livemode";
-    static final String FIELD_NEXT_ACTION = "next_action";
-    static final String FIELD_PAYMENT_METHOD_TYPES = "payment_method_types";
-    static final String FIELD_RECEIPT_EMAIL = "receipt_email";
-    static final String FIELD_SOURCE = "source";
-    static final String FIELD_STATUS = "status";
-    static final String FIELD_SETUP_FUTURE_USAGE = "setup_future_usage";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_OBJECT = "object";
+    private static final String FIELD_AMOUNT = "amount";
+    private static final String FIELD_CREATED = "created";
+    private static final String FIELD_CANCELED = "canceled_at";
+    private static final String FIELD_CAPTURE_METHOD = "capture_method";
+    private static final String FIELD_CLIENT_SECRET = "client_secret";
+    private static final String FIELD_CONFIRMATION_METHOD = "confirmation_method";
+    private static final String FIELD_CURRENCY = "currency";
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_LIVEMODE = "livemode";
+    private static final String FIELD_NEXT_ACTION = "next_action";
+    private static final String FIELD_PAYMENT_METHOD_TYPES = "payment_method_types";
+    private static final String FIELD_RECEIPT_EMAIL = "receipt_email";
+    private static final String FIELD_SOURCE = "source";
+    private static final String FIELD_STATUS = "status";
+    private static final String FIELD_SETUP_FUTURE_USAGE = "setup_future_usage";
 
     private static final String FIELD_NEXT_ACTION_TYPE = "type";
 
@@ -309,32 +306,6 @@ public final class PaymentIntent extends StripeModel implements StripeIntent {
                 source,
                 status,
                 setupFutureUsage);
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_ID, mId);
-        map.put(FIELD_OBJECT, mObjectType);
-        map.put(FIELD_PAYMENT_METHOD_TYPES, mPaymentMethodTypes);
-        map.put(FIELD_AMOUNT, mAmount);
-        map.put(FIELD_CANCELED, mCanceledAt);
-        map.put(FIELD_CLIENT_SECRET, mClientSecret);
-        map.put(FIELD_CAPTURE_METHOD, mCaptureMethod);
-        map.put(FIELD_CONFIRMATION_METHOD, mConfirmationMethod);
-        map.put(FIELD_CREATED, mCreated);
-        map.put(FIELD_CURRENCY, mCurrency);
-        map.put(FIELD_DESCRIPTION, mDescription);
-        map.put(FIELD_LIVEMODE, mLiveMode);
-        map.put(FIELD_NEXT_ACTION, mNextAction);
-        map.put(FIELD_RECEIPT_EMAIL, mReceiptEmail);
-        map.put(FIELD_STATUS, mStatus != null ? mStatus.code : null);
-        map.put(FIELD_SETUP_FUTURE_USAGE,
-                mSetupFutureUsage != null ? mSetupFutureUsage.code : null);
-        map.put(FIELD_SOURCE, mSource);
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -92,27 +92,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         return type != null;
     }
 
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> paymentMethod = new HashMap<>();
-        paymentMethod.put(FIELD_ID, id);
-        paymentMethod.put(FIELD_CREATED, created);
-        paymentMethod.put(FIELD_CUSTOMER, customerId);
-        paymentMethod.put(FIELD_LIVEMODE, liveMode);
-        paymentMethod.put(FIELD_TYPE, type);
-        paymentMethod.put(FIELD_BILLING_DETAILS,
-                billingDetails != null ? billingDetails.toMap() : null);
-        paymentMethod.put(FIELD_CARD,
-                card != null ? card.toMap() : null);
-        paymentMethod.put(FIELD_CARD_PRESENT,
-                cardPresent != null ? cardPresent.toMap() : null);
-        paymentMethod.put(FIELD_IDEAL,
-                ideal != null ? ideal.toMap() : null);
-        paymentMethod.put(FIELD_METADATA, metadata);
-        return paymentMethod;
-    }
-
     @Nullable
     public static PaymentMethod fromString(@Nullable String jsonString) {
         if (jsonString == null) {
@@ -375,16 +354,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                     }
                 };
 
-        /**
-         * @deprecated use {@link #toParamMap()}
-         */
-        @Deprecated
-        @NonNull
-        @Override
-        public Map<String, Object> toMap() {
-            return toParamMap();
-        }
-
         @NonNull
         @Override
         public Map<String, Object> toParamMap() {
@@ -584,23 +553,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             }
         };
 
-        @NonNull
-        @Override
-        public Map<String, Object> toMap() {
-            final AbstractMap<String, Object> map = new HashMap<>();
-            map.put(FIELD_BRAND, brand);
-            map.put(FIELD_CHECKS, checks != null ? checks.toMap() : null);
-            map.put(FIELD_COUNTRY, country);
-            map.put(FIELD_EXP_MONTH, expiryMonth);
-            map.put(FIELD_EXP_YEAR, expiryYear);
-            map.put(FIELD_FUNDING, funding);
-            map.put(FIELD_LAST4, last4);
-            map.put(FIELD_THREE_D_SECURE_USAGE,
-                    threeDSecureUsage != null ? threeDSecureUsage.toMap() : null);
-            map.put(FIELD_WALLET, wallet);
-            return map;
-        }
-
         @Nullable
         public static Card fromJson(@Nullable JSONObject cardJson) {
             if (cardJson == null) {
@@ -762,16 +714,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                         }
                     };
 
-            @NonNull
-            @Override
-            public Map<String, Object> toMap() {
-                final AbstractMap<String, Object> map = new HashMap<>();
-                map.put(FIELD_ADDRESS_LINE1_CHECK, addressLine1Check);
-                map.put(FIELD_ADDRESS_POSTAL_CODE_CHECK, addressPostalCodeCheck);
-                map.put(FIELD_CVC_CHECK, cvcCheck);
-                return map;
-            }
-
             @Nullable
             public static Checks fromJson(@Nullable JSONObject checksJson) {
                 if (checksJson == null) {
@@ -868,14 +810,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                         }
                     };
 
-            @NonNull
-            @Override
-            public Map<String, Object> toMap() {
-                final Map<String, Object> map = new HashMap<>();
-                map.put(FIELD_IS_SUPPORTED, isSupported);
-                return map;
-            }
-
             @Nullable
             public static ThreeDSecureUsage fromJson(@Nullable JSONObject threeDSecureUsage) {
                 if (threeDSecureUsage == null) {
@@ -944,12 +878,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                     }
                 };
 
-        @NonNull
-        @Override
-        public Map<String, Object> toMap() {
-            return new HashMap<>();
-        }
-
         @Override
         public int hashCode() {
             return ObjectUtils.hash(type);
@@ -1002,15 +930,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                 return new Ideal[size];
             }
         };
-
-        @NonNull
-        @Override
-        public Map<String, Object> toMap() {
-            final AbstractMap<String, Object> ideal = new HashMap<>();
-            ideal.put(FIELD_BANK, bank);
-            ideal.put(FIELD_BIC, bankIdentifierCode);
-            return ideal;
-        }
 
         @Nullable
         public static Ideal fromJson(@Nullable JSONObject ideal) {

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.java
@@ -5,14 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.ObjectBuilder;
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -229,26 +226,6 @@ public final class SetupIntent extends StripeModel implements StripeIntent {
                 .setUsage(Usage.fromCode(optString(jsonObject, FIELD_USAGE)))
                 .setNextAction(optMap(jsonObject, FIELD_NEXT_ACTION))
                 .build();
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_ID, mId);
-        map.put(FIELD_OBJECT, mObjectType);
-        map.put(FIELD_PAYMENT_METHOD, mPaymentMethodId);
-        map.put(FIELD_PAYMENT_METHOD_TYPES, mPaymentMethodTypes);
-        map.put(FIELD_CLIENT_SECRET, mClientSecret);
-        map.put(FIELD_CREATED, mCreated);
-        map.put(FIELD_CUSTOMER, mCustomerId);
-        map.put(FIELD_DESCRIPTION, mDescription);
-        map.put(FIELD_LIVEMODE, mLiveMode);
-        map.put(FIELD_NEXT_ACTION, mNextAction);
-        map.put(FIELD_STATUS, mStatus != null ? mStatus.code : null);
-        map.put(FIELD_USAGE, mUsage != null ? mUsage.code : null);
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
@@ -82,16 +82,6 @@ public final class ShippingInformation
                 optString(jsonObject, FIELD_PHONE));
     }
 
-    /**
-     * @deprecated use {@link #toParamMap()}
-     */
-    @Deprecated
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        return toParamMap();
-    }
-
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {

--- a/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
@@ -8,10 +8,7 @@ import android.support.annotation.Size;
 
 import com.stripe.android.utils.ObjectUtils;
 
-import java.util.AbstractMap;
 import java.util.Currency;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -29,13 +26,6 @@ public final class ShippingMethod extends StripeModel implements Parcelable {
             return new ShippingMethod[size];
         }
     };
-
-    private static final String FIELD_AMOUNT = "amount";
-    /*ISO Currency Code*/
-    private static final String FIELD_CURRENCY_CODE = "currency_code";
-    private static final String FIELD_DETAIL = "detail";
-    private static final String FIELD_IDENTIFIER = "identifier";
-    private static final String FIELD_LABEL = "label";
 
     private final long mAmount;
     @NonNull @Size(min = 0, max = 3) private final String mCurrencyCode;
@@ -110,18 +100,6 @@ public final class ShippingMethod extends StripeModel implements Parcelable {
     @NonNull
     public String getIdentifier() {
         return mIdentifier;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_AMOUNT, mAmount);
-        map.put(FIELD_CURRENCY_CODE, mCurrencyCode);
-        map.put(FIELD_DETAIL, mDetail);
-        map.put(FIELD_IDENTIFIER, mIdentifier);
-        map.put(FIELD_LABEL, mLabel);
-        return map;
     }
 
     /************** Parcelable *********************/

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -12,16 +12,13 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.StripeJsonUtils.optLong;
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
@@ -394,43 +391,6 @@ public final class Source extends StripeModel implements StripePaymentSource {
         }
 
         return Objects.requireNonNull(mWeChat);
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_ID, mId);
-        map.put(FIELD_OBJECT, VALUE_SOURCE);
-        map.put(FIELD_AMOUNT, mAmount);
-        map.put(FIELD_CLIENT_SECRET, mClientSecret);
-        if (mCodeVerification != null) {
-            map.put(FIELD_CODE_VERIFICATION, mCodeVerification.toMap());
-        }
-
-        map.put(FIELD_CREATED, mCreated);
-        map.put(FIELD_CURRENCY, mCurrency);
-        map.put(FIELD_FLOW, mFlow);
-        map.put(FIELD_LIVEMODE, mLiveMode);
-        map.put(FIELD_METADATA, mMetaData);
-
-        if (mOwner != null) {
-            map.put(FIELD_OWNER, mOwner.toMap());
-        }
-        if (mReceiver != null) {
-            map.put(FIELD_RECEIVER, mReceiver.toMap());
-        }
-        if (mRedirect != null) {
-            map.put(FIELD_REDIRECT, mRedirect.toMap());
-        }
-
-        map.put(mTypeRaw, mSourceTypeData);
-
-        map.put(FIELD_STATUS, mStatus);
-        map.put(FIELD_TYPE, mTypeRaw);
-        map.put(FIELD_USAGE, mUsage);
-        removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCardData.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 import android.support.annotation.VisibleForTesting;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
@@ -13,9 +12,7 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -164,25 +161,6 @@ public final class SourceCardData extends StripeSourceTypeModel {
     @Nullable
     public String getTokenizationMethod() {
         return mTokenizationMethod;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>(super.toMap());
-        map.put(FIELD_ADDRESS_LINE1_CHECK, mAddressLine1Check);
-        map.put(FIELD_ADDRESS_ZIP_CHECK, mAddressZipCheck);
-        map.put(FIELD_BRAND, mBrand);
-        map.put(FIELD_COUNTRY, mCountry);
-        map.put(FIELD_DYNAMIC_LAST4, mDynamicLast4);
-        map.put(FIELD_EXP_MONTH, mExpiryMonth);
-        map.put(FIELD_EXP_YEAR, mExpiryYear);
-        map.put(FIELD_FUNDING, mFunding);
-        map.put(FIELD_LAST4, mLast4);
-        map.put(FIELD_THREE_D_SECURE, mThreeDSecureStatus);
-        map.put(FIELD_TOKENIZATION_METHOD, mTokenizationMethod);
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCodeVerification.java
@@ -11,8 +11,6 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.HashMap;
-import java.util.Map;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
@@ -59,17 +57,6 @@ public final class SourceCodeVerification extends StripeModel {
     @Status
     public String getStatus() {
         return mStatus;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final Map<String, Object> map = new HashMap<>();
-        map.put(FIELD_ATTEMPTS_REMAINING, mAttemptsRemaining);
-        if (mStatus != null) {
-            map.put(FIELD_STATUS, mStatus);
-        }
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOwner.java
@@ -8,11 +8,6 @@ import com.stripe.android.utils.ObjectUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 /**
@@ -97,26 +92,6 @@ public final class SourceOwner extends StripeModel {
     @Nullable
     public String getVerifiedPhone() {
         return mVerifiedPhone;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        if (mAddress != null) {
-            map.put(FIELD_ADDRESS, mAddress.toMap());
-        }
-        map.put(FIELD_EMAIL, mEmail);
-        map.put(FIELD_NAME, mName);
-        map.put(FIELD_PHONE, mPhone);
-        if (mVerifiedAddress != null) {
-            map.put(FIELD_VERIFIED_ADDRESS, mVerifiedAddress.toMap());
-        }
-        map.put(FIELD_VERIFIED_EMAIL, mVerifiedEmail);
-        map.put(FIELD_VERIFIED_NAME, mVerifiedName);
-        map.put(FIELD_VERIFIED_PHONE, mVerifiedPhone);
-        removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceReceiver.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceReceiver.java
@@ -3,15 +3,10 @@ package com.stripe.android.model;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.StripeTextUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Model for a
@@ -56,20 +51,6 @@ public final class SourceReceiver extends StripeModel {
 
     public long getAmountReturned() {
         return mAmountReturned;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        if (!StripeTextUtils.isBlank(mAddress)) {
-            map.put(FIELD_ADDRESS, mAddress);
-        }
-        map.put(FIELD_ADDRESS, mAddress);
-        map.put(FIELD_AMOUNT_CHARGED, mAmountCharged);
-        map.put(FIELD_AMOUNT_RECEIVED, mAmountReceived);
-        map.put(FIELD_AMOUNT_RETURNED, mAmountReturned);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceRedirect.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceRedirect.java
@@ -12,11 +12,7 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 
-import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 /**
@@ -68,17 +64,6 @@ public final class SourceRedirect extends StripeModel {
     @Nullable
     public String getUrl() {
         return mUrl;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_RETURN_URL, mReturnUrl);
-        map.put(FIELD_STATUS, mStatus);
-        map.put(FIELD_URL, mUrl);
-        removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
@@ -4,15 +4,12 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -116,21 +113,6 @@ public final class SourceSepaDebitData extends StripeSourceTypeModel {
     @Nullable
     public String getMandateUrl() {
         return mMandateUrl;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>(super.toMap());
-        map.put(FIELD_BANK_CODE, mBankCode);
-        map.put(FIELD_BRANCH_CODE, mBranchCode);
-        map.put(FIELD_COUNTRY, mCountry);
-        map.put(FIELD_FINGERPRINT, mFingerPrint);
-        map.put(FIELD_LAST4, mLast4);
-        map.put(FIELD_MANDATE_REFERENCE, mMandateReference);
-        map.put(FIELD_MANDATE_URL, mMandateUrl);
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
-        return map;
     }
 
     @Nullable

--- a/stripe/src/main/java/com/stripe/android/model/StripeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeModel.java
@@ -8,15 +8,11 @@ import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Model for a Stripe API object.
  */
 public abstract class StripeModel {
-
-    @NonNull
-    public abstract Map<String, Object> toMap();
 
     @Override
     public abstract int hashCode();

--- a/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
+++ b/stripe/src/main/java/com/stripe/android/model/StripeSourceTypeModel.java
@@ -23,12 +23,6 @@ public abstract class StripeSourceTypeModel extends StripeModel {
                 builder.mAdditionalFields : new HashMap<String, Object>();
     }
 
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        return new HashMap<>(mAdditionalFields);
-    }
-
     /**
      * Convert a {@link JSONObject} to a flat, string-keyed map.
      *

--- a/stripe/src/main/java/com/stripe/android/model/WeChat.java
+++ b/stripe/src/main/java/com/stripe/android/model/WeChat.java
@@ -8,9 +8,6 @@ import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -47,22 +44,6 @@ public final class WeChat extends StripeModel {
         sign = builder.sign;
         timestamp = builder.timestamp;
         qrCodeUrl = builder.qrCodeUrl;
-    }
-
-    @NonNull
-    @Override
-    public Map<String, Object> toMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_APPID, appId);
-        map.put(FIELD_NONCE, nonce);
-        map.put(FIELD_PACKAGE, packageValue);
-        map.put(FIELD_PARTNERID, partnerId);
-        map.put(FIELD_PREPAYID, prepayId);
-        map.put(FIELD_SIGN, sign);
-        map.put(FIELD_TIMESTAMP, timestamp);
-        map.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
-        map.put(FIELD_QR_CODE_URL, qrCodeUrl);
-        return map;
     }
 
     @Override

--- a/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.java
@@ -4,9 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public final class AmexExpressCheckoutWallet extends Wallet {
     private AmexExpressCheckoutWallet(@NonNull Builder builder) {
         super(Type.AmexExpressCheckout, builder);
@@ -14,12 +11,6 @@ public final class AmexExpressCheckoutWallet extends Wallet {
 
     private AmexExpressCheckoutWallet(@NonNull Parcel in) {
         super(in);
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        return new HashMap<>();
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.java
@@ -4,9 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public final class ApplePayWallet extends Wallet {
     private ApplePayWallet(@NonNull Builder builder) {
         super(Type.ApplePay, builder);
@@ -14,12 +11,6 @@ public final class ApplePayWallet extends Wallet {
 
     private ApplePayWallet(@NonNull Parcel in) {
         super(in);
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        return new HashMap<>();
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.java
@@ -4,9 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public final class GooglePayWallet extends Wallet {
     private GooglePayWallet(@NonNull Builder builder) {
         super(Type.GooglePay, builder);
@@ -14,12 +11,6 @@ public final class GooglePayWallet extends Wallet {
 
     private GooglePayWallet(@NonNull Parcel in) {
         super(in);
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        return new HashMap<>();
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.java
@@ -9,10 +9,6 @@ import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 public final class MasterpassWallet extends Wallet {
@@ -32,19 +28,6 @@ public final class MasterpassWallet extends Wallet {
         email = builder.mEmail;
         name = builder.mName;
         shippingAddress = builder.mShippingAddress;
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        final AbstractMap<String, Object> wallet = new HashMap<>();
-        wallet.put(FIELD_BILLING_ADDRESS,
-                billingAddress != null ? billingAddress.toMap() : null);
-        wallet.put(FIELD_EMAIL, email);
-        wallet.put(FIELD_NAME, name);
-        wallet.put(FIELD_SHIPPING_ADDRESS,
-                shippingAddress != null ? shippingAddress.toMap() : null);
-        return wallet;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.java
@@ -4,9 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public final class SamsungPayWallet extends Wallet {
     private SamsungPayWallet(@NonNull Builder builder) {
         super(Type.SamsungPay, builder);
@@ -14,12 +11,6 @@ public final class SamsungPayWallet extends Wallet {
 
     private SamsungPayWallet(@NonNull Parcel in) {
         super(in);
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        return new HashMap<>();
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.java
@@ -9,10 +9,6 @@ import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.stripe.android.model.StripeJsonUtils.optString;
 
 public final class VisaCheckoutWallet extends Wallet {
@@ -32,19 +28,6 @@ public final class VisaCheckoutWallet extends Wallet {
         email = builder.mEmail;
         name = builder.mName;
         shippingAddress = builder.mShippingAddress;
-    }
-
-    @NonNull
-    @Override
-    Map<String, Object> getWalletTypeMap() {
-        final AbstractMap<String, Object> wallet = new HashMap<>();
-        wallet.put(FIELD_BILLING_ADDRESS,
-                billingAddress != null ? billingAddress.toMap() : null);
-        wallet.put(FIELD_EMAIL, email);
-        wallet.put(FIELD_NAME, name);
-        wallet.put(FIELD_SHIPPING_ADDRESS,
-                shippingAddress != null ? shippingAddress.toMap() : null);
-        return wallet;
     }
 
     @NonNull

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -11,9 +11,6 @@ import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.stripe.android.model.StripeJsonUtils.optString;
@@ -46,16 +43,6 @@ public abstract class Wallet extends StripeModel implements Parcelable {
         dest.writeString(walletType.code);
     }
 
-    @NonNull
-    @Override
-    public final Map<String, Object> toMap() {
-        final AbstractMap<String, Object> wallet = new HashMap<>();
-        wallet.put(FIELD_TYPE, walletType.code);
-        wallet.put(FIELD_DYNAMIC_LAST4, dynamicLast4);
-        wallet.put(walletType.code, getWalletTypeMap());
-        return wallet;
-    }
-
     @Override
     public int hashCode() {
         return ObjectUtils.hash(dynamicLast4, walletType);
@@ -71,14 +58,11 @@ public abstract class Wallet extends StripeModel implements Parcelable {
                 && ObjectUtils.equals(walletType, wallet.walletType);
     }
 
-    @NonNull
-    abstract Map<String, Object> getWalletTypeMap();
-
     abstract static class Builder<W extends Wallet> {
         @Nullable private String mDynamicLast4;
 
         @NonNull
-        public Builder setDynamicLast4(@Nullable String dynamicLast4) {
+        Builder setDynamicLast4(@Nullable String dynamicLast4) {
             this.mDynamicLast4 = dynamicLast4;
             return this;
         }
@@ -173,19 +157,6 @@ public abstract class Wallet extends StripeModel implements Parcelable {
                         return new Address[size];
                     }
                 };
-
-        @NonNull
-        @Override
-        public Map<String, Object> toMap() {
-            final AbstractMap<String, Object> address = new HashMap<>();
-            address.put(FIELD_CITY, city);
-            address.put(FIELD_COUNTRY, country);
-            address.put(FIELD_LINE1, line1);
-            address.put(FIELD_LINE2, line2);
-            address.put(FIELD_POSTAL_CODE, postalCode);
-            address.put(FIELD_STATE, state);
-            return address;
-        }
 
         @Nullable
         static Address fromJson(@Nullable JSONObject addressJson) {

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.java
@@ -3,18 +3,11 @@ package com.stripe.android;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 
-import com.stripe.android.testharness.JsonTestUtils;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -60,29 +53,6 @@ public class EphemeralKeyTest {
     @Test
     public void fromJson_createsObject() throws JSONException {
         assertNotNull(CustomerEphemeralKey.fromJson(new JSONObject(SAMPLE_KEY_RAW)));
-    }
-
-    @Test
-    public void toMap_createsMapWithExpectedValues() throws JSONException {
-        final CustomerEphemeralKey ephemeralKey = getCustomerEphemeralKey();
-        assertNotNull(ephemeralKey);
-        final Map<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put(CustomerEphemeralKey.FIELD_ID, "ephkey_123");
-            put(CustomerEphemeralKey.FIELD_OBJECT, "ephemeral_key");
-            put(CustomerEphemeralKey.FIELD_SECRET, ApiKeyFixtures.FAKE_EPHEMERAL_KEY);
-            put(CustomerEphemeralKey.FIELD_LIVEMODE, false);
-            put(CustomerEphemeralKey.FIELD_CREATED, 1483575790L);
-            put(CustomerEphemeralKey.FIELD_EXPIRES, 1483579790L);
-        }};
-
-        Map<String, String> subMap = new HashMap<>();
-        subMap.put(CustomerEphemeralKey.FIELD_ID, "cus_123");
-        subMap.put(CustomerEphemeralKey.FIELD_TYPE, "customer");
-        List<Object> list = new ArrayList<>();
-        list.add(subMap);
-        expectedMap.put(CustomerEphemeralKey.FIELD_ASSOCIATED_OBJECTS, list);
-
-        JsonTestUtils.assertMapEquals(expectedMap, ephemeralKey.toMap());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/AddressTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/AddressTest.java
@@ -1,13 +1,15 @@
 package com.stripe.android.model;
 
+import android.support.annotation.NonNull;
+
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Test class for {@link Address}.
@@ -32,12 +34,12 @@ public class AddressTest {
         put("state", "CA");
     }};
 
-    private static final Address ADDRESS = Address.fromString(JSON_ADDRESS);
+    @NonNull private static final Address ADDRESS =
+            Objects.requireNonNull(Address.fromString(JSON_ADDRESS));
 
     @Test
-    public void fromJsonString_toMap_createsExpectedMap() {
-        assertNotNull(ADDRESS);
-        assertMapEquals(MAP_ADDRESS, ADDRESS.toMap());
+    public void fromJsonString_toParamMap_createsExpectedParamMap() {
+        assertMapEquals(MAP_ADDRESS, ADDRESS.toParamMap());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.java
@@ -2,10 +2,6 @@ package com.stripe.android.model;
 
 import android.support.annotation.NonNull;
 
-import com.stripe.android.testharness.JsonTestUtils;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -682,14 +678,6 @@ public class CardTest {
         final Card expectedCard = createUsdCard();
         final Card actualCard = Card.fromString(JSON_CARD_USD);
         assertEquals(expectedCard, actualCard);
-    }
-
-    @Test
-    public void toMap_catchesAllFields_fromRawJson() throws JSONException {
-        final JSONObject rawJsonObject = new JSONObject(JSON_CARD_USD);
-        final Map<String, Object> rawMap = StripeJsonUtils.jsonObjectToMap(rawJsonObject);
-        final Card expectedCard = createUsdCard();
-        JsonTestUtils.assertMapEquals(rawMap, expectedCard.toMap());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.java
@@ -1,19 +1,11 @@
 package com.stripe.android.model;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -155,39 +147,6 @@ public class PaymentIntentTest {
             "\t\t}\n" +
             "\t}\n" +
             "}";
-
-    private static final List<String> PAYMENT_METHOD_TYPES = new ArrayList<String>() {{
-        add("card");
-    }};
-
-    private static final Map<String, Object> PAYMENT_INTENT_WITH_SOURCE_MAP =
-            new HashMap<String, Object>() {{
-                put(PaymentIntent.FIELD_ID, "pi_1CkiBMLENEVhOs7YMtUehLau");
-                put(PaymentIntent.FIELD_OBJECT, "payment_intent");
-                put(PaymentIntent.FIELD_PAYMENT_METHOD_TYPES, PAYMENT_METHOD_TYPES);
-                put(PaymentIntent.FIELD_AMOUNT, 1000L);
-                put(PaymentIntent.FIELD_CANCELED, 1530839340L);
-                put(PaymentIntent.FIELD_CLIENT_SECRET,
-                        "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA");
-                put(PaymentIntent.FIELD_CONFIRMATION_METHOD, "publishable");
-                put(PaymentIntent.FIELD_CREATED, 1530838340L);
-                put(PaymentIntent.FIELD_CURRENCY, "usd");
-                put(PaymentIntent.FIELD_DESCRIPTION, "Example PaymentIntent charge");
-                put(PaymentIntent.FIELD_LIVEMODE, false);
-                put(PaymentIntent.FIELD_SOURCE, "src_1CkiC3LENEVhOs7YMSa4yx4G");
-                put(PaymentIntent.FIELD_CAPTURE_METHOD, "automatic");
-                put(PaymentIntent.FIELD_STATUS, StripeIntent.Status.Succeeded.code);
-            }};
-
-    @NonNull private static final PaymentIntent PAYMENT_INTENT_WITH_SOURCE =
-            Objects.requireNonNull(PaymentIntent.fromString(PAYMENT_INTENT_WITH_SOURCE_JSON));
-
-    @Test
-    public void fromJsonString_toMap_createsExpectedMap() {
-        assertNotNull(PAYMENT_INTENT_WITH_SOURCE);
-        final Map<String, Object> paymentIntentMap = PAYMENT_INTENT_WITH_SOURCE.toMap();
-        assertMapEquals(paymentIntentMap, PAYMENT_INTENT_WITH_SOURCE_MAP);
-    }
 
     @Test
     public void getAuthorizationUrl_whenProvidedBadUrl_doesNotCrash() {

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -2,7 +2,6 @@ package com.stripe.android.model;
 
 import android.os.Parcel;
 
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -81,7 +80,7 @@ public class PaymentMethodTest {
 
     @Test
     public void toJson_withIdeal_shouldReturnExpectedJson() {
-        final JSONObject paymentMethod = new JSONObject(new PaymentMethod.Builder()
+        final PaymentMethod paymentMethod = new PaymentMethod.Builder()
                 .setId("pm_123456789")
                 .setCreated(1550757934255L)
                 .setLiveMode(true)
@@ -92,11 +91,9 @@ public class PaymentMethodTest {
                         .setBank("my bank")
                         .setBankIdentifierCode("bank id")
                         .build())
-                .build()
-                .toMap());
+                .build();
 
-        assertEquals(PaymentMethod.fromJson(paymentMethod),
-                PaymentMethod.fromString(RAW_IDEAL_JSON));
+        assertEquals(paymentMethod, PaymentMethod.fromString(RAW_IDEAL_JSON));
     }
 
     @Test
@@ -127,12 +124,12 @@ public class PaymentMethodTest {
     }
 
     @Test
-    public void billingDetailsToMap_removesNullValues() {
+    public void billingDetails_toParamMap_removesNullValues() {
         final Map<String, Object> billingDetails =
                 new PaymentMethod.BillingDetails.Builder()
                         .setName("name")
                         .build()
-                        .toMap();
+                        .toParamMap();
         assertEquals(1, billingDetails.size());
         assertFalse(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_ADDRESS));
         assertTrue(billingDetails.containsKey(PaymentMethod.BillingDetails.FIELD_NAME));

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.java
@@ -27,7 +27,7 @@ public class SetupIntentTest {
         assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV", setupIntent.getId());
         assertEquals("seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y",
                 setupIntent.getClientSecret());
-        assertEquals(1561677666, (long)setupIntent.getCreated());
+        assertEquals(1561677666, setupIntent.getCreated());
         assertEquals("a description", setupIntent.getDescription());
         assertEquals("pm_1EqTSoGMT9dGPIDG7dgafX1H", setupIntent.getPaymentMethodId());
         assertFalse(setupIntent.isLiveMode());
@@ -39,7 +39,7 @@ public class SetupIntentTest {
         assertNotNull(redirectData);
         assertNotNull(redirectData.returnUrl);
         assertNotNull(setupIntent.getRedirectUrl());
-        assertEquals("stripe://setup_intent_return", redirectData.returnUrl.toString());
+        assertEquals("stripe://setup_intent_return", redirectData.returnUrl);
         assertEquals("https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B" +
                 "?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02", redirectData.url.toString());
         assertEquals("https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B" +

--- a/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.java
@@ -4,32 +4,13 @@ import android.support.annotation.NonNull;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Test class for {@link ShippingMethod}
  */
 public class ShippingMethodTest {
-
-    private static final Map<String, Object> EXAMPLE_MAP_SHIPPING_ADDRESS =
-            new HashMap<String, Object>() {{
-                put("amount", 599L);
-                put("currency_code", "USD");
-                put("detail", "Arrives tomorrow");
-                put("identifier", "fedex");
-                put("label", "FedEx");
-            }};
-
     private final static ShippingMethod SHIPPING_METHOD = createShippingMethod();
-
-    @Test
-    public void testMapCreation() {
-        assertMapEquals(SHIPPING_METHOD.toMap(), EXAMPLE_MAP_SHIPPING_ADDRESS);
-    }
 
     @Test
     public void testEquals() {

--- a/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.java
@@ -2,7 +2,6 @@ package com.stripe.android.model;
 
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -41,22 +40,6 @@ public class SourceCardDataTest {
     }
 
     @Test
-    public void fromExampleJsonCard_toMap_createsExpectedMapping() {
-        assertNotNull(CARD_DATA);
-        final Map<String, Object> cardDataMap = CARD_DATA.toMap();
-        assertNotNull(cardDataMap);
-        assertEquals("US", cardDataMap.get("country"));
-        assertEquals("4242", cardDataMap.get("last4"));
-        assertEquals(12, cardDataMap.get("exp_month"));
-        assertEquals(2050, cardDataMap.get("exp_year"));
-        assertEquals(Card.FundingType.CREDIT, cardDataMap.get("funding"));
-        assertEquals(Card.CardBrand.VISA, cardDataMap.get("brand"));
-        assertEquals("optional", cardDataMap.get("three_d_secure"));
-        assertEquals("apple_pay", cardDataMap.get("tokenization_method"));
-        assertEquals("4242", cardDataMap.get("dynamic_last4"));
-    }
-
-    @Test
     public void testEquals() {
         assertEquals(CARD_DATA,
                 SourceCardData.fromString(EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY));
@@ -73,13 +56,16 @@ public class SourceCardDataTest {
 
     @Test
     public void testAsThreeDSecureStatus() {
-        assertEquals(SourceCardData.ThreeDSecureStatus.REQUIRED, SourceCardData.asThreeDSecureStatus("required"));
-        assertEquals(SourceCardData.ThreeDSecureStatus.OPTIONAL, SourceCardData.asThreeDSecureStatus("optional"));
+        assertEquals(SourceCardData.ThreeDSecureStatus.REQUIRED,
+                SourceCardData.asThreeDSecureStatus("required"));
+        assertEquals(SourceCardData.ThreeDSecureStatus.OPTIONAL,
+                SourceCardData.asThreeDSecureStatus("optional"));
         assertEquals(SourceCardData.ThreeDSecureStatus.NOT_SUPPORTED,
                 SourceCardData.asThreeDSecureStatus("not_supported"));
         assertEquals(SourceCardData.ThreeDSecureStatus.RECOMMENDED,
                 SourceCardData.asThreeDSecureStatus("recommended"));
-        assertEquals(SourceCardData.ThreeDSecureStatus.UNKNOWN, SourceCardData.asThreeDSecureStatus("unknown"));
+        assertEquals(SourceCardData.ThreeDSecureStatus.UNKNOWN,
+                SourceCardData.asThreeDSecureStatus("unknown"));
         assertNull(SourceCardData.asThreeDSecureStatus(""));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCodeVerificationTest.java
@@ -2,10 +2,7 @@ package com.stripe.android.model;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -18,17 +15,12 @@ public class SourceCodeVerificationTest {
             "\"status\": \"pending\"" +
             "}";
 
-    private static final Map<String, Object> EXAMPLE_MAP_CODE_VERIFICATION =
-            new HashMap<String, Object>() {{
-                put("attempts_remaining", 3);
-                put("status", "pending");
-            }};
-
     @Test
-    public void fromJsonString_toMap_createsExpectedMap() {
+    public void fromJsonString_createsObject() {
         final SourceCodeVerification codeVerification =
                 SourceCodeVerification.fromString(EXAMPLE_JSON_CODE_VERIFICATION);
         assertNotNull(codeVerification);
-        assertMapEquals(EXAMPLE_MAP_CODE_VERIFICATION, codeVerification.toMap());
+        assertEquals(3, codeVerification.getAttemptsRemaining());
+        assertEquals(SourceCodeVerification.Status.PENDING, codeVerification.getStatus());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceOwnerTest.java
@@ -2,11 +2,7 @@ package com.stripe.android.model;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.stripe.android.model.AddressTest.JSON_ADDRESS;
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -36,21 +32,13 @@ public class SourceOwnerTest {
             "\"verified_phone\": \"4158675309\"" +
             "}";
 
-    static final Map<String, Object> EXAMPLE_MAP_OWNER = new HashMap<String, Object>() {{
-        put("email", "jenny.rosen@example.com");
-        put("name", "Jenny Rosen");
-        put("phone", "4158675309");
-    }};
-
     @Test
     public void fromJsonStringWithoutNulls_isNotNull() {
         assertNotNull(SourceOwner.fromString(EXAMPLE_JSON_OWNER_WITHOUT_NULLS));
     }
 
     @Test
-    public void fromJsonStringWithNulls_toMap_createsExpectedMap() {
-        SourceOwner ownerWithNulls = SourceOwner.fromString(EXAMPLE_JSON_OWNER_WITH_NULLS);
-        assertNotNull("Test Data failure during parsing", ownerWithNulls);
-        assertMapEquals(EXAMPLE_MAP_OWNER, ownerWithNulls.toMap());
+    public void fromJsonStringWithNulls_IsNotNull() {
+        assertNotNull(SourceOwner.fromString(EXAMPLE_JSON_OWNER_WITH_NULLS));
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceReceiverTest.java
@@ -1,13 +1,12 @@
 package com.stripe.android.model;
 
-import org.junit.Before;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test class for {@link SourceReceiver}.
@@ -16,30 +15,19 @@ public class SourceReceiverTest {
 
     private static final String EXAMPLE_JSON_RECEIVER = "{" +
             "\"address\": \"test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N\"," +
-            "\"amount_charged\": 0," +
-            "\"amount_received\": 0," +
-            "\"amount_returned\": 0" +
+            "\"amount_charged\": 10," +
+            "\"amount_received\": 20," +
+            "\"amount_returned\": 30" +
             "}";
 
-    static final Map<String, Object> EXAMPLE_MAP_RECEIVER =
-            new HashMap<String, Object>() {{
-                put("address", "test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N");
-                put("amount_charged", 0L);
-                put("amount_received", 0L);
-                put("amount_returned", 0L);
-            }};
-
-    private SourceReceiver mSourceReceiver;
-
-    @Before
-    public void setup() {
-        mSourceReceiver = SourceReceiver.fromString(EXAMPLE_JSON_RECEIVER);
-        assertNotNull(mSourceReceiver);
-    }
-
     @Test
-    public void fromJsonString_toMap_createsExpectedMap() {
-        assertMapEquals(EXAMPLE_MAP_RECEIVER, mSourceReceiver.toMap());
+    public void fromJson_createsExpectedObject() throws JSONException {
+        final SourceReceiver sourceReceiver = Objects.requireNonNull(
+                        SourceReceiver.fromJson(new JSONObject(EXAMPLE_JSON_RECEIVER)));
+        assertEquals("test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N",
+                sourceReceiver.getAddress());
+        assertEquals(10, sourceReceiver.getAmountCharged());
+        assertEquals(20, sourceReceiver.getAmountReceived());
+        assertEquals(30, sourceReceiver.getAmountReturned());
     }
-
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceRedirectTest.java
@@ -3,10 +3,6 @@ package com.stripe.android.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -19,24 +15,9 @@ public class SourceRedirectTest {
             "\"url\": \"examplecompany://redirect-link\"" +
             "}";
 
-    private static final Map<String, Object> EXAMPLE_MAP_REDIRECT =
-            new HashMap<String, Object>() {{
-                put("return_url", "https://google.com");
-                put("status", "succeeded");
-                put("url", "examplecompany://redirect-link");
-            }};
-
-    private SourceRedirect mSourceRedirect;
-
     @Before
     public void setup() {
-        mSourceRedirect = SourceRedirect.fromString(EXAMPLE_JSON_REDIRECT);
-        assertNotNull(mSourceRedirect);
-    }
-
-    @Test
-    public void fromJsonString_toMap_createsExpectedMap() {
-        assertMapEquals(EXAMPLE_MAP_REDIRECT, mSourceRedirect.toMap());
+        assertNotNull(SourceRedirect.fromString(EXAMPLE_JSON_REDIRECT));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.java
@@ -2,16 +2,10 @@ package com.stripe.android.model;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.stripe.android.model.SourceCardDataTest.EXAMPLE_JSON_SOURCE_CARD_DATA_WITH_APPLE_PAY;
 import static com.stripe.android.model.SourceCodeVerificationTest.EXAMPLE_JSON_CODE_VERIFICATION;
 import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_JSON_OWNER_WITHOUT_NULLS;
-import static com.stripe.android.model.SourceOwnerTest.EXAMPLE_MAP_OWNER;
-import static com.stripe.android.model.SourceReceiverTest.EXAMPLE_MAP_RECEIVER;
 import static com.stripe.android.model.SourceRedirectTest.EXAMPLE_JSON_REDIRECT;
-import static com.stripe.android.testharness.JsonTestUtils.assertMapEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -84,55 +78,6 @@ public class SourceTest {
             "}";
 
     private static final String DOGE_COIN = "dogecoin";
-
-    private static final String EXAMPLE_JSON_SOURCE_WITH_NULLS = "{\n"+
-            "\"id\": \"src_19t3xKBZqEXluyI4uz2dxAfQ\",\n"+
-            "\"object\": \"source\",\n"+
-            "\"amount\": 1000,\n"+
-            "\"client_secret\": \"src_client_secret_of43INi1HteJwXVe3djAUosN\",\n"+
-            "\"created\": 1488499654,\n"+
-            "\"currency\": \"usd\",\n"+
-            "\"flow\": \"receiver\",\n"+
-            "\"livemode\": false,\n"+
-            "\"metadata\": {\n"+
-            "},\n"+
-            "\"owner\": {\n"+
-            "\"address\": null,\n"+
-            "\"email\": \"jenny.rosen@example.com\",\n"+
-            "\"name\": \"Jenny Rosen\",\n"+
-            "\"phone\": \"4158675309\",\n"+
-            "\"verified_address\": null,\n"+
-            "\"verified_email\": null,\n"+
-            "\"verified_name\": null,\n"+
-            "\"verified_phone\": null\n"+
-            "},\n"+
-            "\"receiver\": {\n"+
-            "\"address\": \"test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N\",\n"+
-            "\"amount_charged\": 0,\n"+
-            "\"amount_received\": 0,\n"+
-            "\"amount_returned\": 0\n"+
-            "},\n"+
-            "\"status\": \"pending\",\n"+
-            "\"type\": \"bitcoin\",\n"+
-            "\"usage\": \"single_use\"\n"+
-            "}";
-
-    private static final Map<String, Object> EXAMPLE_SOURCE_MAP = new HashMap<String, Object>() {{
-        put("id", "src_19t3xKBZqEXluyI4uz2dxAfQ");
-        put("object", "source");
-        put("amount", 1000L);
-        put("client_secret", "src_client_secret_of43INi1HteJwXVe3djAUosN");
-        put("created", 1488499654L);
-        put("currency", "usd");
-        put("flow", "receiver");
-        put("livemode", false);
-        put("metadata", new HashMap<String, Object>());
-        put("owner", EXAMPLE_MAP_OWNER);
-        put("receiver", EXAMPLE_MAP_RECEIVER);
-        put("status", "pending");
-        put("type", "bitcoin");
-        put("usage", "single_use");
-    }};
 
     private static final String EXAMPLE_JSON_SOURCE_CUSTOM_TYPE = "{\n"+
             "\"id\": \"src_19t3xKBZqEXluyI4uz2dxAfQ\",\n"+
@@ -240,13 +185,6 @@ public class SourceTest {
     @Test
     public void fromJsonStringWithoutNulls_isNotNull() {
         assertNotNull(Source.fromString(EXAMPLE_JSON_SOURCE_WITHOUT_NULLS));
-    }
-
-    @Test
-    public void fromJsonStringWithNulls_toMap_createsExpectedMap() {
-        Source sourceWithNulls = Source.fromString(EXAMPLE_JSON_SOURCE_WITH_NULLS);
-        assertNotNull(sourceWithNulls);
-        assertMapEquals(EXAMPLE_SOURCE_MAP, sourceWithNulls.toMap());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertNotNull;
 public class Stripe3ds2FingerprintTest {
 
     @NonNull
-    public static final String DS_CERT_DATA_RSA = "-----BEGIN CERTIFICATE-----\n" +
+    static final String DS_CERT_DATA_RSA = "-----BEGIN CERTIFICATE-----\n" +
             "MIIE0TCCA7mgAwIBAgIUXbeqM1duFcHk4dDBwT8o7Ln5wX8wDQYJKoZIhvcNAQEL\n" +
             "BQAwXjELMAkGA1UEBhMCVVMxITAfBgNVBAoTGEFtZXJpY2FuIEV4cHJlc3MgQ29t\n" +
             "cGFueTEsMCoGA1UEAxMjQW1lcmljYW4gRXhwcmVzcyBTYWZla2V5IElzc3Vpbmcg\n" +
@@ -113,7 +113,7 @@ public class Stripe3ds2FingerprintTest {
             return (X509Certificate) factory
                     .generateCertificate(new ByteArrayInputStream(certificate.getBytes()));
         } catch (CertificateException e) {
-            return null;
+            throw new RuntimeException(e);
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.java
@@ -30,14 +30,6 @@ public class StripeJsonUtilsTest {
                     "    \"numkey\": 123\n" +
                     "}";
 
-    private static final String SIMPLE_JSON_HASH_OBJECT =
-            "{\n" +
-                    "    \"akey\": \"avalue\",\n" +
-                    "    \"bkey\": \"bvalue\",\n" +
-                    "    \"ckey\": \"cvalue\",\n" +
-                    "    \"dkey\": \"dvalue\"\n" +
-                    "}";
-
     private static final String NESTED_JSON_TEST_OBJECT =
             "{\n" +
                     "    \"top_key\": {\n" +


### PR DESCRIPTION
A previous PR added `StripeParamsModel` which added
`toParamMap()` for turning a model object into a Map
of API params.

After that change `toMap()` was completely unused,
aside from tests.