### PR TITLE
Support null PaymentMethod in PaymentSession.handlePaymentData()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -99,13 +99,12 @@ class PaymentSession @VisibleForTesting internal constructor(
                 PaymentMethodsActivityStarter.REQUEST_CODE -> {
                     val result =
                         PaymentMethodsActivityStarter.Result.fromIntent(data)
-                    result?.paymentMethod?.run {
-                        persistPaymentMethod(this)
-                        paymentSessionData.paymentMethod = this
-                        paymentSessionData.updateIsPaymentReadyToCharge(config)
-                        paymentSessionListener?.onPaymentSessionDataChanged(paymentSessionData)
-                        paymentSessionListener?.onCommunicatingStateChanged(false)
-                    }
+                    val paymentMethod = result?.paymentMethod
+                    persistPaymentMethod(paymentMethod)
+                    paymentSessionData.paymentMethod = paymentMethod
+                    paymentSessionData.updateIsPaymentReadyToCharge(config)
+                    paymentSessionListener?.onPaymentSessionDataChanged(paymentSessionData)
+                    paymentSessionListener?.onCommunicatingStateChanged(false)
                     return true
                 }
                 PaymentFlowActivityStarter.REQUEST_CODE -> {
@@ -124,12 +123,9 @@ class PaymentSession @VisibleForTesting internal constructor(
         }
     }
 
-    private fun persistPaymentMethod(paymentMethod: PaymentMethod) {
-        val customer = customerSession.cachedCustomer
-        val customerId = customer?.id
-        if (customerId != null && paymentMethod.id != null) {
-            paymentSessionPrefs
-                .saveSelectedPaymentMethodId(customerId, paymentMethod.id)
+    private fun persistPaymentMethod(paymentMethod: PaymentMethod?) {
+        customerSession.cachedCustomer?.id?.let { customerId ->
+            paymentSessionPrefs.saveSelectedPaymentMethodId(customerId, paymentMethod?.id)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.kt
@@ -13,7 +13,7 @@ internal open class PaymentSessionPrefs private constructor(
         return prefs?.getString(getPaymentMethodKey(customerId), null)
     }
 
-    open fun saveSelectedPaymentMethodId(customerId: String, paymentMethodId: String) {
+    open fun saveSelectedPaymentMethodId(customerId: String, paymentMethodId: String?) {
         prefs?.edit()?.putString(getPaymentMethodKey(customerId), paymentMethodId)
             ?.apply()
     }


### PR DESCRIPTION
This is required to update `PaymentSessionData` with a null
`PaymentMethod`.