### PR TITLE
Remove deprecated methods

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -164,9 +164,9 @@ class PaymentSessionActivity : AppCompatActivity() {
     private fun createSampleShippingMethods(): ArrayList<ShippingMethod> {
         val shippingMethods = ArrayList<ShippingMethod>()
         shippingMethods.add(ShippingMethod("UPS Ground", "ups-ground",
-            "Arrives in 3-5 days", 0, "USD"))
+            0, "USD", "Arrives in 3-5 days"))
         shippingMethods.add(ShippingMethod("FedEx", "fedex",
-            "Arrives tomorrow", 599, "USD"))
+            599, "USD", "Arrives tomorrow"))
         return shippingMethods
     }
 

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -689,34 +689,6 @@ class Stripe internal constructor(
     }
 
     /**
-     * Blocking method to create a [Token]. Do not call this on the UI thread or your app
-     * will crash.
-     *
-     * See [Create a card token](https://stripe.com/docs/api/tokens/create_card).
-     *
-     * @param card the [Card] to use for this token
-     * @return a [Token] that can be used for this card
-     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
-     * @throws InvalidRequestException your request has invalid parameters
-     * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws CardException the card cannot be charged for some reason
-     * @throws APIException any other type of problem (for instance, a temporary issue with
-     * Stripe's servers
-     *
-     * @deprecated use [createCardTokenSynchronous]
-     */
-    @Deprecated("Use createCardTokenSynchronous()")
-    @Throws(AuthenticationException::class, InvalidRequestException::class,
-        APIConnectionException::class, CardException::class, APIException::class)
-    fun createTokenSynchronous(card: Card): Token? {
-        return stripeRepository.createToken(
-            stripeNetworkUtils.createCardTokenParams(card),
-            ApiRequest.Options.create(publishableKey, stripeAccountId),
-            Token.TokenType.CARD
-        )
-    }
-
-    /**
      * Create a CVC update token asynchronously.
      *
      * @param cvc the CVC used to create this token

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -182,11 +182,6 @@ class Card private constructor(
         }
     }
 
-    @Deprecated("getCVC() is deprecated", ReplaceWith("Use getCvc()"))
-    fun getCVC(): String? {
-        return cvc
-    }
-
     fun toPaymentMethodParamsCard(): PaymentMethodCreateParams.Card {
         return PaymentMethodCreateParams.Card.Builder()
             .setNumber(number)

--- a/stripe/src/main/java/com/stripe/android/model/ShippingInformation.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingInformation.kt
@@ -26,7 +26,7 @@ data class ShippingInformation constructor(
             FIELD_PHONE to phone,
             FIELD_ADDRESS to address?.toParamMap()
         )
-            .mapNotNull { pair -> pair.second?.let { Pair(pair.first, it) } }
+            .mapNotNull { (first, second) -> second?.let { Pair(first, it) } }
             .toMap()
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/ShippingMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingMethod.kt
@@ -8,7 +8,7 @@ import java.util.Currency
 /**
  * Model representing a shipping method in the Android SDK.
  */
-data class ShippingMethod constructor(
+data class ShippingMethod @JvmOverloads constructor(
     /**
      * Human friendly label specifying the shipping method that can be shown in the UI.
      */
@@ -20,41 +20,39 @@ data class ShippingMethod constructor(
     val identifier: String,
 
     /**
-     * Human friendly information such as estimated shipping times that can be shown in
-     * the UI
-     */
-    val detail: String?,
-
-    /**
      * The cost in minor unit based on [currency]
      */
     val amount: Long,
 
-    @Size(min = 0, max = 3) val currencyCode: String
-) : StripeModel(), Parcelable {
     /**
      * The currency that the specified amount will be rendered in.
      */
-    val currency: Currency
-        get() = Currency.getInstance(currencyCode)
+    val currency: Currency,
 
     /**
-     * @deprecated use primary constructor
+     * Human friendly information such as estimated shipping times that can be shown in
+     * the UI
      */
-    @Deprecated("Use other constructor")
+    val detail: String? = null
+) : StripeModel(), Parcelable {
+
+    @JvmOverloads
     constructor(
         label: String,
         identifier: String,
         amount: Long,
-        @Size(min = 0, max = 3) currencyCode: String
-    ) : this(label, identifier, null, amount, currencyCode)
+        @Size(min = 0, max = 3) currencyCode: String,
+        detail: String? = null
+    ) : this(
+        label, identifier, amount, Currency.getInstance(currencyCode), detail
+    )
 
     private constructor(parcel: Parcel) : this(
         requireNotNull(parcel.readString()),
         requireNotNull(parcel.readString()),
-        parcel.readString(),
         parcel.readLong(),
-        requireNotNull(parcel.readString())
+        Currency.getInstance(requireNotNull(parcel.readString())),
+        parcel.readString()
     )
 
     override fun describeContents(): Int {
@@ -64,9 +62,9 @@ data class ShippingMethod constructor(
     override fun writeToParcel(parcel: Parcel, i: Int) {
         parcel.writeString(label)
         parcel.writeString(identifier)
-        parcel.writeString(detail)
         parcel.writeLong(amount)
-        parcel.writeString(currencyCode)
+        parcel.writeString(currency.currencyCode)
+        parcel.writeString(detail)
     }
 
     companion object {

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.java
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.java
@@ -274,7 +274,7 @@ public final class SourceParams implements StripeParamsModel {
         basicInfoMap.put(FIELD_NUMBER, card.getNumber());
         basicInfoMap.put(FIELD_EXP_MONTH, card.getExpMonth());
         basicInfoMap.put(FIELD_EXP_YEAR, card.getExpYear());
-        basicInfoMap.put(FIELD_CVC, card.getCVC());
+        basicInfoMap.put(FIELD_CVC, card.getCvc());
 
         params.setApiParameterMap(basicInfoMap);
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -150,7 +150,6 @@ open class AddPaymentMethodActivity : StripeActivity() {
     private fun finishWithPaymentMethod(paymentMethod: PaymentMethod) {
         setCommunicatingProgress(false)
         setResult(Activity.RESULT_OK, Intent()
-            .putExtra(EXTRA_NEW_PAYMENT_METHOD, paymentMethod)
             .putExtras(AddPaymentMethodActivityStarter.Result(paymentMethod).toBundle()))
         finish()
     }
@@ -216,9 +215,6 @@ open class AddPaymentMethodActivity : StripeActivity() {
     }
 
     companion object {
-        const val TOKEN_ADD_PAYMENT_METHOD_ACTIVITY = "AddPaymentMethodActivity"
-
-        @Deprecated("use {@link AddPaymentMethodActivityStarter.Result}")
-        const val EXTRA_NEW_PAYMENT_METHOD = "new_payment_method"
+        const val TOKEN_ADD_PAYMENT_METHOD_ACTIVITY: String = "AddPaymentMethodActivity"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android
 
-import android.os.Parcel
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -28,23 +28,10 @@ class EphemeralKeyTest {
     @Test
     @Throws(JSONException::class)
     fun toParcel_fromParcel_createsExpectedObject() {
-        val ephemeralKey = EPHEMERAL_KEY
-        val parcel = Parcel.obtain()
-        ephemeralKey.writeToParcel(parcel, 0)
-        // We need to reset the data position of the parcel or else we'll continue reading
-        // null values off the end.
-        parcel.setDataPosition(0)
-
-        val createdKey = CustomerEphemeralKey.CREATOR.createFromParcel(parcel)
-
-        assertEquals(ephemeralKey.id, createdKey.id)
-        assertEquals(ephemeralKey.created, createdKey.created)
-        assertEquals(ephemeralKey.expires, createdKey.expires)
-        assertEquals(ephemeralKey.customerId, createdKey.customerId)
-        assertEquals(ephemeralKey.type, createdKey.type)
-        assertEquals(ephemeralKey.secret, createdKey.secret)
-        assertEquals(ephemeralKey.isLiveMode, createdKey.isLiveMode)
-        assertEquals(ephemeralKey.objectType, createdKey.objectType)
+        assertEquals(
+            EPHEMERAL_KEY,
+            ParcelUtils.create(EPHEMERAL_KEY, CustomerEphemeralKey.CREATOR)
+        )
     }
 
     companion object {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android
 
-import android.os.Parcel
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
@@ -24,10 +24,9 @@ class PaymentSessionConfigTest {
             .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx))
             .build()
 
-        val parcel = Parcel.obtain()
-        paymentSessionConfig.writeToParcel(parcel, paymentSessionConfig.describeContents())
-        parcel.setDataPosition(0)
-
-        assertEquals(paymentSessionConfig, PaymentSessionConfig.CREATOR.createFromParcel(parcel))
+        assertEquals(
+            paymentSessionConfig,
+            ParcelUtils.create(paymentSessionConfig, PaymentSessionConfig.CREATOR)
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android
 
-import android.os.Parcel
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodTest
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -58,36 +58,30 @@ class PaymentSessionDataTest {
     @Test
     fun writeToParcel_withNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData()
-
         data.cartTotal = 100L
         data.shippingTotal = 150L
         data.isPaymentReadyToCharge = false
 
-        val parcel = Parcel.obtain()
-        data.writeToParcel(parcel, 0)
-        parcel.setDataPosition(0)
-
-        val parceledData = PaymentSessionData.CREATOR.createFromParcel(parcel)
-        assertEquals(data, parceledData)
+        assertEquals(
+            data,
+            ParcelUtils.create(data, PaymentSessionData.CREATOR)
+        )
     }
 
     @Test
     fun writeToParcel_withoutNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData()
-
         data.cartTotal = 100L
         data.shippingTotal = 150L
         data.paymentMethod = PAYMENT_METHOD
         data.isPaymentReadyToCharge = false
         data.shippingInformation = ShippingInformation(null, null, null)
-        data.shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "usd")
+        data.shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "USD")
 
-        val parcel = Parcel.obtain()
-        data.writeToParcel(parcel, 0)
-        parcel.setDataPosition(0)
-
-        val parceledData = PaymentSessionData.CREATOR.createFromParcel(parcel)
-        assertEquals(data, parceledData)
+        assertEquals(
+            data,
+            ParcelUtils.create(data, PaymentSessionData.CREATOR)
+        )
     }
 
     companion object {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -50,7 +50,7 @@ class PaymentSessionDataTest {
         assertFalse(data.updateIsPaymentReadyToCharge(config))
         assertFalse(data.isPaymentReadyToCharge)
 
-        data.shippingMethod = ShippingMethod("label", "id", null, 0, "USD")
+        data.shippingMethod = ShippingMethod("label", "id", 0, "USD")
         assertTrue(data.updateIsPaymentReadyToCharge(config))
         assertTrue(data.isPaymentReadyToCharge)
     }
@@ -80,7 +80,7 @@ class PaymentSessionDataTest {
         data.paymentMethod = PAYMENT_METHOD
         data.isPaymentReadyToCharge = false
         data.shippingInformation = ShippingInformation(null, null, null)
-        data.shippingMethod = ShippingMethod("UPS", "SuperFast", null, 10000L, "usd")
+        data.shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "usd")
 
         val parcel = Parcel.obtain()
         data.writeToParcel(parcel, 0)

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import android.os.Parcel
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -130,13 +130,10 @@ class PaymentMethodTest {
             .setSepaDebit(PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD.sepaDebit)
             .build()
 
-        val parcel = Parcel.obtain()
-        paymentMethod.writeToParcel(parcel, paymentMethod.describeContents())
-        parcel.setDataPosition(0)
-
-        val parcelPaymentMethod = PaymentMethod.CREATOR.createFromParcel(parcel)
-
-        assertEquals(paymentMethod, parcelPaymentMethod)
+        assertEquals(
+            paymentMethod,
+            ParcelUtils.create(paymentMethod, PaymentMethod.CREATOR)
+        )
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.model
 
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Test class for [ShippingMethod]
  */
+@RunWith(RobolectricTestRunner::class)
 class ShippingMethodTest {
 
     @Test
@@ -14,15 +18,15 @@ class ShippingMethodTest {
     }
 
     @Test
-    fun testHashcode() {
-        assertEquals(SHIPPING_METHOD.hashCode(), createShippingMethod().hashCode())
+    fun testParcel() {
+        assertEquals(SHIPPING_METHOD, ParcelUtils.create(SHIPPING_METHOD, ShippingMethod.CREATOR))
     }
 
     companion object {
         private val SHIPPING_METHOD = createShippingMethod()
 
         private fun createShippingMethod(): ShippingMethod {
-            return ShippingMethod("FedEx", "fedex", "Arrives tomorrow", 599, "USD")
+            return ShippingMethod("FedEx", "fedex", 599, "USD", "Arrives tomorrow")
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.kt
@@ -1,9 +1,8 @@
 package com.stripe.android.model.wallets
 
-import android.os.Parcel
+import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.json.JSONObject
 import org.junit.runner.RunWith
@@ -53,24 +52,18 @@ class WalletFactoryTest {
         val walletFactory = WalletFactory()
 
         val samsungPayWallet =
-            walletFactory.create(SAMSUNG_PAY_WALLET_JSON) as SamsungPayWallet?
-        assertNotNull(samsungPayWallet)
-        val samsungWalletParcel = Parcel.obtain()
-        samsungPayWallet!!.writeToParcel(samsungWalletParcel, samsungPayWallet.describeContents())
-        samsungWalletParcel.setDataPosition(0)
-        val parcelSamsungWallet =
-            SamsungPayWallet.CREATOR.createFromParcel(samsungWalletParcel)
-        assertEquals(samsungPayWallet, parcelSamsungWallet)
+            walletFactory.create(SAMSUNG_PAY_WALLET_JSON) as SamsungPayWallet
+        assertEquals(
+            samsungPayWallet,
+            ParcelUtils.create(samsungPayWallet, SamsungPayWallet.CREATOR)
+        )
 
         val visaWallet =
-            walletFactory.create(VISA_WALLET_JSON) as VisaCheckoutWallet?
-        assertNotNull(visaWallet)
-        val visaParcel = Parcel.obtain()
-        visaWallet!!.writeToParcel(visaParcel, visaWallet.describeContents())
-        visaParcel.setDataPosition(0)
-        val parcelVisaWallet =
-            VisaCheckoutWallet.CREATOR.createFromParcel(visaParcel)
-        assertEquals(visaWallet, parcelVisaWallet)
+            walletFactory.create(VISA_WALLET_JSON) as VisaCheckoutWallet
+        assertEquals(
+            visaWallet,
+            ParcelUtils.create(visaWallet, VisaCheckoutWallet.CREATOR)
+        )
     }
 
     companion object {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -215,7 +215,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
         onShippingInfoProcessedValid.putExtra(EXTRA_IS_SHIPPING_INFO_VALID, true)
 
         val shippingMethods = arrayListOf(
-            ShippingMethod("label", "id", null, 0, "USD")
+            ShippingMethod("label", "id", 0, "USD")
         )
         onShippingInfoProcessedValid.putExtra(EXTRA_VALID_SHIPPING_METHODS, shippingMethods)
         LocalBroadcastManager.getInstance(ApplicationProvider.getApplicationContext())

--- a/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
@@ -38,16 +38,16 @@ class SelectShippingMethodWidgetTest {
         private val UPS = ShippingMethod(
             "UPS Ground",
             "ups-ground",
-            "Arrives in 3-5 days",
             0,
-            "USD"
+            "USD",
+            "Arrives in 3-5 days"
         )
         private val FEDEX = ShippingMethod(
             "FedEx",
             "fedex",
-            "Arrives tomorrow",
             599,
-            "USD"
+            "USD",
+            "Arrives tomorrow"
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace `Stripe#createTokenSynchronous(Card)` with
  `Stripe#createCardTokenSynchronous(Card)`
- Replace `Card#getCVC()` with `Card#getCvc()`
- Remove `AddPaymentMethodActivity#EXTRA_NEW_PAYMENT_METHOD`.
  Use `AddPaymentMethodActivityStarter.Result.fromIntent()` instead.
- Create overloaded `ShippingMethod` constructor with optional
  `detail` argument.

## Motivation
These are breaking changes that will go out as part of
upcoming v12 release.

