### PR TITLE
Add Interoperability lint warnings

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -78,6 +78,10 @@ android {
         outputFormat = 'javadoc'
         outputDirectory = "$buildDir/docs/javadoc"
     }
+
+    lintOptions {
+        enable "Interoperability"
+    }
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.java
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.stripe.android.model.StripeModel;
-import com.stripe.android.utils.ObjectUtils;
 
 import java.util.Objects;
 
@@ -94,7 +93,7 @@ abstract class EphemeralKey extends StripeModel implements Parcelable {
      * @param flags any flags (unused) for writing this object
      */
     @Override
-    public void writeToParcel(Parcel out, int flags) {
+    public void writeToParcel(@NonNull Parcel out, int flags) {
         out.writeLong(mCreated);
         out.writeString(objectId);
         out.writeLong(mExpires);

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -352,6 +352,7 @@ public class PaymentSession {
     /**
      * @return the data associated with the instance of this class.
      */
+    @Nullable
     public PaymentSessionData getPaymentSessionData() {
         return mPaymentSessionData;
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
@@ -39,7 +39,7 @@ public class PaymentSessionConfig implements Parcelable {
          */
         @NonNull
         public Builder setHiddenShippingInfoFields(
-                @CustomizableShippingField String ... hiddenShippingInfoFields) {
+                @CustomizableShippingField @NonNull String ... hiddenShippingInfoFields) {
             mHiddenShippingInfoFields = Arrays.asList(hiddenShippingInfoFields);
             return this;
         }
@@ -50,7 +50,7 @@ public class PaymentSessionConfig implements Parcelable {
          */
         @NonNull
         public Builder setOptionalShippingInfoFields(
-                @CustomizableShippingField String ... optionalShippingInfoFields) {
+                @CustomizableShippingField @NonNull String ... optionalShippingInfoFields) {
             mOptionalShippingInfoFields = Arrays.asList(optionalShippingInfoFields);
             return this;
         }
@@ -59,7 +59,7 @@ public class PaymentSessionConfig implements Parcelable {
          * @param shippingInfo that should be prepopulated into the {@link ShippingInfoWidget}
          */
         @NonNull
-        public Builder setPrepopulatedShippingInfo(ShippingInformation shippingInfo) {
+        public Builder setPrepopulatedShippingInfo(@Nullable ShippingInformation shippingInfo) {
             mShippingInformation = shippingInfo;
             return this;
         }
@@ -139,7 +139,7 @@ public class PaymentSessionConfig implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel parcel, int flags) {
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
         parcel.writeList(mHiddenShippingInfoFields);
         parcel.writeList(mOptionalShippingInfoFields);
         parcel.writeParcelable(mShippingInformation, flags);

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.java
@@ -171,7 +171,7 @@ public class PaymentSessionData implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel parcel, int i) {
+    public void writeToParcel(@NonNull Parcel parcel, int i) {
         parcel.writeLong(mCartTotal);
         parcel.writeInt(mIsPaymentReadyToCharge ? 1 : 0);
         parcel.writeParcelable(mPaymentMethod, i);

--- a/stripe/src/main/java/com/stripe/android/model/Address.java
+++ b/stripe/src/main/java/com/stripe/android/model/Address.java
@@ -198,7 +198,7 @@ public final class Address extends StripeModel implements StripeParamsModel, Par
     };
 
     @Override
-    public void writeToParcel(Parcel out, int flags) {
+    public void writeToParcel(@NonNull Parcel out, int flags) {
         out.writeString(mCity);
         out.writeString(mCountry);
         out.writeString(mLine1);

--- a/stripe/src/main/java/com/stripe/android/model/Card.java
+++ b/stripe/src/main/java/com/stripe/android/model/Card.java
@@ -293,10 +293,10 @@ public final class Card extends StripeModel implements StripePaymentSource, Stri
      */
     @NonNull
     public static Card create(
-            String number,
-            Integer expMonth,
-            Integer expYear,
-            String cvc) {
+            @Nullable String number,
+            @Nullable Integer expMonth,
+            @Nullable Integer expYear,
+            @Nullable String cvc) {
         return new Builder(number, expMonth, expYear, cvc)
                 .build();
     }

--- a/stripe/src/main/java/com/stripe/android/model/Customer.java
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.java
@@ -57,14 +57,17 @@ public final class Customer extends StripeModel {
         mUrl = url;
     }
 
+    @Nullable
     public String getId() {
         return mId;
     }
 
+    @Nullable
     public String getDefaultSource() {
         return mDefaultSource;
     }
 
+    @Nullable
     public ShippingInformation getShippingInformation() {
         return mShippingInformation;
     }
@@ -79,10 +82,12 @@ public final class Customer extends StripeModel {
         return mHasMore;
     }
 
+    @Nullable
     public Integer getTotalCount() {
         return mTotalCount;
     }
 
+    @Nullable
     public String getUrl() {
         return mUrl;
     }
@@ -112,7 +117,7 @@ public final class Customer extends StripeModel {
 
     @Nullable
     public static Customer fromJson(@NonNull JSONObject jsonObject) {
-        String objectType = optString(jsonObject, FIELD_OBJECT);
+        final String objectType = optString(jsonObject, FIELD_OBJECT);
         if (!VALUE_CUSTOMER.equals(objectType)) {
             return null;
         }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -194,7 +194,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel dest, int flags) {
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
         dest.writeString(id);
         if (created == null) {
             dest.writeByte((byte) (0x00));
@@ -563,7 +563,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             super.writeToParcel(dest, flags);
             dest.writeString(brand);
             dest.writeParcelable(checks, flags);
@@ -740,7 +740,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             }
 
             @Override
-            public void writeToParcel(Parcel dest, int flags) {
+            public void writeToParcel(@NonNull Parcel dest, int flags) {
                 dest.writeString(addressLine1Check);
                 dest.writeString(addressPostalCodeCheck);
                 dest.writeString(cvcCheck);
@@ -838,7 +838,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
             }
 
             @Override
-            public void writeToParcel(Parcel dest, int flags) {
+            public void writeToParcel(@NonNull Parcel dest, int flags) {
                 dest.writeByte((byte) (isSupported ? 0x01 : 0x00));
             }
 
@@ -958,7 +958,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             super.writeToParcel(dest, flags);
             dest.writeString(bank);
             dest.writeString(bankIdentifierCode);
@@ -1046,7 +1046,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             super.writeToParcel(dest, flags);
             dest.writeString(bank);
             dest.writeString(accountHolderType);
@@ -1132,7 +1132,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             dest.writeString(type.name());
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingMethod.java
@@ -108,7 +108,7 @@ public final class ShippingMethod extends StripeModel implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel parcel, int i) {
+    public void writeToParcel(@NonNull Parcel parcel, int i) {
         parcel.writeLong(mAmount);
         parcel.writeString(mCurrencyCode);
         parcel.writeString(mDetail);

--- a/stripe/src/main/java/com/stripe/android/model/Source.java
+++ b/stripe/src/main/java/com/stripe/android/model/Source.java
@@ -215,10 +215,12 @@ public final class Source extends StripeModel implements StripePaymentSource {
         return mCreated;
     }
 
+    @Nullable
     public String getCurrency() {
         return mCurrency;
     }
 
+    @Nullable
     @SourceFlow
     public String getFlow() {
         return mFlow;
@@ -250,6 +252,7 @@ public final class Source extends StripeModel implements StripePaymentSource {
     }
 
     @SourceStatus
+    @Nullable
     public String getStatus() {
         return mStatus;
     }

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -751,7 +751,7 @@ public final class SourceParams implements StripeParamsModel {
      * @return {@code this}, for chaining purposes
      */
     @NonNull
-    public SourceParams setAmount(long amount) {
+    public SourceParams setAmount(@Nullable @IntRange(from = 0) Long amount) {
         mAmount = amount;
         return this;
     }
@@ -772,7 +772,7 @@ public final class SourceParams implements StripeParamsModel {
      * @return {@code this}, for chaining purposes
      */
     @NonNull
-    public SourceParams setCurrency(String currency) {
+    public SourceParams setCurrency(@NonNull String currency) {
         mCurrency = currency;
         return this;
     }
@@ -795,7 +795,7 @@ public final class SourceParams implements StripeParamsModel {
      * @return {@code this}, for chaining purposes
      */
     @NonNull
-    public SourceParams setRedirect(Map<String, Object> redirect) {
+    public SourceParams setRedirect(@NonNull Map<String, Object> redirect) {
         mRedirect = redirect;
         return this;
     }
@@ -807,7 +807,7 @@ public final class SourceParams implements StripeParamsModel {
      * @return {@code this}, for chaining purposes
      */
     @NonNull
-    public SourceParams setExtraParams(final Map<String, Object> extraParams) {
+    public SourceParams setExtraParams(@NonNull final Map<String, Object> extraParams) {
         mExtraParams = extraParams;
         return this;
     }

--- a/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.java
@@ -57,7 +57,7 @@ public final class SourceSepaDebitData extends StripeSourceTypeModel {
     }
 
     @Nullable
-    public static SourceSepaDebitData fromJson(JSONObject jsonObject) {
+    public static SourceSepaDebitData fromJson(@Nullable JSONObject jsonObject) {
         if (jsonObject == null) {
             return null;
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.java
@@ -136,7 +136,7 @@ public abstract class Wallet extends StripeModel implements Parcelable {
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             dest.writeString(city);
             dest.writeString(country);
             dest.writeString(line1);

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -47,7 +47,7 @@ public class AddPaymentMethodActivity extends StripeActivity {
     private boolean mShouldAttachToCustomer;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         final AddPaymentMethodActivityStarter.Args args =

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -74,7 +74,7 @@ public final class AddPaymentMethodActivityStarter
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             dest.writeInt(shouldAttachToCustomer ? 1 : 0);
             dest.writeInt(shouldRequirePostalCode ? 1 : 0);
             dest.writeInt(isPaymentSessionActive ? 1 : 0);

--- a/stripe/src/main/java/com/stripe/android/view/CardInputListener.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputListener.java
@@ -1,5 +1,6 @@
 package com.stripe.android.view;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringDef;
 
 import java.lang.annotation.Retention;
@@ -31,7 +32,7 @@ public interface CardInputListener {
      *
      * @param focusField a {@link FocusField} to which the focus has just changed.
      */
-    void onFocusChange(@FocusField String focusField);
+    void onFocusChange(@FocusField @NonNull String focusField);
 
     /**
      * Called when a potentially valid card number has been completed in the

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.java
@@ -285,21 +285,21 @@ public class CardInputWidget extends LinearLayout implements CardWidget {
     /**
      * Expose a text watcher to receive updates when the card number is changed.
      */
-    public void setCardNumberTextWatcher(TextWatcher cardNumberTextWatcher) {
+    public void setCardNumberTextWatcher(@Nullable TextWatcher cardNumberTextWatcher) {
         mCardNumberEditText.addTextChangedListener(cardNumberTextWatcher);
     }
 
     /**
      * Expose a text watcher to receive updates when the expiry date is changed.
      */
-    public void setExpiryDateTextWatcher(TextWatcher expiryDateTextWatcher) {
+    public void setExpiryDateTextWatcher(@Nullable TextWatcher expiryDateTextWatcher) {
         mExpiryDateEditText.addTextChangedListener(expiryDateTextWatcher);
     }
 
     /**
      * Expose a text watcher to receive updates when the cvc number is changed.
      */
-    public void setCvcNumberTextWatcher(TextWatcher cvcNumberTextWatcher) {
+    public void setCvcNumberTextWatcher(@Nullable TextWatcher cvcNumberTextWatcher) {
         mCvcNumberEditText.addTextChangedListener(cvcNumberTextWatcher);
     }
 
@@ -318,7 +318,7 @@ public class CardInputWidget extends LinearLayout implements CardWidget {
     }
 
     @Override
-    public boolean onInterceptTouchEvent(MotionEvent ev) {
+    public boolean onInterceptTouchEvent(@NonNull MotionEvent ev) {
         if (ev.getAction() != MotionEvent.ACTION_DOWN) {
             return super.onInterceptTouchEvent(ev);
         }
@@ -331,16 +331,17 @@ public class CardInputWidget extends LinearLayout implements CardWidget {
         return super.onInterceptTouchEvent(ev);
     }
 
+    @NonNull
     @Override
     protected Parcelable onSaveInstanceState() {
-        Bundle bundle = new Bundle();
+        final Bundle bundle = new Bundle();
         bundle.putParcelable(EXTRA_SUPER_STATE, super.onSaveInstanceState());
         bundle.putBoolean(EXTRA_CARD_VIEWED, mCardNumberIsViewed);
         return bundle;
     }
 
     @Override
-    protected void onRestoreInstanceState(Parcelable state) {
+    protected void onRestoreInstanceState(@NonNull Parcelable state) {
         if (state instanceof Bundle) {
             Bundle bundleState = (Bundle) state;
             mCardNumberIsViewed = bundleState.getBoolean(EXTRA_CARD_VIEWED, true);

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.java
@@ -405,28 +405,28 @@ public class CardMultilineWidget extends LinearLayout implements CardWidget {
     /**
      * Expose a text watcher to receive updates when the card number is changed.
      */
-    public void setCardNumberTextWatcher(TextWatcher cardNumberTextWatcher) {
+    public void setCardNumberTextWatcher(@Nullable TextWatcher cardNumberTextWatcher) {
         mCardNumberEditText.addTextChangedListener(cardNumberTextWatcher);
     }
 
     /**
      * Expose a text watcher to receive updates when the expiry date is changed.
      */
-    public void setExpiryDateTextWatcher(TextWatcher expiryDateTextWatcher) {
+    public void setExpiryDateTextWatcher(@Nullable TextWatcher expiryDateTextWatcher) {
         mExpiryDateEditText.addTextChangedListener(expiryDateTextWatcher);
     }
 
     /**
      * Expose a text watcher to receive updates when the cvc number is changed.
      */
-    public void setCvcNumberTextWatcher(TextWatcher cvcNumberTextWatcher) {
+    public void setCvcNumberTextWatcher(@Nullable TextWatcher cvcNumberTextWatcher) {
         mCvcEditText.addTextChangedListener(cvcNumberTextWatcher);
     }
 
     /**
      * Expose a text watcher to receive updates when the cvc number is changed.
      */
-    public void setPostalCodeTextWatcher(TextWatcher postalCodeTextWatcher) {
+    public void setPostalCodeTextWatcher(@Nullable TextWatcher postalCodeTextWatcher) {
         mPostalCodeEditText.addTextChangedListener(postalCodeTextWatcher);
     }
 
@@ -638,17 +638,17 @@ public class CardMultilineWidget extends LinearLayout implements CardWidget {
         final int maxLength = Card.CardBrand.AMERICAN_EXPRESS.equals(mCardBrand) ?
                 Card.CVC_LENGTH_AMERICAN_EXPRESS : Card.CVC_LENGTH_COMMON;
         mCvcEditText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
-        mCvcTextInputLayout.setHint(getCvcLabel());
+        mCvcTextInputLayout.setHint(generateCvcLabel());
     }
 
     @NonNull
-    private String getCvcLabel() {
+    private String generateCvcLabel() {
         if (mCustomCvcLabel != null) {
             return mCustomCvcLabel;
+        } else {
+            return getResources().getString(Card.CardBrand.AMERICAN_EXPRESS.equals(mCardBrand) ?
+                    R.string.cvc_amex_hint : R.string.cvc_number_hint);
         }
-
-        return getResources().getString(Card.CardBrand.AMERICAN_EXPRESS.equals(mCardBrand) ?
-                R.string.cvc_amex_hint : R.string.cvc_number_hint);
     }
 
     private void updateDrawable(@DrawableRes int iconResourceId, boolean needsTint) {

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.java
@@ -47,17 +47,18 @@ public class CardNumberEditText extends StripeEditText {
     private boolean mIgnoreChanges = false;
     private boolean mIsCardNumberValid = false;
 
-    public CardNumberEditText(Context context) {
+    public CardNumberEditText(@NonNull Context context) {
         super(context);
         listenForTextChanges();
     }
 
-    public CardNumberEditText(Context context, AttributeSet attrs) {
+    public CardNumberEditText(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
         listenForTextChanges();
     }
 
-    public CardNumberEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+    public CardNumberEditText(@NonNull Context context, @Nullable AttributeSet attrs,
+                              int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         listenForTextChanges();
     }
@@ -135,7 +136,7 @@ public class CardNumberEditText extends StripeEditText {
             int editActionStart,
             int editActionAddition) {
         int newPosition, gapsJumped = 0;
-        Set<Integer> gapSet = Card.CardBrand.AMERICAN_EXPRESS.equals(mCardBrand)
+        final Set<Integer> gapSet = Card.CardBrand.AMERICAN_EXPRESS.equals(mCardBrand)
                 ? SPACE_SET_AMEX
                 : SPACE_SET_COMMON;
         boolean skipBack = false;
@@ -187,14 +188,14 @@ public class CardNumberEditText extends StripeEditText {
                     return;
                 }
 
-                String spacelessNumber = StripeTextUtils.removeSpacesAndHyphens(s.toString());
+                final String spacelessNumber = StripeTextUtils.removeSpacesAndHyphens(s.toString());
                 if (spacelessNumber == null) {
                     return;
                 }
 
-                String[] cardParts = ViewUtils.separateCardNumberGroups(
+                final String[] cardParts = ViewUtils.separateCardNumberGroups(
                         spacelessNumber, mCardBrand);
-                StringBuilder formattedNumberBuilder = new StringBuilder();
+                final StringBuilder formattedNumberBuilder = new StringBuilder();
                 for (int i = 0; i < cardParts.length; i++) {
                     if (cardParts[i] == null) {
                         break;
@@ -206,8 +207,8 @@ public class CardNumberEditText extends StripeEditText {
                     formattedNumberBuilder.append(cardParts[i]);
                 }
 
-                String formattedNumber = formattedNumberBuilder.toString();
-                int cursorPosition = updateSelectionIndex(
+                final String formattedNumber = formattedNumberBuilder.toString();
+                final int cursorPosition = updateSelectionIndex(
                         formattedNumber.length(),
                         latestChangeStart,
                         latestInsertionSize);

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.java
@@ -19,23 +19,24 @@ import com.stripe.android.R;
  */
 public class ExpiryDateEditText extends StripeEditText {
 
-    static final int INVALID_INPUT = -1;
+    private static final int INVALID_INPUT = -1;
     private static final int MAX_INPUT_LENGTH = 5;
 
-    private ExpiryDateEditListener mExpiryDateEditListener;
+    @Nullable private ExpiryDateEditListener mExpiryDateEditListener;
     private boolean mIsDateValid;
 
-    public ExpiryDateEditText(Context context) {
+    public ExpiryDateEditText(@NonNull Context context) {
         super(context);
         listenForTextChanges();
     }
 
-    public ExpiryDateEditText(Context context, AttributeSet attrs) {
+    public ExpiryDateEditText(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
         listenForTextChanges();
     }
 
-    public ExpiryDateEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+    public ExpiryDateEditText(@NonNull Context context, @Nullable AttributeSet attrs,
+                              int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         listenForTextChanges();
     }
@@ -94,7 +95,7 @@ public class ExpiryDateEditText extends StripeEditText {
         return monthYearPair;
     }
 
-    public void setExpiryDateEditListener(ExpiryDateEditListener expiryDateEditListener) {
+    public void setExpiryDateEditListener(@Nullable ExpiryDateEditListener expiryDateEditListener) {
         mExpiryDateEditListener = expiryDateEditListener;
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
+++ b/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.google.android.material.textfield.TextInputLayout;
@@ -36,15 +38,16 @@ public class IconTextInputLayout extends TextInputLayout {
     @VisibleForTesting private final Rect mBounds;
     @VisibleForTesting private final Method mRecalculateMethod;
 
-    public IconTextInputLayout(Context context) {
+    public IconTextInputLayout(@NonNull Context context) {
         this(context, null);
     }
 
-    public IconTextInputLayout(Context context, AttributeSet attrs) {
+    public IconTextInputLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
         this(context, attrs, 0);
     }
 
-    public IconTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+    public IconTextInputLayout(@NonNull Context context, @Nullable AttributeSet attrs,
+                               int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
         /*

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.java
@@ -63,7 +63,7 @@ public final class PaymentFlowActivityStarter
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             dest.writeParcelable(paymentSessionConfig, 0);
             dest.writeParcelable(paymentSessionData, 0);
             dest.writeInt(isPaymentSessionActive ? 1 : 0);

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -86,7 +86,7 @@ public final class PaymentMethodsActivityStarter
         }
 
         @Override
-        public void writeToParcel(Parcel dest, int flags) {
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
             dest.writeString(initialPaymentMethodId);
             dest.writeInt(shouldRequirePostalCode ? 1 : 0);
             dest.writeInt(isPaymentSessionActive ? 1 : 0);

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.java
@@ -86,13 +86,14 @@ public class StripeEditText extends AppCompatEditText {
         return mDefaultErrorColor;
     }
 
+    @Nullable
     @Override
-    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
+    public InputConnection onCreateInputConnection(@NonNull EditorInfo outAttrs) {
+        final InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
         if (inputConnection == null) {
             return null;
         }
-        return new SoftDeleteInputConnection(super.onCreateInputConnection(outAttrs), true);
+        return new SoftDeleteInputConnection(inputConnection, true);
     }
 
     /**
@@ -130,11 +131,6 @@ public class StripeEditText extends AppCompatEditText {
      */
     public void setErrorColor(@ColorInt int errorColor) {
         mErrorColor = errorColor;
-    }
-
-    @ColorInt
-    private int getErrorColor() {
-        return mErrorColor != null ? mErrorColor : mDefaultErrorColor;
     }
 
     /**
@@ -177,7 +173,7 @@ public class StripeEditText extends AppCompatEditText {
         } else {
             mShouldShowError = shouldShowError;
             if (mShouldShowError) {
-                setTextColor(getErrorColor());
+                setTextColor(mErrorColor != null ? mErrorColor : mDefaultErrorColor);
             } else {
                 setTextColor(mCachedColorStateList);
             }


### PR DESCRIPTION
Add the `Interoperability` lint rule to avoid Java <> Kotlin interoperability issues.
