### PR TITLE
Fix CardNumberEditText not calling onCardNumberComplete()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -50,7 +50,7 @@ class CardNumberEditText @JvmOverloads constructor(
      */
     val cardNumber: String?
         get() = if (isCardNumberValid) {
-            StripeTextUtils.removeSpacesAndHyphens(text?.toString())
+            StripeTextUtils.removeSpacesAndHyphens(fieldText)
         } else {
             null
         }
@@ -183,24 +183,23 @@ class CardNumberEditText @JvmOverloads constructor(
                         setSelection(it)
                     }
                 }
+                formattedNumber = null
+                newCursorPosition = null
 
                 ignoreChanges = false
 
-                if (formattedNumber?.length == lengthMax) {
+                if (fieldText.length == lengthMax) {
                     val before = isCardNumberValid
-                    isCardNumberValid = CardUtils.isValidCardNumber(formattedNumber)
+                    isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
                     shouldShowError = !isCardNumberValid
                     if (!before && isCardNumberValid) {
                         cardNumberCompleteListener?.onCardNumberComplete()
                     }
                 } else {
-                    isCardNumberValid = CardUtils.isValidCardNumber(text?.toString())
+                    isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
                     // Don't show errors if we aren't full-length.
                     shouldShowError = false
                 }
-
-                formattedNumber = null
-                newCursorPosition = null
             }
         })
     }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -57,6 +57,11 @@ open class StripeEditText @JvmOverloads constructor(
             refreshDrawableState()
         }
 
+    protected val fieldText: String
+        get() {
+            return text?.toString().orEmpty()
+        }
+
     @ColorInt
     private var defaultErrorColor: Int = 0
     @ColorInt


### PR DESCRIPTION
In `onAfterTextChanged()`, `formattedNumber` was null during
the logic to check if the card number was at max length,
preventing `cardNumberCompleteListener?.onCardNumberComplete()`
from being called.

Fix this by reading the actual value of the field instead of
the variable `formattedNumber`.