### PR TITLE
Add PaymentConfiguration to AddPaymentMethodActivityStarter.Args

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -1,10 +1,16 @@
 package com.stripe.android;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
-public final class PaymentConfiguration {
+import com.stripe.android.utils.ObjectUtils;
+
+import java.util.Objects;
+
+public final class PaymentConfiguration implements Parcelable {
 
     @Nullable private static PaymentConfiguration mInstance;
     @NonNull private final String mPublishableKey;
@@ -12,6 +18,23 @@ public final class PaymentConfiguration {
     private PaymentConfiguration(@NonNull String publishableKey) {
         mPublishableKey = ApiKeyValidator.get().requireValid(publishableKey);
     }
+
+    private PaymentConfiguration(@NonNull Parcel in) {
+        mPublishableKey = Objects.requireNonNull(in.readString());
+    }
+
+    public static final Creator<PaymentConfiguration> CREATOR =
+            new Creator<PaymentConfiguration>() {
+                @Override
+                public PaymentConfiguration createFromParcel(@NonNull Parcel in) {
+                    return new PaymentConfiguration(in);
+                }
+
+                @Override
+                public PaymentConfiguration[] newArray(int size) {
+                    return new PaymentConfiguration[size];
+                }
+            };
 
     @NonNull
     public static PaymentConfiguration getInstance() {
@@ -38,5 +61,30 @@ public final class PaymentConfiguration {
     @VisibleForTesting
     static void clearInstance() {
         mInstance = null;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(mPublishableKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(mPublishableKey);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return super.equals(obj) ||
+                (obj instanceof PaymentConfiguration && typedEquals((PaymentConfiguration) obj));
+    }
+
+    private boolean typedEquals(@NonNull PaymentConfiguration obj) {
+        return ObjectUtils.equals(mPublishableKey, obj.mPublishableKey);
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -259,13 +259,13 @@ public class PaymentSession {
      */
     public void presentPaymentMethodSelection(boolean shouldRequirePostalCode,
                                               @Nullable String userSelectedPaymentMethodId) {
-
         mPaymentMethodsActivityStarter.startForResult(PAYMENT_METHOD_REQUEST,
                 new PaymentMethodsActivityStarter.Args.Builder()
                         .setInitialPaymentMethodId(
                                 getSelectedPaymentMethodId(userSelectedPaymentMethodId))
                         .setShouldRequirePostalCode(shouldRequirePostalCode)
                         .setIsPaymentSessionActive(true)
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
                         .build()
         );
     }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -49,11 +49,16 @@ public class AddPaymentMethodActivity extends StripeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mStripe = new Stripe(getApplicationContext(),
-                PaymentConfiguration.getInstance().getPublishableKey());
 
         final AddPaymentMethodActivityStarter.Args args =
                 AddPaymentMethodActivityStarter.Args.create(getIntent());
+        final PaymentConfiguration paymentConfiguration;
+        if (args.paymentConfiguration != null) {
+            paymentConfiguration = args.paymentConfiguration;
+        } else {
+            paymentConfiguration = PaymentConfiguration.getInstance();
+        }
+        mStripe = new Stripe(getApplicationContext(), paymentConfiguration.getPublishableKey());
 
         mViewStub.setLayoutResource(R.layout.activity_add_source);
         mViewStub.inflate();

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.stripe.android.ObjectBuilder;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.utils.ObjectUtils;
 
@@ -27,6 +28,7 @@ public class AddPaymentMethodActivityStarter
         final boolean isPaymentSessionActive;
         final boolean shouldInitCustomerSessionTokens;
         @NonNull final PaymentMethod.Type paymentMethodType;
+        @Nullable final PaymentConfiguration paymentConfiguration;
 
         @NonNull
         public static AddPaymentMethodActivityStarter.Args create(@NonNull Intent intent) {
@@ -44,6 +46,7 @@ public class AddPaymentMethodActivityStarter
                     builder.mPaymentMethodType,
                     PaymentMethod.Type.Card
             );
+            this.paymentConfiguration = builder.mPaymentConfiguration;
         }
 
         private Args(@NonNull Parcel in) {
@@ -52,6 +55,8 @@ public class AddPaymentMethodActivityStarter
             this.isPaymentSessionActive = in.readInt() == 1;
             this.shouldInitCustomerSessionTokens = in.readInt() == 1;
             this.paymentMethodType = PaymentMethod.Type.valueOf(in.readString());
+            this.paymentConfiguration =
+                    in.readParcelable(PaymentConfiguration.class.getClassLoader());
         }
 
         @Override
@@ -66,12 +71,14 @@ public class AddPaymentMethodActivityStarter
             dest.writeInt(isPaymentSessionActive ? 1 : 0);
             dest.writeInt(shouldInitCustomerSessionTokens ? 1 : 0);
             dest.writeString(paymentMethodType.name());
+            dest.writeParcelable(paymentConfiguration, 0);
         }
 
         @Override
         public int hashCode() {
             return ObjectUtils.hash(shouldUpdateCustomer, shouldRequirePostalCode,
-                    isPaymentSessionActive, shouldInitCustomerSessionTokens, paymentMethodType);
+                    isPaymentSessionActive, shouldInitCustomerSessionTokens, paymentMethodType,
+                    paymentConfiguration);
         }
 
         @Override
@@ -85,7 +92,9 @@ public class AddPaymentMethodActivityStarter
                     ObjectUtils.equals(isPaymentSessionActive, args.isPaymentSessionActive) &&
                     ObjectUtils.equals(shouldInitCustomerSessionTokens,
                             args.shouldInitCustomerSessionTokens) &&
-                    ObjectUtils.equals(paymentMethodType, args.paymentMethodType);
+                    ObjectUtils.equals(paymentMethodType, args.paymentMethodType) &&
+                    ObjectUtils.equals(paymentConfiguration, args.paymentConfiguration);
+
         }
 
         public static final Parcelable.Creator<AddPaymentMethodActivityStarter.Args> CREATOR =
@@ -109,7 +118,8 @@ public class AddPaymentMethodActivityStarter
             private boolean mShouldRequirePostalCode;
             private boolean mIsPaymentSessionActive = false;
             private boolean mShouldInitCustomerSessionTokens = true;
-            private PaymentMethod.Type mPaymentMethodType;
+            @Nullable private PaymentMethod.Type mPaymentMethodType;
+            @Nullable private PaymentConfiguration mPaymentConfiguration;
 
             /**
              * If true, update using an already-initialized
@@ -142,6 +152,12 @@ public class AddPaymentMethodActivityStarter
             @NonNull
             Builder setPaymentMethodType(@NonNull PaymentMethod.Type paymentMethodType) {
                 this.mPaymentMethodType = paymentMethodType;
+                return this;
+            }
+
+            @NonNull
+            Builder setPaymentConfiguration(@Nullable PaymentConfiguration paymentConfiguration) {
+                this.mPaymentConfiguration = paymentConfiguration;
                 return this;
             }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -83,6 +83,7 @@ public class PaymentMethodsActivity extends AppCompatActivity {
                                         .setShouldRequirePostalCode(shouldShowPostalField)
                                         .setIsPaymentSessionActive(mStartedFromPaymentSession)
                                         .setPaymentMethodType(PaymentMethod.Type.Card)
+                                        .setPaymentConfiguration(args.paymentConfiguration)
                                         .build());
             }
         });

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 
 import com.stripe.android.ObjectBuilder;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.utils.ObjectUtils;
 
@@ -34,6 +35,7 @@ public final class PaymentMethodsActivityStarter
         public final boolean shouldRequirePostalCode;
         final boolean isPaymentSessionActive;
         @NonNull final Set<PaymentMethod.Type> paymentMethodTypes;
+        @Nullable final PaymentConfiguration paymentConfiguration;
 
         @NonNull
         public static Args create(@NonNull Intent intent) {
@@ -49,6 +51,7 @@ public final class PaymentMethodsActivityStarter
                     builder.mPaymentMethodTypes,
                     Collections.singleton(PaymentMethod.Type.Card)
             );
+            paymentConfiguration = builder.mPaymentConfiguration;
         }
 
         private Args(@NonNull Parcel in) {
@@ -61,6 +64,8 @@ public final class PaymentMethodsActivityStarter
             for (int i = 0; i < paymentMethodTypesSize; i++) {
                 paymentMethodTypes.add(PaymentMethod.Type.valueOf(in.readString()));
             }
+
+            paymentConfiguration = in.readParcelable(PaymentConfiguration.class.getClassLoader());
         }
 
         @Override
@@ -78,12 +83,14 @@ public final class PaymentMethodsActivityStarter
             for (PaymentMethod.Type paymentMethodType : paymentMethodTypes) {
                 dest.writeString(paymentMethodType.name());
             }
+
+            dest.writeParcelable(paymentConfiguration, 0);
         }
 
         @Override
         public int hashCode() {
             return ObjectUtils.hash(initialPaymentMethodId, shouldRequirePostalCode,
-                    isPaymentSessionActive, paymentMethodTypes);
+                    isPaymentSessionActive, paymentMethodTypes, paymentConfiguration);
         }
 
         @Override
@@ -95,7 +102,8 @@ public final class PaymentMethodsActivityStarter
             return ObjectUtils.equals(initialPaymentMethodId, args.initialPaymentMethodId) &&
                     ObjectUtils.equals(shouldRequirePostalCode, args.shouldRequirePostalCode) &&
                     ObjectUtils.equals(isPaymentSessionActive, args.isPaymentSessionActive) &&
-                    ObjectUtils.equals(paymentMethodTypes, args.paymentMethodTypes);
+                    ObjectUtils.equals(paymentMethodTypes, args.paymentMethodTypes) &&
+                    ObjectUtils.equals(paymentConfiguration, args.paymentConfiguration);
         }
 
         public static final Parcelable.Creator<Args> CREATOR = new Parcelable.Creator<Args>() {
@@ -115,7 +123,8 @@ public final class PaymentMethodsActivityStarter
             @Nullable private String mInitialPaymentMethodId = null;
             private boolean mShouldRequirePostalCode = false;
             private boolean mIsPaymentSessionActive = false;
-            private Set<PaymentMethod.Type> mPaymentMethodTypes;
+            @Nullable private Set<PaymentMethod.Type> mPaymentMethodTypes;
+            @Nullable private PaymentConfiguration mPaymentConfiguration;
 
             @NonNull
             public Builder setInitialPaymentMethodId(@Nullable String initialPaymentMethodId) {
@@ -139,6 +148,13 @@ public final class PaymentMethodsActivityStarter
             public Builder setPaymentMethodTypes(
                     @NonNull Set<PaymentMethod.Type> paymentMethodTypes) {
                 mPaymentMethodTypes = paymentMethodTypes;
+                return this;
+            }
+
+            @NonNull
+            public Builder setPaymentConfiguration(
+                    @Nullable PaymentConfiguration paymentConfiguration) {
+                this.mPaymentConfiguration = paymentConfiguration;
                 return this;
             }
 

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -116,6 +116,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
                 .setIsPaymentSessionActive(true)
                 .setShouldInitCustomerSessionTokens(false)
                 .setPaymentMethodType(PaymentMethod.Type.Card)
+                .setPaymentConfiguration(PaymentConfiguration.getInstance())
                 .build());
         mCardMultilineWidget = mActivity.findViewById(R.id.add_source_card_entry_widget);
         mProgressBar = mActivity.findViewById(R.id.progress_bar_as);

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android.view;
 
+import com.stripe.android.ApiKeyFixtures;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.utils.ParcelUtils;
 
@@ -20,6 +22,8 @@ public class PaymentMethodsActivityStarterTest {
 
     @Test
     public void testParceling() {
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+
         final Set<PaymentMethod.Type> paymentMethodTypes = new HashSet<>(
                 Arrays.asList(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx)
         );
@@ -29,6 +33,7 @@ public class PaymentMethodsActivityStarterTest {
                         .setIsPaymentSessionActive(true)
                         .setShouldRequirePostalCode(true)
                         .setPaymentMethodTypes(paymentMethodTypes)
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
                         .build();
 
         final PaymentMethodsActivityStarter.Args createdArgs =

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -6,8 +6,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 
+import com.stripe.android.ApiKeyFixtures;
 import com.stripe.android.CustomerSession;
 import com.stripe.android.CustomerSessionTestHelper;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.R;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.PaymentMethodTest;
@@ -67,12 +69,15 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     public void setup() {
         MockitoAnnotations.initMocks(this);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
+        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         mPaymentMethods = Arrays.asList(PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON),
                 PaymentMethod.fromString(MaskedCardAdapterTest.PAYMENT_METHOD_JSON));
 
         mPaymentMethodsActivity = createActivity(
-                new PaymentMethodsActivityStarter.Args.Builder().build()
+                new PaymentMethodsActivityStarter.Args.Builder()
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                        .build()
         );
         mShadowActivity = Shadows.shadowOf(mPaymentMethodsActivity);
 
@@ -152,6 +157,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     @Test
     public void onClickAddSourceView_whenStartedFromPaymentSession_launchesActivityWithLog() {
         mPaymentMethodsActivity = createActivity(new PaymentMethodsActivityStarter.Args.Builder()
+                .setPaymentConfiguration(PaymentConfiguration.getInstance())
                 .setIsPaymentSessionActive(true)
                 .build());
         mShadowActivity = Shadows.shadowOf(mPaymentMethodsActivity);


### PR DESCRIPTION
PaymentConfiguration's singleton instance will be GCed when it is no
longer referenced. Pass it via the Intent to ensure it is not GCed
between `PaymentMethodsActivity` and `AddPaymentMethodActivity`.