### PR TITLE
Cleanup Javadocs

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ActivitySourceCallback.java
+++ b/stripe/src/main/java/com/stripe/android/ActivitySourceCallback.java
@@ -9,8 +9,8 @@ import com.stripe.android.model.Source;
 import java.lang.ref.WeakReference;
 
 /**
- * Abstract implementation of {@link ApiResultCallback<Source>} that holds a {@link WeakReference}
- * to an {@link Activity} object.
+ * Abstract implementation of {@link ApiResultCallback} that holds a {@link WeakReference}
+ * to an <code>Activity</code> object.
  */
 public abstract class ActivitySourceCallback<A extends Activity>
         implements ApiResultCallback<Source> {

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -910,7 +910,7 @@ public class CustomerSession {
 
     /**
      * Abstract implementation of {@link PaymentMethodsRetrievalListener} that holds a
-     * {@link WeakReference} to an {@link Activity} object.
+     * {@link WeakReference} to an <code>Activity</code> object.
      */
     public abstract static class ActivityPaymentMethodsRetrievalListener<A extends Activity>
             implements PaymentMethodsRetrievalListener {
@@ -928,7 +928,7 @@ public class CustomerSession {
 
     /**
      * Abstract implementation of {@link SourceRetrievalListener} that holds a
-     * {@link WeakReference} to an {@link Activity} object.
+     * {@link WeakReference} to an <code>Activity</code> object.
      */
     public abstract static class ActivitySourceRetrievalListener<A extends Activity>
             implements SourceRetrievalListener {
@@ -946,7 +946,7 @@ public class CustomerSession {
 
     /**
      * Abstract implementation of {@link PaymentMethodRetrievalListener} that holds a
-     * {@link WeakReference} to an {@link Activity} object.
+     * {@link WeakReference} to an <code>Activity</code> object.
      */
     public abstract static class ActivityPaymentMethodRetrievalListener<A extends Activity>
             implements PaymentMethodRetrievalListener {

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -44,10 +44,10 @@ public class PaymentSession {
     /**
      * Create a PaymentSession attached to the given host Activity.
      *
-     * @param activity an {@link Activity} from which to launch other Stripe Activities. This
+     * @param activity an <code>Activity</code> from which to launch other Stripe Activities. This
      *                     Activity will receive results in
-     *                     {@link Activity#onActivityResult(int, int, Intent)} that should be passed
-     *                     back to this session.
+     *                     <code>Activity#onActivityResult(int, int, Intent)</code> that should be
+     *                     passed back to this session.
      */
     public PaymentSession(@NonNull Activity activity) {
         this(CustomerSession.getInstance(),
@@ -88,7 +88,7 @@ public class PaymentSession {
 
     /**
      * Method to handle Activity results from Stripe activities. Pass data here from your
-     * host Activity's {@link Activity#onActivityResult(int, int, Intent)} function.
+     * host's <code>#onActivityResult(int, int, Intent)</code> function.
      *
      * @param requestCode the request code used to open the resulting activity
      * @param resultCode a result code representing the success of the intended action
@@ -173,8 +173,9 @@ public class PaymentSession {
      *                 in payment session status, including networking status
      * @param paymentSessionConfig a {@link PaymentSessionConfig} used to decide which items are
      *                             necessary in the PaymentSession.
-     * @param savedInstanceState a {@link Bundle} containing the saved state of a PaymentSession
-     *                           that was stored in {@link #savePaymentSessionInstanceState(Bundle)}
+     * @param savedInstanceState a <code>Bundle</code> containing the saved state of a
+     *                           PaymentSession that was stored in
+     *                           {@link #savePaymentSessionInstanceState(Bundle)}
      * @return {@code true} if the PaymentSession is initialized, {@code false} if a state error
      * occurs. Failure can only occur if there is no initialized {@link CustomerSession}.
      */
@@ -280,10 +281,10 @@ public class PaymentSession {
     }
 
     /**
-     * Save the data associated with this PaymentSession. This should be called in the host Activity
-     * {@link Activity#onSaveInstanceState(Bundle)} method.
+     * Save the data associated with this PaymentSession. This should be called in the host's
+     * <code>onSaveInstanceState(Bundle)</code> method.
      *
-     * @param outState the host activity's outgoing {@link Bundle}
+     * @param outState the host activity's outgoing <code>Bundle</code>
      */
     public void savePaymentSessionInstanceState(@NonNull Bundle outState) {
         outState.putParcelable(PAYMENT_SESSION_DATA_KEY, mPaymentSessionData);
@@ -318,7 +319,7 @@ public class PaymentSession {
     }
 
     /**
-     * Should be called during the host {@link Activity}'s onDestroy to detach listeners.
+     * Should be called during the host <code>Activity</code>'s onDestroy to detach listeners.
      */
     public void onDestroy() {
         mPaymentSessionListener = null;
@@ -383,7 +384,7 @@ public class PaymentSession {
 
     /**
      * Abstract implementation of {@link PaymentSessionListener} that holds a
-     * {@link WeakReference} to an {@link Activity} object.
+     * {@link WeakReference} to an <code>Activity</code> object.
      */
     public abstract static class ActivityPaymentSessionListener<A extends Activity>
             implements PaymentSessionListener {

--- a/stripe/src/main/java/com/stripe/android/SourceCallback.java
+++ b/stripe/src/main/java/com/stripe/android/SourceCallback.java
@@ -6,7 +6,7 @@ import com.stripe.android.model.Source;
  * An interface representing a callback to be notified about the results of
  * creating or finding a {@link Source}.
  *
- * @deprecated use {@link ApiResultCallback<Source>}
+ * @deprecated use {@link ApiResultCallback}
  */
 @Deprecated
 public interface SourceCallback extends ApiResultCallback<Source> {

--- a/stripe/src/main/java/com/stripe/android/Stripe.java
+++ b/stripe/src/main/java/com/stripe/android/Stripe.java
@@ -141,7 +141,7 @@ public class Stripe {
     /**
      * Confirm and, if necessary, authenticate a {@link SetupIntent}.
      *
-     * @param activity the {@link Activity} that is launching the payment authentication flow
+     * @param activity the <code>Activity</code> that is launching the payment authentication flow
      */
     public void confirmSetupIntent(@NonNull Activity activity,
                                    @NonNull ConfirmSetupIntentParams confirmSetupIntentParams,
@@ -164,7 +164,7 @@ public class Stripe {
     /**
      * Confirm and, if necessary, authenticate a {@link SetupIntent}.
      *
-     * @param fragment the {@link Fragment} that is launching the payment authentication flow
+     * @param fragment the <code>Fragment</code> that is launching the payment authentication flow
      */
     public void confirmSetupIntent(@NonNull Fragment fragment,
                                    @NonNull ConfirmSetupIntentParams confirmSetupIntentParams,
@@ -189,7 +189,7 @@ public class Stripe {
      * "https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow">
      * automatic confirmation</a> flow.
      *
-     * @param activity the {@link Activity} that is launching the payment authentication flow
+     * @param activity the <code>Activity</code> that is launching the payment authentication flow
      * @param confirmPaymentIntentParams {@link ConfirmPaymentIntentParams} used to confirm the
      *                                   {@link PaymentIntent}
      */
@@ -216,7 +216,7 @@ public class Stripe {
      * "https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow">
      * automatic confirmation</a> flow.
      *
-     * @param fragment the {@link Fragment} that is launching the payment authentication flow
+     * @param fragment the <code>Fragment</code> that is launching the payment authentication flow
      * @param confirmPaymentIntentParams {@link ConfirmPaymentIntentParams} used to confirm the
      *                                   {@link PaymentIntent}
      */
@@ -243,8 +243,9 @@ public class Stripe {
      * "https://stripe.com/docs/payments/payment-intents/quickstart#manual-confirmation-flow">
      * manual confirmation</a> flow.
      *
-     * @param activity the {@link Activity} that is launching the payment authentication flow
-     * @param clientSecret the `client_secret` property of a confirmed {@link PaymentIntent} object
+     * @param activity the <code>Activity</code> that is launching the payment authentication flow
+     * @param clientSecret the <a href="https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret">client_secret</a>
+     *                     property of a confirmed {@link PaymentIntent} object
      */
     public void authenticatePayment(@NonNull Activity activity,
                                     @NonNull String clientSecret,
@@ -269,8 +270,9 @@ public class Stripe {
      * "https://stripe.com/docs/payments/payment-intents/quickstart#manual-confirmation-flow">
      * manual confirmation</a> flow.
      *
-     * @param fragment the {@link Activity} that is launching the payment authentication flow
-     * @param clientSecret the `client_secret` property of a confirmed {@link PaymentIntent} object
+     * @param fragment the <code>Fragment</code> that is launching the payment authentication flow
+     * @param clientSecret the <a href="https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret">client_secret</a>
+     *                     property of a confirmed {@link PaymentIntent} object
      */
     public void authenticatePayment(@NonNull Fragment fragment,
                                     @NonNull String clientSecret,
@@ -293,8 +295,10 @@ public class Stripe {
     /**
      * Authenticate a {@link SetupIntent}. Used for manual confirmation flow.
      *
-     * @param activity     the {@link Activity} that is launching the payment authentication flow
-     * @param clientSecret the `client_secret` property of a confirmed {@link SetupIntent} object
+     * @param activity     the <code>Activity</code> that is launching the payment authentication
+     *                     flow
+     * @param clientSecret the <a href="https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret">client_secret</a>
+     *                     property of a confirmed {@link SetupIntent} object
      */
     public void authenticateSetup(@NonNull Activity activity,
                                   @NonNull String clientSecret,
@@ -317,8 +321,9 @@ public class Stripe {
     /**
      * Authenticate a {@link SetupIntent}. Used for manual confirmation flow.
      *
-     * @param fragment     the {@link Fragment} that is launching the payment authentication flow
-     * @param clientSecret the `client_secret` property of a confirmed {@link SetupIntent} object
+     * @param fragment     the <code>Fragment</code> launching the payment authentication flow
+     * @param clientSecret the <a href="https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret">client_secret</a>
+     *                     property of a confirmed {@link SetupIntent} object
      */
     public void authenticateSetup(@NonNull Fragment fragment,
                                   @NonNull String clientSecret,
@@ -401,7 +406,7 @@ public class Stripe {
      * {@link Executor} and with the currently set {@link #mDefaultPublishableKey}.
      *
      * @param bankAccount the {@link BankAccount} used to create this token
-     * @param callback a {@link ApiResultCallback<Token>} to receive either the token or an error
+     * @param callback a {@link ApiResultCallback} to receive either the token or an error
      */
     public void createBankAccountToken(
             @NonNull final BankAccount bankAccount,
@@ -417,7 +422,7 @@ public class Stripe {
      * @param publishableKey the publishable key to use
      * @param executor an {@link Executor} to run this operation on. If null, this is run on a
      *         default non-ui executor
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result or error message
+     * @param callback a {@link ApiResultCallback} to receive the result or error message
      */
     public void createBankAccountToken(
             @NonNull final BankAccount bankAccount,
@@ -440,7 +445,7 @@ public class Stripe {
      * {@link Executor} and with the currently set {@link #mDefaultPublishableKey}.
      *
      * @param personalId the personal id used to create this token
-     * @param callback a {@link ApiResultCallback<Token>} to receive either the token or an error
+     * @param callback a {@link ApiResultCallback} to receive either the token or an error
      */
     public void createPiiToken(
             @NonNull final String personalId,
@@ -456,7 +461,7 @@ public class Stripe {
      * @param publishableKey the publishable key to use
      * @param executor an {@link Executor} to run this operation on. If null, this is run on a
      *         default non-ui executor
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result or error message
+     * @param callback a {@link ApiResultCallback} to receive the result or error message
      */
     public void createPiiToken(
             @NonNull final String personalId,
@@ -533,7 +538,7 @@ public class Stripe {
      * {@link Executor} and with the currently set {@link #mDefaultPublishableKey}.
      *
      * @param cvc the CVC used to create this token
-     * @param callback a {@link ApiResultCallback<Token>} to receive either the token or an error
+     * @param callback a {@link ApiResultCallback} to receive either the token or an error
      */
     public void createCvcUpdateToken(
             @NonNull @Size(min = 3, max = 4) final String cvc,
@@ -549,7 +554,7 @@ public class Stripe {
      * @param publishableKey the publishable key to use
      * @param executor an {@link Executor} to run this operation on. If null, this is run on a
      *         default non-ui executor
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result or error message
+     * @param callback a {@link ApiResultCallback} to receive the result or error message
      */
     public void createCvcUpdateToken(
             @NonNull @Size(min = 3, max = 4) final String cvc,
@@ -569,7 +574,7 @@ public class Stripe {
      * publishable api key that has already been set on this {@link Stripe} instance.
      *
      * @param sourceParams the {@link SourceParams} to be used
-     * @param callback a {@link ApiResultCallback<Source>} to receive a result or an error message
+     * @param callback a {@link ApiResultCallback} to receive a result or an error message
      */
     public void createSource(@NonNull SourceParams sourceParams,
                              @NonNull ApiResultCallback<Source> callback) {
@@ -580,9 +585,10 @@ public class Stripe {
      * Create a {@link Source} using an {@link AsyncTask}.
      *
      * @param sourceParams the {@link SourceParams} to be used
-     * @param callback a {@link ApiResultCallback<Source>} to receive a result or an error message
+     * @param callback a {@link ApiResultCallback} to receive a result or an error message
      * @param publishableKey the publishable api key to be used
-     * @param executor an {@link Executor} on which to execute the task, or {@link null} for default
+     * @param executor an {@link Executor} on which to execute the task,
+     *                 or <code>null</code> for default
      */
     public void createSource(
             @NonNull SourceParams sourceParams,
@@ -599,7 +605,7 @@ public class Stripe {
      * with a publishable api key that has already been set on this {@link Stripe} instance.
      *
      * @param paymentMethodCreateParams the {@link PaymentMethodCreateParams} to be used
-     * @param callback a {@link ApiResultCallback<PaymentMethod>} to receive a result or an error
+     * @param callback a {@link ApiResultCallback} to receive a result or an error
      *         message
      */
     public void createPaymentMethod(@NonNull PaymentMethodCreateParams paymentMethodCreateParams,
@@ -611,10 +617,10 @@ public class Stripe {
      * Create a {@link PaymentMethod} using an {@link AsyncTask}.
      *
      * @param paymentMethodCreateParams the {@link PaymentMethodCreateParams} to be used
-     * @param callback a {@link ApiResultCallback<PaymentMethod>} to receive a result or an error
-     *         message
+     * @param callback a {@link ApiResultCallback} to receive a result or an error message
      * @param publishableKey the publishable api key to be used
-     * @param executor an {@link Executor} on which to execute the task, or {@link null} for default
+     * @param executor an {@link Executor} on which to execute the task,
+     *                 or <code>null</code> for default for default
      */
     public void createPaymentMethod(
             @NonNull PaymentMethodCreateParams paymentMethodCreateParams,
@@ -627,11 +633,11 @@ public class Stripe {
 
     /**
      * The simplest way to create a token, using a {@link Card} and
-     * {@link ApiResultCallback<Token>}. This runs on the default {@link Executor} and with the
+     * {@link ApiResultCallback}. This runs on the default {@link Executor} and with the
      * currently set {@link #mDefaultPublishableKey}.
      *
      * @param card the {@link Card} used to create this payment token
-     * @param callback a {@link ApiResultCallback<Token>} to receive either the token or an error
+     * @param callback a {@link ApiResultCallback} to receive either the token or an error
      */
     public void createToken(@NonNull final Card card,
                             @NonNull final ApiResultCallback<Token> callback) {
@@ -643,7 +649,7 @@ public class Stripe {
      *
      * @param card the {@link Card} used for this transaction
      * @param publishableKey the public key used for this transaction
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result of this operation
+     * @param callback a {@link ApiResultCallback} to receive the result of this operation
      */
     public void createToken(
             @NonNull final Card card,
@@ -658,7 +664,7 @@ public class Stripe {
      * @param card the {@link Card} to use for this token creation
      * @param executor An {@link Executor} on which to run this operation. If you don't wish to
      *         specify an executor, use one of the other createTokenFromParams methods.
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result of this operation
+     * @param callback a {@link ApiResultCallback} to receive the result of this operation
      */
     public void createToken(
             @NonNull final Card card,
@@ -674,7 +680,7 @@ public class Stripe {
      * @param publishableKey the publishable key to use
      * @param executor an {@link Executor} to run this operation on. If null, this is run on a
      *         default non-ui executor
-     * @param callback a {@link ApiResultCallback<Token>} to receive the result or error message
+     * @param callback a {@link ApiResultCallback} to receive the result or error message
      */
     public void createToken(
             @NonNull final Card card,

--- a/stripe/src/main/java/com/stripe/android/TokenCallback.java
+++ b/stripe/src/main/java/com/stripe/android/TokenCallback.java
@@ -6,7 +6,7 @@ import com.stripe.android.model.Token;
  * An interface representing a callback to be notified about the results of
  * {@link Token} creation or requests
  *
- * @deprecated use {@link ApiResultCallback<Token>}
+ * @deprecated use {@link ApiResultCallback}
  */
 @Deprecated
 public interface TokenCallback extends ApiResultCallback<Token> {

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -26,24 +26,13 @@ public final class AccountParams implements StripeParamsModel {
      * Create an {@link AccountParams} instance for a {@link BusinessType#Individual} or
      * {@link BusinessType#Company}.
      *
-     * <ol>
-     * <li>
-     * <a href="https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted">account.tos_shown_and_accepted</a>
-     * </li>
-     * <li>
-     * <a href="https://stripe.com/docs/api/accounts/create#create_account-company">company</a>
-     * </li>
-     * <li>
-     * <a href="https://stripe.com/docs/api/accounts/create#create_account-individual">individual</a>
-     * </li>
-     * </ol>
-     *
      * @param tosShownAndAccepted Whether the user described by the data in the token has been shown
-     *                            the Stripe Connected Account Agreement [1]. When creating an
-     *                            account token to create a new Connect account, this value must
-     *                            be true.
+     *                            the <a href="https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted">Stripe Connected Account Agreement</a>.
+     *                            When creating an account token to create a new Connect account,
+     *                            this value must be <code>true</code>.
      * @param businessType        See {@link BusinessType}
-     * @param businessData        A map of company [2] or individual [3] params.
+     * @param businessData        A map of <a href="https://stripe.com/docs/api/accounts/create#create_account-company">company</a>
+     *                            or <a href="https://stripe.com/docs/api/accounts/create#create_account-individual">individual</a> params.
      *
      *
      * @return {@link AccountParams}

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -82,7 +82,8 @@ public final class SourceParams implements StripeParamsModel {
      *
      * @param amount A positive integer in the smallest currency unit representing the amount to
      *               charge the customer (e.g., 1099 for a €10.99 payment).
-     * @param currency `eur` or `pln` (P24 payments must be in either Euros or Polish Zloty).
+     * @param currency <code>eur</code> or <code>pln</code> (P24 payments must be in either Euros
+     *                 or Polish Zloty).
      * @param name The name of the account holder (optional).
      * @param email The email address of the account holder.
      * @param returnUrl The URL the customer should be redirected to after the authorization

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -246,8 +246,8 @@ public class AddPaymentMethodActivity extends StripeActivity {
     }
 
     /**
-     * Abstract implementation of {@link ApiResultCallback<PaymentMethod>} that holds a
-     * {@link WeakReference} to an {@link Activity} object.
+     * Abstract implementation of {@link ApiResultCallback} that holds a {@link WeakReference}
+     * to an <code>Activity</code> object.
      */
     private abstract static class ActivityPaymentMethodCallback<A extends Activity>
             implements ApiResultCallback<PaymentMethod> {

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -227,7 +227,7 @@ public class CardMultilineWidget extends LinearLayout implements CardWidget {
     }
 
     /**
-     * Set an optional CVC field label to override defaults. Set to `null` to use defaults.
+     * Set an optional CVC field label to override defaults, or <code>null</code> to use defaults.
      */
     public void setCvcLabel(@Nullable String cvcLabel) {
         mCustomCvcLabel = cvcLabel;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * A {@link WebView} used for authenticating payment details
+ * A <code>WebView</code> used for authenticating payment details
  */
 class PaymentAuthWebView extends WebView {
     @SuppressWarnings("RedundantModifier")

--- a/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.java
@@ -10,7 +10,7 @@ import android.support.v7.app.AppCompatActivity;
 import static com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION;
 
 /**
- * An {@link Activity} that relays the intent extras that it received as a result and finishes.
+ * An <code>Activity</code> that relays the intent extras that it received as a result and finishes.
  */
 public class PaymentRelayActivity extends AppCompatActivity {
     @Override


### PR DESCRIPTION
- Generic types shouldn't be used in Javadocs
- Don't link to Android objects
- Link to client_secret property
