### PR TITLE
Make FpxBank enum public

### DIFF
--- a/example/res/layout/activity_fpx_payment.xml
+++ b/example/res/layout/activity_fpx_payment.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="20dp">
 
     <Button
         android:id="@+id/btn_select_payment_method"
@@ -18,6 +19,14 @@
         android:id="@+id/payment_method_result"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:typeface="monospace"
-        android:padding="20dp"/>
+        android:paddingTop="20dp"
+        android:typeface="monospace" />
+
+    <TextView
+        android:id="@+id/fpx_bank_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:paddingTop="20dp"
+        android:visibility="gone" />
 </LinearLayout>

--- a/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
@@ -1,16 +1,20 @@
 package com.stripe.example.activity;
 
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.view.AddPaymentMethodActivityStarter;
+import com.stripe.android.view.FpxBank;
 import com.stripe.example.R;
 import com.stripe.example.Settings;
 
@@ -19,6 +23,7 @@ import java.util.Objects;
 public class FpxPaymentActivity extends AppCompatActivity {
 
     private TextView resultView;
+    private TextView fpxBankInfo;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -32,6 +37,7 @@ public class FpxPaymentActivity extends AppCompatActivity {
         findViewById(R.id.btn_select_payment_method)
                 .setOnClickListener(view -> launchAddPaymentMethod());
         resultView = findViewById(R.id.payment_method_result);
+        fpxBankInfo = findViewById(R.id.fpx_bank_info);
     }
 
     private void launchAddPaymentMethod() {
@@ -54,10 +60,21 @@ public class FpxPaymentActivity extends AppCompatActivity {
     }
 
     private void onPaymentMethodResult(@NonNull PaymentMethod paymentMethod) {
+        final String fpxBankCode = Objects.requireNonNull(paymentMethod.fpx).bank;
         final String resultMessage = "Created Payment Method\n" +
                 "\nType: " + paymentMethod.type +
                 "\nId: " + paymentMethod.id +
-                "\nBank name: " + Objects.requireNonNull(paymentMethod.fpx).bank;
+                "\nBank code: " + fpxBankCode;
         resultView.setText(resultMessage);
+
+        final FpxBank fpxBank = FpxBank.get(fpxBankCode);
+        if (fpxBank != null) {
+            fpxBankInfo.setVisibility(View.VISIBLE);
+            final Drawable fpxIcon = ContextCompat.getDrawable(this, fpxBank.getBrandIconResId());
+            fpxBankInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(fpxIcon, null, null, null);
+            fpxBankInfo.setText(fpxBank.getDisplayName());
+        } else {
+            fpxBankInfo.setVisibility(View.GONE);
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -470,6 +470,12 @@ data class PaymentMethod internal constructor(
         }
     }
 
+    /**
+     * Requires the FPX payment method enabled on your account via
+     * https://dashboard.stripe.com/account/payments/settings.
+     *
+     * To obtain the FPX bank's display name and icon, see [com.stripe.android.view.FpxBank].
+     */
     @Parcelize
     data class Fpx internal constructor(
         @JvmField val bank: String?,

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -133,31 +133,6 @@ internal class AddPaymentMethodFpxView private constructor(
         }
     }
 
-    private enum class FpxBank(
-        val code: String,
-        val displayName: String,
-        val brandIconResId: Int = R.drawable.ic_bank_generic
-    ) {
-        AffinBank("affin_bank", "Affin Bank", R.drawable.ic_bank_affin),
-        AllianceBankBusiness("alliance_bank", "Alliance Bank (Business)", R.drawable.ic_bank_alliance),
-        AmBank("ambank", "AmBank", R.drawable.ic_bank_ambank),
-        BankIslam("bank_islam", "Bank Islam", R.drawable.ic_bank_islam),
-        BankMuamalat("bank_muamalat", "Bank Muamalat", R.drawable.ic_bank_muamalat),
-        BankRakyat("bank_rakyat", "Bank Rakyat", R.drawable.ic_bank_raykat),
-        Bsn("bsn", "BSN", R.drawable.ic_bank_bsn),
-        Cimb("cimb", "CIMB Clicks", R.drawable.ic_bank_cimb),
-        HongLeongBank("hong_leong_bank", "Hong Leong Bank", R.drawable.ic_bank_hong_leong),
-        Hsbc("hsbc", "HSBC BANK", R.drawable.ic_bank_hsbc),
-        Kfh("kfh", "KFH", R.drawable.ic_bank_kfh),
-        Maybank2E("maybank2e", "Maybank2E", R.drawable.ic_bank_maybank),
-        Maybank2U("maybank2u", "Maybank2U", R.drawable.ic_bank_maybank),
-        Ocbc("ocbc", "OCBC Bank", R.drawable.ic_bank_ocbc),
-        PublicBank("public_bank", "Public Bank", R.drawable.ic_bank_public),
-        Rhb("rhb", "RHB Bank", R.drawable.ic_bank_rhb),
-        StandardChartered("standard_chartered", "Standard Chartered", R.drawable.ic_bank_standard_chartered),
-        UobBank("uob", "UOB Bank", R.drawable.ic_bank_uob)
-    }
-
     private class SavedState : BaseSavedState {
         internal val selectedPosition: Int
 

--- a/stripe/src/main/java/com/stripe/android/view/FpxBank.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxBank.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.view
+
+import com.stripe.android.R
+import com.stripe.android.model.PaymentMethod
+
+@Suppress("unused")
+enum class FpxBank(
+    val code: String,
+    val displayName: String,
+    val brandIconResId: Int = R.drawable.ic_bank_generic
+) {
+    AffinBank("affin_bank", "Affin Bank",
+        R.drawable.ic_bank_affin),
+    AllianceBankBusiness("alliance_bank", "Alliance Bank (Business)",
+        R.drawable.ic_bank_alliance),
+    AmBank("ambank", "AmBank",
+        R.drawable.ic_bank_ambank),
+    BankIslam("bank_islam", "Bank Islam",
+        R.drawable.ic_bank_islam),
+    BankMuamalat("bank_muamalat", "Bank Muamalat",
+        R.drawable.ic_bank_muamalat),
+    BankRakyat("bank_rakyat", "Bank Rakyat",
+        R.drawable.ic_bank_raykat),
+    Bsn("bsn", "BSN",
+        R.drawable.ic_bank_bsn),
+    Cimb("cimb", "CIMB Clicks",
+        R.drawable.ic_bank_cimb),
+    HongLeongBank("hong_leong_bank", "Hong Leong Bank",
+        R.drawable.ic_bank_hong_leong),
+    Hsbc("hsbc", "HSBC BANK",
+        R.drawable.ic_bank_hsbc),
+    Kfh("kfh", "KFH",
+        R.drawable.ic_bank_kfh),
+    Maybank2E("maybank2e", "Maybank2E",
+        R.drawable.ic_bank_maybank),
+    Maybank2U("maybank2u", "Maybank2U",
+        R.drawable.ic_bank_maybank),
+    Ocbc("ocbc", "OCBC Bank",
+        R.drawable.ic_bank_ocbc),
+    PublicBank("public_bank", "Public Bank",
+        R.drawable.ic_bank_public),
+    Rhb("rhb", "RHB Bank",
+        R.drawable.ic_bank_rhb),
+    StandardChartered("standard_chartered", "Standard Chartered",
+        R.drawable.ic_bank_standard_chartered),
+    UobBank("uob", "UOB Bank",
+        R.drawable.ic_bank_uob);
+
+    companion object {
+        /**
+         * Return the [FpxBank] that matches the given bank code (e.g. "affin_bank", "hsbc"),
+         * or null if no match is found.
+         *
+         * The bank code should be obtained from [PaymentMethod.Fpx.bank].
+         */
+        @JvmStatic
+        fun get(bankCode: String?): FpxBank? {
+            return values().firstOrNull { it.code == bankCode }
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/FpxBankTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/FpxBankTest.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.view
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FpxBankTest {
+    @Test
+    fun testGet_withValidBank() {
+        assertEquals(FpxBank.Hsbc, FpxBank.get("hsbc"))
+    }
+
+    @Test
+    fun testGet_withInvalidBank() {
+        assertNull(FpxBank.get("not_a_bank"))
+    }
+}


### PR DESCRIPTION
Use `FpxBank.get(bankCode)` to obtain the bank details.

This will allow users to use the FPX bank's icon and display name in their app.

Update `FpxPaymentActivity` to demonstrate usage.