### PR TITLE
Catch IOException in ApiOperation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiOperation.kt
@@ -1,7 +1,9 @@
 package com.stripe.android
 
 import android.os.AsyncTask
+import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.StripeException
+import java.io.IOException
 import org.json.JSONException
 
 internal abstract class ApiOperation<ResultType>(
@@ -17,6 +19,8 @@ internal abstract class ApiOperation<ResultType>(
             ResultWrapper.create(e)
         } catch (e: JSONException) {
             ResultWrapper.create(e)
+        } catch (e: IOException) {
+            ResultWrapper.create(APIConnectionException.create(e))
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
@@ -26,7 +26,7 @@ internal class StripeApiRequestExecutor internal constructor(
                 return stripeResponse
             } catch (e: IOException) {
                 logger.error("Exception while making Stripe API request", e)
-                throw APIConnectionException.create(request.baseUrl, e)
+                throw APIConnectionException.create(e, request.baseUrl)
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/StripeFireAndForgetRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeFireAndForgetRequestExecutor.kt
@@ -31,7 +31,7 @@ internal class StripeFireAndForgetRequestExecutor(
                 // required to trigger the request
                 return it.responseCode
             } catch (e: IOException) {
-                throw APIConnectionException.create(request.baseUrl, e)
+                throw APIConnectionException.create(e, request.baseUrl)
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.exception
 
+import java.io.IOException
+
 /**
  * An [Exception] that represents a failure to connect to Stripe's API.
  */
@@ -11,9 +13,13 @@ class APIConnectionException(
         private const val STATUS_CODE = 0
 
         @JvmStatic
-        fun create(url: String, e: Exception): APIConnectionException {
+        fun create(e: IOException, url: String? = null): APIConnectionException {
+            val displayUrl = listOfNotNull(
+                "Stripe",
+                "($url)".takeUnless { url.isNullOrBlank() }
+            ).joinToString(" ")
             return APIConnectionException(
-                "IOException during API request to Stripe ($url): ${e.message}. " +
+                "IOException during API request to $displayUrl: ${e.message}. " +
                     "Please check your internet connection and try again. " +
                     "If this problem persists, you should check Stripe's " +
                     "service status at https://twitter.com/stripestatus, " +

--- a/stripe/src/test/java/com/stripe/android/exception/APIConnectionExceptionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/exception/APIConnectionExceptionTest.kt
@@ -1,23 +1,39 @@
 package com.stripe.android.exception
 
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class APIConnectionExceptionTest {
 
     @Test
-    fun testCreate() {
+    fun testCreateWithUrl() {
         val ex = APIConnectionException.create(
-            "https://api.stripe.com/v1/payment_methods",
-            IllegalArgumentException("Invalid id")
+            IOException("Could not connect"),
+            "https://api.stripe.com/v1/payment_methods"
         )
         assertEquals(
             "IOException during API request to Stripe " +
-            "(https://api.stripe.com/v1/payment_methods): Invalid id. " +
-            "Please check your internet connection and try again. " +
-            "If this problem persists, you should check Stripe's service " +
-            "status at https://twitter.com/stripestatus, " +
-            "or let us know at support@stripe.com.",
+                "(https://api.stripe.com/v1/payment_methods): Could not connect. " +
+                "Please check your internet connection and try again. " +
+                "If this problem persists, you should check Stripe's service " +
+                "status at https://twitter.com/stripestatus, " +
+                "or let us know at support@stripe.com.",
+            ex.message
+        )
+    }
+
+    @Test
+    fun testCreateWithoutUrl() {
+        val ex = APIConnectionException.create(
+            IOException("Could not connect")
+        )
+        assertEquals(
+            "IOException during API request to Stripe: Could not connect. " +
+                "Please check your internet connection and try again. " +
+                "If this problem persists, you should check Stripe's service " +
+                "status at https://twitter.com/stripestatus, " +
+                "or let us know at support@stripe.com.",
             ex.message
         )
     }


### PR DESCRIPTION
Previously, attempting an HTTP operation on the 3DS2 challenge
screen in airplane mode threw a fatal exception. Catch this
exception. and return it to the user.