### PR TITLE
Enable specifying Payment Method type to use in UI components

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -88,13 +88,18 @@ data class PaymentSessionConfig internal constructor(
             return this
         }
 
-        // TODO(mshafrir-stripe): make public
         /**
          * @param paymentMethodTypes a list of [PaymentMethod.Type] that indicates the types of
-         * Payment Methods that the customer can select or add via the Stripe UI components.
+         * Payment Methods that the customer can select or add via Stripe UI components.
+         *
+         * The order of the [PaymentMethod.Type] values in the list will be used to
+         * arrange the add buttons in the Stripe UI components. They will be arranged vertically
+         * from first to last.
+         *
+         * Currently only [PaymentMethod.Type.Card] and [PaymentMethod.Type.Fpx] are supported.
          * If not specified or empty, [PaymentMethod.Type.Card] will be used.
          */
-        internal fun setPaymentMethodTypes(paymentMethodTypes: List<PaymentMethod.Type>): Builder {
+        fun setPaymentMethodTypes(paymentMethodTypes: List<PaymentMethod.Type>): Builder {
             this.paymentMethodTypes = paymentMethodTypes
             return this
         }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -42,7 +42,7 @@ class AddPaymentMethodActivityStarter internal constructor(
             private var shouldRequirePostalCode: Boolean = false
             private var isPaymentSessionActive = false
             private var shouldInitCustomerSessionTokens = true
-            private var paymentMethodType: PaymentMethod.Type? = null
+            private var paymentMethodType: PaymentMethod.Type? = PaymentMethod.Type.Card
             private var paymentConfiguration: PaymentConfiguration? = null
             @LayoutRes
             private var addPaymentMethodFooter: Int = 0
@@ -65,6 +65,17 @@ class AddPaymentMethodActivityStarter internal constructor(
                 return this
             }
 
+            /**
+             * Optional: specify the [PaymentMethod.Type] of the payment method to create based on
+             * the customer's input (i.e. the form that will be presented to the customer).
+             * If unspecified, defaults to [PaymentMethod.Type.Card].
+             * Currently only [PaymentMethod.Type.Card] and [PaymentMethod.Type.Fpx] are supported.
+             */
+            fun setPaymentMethodType(paymentMethodType: PaymentMethod.Type): Builder {
+                this.paymentMethodType = paymentMethodType
+                return this
+            }
+
             internal fun setIsPaymentSessionActive(isPaymentSessionActive: Boolean): Builder {
                 this.isPaymentSessionActive = isPaymentSessionActive
                 return this
@@ -74,11 +85,6 @@ class AddPaymentMethodActivityStarter internal constructor(
                 shouldInitCustomerSessionTokens: Boolean
             ): Builder {
                 this.shouldInitCustomerSessionTokens = shouldInitCustomerSessionTokens
-                return this
-            }
-
-            internal fun setPaymentMethodType(paymentMethodType: PaymentMethod.Type): Builder {
-                this.paymentMethodType = paymentMethodType
                 return this
             }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -77,7 +77,18 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                 return this
             }
 
-            internal fun setPaymentMethodTypes(
+            /**
+             * @param paymentMethodTypes a list of [PaymentMethod.Type] that indicates the types of
+             * Payment Methods that the customer can select or add via Stripe UI components.
+             *
+             * The order of the [PaymentMethod.Type] values in the list will be used to
+             * arrange the add buttons in the Stripe UI components. They will be arranged vertically
+             * from first to last.
+             *
+             * Currently only [PaymentMethod.Type.Card] and [PaymentMethod.Type.Fpx] are supported.
+             * If not specified or empty, [PaymentMethod.Type.Card] will be used.
+             */
+            fun setPaymentMethodTypes(
                 paymentMethodTypes: List<PaymentMethod.Type>
             ): Builder {
                 this.paymentMethodTypes = paymentMethodTypes


### PR DESCRIPTION
## Summary
- Make `PaymentSessionConfig#setPaymentMethodTypes()` public
- Make `PaymentMethodsActivityStarter.Args.Builder#setPaymentMethodTypes()` public
- Make `AddPaymentMethodActivityStarter.Args.Builder#setPaymentMethodType()` public
- Update and cleanup PaymentSessionActivity

## Motivation
Allow users to specify other payment methods, such as `PaymentMethod.Type.Fpx`

## Testing
Manually tested
