### PR TITLE
Create AddPaymentMethodActivityStarter.Result

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.java
@@ -2,6 +2,7 @@ package com.stripe.android.view;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
@@ -66,5 +67,8 @@ public abstract class ActivityStarter
 
     public interface Result extends Parcelable {
         String EXTRA = "extra_activity_result";
+
+        @NonNull
+        Bundle toBundle();
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.java
@@ -37,6 +37,10 @@ public class AddPaymentMethodActivity extends StripeActivity {
 
     public static final String TOKEN_ADD_PAYMENT_METHOD_ACTIVITY = "AddPaymentMethodActivity";
 
+    /**
+     * @deprecated use {@link AddPaymentMethodActivityStarter.Result}
+     */
+    @Deprecated
     public static final String EXTRA_NEW_PAYMENT_METHOD = "new_payment_method";
 
     @Nullable private AddPaymentMethodView mAddPaymentMethodView;
@@ -152,7 +156,9 @@ public class AddPaymentMethodActivity extends StripeActivity {
 
     private void finishWithPaymentMethod(@NonNull PaymentMethod paymentMethod) {
         setCommunicatingProgress(false);
-        setResult(RESULT_OK, new Intent().putExtra(EXTRA_NEW_PAYMENT_METHOD, paymentMethod));
+        setResult(RESULT_OK, new Intent()
+                .putExtra(EXTRA_NEW_PAYMENT_METHOD, paymentMethod)
+                .putExtras(new AddPaymentMethodActivityStarter.Result(paymentMethod).toBundle()));
         finish();
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -2,6 +2,7 @@ package com.stripe.android.view;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -180,5 +181,76 @@ public final class AddPaymentMethodActivityStarter
                 return new AddPaymentMethodActivityStarter.Args(this);
             }
         }
+    }
+
+    /**
+     * The result of a {@link AddPaymentMethodActivity}.
+     *
+     * <p>Retrieve in <code>#onActivityResult()</code> using {@link #fromIntent(Intent)}.
+     */
+    public static final class Result implements ActivityStarter.Result {
+        @NonNull public final PaymentMethod paymentMethod;
+
+        /**
+         * @return the {@link Result} object from the given <code>Intent</code>
+         */
+        @Nullable
+        static Result fromIntent(@NonNull Intent intent) {
+            return intent.getParcelableExtra(EXTRA);
+        }
+
+        Result(@NonNull PaymentMethod paymentMethod) {
+            this.paymentMethod = paymentMethod;
+        }
+
+        private Result(@NonNull Parcel parcel) {
+            this.paymentMethod = Objects.requireNonNull(
+                    parcel.<PaymentMethod>readParcelable(PaymentMethod.class.getClassLoader())
+            );
+        }
+
+        @NonNull
+        @Override
+        public Bundle toBundle() {
+            final Bundle bundle = new Bundle();
+            bundle.putParcelable(EXTRA, this);
+            return bundle;
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            dest.writeParcelable(paymentMethod, flags);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(paymentMethod);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return super.equals(obj) || (obj instanceof Result && typedEquals((Result) obj));
+        }
+
+        private boolean typedEquals(@NonNull Result other) {
+            return Objects.equals(paymentMethod, other.paymentMethod);
+        }
+
+        public static final Creator<Result> CREATOR = new Creator<Result>() {
+            @Override
+            public Result createFromParcel(Parcel in) {
+                return new Result(in);
+            }
+
+            @Override
+            public Result[] newArray(int size) {
+                return new Result[size];
+            }
+        };
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.java
@@ -28,7 +28,6 @@ import com.stripe.android.view.i18n.TranslatorManager;
 import java.util.List;
 
 import static com.stripe.android.PaymentSession.TOKEN_PAYMENT_SESSION;
-import static com.stripe.android.view.AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD;
 
 /**
  * <p>An activity that allows a customer to select from their attach payment methods,
@@ -143,9 +142,11 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     private void onPaymentMethodCreated(@Nullable Intent data) {
         initLoggingTokens();
 
-        if (data != null && data.hasExtra(EXTRA_NEW_PAYMENT_METHOD)) {
-            final PaymentMethod paymentMethod =
-                    data.getParcelableExtra(EXTRA_NEW_PAYMENT_METHOD);
+        if (data != null) {
+            final AddPaymentMethodActivityStarter.Result result =
+                    AddPaymentMethodActivityStarter.Result.fromIntent(data);
+            final PaymentMethod paymentMethod = result != null ?
+                    result.paymentMethod : null;
             onAddedPaymentMethod(paymentMethod);
         } else {
             fetchCustomerPaymentMethods();

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -207,6 +207,7 @@ public final class PaymentMethodsActivityStarter
         }
 
         @NonNull
+        @Override
         public Bundle toBundle() {
             final Bundle bundle = new Bundle();
             bundle.putParcelable(EXTRA, this);

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.java
@@ -1,7 +1,13 @@
 package com.stripe.android.view;
 
+import android.content.Intent;
+import android.os.Bundle;
+
 import com.stripe.android.model.PaymentMethod;
+import com.stripe.android.model.PaymentMethodFixtures;
 import com.stripe.android.utils.ParcelUtils;
+
+import java.util.Objects;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,5 +30,20 @@ public class AddPaymentMethodActivityStarterTest {
         final AddPaymentMethodActivityStarter.Args createdArgs =
                 ParcelUtils.create(args, AddPaymentMethodActivityStarter.Args.CREATOR);
         assertEquals(args, createdArgs);
+    }
+
+    @Test
+    public void testResultParceling() {
+        final Bundle bundle =
+                new AddPaymentMethodActivityStarter
+                        .Result(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                        .toBundle();
+        final Intent intent = new Intent().putExtras(bundle);
+        final AddPaymentMethodActivityStarter.Result result =
+                Objects.requireNonNull(AddPaymentMethodActivityStarter.Result.fromIntent(intent));
+        assertEquals(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                result.paymentMethod
+        );
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.java
@@ -202,10 +202,8 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         final Intent intent = mShadowActivity.getResultIntent();
 
         assertTrue(mActivity.isFinishing());
-        assertTrue(intent.hasExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD));
-        final PaymentMethod paymentMethod =
-                intent.getParcelableExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD);
-        assertNotNull(paymentMethod);
+
+        final PaymentMethod paymentMethod = getPaymentMethodFromIntent(intent);
         assertEquals(expectedPaymentMethod, paymentMethod);
     }
 
@@ -250,10 +248,8 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         final Intent intent = mShadowActivity.getResultIntent();
 
         assertTrue(mActivity.isFinishing());
-        assertTrue(intent.hasExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD));
-        final PaymentMethod paymentMethod =
-                intent.getParcelableExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD);
-        assertNotNull(paymentMethod);
+
+        final PaymentMethod paymentMethod = getPaymentMethodFromIntent(intent);
         assertEquals(expectedPaymentMethod, paymentMethod);
     }
 
@@ -366,10 +362,18 @@ public class AddPaymentMethodActivityTest extends BaseViewTest<AddPaymentMethodA
         final Intent intent = mShadowActivity.getResultIntent();
 
         assertTrue(mActivity.isFinishing());
-        assertTrue(intent.hasExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD));
-        final PaymentMethod newPaymentMethod =
-                intent.getParcelableExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD);
-        assertNotNull(newPaymentMethod);
-        assertEquals(expectedPaymentMethod, newPaymentMethod);
+
+        final PaymentMethod paymentMethod = getPaymentMethodFromIntent(intent);
+        assertEquals(expectedPaymentMethod, paymentMethod);
+    }
+
+    @NonNull
+    private static PaymentMethod getPaymentMethodFromIntent(@NonNull Intent intent) {
+        final AddPaymentMethodActivityStarter.Result result =
+                AddPaymentMethodActivityStarter.Result.fromIntent(intent);
+        assertNotNull(result);
+        final PaymentMethod paymentMethod = result.paymentMethod;
+        assertNotNull(paymentMethod);
+        return paymentMethod;
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.java
@@ -176,8 +176,7 @@ public class PaymentMethodsActivityTest extends BaseViewTest<PaymentMethodsActiv
         assertNotNull(paymentMethod);
 
         final Intent resultIntent = new Intent()
-                .putExtra(AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD, paymentMethod);
-
+                .putExtras(new AddPaymentMethodActivityStarter.Result(paymentMethod).toBundle());
         mPaymentMethodsActivity.onActivityResult(
                 AddPaymentMethodActivityStarter.REQUEST_CODE, RESULT_OK, resultIntent
         );


### PR DESCRIPTION
This is a similar pattern to `PaymentMethodsActivityStarter.Result`
and provides typed results from a `PaymentMethodsActivity`.

Also, mark `AddPaymentMethodActivity.EXTRA_NEW_PAYMENT_METHOD`
as `@Deprecated`. Users should migrate to
`AddPaymentMethodActivityStarter.Result`.