### PR TITLE
Create StripeConnection

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
@@ -3,10 +3,6 @@ package com.stripe.android
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.InvalidRequestException
 import java.io.IOException
-import java.io.InputStream
-import java.net.HttpURLConnection
-import java.nio.charset.StandardCharsets
-import java.util.Scanner
 
 /**
  * Used by [StripeApiRepository] to make HTTP requests
@@ -22,42 +18,16 @@ internal class StripeApiRequestExecutor internal constructor(
     @Throws(APIConnectionException::class, InvalidRequestException::class)
     override fun execute(request: ApiRequest): StripeResponse {
         logger.info(request.toString())
-        // HttpURLConnection verifies SSL cert by default
-        var conn: HttpURLConnection? = null
-        try {
-            conn = connectionFactory.create(request)
-            // trigger the request
-            val responseCode = conn.responseCode
-            val responseBody = if (responseCode in 200..299) {
-                getResponseBody(conn.inputStream)
-            } else {
-                getResponseBody(conn.errorStream)
+
+        connectionFactory.create(request).use {
+            try {
+                val stripeResponse = it.response
+                logger.info(stripeResponse.toString())
+                return stripeResponse
+            } catch (e: IOException) {
+                logger.error("Exception while making Stripe API request", e)
+                throw APIConnectionException.create(request.baseUrl, e)
             }
-            val stripeResponse = StripeResponse(responseCode, responseBody, conn.headerFields)
-            logger.info(stripeResponse.toString())
-            return stripeResponse
-        } catch (e: IOException) {
-            logger.error("Exception while making Stripe API request", e)
-            throw APIConnectionException.create(request.baseUrl, e)
-        } finally {
-            conn?.disconnect()
         }
-    }
-
-    @Throws(IOException::class)
-    private fun getResponseBody(responseStream: InputStream?): String? {
-        if (responseStream == null) {
-            return null
-        }
-
-        // \A is the beginning of the stream boundary
-        val scanner = Scanner(responseStream, CHARSET).useDelimiter("\\A")
-        val responseBody = if (scanner.hasNext()) scanner.next() else null
-        responseStream.close()
-        return responseBody
-    }
-
-    companion object {
-        private val CHARSET = StandardCharsets.UTF_8.name()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeConnection.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeConnection.kt
@@ -1,0 +1,72 @@
+package com.stripe.android
+
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.nio.charset.StandardCharsets
+import java.util.Scanner
+import javax.net.ssl.HttpsURLConnection
+
+/**
+ * A wrapper for accessing a [HttpURLConnection]. Implements [Closeable] to simplify closing related
+ * resources.
+ */
+internal class StripeConnection(
+    private val conn: HttpsURLConnection
+) : Closeable {
+    internal val responseCode: Int
+        get() {
+            return conn.responseCode
+        }
+
+    internal val response: StripeResponse
+        @Throws(IOException::class)
+        get() {
+            // trigger the request
+            val responseCode = this.responseCode
+            return StripeResponse(responseCode, responseBody, conn.headerFields)
+        }
+
+    private val responseBody: String?
+        @Throws(IOException::class)
+        get() {
+            return getResponseBody(responseStream)
+        }
+
+    private val responseStream: InputStream?
+        @Throws(IOException::class)
+        get() {
+            return if (responseCode in 200..299) {
+                conn.inputStream
+            } else {
+                conn.errorStream
+            }
+        }
+
+    @Throws(IOException::class)
+    private fun getResponseBody(responseStream: InputStream?): String? {
+        if (responseStream == null) {
+            return null
+        }
+
+        // \A is the beginning of the stream boundary
+        val scanner = Scanner(responseStream, CHARSET).useDelimiter("\\A")
+        val responseBody = if (scanner.hasNext()) {
+            scanner.next()
+        } else {
+            null
+        }
+        responseStream.close()
+        return responseBody
+    }
+
+    override fun close() {
+        responseStream?.close()
+        conn.disconnect()
+    }
+
+    companion object {
+        private val CHARSET = StandardCharsets.UTF_8.name()
+    }
+}


### PR DESCRIPTION
A wrapper for accessing a `HttpsURLConnection`.
Implements `Closeable` to simplify closing related resources.

This greatly simplifies the implementations of `StripeApiRequestExecutor`
and `StripeFireAndForgetRequestExecutor`.