### PR TITLE
Handle exceptions in StripeFireAndForgetRequestExecutor

### DIFF
--- a/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.kt
+++ b/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.kt
@@ -21,7 +21,7 @@ class AsyncTaskTokenController(
     private val progressDialogController: ProgressDialogController,
     publishableKey: String
 ) {
-    private val stripe: Stripe = Stripe(context, publishableKey)
+    private val stripe: Stripe = Stripe(context, publishableKey, enableLogging = true)
 
     init {
         button.setOnClickListener {

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -47,7 +47,7 @@ internal open class PaymentController @VisibleForTesting constructor(
     private val threeDs2Service: StripeThreeDs2Service =
         StripeThreeDs2ServiceImpl(context, StripeSSLSocketFactory(), enableLogging),
     private val analyticsRequestExecutor: FireAndForgetRequestExecutor =
-        StripeFireAndForgetRequestExecutor(),
+        StripeFireAndForgetRequestExecutor(Logger.getInstance(enableLogging)),
     private val analyticsDataFactory: AnalyticsDataFactory =
         AnalyticsDataFactory.create(context.applicationContext),
     private val challengeFlowStarter: ChallengeFlowStarter =

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -39,7 +39,7 @@ internal class StripeApiRepository @JvmOverloads constructor(
     private val logger: Logger = Logger.noop(),
     private val stripeApiRequestExecutor: ApiRequestExecutor = StripeApiRequestExecutor(logger),
     private val fireAndForgetRequestExecutor: FireAndForgetRequestExecutor =
-        StripeFireAndForgetRequestExecutor(),
+        StripeFireAndForgetRequestExecutor(logger),
     private val fingerprintRequestFactory: FingerprintRequestFactory =
         FingerprintRequestFactory(context),
     private val uidParamsFactory: UidParamsFactory = UidParamsFactory.create(context),

--- a/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
@@ -37,7 +37,7 @@ internal class StripeApiRequestExecutor internal constructor(
             logger.info(stripeResponse.toString())
             return stripeResponse
         } catch (e: IOException) {
-            logger.error("Exception while making Stripe API request.", e)
+            logger.error("Exception while making Stripe API request", e)
             throw APIConnectionException.create(request.baseUrl, e)
         } finally {
             conn?.disconnect()


### PR DESCRIPTION
## Summary
Exceptions thrown in coroutines need to be handled
See https://proandroiddev.com/kotlin-coroutines-patterns-anti-patterns-f9d12984c68e

## Motivation
Ensure that exceptions thrown in `StripeFireAndForgetRequestExecutor`
don't crash the app.

ANDROID-428

## Testing
Launched example app in airplane mode and verified that API operations
don't crash the app.