### PR TITLE
Persist PaymentConfiguration to SharedPreferences

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardTokenActivity.kt
@@ -18,7 +18,7 @@ class CardTokenActivity : AppCompatActivity() {
             this,
             findViewById(R.id.card_input_widget),
             findViewById(R.id.listview),
-            PaymentConfiguration.getInstance().publishableKey
+            PaymentConfiguration.getInstance(this).publishableKey
         )
 
         dependencyHandler.attachAsyncTaskTokenController(findViewById(R.id.save))

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -73,7 +73,10 @@ class FragmentExamplesActivity : AppCompatActivity() {
             super.onActivityCreated(savedInstanceState)
 
             backendApi = RetrofitFactory.instance.create(BackendApi::class.java)
-            stripe = Stripe(requireContext(), PaymentConfiguration.getInstance().publishableKey)
+            stripe = Stripe(
+                requireContext(),
+                PaymentConfiguration.getInstance(requireContext()).publishableKey
+            )
             paymentSession = createPaymentSession(createCustomerSession())
 
             val rootView = view!!

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -21,7 +21,7 @@ class LauncherActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_launcher)
 
-        PaymentConfiguration.init(Settings.PUBLISHABLE_KEY)
+        PaymentConfiguration.init(this, Settings.PUBLISHABLE_KEY)
 
         val examples = findViewById<RecyclerView>(R.id.examples)
         val linearLayoutManager = LinearLayoutManager(this)

--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
@@ -36,7 +36,7 @@ class PayWithGoogleActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pay_with_google)
 
-        stripe = Stripe(this, PaymentConfiguration.getInstance().publishableKey)
+        stripe = Stripe(this, PaymentConfiguration.getInstance(this).publishableKey)
 
         paymentsClient = Wallet.getPaymentsClient(this,
             Wallet.WalletOptions.Builder()
@@ -195,7 +195,8 @@ class PayWithGoogleActivity : AppCompatActivity() {
             .put(
                 "parameters", cardPaymentMethodParams
             )
-            .put("tokenizationSpecification", GooglePayConfig().tokenizationSpecification)
+            .put("tokenizationSpecification",
+                GooglePayConfig(this).tokenizationSpecification)
 
         val paymentDataRequest = JSONObject()
             .put("apiVersion", 2)

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -64,10 +64,11 @@ class PaymentAuthActivity : AppCompatActivity() {
         }
 
         backendApi = RetrofitFactory.instance.create(BackendApi::class.java)
+        val publishableKey = PaymentConfiguration.getInstance(this).publishableKey
         stripe = if (stripeAccountId != null) {
-            Stripe(this, PaymentConfiguration.getInstance().publishableKey, stripeAccountId)
+            Stripe(this, publishableKey, stripeAccountId)
         } else {
-            Stripe(this, PaymentConfiguration.getInstance().publishableKey)
+            Stripe(this, publishableKey)
         }
 
         buyButton = findViewById(R.id.buy_button)

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
@@ -57,7 +57,7 @@ class PaymentIntentActivity : AppCompatActivity() {
 
         progressDialogController = ProgressDialogController(supportFragmentManager, resources)
         errorDialogHandler = ErrorDialogHandler(this)
-        stripe = Stripe(applicationContext, PaymentConfiguration.getInstance().publishableKey)
+        stripe = Stripe(applicationContext, PaymentConfiguration.getInstance(this).publishableKey)
         val retrofit = RetrofitFactory.instance
         backendApi = retrofit.create(BackendApi::class.java)
 

--- a/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentMultilineActivity.kt
@@ -53,8 +53,10 @@ class PaymentMultilineActivity : AppCompatActivity() {
     private fun saveCard() {
         val card = cardMultilineWidget.card ?: return
 
-        val stripe = Stripe(applicationContext,
-            PaymentConfiguration.getInstance().publishableKey)
+        val stripe = Stripe(
+            applicationContext,
+            PaymentConfiguration.getInstance(applicationContext).publishableKey
+        )
         val cardSourceParams = PaymentMethodCreateParams.create(card.toPaymentMethodParamsCard(), null)
         // Note: using this style of Observable creation results in us having a method that
         // will not be called until we subscribe to it.

--- a/example/src/main/java/com/stripe/example/activity/RedirectActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/RedirectActivity.kt
@@ -48,7 +48,7 @@ class RedirectActivity : AppCompatActivity() {
             resources)
         redirectDialogController = RedirectDialogController(this)
 
-        val publishableKey = PaymentConfiguration.getInstance().publishableKey
+        val publishableKey = PaymentConfiguration.getInstance(this).publishableKey
         stripe = Stripe(applicationContext, publishableKey)
 
         val threeDSecureButton = findViewById<Button>(R.id.btn_three_d_secure)

--- a/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SetupIntentActivity.kt
@@ -62,7 +62,7 @@ class SetupIntentActivity : AppCompatActivity() {
         errorDialogHandler = ErrorDialogHandler(this)
 
         stripe = Stripe(this,
-            PaymentConfiguration.getInstance().publishableKey)
+            PaymentConfiguration.getInstance(this).publishableKey)
         val retrofit = RetrofitFactory.instance
         backendApi = retrofit.create(BackendApi::class.java)
 

--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.kt
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.kt
@@ -29,7 +29,7 @@ class TokenIntentService : IntentService("TokenIntentService") {
             val card = Card.create(cardNumber, month, year, cvc)
 
             val stripe = Stripe(applicationContext,
-                PaymentConfiguration.getInstance().publishableKey)
+                PaymentConfiguration.getInstance(this).publishableKey)
             try {
                 token = stripe.createTokenSynchronous(card)
             } catch (stripeEx: StripeException) {

--- a/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.kt
+++ b/samplestore/src/main/java/com/stripe/samplestore/PaymentActivity.kt
@@ -107,11 +107,11 @@ class PaymentActivity : AppCompatActivity() {
                 .build())
             .build())
 
+        val publishableKey = PaymentConfiguration.getInstance(this).publishableKey
         stripe = if (Settings.STRIPE_ACCOUNT_ID != null) {
-            Stripe(this, PaymentConfiguration.getInstance().publishableKey,
-                    Settings.STRIPE_ACCOUNT_ID)
+            Stripe(this, publishableKey, Settings.STRIPE_ACCOUNT_ID)
         } else {
-            Stripe(this, PaymentConfiguration.getInstance().publishableKey)
+            Stripe(this, publishableKey)
         }
 
         service = RetrofitFactory.instance.create(BackendApi::class.java)

--- a/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.kt
+++ b/samplestore/src/main/java/com/stripe/samplestore/StoreActivity.kt
@@ -40,7 +40,7 @@ class StoreActivity : AppCompatActivity(), StoreAdapter.TotalItemsChangedListene
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_store)
 
-        PaymentConfiguration.init(Settings.PUBLISHABLE_KEY)
+        PaymentConfiguration.init(this, Settings.PUBLISHABLE_KEY)
         goToCartButton = findViewById(R.id.fab_checkout)
         storeAdapter = StoreAdapter(this, priceMultiplier)
 

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -123,7 +123,7 @@ public class CustomerSession {
     /**
      * Create a CustomerSession with the provided {@link EphemeralKeyProvider}.
      *
-     * <p>You must call {@link PaymentConfiguration#init(String)} with your publishable key
+     * <p>You must call {@link PaymentConfiguration#init(Context, String)} with your publishable key
      * before calling this method.</p>
      *
      * @param context The application context
@@ -141,7 +141,7 @@ public class CustomerSession {
                                            @Nullable String stripeAccountId,
                                            boolean shouldPrefetchEphemeralKey) {
         setInstance(new CustomerSession(context, ephemeralKeyProvider, Stripe.getAppInfo(),
-                PaymentConfiguration.getInstance().getPublishableKey(),
+                PaymentConfiguration.getInstance(context).getPublishableKey(),
                 stripeAccountId, shouldPrefetchEphemeralKey));
     }
 

--- a/stripe/src/main/java/com/stripe/android/GooglePayConfig.java
+++ b/stripe/src/main/java/com/stripe/android/GooglePayConfig.java
@@ -1,5 +1,6 @@
 package com.stripe.android;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 import org.json.JSONException;
@@ -14,8 +15,8 @@ public final class GooglePayConfig {
      * Instantiate with {@link PaymentConfiguration}. {@link PaymentConfiguration} must be
      * initialized.
      */
-    public GooglePayConfig() {
-        this(PaymentConfiguration.getInstance().getPublishableKey());
+    public GooglePayConfig(@NonNull Context context) {
+        this(PaymentConfiguration.getInstance(context).getPublishableKey());
     }
 
     public GooglePayConfig(@NonNull String publishableKey) {

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.java
@@ -1,5 +1,7 @@
 package com.stripe.android;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -36,11 +38,22 @@ public final class PaymentConfiguration implements Parcelable {
                 }
             };
 
+    /**
+     * Attempts to load a {@link PaymentConfiguration} instance. First attempt to use the class's
+     * singleton instance. If unavailable, attempt to load from {@link Store}.
+     *
+     * @param context application context
+     * @return a {@link PaymentConfiguration} instance, or throw an exception
+     */
     @NonNull
-    public static PaymentConfiguration getInstance() {
+    public static PaymentConfiguration getInstance(@NonNull Context context) {
         if (mInstance == null) {
-            throw new IllegalStateException(
-                    "Attempted to get instance of PaymentConfiguration without initialization.");
+            final PaymentConfiguration loadedInstance = new Store(context).load();
+            if (loadedInstance != null) {
+                mInstance = loadedInstance;
+            } else {
+                throw new IllegalStateException("PaymentConfiguration was not initialized");
+            }
         }
         return mInstance;
     }
@@ -49,8 +62,9 @@ public final class PaymentConfiguration implements Parcelable {
      * A publishable key from the Dashboard's
      * <a href="https://dashboard.stripe.com/apikeys">API keys</a> page.
      */
-    public static void init(@NonNull String publishableKey) {
+    public static void init(@NonNull Context context, @NonNull String publishableKey) {
         mInstance = new PaymentConfiguration(publishableKey);
+        new Store(context).save(publishableKey);
     }
 
     @NonNull
@@ -86,5 +100,34 @@ public final class PaymentConfiguration implements Parcelable {
 
     private boolean typedEquals(@NonNull PaymentConfiguration obj) {
         return ObjectUtils.equals(mPublishableKey, obj.mPublishableKey);
+    }
+
+    /**
+     * Manages saving and loading {@link PaymentConfiguration} data to SharedPreferences.
+     */
+    private static final class Store {
+        @NonNull private final SharedPreferences mPrefs;
+        private static final String NAME = PaymentConfiguration.class.getCanonicalName();
+
+        private static final String KEY_PUBLISHABLE_KEY = "key_publishable_key";
+
+        private Store(@NonNull Context context) {
+            mPrefs = context.getApplicationContext().getSharedPreferences(NAME, 0);
+        }
+
+        private void save(@NonNull String publishableKey) {
+            mPrefs.edit()
+                    .putString(KEY_PUBLISHABLE_KEY, publishableKey)
+                    .apply();
+        }
+
+        @Nullable
+        private PaymentConfiguration load() {
+            final String publishableKey = mPrefs.getString(KEY_PUBLISHABLE_KEY, null);
+            if (publishableKey == null) {
+                return null;
+            }
+            return new PaymentConfiguration(publishableKey);
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -1,6 +1,7 @@
 package com.stripe.android;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.IntRange;
@@ -36,6 +37,7 @@ public class PaymentSession {
     private final ActivityStarter<PaymentFlowActivity, PaymentFlowActivityStarter.Args>
             mPaymentFlowActivityStarter;
 
+    @NonNull private final Context mContext;
     @NonNull private final CustomerSession mCustomerSession;
     @NonNull private final PaymentSessionPrefs mPaymentSessionPrefs;
     private PaymentSessionData mPaymentSessionData;
@@ -51,23 +53,24 @@ public class PaymentSession {
      *                     passed back to this session.
      */
     public PaymentSession(@NonNull Activity activity) {
-        this(CustomerSession.getInstance(),
+        this(activity.getApplicationContext(),
+                CustomerSession.getInstance(),
                 new PaymentMethodsActivityStarter(activity),
                 new PaymentFlowActivityStarter(activity),
-                new PaymentSessionData(),
-                new PaymentSessionPrefs(activity));
+                new PaymentSessionData(), new PaymentSessionPrefs(activity));
     }
 
     public PaymentSession(@NonNull Fragment fragment) {
-        this(CustomerSession.getInstance(),
+        this(fragment.requireContext().getApplicationContext(),
+                CustomerSession.getInstance(),
                 new PaymentMethodsActivityStarter(fragment),
                 new PaymentFlowActivityStarter(fragment),
-                new PaymentSessionData(),
-                new PaymentSessionPrefs(fragment.requireActivity()));
+                new PaymentSessionData(), new PaymentSessionPrefs(fragment.requireActivity()));
     }
 
     @VisibleForTesting
     PaymentSession(
+            @NonNull Context context,
             @NonNull CustomerSession customerSession,
             @NonNull ActivityStarter<PaymentMethodsActivity, PaymentMethodsActivityStarter.Args>
                     paymentMethodsActivityStarter,
@@ -75,6 +78,7 @@ public class PaymentSession {
                     paymentFlowActivityStarter,
             @NonNull PaymentSessionData paymentSessionData,
             @NonNull PaymentSessionPrefs paymentSessionPrefs) {
+        mContext = context;
         mCustomerSession = customerSession;
         mPaymentMethodsActivityStarter = paymentMethodsActivityStarter;
         mPaymentFlowActivityStarter = paymentFlowActivityStarter;
@@ -288,7 +292,7 @@ public class PaymentSession {
                                 getSelectedPaymentMethodId(userSelectedPaymentMethodId))
                         .setShouldRequirePostalCode(shouldRequirePostalCode)
                         .setIsPaymentSessionActive(true)
-                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance(mContext))
                         .build()
         );
     }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -55,7 +55,7 @@ public class AddPaymentMethodActivity extends StripeActivity {
         if (args.paymentConfiguration != null) {
             paymentConfiguration = args.paymentConfiguration;
         } else {
-            paymentConfiguration = PaymentConfiguration.getInstance();
+            paymentConfiguration = PaymentConfiguration.getInstance(this);
         }
         mStripe = new Stripe(getApplicationContext(), paymentConfiguration.getPublishableKey());
         mPaymentMethodType = args.paymentMethodType;

--- a/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.java
+++ b/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.java
@@ -1,17 +1,25 @@
 package com.stripe.android;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(RobolectricTestRunner.class)
 public class GooglePayConfigTest {
 
     @Test
     public void getTokenizationSpecification() throws JSONException {
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
-        final JSONObject tokenizationSpec = new GooglePayConfig().getTokenizationSpecification();
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        final JSONObject tokenizationSpec =
+                new GooglePayConfig(ApplicationProvider.getApplicationContext())
+                        .getTokenizationSpecification();
         final JSONObject params = tokenizationSpec.getJSONObject("parameters");
         assertEquals("stripe",
                 params.getString("gateway"));

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.java
@@ -1,5 +1,7 @@
 package com.stripe.android;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -26,15 +28,21 @@ public class PaymentConfigurationTest {
         assertThrows(IllegalStateException.class, new ThrowingRunnable() {
             @Override
             public void run() {
-                PaymentConfiguration.getInstance();
+                PaymentConfiguration.getInstance(ApplicationProvider.getApplicationContext());
             }
         });
     }
 
     @Test
-    public void getInstance_withPublicKey_returnsDefaultInstance() {
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+    public void getInstance_whenInstanceIsNull_loadsFromPrefs() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+
+        PaymentConfiguration.clearInstance();
+
         assertEquals(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                PaymentConfiguration.getInstance().getPublishableKey());
+                PaymentConfiguration
+                        .getInstance(ApplicationProvider.getApplicationContext())
+                        .getPublishableKey());
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.java
@@ -87,7 +87,9 @@ public class PaymentSessionTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) {
@@ -341,8 +343,8 @@ public class PaymentSessionTest {
 
     @NonNull
     private PaymentSession createPaymentSession() {
-        return new PaymentSession(mCustomerSession, mPaymentMethodsActivityStarter,
-                mPaymentFlowActivityStarter, mPaymentSessionData,
+        return new PaymentSession(ApplicationProvider.getApplicationContext(), mCustomerSession,
+                mPaymentMethodsActivityStarter, mPaymentFlowActivityStarter, mPaymentSessionData,
                 mPaymentSessionPrefs);
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -1,11 +1,14 @@
 package com.stripe.android.view;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
 import android.widget.ProgressBar;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import com.stripe.android.ApiKeyFixtures;
 import com.stripe.android.ApiResultCallback;
@@ -59,6 +62,7 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodActivity> {
 
+    private Context mContext;
     private CardMultilineWidget mCardMultilineWidget;
     private CardMultilineWidgetTest.WidgetControlGroup mWidgetControlGroup;
     private ProgressBar mProgressBar;
@@ -87,8 +91,11 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
     public void setup() {
         // The input in this test class will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050);
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+
         MockitoAnnotations.initMocks(this);
+        mContext = ApplicationProvider.getApplicationContext();
+
+        PaymentConfiguration.init(mContext, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
         CustomerSessionTestHelper.setInstance(mCustomerSession);
     }
 
@@ -116,7 +123,7 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
                 .setIsPaymentSessionActive(true)
                 .setShouldInitCustomerSessionTokens(false)
                 .setPaymentMethodType(paymentMethodType)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                .setPaymentConfiguration(PaymentConfiguration.getInstance(mContext))
                 .build());
 
         mProgressBar = mActivity.findViewById(R.id.progress_bar_as);

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.java
@@ -78,7 +78,8 @@ public class PaymentFlowActivityTest extends BaseViewTest<PaymentFlowActivity> {
                 .getInstance(ApplicationProvider.getApplicationContext());
         mLocalBroadcastManager.registerReceiver(mBroadcastReceiver,
                 new IntentFilter(PaymentFlowExtras.EVENT_SHIPPING_INFO_SUBMITTED));
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
         CustomerSession.initCustomerSession(ApplicationProvider.getApplicationContext(),
                 mEphemeralKeyProvider);
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.java
@@ -1,5 +1,9 @@
 package com.stripe.android.view;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
 import com.stripe.android.ApiKeyFixtures;
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.PaymentMethod;
@@ -22,7 +26,8 @@ public class PaymentMethodsActivityStarterTest {
 
     @Test
     public void testParceling() {
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        final Context context = ApplicationProvider.getApplicationContext();
+        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         final Set<PaymentMethod.Type> paymentMethodTypes = new HashSet<>(
                 Arrays.asList(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx)
@@ -33,7 +38,7 @@ public class PaymentMethodsActivityStarterTest {
                         .setIsPaymentSessionActive(true)
                         .setShouldRequirePostalCode(true)
                         .setPaymentMethodTypes(paymentMethodTypes)
-                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
                         .build();
 
         final PaymentMethodsActivityStarter.Args createdArgs =

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -1,10 +1,13 @@
 package com.stripe.android.view;
 
+import android.content.Context;
 import android.content.Intent;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import com.stripe.android.ApiKeyFixtures;
 import com.stripe.android.CustomerSession;
@@ -56,6 +59,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     @Mock private CustomerSession mCustomerSession;
     @Captor private ArgumentCaptor<CustomerSession.PaymentMethodsRetrievalListener> mListenerArgumentCaptor;
 
+    private Context mContext;
     private PaymentMethodsActivity mPaymentMethodsActivity;
     private ProgressBar mProgressBar;
     private RecyclerView mRecyclerView;
@@ -69,12 +73,15 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
+
+        mContext = ApplicationProvider.getApplicationContext();
+
         CustomerSessionTestHelper.setInstance(mCustomerSession);
-        PaymentConfiguration.init(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
+        PaymentConfiguration.init(mContext, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY);
 
         mPaymentMethodsActivity = createActivity(
                 new PaymentMethodsActivityStarter.Args.Builder()
-                        .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                        .setPaymentConfiguration(PaymentConfiguration.getInstance(mContext))
                         .build()
         );
         mShadowActivity = Shadows.shadowOf(mPaymentMethodsActivity);
@@ -155,7 +162,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
     @Test
     public void onClickAddSourceView_whenStartedFromPaymentSession_launchesActivityWithLog() {
         mPaymentMethodsActivity = createActivity(new PaymentMethodsActivityStarter.Args.Builder()
-                .setPaymentConfiguration(PaymentConfiguration.getInstance())
+                .setPaymentConfiguration(PaymentConfiguration.getInstance(mContext))
                 .setIsPaymentSessionActive(true)
                 .build());
         mShadowActivity = Shadows.shadowOf(mPaymentMethodsActivity);


### PR DESCRIPTION

## Summary/Motivation
This change allows the `PaymentConfiguration` instance
to be restored on app/activity death.

This is a minor breaking change, because it requires the
user to pass in a `Context`.

## Testing
Manually tested
