### PR TITLE
Add FPX support in PaymentMethodsActivity

### DIFF
--- a/stripe/res/layout/add_payment_method_fpx_row.xml
+++ b/stripe/res/layout/add_payment_method_fpx_row.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/activity_total_margin"
+    android:focusableInTouchMode="true"
+    android:paddingStart="@dimen/list_row_start_padding"
+    android:paddingEnd="@dimen/list_row_end_padding"
+    android:paddingTop="@dimen/add_payment_method_vertical_padding"
+    android:paddingBottom="@dimen/add_payment_method_vertical_padding"
+    android:background="@drawable/simple_button_background"
+    android:orientation="horizontal">
+
+    <android.support.v7.widget.AppCompatImageView
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/masked_card_icon_width"
+        android:src="@drawable/ic_add_black_32dp"
+        android:tint="?attr/colorAccent"
+        android:focusableInTouchMode="false"
+        android:clickable="false"
+        android:layout_gravity="center_vertical|start"
+        />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="@dimen/list_row_start_padding"
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Medium"
+        android:text="@string/payment_method_add_new_fpx"
+        android:textColor="?attr/colorAccent"
+        android:focusableInTouchMode="false"
+        android:clickable="false"
+        android:layout_gravity="center_vertical|start"
+        />
+
+</LinearLayout>

--- a/stripe/res/values/ids.xml
+++ b/stripe/res/values/ids.xml
@@ -3,4 +3,5 @@
 <resources>
     <item type="id" name="default_reader_id" />
     <item type="id" name="payment_methods_add_card" />
+    <item type="id" name="payment_methods_add_fpx" />
 </resources>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="invalid_cvc">Your card\'s security code is invalid.</string>
     <string name="invalid_zip">Your postal code is incomplete.</string>
     <string name="payment_method_add_new_card">Add new card&#8230;</string>
+    <string name="payment_method_add_new_fpx" tools:ignore="MissingTranslation">Select Bank Account (FPX)&#8230;</string>
     <!--Human-friendly label for something with $0 price-->
     <string name="price_free">Free</string>
     <string name="title_add_a_card">Add a Card</string>

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxRowView.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxRowView.java
@@ -8,17 +8,15 @@ import com.stripe.android.R;
 import com.stripe.android.model.PaymentMethod;
 
 @SuppressLint("ViewConstructor")
-public class AddPaymentMethodCardRowView extends AddPaymentMethodRowView {
-    AddPaymentMethodCardRowView(@NonNull final Activity activity,
-                                @NonNull final PaymentMethodsActivityStarter.Args args) {
+public class AddPaymentMethodFpxRowView extends AddPaymentMethodRowView {
+    AddPaymentMethodFpxRowView(@NonNull final Activity activity,
+                               @NonNull final PaymentMethodsActivityStarter.Args args) {
         super(activity,
-                R.layout.add_payment_method_card_row,
-                R.id.payment_methods_add_card,
+                R.layout.add_payment_method_fpx_row,
+                R.id.payment_methods_add_fpx,
                 new AddPaymentMethodActivityStarter.Args.Builder()
-                        .setShouldUpdateCustomer(true)
-                        .setShouldRequirePostalCode(args.shouldRequirePostalCode)
                         .setIsPaymentSessionActive(args.isPaymentSessionActive)
-                        .setPaymentMethodType(PaymentMethod.Type.Card)
+                        .setPaymentMethodType(PaymentMethod.Type.Fpx)
                         .setPaymentConfiguration(args.paymentConfiguration)
                         .build());
     }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.java
@@ -1,0 +1,27 @@
+package com.stripe.android.view;
+
+import android.app.Activity;
+import android.support.annotation.IdRes;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.FrameLayout;
+
+abstract class AddPaymentMethodRowView extends FrameLayout {
+    AddPaymentMethodRowView(@NonNull final Activity activity,
+                            @LayoutRes int layoutId,
+                            @IdRes int idRes,
+                            @NonNull final AddPaymentMethodActivityStarter.Args args) {
+        super(activity);
+        inflate(activity, layoutId, this);
+        setId(idRes);
+
+        setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(@NonNull View view) {
+                new AddPaymentMethodActivityStarter(activity).startForResult(
+                        PaymentMethodsActivity.REQUEST_CODE_ADD_PAYMENT_METHOD, args);
+            }
+        });
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -82,6 +82,9 @@ public class PaymentMethodsActivity extends AppCompatActivity {
 
         final View addCardView = new AddPaymentMethodCardRowView(this, args);
         addPaymentMethodsContainer.addView(addCardView);
+        if (args.paymentMethodTypes.contains(PaymentMethod.Type.Fpx)) {
+            addPaymentMethodsContainer.addView(new AddPaymentMethodFpxRowView(this, args));
+        }
 
         final Toolbar toolbar = findViewById(R.id.payment_methods_toolbar);
         setSupportActionBar(toolbar);


### PR DESCRIPTION
If PaymentMethodsActivity is started with FPX support,
an option to select an FPX bank will be shown.
