### PR TITLE
Add support for confirm dialogs in PaymentAuthWebView

### DIFF
--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -27,4 +27,6 @@
 
     <style name="StripeDefaultTheme" parent="StripeBaseTheme"/>
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
+
+    <style name="AlertDialogStyle" parent="Theme.AppCompat.DayNight.Dialog" />
 </resources>


### PR DESCRIPTION
When a webpage in a WebView attempts to show a Javascript
confirm dialog, the event must be captured and rendered to
the user natively on Android (i.e. using an `AlertDialog`).

![confirm](https://user-images.githubusercontent.com/45020849/67917079-37a44e80-fb6e-11e9-9a0c-a862bf5b2b87.gif)
