### PR TITLE
Improve PaymentMethodsAdapter and PaymentMethodsActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.java
@@ -91,9 +91,12 @@ final class PaymentMethodsAdapter extends RecyclerView.Adapter<PaymentMethodsAda
             public void onClick(View view) {
                 final int currentPosition = holder.getAdapterPosition();
                 if (currentPosition != mSelectedIndex) {
+                    final int prevSelectedIndex = mSelectedIndex;
                     holder.toggleSelected();
                     setSelectedIndex(currentPosition);
-                    notifyDataSetChanged();
+
+                    notifyItemChanged(prevSelectedIndex);
+                    notifyItemChanged(currentPosition);
                 }
             }
         });


### PR DESCRIPTION
- `PaymentMethodsAdapter`
  - Use `notifyItemChanged()` instead of `notifyDataSetChanged()`
- `PaymentMethodsActivity`
  - Disable RecyclerView item animation
  - Instantiate `PaymentMethodsAdapter` in `onCreate()` and
    remove `@Nullable` annotation

![Screenshot_1565878610](https://user-images.githubusercontent.com/45020849/63100810-d5ac5380-bf45-11e9-8c7b-e465aa6af609.png)
