### PR TITLE
Pass Accept-Language header in API requests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -40,9 +40,7 @@ internal class ApiRequest internal constructor(
                 mapOf("Stripe-Account" to it)
             }.orEmpty()
         ).plus(
-            (languageTag.takeIf { SHOULD_INCLUDE_ACCEPT_LANGUAGE_HEADER })?.let {
-                mapOf("Accept-Language" to it)
-            }.orEmpty()
+            languageTag?.let { mapOf("Accept-Language" to it) }.orEmpty()
         )
     }
 
@@ -136,9 +134,6 @@ internal class ApiRequest internal constructor(
 
         // this is the default user agent set by the system
         private const val PROP_USER_AGENT = "http.agent"
-
-        // TODO(mshafrir-stripe) - enable in next major version
-        private const val SHOULD_INCLUDE_ACCEPT_LANGUAGE_HEADER = false
 
         @JvmStatic
         fun createGet(

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -29,6 +29,8 @@ internal class ApiRequestTest {
 
     @Test
     fun getHeaders_withAllRequestOptions_properlyMapsRequestOptions() {
+        Locale.setDefault(Locale.US)
+
         val stripeAccount = "acct_123abc"
         val headers = ApiRequest.createGet(StripeApiRepository.sourcesUrl,
             ApiRequest.Options.create(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
@@ -41,7 +43,7 @@ internal class ApiRequestTest {
         )
         assertEquals(ApiVersion.get().code, headers["Stripe-Version"])
         assertEquals(stripeAccount, headers["Stripe-Account"])
-        assertFalse(headers.contains("Accept-Language"))
+        assertEquals("en-US", headers["Accept-Language"])
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.stripe.android.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
+import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.Address;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -1037,6 +1039,23 @@ public class StripeTest {
                 }
         );
         assertEquals("Your card number is incorrect.", cardException.getMessage());
+    }
+
+    @Ignore("enable after bumping version to v12.0.0")
+    public void retrievePaymentIntent_withInvalidClientSecretInGermanyLocale_shouldReturnLocalizedMessage() {
+        Locale.setDefault(Locale.GERMANY);
+
+        // This card is missing quite a few numbers.
+        final Stripe stripe = createStripe();
+        final InvalidRequestException exception = assertThrows(
+                InvalidRequestException.class,
+                new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        stripe.retrievePaymentIntentSynchronous("invalid");
+                    }
+                });
+        assertEquals("Keine solche payment_intent: invalid", exception.getStripeError().getMessage());
     }
 
     @Test


### PR DESCRIPTION
This will return localized error messages for requests to /v1/payment_intents.