### PR TITLE
Refactor ActivityStarter

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -13,6 +13,7 @@ import com.stripe.android.CustomerSession
 import com.stripe.android.StripeError
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.view.AddPaymentMethodActivityStarter
 import com.stripe.android.view.PaymentMethodsActivity
 import com.stripe.android.view.PaymentMethodsActivityStarter
 import com.stripe.example.R
@@ -55,13 +56,15 @@ class CustomerSessionActivity : AppCompatActivity() {
     }
 
     private fun launchWithCustomer() {
-        PaymentMethodsActivityStarter(this).startForResult(REQUEST_CODE_SELECT_SOURCE)
+        PaymentMethodsActivityStarter(this).startForResult()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == REQUEST_CODE_SELECT_SOURCE && resultCode == Activity.RESULT_OK) {
-            val paymentMethod = data!!.getParcelableExtra<PaymentMethod>(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT)
+        if (requestCode == AddPaymentMethodActivityStarter.REQUEST_CODE &&
+            resultCode == Activity.RESULT_OK && data != null) {
+            val paymentMethod = data
+                .getParcelableExtra<PaymentMethod>(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT)
 
             if (paymentMethod?.card != null) {
                 selectedSourceTextView.text = buildCardString(paymentMethod.card!!)
@@ -110,9 +113,5 @@ class CustomerSessionActivity : AppCompatActivity() {
                 }
             }
         }
-    }
-
-    companion object {
-        private const val REQUEST_CODE_SELECT_SOURCE = 55
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -27,9 +27,6 @@ public class PaymentSession {
     public static final String TOKEN_PAYMENT_SESSION = "PaymentSession";
     public static final String EXTRA_PAYMENT_SESSION_ACTIVE = "payment_session_active";
 
-    static final int PAYMENT_SHIPPING_DETAILS_REQUEST = 3004;
-    static final int PAYMENT_METHOD_REQUEST = 3003;
-
     public static final String PAYMENT_SESSION_DATA_KEY = "payment_session_data";
 
     @NonNull
@@ -103,8 +100,8 @@ public class PaymentSession {
      * otherwise {@code false}
      */
     public boolean handlePaymentData(int requestCode, int resultCode, @NonNull Intent data) {
-        if (requestCode != PAYMENT_METHOD_REQUEST &&
-                requestCode != PAYMENT_SHIPPING_DETAILS_REQUEST) {
+        if (requestCode != PaymentMethodsActivityStarter.REQUEST_CODE &&
+                requestCode != PaymentFlowActivityStarter.REQUEST_CODE) {
             return false;
         }
 
@@ -113,7 +110,7 @@ public class PaymentSession {
             return false;
         } else if (resultCode == Activity.RESULT_OK) {
             switch (requestCode) {
-                case PAYMENT_METHOD_REQUEST: {
+                case PaymentMethodsActivityStarter.REQUEST_CODE: {
                     final PaymentMethod paymentMethod =
                             data.getParcelableExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT);
                     if (paymentMethod != null) {
@@ -128,7 +125,7 @@ public class PaymentSession {
                     }
                     return true;
                 }
-                case PAYMENT_SHIPPING_DETAILS_REQUEST: {
+                case PaymentFlowActivityStarter.REQUEST_CODE: {
                     final PaymentSessionData paymentSessionData = data.getParcelableExtra(
                             PAYMENT_SESSION_DATA_KEY);
                     paymentSessionData.updateIsPaymentReadyToCharge(mPaymentSessionConfig);
@@ -283,7 +280,7 @@ public class PaymentSession {
      */
     public void presentPaymentMethodSelection(boolean shouldRequirePostalCode,
                                               @Nullable String userSelectedPaymentMethodId) {
-        mPaymentMethodsActivityStarter.startForResult(PAYMENT_METHOD_REQUEST,
+        mPaymentMethodsActivityStarter.startForResult(
                 new PaymentMethodsActivityStarter.Args.Builder()
                         .setInitialPaymentMethodId(
                                 getSelectedPaymentMethodId(userSelectedPaymentMethodId))
@@ -336,12 +333,13 @@ public class PaymentSession {
      * Launch the {@link PaymentFlowActivity} to allow the user to fill in payment details.
      */
     public void presentShippingFlow() {
-        mPaymentFlowActivityStarter.startForResult(PAYMENT_SHIPPING_DETAILS_REQUEST,
+        mPaymentFlowActivityStarter.startForResult(
                 new PaymentFlowActivityStarter.Args.Builder()
                         .setPaymentSessionConfig(mPaymentSessionConfig)
                         .setPaymentSessionData(mPaymentSessionData)
                         .setIsPaymentSessionActive(true)
-                        .build());
+                        .build()
+        );
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
@@ -15,37 +15,42 @@ public abstract class ActivityStarter
     @Nullable private final Fragment mFragment;
     @NonNull private final Class<TargetActivityType> mTargetClass;
     @NonNull private final ArgsType mDefaultArgs;
+    @NonNull private final int mRequestCode;
 
     ActivityStarter(@NonNull Activity activity,
                     @NonNull Class<TargetActivityType> targetClass,
-                    @NonNull ArgsType args) {
+                    @NonNull ArgsType args,
+                    int requestCode) {
         mActivity = activity;
         mFragment = null;
         mTargetClass = targetClass;
         mDefaultArgs = args;
+        mRequestCode = requestCode;
     }
 
     ActivityStarter(@NonNull Fragment fragment,
                     @NonNull Class<TargetActivityType> targetClass,
-                    @NonNull ArgsType args) {
+                    @NonNull ArgsType args,
+                    int requestCode) {
         mActivity = fragment.requireActivity();
         mFragment = fragment;
         mTargetClass = targetClass;
         mDefaultArgs = args;
+        mRequestCode = requestCode;
     }
 
-    public final void startForResult(final int requestCode) {
-        startForResult(requestCode, mDefaultArgs);
+    public final void startForResult() {
+        startForResult(mDefaultArgs);
     }
 
-    public final void startForResult(int requestCode, @NonNull ArgsType args) {
+    public final void startForResult(@NonNull ArgsType args) {
         final Intent intent = newIntent()
                 .putExtra(Args.EXTRA, args);
 
         if (mFragment != null) {
-            Objects.requireNonNull(mFragment).startActivityForResult(intent, requestCode);
+            Objects.requireNonNull(mFragment).startActivityForResult(intent, mRequestCode);
         } else {
-            mActivity.startActivityForResult(intent, requestCode);
+            mActivity.startActivityForResult(intent, mRequestCode);
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -62,7 +62,7 @@ public class AddPaymentMethodActivity extends StripeActivity {
 
         configureView(args);
 
-        mShouldAttachToCustomer = mPaymentMethodType.isReusable && args.shouldUpdateCustomer;
+        mShouldAttachToCustomer = mPaymentMethodType.isReusable && args.shouldAttachToCustomer;
         mStartedFromPaymentSession = args.isPaymentSessionActive;
 
         if (mShouldAttachToCustomer && args.shouldInitCustomerSessionTokens) {

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -14,16 +14,24 @@ import com.stripe.android.utils.ObjectUtils;
 
 import java.util.Objects;
 
-public class AddPaymentMethodActivityStarter
+/**
+ * A class to start {@link AddPaymentMethodActivity}. Arguments for the activity can be
+ * specified with {@link Args} and constructed with {@link Args.Builder}.
+ *
+ * <p>The result will be returned with request code {@link #REQUEST_CODE}.</p>
+ */
+public final class AddPaymentMethodActivityStarter
         extends ActivityStarter<AddPaymentMethodActivity, AddPaymentMethodActivityStarter.Args> {
+    public static final int REQUEST_CODE = 6001;
+
     AddPaymentMethodActivityStarter(@NonNull Activity activity) {
-        super(activity, AddPaymentMethodActivity.class, Args.DEFAULT);
+        super(activity, AddPaymentMethodActivity.class, Args.DEFAULT, REQUEST_CODE);
     }
 
     public static final class Args implements ActivityStarter.Args {
         private static final Args DEFAULT = new Args.Builder().build();
 
-        final boolean shouldUpdateCustomer;
+        final boolean shouldAttachToCustomer;
         final boolean shouldRequirePostalCode;
         final boolean isPaymentSessionActive;
         final boolean shouldInitCustomerSessionTokens;
@@ -38,7 +46,7 @@ public class AddPaymentMethodActivityStarter
         }
 
         private Args(@NonNull AddPaymentMethodActivityStarter.Args.Builder builder) {
-            this.shouldUpdateCustomer = builder.mShouldUpdateCustomer;
+            this.shouldAttachToCustomer = builder.mShouldAttachToCustomer;
             this.shouldRequirePostalCode = builder.mShouldRequirePostalCode;
             this.isPaymentSessionActive = builder.mIsPaymentSessionActive;
             this.shouldInitCustomerSessionTokens = builder.mShouldInitCustomerSessionTokens;
@@ -50,7 +58,7 @@ public class AddPaymentMethodActivityStarter
         }
 
         private Args(@NonNull Parcel in) {
-            this.shouldUpdateCustomer = in.readInt() == 1;
+            this.shouldAttachToCustomer = in.readInt() == 1;
             this.shouldRequirePostalCode = in.readInt() == 1;
             this.isPaymentSessionActive = in.readInt() == 1;
             this.shouldInitCustomerSessionTokens = in.readInt() == 1;
@@ -66,7 +74,7 @@ public class AddPaymentMethodActivityStarter
 
         @Override
         public void writeToParcel(Parcel dest, int flags) {
-            dest.writeInt(shouldUpdateCustomer ? 1 : 0);
+            dest.writeInt(shouldAttachToCustomer ? 1 : 0);
             dest.writeInt(shouldRequirePostalCode ? 1 : 0);
             dest.writeInt(isPaymentSessionActive ? 1 : 0);
             dest.writeInt(shouldInitCustomerSessionTokens ? 1 : 0);
@@ -76,7 +84,7 @@ public class AddPaymentMethodActivityStarter
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(shouldUpdateCustomer, shouldRequirePostalCode,
+            return ObjectUtils.hash(shouldAttachToCustomer, shouldRequirePostalCode,
                     isPaymentSessionActive, shouldInitCustomerSessionTokens, paymentMethodType,
                     paymentConfiguration);
         }
@@ -87,7 +95,7 @@ public class AddPaymentMethodActivityStarter
         }
 
         private boolean typedEquals(@NonNull Args args) {
-            return ObjectUtils.equals(shouldUpdateCustomer, args.shouldUpdateCustomer) &&
+            return ObjectUtils.equals(shouldAttachToCustomer, args.shouldAttachToCustomer) &&
                     ObjectUtils.equals(shouldRequirePostalCode, args.shouldRequirePostalCode) &&
                     ObjectUtils.equals(isPaymentSessionActive, args.isPaymentSessionActive) &&
                     ObjectUtils.equals(shouldInitCustomerSessionTokens,
@@ -114,7 +122,7 @@ public class AddPaymentMethodActivityStarter
 
         public static final class Builder
                 implements ObjectBuilder<AddPaymentMethodActivityStarter.Args> {
-            private boolean mShouldUpdateCustomer;
+            private boolean mShouldAttachToCustomer;
             private boolean mShouldRequirePostalCode;
             private boolean mIsPaymentSessionActive = false;
             private boolean mShouldInitCustomerSessionTokens = true;
@@ -122,17 +130,21 @@ public class AddPaymentMethodActivityStarter
             @Nullable private PaymentConfiguration mPaymentConfiguration;
 
             /**
-             * If true, update using an already-initialized
-             * {@link com.stripe.android.CustomerSession}
+             * If true, the created Payment Method will be attached to the current Customer
+             * using an already-initialized {@link com.stripe.android.CustomerSession}.
              */
             @NonNull
-            Builder setShouldUpdateCustomer(boolean shouldUpdateCustomer) {
-                this.mShouldUpdateCustomer = shouldUpdateCustomer;
+            public Builder setShouldAttachToCustomer(boolean shouldAttachToCustomer) {
+                this.mShouldAttachToCustomer = shouldAttachToCustomer;
                 return this;
             }
 
+            /**
+             * If true, a postal code field will be shown and validated.
+             * Currently, only US ZIP Codes are supported.
+             */
             @NonNull
-            Builder setShouldRequirePostalCode(boolean shouldRequirePostalCode) {
+            public Builder setShouldRequirePostalCode(boolean shouldRequirePostalCode) {
                 this.mShouldRequirePostalCode = shouldRequirePostalCode;
                 return this;
             }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.java
@@ -15,7 +15,7 @@ public class AddPaymentMethodCardRowView extends AddPaymentMethodRowView {
                 R.layout.add_payment_method_card_row,
                 R.id.payment_methods_add_card,
                 new AddPaymentMethodActivityStarter.Args.Builder()
-                        .setShouldUpdateCustomer(true)
+                        .setShouldAttachToCustomer(true)
                         .setShouldRequirePostalCode(args.shouldRequirePostalCode)
                         .setIsPaymentSessionActive(args.isPaymentSessionActive)
                         .setPaymentMethodType(PaymentMethod.Type.Card)

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.java
@@ -19,8 +19,7 @@ abstract class AddPaymentMethodRowView extends FrameLayout {
         setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(@NonNull View view) {
-                new AddPaymentMethodActivityStarter(activity).startForResult(
-                        PaymentMethodsActivity.REQUEST_CODE_CREATE_PAYMENT_METHOD, args);
+                new AddPaymentMethodActivityStarter(activity).startForResult(args);
             }
         });
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.java
@@ -17,12 +17,14 @@ import java.util.Objects;
 
 public final class PaymentFlowActivityStarter
         extends ActivityStarter<PaymentFlowActivity, PaymentFlowActivityStarter.Args> {
+    public static final int REQUEST_CODE = 6002;
+
     public PaymentFlowActivityStarter(@NonNull Activity activity) {
-        super(activity, PaymentFlowActivity.class, Args.DEFAULT);
+        super(activity, PaymentFlowActivity.class, Args.DEFAULT, REQUEST_CODE);
     }
 
     public PaymentFlowActivityStarter(@NonNull Fragment fragment) {
-        super(fragment, PaymentFlowActivity.class, Args.DEFAULT);
+        super(fragment, PaymentFlowActivity.class, Args.DEFAULT, REQUEST_CODE);
     }
 
     public static final class Args implements ActivityStarter.Args {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -41,7 +41,6 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     public static final String EXTRA_SELECTED_PAYMENT = "selected_payment";
     public static final String TOKEN_PAYMENT_METHODS_ACTIVITY = "PaymentMethodsActivity";
 
-    static final int REQUEST_CODE_CREATE_PAYMENT_METHOD = 700;
     private boolean mCommunicating;
     private PaymentMethodsAdapter mAdapter;
     private ProgressBar mProgressBar;
@@ -110,7 +109,8 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == REQUEST_CODE_CREATE_PAYMENT_METHOD && resultCode == RESULT_OK) {
+        if (requestCode == AddPaymentMethodActivityStarter.REQUEST_CODE &&
+                resultCode == RESULT_OK) {
             onPaymentMethodCreated(data);
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -20,12 +20,14 @@ import java.util.Set;
 
 public final class PaymentMethodsActivityStarter
         extends ActivityStarter<PaymentMethodsActivity, PaymentMethodsActivityStarter.Args> {
+    public static final int REQUEST_CODE = 6000;
+
     public PaymentMethodsActivityStarter(@NonNull Activity activity) {
-        super(activity, PaymentMethodsActivity.class, Args.DEFAULT);
+        super(activity, PaymentMethodsActivity.class, Args.DEFAULT, REQUEST_CODE);
     }
 
     public PaymentMethodsActivityStarter(@NonNull Fragment fragment) {
-        super(fragment, PaymentMethodsActivity.class, Args.DEFAULT);
+        super(fragment, PaymentMethodsActivity.class, Args.DEFAULT, REQUEST_CODE);
     }
 
     public static final class Args implements ActivityStarter.Args {
@@ -145,16 +147,15 @@ public final class PaymentMethodsActivityStarter
             }
 
             @NonNull
-            public Builder setPaymentMethodTypes(
-                    @NonNull Set<PaymentMethod.Type> paymentMethodTypes) {
-                mPaymentMethodTypes = paymentMethodTypes;
+            public Builder setPaymentConfiguration(
+                    @Nullable PaymentConfiguration paymentConfiguration) {
+                this.mPaymentConfiguration = paymentConfiguration;
                 return this;
             }
 
             @NonNull
-            public Builder setPaymentConfiguration(
-                    @Nullable PaymentConfiguration paymentConfiguration) {
-                this.mPaymentConfiguration = paymentConfiguration;
+            Builder setPaymentMethodTypes(@NonNull Set<PaymentMethod.Type> paymentMethodTypes) {
+                mPaymentMethodTypes = paymentMethodTypes;
                 return this;
             }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -150,7 +150,7 @@ public class PaymentSessionTest {
         reset(mPaymentSessionListener);
 
         final boolean handled = paymentSession.handlePaymentData(
-                PaymentSession.PAYMENT_METHOD_REQUEST, RESULT_OK,
+                PaymentMethodsActivityStarter.REQUEST_CODE, RESULT_OK,
                 new Intent().putExtra(PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT,
                         PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON)));
         assertTrue(handled);
@@ -173,7 +173,7 @@ public class PaymentSessionTest {
         paymentSession.presentPaymentMethodSelection();
 
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
-                eq(PaymentSession.PAYMENT_METHOD_REQUEST));
+                eq(PaymentMethodsActivityStarter.REQUEST_CODE));
 
         final Intent intent = mIntentArgumentCaptor.getValue();
         assertNotNull(intent.getComponent());
@@ -194,7 +194,7 @@ public class PaymentSessionTest {
         paymentSession.presentPaymentMethodSelection(true);
 
         verify(mActivity).startActivityForResult(mIntentArgumentCaptor.capture(),
-                eq(PaymentSession.PAYMENT_METHOD_REQUEST));
+                eq(PaymentMethodsActivityStarter.REQUEST_CODE));
         assertTrue(PaymentMethodsActivityStarter.Args.create(mIntentArgumentCaptor.getValue())
                 .shouldRequirePostalCode);
     }
@@ -333,7 +333,7 @@ public class PaymentSessionTest {
     @Test
     public void handlePaymentData_withValidRequestCodeAndCanceledResult_retrievesCustomer() {
         final PaymentSession paymentSession = createPaymentSession();
-        assertFalse(paymentSession.handlePaymentData(PaymentSession.PAYMENT_METHOD_REQUEST,
+        assertFalse(paymentSession.handlePaymentData(PaymentMethodsActivityStarter.REQUEST_CODE,
                 RESULT_CANCELED, new Intent()));
         verify(mCustomerSession).retrieveCurrentCustomer(
                 ArgumentMatchers.<CustomerSession.CustomerRetrievalListener>any());

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -111,7 +111,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
 
     private void setUpForProxySessionTest(@NonNull PaymentMethod.Type paymentMethodType) {
         mActivity = createActivity(new AddPaymentMethodActivityStarter.Args.Builder()
-                .setShouldUpdateCustomer(true)
+                .setShouldAttachToCustomer(true)
                 .setShouldRequirePostalCode(true)
                 .setIsPaymentSessionActive(true)
                 .setShouldInitCustomerSessionTokens(false)

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import static android.app.Activity.RESULT_OK;
 import static com.stripe.android.PaymentSession.EXTRA_PAYMENT_SESSION_ACTIVE;
 import static com.stripe.android.view.PaymentMethodsActivity.EXTRA_SELECTED_PAYMENT;
-import static com.stripe.android.view.PaymentMethodsActivity.REQUEST_CODE_CREATE_PAYMENT_METHOD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -182,7 +181,9 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         final Intent resultIntent = new Intent()
                 .putExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD, paymentMethod);
 
-        mPaymentMethodsActivity.onActivityResult(REQUEST_CODE_CREATE_PAYMENT_METHOD, RESULT_OK, resultIntent);
+        mPaymentMethodsActivity.onActivityResult(
+                AddPaymentMethodActivityStarter.REQUEST_CODE, RESULT_OK, resultIntent
+        );
         assertEquals(View.VISIBLE, mProgressBar.getVisibility());
         verify(mCustomerSession, times(2)).getPaymentMethods(
                 eq(PaymentMethod.Type.Card), mListenerArgumentCaptor.capture());


### PR DESCRIPTION
## Summary
- Make `AddPaymentMethodActivityStarter()` public
- Specify a request code for each `ActivityStarter` instance instead of passing it in via `startForResult()`.

## Motivation
- Simplify the `ActivityStarter` interface
- Fixes #1411

## Testing
Manually tested standard integration flow
