### PR TITLE
Implement deleting a Payment Method

### DIFF
--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -125,4 +125,6 @@
 
     <!-- TODO(mshafrir-stripe): translate string - ANDROID-413 -->
     <string name="added" tools:ignore="MissingTranslation">Added %s</string>
+    <string name="removed" tools:ignore="MissingTranslation">Removed %s</string>
+    <string name="delete_payment_method" tools:ignore="MissingTranslation">Delete Payment Method?</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -134,6 +134,21 @@ internal class PaymentMethodsAdapter @JvmOverloads constructor(
         return PaymentMethodViewHolder(itemView)
     }
 
+    fun deletePaymentMethod(paymentMethod: PaymentMethod) {
+        val indexToDelete = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
+        if (indexToDelete >= 0) {
+            paymentMethods.removeAt(indexToDelete)
+            notifyItemRemoved(indexToDelete)
+        }
+    }
+
+    fun resetPaymentMethod(paymentMethod: PaymentMethod) {
+        val indexToReset = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
+        if (indexToReset >= 0) {
+            notifyItemChanged(indexToReset)
+        }
+    }
+
     private fun getAddableTypesPosition(position: Int) = position - paymentMethods.size
 
     internal class PaymentMethodViewHolder constructor(


### PR DESCRIPTION
On swipe, prompt user to confirm deletion.

If deletion is confirmed, Payment Method is removed
from the adapter and detached from the Customer. Finally,
a Snackbar is shown notifying the user.

![delete_payment_method](https://user-images.githubusercontent.com/45020849/64985809-bc276000-d893-11e9-9cc6-f70444608c65.gif)
