### PR TITLE
Update BouncyCastle ProGuard rules

### DIFF
--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -1,6 +1,7 @@
 -keep class android.support.design.widget.TextInputLayout { *; }
 -keep class android.support.design.widget.CollapsingTextHelper { *; }
--keep class org.bouncycastle.** { *; }
+-keep class org.bouncycastle.jcajce.provider.** { *; }
+-keep class org.bouncycastle.jce.provider.** { *; }
 
 -keep class com.stripe.android.** { *; }
 -dontwarn com.stripe.android.view.**


### PR DESCRIPTION
Keep only the BouncyCastle provider classes

Tested and verified by running 3DS2 on a real card

Fixes #1559