### PR TITLE
Fix out-of-band web payment authentication

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.java
@@ -65,8 +65,11 @@ public class PaymentAuthWebViewActivity
 
         if (mWebView != null && mWebView.hasOpenedApp()) {
             // If another app was opened, assume it was a bank app where payment authentication
-            // was completed. Upon foregrounding this screen, finish the Activity.
-            finish();
+            // was completed. Upon foregrounding this screen, load the completion URL.
+            final String completionUrl = mWebView.getCompletionUrl();
+            if (completionUrl != null) {
+                mWebView.loadUrl(completionUrl);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
When a user enters the in-app web payment authentication flow,
is taken to another app to complete payment authentication
out-of-band (i.e. a bank app), then returns to the WebView,
make a request to the completion URL.

This resolves the issue where the bank page loaded in the
WebView doesn't detect that the user returned from the
bank app.

## Testing
Unit test and manual testing
