### PR TITLE
Remove toggleSelected() in PaymentMethodsAdapter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/MaskedCardView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/MaskedCardView.kt
@@ -90,13 +90,6 @@ internal class MaskedCardView @JvmOverloads constructor(
         cardInformationTextView.text = createDisplayString()
     }
 
-    /**
-     * Toggle the view from selected to unselected or vice-versa.
-     */
-    fun toggleSelected() {
-        setSelected(!isSelected)
-    }
-
     private fun initializeCheckMark() {
         updateDrawable(R.drawable.ic_checkmark, checkMarkImageView, true)
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -78,7 +79,7 @@ public class PaymentMethodsActivity extends AppCompatActivity {
         recyclerView.setHasFixedSize(false);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(mAdapter);
-        recyclerView.setItemAnimator(null);
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
 
         mCustomerSession = CustomerSession.getInstance();
         mStartedFromPaymentSession = args.isPaymentSessionActive;

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -81,7 +81,6 @@ internal class PaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodsAdapte
             val currentPosition = holder.adapterPosition
             if (currentPosition != selectedIndex) {
                 val prevSelectedIndex = selectedIndex
-                holder.toggleSelected()
                 setSelectedIndex(currentPosition)
 
                 notifyItemChanged(prevSelectedIndex)
@@ -131,10 +130,6 @@ internal class PaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodsAdapte
 
         fun setSelected(selected: Boolean) {
             cardView.isSelected = selected
-        }
-
-        fun toggleSelected() {
-            cardView.toggleSelected()
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/MaskedCardViewTest.java
@@ -83,23 +83,6 @@ public class MaskedCardViewTest {
     }
 
     @Test
-    public void toggleSelected_switchesState() {
-        final PaymentMethod paymentMethod =
-                PaymentMethod.fromString(PaymentMethodTest.PM_CARD_JSON);
-        assertNotNull(paymentMethod);
-        mMaskedCardView.setPaymentMethod(paymentMethod);
-        assertFalse(mMaskedCardView.isSelected());
-
-        mMaskedCardView.toggleSelected();
-        assertTrue(mMaskedCardView.isSelected());
-        assertEquals(View.VISIBLE, mSelectedImageView.getVisibility());
-
-        mMaskedCardView.toggleSelected();
-        assertFalse(mMaskedCardView.isSelected());
-        assertEquals(View.INVISIBLE, mSelectedImageView.getVisibility());
-    }
-
-    @Test
     public void whenSourceNotCard_doesNotCrash() {
         final PaymentMethod paymentMethod = new PaymentMethod.Builder().build();
         mMaskedCardView.setPaymentMethod(paymentMethod);


### PR DESCRIPTION
This call is unnecessary - we handle updating the UI by
calling `setSelectedIndex()` and `notifyItemChanged()`
on the impacted items.

Also re-enable item animation now that this is fixed.