### PR TITLE
3DS2 Theme and Night Mode

### DIFF
--- a/example/res/color/threeds2_footer_header.xml
+++ b/example/res/color/threeds2_footer_header.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorControlActivated" android:state_enabled="true" />
+    <item android:color="?android:attr/textColor" />
+</selector>

--- a/example/res/values-night/colors.xml
+++ b/example/res/values-night/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="primary">#1f1f1f</color>
+    <color name="primaryDark">#000000</color>
+    <color name="accent">#5a5a5a</color>
+    <color name="title">#ffffff</color>
+    <color name="textPrimary">@android:color/white</color>
+    <color name="text">#e1e1e1</color>
+</resources>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -9,4 +9,66 @@
         <item name="android:textColorPrimary">@color/textPrimary</item>
         <item name="android:textColor">@color/text</item>
     </style>
+
+    <style name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme">
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primaryDark</item>
+        <item name="android:textColorPrimary">@color/title</item>
+        <item name="android:textColor">@color/textPrimary</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="android:textColorHint">@color/textPrimary</item>
+        <item name="textInputStyle">@style/Stripe3DS2TextInput</item>
+        <item name="android:editTextColor">@color/textPrimary</item>
+        <item name="editTextColor">@color/textPrimary</item>
+    </style>
+
+    <!-- styles for text input -->
+    <style name="Stripe3DS2TextInput" parent="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense">
+        <item name="boxBackgroundColor">@android:color/transparent</item> <!-- edit text background color -->
+        <item name="hintTextAppearance">@style/Stripe3DS2TextInputHintTextAppearance</item>
+    </style>
+
+    <style name="Stripe3DS2EditTextTheme" parent="Stripe3DS2Theme">
+        <item name="colorControlActivated">@color/accent</item> <!-- edit text underline color when active, cursor color -->
+        <item name="colorControlNormal">@color/accent</item> <!-- edit text underline color when inactive -->
+    </style>
+
+    <style name="Stripe3DS2TextInputHintTextAppearance" parent="TextAppearance.Design.Hint">
+        <!-- Inactive and Active label color, pointing to a selector-->
+        <item name="android:textColor">@color/textPrimary</item>
+    </style>
+
+    <style name="Stripe3DS2ActionBarButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/title</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:minWidth">0dp</item>
+    </style>
+
+    <style name="Stripe3DS2Button" parent="Widget.MaterialComponents.Button">
+        <item name="android:textAllCaps">false</item>
+        <item name="cornerRadius">5dp</item>
+        <item name="android:textSize">19sp</item>
+        <item name="backgroundTint">@color/accent</item>
+    </style>
+
+    <style name="Stripe3DS2TextButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">19sp</item>
+        <item name="android:textColor">@color/accent</item>
+    </style>
+    
+    <style name="Stripe3DS2Divider">
+        <item name="android:visibility">gone</item>
+    </style>
+
+    <style name="Stripe3DS2FooterHeader">
+        <item name="android:textColor">@color/threeds2_footer_header</item>
+    </style>
+
+    <style name="Stripe3DS2FooterText"/>
+
+    <style name="Stripe3DS2FooterChevron">
+        <item name="tint">@color/threeds2_footer_header</item>
+    </style>
+
 </resources>

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -46,8 +46,7 @@ class PaymentAuthActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_payment_auth)
 
-        val uiCustomization = PaymentAuthConfig.Stripe3ds2UiCustomization.Builder.createWithAppTheme(this)
-            .build()
+        val uiCustomization = PaymentAuthConfig.Stripe3ds2UiCustomization.Builder().build()
         PaymentAuthConfig.init(PaymentAuthConfig.Builder()
             .set3ds2Config(PaymentAuthConfig.Stripe3ds2Config.Builder()
                 .setTimeout(6)

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -24,4 +24,6 @@
         <item name="android:textColor">#999999</item>
         <item name="android:textSize">@dimen/notification_text_size</item>
     </style>
+
+    <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 </resources>


### PR DESCRIPTION
## Summary

Add example of 3DS2 theme, and support for night mode across the example app.

## Motivation

Providing an example of 3DS2 theme customization.

## Testing

Tested in example app.

![Screenshot_1569953098](https://user-images.githubusercontent.com/48026502/65987762-79998200-e454-11e9-9fa6-444905033b56.png)
![Screenshot_1569953091](https://user-images.githubusercontent.com/48026502/65987763-79998200-e454-11e9-92bd-a49183832e2c.png)
![Screenshot_1569953073](https://user-images.githubusercontent.com/48026502/65987764-79998200-e454-11e9-9866-39a98e2eb8e4.png)
![Screenshot_1569953070](https://user-images.githubusercontent.com/48026502/65987765-79998200-e454-11e9-8f21-8d4839ba4e6a.png)
![Screenshot_1569953060](https://user-images.githubusercontent.com/48026502/65987766-79998200-e454-11e9-87cf-c17d51a526b8.png)
