### PR TITLE
Fix crash when Fragment is not attached

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
@@ -26,7 +26,9 @@ internal interface AuthActivityStarter<StartDataType> {
 
             if (fragmentRef != null) {
                 val fragment = fragmentRef.get()
-                fragment?.startActivityForResult(intent, requestCode)
+                if (fragment?.isAdded == true) {
+                    fragment.startActivityForResult(intent, requestCode)
+                }
             } else {
                 activity.startActivityForResult(intent, requestCode)
             }


### PR DESCRIPTION
Check that the fragment is attached before calling `startActivityForResult()`.

Fixes #1517
