### PR TITLE
Add Analytics events for 3DS1 SDK and 3DS2 Fallback

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -25,11 +25,12 @@ internal class AnalyticsDataFactory @VisibleForTesting constructor(
         EventName.ADD_SOURCE, EventName.DEFAULT_SOURCE, EventName.DELETE_SOURCE,
         EventName.SET_SHIPPING_INFO, EventName.CONFIRM_PAYMENT_INTENT,
         EventName.RETRIEVE_PAYMENT_INTENT, EventName.CONFIRM_SETUP_INTENT,
-        EventName.RETRIEVE_SETUP_INTENT, EventName.AUTH_3DS2_FINGERPRINT, EventName.AUTH_3DS2_START,
+        EventName.RETRIEVE_SETUP_INTENT, EventName.AUTH_3DS1_SDK,
+        EventName.AUTH_3DS2_FINGERPRINT, EventName.AUTH_3DS2_START,
         EventName.AUTH_3DS2_FRICTIONLESS, EventName.AUTH_3DS2_CHALLENGE_PRESENTED,
         EventName.AUTH_3DS2_CHALLENGE_CANCELED, EventName.AUTH_3DS2_CHALLENGE_COMPLETED,
         EventName.AUTH_3DS2_CHALLENGE_ERRORED, EventName.AUTH_3DS2_CHALLENGE_TIMEDOUT,
-        EventName.AUTH_REDIRECT, EventName.AUTH_ERROR)
+        EventName.AUTH_3DS2_FALLBACK, EventName.AUTH_REDIRECT, EventName.AUTH_ERROR)
     internal annotation class EventName {
         companion object {
             const val TOKEN_CREATION = "token_creation"
@@ -46,6 +47,8 @@ internal class AnalyticsDataFactory @VisibleForTesting constructor(
             const val CONFIRM_SETUP_INTENT = "setup_intent_confirmation"
             const val RETRIEVE_SETUP_INTENT = "setup_intent_retrieval"
 
+            const val AUTH_3DS1_SDK = "3ds1_sdk"
+
             const val AUTH_3DS2_FINGERPRINT = "3ds2_fingerprint"
             const val AUTH_3DS2_START = "3ds2_authenticate"
             const val AUTH_3DS2_FRICTIONLESS = "3ds2_frictionless_flow"
@@ -54,6 +57,8 @@ internal class AnalyticsDataFactory @VisibleForTesting constructor(
             const val AUTH_3DS2_CHALLENGE_COMPLETED = "3ds2_challenge_flow_completed"
             const val AUTH_3DS2_CHALLENGE_ERRORED = "3ds2_challenge_flow_errored"
             const val AUTH_3DS2_CHALLENGE_TIMEDOUT = "3ds2_challenge_flow_timed_out"
+            const val AUTH_3DS2_FALLBACK = "3ds2_fallback"
+
             const val AUTH_REDIRECT = "url_redirect_next_action"
             const val AUTH_ERROR = "auth_error"
         }

--- a/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
+++ b/stripe/src/test/java/com/stripe/android/PaymentControllerTest.java
@@ -26,6 +26,13 @@ import com.stripe.android.stripe3ds2.views.ChallengeProgressDialogActivity;
 import com.stripe.android.view.AuthActivityStarter;
 import com.stripe.android.view.StripeIntentResultExtras;
 
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,13 +42,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-
-import java.security.PublicKey;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -206,6 +206,12 @@ public class PaymentControllerTest {
                 intent.getStringExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL)
         );
         assertNull(intent.getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL));
+
+        verify(mFireAndForgetRequestExecutor).executeAsync(mApiRequestArgumentCaptor.capture());
+        final StripeRequest analyticsRequest = mApiRequestArgumentCaptor.getValue();
+        final Map<String, ?> analyticsParams = Objects.requireNonNull(analyticsRequest.params);
+        assertEquals("stripe_android.3ds1_sdk",
+                analyticsParams.get(AnalyticsDataFactory.FIELD_EVENT));
     }
 
     @Test
@@ -584,6 +590,12 @@ public class PaymentControllerTest {
                 intent.getStringExtra(PaymentAuthWebViewStarter.EXTRA_AUTH_URL)
         );
         assertNull(intent.getStringExtra(PaymentAuthWebViewStarter.EXTRA_RETURN_URL));
+
+        verify(mFireAndForgetRequestExecutor).executeAsync(mApiRequestArgumentCaptor.capture());
+        final StripeRequest analyticsRequest = mApiRequestArgumentCaptor.getValue();
+        final Map<String, ?> analyticsParams = Objects.requireNonNull(analyticsRequest.params);
+        assertEquals("stripe_android.3ds2_fallback",
+                analyticsParams.get(AnalyticsDataFactory.FIELD_EVENT));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fire analytics events for 3DS1 via the SDK and 3DS2 fallback.
 
## Motivation
Resolve gaps in analytics

## Testing
Unit tests
