### PR TITLE
Add support for FPX type in Payment Methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -39,29 +39,35 @@ import static com.stripe.android.model.StripeJsonUtils.optString;
 public final class PaymentMethod extends StripeModel implements Parcelable {
     private static final String FIELD_ID = "id";
     private static final String FIELD_BILLING_DETAILS = "billing_details";
-    private static final String FIELD_CARD = "card";
-    private static final String FIELD_CARD_PRESENT = "card_present";
     private static final String FIELD_CREATED = "created";
     private static final String FIELD_CUSTOMER = "customer";
-    private static final String FIELD_IDEAL = "ideal";
     private static final String FIELD_LIVEMODE = "livemode";
     private static final String FIELD_METADATA = "metadata";
+
+    // types
     private static final String FIELD_TYPE = "type";
+    private static final String FIELD_CARD = "card";
+    private static final String FIELD_CARD_PRESENT = "card_present";
+    private static final String FIELD_FPX = "fpx";
+    private static final String FIELD_IDEAL = "ideal";
 
     @Nullable public final String id;
     @Nullable public final Long created;
     public final boolean liveMode;
     @Nullable public final String type;
     @Nullable public final BillingDetails billingDetails;
-    @Nullable public final Card card;
-    @Nullable public final CardPresent cardPresent;
-    @Nullable public final Ideal ideal;
     @Nullable public final String customerId;
     @Nullable public final Map<String, String> metadata;
+
+    @Nullable public final Card card;
+    @Nullable public final CardPresent cardPresent;
+    @Nullable public final Fpx fpx;
+    @Nullable public final Ideal ideal;
 
     public enum Type {
         Card("card"),
         CardPresent("card_present"),
+        Fpx("fpx"),
         Ideal("ideal");
 
         @NonNull public final String code;
@@ -78,11 +84,12 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         created = builder.mCreated;
         billingDetails = builder.mBillingDetails;
         customerId = builder.mCustomerId;
+        metadata = builder.mMetadata;
 
         card = builder.mCard;
         cardPresent = builder.mCardPresent;
+        fpx = builder.mFpx;
         ideal = builder.mIdeal;
-        metadata = builder.mMetadata;
     }
 
     /**
@@ -128,6 +135,8 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             builder.setCardPresent(CardPresent.EMPTY);
         } else if (FIELD_IDEAL.equals(type)) {
             builder.setIdeal(Ideal.fromJson(paymentMethod.optJSONObject(FIELD_IDEAL)));
+        } else if (FIELD_FPX.equals(type)) {
+            builder.setFpx(Fpx.fromJson(paymentMethod.optJSONObject(FIELD_FPX)));
         }
 
         return builder.build();
@@ -146,6 +155,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
                 && ObjectUtils.equals(billingDetails, paymentMethod.billingDetails)
                 && ObjectUtils.equals(card, paymentMethod.card)
                 && ObjectUtils.equals(cardPresent, paymentMethod.cardPresent)
+                && ObjectUtils.equals(fpx, paymentMethod.fpx)
                 && ObjectUtils.equals(ideal, paymentMethod.ideal)
                 && ObjectUtils.equals(customerId, paymentMethod.customerId);
     }
@@ -153,7 +163,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
     @Override
     public int hashCode() {
         return ObjectUtils.hash(id, created, liveMode, type, billingDetails, card, cardPresent,
-                ideal, customerId);
+                fpx, ideal, customerId);
     }
 
     @Override
@@ -175,6 +185,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         dest.writeParcelable(billingDetails, flags);
         dest.writeParcelable(card, flags);
         dest.writeParcelable(cardPresent, flags);
+        dest.writeParcelable(fpx, flags);
         dest.writeParcelable(ideal, flags);
         dest.writeString(customerId);
         dest.writeInt(metadata == null ? -1 : metadata.size());
@@ -194,6 +205,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         billingDetails = in.readParcelable(BillingDetails.class.getClassLoader());
         card = in.readParcelable(Card.class.getClassLoader());
         cardPresent = in.readParcelable(CardPresent.class.getClassLoader());
+        fpx = in.readParcelable(Fpx.class.getClassLoader());
         ideal = in.readParcelable(Ideal.class.getClassLoader());
         customerId = in.readString();
         final int mapSize = in.readInt();
@@ -230,10 +242,12 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         private String mType;
         private BillingDetails mBillingDetails;
         private Map<String, String> mMetadata;
+        private String mCustomerId;
+
         private Card mCard;
         private CardPresent mCardPresent;
         private Ideal mIdeal;
-        private String mCustomerId;
+        private Fpx mFpx;
 
         @NonNull
         public Builder setId(@Nullable String id) {
@@ -292,6 +306,12 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         @NonNull
         public Builder setIdeal(@Nullable Ideal ideal) {
             this.mIdeal = ideal;
+            return this;
+        }
+
+        @NonNull
+        public Builder setFpx(@Nullable Fpx fpx) {
+            this.mFpx = fpx;
             return this;
         }
 
@@ -977,6 +997,94 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             @NonNull
             public Ideal build() {
                 return new Ideal(this);
+            }
+        }
+    }
+
+    public static final class Fpx extends PaymentMethodTypeImpl {
+        private static final String FIELD_ACCOUNT_HOLDER_TYPE = "account_holder_type";
+        private static final String FIELD_BANK = "bank";
+
+        @Nullable public final String bank;
+        @Nullable public final String accountHolderType;
+
+        private Fpx(@NonNull Builder builder) {
+            super(Type.Fpx);
+            bank = builder.mBank;
+            accountHolderType = builder.mAccountHolderType;
+        }
+
+        private Fpx(@NonNull Parcel in) {
+            super(in);
+            bank = in.readString();
+            accountHolderType = in.readString();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeString(bank);
+            dest.writeString(accountHolderType);
+        }
+
+        public static final Parcelable.Creator<Fpx> CREATOR = new Parcelable.Creator<Fpx>() {
+            @Override
+            public Fpx createFromParcel(@NonNull Parcel in) {
+                return new Fpx(in);
+            }
+
+            @Override
+            public Fpx[] newArray(int size) {
+                return new Fpx[size];
+            }
+        };
+
+        @Nullable
+        public static Fpx fromJson(@Nullable JSONObject fpx) {
+            if (fpx == null) {
+                return null;
+            }
+
+            return new Fpx.Builder()
+                    .setBank(optString(fpx, FIELD_BANK))
+                    .setAccountHolderType(optString(fpx, FIELD_ACCOUNT_HOLDER_TYPE))
+                    .build();
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectUtils.hash(bank, accountHolderType);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return this == obj || obj instanceof Fpx && typedEquals((Fpx) obj);
+        }
+
+        private boolean typedEquals(@NonNull Fpx obj) {
+            return ObjectUtils.equals(bank, obj.bank)
+                    && ObjectUtils.equals(accountHolderType, obj.accountHolderType);
+        }
+
+        public static final class Builder implements ObjectBuilder<Fpx> {
+            private String mBank;
+            private String mAccountHolderType;
+
+            @NonNull
+            public Builder setBank(@Nullable String bank) {
+                this.mBank = bank;
+                return this;
+            }
+
+            @NonNull
+            public Builder setAccountHolderType(@Nullable String bankIdentifierCode) {
+                this.mAccountHolderType = bankIdentifierCode;
+                return this;
+            }
+
+            @NonNull
+            public Fpx build() {
+                return new Fpx(this);
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
@@ -26,17 +26,25 @@ import java.util.Objects;
  */
 public final class PaymentMethodCreateParams implements StripeParamsModel {
 
-    private static final String FIELD_BILLING_DETAILS = "billing_details";
-    private static final String FIELD_CARD = "card";
-    private static final String FIELD_IDEAL = "ideal";
-    private static final String FIELD_METADATA = "metadata";
     private static final String FIELD_TYPE = "type";
+    private static final String FIELD_CARD = "card";
+    private static final String FIELD_FPX = "fpx";
+    private static final String FIELD_IDEAL = "ideal";
+
+    private static final String FIELD_BILLING_DETAILS = "billing_details";
+    private static final String FIELD_METADATA = "metadata";
 
     @NonNull private final Type type;
     @Nullable private final PaymentMethodCreateParams.Card card;
     @Nullable private final PaymentMethodCreateParams.Ideal ideal;
+    @Nullable private final PaymentMethodCreateParams.Fpx fpx;
     @Nullable private final PaymentMethod.BillingDetails billingDetails;
     @Nullable private final Map<String, String> metadata;
+
+    @NonNull
+    public static PaymentMethodCreateParams create(@NonNull PaymentMethodCreateParams.Card card) {
+        return create(card, null);
+    }
 
     @NonNull
     public static PaymentMethodCreateParams create(
@@ -54,6 +62,11 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
     }
 
     @NonNull
+    public static PaymentMethodCreateParams create(@NonNull PaymentMethodCreateParams.Ideal ideal) {
+        return new PaymentMethodCreateParams(ideal, null, null);
+    }
+
+    @NonNull
     public static PaymentMethodCreateParams create(
             @NonNull PaymentMethodCreateParams.Ideal ideal,
             @Nullable PaymentMethod.BillingDetails billingDetails) {
@@ -66,6 +79,28 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
             @Nullable PaymentMethod.BillingDetails billingDetails,
             @Nullable Map<String, String> metadata) {
         return new PaymentMethodCreateParams(ideal, billingDetails, metadata);
+    }
+
+    @NonNull
+    public static PaymentMethodCreateParams create(@NonNull PaymentMethodCreateParams.Fpx fpx) {
+        return create(fpx, null);
+    }
+
+
+    @NonNull
+    public static PaymentMethodCreateParams create(
+            @NonNull PaymentMethodCreateParams.Fpx fpx,
+            @Nullable PaymentMethod.BillingDetails billingDetails) {
+        return create(fpx, billingDetails, null);
+    }
+
+
+    @NonNull
+    public static PaymentMethodCreateParams create(
+            @NonNull PaymentMethodCreateParams.Fpx fpx,
+            @Nullable PaymentMethod.BillingDetails billingDetails,
+            @Nullable Map<String, String> metadata) {
+        return new PaymentMethodCreateParams(fpx, billingDetails, metadata);
     }
 
     /**
@@ -122,6 +157,7 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
         this.type = Type.Card;
         this.card = card;
         this.ideal = null;
+        this.fpx = null;
         this.billingDetails = billingDetails;
         this.metadata = metadata;
     }
@@ -132,6 +168,18 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
         this.type = Type.Ideal;
         this.card = null;
         this.ideal = ideal;
+        this.fpx = null;
+        this.billingDetails = billingDetails;
+        this.metadata = metadata;
+    }
+
+    private PaymentMethodCreateParams(@NonNull PaymentMethodCreateParams.Fpx fpx,
+                                      @Nullable PaymentMethod.BillingDetails billingDetails,
+                                      @Nullable Map<String, String> metadata) {
+        this.type = Type.Fpx;
+        this.card = null;
+        this.ideal = null;
+        this.fpx = fpx;
         this.billingDetails = billingDetails;
         this.metadata = metadata;
     }
@@ -146,6 +194,8 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
             params.put(FIELD_CARD, card.toParamMap());
         } else if (type == Type.Ideal && ideal != null) {
             params.put(FIELD_IDEAL, ideal.toParamMap());
+        } else if (type == Type.Fpx && fpx != null) {
+            params.put(FIELD_FPX, fpx.toParamMap());
         }
 
         if (billingDetails != null) {
@@ -166,7 +216,7 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
 
     @Override
     public int hashCode() {
-        return ObjectUtils.hash(type, card, ideal, billingDetails, metadata);
+        return ObjectUtils.hash(type, card, fpx, ideal, billingDetails, metadata);
     }
 
     @Override
@@ -179,6 +229,7 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
     private boolean typedEquals(@NonNull PaymentMethodCreateParams params) {
         return ObjectUtils.equals(type, params.type)
                 && ObjectUtils.equals(card, params.card)
+                && ObjectUtils.equals(fpx, params.fpx)
                 && ObjectUtils.equals(ideal, params.ideal)
                 && ObjectUtils.equals(billingDetails, params.billingDetails)
                 && ObjectUtils.equals(metadata, params.metadata);
@@ -186,7 +237,8 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
 
     enum Type {
         Card("card"),
-        Ideal("ideal");
+        Ideal("ideal"),
+        Fpx("fpx");
 
         @NonNull private final String mCode;
 
@@ -358,6 +410,53 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
             @NonNull
             public Ideal build() {
                 return new Ideal(this);
+            }
+        }
+    }
+
+    public static final class Fpx implements StripeParamsModel {
+        private static final String FIELD_BANK = "bank";
+
+        @Nullable private final String mBank;
+
+        private Fpx(@NonNull Fpx.Builder builder) {
+            this.mBank = builder.mBank;
+        }
+
+        @NonNull
+        @Override
+        public Map<String, Object> toParamMap() {
+            final AbstractMap<String, Object> map = new HashMap<>();
+            map.put(FIELD_BANK, mBank);
+            return map;
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectUtils.hash(mBank);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return this == obj || (obj instanceof Fpx && typedEquals((Fpx) obj));
+        }
+
+        private boolean typedEquals(@NonNull Fpx fpx) {
+            return ObjectUtils.equals(mBank, fpx.mBank);
+        }
+
+        public static final class Builder implements ObjectBuilder<Fpx> {
+            @Nullable private String mBank;
+
+            @NonNull
+            public Fpx.Builder setBank(@Nullable String bank) {
+                this.mBank = bank;
+                return this;
+            }
+
+            @NonNull
+            public Fpx build() {
+                return new Fpx(this);
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 public class PaymentSessionDataTest {
 
     private static final PaymentMethod PAYMENT_METHOD =
-            PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+            PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
 
     @Test
     public void updateIsPaymentReadyToCharge_noShippingRequired() {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -99,7 +99,7 @@ public class PaymentSessionTest {
         assertNotNull(FIRST_CUSTOMER);
 
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
 
         when(mApiHandler.retrieveCustomer(anyString(), ArgumentMatchers.<ApiRequest.Options>any()))
@@ -181,7 +181,7 @@ public class PaymentSessionTest {
         boolean handled = paymentSession.handlePaymentData(
                 PaymentSession.PAYMENT_METHOD_REQUEST, RESULT_OK,
                 new Intent().putExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT,
-                        PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON)));
+                        PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON)));
 
         assertTrue(handled);
 
@@ -189,7 +189,7 @@ public class PaymentSessionTest {
                 .onPaymentSessionDataChanged(mPaymentSessionDataArgumentCaptor.capture());
         final PaymentSessionData data = mPaymentSessionDataArgumentCaptor.getValue();
         assertNotNull(data);
-        assertEquals(PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON),
+        assertEquals(PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON),
                 data.getPaymentMethod());
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.model;
 
+import android.support.annotation.NonNull;
+
 import org.json.JSONException;
 import org.junit.Test;
 
@@ -57,5 +59,32 @@ public class PaymentMethodCreateParamsTest {
                         .build()
         );
         assertEquals(expectedParams, createdParams);
+    }
+
+    @Test
+    public void equals_withFpx() {
+        assertEquals(createFpx(), createFpx());
+    }
+
+    @NonNull
+    private PaymentMethodCreateParams createFpx() {
+        return PaymentMethodCreateParams.create(
+                new PaymentMethodCreateParams.Fpx.Builder()
+                        .setBank("hsbc")
+                        .build(),
+                new PaymentMethod.BillingDetails.Builder()
+                        .setPhone("1-888-555-1234")
+                        .setEmail("stripe@example.com")
+                        .setName("Stripe Johnson")
+                        .setAddress(new Address.Builder()
+                                .setLine1("510 Townsend St")
+                                .setLine2("")
+                                .setCity("San Francisco")
+                                .setState("CA")
+                                .setPostalCode("94103")
+                                .setCountry("US")
+                                .build())
+                        .build()
+        );
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -2,6 +2,8 @@ package com.stripe.android.model;
 
 import android.os.Parcel;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -16,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class PaymentMethodTest {
-    public static final String RAW_CARD_JSON = "{\n" +
+    public static final String PM_CARD_JSON = "{\n" +
             "\t\"id\": \"pm_123456789\",\n" +
             "\t\"created\": 1550757934255,\n" +
             "\t\"customer\": \"cus_AQsHpvKfKwJDrF\",\n" +
@@ -54,7 +56,7 @@ public class PaymentMethodTest {
             "\t}\n" +
             "}";
 
-    private static final String RAW_IDEAL_JSON = "{\n" +
+    private static final String PM_IDEAL_JSON = "{\n" +
             "\t\"id\": \"pm_123456789\",\n" +
             "\t\"created\": 1550757934255,\n" +
             "\t\"customer\": \"cus_AQsHpvKfKwJDrF\",\n" +
@@ -78,8 +80,35 @@ public class PaymentMethodTest {
             "\t}\n" +
             "}";
 
+    private static final String PM_FPX_JSON = "{\n" +
+            "\t\"id\": \"pm_1F5GlnH8dsfnfKo3gtixzcq0\",\n" +
+            "\t\"object\": \"payment_method\",\n" +
+            "\t\"billing_details\": {\n" +
+            "\t\t\"address\": {\n" +
+            "\t\t\t\"city\": \"San Francisco\",\n" +
+            "\t\t\t\"country\": \"USA\",\n" +
+            "\t\t\t\"line1\": \"510 Townsend St\",\n" +
+            "\t\t\t\"line2\": null,\n" +
+            "\t\t\t\"postal_code\": \"94103\",\n" +
+            "\t\t\t\"state\": \"CA\"\n" +
+            "\t\t},\n" +
+            "\t\t\"email\": \"patrick@example.com\",\n" +
+            "\t\t\"name\": \"Patrick\",\n" +
+            "\t\t\"phone\": \"123-456-7890\"\n" +
+            "\t},\n" +
+            "\t\"created\": 1565290527,\n" +
+            "\t\"customer\": null,\n" +
+            "\t\"fpx\": {\n" +
+            "\t\t\"account_holder_type\": \"individual\",\n" +
+            "\t\t\"bank\": \"hsbc\"\n" +
+            "\t},\n" +
+            "\t\"livemode\": true,\n" +
+            "\t\"metadata\": {},\n" +
+            "\t\"type\": \"fpx\"\n" +
+            "}";
+
     @Test
-    public void toJson_withIdeal_shouldReturnExpectedJson() {
+    public void toJson_withIdeal_shouldCreateExpectedObject() throws JSONException {
         final PaymentMethod paymentMethod = new PaymentMethod.Builder()
                 .setId("pm_123456789")
                 .setCreated(1550757934255L)
@@ -93,7 +122,24 @@ public class PaymentMethodTest {
                         .build())
                 .build();
 
-        assertEquals(paymentMethod, PaymentMethod.fromString(RAW_IDEAL_JSON));
+        assertEquals(paymentMethod, PaymentMethod.fromJson(new JSONObject(PM_IDEAL_JSON)));
+    }
+
+    @Test
+    public void toJson_withFpx_shouldCreateExpectedObject() throws JSONException {
+        final PaymentMethod paymentMethod = new PaymentMethod.Builder()
+                .setId("pm_1F5GlnH8dsfnfKo3gtixzcq0")
+                .setCreated(1565290527L)
+                .setLiveMode(true)
+                .setType("fpx")
+                .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
+                .setFpx(new PaymentMethod.Fpx.Builder()
+                        .setBank("hsbc")
+                        .setAccountHolderType("individual")
+                        .build())
+                .build();
+
+        assertEquals(paymentMethod, PaymentMethod.fromJson(new JSONObject(PM_FPX_JSON)));
     }
 
     @Test
@@ -111,14 +157,14 @@ public class PaymentMethodTest {
     }
 
     @Test
-    public void fromString_shouldReturnExpectedPaymentMethod() {
+    public void fromString_shouldReturnExpectedPaymentMethod() throws JSONException {
         assertEquals(PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                PaymentMethod.fromString(RAW_CARD_JSON));
+                PaymentMethod.fromJson(new JSONObject(PM_CARD_JSON)));
     }
 
     @Test
-    public void fromString_withIdeal_returnsExpectedObject() {
-        final PaymentMethod paymentMethod = PaymentMethod.fromString(RAW_IDEAL_JSON);
+    public void fromString_withIdeal_returnsExpectedObject() throws JSONException {
+        final PaymentMethod paymentMethod = PaymentMethod.fromJson(new JSONObject(PM_IDEAL_JSON));
         assertNotNull(paymentMethod);
         assertEquals("ideal", paymentMethod.type);
     }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -211,7 +211,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         assertFalse(mCardMultilineWidget.isEnabled());
 
         final PaymentMethod expectedPaymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(expectedPaymentMethod);
         callback.onSuccess(expectedPaymentMethod);
 
@@ -307,7 +307,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         assertFalse(mCardMultilineWidget.isEnabled());
 
         final PaymentMethod expectedPaymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(expectedPaymentMethod);
         callback.onSuccess(expectedPaymentMethod);
 
@@ -353,7 +353,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         assertEquals(View.VISIBLE, mProgressBar.getVisibility());
 
         final PaymentMethod expectedPaymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(expectedPaymentMethod);
         callback.onSuccess(expectedPaymentMethod);
         assertEquals(RESULT_OK, mShadowActivity.getResultCode());

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardAdapterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardAdapterTest.java
@@ -80,7 +80,7 @@ public class MaskedCardAdapterTest {
     @Test
     public void setSelection_changesSelection() {
         final PaymentMethod paymentMethod1 =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         final PaymentMethod paymentMethod2 = PaymentMethod.fromString(PAYMENT_METHOD_JSON);
         assertNotNull(paymentMethod1);
         assertNotNull(paymentMethod2);
@@ -108,7 +108,7 @@ public class MaskedCardAdapterTest {
     @Test
     public void updatePaymentMethods_removesExistingPaymentMethodsAndAddsAllPaymentMethods() {
         final PaymentMethod paymentMethod1 =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         final PaymentMethod paymentMethod2 = PaymentMethod.fromString(PAYMENT_METHOD_JSON);
         final List<PaymentMethod> singlePaymentMethod = Collections.singletonList(paymentMethod1);
         final List<PaymentMethod> paymentMethods = Arrays.asList(paymentMethod1, paymentMethod2);
@@ -132,7 +132,7 @@ public class MaskedCardAdapterTest {
     @Test
     public void updatePaymentMethods_withSelection_updatesPaymentMethodsAndSelectionMaintained() {
         final PaymentMethod paymentMethod1 =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         final PaymentMethod paymentMethod2 = PaymentMethod.fromString(PAYMENT_METHOD_JSON);
         assertNotNull(paymentMethod1);
         assertNotNull(paymentMethod2);

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
@@ -58,7 +58,7 @@ public class MaskedCardViewTest {
     @Test
     public void setPaymentMethod_setsCorrectData() {
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
         mMaskedCardView.setPaymentMethod(paymentMethod);
         assertEquals("4242", mMaskedCardView.getLast4());
@@ -69,7 +69,7 @@ public class MaskedCardViewTest {
     @Test
     public void setSelected_changesCheckMarkVisibility() {
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
         mMaskedCardView.setPaymentMethod(paymentMethod);
 
@@ -85,7 +85,7 @@ public class MaskedCardViewTest {
     @Test
     public void toggleSelected_switchesState() {
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
         mMaskedCardView.setPaymentMethod(paymentMethod);
         assertFalse(mMaskedCardView.isSelected());

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -68,7 +68,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         MockitoAnnotations.initMocks(this);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
 
-        mPaymentMethods = Arrays.asList(PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON),
+        mPaymentMethods = Arrays.asList(PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON),
                 PaymentMethod.fromString(MaskedCardAdapterTest.PAYMENT_METHOD_JSON));
 
         mPaymentMethodsActivity = createActivity();
@@ -113,7 +113,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         // reset the mock because the activity is being re-created again
         reset(mCustomerSession);
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
         mPaymentMethodsActivity = createActivity(new Intent().putExtra(
                 PaymentMethodsActivity.EXTRA_INITIAL_SELECTED_PAYMENT_METHOD_ID, paymentMethod.id));
@@ -166,7 +166,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     @Test
     public void onActivityResult_withValidPaymentMethod_refreshesPaymentMethods() {
         final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.RAW_CARD_JSON);
+                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
         assertNotNull(paymentMethod);
 
         final Intent resultIntent = new Intent()


### PR DESCRIPTION
## Summary
Add support for creating an FPX Payment Method and
parsing the response.

## Testing
Unit tests and integration test