### PR TITLE
Bump API version to 2019-09-09

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -16,7 +16,7 @@ internal data class ApiVersion constructor(val code: String) {
     }
 
     companion object {
-        private const val API_VERSION_CODE = "2019-08-14"
+        private const val API_VERSION_CODE = "2019-09-09"
 
         private val INSTANCE = ApiVersion(API_VERSION_CODE)
 

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -107,7 +107,7 @@ public class StripeTest {
 
     @Test
     public void testApiVersion() {
-        assertEquals("2019-08-14", Stripe.API_VERSION);
+        assertEquals("2019-09-09", Stripe.API_VERSION);
     }
 
     @Test


### PR DESCRIPTION
https://stripe.com/docs/upgrades#2019-09-09