### PR TITLE
Add support for an add payment method footer

### DIFF
--- a/example/res/layout/add_payment_method_footer.xml
+++ b/example/res/layout/add_payment_method_footer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/add_card_total_margin"
+    android:text="@string/add_payment_method_footer" />

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="payment_session_select_shipping">Set Shipping Information</string>
     <string name="payment_session_data">Payment Session Data</string>
     <string name="ok">OK</string>
+    <string name="add_payment_method_footer">Please read and review our <a href="https://stripe.com/privacy">privacy policy</a>.</string>
 
     <string name="label_source_type">Type</string>
     <string name="label_3ds_status">3DS status</string>

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -114,6 +114,7 @@ class PaymentSessionActivity : AppCompatActivity() {
         val paymentSessionInitialized = paymentSession.init(
             PaymentSessionListenerImpl(this, customerSession),
             PaymentSessionConfig.Builder()
+                .setAddPaymentMethodFooter(R.layout.add_payment_method_footer)
                 .setPrepopulatedShippingInfo(EXAMPLE_SHIPPING_INFO)
                 .setHiddenShippingInfoFields(
                     ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD,

--- a/stripe/res/layout/add_payment_method_layout.xml
+++ b/stripe/res/layout/add_payment_method_layout.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <LinearLayout
+        android:id="@+id/stripe_add_payment_method_content_root"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" />

--- a/stripe/res/layout/add_payment_method_layout.xml
+++ b/stripe/res/layout/add_payment_method_layout.xml
@@ -3,4 +3,9 @@
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
+</ScrollView>

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.java
@@ -292,6 +292,8 @@ public class PaymentSession {
                         .setInitialPaymentMethodId(
                                 getSelectedPaymentMethodId(userSelectedPaymentMethodId))
                         .setShouldRequirePostalCode(shouldRequirePostalCode)
+                        .setAddPaymentMethodFooter(
+                                mPaymentSessionConfig.getAddPaymentMethodFooter())
                         .setIsPaymentSessionActive(true)
                         .setPaymentConfiguration(PaymentConfiguration.getInstance(mContext))
                         .build()

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.java
@@ -3,6 +3,7 @@ package com.stripe.android;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -26,6 +27,7 @@ public class PaymentSessionConfig implements Parcelable {
     @Nullable private final ShippingInformation mShippingInformation;
     private final boolean mShippingInfoRequired;
     private final boolean mShippingMethodRequired;
+    @LayoutRes private final int mAddPaymentMethodFooter;
 
      public static class Builder implements ObjectBuilder<PaymentSessionConfig> {
         private boolean mShippingInfoRequired = true;
@@ -33,6 +35,7 @@ public class PaymentSessionConfig implements Parcelable {
         @Nullable private List<String> mHiddenShippingInfoFields;
         @Nullable private List<String> mOptionalShippingInfoFields;
         @Nullable private ShippingInformation mShippingInformation;
+        @LayoutRes private int mAddPaymentMethodFooter;
 
         /**
          * @param hiddenShippingInfoFields that should be hidden in the {@link ShippingInfoWidget}.
@@ -88,6 +91,12 @@ public class PaymentSessionConfig implements Parcelable {
         }
 
         @NonNull
+        public Builder setAddPaymentMethodFooter(@LayoutRes int addPaymentMethodFooterLayoutId) {
+            mAddPaymentMethodFooter = addPaymentMethodFooterLayoutId;
+            return this;
+        }
+
+        @NonNull
         public PaymentSessionConfig build() {
             return new PaymentSessionConfig(this);
         }
@@ -101,6 +110,7 @@ public class PaymentSessionConfig implements Parcelable {
         mShippingInformation = builder.mShippingInformation;
         mShippingInfoRequired = builder.mShippingInfoRequired;
         mShippingMethodRequired = builder.mShippingMethodsRequired;
+        mAddPaymentMethodFooter = builder.mAddPaymentMethodFooter;
     }
 
     private PaymentSessionConfig(@NonNull Parcel in) {
@@ -111,6 +121,7 @@ public class PaymentSessionConfig implements Parcelable {
         mShippingInformation = in.readParcelable(ShippingInformation.class.getClassLoader());
         mShippingInfoRequired = in.readInt() == 1;
         mShippingMethodRequired = in.readInt() == 1;
+        mAddPaymentMethodFooter = in.readInt();
     }
 
     @Override
@@ -124,13 +135,15 @@ public class PaymentSessionConfig implements Parcelable {
                 Objects.equals(mOptionalShippingInfoFields, obj.mOptionalShippingInfoFields) &&
                 Objects.equals(mShippingInformation, obj.mShippingInformation) &&
                 Objects.equals(mShippingInfoRequired, obj.mShippingInfoRequired) &&
-                Objects.equals(mShippingMethodRequired, obj.mShippingMethodRequired);
+                Objects.equals(mShippingMethodRequired, obj.mShippingMethodRequired) &&
+                Objects.equals(mAddPaymentMethodFooter, obj.mAddPaymentMethodFooter);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(mHiddenShippingInfoFields, mOptionalShippingInfoFields,
-                mShippingInformation, mShippingInfoRequired, mShippingMethodRequired);
+                mShippingInformation, mShippingInfoRequired, mShippingMethodRequired,
+                mAddPaymentMethodFooter);
     }
 
     @Override
@@ -145,6 +158,7 @@ public class PaymentSessionConfig implements Parcelable {
         parcel.writeParcelable(mShippingInformation, flags);
         parcel.writeInt(mShippingInfoRequired ? 1 : 0);
         parcel.writeInt(mShippingMethodRequired ? 1 : 0);
+        parcel.writeInt(mAddPaymentMethodFooter);
     }
 
     @NonNull
@@ -168,6 +182,11 @@ public class PaymentSessionConfig implements Parcelable {
 
     public boolean isShippingMethodRequired() {
         return mShippingMethodRequired;
+    }
+
+    @LayoutRes
+    public int getAddPaymentMethodFooter() {
+         return mAddPaymentMethodFooter;
     }
 
     public static final Parcelable.Creator<PaymentSessionConfig> CREATOR = new Parcelable

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -4,9 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.os.IBinder
+import android.text.method.LinkMovementMethod
+import android.text.util.Linkify
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.text.util.LinkifyCompat
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentConfiguration
@@ -80,6 +84,15 @@ open class AddPaymentMethodActivity : StripeActivity() {
 
         addPaymentMethodView = createPaymentMethodView(args)
         contentRoot.addView(addPaymentMethodView)
+
+        if (args.addPaymentMethodFooter  > 0) {
+            val footerView = layoutInflater.inflate(args.addPaymentMethodFooter, contentRoot, false)
+            if (footerView is TextView) {
+                LinkifyCompat.addLinks(footerView, Linkify.ALL)
+                footerView.movementMethod = LinkMovementMethod.getInstance()
+            }
+            contentRoot.addView(footerView)
+        }
 
         setTitle(titleStringRes)
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -80,7 +80,7 @@ open class AddPaymentMethodActivity : StripeActivity() {
     private fun configureView(args: AddPaymentMethodActivityStarter.Args) {
         viewStub.layoutResource = R.layout.add_payment_method_layout
         val scrollView = viewStub.inflate() as ViewGroup
-        val contentRoot = scrollView.getChildAt(0) as ViewGroup
+        val contentRoot = scrollView.findViewById<ViewGroup>(R.id.stripe_add_payment_method_content_root)
 
         addPaymentMethodView = createPaymentMethodView(args)
         contentRoot.addView(addPaymentMethodView)
@@ -92,7 +92,7 @@ open class AddPaymentMethodActivity : StripeActivity() {
                 footerView.movementMethod = LinkMovementMethod.getInstance()
             }
             contentRoot.addView(footerView)
-        }
+        }   
 
         setTitle(titleStringRes)
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -75,7 +75,8 @@ open class AddPaymentMethodActivity : StripeActivity() {
 
     private fun configureView(args: AddPaymentMethodActivityStarter.Args) {
         viewStub.layoutResource = R.layout.add_payment_method_layout
-        val contentRoot = viewStub.inflate() as ViewGroup
+        val scrollView = viewStub.inflate() as ViewGroup
+        val contentRoot = scrollView.getChildAt(0) as ViewGroup
 
         addPaymentMethodView = createPaymentMethodView(args)
         contentRoot.addView(addPaymentMethodView)

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -85,7 +85,7 @@ open class AddPaymentMethodActivity : StripeActivity() {
         addPaymentMethodView = createPaymentMethodView(args)
         contentRoot.addView(addPaymentMethodView)
 
-        if (args.addPaymentMethodFooter  > 0) {
+        if (args.addPaymentMethodFooter > 0) {
             val footerView = layoutInflater.inflate(args.addPaymentMethodFooter, contentRoot, false)
             if (footerView is TextView) {
                 LinkifyCompat.addLinks(footerView, Linkify.ALL)

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -92,7 +92,7 @@ open class AddPaymentMethodActivity : StripeActivity() {
                 footerView.movementMethod = LinkMovementMethod.getInstance()
             }
             contentRoot.addView(footerView)
-        }   
+        }
 
         setTitle(titleStringRes)
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -39,6 +40,7 @@ public final class AddPaymentMethodActivityStarter
         final boolean shouldInitCustomerSessionTokens;
         @NonNull final PaymentMethod.Type paymentMethodType;
         @Nullable final PaymentConfiguration paymentConfiguration;
+        @LayoutRes final int addPaymentMethodFooter;
 
         @NonNull
         public static AddPaymentMethodActivityStarter.Args create(@NonNull Intent intent) {
@@ -57,6 +59,7 @@ public final class AddPaymentMethodActivityStarter
                     PaymentMethod.Type.Card
             );
             this.paymentConfiguration = builder.mPaymentConfiguration;
+            this.addPaymentMethodFooter = builder.mAddPaymentMethodFooter;
         }
 
         private Args(@NonNull Parcel in) {
@@ -67,6 +70,7 @@ public final class AddPaymentMethodActivityStarter
             this.paymentMethodType = PaymentMethod.Type.valueOf(in.readString());
             this.paymentConfiguration =
                     in.readParcelable(PaymentConfiguration.class.getClassLoader());
+            this.addPaymentMethodFooter = in.readInt();
         }
 
         @Override
@@ -82,13 +86,14 @@ public final class AddPaymentMethodActivityStarter
             dest.writeInt(shouldInitCustomerSessionTokens ? 1 : 0);
             dest.writeString(paymentMethodType.name());
             dest.writeParcelable(paymentConfiguration, 0);
+            dest.writeInt(addPaymentMethodFooter);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(shouldAttachToCustomer, shouldRequirePostalCode,
                     isPaymentSessionActive, shouldInitCustomerSessionTokens, paymentMethodType,
-                    paymentConfiguration);
+                    paymentConfiguration, addPaymentMethodFooter);
         }
 
         @Override
@@ -103,6 +108,7 @@ public final class AddPaymentMethodActivityStarter
                     Objects.equals(shouldInitCustomerSessionTokens,
                             args.shouldInitCustomerSessionTokens) &&
                     Objects.equals(paymentMethodType, args.paymentMethodType) &&
+                    Objects.equals(addPaymentMethodFooter, args.addPaymentMethodFooter) &&
                     Objects.equals(paymentConfiguration, args.paymentConfiguration);
 
         }
@@ -130,6 +136,7 @@ public final class AddPaymentMethodActivityStarter
             private boolean mShouldInitCustomerSessionTokens = true;
             @Nullable private PaymentMethod.Type mPaymentMethodType;
             @Nullable private PaymentConfiguration mPaymentConfiguration;
+            @LayoutRes private int mAddPaymentMethodFooter;
 
             /**
              * If true, the created Payment Method will be attached to the current Customer
@@ -172,6 +179,12 @@ public final class AddPaymentMethodActivityStarter
             @NonNull
             Builder setPaymentConfiguration(@Nullable PaymentConfiguration paymentConfiguration) {
                 this.mPaymentConfiguration = paymentConfiguration;
+                return this;
+            }
+
+            @NonNull
+            Builder setAddPaymentMethodFooter(@LayoutRes int addPaymentMethodFooter) {
+                this.mAddPaymentMethodFooter = addPaymentMethodFooter;
                 return this;
             }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.java
@@ -183,7 +183,7 @@ public final class AddPaymentMethodActivityStarter
             }
 
             @NonNull
-            Builder setAddPaymentMethodFooter(@LayoutRes int addPaymentMethodFooter) {
+            public Builder setAddPaymentMethodFooter(@LayoutRes int addPaymentMethodFooter) {
                 this.mAddPaymentMethodFooter = addPaymentMethodFooter;
                 return this;
             }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.kt
@@ -18,6 +18,7 @@ internal class AddPaymentMethodCardRowView internal constructor(
         .setShouldRequirePostalCode(args.shouldRequirePostalCode)
         .setIsPaymentSessionActive(args.isPaymentSessionActive)
         .setPaymentMethodType(PaymentMethod.Type.Card)
+        .setAddPaymentMethodFooter(args.addPaymentMethodFooter)
         .setPaymentConfiguration(args.paymentConfiguration)
         .build()
 )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -45,6 +46,7 @@ public final class PaymentMethodsActivityStarter
 
         @Nullable final String initialPaymentMethodId;
         public final boolean shouldRequirePostalCode;
+        @LayoutRes public final int addPaymentMethodFooter;
         final boolean isPaymentSessionActive;
         @NonNull final List<PaymentMethod.Type> paymentMethodTypes;
         @Nullable final PaymentConfiguration paymentConfiguration;
@@ -64,6 +66,7 @@ public final class PaymentMethodsActivityStarter
                     Collections.singletonList(PaymentMethod.Type.Card)
             );
             paymentConfiguration = builder.mPaymentConfiguration;
+            addPaymentMethodFooter = builder.mAddPaymentMethodFooter;
         }
 
         private Args(@NonNull Parcel in) {
@@ -78,6 +81,8 @@ public final class PaymentMethodsActivityStarter
             }
 
             paymentConfiguration = in.readParcelable(PaymentConfiguration.class.getClassLoader());
+
+            addPaymentMethodFooter = in.readInt();
         }
 
         @Override
@@ -97,12 +102,15 @@ public final class PaymentMethodsActivityStarter
             }
 
             dest.writeParcelable(paymentConfiguration, 0);
+
+            dest.writeInt(addPaymentMethodFooter);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(initialPaymentMethodId, shouldRequirePostalCode,
-                    isPaymentSessionActive, paymentMethodTypes, paymentConfiguration);
+                    isPaymentSessionActive, paymentMethodTypes, paymentConfiguration,
+                    addPaymentMethodFooter);
         }
 
         @Override
@@ -115,6 +123,7 @@ public final class PaymentMethodsActivityStarter
                     Objects.equals(shouldRequirePostalCode, args.shouldRequirePostalCode) &&
                     Objects.equals(isPaymentSessionActive, args.isPaymentSessionActive) &&
                     Objects.equals(paymentMethodTypes, args.paymentMethodTypes) &&
+                    Objects.equals(addPaymentMethodFooter, args.addPaymentMethodFooter) &&
                     Objects.equals(paymentConfiguration, args.paymentConfiguration);
         }
 
@@ -137,6 +146,7 @@ public final class PaymentMethodsActivityStarter
             private boolean mIsPaymentSessionActive = false;
             @Nullable private List<PaymentMethod.Type> mPaymentMethodTypes;
             @Nullable private PaymentConfiguration mPaymentConfiguration;
+            @LayoutRes private int mAddPaymentMethodFooter;
 
             @NonNull
             public Builder setInitialPaymentMethodId(@Nullable String initialPaymentMethodId) {
@@ -166,6 +176,12 @@ public final class PaymentMethodsActivityStarter
             @NonNull
             Builder setPaymentMethodTypes(@NonNull List<PaymentMethod.Type> paymentMethodTypes) {
                 mPaymentMethodTypes = paymentMethodTypes;
+                return this;
+            }
+
+            @NonNull
+            public Builder setAddPaymentMethodFooter(@LayoutRes int addPaymentMethodFooter) {
+                mAddPaymentMethodFooter = addPaymentMethodFooter;
                 return this;
             }
 


### PR DESCRIPTION
## Summary

Add the ability to insert a custom layout into the add payment method view for compliance/regulatory info and links.

## Motivation

`ANDROID-407`

## Testing

![Screenshot_1570136776](https://user-images.githubusercontent.com/48026502/66164200-2106e800-e600-11e9-8831-5aed27fd548b.png)

Add example in example app. Payment Session > Select Payment Method > Add Card.
