### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ POM_DEVELOPER_EMAIL=support+android@stripe.com
 
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false


### PR DESCRIPTION
None of our dependencies use Android Support Libraries, so jetifier can be disabled.