### PR TITLE
Create ConfirmSetupIntentParams.createWithoutPaymentMethod()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -9,9 +9,9 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_RE
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_USE_STRIPE_SDK
 
 data class ConfirmSetupIntentParams internal constructor(
-    override val clientSecret: String,
-    internal val paymentMethodId: String? = null,
-    val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
+    @get:JvmSynthetic override val clientSecret: String,
+    @get:JvmSynthetic internal val paymentMethodId: String? = null,
+    @get:JvmSynthetic internal val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     private val returnUrl: String? = null,
     private val useStripeSdk: Boolean
 ) : ConfirmStripeIntentParams {

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -9,10 +9,10 @@ interface ConfirmStripeIntentParams : StripeParamsModel {
     fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmStripeIntentParams
 
     companion object {
-        const val API_PARAM_CLIENT_SECRET = "client_secret"
-        const val API_PARAM_RETURN_URL = "return_url"
-        const val API_PARAM_PAYMENT_METHOD_ID = "payment_method"
-        const val API_PARAM_PAYMENT_METHOD_DATA = "payment_method_data"
-        const val API_PARAM_USE_STRIPE_SDK = "use_stripe_sdk"
+        internal const val API_PARAM_CLIENT_SECRET: String = "client_secret"
+        internal const val API_PARAM_RETURN_URL: String = "return_url"
+        internal const val API_PARAM_PAYMENT_METHOD_ID: String = "payment_method"
+        internal const val API_PARAM_PAYMENT_METHOD_DATA: String = "payment_method_data"
+        internal const val API_PARAM_USE_STRIPE_SDK: String = "use_stripe_sdk"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -24,7 +24,7 @@ class ConfirmSetupIntentParamsTest {
     @Test
     fun shouldUseStripeSdk_withPaymentMethodCreateParams() {
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PM_CREATE_PARAMS,
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             "client_secret",
             "return_url"
         )
@@ -46,7 +46,8 @@ class ConfirmSetupIntentParamsTest {
     @Test
     fun toBuilder_withPaymentMethodCreateParams_shouldCreateEqualObject() {
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PM_CREATE_PARAMS, "client_secret", "return_url")
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            "client_secret", "return_url")
         assertEquals(confirmSetupIntentParams,
             confirmSetupIntentParams.toBuilder().build())
     }
@@ -67,7 +68,7 @@ class ConfirmSetupIntentParamsTest {
     @Test
     fun create_withPaymentMethodCreateParams_shouldPopulateParamMapCorrectly() {
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PM_CREATE_PARAMS,
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             "client_secret", null
         )
         val params = confirmSetupIntentParams.toParamMap()
@@ -78,15 +79,10 @@ class ConfirmSetupIntentParamsTest {
         assertNotNull(paymentMethodData["card"])
     }
 
-    companion object {
-
-        private val PM_CREATE_PARAMS = PaymentMethodCreateParams.create(
-            PaymentMethodCreateParams.Card.Builder()
-                .setNumber("4242424242424242")
-                .setExpiryMonth(1)
-                .setExpiryYear(2024)
-                .setCvc("111")
-                .build(), null
-        )
+    @Test
+    fun create_withoutPaymentMethod() {
+        val params = ConfirmSetupIntentParams.createWithoutPaymentMethod("client_secret")
+        assertNull(params.paymentMethodCreateParams)
+        assertNull(params.paymentMethodId)
     }
 }


### PR DESCRIPTION
A method to create a `ConfirmSetupIntentParams` without
specifying a payment method to attach.

Fixes #1730