### PR TITLE
Refactor PaymentMethodsActivity

### DIFF
--- a/stripe/res/layout/activity_payment_methods.xml
+++ b/stripe/res/layout/activity_payment_methods.xml
@@ -28,7 +28,7 @@
             android:layout_below="@id/payment_methods_toolbar"
             android:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <com.stripe.android.view.PaymentMethodsRecyclerView
             android:id="@+id/payment_methods_recycler"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -15,15 +15,15 @@ import java.util.ArrayList
  * A [RecyclerView.Adapter] that holds a set of [MaskedCardView] items for a given set
  * of [PaymentMethod] objects.
  */
-internal class PaymentMethodsAdapter @JvmOverloads constructor(
+internal class PaymentMethodsAdapter @JvmOverloads internal constructor(
     initiallySelectedPaymentMethodId: String?,
     private val intentArgs: PaymentMethodsActivityStarter.Args,
     private val addableTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card)
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    val paymentMethods = ArrayList<PaymentMethod>()
-    var selectedPaymentMethodId: String? = initiallySelectedPaymentMethodId
-    val selectedPaymentMethod: PaymentMethod?
+    internal val paymentMethods = ArrayList<PaymentMethod>()
+    internal var selectedPaymentMethodId: String? = initiallySelectedPaymentMethodId
+    internal val selectedPaymentMethod: PaymentMethod?
         get() {
             // return the selected Payment Method, if it exists;
             // otherwise, return the most recently created Payment Method
@@ -32,14 +32,15 @@ internal class PaymentMethodsAdapter @JvmOverloads constructor(
             } ?: (paymentMethods.maxBy { it.created ?: 0 })
         }
 
-    var listener: Listener? = null
+    internal var listener: Listener? = null
     private val handler = Handler(Looper.getMainLooper())
 
     init {
         setHasStableIds(true)
     }
 
-    fun setPaymentMethods(paymentMethods: List<PaymentMethod>) {
+    @JvmSynthetic
+    internal fun setPaymentMethods(paymentMethods: List<PaymentMethod>) {
         this.paymentMethods.clear()
         this.paymentMethods.addAll(paymentMethods)
         notifyDataSetChanged()
@@ -137,7 +138,7 @@ internal class PaymentMethodsAdapter @JvmOverloads constructor(
         return PaymentMethodViewHolder(itemView)
     }
 
-    fun deletePaymentMethod(paymentMethod: PaymentMethod) {
+    internal fun deletePaymentMethod(paymentMethod: PaymentMethod) {
         val indexToDelete = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
         if (indexToDelete >= 0) {
             val wasSelectedPaymentMethod =
@@ -153,7 +154,7 @@ internal class PaymentMethodsAdapter @JvmOverloads constructor(
         }
     }
 
-    fun resetPaymentMethod(paymentMethod: PaymentMethod) {
+    internal fun resetPaymentMethod(paymentMethod: PaymentMethod) {
         val indexToReset = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
         if (indexToReset >= 0) {
             notifyItemChanged(indexToReset)
@@ -182,7 +183,7 @@ internal class PaymentMethodsAdapter @JvmOverloads constructor(
     internal class AddFpxPaymentMethodViewHolder(itemView: View) :
         RecyclerView.ViewHolder(itemView)
 
-    interface Listener {
+    internal interface Listener {
         fun onClick(paymentMethod: PaymentMethod)
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsRecyclerView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsRecyclerView.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.stripe.android.model.PaymentMethod
+
+internal class PaymentMethodsRecyclerView @JvmOverloads internal constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr) {
+
+    internal var listener: Listener? = null
+    internal var tappedPaymentMethod: PaymentMethod? = null
+
+    init {
+        setHasFixedSize(false)
+        layoutManager = LinearLayoutManager(context)
+
+        itemAnimator = object : DefaultItemAnimator() {
+            override fun onAnimationFinished(viewHolder: ViewHolder) {
+                super.onAnimationFinished(viewHolder)
+
+                // wait until post-tap animations are completed before finishing activity
+                tappedPaymentMethod?.let { listener?.onPaymentMethodSelected(it) }
+                tappedPaymentMethod = null
+            }
+        }
+    }
+
+    @JvmSynthetic
+    internal fun attachItemTouchHelper(callback: ItemTouchHelper.SimpleCallback) {
+        ItemTouchHelper(callback).attachToRecyclerView(this)
+    }
+
+    internal interface Listener {
+        fun onPaymentMethodSelected(paymentMethod: PaymentMethod)
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/SwipeToDeleteCallbackListener.kt
+++ b/stripe/src/main/java/com/stripe/android/view/SwipeToDeleteCallbackListener.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.view
+
+import androidx.appcompat.app.AlertDialog
+import com.stripe.android.CustomerSession
+import com.stripe.android.R
+import com.stripe.android.StripeError
+import com.stripe.android.model.PaymentMethod
+
+internal class SwipeToDeleteCallbackListener internal constructor(
+    private val activity: PaymentMethodsActivity,
+    private val adapter: PaymentMethodsAdapter,
+    private val cardDisplayTextFactory: CardDisplayTextFactory,
+    private val customerSession: CustomerSession
+) : PaymentMethodSwipeCallback.Listener {
+
+    override fun onSwiped(paymentMethod: PaymentMethod) {
+        confirmDeletePaymentMethod(paymentMethod)
+    }
+
+    private fun confirmDeletePaymentMethod(paymentMethod: PaymentMethod) {
+        val message = paymentMethod.card?.let {
+            cardDisplayTextFactory.createUnstyled(it)
+        }
+        AlertDialog.Builder(activity, R.style.AlertDialogStyle)
+            .setTitle(R.string.delete_payment_method)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.yes) { _, _ ->
+                onDeletedPaymentMethod(paymentMethod)
+            }
+            .setNegativeButton(android.R.string.no) { _, _ ->
+                adapter.resetPaymentMethod(paymentMethod)
+            }
+            .setOnCancelListener {
+                adapter.resetPaymentMethod(paymentMethod)
+            }
+            .create()
+            .show()
+    }
+
+    private fun onDeletedPaymentMethod(paymentMethod: PaymentMethod) {
+        adapter.deletePaymentMethod(paymentMethod)
+
+        paymentMethod.id?.let { paymentMethodId ->
+            customerSession.detachPaymentMethod(paymentMethodId, PaymentMethodDeleteListener())
+        }
+
+        activity.showSnackbar(paymentMethod, R.string.removed)
+    }
+
+    private class PaymentMethodDeleteListener : CustomerSession.PaymentMethodRetrievalListener {
+        override fun onPaymentMethodRetrieved(paymentMethod: PaymentMethod) {
+        }
+
+        override fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?) {
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CustomerSession
 import com.stripe.android.CustomerSessionTestHelper
@@ -29,7 +30,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
@@ -86,7 +86,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
         assertNotNull(recyclerView)
         assertNotNull(addCardView)
 
-        verify<CustomerSession>(customerSession).getPaymentMethods(
+        verify(customerSession).getPaymentMethods(
             eq(PaymentMethod.Type.Card),
             listenerArgumentCaptor.capture()
         )
@@ -112,7 +112,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
             .build())
         recyclerView = paymentMethodsActivity.findViewById(R.id.payment_methods_recycler)
 
-        verify<CustomerSession>(customerSession)
+        verify(customerSession)
             .getPaymentMethods(eq(PaymentMethod.Type.Card), listenerArgumentCaptor.capture())
 
         listenerArgumentCaptor.firstValue
@@ -159,7 +159,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
             AddPaymentMethodActivityStarter.REQUEST_CODE, RESULT_OK, resultIntent
         )
         assertEquals(View.VISIBLE, progressBar.visibility)
-        verify<CustomerSession>(customerSession, times(2))
+        verify(customerSession, times(2))
             .getPaymentMethods(eq(PaymentMethod.Type.Card), listenerArgumentCaptor.capture())
 
         listenerArgumentCaptor.firstValue
@@ -174,7 +174,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
 
     @Test
     fun setSelectionAndFinish_finishedWithExpectedResult() {
-        verify<CustomerSession>(customerSession).getPaymentMethods(
+        verify(customerSession).getPaymentMethods(
             eq(PaymentMethod.Type.Card),
             listenerArgumentCaptor.capture()
         )


### PR DESCRIPTION
Move some logic from `PaymentMethodsActivity` to
`PaymentMethodsRecyclerView` and `SwipeToDeleteCallbackListener`.

Manually verified existing functionality.