### PR TITLE
Add shouldPrefetchEphemeralKey arg to CustomerSession.initCustomerSession()

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -41,8 +41,11 @@ class CustomerSessionActivity : AppCompatActivity() {
         selectSourceButton = findViewById(R.id.btn_launch_payment_methods_acs)
         selectSourceButton.isEnabled = false
         errorDialogHandler = ErrorDialogHandler(this)
-        CustomerSession.initCustomerSession(this,
-            ExampleEphemeralKeyProvider(ProgressListenerImpl(this)))
+        CustomerSession.initCustomerSession(
+            this,
+            ExampleEphemeralKeyProvider(ProgressListenerImpl(this)),
+            false
+        )
 
         progressBar.visibility = View.VISIBLE
         CustomerSession.getInstance().retrieveCurrentCustomer(

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -102,8 +102,11 @@ class PaymentSessionActivity : AppCompatActivity() {
     }
 
     private fun createCustomerSession(): CustomerSession {
-        CustomerSession.initCustomerSession(this,
-            ExampleEphemeralKeyProvider(ProgressListenerImpl(this)))
+        CustomerSession.initCustomerSession(
+            this,
+            ExampleEphemeralKeyProvider(ProgressListenerImpl(this)),
+            false
+        )
         return CustomerSession.getInstance()
     }
 

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.java
@@ -28,14 +28,18 @@ class EphemeralKeyManager<TEphemeralKey extends EphemeralKey> {
             long timeBufferInSeconds,
             @Nullable Calendar overrideCalendar,
             @NonNull OperationIdFactory operationIdFactory,
-            @NonNull EphemeralKey.Factory<TEphemeralKey> factory) {
+            @NonNull EphemeralKey.Factory<TEphemeralKey> factory,
+            boolean shouldPrefetchEphemeralKey) {
         mFactory = factory;
         mEphemeralKeyProvider = ephemeralKeyProvider;
         mListener = keyManagerListener;
         mTimeBufferInSeconds = timeBufferInSeconds;
         mOverrideCalendar = overrideCalendar;
         mApiVersion = ApiVersion.get().code;
-        retrieveEphemeralKey(operationIdFactory.create(), null, null);
+
+        if (shouldPrefetchEphemeralKey) {
+            retrieveEphemeralKey(operationIdFactory.create(), null, null);
+        }
     }
 
     void retrieveEphemeralKey(@NonNull String operationId,

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -73,14 +73,16 @@ public class IssuingCardPinService
             @NonNull StripeApiHandler apiHandler,
             @NonNull OperationIdFactory operationIdFactory) {
         mOperationIdFactory = operationIdFactory;
+        mApiHandler = apiHandler;
         mEphemeralKeyManager = new EphemeralKeyManager<>(
                 keyProvider,
                 this,
                 KEY_REFRESH_BUFFER_IN_SECONDS,
                 null,
                 operationIdFactory,
-                new IssuingCardEphemeralKey.Factory());
-        mApiHandler = apiHandler;
+                new IssuingCardEphemeralKey.Factory(),
+                true
+        );
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.java
@@ -1152,6 +1152,6 @@ public class CustomerSessionTest extends BaseViewTest<PaymentFlowActivity> {
         return new CustomerSession(ApplicationProvider.getApplicationContext(),
                 mEphemeralKeyProvider, calendar, mThreadPoolExecutor, mApiHandler,
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                "acct_abc123");
+                "acct_abc123", true);
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -234,14 +234,14 @@ public class PaymentSessionTest {
     public void getSelectedPaymentMethodId_whenPrefsNotSet_returnsNull() {
         when(mCustomerSession.getCachedCustomer()).thenReturn(FIRST_CUSTOMER);
         CustomerSession.setInstance(mCustomerSession);
-        assertNull(createPaymentSesson().getSelectedPaymentMethodId(null));
+        assertNull(createPaymentSession().getSelectedPaymentMethodId(null));
     }
 
     @Test
     public void getSelectedPaymentMethodId_whenHasPaymentSessionData_returnsExpectedId() {
         mPaymentSessionData.setPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD);
         assertEquals("pm_123456789",
-                createPaymentSesson().getSelectedPaymentMethodId(null));
+                createPaymentSession().getSelectedPaymentMethodId(null));
     }
 
     @Test
@@ -253,14 +253,14 @@ public class PaymentSessionTest {
         CustomerSession.setInstance(mCustomerSession);
 
         assertEquals("pm_12345",
-                createPaymentSesson().getSelectedPaymentMethodId(null));
+                createPaymentSession().getSelectedPaymentMethodId(null));
     }
 
     @Test
     public void getSelectedPaymentMethodId_whenHasUserSpecifiedPaymentMethod_returnsExpectedId() {
         mPaymentSessionData.setPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD);
         assertEquals("pm_987",
-                createPaymentSesson().getSelectedPaymentMethodId("pm_987"));
+                createPaymentSession().getSelectedPaymentMethodId("pm_987"));
     }
 
     @Test
@@ -355,7 +355,7 @@ public class PaymentSessionTest {
 
     @Test
     public void handlePaymentData_withInvalidRequestCode_aborts() {
-        final PaymentSession paymentSession = createPaymentSesson();
+        final PaymentSession paymentSession = createPaymentSession();
         assertFalse(paymentSession.handlePaymentData(-1, RESULT_CANCELED, new Intent()));
         verify(mCustomerSession, never()).retrieveCurrentCustomer(
                 ArgumentMatchers.<CustomerSession.CustomerRetrievalListener>any());
@@ -363,7 +363,7 @@ public class PaymentSessionTest {
 
     @Test
     public void handlePaymentData_withValidRequestCodeAndCanceledResult_retrievesCustomer() {
-        final PaymentSession paymentSession = createPaymentSesson();
+        final PaymentSession paymentSession = createPaymentSession();
         assertFalse(paymentSession.handlePaymentData(PaymentSession.PAYMENT_METHOD_REQUEST,
                 RESULT_CANCELED, new Intent()));
         verify(mCustomerSession).retrieveCurrentCustomer(
@@ -371,7 +371,7 @@ public class PaymentSessionTest {
     }
 
     @NonNull
-    private PaymentSession createPaymentSesson() {
+    private PaymentSession createPaymentSession() {
         return new PaymentSession(mCustomerSession, mPaymentMethodsActivityStarter,
                 mPaymentFlowActivityStarter, mPaymentSessionData,
                 mPaymentSessionPrefs);
@@ -382,6 +382,6 @@ public class PaymentSessionTest {
         return new CustomerSession(ApplicationProvider.getApplicationContext(),
                 mEphemeralKeyProvider, null, mThreadPoolExecutor, mApiHandler,
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                "acct_abc123");
+                "acct_abc123", true);
     }
 }


### PR DESCRIPTION
## Summary
If `shouldPrefetchEphemeralKey` is true, an ephemeral key will be fetched immediately in `EphemeralKeyManager`. Otherwise, only fetch an ephemeral key when needed.

Default `true` to maintain existing behavior.

## Motivation
Fixes #797

## Testing
Added unit tests + manually verified
