### PR TITLE
Create Stripe.createCardTokenSynchronous()

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -233,10 +233,10 @@ class PaymentAuthActivity : AppCompatActivity() {
     }
 
     private class SetupAuthResultListener constructor(activity: PaymentAuthActivity) : ApiResultCallback<SetupIntentResult> {
-        private val mActivityRef: WeakReference<PaymentAuthActivity> = WeakReference(activity)
+        private val activityRef: WeakReference<PaymentAuthActivity> = WeakReference(activity)
 
         override fun onSuccess(setupIntentResult: SetupIntentResult) {
-            val activity = mActivityRef.get() ?: return
+            val activity = activityRef.get() ?: return
 
             val setupIntent = setupIntentResult.intent
             activity.statusTextView.append("\n\n" + activity.getString(R.string.setup_intent_status, setupIntent.status))
@@ -244,7 +244,7 @@ class PaymentAuthActivity : AppCompatActivity() {
         }
 
         override fun onError(e: Exception) {
-            val activity = mActivityRef.get() ?: return
+            val activity = activityRef.get() ?: return
 
             activity.statusTextView.append("\n\nException: " + e.message)
             activity.onAuthComplete()

--- a/example/src/main/java/com/stripe/example/module/DependencyHandler.kt
+++ b/example/src/main/java/com/stripe/example/module/DependencyHandler.kt
@@ -47,13 +47,14 @@ class DependencyHandler(
                 errorDialogHandler,
                 listViewController,
                 progressDialogController,
-                publishableKey)
+                publishableKey
+            )
         }
     }
 
     /**
      * Attach a listener that creates a token using a [rx.Subscription] and the
-     * synchronous [com.stripe.android.Stripe.createTokenSynchronous] method.
+     * synchronous [com.stripe.android.Stripe.createCardTokenSynchronous] method.
      *
      * Only gets attached once, unless you call [.clearReferences].
      *
@@ -67,7 +68,8 @@ class DependencyHandler(
                 context,
                 listViewController,
                 progressDialogController,
-                publishableKey)
+                publishableKey
+            )
         }
     }
 
@@ -75,14 +77,8 @@ class DependencyHandler(
      * Clear all the references so that we can start over again.
      */
     fun clearReferences() {
-
-        if (asyncTaskController != null) {
-            asyncTaskController!!.detach()
-        }
-
-        if (rxTokenController != null) {
-            rxTokenController!!.detach()
-        }
+        asyncTaskController?.detach()
+        rxTokenController?.detach()
 
         asyncTaskController = null
         rxTokenController = null

--- a/example/src/main/java/com/stripe/example/service/TokenIntentService.kt
+++ b/example/src/main/java/com/stripe/example/service/TokenIntentService.kt
@@ -29,7 +29,7 @@ class TokenIntentService : IntentService("TokenIntentService") {
             val stripe = Stripe(applicationContext,
                 PaymentConfiguration.getInstance(this).publishableKey)
             try {
-                token = stripe.createTokenSynchronous(card)
+                token = stripe.createCardTokenSynchronous(card)
             } catch (stripeEx: StripeException) {
                 errorMessage = stripeEx.localizedMessage
             }

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -180,7 +180,7 @@ public class StripeTest {
     public void createCardTokenSynchronous_withValidData_returnsToken()
             throws StripeException {
         final Stripe stripe = createStripe();
-        final Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createCardTokenSynchronous(CARD);
 
         assertNotNull(token);
         Card returnedCard = token.getCard();
@@ -203,7 +203,7 @@ public class StripeTest {
                 "acct_1Acj2PBUgO3KuWzz"
         );
 
-        final Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createCardTokenSynchronous(CARD);
 
         assertNotNull(token);
         Card returnedCard = token.getCard();
@@ -221,7 +221,7 @@ public class StripeTest {
     public void createToken_createSource_returnsSource()
             throws StripeException {
         final Stripe stripe = createStripe();
-        final Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createCardTokenSynchronous(CARD);
         assertNotNull(token);
 
         final SourceParams sourceParams = SourceParams.createSourceFromTokenParams(token.getId());
@@ -233,7 +233,7 @@ public class StripeTest {
     public void createToken_createSourceWithTokenToSourceParams_returnsSource()
             throws StripeException {
         final Stripe stripe = createStripe();
-        final Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createCardTokenSynchronous(CARD);
         assertNotNull(token);
 
         final SourceParams sourceParams = SourceParams.createSourceFromTokenParams(token.getId());
@@ -1014,7 +1014,7 @@ public class StripeTest {
                 new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        stripe.createTokenSynchronous(CARD);
+                        stripe.createCardTokenSynchronous(CARD);
                     }
                 }
         );
@@ -1032,7 +1032,7 @@ public class StripeTest {
                 new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        stripe.createTokenSynchronous(card);
+                        stripe.createCardTokenSynchronous(card);
                     }
                 }
         );
@@ -1049,7 +1049,7 @@ public class StripeTest {
                 new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        stripe.createTokenSynchronous(card);
+                        stripe.createCardTokenSynchronous(card);
                     }
                 }
         );
@@ -1090,7 +1090,7 @@ public class StripeTest {
     public void createPaymentMethod_withCardToken()
             throws StripeException {
         final Stripe stripe = createStripe();
-        final Token token = stripe.createTokenSynchronous(CARD);
+        final Token token = stripe.createCardTokenSynchronous(CARD);
 
         final PaymentMethodCreateParams paymentMethodCreateParams =
                 PaymentMethodCreateParams.create(


### PR DESCRIPTION
Mark `Stripe#createTokenSynchronous()` as `@Deprecated` because it
has an ambiguous name (there are various types of Tokens, not just
Card). Instead, use `Stripe#createCardTokenSynchronous()`.