### PR TITLE
Update AddPaymentMethodActivity logic for attaching to customer

### DIFF
--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.java
@@ -103,7 +103,7 @@ public class StripeNetworkUtilsTest {
     public void addUidParamsToPaymentIntent_withPaymentMethodParams_addsUidAtRightLevel() {
         final Map<String, Object> existingMap = new HashMap<>();
         final Map<String, Object> paymentMethodCreateParamsMap =
-                PaymentMethodCreateParamsFixtures.DEFAULT.toParamMap();
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap();
         existingMap.put(ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_DATA,
                 paymentMethodCreateParamsMap);
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1197,7 +1197,7 @@ public class StripeTest {
                 .build();
 
         final PaymentMethodCreateParams paymentMethodCreateParams =
-                PaymentMethodCreateParamsFixtures.DEFAULT;
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD;
         final Stripe stripe = createStripe();
         final PaymentMethod createdPaymentMethod = stripe.createPaymentMethodSynchronous(
                 paymentMethodCreateParams);

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.java
@@ -74,7 +74,7 @@ public class ConfirmPaymentIntentParamsTest {
     @Test
     public void createWithPaymentMethodCreateParams_hasExpectedFields() {
         final PaymentMethodCreateParams paymentMethodCreateParams =
-                PaymentMethodCreateParamsFixtures.DEFAULT;
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD;
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodCreateParams(paymentMethodCreateParams,
                         CLIENT_SECRET, RETURN_URL);
@@ -100,7 +100,7 @@ public class ConfirmPaymentIntentParamsTest {
     @Test
     public void createConfirmPaymentIntentWithPaymentMethodCreateParams_withSavePaymentMethod_hasExpectedFields() {
         final PaymentMethodCreateParams paymentMethodCreateParams =
-                PaymentMethodCreateParamsFixtures.DEFAULT;
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD;
         final ConfirmPaymentIntentParams params = ConfirmPaymentIntentParams
                 .createWithPaymentMethodCreateParams(paymentMethodCreateParams,
                         CLIENT_SECRET, RETURN_URL, true);
@@ -222,7 +222,7 @@ public class ConfirmPaymentIntentParamsTest {
         extraParams.put("key", "value");
         final ConfirmPaymentIntentParams params =
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                        PaymentMethodCreateParamsFixtures.DEFAULT, CLIENT_SECRET, RETURN_URL, true, extraParams
+                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD, CLIENT_SECRET, RETURN_URL, true, extraParams
                 );
 
         assertEquals(params, params.toBuilder().build());

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.java
@@ -26,10 +26,17 @@ public final class PaymentMethodCreateParamsFixtures {
                             .build())
                     .build();
 
-    public static final PaymentMethodCreateParams DEFAULT =
+    public static final PaymentMethodCreateParams DEFAULT_CARD =
             PaymentMethodCreateParams.create(
                     CARD,
                     BILLING_DETAILS
+            );
+
+    public static final PaymentMethodCreateParams DEFAULT_FPX =
+            PaymentMethodCreateParams.create(
+                    new PaymentMethodCreateParams.Fpx.Builder()
+                            .setBank("hsbc")
+                            .build()
             );
 
     @NonNull

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodFixtures.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodFixtures.java
@@ -38,6 +38,19 @@ public final class PaymentMethodFixtures {
 
     public static final PaymentMethod CARD_PAYMENT_METHOD;
 
+    public static final PaymentMethod FPX_PAYMENT_METHOD =
+            new PaymentMethod.Builder()
+                    .setId("pm_1F5GlnH8dsfnfKo3gtixzcq0")
+                    .setCreated(1565290527L)
+                    .setLiveMode(true)
+                    .setType("fpx")
+                    .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
+                    .setFpx(new PaymentMethod.Fpx.Builder()
+                            .setBank("hsbc")
+                            .setAccountHolderType("individual")
+                            .build())
+                    .build();
+
     static {
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("order_id", "123456789");

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.java
@@ -127,19 +127,8 @@ public class PaymentMethodTest {
 
     @Test
     public void toJson_withFpx_shouldCreateExpectedObject() throws JSONException {
-        final PaymentMethod paymentMethod = new PaymentMethod.Builder()
-                .setId("pm_1F5GlnH8dsfnfKo3gtixzcq0")
-                .setCreated(1565290527L)
-                .setLiveMode(true)
-                .setType("fpx")
-                .setBillingDetails(PaymentMethodFixtures.BILLING_DETAILS)
-                .setFpx(new PaymentMethod.Fpx.Builder()
-                        .setBank("hsbc")
-                        .setAccountHolderType("individual")
-                        .build())
-                .build();
-
-        assertEquals(paymentMethod, PaymentMethod.fromJson(new JSONObject(PM_FPX_JSON)));
+        assertEquals(PaymentMethodFixtures.FPX_PAYMENT_METHOD,
+                PaymentMethod.fromJson(new JSONObject(PM_FPX_JSON)));
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodCardViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodCardViewTest.java
@@ -33,7 +33,7 @@ public class AddPaymentMethodCardViewTest {
     @Test
     public void softEnterKey_whenDataIsValid_hidesKeyboardAndAttemptsToSave() {
         when(mAddPaymentMethodCardView.getCreateParams())
-                .thenReturn(PaymentMethodCreateParamsFixtures.DEFAULT);
+                .thenReturn(PaymentMethodCreateParamsFixtures.DEFAULT_CARD);
         new AddPaymentMethodCardView.OnEditorActionListenerImpl(
                 mActivity, mAddPaymentMethodCardView, mInputMethodManager)
                 .onEditorAction(null, EditorInfo.IME_ACTION_DONE, null);


### PR DESCRIPTION
Only reusable Payment Methods can be attached to the customer.

Refactor `AddPaymentMethodActivity#createPaymentMethod()` to
take a params object, so that its test doesn't need to set up
and populate the views.