### PR TITLE
Mark Stripe.setStripeAccount() as deprecated

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -64,12 +64,10 @@ class PaymentAuthActivity : AppCompatActivity() {
         }
 
         stripeService = RetrofitFactory.instance.create(StripeService::class.java)
-        stripe = Stripe(this, PaymentConfiguration.getInstance().publishableKey)
-
-        // set an optional Stripe Connect account to use for API requests
-
-        if (stripeAccountId != null) {
-            stripe.setStripeAccount(stripeAccountId)
+        stripe = if (stripeAccountId != null) {
+            Stripe(this, PaymentConfiguration.getInstance().publishableKey, stripeAccountId)
+        } else {
+            Stripe(this, PaymentConfiguration.getInstance().publishableKey)
         }
 
         buyButton = findViewById(R.id.buy_button)

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.kt
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.kt
@@ -92,9 +92,11 @@ class PaymentActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_payment)
 
-        stripe = Stripe(this, PaymentConfiguration.getInstance().publishableKey)
-        if (Settings.STRIPE_ACCOUNT_ID != null) {
-            stripe.setStripeAccount(Settings.STRIPE_ACCOUNT_ID)
+        stripe = if (Settings.STRIPE_ACCOUNT_ID != null) {
+            Stripe(this, PaymentConfiguration.getInstance().publishableKey,
+                Settings.STRIPE_ACCOUNT_ID)
+        } else {
+            Stripe(this, PaymentConfiguration.getInstance().publishableKey)
         }
 
         val selectCustomization = PaymentAuthConfig.Stripe3ds2ButtonCustomization.Builder()

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -128,7 +128,8 @@ public class CustomerSession {
      * @param keyProvider An {@link EphemeralKeyProvider} used to retrieve
      *                    {@link CustomerEphemeralKey EphemeralKeys}
      * @param stripeAccountId An optional Stripe Connect account to associate with Customer-related
-     *                        Stripe API Requests. See {@link Stripe#setStripeAccount(String)}.
+     *                        Stripe API Requests.
+     *                        See {@link Stripe#Stripe(Context, String, String)}.
      */
     public static void initCustomerSession(@NonNull Context context,
                                            @NonNull EphemeralKeyProvider keyProvider,

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.java
@@ -147,7 +147,8 @@ public class StripePaymentAuthTest {
                         null),
                 new StripeNetworkUtils(mContext),
                 mPaymentController,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                null
         );
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -306,9 +306,11 @@ public class StripeTest {
     @Test
     public void createCardTokenSynchronous_withValidDataAndConnectAccount_returnsToken()
             throws StripeException {
-        final Stripe stripe = new Stripe(mContext,
-                ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY);
-        stripe.setStripeAccount("acct_1Acj2PBUgO3KuWzz");
+        final Stripe stripe = new Stripe(
+                mContext,
+                ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY,
+                "acct_1Acj2PBUgO3KuWzz"
+        );
 
         final Token token = stripe.createTokenSynchronous(CARD);
 
@@ -1402,7 +1404,8 @@ public class StripeTest {
                 apiHandler,
                 new StripeNetworkUtils(mContext),
                 new PaymentController(mContext, apiHandler),
-                publishableKey
+                publishableKey,
+                null
         );
     }
 
@@ -1415,6 +1418,7 @@ public class StripeTest {
                 new StripeNetworkUtils(mContext),
                 new PaymentController(mContext, apiHandler),
                 NON_LOGGING_PK,
+                null,
                 tokenCreator
         );
     }


### PR DESCRIPTION
Stripe Account Id should be specified via the appropriate
`Stripe` constructor.