### PR TITLE
Mark Stripe.createToken() as Deprecated

### DIFF
--- a/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.kt
+++ b/example/src/main/java/com/stripe/example/controller/AsyncTaskTokenController.kt
@@ -9,15 +9,14 @@ import com.stripe.android.view.CardInputWidget
 import com.stripe.example.R
 
 /**
- * Logic needed to create tokens using the [android.os.AsyncTask] methods included in the
- * sdk: [Stripe.createToken].
+ * Logic needed to create a Card Token asynchronously using [Stripe.createCardToken].
  */
 class AsyncTaskTokenController(
     button: Button,
     private var cardInputWidget: CardInputWidget?,
     context: Context,
     private val errorDialogHandler: ErrorDialogHandler,
-    outputListController: ListViewController,
+    private val outputListController: ListViewController,
     private val progressDialogController: ProgressDialogController,
     publishableKey: String
 ) {
@@ -25,11 +24,7 @@ class AsyncTaskTokenController(
 
     init {
         button.setOnClickListener {
-            saveCard(TokenCallbackImpl(
-                errorDialogHandler,
-                outputListController,
-                progressDialogController
-            ))
+            saveCard()
         }
     }
 
@@ -37,15 +32,15 @@ class AsyncTaskTokenController(
         cardInputWidget = null
     }
 
-    private fun saveCard(tokenCallback: ApiResultCallback<Token>) {
-        val cardToSave = cardInputWidget?.card
-        if (cardToSave == null) {
-            errorDialogHandler.show("Invalid Card Data")
-            return
-        }
-
-        progressDialogController.show(R.string.progressMessage)
-        stripe.createToken(cardToSave, callback = tokenCallback)
+    private fun saveCard() {
+        cardInputWidget?.card?.let { card ->
+            progressDialogController.show(R.string.progressMessage)
+            stripe.createCardToken(card, callback = TokenCallbackImpl(
+                errorDialogHandler,
+                outputListController,
+                progressDialogController
+            ))
+        } ?: errorDialogHandler.show("Invalid Card Data")
     }
 
     private class TokenCallbackImpl constructor(

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -729,7 +729,34 @@ class Stripe internal constructor(
      */
     @UiThread
     @JvmOverloads
+    @Deprecated("Deprecated, replace with Stripe#createCardToken()",
+        ReplaceWith("Stripe#createCardToken()"))
     fun createToken(
+        card: Card,
+        idempotencyKey: String? = null,
+        callback: ApiResultCallback<Token>
+    ) {
+        createTokenFromParams(
+            stripeNetworkUtils.createCardTokenParams(card),
+            Token.TokenType.CARD,
+            idempotencyKey,
+            callback
+        )
+    }
+
+    /**
+     * Create a Card token asynchronously.
+     *
+     * See [Create a card token](https://stripe.com/docs/api/tokens/create_card).
+     * `POST /v1/tokens`
+     *
+     * @param card the [Card] used to create this payment token
+     * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param callback a [ApiResultCallback] to receive the result or error
+     */
+    @UiThread
+    @JvmOverloads
+    fun createCardToken(
         card: Card,
         idempotencyKey: String? = null,
         callback: ApiResultCallback<Token>

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -145,7 +145,7 @@ public class StripeTest {
     }
 
     @Test
-    public void createTokenShouldCallTokenCreator() {
+    public void createCardTokenShouldCallTokenCreator() {
         final boolean[] tokenCreatorCalled = { false };
         final Stripe stripe = createStripe(
                 new Stripe.TokenCreator() {
@@ -158,12 +158,12 @@ public class StripeTest {
                         tokenCreatorCalled[0] = true;
                     }
                 });
-        stripe.createToken(CARD, DEFAULT_TOKEN_CALLBACK);
+        stripe.createCardToken(CARD, DEFAULT_TOKEN_CALLBACK);
         assertTrue(tokenCreatorCalled[0]);
     }
 
     @Test
-    public void createTokenShouldUseProvidedKey() {
+    public void createCardTokenShouldUseProvidedKey() {
         final Stripe stripe = createStripe(
                 new Stripe.TokenCreator() {
                     @Override
@@ -177,7 +177,7 @@ public class StripeTest {
                         assertEquals(DEFAULT_TOKEN_CALLBACK, callback);
                     }
                 });
-        stripe.createToken(CARD, DEFAULT_TOKEN_CALLBACK);
+        stripe.createCardToken(CARD, DEFAULT_TOKEN_CALLBACK);
     }
 
     @Test


### PR DESCRIPTION
Replace with `Stripe.createCardToken()`. The method name change
clarifies the type of Token that is being created.