### PR TITLE
Refactor ApiRequest

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -91,26 +91,12 @@ internal class ApiRequest internal constructor(
     /**
      * Data class representing options for a Stripe API request.
      */
-    internal class Options private constructor(
-        apiKey: String,
+    internal data class Options internal constructor(
+        val apiKey: String,
         val stripeAccount: String?
     ) {
-        val apiKey: String = ApiKeyValidator().requireValid(apiKey)
-
-        override fun hashCode(): Int {
-            return Objects.hash(apiKey, stripeAccount)
-        }
-
-        override fun equals(other: Any?): Boolean {
-            return when {
-                this === other -> true
-                other is Options -> typedEquals(other)
-                else -> false
-            }
-        }
-
-        private fun typedEquals(obj: Options): Boolean {
-            return apiKey == obj.apiKey && stripeAccount == obj.stripeAccount
+        init {
+            ApiKeyValidator().requireValid(apiKey)
         }
 
         companion object {
@@ -139,16 +125,7 @@ internal class ApiRequest internal constructor(
         internal fun createGet(
             url: String,
             options: Options,
-            appInfo: AppInfo? = null
-        ): ApiRequest {
-            return ApiRequest(Method.GET, url, null, options, appInfo)
-        }
-
-        @JvmSynthetic
-        internal fun createGet(
-            url: String,
-            params: Map<String, *>,
-            options: Options,
+            params: Map<String, *>? = null,
             appInfo: AppInfo? = null
         ): ApiRequest {
             return ApiRequest(Method.GET, url, params, options, appInfo)
@@ -158,16 +135,7 @@ internal class ApiRequest internal constructor(
         internal fun createPost(
             url: String,
             options: Options,
-            appInfo: AppInfo? = null
-        ): ApiRequest {
-            return ApiRequest(Method.POST, url, null, options, appInfo)
-        }
-
-        @JvmSynthetic
-        internal fun createPost(
-            url: String,
-            params: Map<String, *>,
-            options: Options,
+            params: Map<String, *>? = null,
             appInfo: AppInfo? = null
         ): ApiRequest {
             return ApiRequest(Method.POST, url, params, options, appInfo)

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -80,7 +80,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val paymentIntentId = PaymentIntent.parseIdFromClientSecret(
                 confirmPaymentIntentParams.clientSecret)
             val response = makeApiRequest(ApiRequest.createPost(
-                getConfirmPaymentIntentUrl(paymentIntentId), params, options, appInfo))
+                getConfirmPaymentIntentUrl(paymentIntentId), options, params, appInfo))
             return PaymentIntent.fromString(response.responseBody)
         } catch (unexpected: CardException) {
             // This particular kind of exception should not be possible from a PaymentI API endpoint
@@ -108,8 +108,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val paymentIntentId = PaymentIntent.parseIdFromClientSecret(clientSecret)
             val response = makeApiRequest(
                 ApiRequest.createGet(getRetrievePaymentIntentUrl(paymentIntentId),
-                    createClientSecretParam(clientSecret),
                     options,
+                    createClientSecretParam(clientSecret),
                     appInfo))
             return PaymentIntent.fromString(response.responseBody)
         } catch (unexpected: CardException) {
@@ -141,8 +141,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val response = makeApiRequest(
                 ApiRequest.createPost(
                     getConfirmSetupIntentUrl(setupIntentId),
-                    params,
                     options,
+                    params,
                     appInfo
                 )
             )
@@ -184,8 +184,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val response = makeApiRequest(
                 ApiRequest.createGet(
                     getRetrieveSetupIntentUrl(setupIntentId),
-                    createClientSecretParam(clientSecret),
                     options,
+                    createClientSecretParam(clientSecret),
                     appInfo
                 )
             )
@@ -223,9 +223,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val response = makeApiRequest(
                 ApiRequest.createPost(
                     sourcesUrl,
+                    options,
                     sourceParams.toParamMap()
                         .plus(uidParamsFactory.createParams()),
-                    options,
                     appInfo
                 )
             )
@@ -261,8 +261,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val response = makeApiRequest(
                 ApiRequest.createGet(
                     getRetrieveSourceApiUrl(sourceId),
-                    SourceParams.createRetrieveSourceParams(clientSecret),
                     options,
+                    SourceParams.createRetrieveSourceParams(clientSecret),
                     appInfo
                 )
             )
@@ -286,9 +286,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             val response = makeApiRequest(
                 ApiRequest.createPost(
                     paymentMethodsUrl,
+                    options,
                     paymentMethodCreateParams.toParamMap()
                         .plus(uidParamsFactory.createParams()),
-                    options,
                     appInfo
                 )
             )
@@ -370,8 +370,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getAddCustomerSourceUrl(customerId),
-                mapOf("source" to sourceId),
                 requestOptions,
+                mapOf("source" to sourceId),
                 appInfo
             )
         )
@@ -425,8 +425,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getAttachPaymentMethodUrl(paymentMethodId),
-                mapOf("customer" to customerId),
-                requestOptions, appInfo
+                requestOptions,
+                mapOf("customer" to customerId), appInfo
             )
         )
         // Method throws if errors are found, so no return value occurs.
@@ -452,7 +452,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getDetachPaymentMethodUrl(paymentMethodId),
-                requestOptions, appInfo)
+                requestOptions,
+                appInfo = appInfo
+            )
         )
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response)
@@ -486,8 +488,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createGet(
                 paymentMethodsUrl,
-                queryParams,
-                requestOptions, appInfo)
+                requestOptions,
+                queryParams, appInfo)
         )
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response)
@@ -527,8 +529,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getRetrieveCustomerUrl(customerId),
-                mapOf("default_source" to sourceId),
                 requestOptions,
+                mapOf("default_source" to sourceId),
                 appInfo
             )
         )
@@ -559,8 +561,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getRetrieveCustomerUrl(customerId),
-                mapOf("shipping" to shippingInformation.toParamMap()),
-                requestOptions, appInfo)
+                requestOptions,
+                mapOf("shipping" to shippingInformation.toParamMap()), appInfo)
         )
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response)
@@ -574,8 +576,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         requestOptions: ApiRequest.Options
     ): Customer? {
         val response = fireStripeApiRequest(
-            ApiRequest.createGet(getRetrieveCustomerUrl(customerId),
-                requestOptions, appInfo)
+            ApiRequest.createGet(
+                getRetrieveCustomerUrl(customerId),
+                requestOptions,
+                appInfo = appInfo
+            )
         )
         convertErrorsToExceptionsAndThrowIfNecessary(response)
         return Customer.fromString(response.responseBody)
@@ -592,8 +597,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createGet(
                 getIssuingCardPinUrl(cardId),
-                mapOf("verification" to createVerificationParam(verificationId, userOneTimeCode)),
                 ApiRequest.Options.create(ephemeralKeySecret),
+                mapOf("verification" to createVerificationParam(verificationId, userOneTimeCode)),
                 appInfo
             )
         )
@@ -615,11 +620,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getIssuingCardPinUrl(cardId),
+                ApiRequest.Options.create(ephemeralKeySecret),
                 mapOf(
                     "verification" to createVerificationParam(verificationId, userOneTimeCode),
                     "pin" to newPin
-                ),
-                ApiRequest.Options.create(ephemeralKeySecret), appInfo)
+                ), appInfo)
         )
         // Method throws if errors are found, so no return value occurs.
         convertErrorsToExceptionsAndThrowIfNecessary(response)
@@ -631,8 +636,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createGet(
                 getApiUrl("fpx/bank_statuses"),
-                mapOf("account_holder_type" to "individual"),
                 options,
+                mapOf("account_holder_type" to "individual"),
                 appInfo
             )
         )
@@ -658,8 +663,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getApiUrl("3ds2/authenticate"),
-                authParams.toParamMap(),
                 requestOptions,
+                authParams.toParamMap(),
                 appInfo
             )
         )
@@ -684,8 +689,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = fireStripeApiRequest(
             ApiRequest.createPost(
                 getApiUrl("3ds2/challenge_complete"),
-                mapOf("source" to sourceId),
                 requestOptions,
+                mapOf("source" to sourceId),
                 appInfo
             )
         )
@@ -892,7 +897,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         options: ApiRequest.Options
     ): Token? {
         val response = makeApiRequest(
-            ApiRequest.createPost(url, params, options, appInfo)
+            ApiRequest.createPost(url, options, params, appInfo)
         )
         return Token.fromString(response.responseBody)
     }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -94,8 +94,8 @@ internal class ApiRequestTest {
     @Throws(UnsupportedEncodingException::class, InvalidRequestException::class)
     fun createQuery_withCardData_createsProperQueryString() {
         val cardMap = NETWORK_UTILS.createCardTokenParams(CardFixtures.MINIMUM_CARD)
-        val query = ApiRequest.createGet(StripeApiRepository.sourcesUrl, cardMap,
-            ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null)
+        val query = ApiRequest.createGet(StripeApiRepository.sourcesUrl, ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+            cardMap, null)
             .createQuery()
 
         val expectedValue = "muid=BF3BF4D775100923AAAFA82884FB759001162E28&product_usage=&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123"
@@ -125,8 +125,8 @@ internal class ApiRequestTest {
         val params = mapOf("customer" to "cus_123")
 
         val output = ApiRequest.createPost(StripeApiRepository.paymentMethodsUrl,
-            params,
-            ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null)
+            ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+            params, null)
             .getOutputBytes()
         assertEquals(16, output.size)
     }
@@ -136,21 +136,21 @@ internal class ApiRequestTest {
         val params = mapOf("customer" to "cus_123")
         assertEquals(
             ApiRequest.createPost(StripeApiRepository.paymentMethodsUrl,
-                params,
-                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null),
+                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+                params, null),
             ApiRequest.createPost(StripeApiRepository.paymentMethodsUrl,
-                params,
-                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null)
+                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+                params, null)
         )
 
         assertNotEquals(
             ApiRequest.createPost(StripeApiRepository.paymentMethodsUrl,
-                params,
-                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY), null),
+                ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+                params, null),
             ApiRequest.createPost(StripeApiRepository.paymentMethodsUrl,
-                params,
                 ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
-                    "acct"), null)
+                    "acct"),
+                params, null)
         )
     }
 
@@ -160,7 +160,8 @@ internal class ApiRequestTest {
         val apiRequest = ApiRequest.createGet(
             StripeApiRepository.paymentMethodsUrl,
             ApiRequest.Options.create(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
-            AppInfoTest.APP_INFO)
+            appInfo = AppInfoTest.APP_INFO
+        )
         val headers = apiRequest.headers
         assertEquals(
             "${StripeRequest.DEFAULT_USER_AGENT} MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -238,11 +238,11 @@ class StripeApiRepositoryTest {
         val response = stripeApiRepository.makeApiRequest(
             ApiRequest.createPost(
                 StripeApiRepository.sourcesUrl,
-                SourceParams.createCardParams(CARD).toParamMap(),
                 ApiRequest.Options.create(
                     ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY,
                     connectAccountId
                 ),
+                SourceParams.createCardParams(CARD).toParamMap(),
                 null)
         )
         assertNotNull(response)
@@ -507,7 +507,7 @@ class StripeApiRepositoryTest {
         val options = ApiRequest.Options
             .create(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
         val url = ApiRequest.createGet(StripeApiRepository.paymentMethodsUrl,
-            queryParams, options, null)
+            options, queryParams, null)
             .url
 
         `when`(
@@ -548,8 +548,8 @@ class StripeApiRepositoryTest {
         val options = ApiRequest.Options.create(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
         val url = ApiRequest.createGet(
             StripeApiRepository.paymentMethodsUrl,
-            queryParams,
-            options, null)
+            options,
+            queryParams, null)
             .url
 
         `when`(


### PR DESCRIPTION
- Use overloaded methods for createGet() and createPost()
- Make ApiRequest.Options a data class
