### PR TITLE
Add Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlinVersion = '1.3.50'
-    ext.dokkaVersion = '0.9.18'
+    ext.dokkaVersion = '0.9.17' // 0.9.18 has a bug that causes the task to fail
 
     repositories {
         jcenter()

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -4,9 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'checkstyle'
 // make sure this line comes *after* you apply the Android plugin
 apply plugin: 'com.getkeepsafe.dexcount'
+apply plugin: 'org.jetbrains.dokka-android'
 
 assemble.dependsOn('lint')
 check.dependsOn('checkstyle')
+assemble.dependsOn('dokka')
 
 configurations {
     javadocDeps
@@ -76,6 +78,11 @@ android {
 
     lintOptions {
         enable "Interoperability"
+    }
+
+    dokka {
+        outputFormat = 'javadoc'
+        outputDirectory = "$buildDir/docs/javadoc"
     }
 }
 


### PR DESCRIPTION
Re-add Dokka. Use `0.9.17` because `0.9.18` has a bug that causes the task to fail.