### PR TITLE
Finish PaymentAuthWebViewActivity after returning from bank app

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -20,6 +20,7 @@ import android.widget.ProgressBar
  * A `WebView` used for authenticating payment details
  */
 internal class PaymentAuthWebView : WebView {
+    private var webViewClient: PaymentAuthWebViewClient? = null
 
     @JvmOverloads
     constructor(context: Context, attrs: AttributeSet? = null) : super(context, attrs) {
@@ -42,6 +43,11 @@ internal class PaymentAuthWebView : WebView {
     ) {
         webViewClient = PaymentAuthWebViewClient(activity, activity.packageManager, progressBar,
             clientSecret, returnUrl)
+        setWebViewClient(webViewClient)
+    }
+
+    fun hasOpenedApp(): Boolean {
+        return webViewClient?.hasOpenedApp == true
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -58,6 +64,9 @@ internal class PaymentAuthWebView : WebView {
         returnUrl: String?
     ) : WebViewClient() {
         private val returnUri: Uri? = if (returnUrl != null) Uri.parse(returnUrl) else null
+
+        var hasOpenedApp: Boolean = false
+            private set
 
         override fun onPageCommitVisible(view: WebView, url: String) {
             super.onPageCommitVisible(view, url)
@@ -109,6 +118,7 @@ internal class PaymentAuthWebView : WebView {
 
         private fun openIntent(intent: Intent) {
             if (intent.resolveActivity(packageManager) != null) {
+                hasOpenedApp = true
                 activity.startActivity(intent)
             } else {
                 // complete auth if the deep-link can't be opened

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -27,6 +27,7 @@ public class PaymentAuthWebViewActivity
         extends AppCompatActivity {
 
     @Nullable private ToolbarCustomization mToolbarCustomization;
+    private PaymentAuthWebView mWebView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -54,6 +55,19 @@ public class PaymentAuthWebViewActivity
         final ProgressBar progressBar = findViewById(R.id.auth_web_view_progress_bar);
         webView.init(this, progressBar, clientSecret, returnUrl);
         webView.loadUrl(getIntent().getStringExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL));
+
+        mWebView = webView;
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+
+        if (mWebView != null && mWebView.hasOpenedApp()) {
+            // If another app was opened, assume it was a bank app where payment authentication
+            // was completed. Upon foregrounding this screen, finish the Activity.
+            finish();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
If an app was launched from `PaymentAuthWebViewActivity`, assume
that payment authentication was completed in the app. When
the user returns to `PaymentAuthWebViewActivity`, close it.

![demo](https://user-images.githubusercontent.com/45020849/64803848-ad6f3f00-d55b-11e9-9763-c1f56e006a85.gif)

## Motivation
ANDROID-409

## Testing
Manually tested
