### PR TITLE
Clean up visibility of Kotlin methods

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsRequest.kt
@@ -3,9 +3,9 @@ package com.stripe.android
 internal object AnalyticsRequest {
     const val HOST = "https://q.stripe.com"
 
-    @JvmStatic
+    @JvmSynthetic
     @JvmOverloads
-    fun create(
+    internal fun create(
         params: Map<String, *>,
         requestOptions: ApiRequest.Options,
         appInfo: AppInfo? = null

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -688,8 +688,8 @@ internal open class PaymentController @VisibleForTesting constructor(
     }
 
     companion object {
-        const val PAYMENT_REQUEST_CODE = 50000
-        const val SETUP_REQUEST_CODE = 50001
+        internal const val PAYMENT_REQUEST_CODE = 50000
+        internal const val SETUP_REQUEST_CODE = 50001
 
         /**
          * Get the appropriate request code for the given stripe intent type
@@ -697,11 +697,13 @@ internal open class PaymentController @VisibleForTesting constructor(
          * @param intent the [StripeIntent] to get the request code for
          * @return PAYMENT_REQUEST_CODE or SETUP_REQUEST_CODE
          */
-        @JvmStatic
-        fun getRequestCode(intent: StripeIntent): Int {
+        @JvmSynthetic
+        internal fun getRequestCode(intent: StripeIntent): Int {
             return if (intent is PaymentIntent) {
                 PAYMENT_REQUEST_CODE
-            } else SETUP_REQUEST_CODE
+            } else {
+                SETUP_REQUEST_CODE
+            }
         }
 
         /**
@@ -710,11 +712,13 @@ internal open class PaymentController @VisibleForTesting constructor(
          * @param params the [ConfirmStripeIntentParams] to get the request code for
          * @return PAYMENT_REQUEST_CODE or SETUP_REQUEST_CODE
          */
-        @JvmStatic
-        fun getRequestCode(params: ConfirmStripeIntentParams): Int {
+        @JvmSynthetic
+        internal fun getRequestCode(params: ConfirmStripeIntentParams): Int {
             return if (params is ConfirmPaymentIntentParams) {
                 PAYMENT_REQUEST_CODE
-            } else SETUP_REQUEST_CODE
+            } else {
+                SETUP_REQUEST_CODE
+            }
         }
 
         /**
@@ -743,8 +747,8 @@ internal open class PaymentController @VisibleForTesting constructor(
                 .start(PaymentRelayStarter.Data.create(exception))
         }
 
-        @JvmOverloads
         @JvmStatic
+        @JvmOverloads
         fun create(
             context: Context,
             stripeRepository: StripeRepository,

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -945,32 +945,30 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         /**
          * @return `https://api.stripe.com/v1/tokens`
          */
-        @JvmStatic
-        val tokensUrl: String
+        internal val tokensUrl: String
+            @JvmSynthetic
             get() = getApiUrl("tokens")
 
         /**
          * @return `https://api.stripe.com/v1/sources`
          */
-        @JvmStatic
-        val sourcesUrl: String
-            @VisibleForTesting
+        internal val sourcesUrl: String
+            @JvmSynthetic
             get() = getApiUrl("sources")
 
         /**
          * @return `https://api.stripe.com/v1/payment_methods`
          */
-        @JvmStatic
-        val paymentMethodsUrl: String
-            @VisibleForTesting
+        internal val paymentMethodsUrl: String
+            @JvmSynthetic
             get() = getApiUrl("payment_methods")
 
         /**
          * @return `https://api.stripe.com/v1/payment_intents/:id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getRetrievePaymentIntentUrl(paymentIntentId: String): String {
+        @JvmSynthetic
+        internal fun getRetrievePaymentIntentUrl(paymentIntentId: String): String {
             return getApiUrl("payment_intents/%s", paymentIntentId)
         }
 
@@ -978,8 +976,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/payment_intents/:id/confirm`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getConfirmPaymentIntentUrl(paymentIntentId: String): String {
+        @JvmSynthetic
+        internal fun getConfirmPaymentIntentUrl(paymentIntentId: String): String {
             return getApiUrl("payment_intents/%s/confirm", paymentIntentId)
         }
 
@@ -987,8 +985,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/payment_intents/:id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getRetrieveSetupIntentUrl(setupIntentId: String): String {
+        @JvmSynthetic
+        internal fun getRetrieveSetupIntentUrl(setupIntentId: String): String {
             return getApiUrl("setup_intents/%s", setupIntentId)
         }
 
@@ -996,8 +994,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/payment_intents/:id/confirm`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getConfirmSetupIntentUrl(setupIntentId: String): String {
+        @JvmSynthetic
+        internal fun getConfirmSetupIntentUrl(setupIntentId: String): String {
             return getApiUrl("setup_intents/%s/confirm", setupIntentId)
         }
 
@@ -1005,8 +1003,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/customers/:customer_id/sources`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getAddCustomerSourceUrl(customerId: String): String {
+        @JvmSynthetic
+        internal fun getAddCustomerSourceUrl(customerId: String): String {
             return getApiUrl("customers/%s/sources", customerId)
         }
 
@@ -1014,8 +1012,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/customers/:customer_id/sources/:source_id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getDeleteCustomerSourceUrl(customerId: String, sourceId: String): String {
+        @JvmSynthetic
+        internal fun getDeleteCustomerSourceUrl(customerId: String, sourceId: String): String {
             return getApiUrl("customers/%s/sources/%s", customerId, sourceId)
         }
 
@@ -1023,8 +1021,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/payment_methods/:id/attach`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getAttachPaymentMethodUrl(paymentMethodId: String): String {
+        @JvmSynthetic
+        internal fun getAttachPaymentMethodUrl(paymentMethodId: String): String {
             return getApiUrl("payment_methods/%s/attach", paymentMethodId)
         }
 
@@ -1032,8 +1030,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/customers/:id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getRetrieveCustomerUrl(customerId: String): String {
+        @JvmSynthetic
+        internal fun getRetrieveCustomerUrl(customerId: String): String {
             return getApiUrl("customers/%s", customerId)
         }
 
@@ -1041,8 +1039,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/sources/:id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getRetrieveSourceApiUrl(sourceId: String): String {
+        @JvmSynthetic
+        internal fun getRetrieveSourceApiUrl(sourceId: String): String {
             return getApiUrl("sources/%s", sourceId)
         }
 
@@ -1050,8 +1048,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/tokens/:id`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getRetrieveTokenApiUrl(tokenId: String): String {
+        @JvmSynthetic
+        internal fun getRetrieveTokenApiUrl(tokenId: String): String {
             return getApiUrl("tokens/%s", tokenId)
         }
 
@@ -1059,8 +1057,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
          * @return `https://api.stripe.com/v1/issuing/cards/:id/pin`
          */
         @VisibleForTesting
-        @JvmStatic
-        fun getIssuingCardPinUrl(cardId: String): String {
+        @JvmSynthetic
+        internal fun getIssuingCardPinUrl(cardId: String): String {
             return getApiUrl("issuing/cards/%s/pin", cardId)
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/ModelUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ModelUtils.kt
@@ -14,8 +14,8 @@ internal object ModelUtils {
      * @param value the input string to test
      * @return `true` if the input value consists entirely of integers
      */
-    @JvmStatic
-    fun isWholePositiveNumber(value: String?): Boolean {
+    @JvmSynthetic
+    internal fun isWholePositiveNumber(value: String?): Boolean {
         return value != null && isDigitsOnly(value)
     }
 
@@ -43,8 +43,8 @@ internal object ModelUtils {
      * @return `true` if the input time has passed the specified current time,
      * `false` otherwise.
      */
-    @JvmStatic
-    fun hasMonthPassed(year: Int, month: Int, now: Calendar): Boolean {
+    @JvmSynthetic
+    internal fun hasMonthPassed(year: Int, month: Int, now: Calendar): Boolean {
         return if (hasYearPassed(year, now)) {
             true
         } else {
@@ -62,13 +62,13 @@ internal object ModelUtils {
      * @return `true` if the input year has passed the year of the specified current time
      * `false` otherwise.
      */
-    @JvmStatic
-    fun hasYearPassed(year: Int, now: Calendar): Boolean {
+    @JvmSynthetic
+    internal fun hasYearPassed(year: Int, now: Calendar): Boolean {
         return normalizeYear(year, now) < now.get(Calendar.YEAR)
     }
 
-    @JvmStatic
-    fun normalizeYear(year: Int, now: Calendar): Int {
+    @JvmSynthetic
+    internal fun normalizeYear(year: Int, now: Calendar): Int {
         return if (year in 0..99) {
             val currentYear = now.get(Calendar.YEAR).toString()
             val prefix = currentYear.substring(0, currentYear.length - 2)

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.kt
@@ -42,7 +42,7 @@ internal class Stripe3ds2Fingerprint private constructor(
             private const val FIELD_KEY_ID = "key_id"
             private const val FIELD_ROOT_CAS = "root_certificate_authorities"
 
-            @JvmStatic
+            @JvmSynthetic
             @Throws(CertificateException::class)
             internal fun create(data: Map<String, *>): DirectoryServerEncryption {
                 val rootCertData: List<String> = if (data.containsKey(FIELD_ROOT_CAS)) {
@@ -60,12 +60,13 @@ internal class Stripe3ds2Fingerprint private constructor(
         }
     }
 
-    enum class DirectoryServer constructor(val networkName: String, val id: String) {
+    internal enum class DirectoryServer constructor(val networkName: String, val id: String) {
         Visa("visa", "A000000003"),
         Mastercard("mastercard", "A000000004"),
         Amex("american_express", "A000000025");
 
         companion object {
+            @JvmSynthetic
             internal fun lookup(networkName: String): DirectoryServer {
                 return values().find { it.networkName == networkName }
                     ?: error("Invalid directory server networkName: '$networkName'")
@@ -79,9 +80,9 @@ internal class Stripe3ds2Fingerprint private constructor(
         private const val FIELD_SERVER_TRANSACTION_ID = "server_transaction_id"
         private const val FIELD_DIRECTORY_SERVER_ENCRYPTION = "directory_server_encryption"
 
-        @JvmStatic
+        @JvmSynthetic
         @Throws(CertificateException::class)
-        fun create(sdkData: StripeIntent.SdkData): Stripe3ds2Fingerprint {
+        internal fun create(sdkData: StripeIntent.SdkData): Stripe3ds2Fingerprint {
             require(sdkData.is3ds2) { "Expected SdkData with type='stripe_3ds2_fingerprint'." }
 
             return Stripe3ds2Fingerprint(

--- a/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -14,13 +14,13 @@ internal object CountryUtils {
                 .associateBy { Locale("", it).displayCountry }
         }
 
-    @JvmStatic
-    fun getCountryCode(countryName: String?): String? {
+    @JvmSynthetic
+    internal fun getCountryCode(countryName: String?): String? {
         return COUNTRY_NAMES_TO_CODES[countryName]
     }
 
-    @JvmStatic
-    fun getOrderedCountries(currentLocale: Locale): List<String> {
+    @JvmSynthetic
+    internal fun getOrderedCountries(currentLocale: Locale): List<String> {
         // Show user's current locale first, followed by countries alphabetized by display name
         return listOf(currentLocale.displayCountry)
             .plus(
@@ -30,8 +30,8 @@ internal object CountryUtils {
             )
     }
 
-    @JvmStatic
-    fun doesCountryUsePostalCode(countryCode: String): Boolean {
+    @JvmSynthetic
+    internal fun doesCountryUsePostalCode(countryCode: String): Boolean {
         return !NO_POSTAL_CODE_COUNTRIES_SET.contains(countryCode)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentUtils.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.util.Currency
 import java.util.Locale
@@ -11,14 +12,18 @@ internal object PaymentUtils {
      * Formats a monetary amount into a human friendly string where zero is returned
      * as free.
      */
-    @JvmStatic
-    fun formatPriceStringUsingFree(amount: Long, currency: Currency, free: String): String {
+    @JvmSynthetic
+    internal fun formatPriceStringUsingFree(
+        amount: Long,
+        currency: Currency,
+        free: String
+    ): String {
         if (amount == 0L) {
             return free
         }
 
         val currencyFormat = NumberFormat.getCurrencyInstance()
-        val decimalFormatSymbols = (currencyFormat as java.text.DecimalFormat)
+        val decimalFormatSymbols = (currencyFormat as DecimalFormat)
             .decimalFormatSymbols
         decimalFormatSymbols.currencySymbol = currency.getSymbol(Locale.getDefault())
         currencyFormat.decimalFormatSymbols = decimalFormatSymbols
@@ -29,12 +34,12 @@ internal object PaymentUtils {
     /**
      * Formats a monetary amount into a human friendly string.
      */
-    @JvmStatic
-    fun formatPriceString(amount: Double, currency: Currency): String {
+    @JvmSynthetic
+    internal fun formatPriceString(amount: Double, currency: Currency): String {
         val majorUnitAmount = amount / 10.0.pow(currency.defaultFractionDigits.toDouble())
         val currencyFormat = NumberFormat.getCurrencyInstance()
         return try {
-            val decimalFormatSymbols = (currencyFormat as java.text.DecimalFormat)
+            val decimalFormatSymbols = (currencyFormat as DecimalFormat)
                 .decimalFormatSymbols
             decimalFormatSymbols.currencySymbol = currency.getSymbol(Locale.getDefault())
             currencyFormat.decimalFormatSymbols = decimalFormatSymbols

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.view
 
-import android.content.Context
 import com.stripe.android.model.Card
 import com.stripe.android.model.Card.Companion.CVC_LENGTH_AMERICAN_EXPRESS
 import com.stripe.android.model.Card.Companion.CVC_LENGTH_COMMON
@@ -85,10 +84,5 @@ internal object ViewUtils {
         }
 
         return numberGroups
-    }
-
-    @JvmStatic
-    fun getPxFromDp(context: Context, dp: Int): Int {
-        return (dp * context.resources.displayMetrics.density).toInt()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTestHelper.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTestHelper.kt
@@ -1,8 +1,7 @@
 package com.stripe.android
 
 internal object CustomerSessionTestHelper {
-    @JvmStatic
-    fun setInstance(customerSession: CustomerSession) {
+    internal fun setInstance(customerSession: CustomerSession) {
         CustomerSession.setInstance(customerSession)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -1,8 +1,7 @@
 package com.stripe.android.model
 
 internal object PaymentMethodCreateParamsFixtures {
-    @JvmField
-    val CARD = PaymentMethodCreateParams.Card.Builder()
+    internal val CARD = PaymentMethodCreateParams.Card.Builder()
         .setNumber("4242424242424242")
         .setExpiryMonth(1)
         .setExpiryYear(2024)
@@ -10,7 +9,7 @@ internal object PaymentMethodCreateParamsFixtures {
         .build()
 
     @JvmField
-    val BILLING_DETAILS = PaymentMethod.BillingDetails.Builder()
+    internal val BILLING_DETAILS = PaymentMethod.BillingDetails.Builder()
         .setName("Home")
         .setEmail("me@example.com")
         .setPhone("1-800-555-1234")
@@ -23,20 +22,18 @@ internal object PaymentMethodCreateParamsFixtures {
         .build()
 
     @JvmField
-    val DEFAULT_CARD = PaymentMethodCreateParams.create(
+    internal val DEFAULT_CARD = PaymentMethodCreateParams.create(
         CARD,
         BILLING_DETAILS
     )
 
-    @JvmField
-    val DEFAULT_FPX = PaymentMethodCreateParams.create(
+    internal val DEFAULT_FPX = PaymentMethodCreateParams.create(
         PaymentMethodCreateParams.Fpx.Builder()
             .setBank("hsbc")
             .build()
     )
 
-    @JvmField
-    val DEFAULT_SEPA_DEBIT = PaymentMethodCreateParams.create(
+    internal val DEFAULT_SEPA_DEBIT = PaymentMethodCreateParams.create(
         PaymentMethodCreateParams.SepaDebit.Builder()
             .setIban("my_iban")
             .build()

--- a/stripe/src/test/java/com/stripe/android/utils/ParcelUtils.kt
+++ b/stripe/src/test/java/com/stripe/android/utils/ParcelUtils.kt
@@ -3,14 +3,13 @@ package com.stripe.android.utils
 import android.os.Bundle
 import android.os.Parcelable
 
-object ParcelUtils {
+internal object ParcelUtils {
     /**
      * @param source the source from which to parcel and unparcel a new object
      *
      * @return a new [Source] instance based on the original source
      */
-    @JvmStatic
-    fun <Source : Parcelable> create(
+    internal fun <Source : Parcelable> create(
         source: Source
     ): Source {
         val bundle = Bundle()


### PR DESCRIPTION
Remove `@JvmStatic` from internal methods now that code has been
mostly migrated to Kotlin.