### PR TITLE
Create PaymentMethodsViewModel

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.1.0"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
+
     // Api for this import because we use reflection to alter TextInputLayout
     api 'com.google.android.material:material:1.0.0'
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.view
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.stripe.android.CustomerSession
+import com.stripe.android.StripeError
+import com.stripe.android.exception.APIException
+import com.stripe.android.exception.StripeException
+import com.stripe.android.model.PaymentMethod
+
+internal class PaymentMethodsViewModel : ViewModel() {
+    private val customerSession: CustomerSession = CustomerSession.getInstance()
+
+    @JvmSynthetic
+    internal val paymentMethods: MutableLiveData<Result<*>> = MutableLiveData()
+
+    @JvmSynthetic
+    internal fun loadPaymentMethods() {
+        customerSession.getPaymentMethods(PaymentMethod.Type.Card,
+            object : CustomerSession.PaymentMethodsRetrievalListener {
+                override fun onPaymentMethodsRetrieved(paymentMethods: List<PaymentMethod>) {
+                    this@PaymentMethodsViewModel.paymentMethods.value =
+                        Result.create(paymentMethods)
+                }
+
+                override fun onError(
+                    errorCode: Int,
+                    errorMessage: String,
+                    stripeError: StripeError?
+                ) {
+                    paymentMethods.value = Result.create(
+                        APIException(
+                            statusCode = errorCode,
+                            message = errorMessage,
+                            stripeError = stripeError
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    internal data class Result<out T> internal constructor(
+        internal val status: Status,
+        internal val data: T
+    ) {
+        enum class Status {
+            SUCCESS, ERROR
+        }
+
+        companion object {
+            @JvmSynthetic
+            internal fun create(paymentMethods: List<PaymentMethod>): Result<List<PaymentMethod>> {
+                return Result(Status.SUCCESS, paymentMethods)
+            }
+
+            @JvmSynthetic
+            internal fun create(exception: StripeException): Result<StripeException> {
+                return Result(Status.ERROR, exception)
+            }
+        }
+    }
+}


### PR DESCRIPTION
##  Summary
- Create `PaymentMethodsViewModel` to manage loading a customer's
  `PaymentMethod`s in `PaymentMethodsActivity`
- Change `private` constructors to `internal` for `@Parcelize` classes

## Motivation
Simplify data loading

## Testing
Tested on `PaymentMethodsActivity` both for success and error
