### PR TITLE
Rename MaskedCardAdapter to PaymentMethodsAdapter

### DIFF
--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -72,7 +72,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         mPaymentMethods = Arrays.asList(PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON),
-                PaymentMethod.fromString(MaskedCardAdapterTest.PAYMENT_METHOD_JSON));
+                PaymentMethod.fromString(PaymentMethodsAdapterTest.PAYMENT_METHOD_JSON));
 
         mPaymentMethodsActivity = createActivity(
                 new PaymentMethodsActivityStarter.Args.Builder()
@@ -136,10 +136,10 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
 
         listener.onPaymentMethodsRetrieved(mPaymentMethods);
 
-        final MaskedCardAdapter maskedCardAdapter = (MaskedCardAdapter) mRecyclerView.getAdapter();
-        assertNotNull(maskedCardAdapter);
-        assertNotNull(maskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod.id, maskedCardAdapter.getSelectedPaymentMethod().id);
+        final PaymentMethodsAdapter paymentMethodsAdapter = (PaymentMethodsAdapter) mRecyclerView.getAdapter();
+        assertNotNull(paymentMethodsAdapter);
+        assertNotNull(paymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod.id, paymentMethodsAdapter.getSelectedPaymentMethod().id);
     }
 
     @Test
@@ -197,10 +197,11 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         assertNotNull(mRecyclerView.getAdapter());
         assertEquals(2, mRecyclerView.getAdapter().getItemCount());
 
-        final MaskedCardAdapter maskedCardAdapter = (MaskedCardAdapter) mRecyclerView.getAdapter();
-        assertNotNull(maskedCardAdapter);
-        assertNotNull(maskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod.id, maskedCardAdapter.getSelectedPaymentMethod().id);
+        final PaymentMethodsAdapter paymentMethodsAdapter =
+                (PaymentMethodsAdapter) mRecyclerView.getAdapter();
+        assertNotNull(paymentMethodsAdapter);
+        assertNotNull(paymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod.id, paymentMethodsAdapter.getSelectedPaymentMethod().id);
     }
 
     @Test
@@ -218,9 +219,9 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         assertNotNull(listener);
 
         listener.onPaymentMethodsRetrieved(mPaymentMethods);
-        final MaskedCardAdapter maskedCardAdapter = (MaskedCardAdapter) mRecyclerView.getAdapter();
-        assertNotNull(maskedCardAdapter);
-        maskedCardAdapter.setSelectedIndex(0);
+        final PaymentMethodsAdapter paymentMethodsAdapter = (PaymentMethodsAdapter) mRecyclerView.getAdapter();
+        assertNotNull(paymentMethodsAdapter);
+        paymentMethodsAdapter.setSelectedIndex(0);
 
         final MenuItem menuItem = mock(MenuItem.class);
         when(menuItem.getItemId()).thenReturn(R.id.action_save);

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -23,12 +22,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * Test class for {@link MaskedCardAdapter}
+ * Test class for {@link PaymentMethodsAdapter}
  */
 @RunWith(RobolectricTestRunner.class)
-public class MaskedCardAdapterTest {
+public class PaymentMethodsAdapterTest {
 
-    public static final String PAYMENT_METHOD_JSON = "{\n" +
+    static final String PAYMENT_METHOD_JSON = "{\n" +
             "\t\"id\": \"pm_987654321\",\n" +
             "\t\"created\": 1550757934256,\n" +
             "\t\"customer\": \"cus_AQsHpvKfKwJDrF\",\n" +
@@ -68,13 +67,13 @@ public class MaskedCardAdapterTest {
 
 
     @Mock RecyclerView.AdapterDataObserver mAdapterDataObserver;
-    private MaskedCardAdapter mMaskedCardAdapter;
+    private PaymentMethodsAdapter mPaymentMethodsAdapter;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mMaskedCardAdapter = new MaskedCardAdapter(new ArrayList<PaymentMethod>());
-        mMaskedCardAdapter.registerAdapterDataObserver(mAdapterDataObserver);
+        mPaymentMethodsAdapter = new PaymentMethodsAdapter();
+        mPaymentMethodsAdapter.registerAdapterDataObserver(mAdapterDataObserver);
     }
 
     @Test
@@ -87,22 +86,22 @@ public class MaskedCardAdapterTest {
         assertNotNull(paymentMethod1.id);
         assertNotNull(paymentMethod2.id);
         final List<PaymentMethod> paymentMethods = Arrays.asList(paymentMethod1, paymentMethod2);
-        mMaskedCardAdapter.setPaymentMethods(paymentMethods);
-        assertEquals(2, mMaskedCardAdapter.getItemCount());
+        mPaymentMethodsAdapter.setPaymentMethods(paymentMethods);
+        assertEquals(2, mPaymentMethodsAdapter.getItemCount());
         verify(mAdapterDataObserver, times(1)).onChanged();
 
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod2.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod2.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
 
-        mMaskedCardAdapter.setSelectedPaymentMethod(paymentMethod1.id);
+        mPaymentMethodsAdapter.setSelectedPaymentMethod(paymentMethod1.id);
         verify(mAdapterDataObserver, times(1)).onChanged();
 
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod1.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod1.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
 
-        mMaskedCardAdapter.setSelectedIndex(1);
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod2.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        mPaymentMethodsAdapter.setSelectedIndex(1);
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod2.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
     }
 
     @Test
@@ -116,16 +115,16 @@ public class MaskedCardAdapterTest {
         assertNotNull(paymentMethod1);
         assertNotNull(paymentMethod1.id);
 
-        mMaskedCardAdapter.setPaymentMethods(singlePaymentMethod);
-        assertEquals(1, mMaskedCardAdapter.getItemCount());
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
+        mPaymentMethodsAdapter.setPaymentMethods(singlePaymentMethod);
+        assertEquals(1, mPaymentMethodsAdapter.getItemCount());
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
 
-        assertEquals(paymentMethod1.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        assertEquals(paymentMethod1.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
 
-        mMaskedCardAdapter.setPaymentMethods(paymentMethods);
-        assertEquals(2, mMaskedCardAdapter.getItemCount());
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod1.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        mPaymentMethodsAdapter.setPaymentMethods(paymentMethods);
+        assertEquals(2, mPaymentMethodsAdapter.getItemCount());
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod1.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
         verify(mAdapterDataObserver, times(2)).onChanged();
     }
 
@@ -139,14 +138,14 @@ public class MaskedCardAdapterTest {
         final List<PaymentMethod> singlePaymentMethod = Collections.singletonList(paymentMethod2);
         final List<PaymentMethod> paymentMethods = Arrays.asList(paymentMethod1, paymentMethod2);
 
-        mMaskedCardAdapter.setPaymentMethods(singlePaymentMethod);
-        assertEquals(1, mMaskedCardAdapter.getItemCount());
-        mMaskedCardAdapter.setSelectedIndex(0);
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
+        mPaymentMethodsAdapter.setPaymentMethods(singlePaymentMethod);
+        assertEquals(1, mPaymentMethodsAdapter.getItemCount());
+        mPaymentMethodsAdapter.setSelectedIndex(0);
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
 
-        mMaskedCardAdapter.setPaymentMethods(paymentMethods);
-        assertEquals(2, mMaskedCardAdapter.getItemCount());
-        assertNotNull(mMaskedCardAdapter.getSelectedPaymentMethod());
-        assertEquals(paymentMethod2.id, mMaskedCardAdapter.getSelectedPaymentMethod().id);
+        mPaymentMethodsAdapter.setPaymentMethods(paymentMethods);
+        assertEquals(2, mPaymentMethodsAdapter.getItemCount());
+        assertNotNull(mPaymentMethodsAdapter.getSelectedPaymentMethod());
+        assertEquals(paymentMethod2.id, mPaymentMethodsAdapter.getSelectedPaymentMethod().id);
     }
 }


### PR DESCRIPTION
This refactor makes `PaymentMethodsAdapter` more generic
with the goal of supporting a variety of view types.

- Override getItemId() and getItemViewType()
- Set hasStableIds to true