### PR TITLE
Fix ShippingMethodView height

### DIFF
--- a/stripe/res/layout/shipping_method_view.xml
+++ b/stripe/res/layout/shipping_method_view.xml
@@ -1,52 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    >
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        >
+        android:layout_centerVertical="true">
 
-    <TextView
-        android:id="@+id/tv_label_smv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_toStartOf="@+id/tv_amount_smv"
-        android:paddingTop="@dimen/shipping_widget_vertical_margin"
-        android:textAppearance="@style/TextAppearance.AppCompat.Menu"
-        />
+        <TextView
+            android:id="@+id/shipping_method_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_toStartOf="@+id/shipping_method_price"
+            android:paddingTop="@dimen/shipping_widget_vertical_margin"
+            android:textAppearance="@style/TextAppearance.AppCompat.Menu" />
 
-    <TextView
-        android:id="@+id/tv_detail_smv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/tv_label_smv"
-        android:layout_marginTop="@dimen/shipping_widget_vertical_margin"
-        android:layout_toStartOf="@+id/tv_amount_smv"
-        android:paddingBottom="@dimen/shipping_widget_vertical_margin"
-        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small"
-        />
+        <TextView
+            android:id="@+id/shipping_method_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/shipping_method_name"
+            android:layout_marginTop="@dimen/shipping_widget_vertical_margin"
+            android:layout_toStartOf="@+id/shipping_method_price"
+            android:paddingBottom="@dimen/shipping_widget_vertical_margin"
+            android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small" />
 
-    <TextView
-        android:id="@+id/tv_amount_smv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:layout_marginEnd="@dimen/shipping_widget_horizontal_margin"
-        android:layout_toStartOf="@+id/iv_selected_icon"
-        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small"
-        />
+        <TextView
+            android:id="@+id/shipping_method_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/shipping_widget_horizontal_margin"
+            android:layout_toStartOf="@+id/selected_icon"
+            android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/iv_selected_icon"
-        android:layout_width="@dimen/shipping_check_icon_width"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
-        android:background="@drawable/ic_checkmark_tinted"
-        />
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/selected_icon"
+            android:layout_width="@dimen/shipping_check_icon_width"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@drawable/ic_checkmark_tinted" />
     </RelativeLayout>
 </merge>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -28,5 +28,4 @@
     <dimen name="shipping_widget_vertical_margin">4dp</dimen>
     <dimen name="shipping_widget_horizontal_margin">16dp</dimen>
     <dimen name="shipping_widget_outer_margin">12dp</dimen>
-    <dimen name="shipping_method_view_height">21dp</dimen>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodView.kt
@@ -2,16 +2,13 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.RelativeLayout
-import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import com.stripe.android.R
 import com.stripe.android.model.ShippingMethod
+import kotlinx.android.synthetic.main.shipping_method_view.view.*
 
 /**
  * Renders the information related to a shipping method.
@@ -21,10 +18,6 @@ internal class ShippingMethodView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : RelativeLayout(context, attrs, defStyleAttr) {
-    private val label: TextView
-    private val detail: TextView
-    private val amount: TextView
-    private val checkmark: ImageView
     private val colorUtils = StripeColorUtils(context)
 
     @ColorInt
@@ -36,10 +29,6 @@ internal class ShippingMethodView @JvmOverloads constructor(
 
     init {
         View.inflate(context, R.layout.shipping_method_view, this)
-        label = findViewById(R.id.tv_label_smv)
-        detail = findViewById(R.id.tv_detail_smv)
-        amount = findViewById(R.id.tv_amount_smv)
-        checkmark = findViewById(R.id.iv_selected_icon)
 
         val rawSelectedColorInt = colorUtils.getThemeAccentColor().data
         val rawUnselectedTextColorPrimaryInt = colorUtils.getThemeTextColorPrimary().data
@@ -65,34 +54,26 @@ internal class ShippingMethodView @JvmOverloads constructor(
             } else {
                 rawUnselectedTextColorSecondaryInt
             }
-
-        val params = LayoutParams(LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        params.addRule(Gravity.CENTER_VERTICAL)
-        params.height = ViewUtils.getPxFromDp(
-            context,
-            resources.getDimensionPixelSize(R.dimen.shipping_method_view_height)
-        )
-        layoutParams = params
     }
 
     override fun setSelected(selected: Boolean) {
         if (selected) {
-            label.setTextColor(selectedColorInt)
-            detail.setTextColor(selectedColorInt)
-            amount.setTextColor(selectedColorInt)
-            checkmark.visibility = View.VISIBLE
+            shipping_method_name.setTextColor(selectedColorInt)
+            shipping_method_description.setTextColor(selectedColorInt)
+            shipping_method_price.setTextColor(selectedColorInt)
+            selected_icon.visibility = View.VISIBLE
         } else {
-            label.setTextColor(unselectedTextColorPrimaryInt)
-            detail.setTextColor(unselectedTextColorSecondaryInt)
-            amount.setTextColor(unselectedTextColorPrimaryInt)
-            checkmark.visibility = View.INVISIBLE
+            shipping_method_name.setTextColor(unselectedTextColorPrimaryInt)
+            shipping_method_description.setTextColor(unselectedTextColorSecondaryInt)
+            shipping_method_price.setTextColor(unselectedTextColorPrimaryInt)
+            selected_icon.visibility = View.INVISIBLE
         }
     }
 
     fun setShippingMethod(shippingMethod: ShippingMethod) {
-        label.text = shippingMethod.label
-        detail.text = shippingMethod.detail
-        amount.text = PaymentUtils.formatPriceStringUsingFree(
+        shipping_method_name.text = shippingMethod.label
+        shipping_method_description.text = shippingMethod.detail
+        shipping_method_price.text = PaymentUtils.formatPriceStringUsingFree(
             shippingMethod.amount,
             shippingMethod.currency,
             context.getString(R.string.price_free)


### PR DESCRIPTION
The height of `ShippingMethodView` was being set to
`R.dimen.shipping_method_view_height`, which was causing some
of its contents to be cut off.

This logic appears to be unnecessary, although may have been required for older APIs that we no longer support. Tested on API 19 and 29.

![Screenshot_1568740341](https://user-images.githubusercontent.com/45020849/65063894-2fd97380-d94d-11e9-9f01-bcda23b03bbd.png)

![Screenshot_1568740365](https://user-images.githubusercontent.com/45020849/65063899-323bcd80-d94d-11e9-9145-84d4845411db.png)
