### PR TITLE
Fix crash in "Add an Address" screen when Country is empty

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
@@ -55,8 +55,11 @@ internal class CountryAdapter(
                 return filterResults
             }
 
-            override fun publishResults(charSequence: CharSequence, filterResults: FilterResults) {
-                suggestions = filterResults.values as List<String>
+            override fun publishResults(
+                constraint: CharSequence?,
+                filterResults: FilterResults?
+            ) {
+                suggestions = filterResults?.values as List<String>
                 notifyDataSetChanged()
             }
         }


### PR DESCRIPTION
The arguments of `publishResults()` were marked as non-null, but Android may pass a null `CharSequence` as the first argument.

```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter constraint
```

![Screenshot_1567165094](https://user-images.githubusercontent.com/45020849/64018041-3f595f80-caf9-11e9-91d0-badb2915dcd4.png)
