### PR TITLE
Refactor OperationIdFactory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.java
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.java
@@ -195,7 +195,7 @@ public class CustomerSession {
             @NonNull String publishableKey,
             @Nullable String stripeAccountId,
             boolean shouldPrefetchEphemeralKey) {
-        mOperationIdFactory = new OperationIdFactory();
+        mOperationIdFactory = new StripeOperationIdFactory();
         mThreadPoolExecutor = threadPoolExecutor;
         mProxyNowCalendar = proxyNowCalendar;
         mProductUsage = new CustomerSessionProductUsage();

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.java
@@ -64,7 +64,8 @@ public class IssuingCardPinService
             @NonNull Context context,
             @NonNull EphemeralKeyProvider keyProvider,
             @Nullable AppInfo appInfo) {
-        this(keyProvider, new StripeApiRepository(context, appInfo), new OperationIdFactory());
+        this(keyProvider, new StripeApiRepository(context, appInfo),
+                new StripeOperationIdFactory());
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/OperationIdFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/OperationIdFactory.kt
@@ -1,9 +1,10 @@
 package com.stripe.android
 
-import java.util.UUID
+internal interface OperationIdFactory {
+    fun create(): String
 
-internal open class OperationIdFactory {
-    open fun create(): String {
-        return UUID.randomUUID().toString()
+    companion object {
+        @JvmSynthetic
+        internal fun get(): OperationIdFactory = StripeOperationIdFactory()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeOperationIdFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeOperationIdFactory.kt
@@ -1,0 +1,9 @@
+package com.stripe.android
+
+import java.util.UUID
+
+internal class StripeOperationIdFactory : OperationIdFactory {
+    override fun create(): String {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
@@ -35,7 +35,7 @@ class EphemeralKeyManagerTest {
     @Mock
     private lateinit var keyManagerListener: EphemeralKeyManager.KeyManagerListener
 
-    private val operationIdFactory = OperationIdFactory()
+    private val operationIdFactory = OperationIdFactory.get()
 
     private lateinit var argCaptor: KArgumentCaptor<Map<String, Any>>
     private lateinit var actionArgumentCaptor: KArgumentCaptor<String>

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
@@ -48,7 +48,7 @@ class IssuingCardPinServiceTest {
         )
 
         service = IssuingCardPinService(ephemeralKeyProvider, stripeRepository,
-            OperationIdFactory())
+            OperationIdFactory.get())
     }
 
     @Test


### PR DESCRIPTION
Make OperationIdFactory an interface and StripeOperationIdFactory
the implementation so that the implementation does not need to
be marked as `open`.