### PR TITLE
Handle opaque URIs in PaymentAuthWebViewClient

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.java
@@ -129,11 +129,15 @@ class PaymentAuthWebView extends WebView {
                         mReturnUrl.getHost() != null &&
                         mReturnUrl.getHost().equals(uri.getHost());
             } else {
+                // Skip opaque (i.e. non-hierarchical) URIs
+                if (uri.isOpaque()) {
+                    return false;
+                }
+
                 // If the `returnUrl` is unknown, look for URIs that contain a
                 // `payment_intent_client_secret` or `setup_intent_client_secret`
                 // query parameter, and check if its values matches the given `clientSecret`
                 // as a query parameter.
-
                 final Set<String> paramNames = uri.getQueryParameterNames();
                 final String clientSecret;
                 if (paramNames.contains(PARAM_PAYMENT_CLIENT_SECRET)) {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.java
@@ -112,4 +112,14 @@ public class PaymentAuthWebViewTest {
                 "https://hooks.stripe.com/redirect/complete/src_1ExLWoCRMbs6FrXfjPJRYtng");
         verify(mActivity).finish();
     }
+
+    @Test
+    public void shouldOverrideUrlLoading_withOpaqueUri_shouldNotCrash() {
+        final String deepLink = "mailto:patrick@example.com?payment_intent=pi_123&" +
+                "payment_intent_client_secret=pi_123_secret_456&source_type=card";
+        final PaymentAuthWebView.PaymentAuthWebViewClient paymentAuthWebViewClient =
+                new PaymentAuthWebView.PaymentAuthWebViewClient(mActivity, mProgressBar,
+                        "pi_123_secret_456", null);
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(mWebView, deepLink);
+    }
 }


### PR DESCRIPTION
`Uri#getQueryParameterNames()` throws an exception
on opaque URIs (e.g. mailto:person@example.com).