### PR TITLE
Add base stripe to allow for a hook for developer customization

### DIFF
--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="android:textColor">@color/text</item>
     </style>
 
-    <style name="StripeDefaultTheme" parent="BaseStripeTheme">
+    <style name="StripeDefaultTheme" parent="StripeBaseTheme">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="android:textColorPrimary">@color/title</item>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -10,6 +10,18 @@
         <item name="android:textColor">@color/text</item>
     </style>
 
+    <style name="StripeDefaultTheme" parent="BaseStripeTheme">
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primaryDark</item>
+        <item name="android:textColorPrimary">@color/title</item>
+        <item name="android:textColor">@color/textPrimary</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="android:textColorHint">@color/textPrimary</item>
+        <item name="textInputStyle">@style/Stripe3DS2TextInput</item>
+        <item name="android:editTextColor">@color/textPrimary</item>
+        <item name="editTextColor">@color/textPrimary</item>
+    </style>
+
     <style name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primaryDark</item>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -14,7 +14,7 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="android:textColorPrimary">@color/title</item>
-        <item name="android:textColorSecondary">@color/title</item>
+        <item name="android:textColorSecondary">@color/textPrimary</item>
         <item name="android:textColor">@color/textPrimary</item>
         <item name="titleTextColor">@color/title</item>
         <item name="colorAccent">@color/accent</item>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -14,10 +14,11 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="android:textColorPrimary">@color/title</item>
+        <item name="android:textColorSecondary">@color/title</item>
         <item name="android:textColor">@color/textPrimary</item>
+        <item name="titleTextColor">@color/title</item>
         <item name="colorAccent">@color/accent</item>
-        <item name="android:textColorHint">@color/textPrimary</item>
-        <item name="textInputStyle">@style/Stripe3DS2TextInput</item>
+        <item name="colorControlNormal">@color/accent</item>
         <item name="android:editTextColor">@color/textPrimary</item>
         <item name="editTextColor">@color/textPrimary</item>
     </style>

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="BaseStripeTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+    <style name="StripeBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorAccent">@color/stripe_accent_color_default</item>
         <item name="colorControlNormal">@color/stripe_control_normal_color_default</item>
         <item name="colorPrimary">@color/stripe_toolbar_color_default</item>
@@ -25,6 +25,6 @@
         <item name="android:textSize">@dimen/stripe_notification_text_size</item>
     </style>
 
-    <style name="StripeDefaultTheme" parent="BaseStripeTheme"/>
+    <style name="StripeDefaultTheme" parent="StripeBaseTheme"/>
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 </resources>

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="StripeDefaultTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+    <style name="BaseStripeTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorAccent">@color/stripe_accent_color_default</item>
         <item name="colorControlNormal">@color/stripe_control_normal_color_default</item>
         <item name="colorPrimary">@color/stripe_toolbar_color_default</item>
@@ -25,5 +25,6 @@
         <item name="android:textSize">@dimen/stripe_notification_text_size</item>
     </style>
 
+    <style name="StripeDefaultTheme" parent="BaseStripeTheme"/>
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 </resources>


### PR DESCRIPTION
## Summary

Adds a base Stripe theme, `BaseStripeTheme`, which allows developers to extend to customize in their own applications.

As seen in the example app, `BaseStripeTheme` can be extended and then customized:

``` xml
    <style name="StripeDefaultTheme" parent="BaseStripeTheme">
        <item name="colorPrimary">@color/primary</item>
        <item name="colorPrimaryDark">@color/primaryDark</item>
        <item name="android:textColorPrimary">@color/title</item>
        <item name="android:textColorSecondary">@color/title</item>
        <item name="android:textColor">@color/textPrimary</item>
        <item name="titleTextColor">@color/title</item>
        <item name="colorAccent">@color/accent</item>
        <item name="colorControlNormal">@color/accent</item>
        <item name="android:editTextColor">@color/textPrimary</item>
        <item name="editTextColor">@color/textPrimary</item>
    </style>
```

## Motivation

Allow users to customize Stripe activities much like customizing 3DS2 UI activities and issue #513

## Testing

Tested with example app payment sessions.
