### PR TITLE
Don't make :stripe assemble depend on dokka

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'org.jetbrains.dokka-android'
 
 assemble.dependsOn('lint')
 check.dependsOn('checkstyle')
-assemble.dependsOn('dokka')
 
 configurations {
     javadocDeps


### PR DESCRIPTION
Doc generation is run ad-hoc when we're ready to launch a new
release.
