### PR TITLE
Consolidate parameter compacting logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiRequest.java
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.java
@@ -11,7 +11,6 @@ import com.stripe.android.utils.ObjectUtils;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -103,8 +102,11 @@ final class ApiRequest extends StripeRequest {
 
     @NonNull
     private String createStripeClientUserAgent() {
-        final AbstractMap<String, String> propertyMap = new HashMap<>();
-        propertyMap.put("java.version", System.getProperty("java.version"));
+        final Map<String, String> propertyMap = new HashMap<>();
+        final String javaVersion = System.getProperty("java.version");
+        if (javaVersion != null) {
+            propertyMap.put("java.version", javaVersion);
+        }
         propertyMap.put("os.name", "android");
         propertyMap.put("os.version", String.valueOf(Build.VERSION.SDK_INT));
         propertyMap.put("bindings.version", BuildConfig.VERSION_NAME);

--- a/stripe/src/main/java/com/stripe/android/FingerprintRequestFactory.java
+++ b/stripe/src/main/java/com/stripe/android/FingerprintRequestFactory.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import java.util.Map;
-
 final class FingerprintRequestFactory implements Factory0<FingerprintRequest> {
 
     @NonNull private final TelemetryClientUtil mTelemetryClientUtil;
@@ -22,8 +20,9 @@ final class FingerprintRequestFactory implements Factory0<FingerprintRequest> {
     @NonNull
     @Override
     public FingerprintRequest create() {
-        final Map<String, Object> params = mTelemetryClientUtil.createTelemetryMap();
-        StripeNetworkUtils.removeNullAndEmptyParams(params);
-        return new FingerprintRequest(params, mTelemetryClientUtil.getHashedId());
+        return new FingerprintRequest(
+                mTelemetryClientUtil.createTelemetryMap(),
+                mTelemetryClientUtil.getHashedId()
+        );
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.java
@@ -10,7 +10,6 @@ import com.stripe.android.model.Token;
 
 import java.util.AbstractMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -60,9 +59,6 @@ public class StripeNetworkUtils {
         cardParams.put("address_state", StripeTextUtils.nullIfBlank(card.getAddressState()));
         cardParams.put("address_country", StripeTextUtils.nullIfBlank(card.getAddressCountry()));
 
-        // Remove all null values; they cause validation errors
-        removeNullAndEmptyParams(cardParams);
-
         // We store the logging items in this field, which is extracted from the parameters
         // sent to the API.
         tokenParams.put(AnalyticsDataFactory.FIELD_PRODUCT_USAGE, card.getLoggingTokens());
@@ -71,36 +67,6 @@ public class StripeNetworkUtils {
         tokenParams.putAll(createUidParams());
 
         return tokenParams;
-    }
-
-    /**
-     * Remove null values from a map. This helps with JSON conversion and validation.
-     *
-     * @param mapToEdit a {@link Map} from which to remove the keys that have {@code null} values
-     */
-    @SuppressWarnings("unchecked")
-    public static void removeNullAndEmptyParams(@NonNull Map<String, Object> mapToEdit) {
-        // Remove all null values; they cause validation errors
-        for (String key : new HashSet<>(mapToEdit.keySet())) {
-            if (mapToEdit.get(key) == null) {
-                mapToEdit.remove(key);
-            }
-
-            if (mapToEdit.get(key) instanceof CharSequence) {
-                CharSequence sequence = (CharSequence) mapToEdit.get(key);
-                if (StripeTextUtils.isEmpty(sequence)) {
-                    mapToEdit.remove(key);
-                }
-            }
-
-            if (mapToEdit.get(key) instanceof Map) {
-                final Map<String, Object> stringObjectMap =
-                        (Map<String, Object>) mapToEdit.get(key);
-                if (stringObjectMap != null) {
-                    removeNullAndEmptyParams(stringObjectMap);
-                }
-            }
-        }
     }
 
     void addUidToConfirmPaymentIntentParams(

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.java
@@ -8,8 +8,6 @@ import com.stripe.android.utils.ObjectUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
-
 /**
  * Represents a grouping of parameters needed to create a Token for a Connect account on the server.
  */
@@ -73,7 +71,6 @@ public final class AccountParams implements StripeParamsModel {
 
         final Map<String, Object> params = new HashMap<>();
         params.put("account", accountData);
-        removeNullAndEmptyParams(params);
         return params;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -7,7 +7,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.ObjectBuilder;
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONException;
@@ -15,7 +14,6 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -118,7 +116,7 @@ public final class Address extends StripeModel implements StripeParamsModel, Par
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         if (mCity != null) {
             map.put(FIELD_CITY, mCity);
         }
@@ -137,7 +135,6 @@ public final class Address extends StripeModel implements StripeParamsModel, Par
         if (mState != null) {
             map.put(FIELD_STATE, mState);
         }
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.java
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.StripeTextUtils;
 import com.stripe.android.utils.ObjectUtils;
 
@@ -200,9 +199,6 @@ public final class BankAccount implements StripeParamsModel {
                 StripeTextUtils.nullIfBlank(getAccountHolderName()));
         accountParams.put("account_holder_type",
                 StripeTextUtils.nullIfBlank(getAccountHolderType()));
-
-        // Remove all null values; they cause validation errors
-        StripeNetworkUtils.removeNullAndEmptyParams(accountParams);
 
         params.put(Token.TokenType.BANK_ACCOUNT, accountParams);
 

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.java
@@ -7,7 +7,6 @@ import android.support.annotation.VisibleForTesting;
 import com.stripe.android.ObjectBuilder;
 import com.stripe.android.utils.ObjectUtils;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -371,7 +370,7 @@ public final class ConfirmPaymentIntentParams implements ConfirmStripeIntentPara
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {
-        final AbstractMap<String, Object> networkReadyMap = new HashMap<>();
+        final Map<String, Object> networkReadyMap = new HashMap<>();
 
         if (mPaymentMethodCreateParams != null) {
             networkReadyMap.put(API_PARAM_PAYMENT_METHOD_DATA,

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -7,7 +7,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 
 import com.stripe.android.ObjectBuilder;
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.model.wallets.Wallet;
 import com.stripe.android.model.wallets.WalletFactory;
 import com.stripe.android.utils.ObjectUtils;
@@ -17,7 +16,6 @@ import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -210,9 +208,13 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         customerId = in.readString();
         final int mapSize = in.readInt();
         if (mapSize >= 0) {
-            final AbstractMap<String, String> metadata = new HashMap<>(mapSize);
+            final Map<String, String> metadata = new HashMap<>(mapSize);
             for (int i = 0; i < mapSize; i++) {
-                metadata.put(in.readString(), in.readString());
+                final String key = in.readString();
+                final String value = in.readString();
+                if (key != null && value != null) {
+                    metadata.put(key, value);
+                }
             }
             this.metadata = metadata;
         } else {
@@ -390,7 +392,6 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             if (phone != null) {
                 billingDetails.put(FIELD_PHONE, phone);
             }
-            StripeNetworkUtils.removeNullAndEmptyParams(billingDetails);
             return billingDetails;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.java
@@ -379,8 +379,10 @@ public final class PaymentMethodCreateParams implements StripeParamsModel {
         @NonNull
         @Override
         public Map<String, Object> toParamMap() {
-            final AbstractMap<String, Object> map = new HashMap<>();
-            map.put(FIELD_BANK, mBank);
+            final Map<String, Object> map = new HashMap<>();
+            if (mBank != null) {
+                map.put(FIELD_BANK, mBank);
+            }
             return map;
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingInformation.java
@@ -5,12 +5,10 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.StripeNetworkUtils;
 import com.stripe.android.utils.ObjectUtils;
 
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -85,13 +83,16 @@ public final class ShippingInformation
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {
-        final AbstractMap<String, Object> map = new HashMap<>();
-        map.put(FIELD_NAME, mName);
-        map.put(FIELD_PHONE, mPhone);
+        final Map<String, Object> map = new HashMap<>();
+        if (mName != null) {
+            map.put(FIELD_NAME, mName);
+        }
+        if (mPhone != null) {
+            map.put(FIELD_PHONE, mPhone);
+        }
         if (mAddress != null) {
             map.put(FIELD_ADDRESS, mAddress.toParamMap());
         }
-        StripeNetworkUtils.removeNullAndEmptyParams(map);
         return map;
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -10,12 +10,10 @@ import com.stripe.android.utils.ObjectUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.stripe.android.StripeNetworkUtils.removeNullAndEmptyParams;
 import static com.stripe.android.model.Source.SourceType;
 
 /**
@@ -104,10 +102,9 @@ public final class SourceParams implements StripeParamsModel {
                 .setCurrency(currency)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
-        final AbstractMap<String, Object> ownerMap = new HashMap<>();
+        final Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, name);
         ownerMap.put(FIELD_EMAIL, email);
-        removeNullAndEmptyParams(ownerMap);
         if (!ownerMap.isEmpty()) {
             params.setOwner(ownerMap);
         }
@@ -140,10 +137,13 @@ public final class SourceParams implements StripeParamsModel {
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl))
                 .setUsage(Source.Usage.REUSABLE);
 
-        final AbstractMap<String, Object> ownerMap = new HashMap<>();
-        ownerMap.put(FIELD_NAME, name);
-        ownerMap.put(FIELD_EMAIL, email);
-        removeNullAndEmptyParams(ownerMap);
+        final Map<String, Object> ownerMap = new HashMap<>();
+        if (name != null) {
+            ownerMap.put(FIELD_NAME, name);
+        }
+        if (email != null) {
+            ownerMap.put(FIELD_EMAIL, email);
+        }
         if (!ownerMap.isEmpty()) {
             params.setOwner(ownerMap);
         }
@@ -179,10 +179,14 @@ public final class SourceParams implements StripeParamsModel {
                 .setAmount(amount)
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
-        final AbstractMap<String, Object> ownerMap = new HashMap<>();
-        ownerMap.put(FIELD_NAME, name);
-        ownerMap.put(FIELD_EMAIL, email);
-        removeNullAndEmptyParams(ownerMap);
+        final Map<String, Object> ownerMap = new HashMap<>();
+        if (name != null) {
+            ownerMap.put(FIELD_NAME, name);
+        }
+        if (email != null) {
+            ownerMap.put(FIELD_EMAIL, email);
+        }
+
         if (!ownerMap.isEmpty()) {
             params.setOwner(ownerMap);
         }
@@ -233,12 +237,13 @@ public final class SourceParams implements StripeParamsModel {
                 .setRedirect(createSimpleMap(FIELD_RETURN_URL, returnUrl));
 
         if (statementDescriptor != null || preferredLanguage != null) {
-            final AbstractMap<String, Object> additionalParamsMap = new HashMap<>();
-
-            additionalParamsMap.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
-            additionalParamsMap.put(FIELD_PREFERRED_LANGUAGE, preferredLanguage);
-            removeNullAndEmptyParams(additionalParamsMap);
-
+            final Map<String, Object> additionalParamsMap = new HashMap<>();
+            if (statementDescriptor != null) {
+                additionalParamsMap.put(FIELD_STATEMENT_DESCRIPTOR, statementDescriptor);
+            }
+            if (preferredLanguage != null) {
+                additionalParamsMap.put(FIELD_PREFERRED_LANGUAGE, preferredLanguage);
+            }
             params.setApiParameterMap(additionalParamsMap);
         }
 
@@ -283,12 +288,11 @@ public final class SourceParams implements StripeParamsModel {
 
         // Not enforcing all fields to exist at this level.
         // Instead, the server will return an error for invalid data.
-        final AbstractMap<String, Object> basicInfoMap = new HashMap<>();
+        final Map<String, Object> basicInfoMap = new HashMap<>();
         basicInfoMap.put(FIELD_NUMBER, card.getNumber());
         basicInfoMap.put(FIELD_EXP_MONTH, card.getExpMonth());
         basicInfoMap.put(FIELD_EXP_YEAR, card.getExpYear());
         basicInfoMap.put(FIELD_CVC, card.getCVC());
-        removeNullAndEmptyParams(basicInfoMap);
 
         params.setApiParameterMap(basicInfoMap);
 
@@ -303,12 +307,11 @@ public final class SourceParams implements StripeParamsModel {
                 .toParamMap();
 
         // If there are any keys left...
-        final AbstractMap<String, Object> ownerMap = new HashMap<>();
+        final Map<String, Object> ownerMap = new HashMap<>();
         ownerMap.put(FIELD_NAME, card.getName());
         if (!addressMap.isEmpty()) {
             ownerMap.put(FIELD_ADDRESS, addressMap);
         }
-        removeNullAndEmptyParams(ownerMap);
         if (!ownerMap.isEmpty()) {
             params.setOwner(ownerMap);
         }
@@ -346,19 +349,23 @@ public final class SourceParams implements StripeParamsModel {
         final String phone;
         final String name;
         if (googlePayBillingAddress != null) {
-            name = googlePayBillingAddress.optString("name");
-            phone = googlePayBillingAddress.optString("phoneNumber");
-
+            name = StripeJsonUtils.optString(googlePayBillingAddress, "name");
+            phone = StripeJsonUtils.optString(googlePayBillingAddress, "phoneNumber");
             addressMap = new Address.Builder()
-                    .setLine1(googlePayBillingAddress.optString("address1"))
-                    .setLine2(googlePayBillingAddress.optString("address2"))
-                    .setCity(googlePayBillingAddress.optString("locality"))
-                    .setState(googlePayBillingAddress.optString("administrativeArea"))
-                    .setPostalCode(googlePayBillingAddress.optString("postalCode"))
-                    .setCountry(googlePayBillingAddress.optString("countryCode"))
+                    .setLine1(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "address1"))
+                    .setLine2(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "address2"))
+                    .setCity(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "locality"))
+                    .setState(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "administrativeArea"))
+                    .setPostalCode(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "postalCode"))
+                    .setCountry(StripeJsonUtils.optString(
+                            googlePayBillingAddress, "countryCode"))
                     .build()
                     .toParamMap();
-            removeNullAndEmptyParams(addressMap);
         } else {
             name = null;
             phone = null;
@@ -366,7 +373,10 @@ public final class SourceParams implements StripeParamsModel {
         }
 
         final Map<String, Object> ownerMap = new HashMap<>();
-        ownerMap.put(FIELD_EMAIL, googlePayPaymentData.optString("email"));
+        final String email = StripeJsonUtils.optString(googlePayPaymentData, "email");
+        if (email != null) {
+            ownerMap.put(FIELD_EMAIL, email);
+        }
         if (name != null) {
             ownerMap.put(FIELD_NAME, name);
         }
@@ -376,7 +386,6 @@ public final class SourceParams implements StripeParamsModel {
         if (addressMap != null && !addressMap.isEmpty()) {
             ownerMap.put(FIELD_ADDRESS, addressMap);
         }
-        removeNullAndEmptyParams(ownerMap);
         if (!ownerMap.isEmpty()) {
             params.setOwner(ownerMap);
         }
@@ -896,24 +905,40 @@ public final class SourceParams implements StripeParamsModel {
     @NonNull
     @Override
     public Map<String, Object> toParamMap() {
-        final AbstractMap<String, Object> networkReadyMap = new HashMap<>();
+        final Map<String, Object> networkReadyMap = new HashMap<>();
 
         networkReadyMap.put(API_PARAM_TYPE, mTypeRaw);
-        networkReadyMap.put(mTypeRaw, mApiParameterMap);
-        networkReadyMap.put(API_PARAM_AMOUNT, mAmount);
-        networkReadyMap.put(API_PARAM_CURRENCY, mCurrency);
-        networkReadyMap.put(API_PARAM_OWNER, mOwner);
-        networkReadyMap.put(API_PARAM_REDIRECT, mRedirect);
-        networkReadyMap.put(API_PARAM_METADATA, mMetaData);
-        networkReadyMap.put(API_PARAM_TOKEN, mToken);
-        networkReadyMap.put(API_PARAM_USAGE, mUsage);
+
+        if (mApiParameterMap != null) {
+            networkReadyMap.put(mTypeRaw, mApiParameterMap);
+        }
+        if (mAmount != null) {
+            networkReadyMap.put(API_PARAM_AMOUNT, mAmount);
+        }
+        if (mCurrency != null) {
+            networkReadyMap.put(API_PARAM_CURRENCY, mCurrency);
+        }
+        if (mOwner != null) {
+            networkReadyMap.put(API_PARAM_OWNER, mOwner);
+        }
+        if (mRedirect != null) {
+            networkReadyMap.put(API_PARAM_REDIRECT, mRedirect);
+        }
+        if (mMetaData != null) {
+            networkReadyMap.put(API_PARAM_METADATA, mMetaData);
+        }
+        if (mToken != null) {
+            networkReadyMap.put(API_PARAM_TOKEN, mToken);
+        }
+        if (mUsage != null) {
+            networkReadyMap.put(API_PARAM_USAGE, mUsage);
+        }
         if (mExtraParams != null) {
             networkReadyMap.putAll(mExtraParams);
         }
         if (mWeChatParams != null) {
             networkReadyMap.put(API_PARAM_WECHAT, mWeChatParams.toParamMap());
         }
-        removeNullAndEmptyParams(networkReadyMap);
         return networkReadyMap;
     }
 

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.java
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.java
@@ -108,7 +108,7 @@ public class ApiRequestTest {
                 ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null)
                 .createQuery();
 
-        final String expectedValue = "muid=BF3BF4D775100923AAAFA82884FB759001162E28&product_usage=&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050";
+        final String expectedValue = "muid=BF3BF4D775100923AAAFA82884FB759001162E28&product_usage=&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123";
         assertEquals(expectedValue, query);
     }
 

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.java
@@ -72,7 +72,7 @@ public class IssuingCardPinServiceTest {
         when(mStripeApiRequestExecutor.execute(
                 argThat(new ApiRequestMatcher(
                         StripeRequest.Method.GET,
-                        "https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin?verification%5Bid%5D=iv_abcd&verification%5Bone_time_code%5D=123-456",
+                        "https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin?verification%5Bone_time_code%5D=123-456&verification%5Bid%5D=iv_abcd",
                         ApiRequest.Options.create("ek_test_123")
                 ))))
                 .thenReturn(response);
@@ -132,7 +132,7 @@ public class IssuingCardPinServiceTest {
         when(mStripeApiRequestExecutor.execute(
                 argThat(new ApiRequestMatcher(
                         StripeRequest.Method.GET,
-                        "https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin?verification%5Bid%5D=iv_abcd&verification%5Bone_time_code%5D=123-456",
+                        "https://api.stripe.com/v1/issuing/cards/ic_abcdef/pin?verification%5Bone_time_code%5D=123-456&verification%5Bid%5D=iv_abcd",
                         ApiRequest.Options.create("ek_test_123")
                 ))))
                 .thenReturn(response);

--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.java
@@ -3,7 +3,6 @@ package com.stripe.android;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.CardFixtures;
 import com.stripe.android.model.ConfirmPaymentIntentParams;
@@ -15,12 +14,10 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -40,10 +37,6 @@ public class StripeNetworkUtilsTest {
     private static final String CARD_NUMBER = "4242424242424242";
     private static final String CARD_STATE = "CA";
     private static final String CARD_ZIP = "94107";
-
-    private static final String BANK_ACCOUNT_NUMBER = "000123456789";
-    private static final String BANK_ROUTING_NUMBER = "110000000";
-    private static final String BANK_ACCOUNT_HOLDER_NAME = "Lily Thomas";
 
     @NonNull private final StripeNetworkUtils mNetworkUtils =
             new StripeNetworkUtils("com.example.app", new FakeUidSupplier());
@@ -73,23 +66,7 @@ public class StripeNetworkUtilsTest {
     }
 
     @Test
-    public void hashMapFromBankAccount_mapsCorrectFields() {
-        final BankAccount bankAccount = new BankAccount(BANK_ACCOUNT_NUMBER,
-                BANK_ACCOUNT_HOLDER_NAME, BankAccount.BankAccountType.INDIVIDUAL, null, "US",
-                "usd", null, null, BANK_ROUTING_NUMBER);
-        final Map<String, Object> bankAccountMap = getBankAccountTokenParamData(bankAccount);
-        assertNotNull(bankAccountMap);
-
-        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
-        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
-        assertEquals("US", bankAccountMap.get("country"));
-        assertEquals("usd", bankAccountMap.get("currency"));
-        assertEquals(BANK_ACCOUNT_HOLDER_NAME, bankAccountMap.get("account_holder_name"));
-        assertEquals(BankAccount.BankAccountType.INDIVIDUAL, bankAccountMap.get("account_holder_type"));
-    }
-
-    @Test
-    public void hashMapFromCard_omitsEmptyFields() {
+    public void createCardTokenParams_hasExpectedEntries() {
         final Card card = new Card.Builder(CARD_NUMBER, 8, 2019, CARD_CVC)
                 .build();
 
@@ -100,77 +77,6 @@ public class StripeNetworkUtilsTest {
         assertEquals(CARD_CVC, cardMap.get("cvc"));
         assertEquals(8, cardMap.get("exp_month"));
         assertEquals(2019, cardMap.get("exp_year"));
-        assertFalse(cardMap.containsKey("name"));
-        assertFalse(cardMap.containsKey("currency"));
-        assertFalse(cardMap.containsKey("address_line1"));
-        assertFalse(cardMap.containsKey("address_line2"));
-        assertFalse(cardMap.containsKey("address_city"));
-        assertFalse(cardMap.containsKey("address_zip"));
-        assertFalse(cardMap.containsKey("address_state"));
-        assertFalse(cardMap.containsKey("address_country"));
-    }
-
-    @Test
-    public void hashMapFromBankAccount_omitsEmptyFields() {
-        final BankAccount bankAccount = new BankAccount(BANK_ACCOUNT_NUMBER, "US",
-                "usd", BANK_ROUTING_NUMBER);
-        final Map<String, Object> bankAccountMap = getBankAccountTokenParamData(bankAccount);
-        assertNotNull(bankAccountMap);
-
-        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
-        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
-        assertEquals("US", bankAccountMap.get("country"));
-        assertEquals("usd", bankAccountMap.get("currency"));
-        assertFalse(bankAccountMap.containsKey("account_holder_name"));
-        assertFalse(bankAccountMap.containsKey("account_holder_type"));
-    }
-
-    @Test
-    public void removeNullAndEmptyParams_removesNullParams() {
-        final AbstractMap<String, Object> testMap = new HashMap<>();
-        testMap.put("a", null);
-        testMap.put("b", "not null");
-        StripeNetworkUtils.removeNullAndEmptyParams(testMap);
-        assertEquals(1, testMap.size());
-        assertTrue(testMap.containsKey("b"));
-    }
-
-    @Test
-    public void removeNullAndEmptyParams_removesEmptyStringParams() {
-        final Map<String, Object> testMap = new HashMap<>();
-        testMap.put("a", "fun param");
-        testMap.put("b", "not null");
-        testMap.put("c", "");
-        StripeNetworkUtils.removeNullAndEmptyParams(testMap);
-        assertEquals(2, testMap.size());
-        assertTrue(testMap.containsKey("a"));
-        assertTrue(testMap.containsKey("b"));
-    }
-
-    @Test
-    public void removeNullAndEmptyParams_removesNestedEmptyParams() {
-        final Map<String, Object> testMap = new HashMap<>();
-        final AbstractMap<String, Object> firstNestedMap = new HashMap<>();
-        final Map<String, Object> secondNestedMap = new HashMap<>();
-        testMap.put("a", "fun param");
-        testMap.put("b", "not null");
-        firstNestedMap.put("1a", "something");
-        firstNestedMap.put("1b", null);
-        secondNestedMap.put("2a", "");
-        secondNestedMap.put("2b", "hello world");
-        firstNestedMap.put("1c", secondNestedMap);
-        testMap.put("c", firstNestedMap);
-
-        StripeNetworkUtils.removeNullAndEmptyParams(testMap);
-        assertEquals(3, testMap.size());
-        assertTrue(testMap.containsKey("a"));
-        assertTrue(testMap.containsKey("b"));
-        assertTrue(testMap.containsKey("c"));
-        assertEquals(2, firstNestedMap.size());
-        assertTrue(firstNestedMap.containsKey("1a"));
-        assertTrue(firstNestedMap.containsKey("1c"));
-        assertEquals(1, secondNestedMap.size());
-        assertTrue(secondNestedMap.containsKey("2b"));
     }
 
     @Test
@@ -214,14 +120,4 @@ public class StripeNetworkUtilsTest {
         assertNotNull(cardTokenParams);
         return (Map<String, Object>) cardTokenParams.get("card");
     }
-
-    @SuppressWarnings("unchecked")
-    @Nullable
-    private Map<String, Object> getBankAccountTokenParamData(@NonNull BankAccount bankAccount) {
-        final Map<String, Object> params = bankAccount.toParamMap();
-        params.putAll(mNetworkUtils.createUidParams());
-        assertNotNull(params);
-        return (Map<String, Object>) params.get("bank_account");
-    }
-
 }

--- a/stripe/src/test/java/com/stripe/android/StripeRequestCompactParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeRequestCompactParamsTest.java
@@ -1,0 +1,109 @@
+package com.stripe.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StripeRequestCompactParamsTest {
+    @Test
+    public void compatParams_removesNullParams() {
+        final AbstractMap<String, Object> params = new HashMap<>();
+        params.put("a", null);
+        params.put("b", "not null");
+
+        final Map<String, ?> compactParams = getCompactedParams(params);
+        assertEquals(1, compactParams.size());
+        assertTrue(compactParams.containsKey("b"));
+    }
+
+    @Test
+    public void compatParams_removesEmptyStringParams() {
+        final Map<String, Object> params = new HashMap<>();
+        params.put("a", "fun param");
+        params.put("b", "not null");
+        params.put("c", "");
+
+        final Map<String, ?> compactParams = getCompactedParams(params);
+        assertEquals(2, compactParams.size());
+        assertTrue(compactParams.containsKey("a"));
+        assertTrue(compactParams.containsKey("b"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void compatParams_removesNestedEmptyParams() {
+        final Map<String, ?> outParams = getCompactedParams(createParamsWithNestedMap());
+
+        assertEquals(3, outParams.size());
+        assertTrue(outParams.containsKey("a"));
+        assertTrue(outParams.containsKey("b"));
+        assertTrue(outParams.containsKey("c"));
+
+        final Map<String, Object> firstNestedMap =
+                Objects.requireNonNull((Map<String, Object>) outParams.get("c"));
+        assertEquals(2, firstNestedMap.size());
+        assertTrue(firstNestedMap.containsKey("1a"));
+        assertTrue(firstNestedMap.containsKey("1c"));
+
+        final Map<String, Object> secondNestedMap =
+                Objects.requireNonNull((Map<String, Object>) firstNestedMap.get("1c"));
+        assertEquals(1, secondNestedMap.size());
+        assertTrue(secondNestedMap.containsKey("2b"));
+    }
+
+    @NonNull
+    private Map<String, Object> createParamsWithNestedMap() {
+        final Map<String, Object> inParams = new HashMap<>();
+        final AbstractMap<String, Object> firstNestedMap = new HashMap<>();
+        final Map<String, Object> secondNestedMap = new HashMap<>();
+        inParams.put("a", "fun param");
+        inParams.put("b", "not null");
+        firstNestedMap.put("1a", "something");
+        firstNestedMap.put("1b", null);
+        secondNestedMap.put("2a", "");
+        secondNestedMap.put("2b", "hello world");
+        firstNestedMap.put("1c", secondNestedMap);
+        inParams.put("c", firstNestedMap);
+        return inParams;
+    }
+
+    @NonNull
+    private Map<String, ?> getCompactedParams(@NonNull Map<String, Object> params) {
+        return Objects.requireNonNull(new FakeRequest(params).params);
+    }
+
+    private static final class FakeRequest extends StripeRequest {
+        FakeRequest(@Nullable Map<String, ?> params) {
+            super(Method.POST, "https://example.com", params,
+                    "application/x-www-form-urlencoded");
+        }
+
+        @NonNull
+        @Override
+        Map<String, String> createHeaders() {
+            return Collections.emptyMap();
+        }
+
+        @NonNull
+        @Override
+        String getUserAgent() {
+            return "";
+        }
+
+        @NonNull
+        @Override
+        byte[] getOutputBytes() {
+            return new byte[0];
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -208,18 +207,22 @@ public class StripeTest {
         });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createTokenShouldFailWithNullPublishableKey() {
-        new Stripe(mContext)
-                .createToken(DEFAULT_CARD, new ApiResultCallback<Token>() {
+        final Stripe stripe = new Stripe(mContext);
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
                     @Override
-                    public void onError(@NonNull Exception error) {
-                        fail("Should not call method");
-                    }
+                    public void run() {
+                        stripe.createToken(DEFAULT_CARD, new ApiResultCallback<Token>() {
+                            @Override
+                            public void onError(@NonNull Exception error) {
+                            }
 
-                    @Override
-                    public void onSuccess(@NonNull Token token) {
-                        fail("Should not call method");
+                            @Override
+                            public void onSuccess(@NonNull Token token) {
+                            }
+                        });
                     }
                 });
     }
@@ -1130,12 +1133,16 @@ public class StripeTest {
                 authenticationException.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void createTokenSynchronous_withoutKey_shouldThrowException()
-            throws StripeException {
+    @Test
+    public void createTokenSynchronous_withoutKey_shouldThrowException() {
         final Stripe stripe = new Stripe(mContext);
-        // This test should not log anything, so we set it to be theoretically capable of logging
-        stripe.createTokenSynchronous(CARD);
+        assertThrows(IllegalArgumentException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        stripe.createTokenSynchronous(CARD);
+                    }
+                });
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/BankAccountTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/BankAccountTest.java
@@ -1,13 +1,32 @@
 package com.stripe.android.model;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test class for {@link BankAccount}.
  */
 public class BankAccountTest {
+    private static final String BANK_ACCOUNT_NUMBER = "000123456789";
+    private static final String BANK_ROUTING_NUMBER = "110000000";
+    private static final String BANK_ACCOUNT_HOLDER_NAME = "Lily Thomas";
+
+    private static final Map<String, String> GUID_PARAMS;
+
+    static {
+        GUID_PARAMS = new HashMap<>();
+        GUID_PARAMS.put("guid", UUID.randomUUID().toString());
+        GUID_PARAMS.put("muid", UUID.randomUUID().toString());
+    }
 
     private static final String RAW_BANK_ACCOUNT = "{\n" +
             "    \"id\": \"ba_19d8Fh2eZvKYlo2C9qw8RwpV\",\n" +
@@ -36,5 +55,43 @@ public class BankAccountTest {
                 "110000000");
         final BankAccount actualAccount = BankAccount.fromString(RAW_BANK_ACCOUNT);
         assertEquals(expectedAccount, actualAccount);
+    }
+
+    @Test
+    public void createBankTokenParams_hasExpectedEntries() {
+        final BankAccount bankAccount = new BankAccount(BANK_ACCOUNT_NUMBER, "US",
+                "usd", BANK_ROUTING_NUMBER);
+        final Map<String, Object> bankAccountMap = getBankAccountTokenParamData(bankAccount);
+        assertNotNull(bankAccountMap);
+
+        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
+        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
+        assertEquals("US", bankAccountMap.get("country"));
+        assertEquals("usd", bankAccountMap.get("currency"));
+    }
+
+    @Test
+    public void hashMapFromBankAccount_mapsCorrectFields() {
+        final BankAccount bankAccount = new BankAccount(BANK_ACCOUNT_NUMBER,
+                BANK_ACCOUNT_HOLDER_NAME, BankAccount.BankAccountType.INDIVIDUAL, null, "US",
+                "usd", null, null, BANK_ROUTING_NUMBER);
+        final Map<String, Object> bankAccountMap = getBankAccountTokenParamData(bankAccount);
+        assertNotNull(bankAccountMap);
+
+        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap.get("account_number"));
+        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap.get("routing_number"));
+        assertEquals("US", bankAccountMap.get("country"));
+        assertEquals("usd", bankAccountMap.get("currency"));
+        assertEquals(BANK_ACCOUNT_HOLDER_NAME, bankAccountMap.get("account_holder_name"));
+        assertEquals(BankAccount.BankAccountType.INDIVIDUAL, bankAccountMap.get("account_holder_type"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private Map<String, Object> getBankAccountTokenParamData(@NonNull BankAccount bankAccount) {
+        final Map<String, Object> params = bankAccount.toParamMap();
+        params.putAll(GUID_PARAMS);
+        assertNotNull(params);
+        return (Map<String, Object>) params.get("bank_account");
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.java
@@ -550,7 +550,7 @@ public class SourceParamsTest {
                 "stripe://testactivity",
                 "multibancoholder@stripe.com");
 
-        Map<String, Object> expectedMap = new HashMap<>();
+        final Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("type", Source.SourceType.MULTIBANCO);
         expectedMap.put("currency", Source.EURO);
         expectedMap.put("amount", 150L);
@@ -652,7 +652,7 @@ public class SourceParamsTest {
                 "UK",
                 "a thing you bought");
 
-        Map<String, Object> expectedMap = new HashMap<>();
+        final Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("type", Source.SourceType.SOFORT);
         expectedMap.put("currency", Source.EURO);
         expectedMap.put("amount", 50000L);
@@ -697,7 +697,7 @@ public class SourceParamsTest {
                 "stripe://returnaddress",
                 "card_id_123");
 
-        Map<String, Object> expectedMap = new HashMap<>();
+        final Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("type", Source.SourceType.THREE_D_SECURE);
         expectedMap.put("currency", "brl");
         expectedMap.put("amount", 99000L);


### PR DESCRIPTION
The Stripe API doesn't allow for null values to be passed
as parameters, so the SDK is responsible for removing them.

The "compacting" logic (i.e. removing nulls and empty values)
was done across our codebase. This logic only needs to be
applied once, at the point that the request object is
being created.

This PR moves the logic to a single place - the `StripeRequest`
constructor.