### PR TITLE
Add paymentMethodTypes to PaymentSessionConfig

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.java
@@ -63,7 +63,7 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
     @Nullable public final Fpx fpx;
     @Nullable public final Ideal ideal;
 
-    public enum Type {
+    public enum Type implements Parcelable {
         Card("card"),
         CardPresent("card_present"),
         Fpx("fpx", false),
@@ -98,6 +98,28 @@ public final class PaymentMethod extends StripeModel implements Parcelable {
 
             return null;
         }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel parcel, int i) {
+            parcel.writeInt(ordinal());
+        }
+
+        public static final Creator<Type> CREATOR = new Creator<Type>() {
+            @Override
+            public Type createFromParcel(@NonNull Parcel in) {
+                return values()[in.readInt()];
+            }
+
+            @Override
+            public Type[] newArray(int size) {
+                return new Type[size];
+            }
+        };
     }
 
     private PaymentMethod(@NonNull Builder builder) {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import android.os.Parcel
 import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,6 +21,7 @@ class PaymentSessionConfigTest {
                 Address.Builder().build(), null, null))
             .setShippingInfoRequired(true)
             .setShippingMethodsRequired(true)
+            .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx))
             .build()
 
         val parcel = Parcel.obtain()


### PR DESCRIPTION
## Summary
Add `paymentMethodTypes` property to `PaymentSessionConfig`.

## Motivation
Allow users to specify a white-list of Payment Method types that the customer can select and add through the UI.

## Testing
Unit and manual testing.
