### PR TITLE
Add paymentMethodTypes field to PaymentMethodsActivityStarter.Args

### DIFF
--- a/stripe/src/main/java/com/stripe/android/utils/ObjectUtils.java
+++ b/stripe/src/main/java/com/stripe/android/utils/ObjectUtils.java
@@ -4,11 +4,13 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
 
 public final class ObjectUtils {
 
     public static boolean equals(@Nullable Object obj1, @Nullable Object obj2) {
-        return (obj1 == obj2) || (obj1 != null && obj1.equals(obj2));
+        return Objects.equals(obj1, obj2);
     }
 
     public static int hash(@Nullable Object... values) {
@@ -18,5 +20,10 @@ public final class ObjectUtils {
     @NonNull
     public static <T> T getOrDefault(@Nullable T obj, @NonNull T defaultValue) {
         return obj != null ? obj : defaultValue;
+    }
+
+    @NonNull
+    public static <T extends Collection> T getOrEmpty(@Nullable T obj, @NonNull T emptyValue) {
+        return (obj != null && !obj.isEmpty()) ? obj : emptyValue;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/utils/ParcelUtils.java
+++ b/stripe/src/test/java/com/stripe/android/utils/ParcelUtils.java
@@ -1,0 +1,22 @@
+package com.stripe.android.utils;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+public final class ParcelUtils {
+    /**
+     * @param source  the source from which to parcel and unparcel a new object
+     * @param creator the {@link Parcelable.Creator}
+     * @return a new {@link Source} instance based on the original source
+     */
+    @NonNull
+    public static <Source extends Parcelable> Source create(
+            @NonNull Source source,
+            @NonNull Parcelable.Creator<Source> creator) {
+        final Parcel parcel = Parcel.obtain();
+        source.writeToParcel(parcel, source.describeContents());
+        parcel.setDataPosition(0);
+        return creator.createFromParcel(parcel);
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
@@ -1,0 +1,48 @@
+package com.stripe.android.view;
+
+import com.stripe.android.model.PaymentMethod;
+import com.stripe.android.utils.ParcelUtils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class PaymentMethodsActivityStarterTest {
+
+    @Test
+    public void testParceling() {
+        final Set<PaymentMethod.Type> paymentMethodTypes = new HashSet<>(
+                Arrays.asList(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx)
+        );
+        final PaymentMethodsActivityStarter.Args args =
+                new PaymentMethodsActivityStarter.Args.Builder()
+                        .setInitialPaymentMethodId("pm_12345")
+                        .setIsPaymentSessionActive(true)
+                        .setShouldRequirePostalCode(true)
+                        .setPaymentMethodTypes(paymentMethodTypes)
+                        .build();
+
+        final PaymentMethodsActivityStarter.Args createdArgs =
+                ParcelUtils.create(args, PaymentMethodsActivityStarter.Args.CREATOR);
+        assertEquals(args, createdArgs);
+    }
+
+    @Test
+    public void testDefaultPaymentMethodTypes_isCard() {
+        assertEquals(
+                Collections.singleton(PaymentMethod.Type.Card),
+                new PaymentMethodsActivityStarter.Args.Builder()
+                        .build()
+                        .paymentMethodTypes
+        );
+    }
+}


### PR DESCRIPTION
## Summary
See [PaymentIntent.payment_method_types](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_types)

## Motivation
Will be used to specify what Payment Method types should
be shown/accepted in UI.

## Testing
Added tests
