### PR TITLE
Add support for bank icons and checkmark for selected bank

### DIFF
--- a/stripe/res/drawable/ic_bank_generic.xml
+++ b/stripe/res/drawable/ic_bank_generic.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M0,0h32v32H0z"
+      android:fillColor="#e3e8ee"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M7.274,13.5a1.25,1.25 0,0 1,-0.649 -2.333C7.024,10.937 10.15,9.215 16,6c5.851,3.215 8.976,4.937 9.375,5.167a1.25,1.25 0,0 1,-0.65 2.333zM19.75,23.5v-8.125h3.75L23.5,23.5L25,23.5a1,1 0,0 1,1 1L26,26L6,26v-1.5a1,1 0,0 1,1 -1h1.5v-8.125h3.75L12.25,23.5h1.875v-8.125h3.75L17.875,23.5z"
+      android:fillColor="#697386"
+      android:fillType="evenOdd"/>
+</vector>

--- a/stripe/res/drawable/ic_bank_generic.xml
+++ b/stripe/res/drawable/ic_bank_generic.xml
@@ -5,7 +5,7 @@
     android:viewportHeight="32">
   <path
       android:pathData="M0,0h32v32H0z"
-      android:fillColor="#e3e8ee"
+      android:fillColor="#00e3e8ee"
       android:fillType="evenOdd"/>
   <path
       android:pathData="M7.274,13.5a1.25,1.25 0,0 1,-0.649 -2.333C7.024,10.937 10.15,9.215 16,6c5.851,3.215 8.976,4.937 9.375,5.167a1.25,1.25 0,0 1,-0.65 2.333zM19.75,23.5v-8.125h3.75L23.5,23.5L25,23.5a1,1 0,0 1,1 1L26,26L6,26v-1.5a1,1 0,0 1,1 -1h1.5v-8.125h3.75L12.25,23.5h1.875v-8.125h3.75L17.875,23.5z"

--- a/stripe/res/layout/fpx_bank.xml
+++ b/stripe/res/layout/fpx_bank.xml
@@ -4,7 +4,7 @@
     android:layout_height="wrap_content"
     android:minHeight="@dimen/list_row_height"
     android:orientation="horizontal"
-    android:paddingStart="@dimen/list_row_start_padding"
+    android:paddingStart="16dp"
     android:paddingEnd="12dp">
 
     <android.support.v7.widget.AppCompatImageView

--- a/stripe/res/layout/fpx_bank.xml
+++ b/stripe/res/layout/fpx_bank.xml
@@ -1,16 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingEnd="@dimen/list_row_end_padding"
+    android:minHeight="@dimen/list_row_height"
+    android:orientation="horizontal"
     android:paddingStart="@dimen/list_row_start_padding"
-    android:minHeight="@dimen/list_row_height">
+    android:paddingEnd="12dp">
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/icon"
+        android:layout_width="@dimen/masked_card_icon_width"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|start"
+        android:src="@drawable/ic_unknown" />
 
     <android.support.v7.widget.AppCompatTextView
         android:id="@+id/name"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|start"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_marginStart="8dp"
         android:textAppearance="@android:style/TextAppearance.DeviceDefault.Medium" />
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/check_icon"
+        android:layout_width="@dimen/masked_card_icon_width"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_checkmark" />
+
 </LinearLayout>

--- a/stripe/res/layout/fpx_bank.xml
+++ b/stripe/res/layout/fpx_bank.xml
@@ -12,7 +12,7 @@
         android:layout_width="@dimen/masked_card_icon_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|start"
-        android:src="@drawable/ic_unknown" />
+        android:src="@drawable/ic_bank_generic" />
 
     <android.support.v7.widget.AppCompatTextView
         android:id="@+id/name"

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.view
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.os.Parcel
 import android.os.Parcelable
+import android.support.v4.widget.ImageViewCompat
+import android.support.v7.widget.AppCompatImageView
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -78,9 +81,8 @@ internal class AddPaymentMethodFpxView private constructor(
 
         override fun onBindViewHolder(viewHolder: ViewHolder, i: Int) {
             viewHolder.setSelected(i == selectedPosition)
-            viewHolder.update(FpxBank.values()[i].displayName)
+            viewHolder.update(FpxBank.values()[i])
             viewHolder.itemView.setOnClickListener {
-                // TODO(mshafrir): update UI for selected bank
                 val currentPosition = viewHolder.adapterPosition
                 if (currentPosition != selectedPosition) {
                     val prevSelectedPosition = selectedPosition
@@ -93,7 +95,7 @@ internal class AddPaymentMethodFpxView private constructor(
         }
 
         override fun getItemId(position: Int): Long {
-            return FpxBank.values()[position].hashCode().toLong()
+            return position.toLong()
         }
 
         override fun getItemCount(): Int {
@@ -109,14 +111,20 @@ internal class AddPaymentMethodFpxView private constructor(
             itemView: View,
             private val themeConfig: ThemeConfig
         ) : RecyclerView.ViewHolder(itemView) {
-            private val name: TextView = itemView.findViewById(R.id.name)
 
-            internal fun update(bankName: String) {
-                name.text = bankName
+            private val name: TextView = itemView.findViewById(R.id.name)
+            private val icon: AppCompatImageView = itemView.findViewById(R.id.icon)
+            private val checkMark: AppCompatImageView = itemView.findViewById(R.id.check_icon)
+
+            internal fun update(fpxBank: FpxBank) {
+                name.text = fpxBank.displayName
+                icon.setImageResource(fpxBank.brandIconResId)
             }
 
             internal fun setSelected(isSelected: Boolean) {
                 name.setTextColor(themeConfig.getTextColor(isSelected))
+                ImageViewCompat.setImageTintList(checkMark, ColorStateList.valueOf(themeConfig.getTintColor(isSelected)))
+                checkMark.visibility = if (isSelected) View.VISIBLE else View.GONE
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -121,7 +121,7 @@ internal class AddPaymentMethodFpxView private constructor(
         }
     }
 
-    private enum class FpxBank(val code: String, val displayName: String) {
+    private enum class FpxBank(val code: String, val displayName: String, val brandIconResId: Int = 0) {
         AffinBank("affin_bank", "Affin Bank"),
         AllianceBankBusiness("alliance_bank", "Alliance Bank (Business)"),
         AmBank("ambank", "AmBank"),

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -129,7 +129,7 @@ internal class AddPaymentMethodFpxView private constructor(
         }
     }
 
-    private enum class FpxBank(val code: String, val displayName: String, val brandIconResId: Int = 0) {
+    private enum class FpxBank(val code: String, val displayName: String, val brandIconResId: Int = R.drawable.ic_bank_generic) {
         AffinBank("affin_bank", "Affin Bank"),
         AllianceBankBusiness("alliance_bank", "Alliance Bank (Business)"),
         AmBank("ambank", "AmBank"),


### PR DESCRIPTION
## Summary

Add support for bank icons and checkmark for selected bank.

![Screenshot_1567028159](https://user-images.githubusercontent.com/48026502/63894375-80972580-c9ba-11e9-8213-a7fc11182594.png)

## Motivation

Better UX/UI.

## Testing

Example app. Payment Session. Select Payment Method. Select Bank Account (FPX).
