### PR TITLE
Update PaymentSessionActivity example

### DIFF
--- a/example/res/drawable/ic_cancel.xml
+++ b/example/res/drawable/ic_cancel.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM15.59,7L12,10.59 8.41,7 7,8.41 10.59,12 7,15.59 8.41,17 12,13.41 15.59,17 17,15.59 13.41,12 17,8.41z"/>
+</vector>

--- a/example/res/drawable/ic_check.xml
+++ b/example/res/drawable/ic_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M16.59,7.58L10,14.17l-3.59,-3.58L5,12l5,5 8,-8zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/example/res/drawable/ic_credit_card.xml
+++ b/example/res/drawable/ic_credit_card.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,4L4,4c-1.11,0 -1.99,0.89 -1.99,2L2,18c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2L22,6c0,-1.11 -0.89,-2 -2,-2zM20,18L4,18v-6h16v6zM20,8L4,8L4,6h16v2z"/>
+</vector>

--- a/example/res/drawable/ic_home.xml
+++ b/example/res/drawable/ic_home.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/example/res/drawable/ic_shipping_method.xml
+++ b/example/res/drawable/ic_shipping_method.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,8h-3L17,4L3,4c-1.1,0 -2,0.9 -2,2v11h2c0,1.66 1.34,3 3,3s3,-1.34 3,-3h6c0,1.66 1.34,3 3,3s3,-1.34 3,-3h2v-5l-3,-4zM6,18.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM19.5,9.5l1.96,2.5L17,12L17,9.5h2.5zM18,18.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5z"/>
+</vector>

--- a/example/res/layout/activity_payment_session.xml
+++ b/example/res/layout/activity_payment_session.xml
@@ -16,7 +16,7 @@
     <Button
         android:id="@+id/btn_select_payment_method"
         android:enabled="false"
-        android:layout_width="200dp"
+        android:layout_width="320dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="@dimen/example_vertical_spacing"
@@ -26,32 +26,57 @@
     <Button
         android:id="@+id/btn_start_payment_flow"
         android:enabled="false"
-        android:layout_width="200dp"
+        android:layout_width="320dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="@dimen/example_vertical_spacing"
+        android:layout_marginBottom="@dimen/example_vertical_spacing"
         android:text="@string/payment_session_select_shipping"
         />
 
     <TextView
-        android:id="@+id/tv_payment_session_data_title"
+        android:id="@+id/tv_ready_to_charge"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
         android:layout_margin="16dp"
-        android:layout_marginTop="@dimen/example_vertical_spacing"
-        android:text="@string/payment_session_data"
-        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Medium"
-        android:visibility="invisible"
+        android:layout_marginTop="24dp"
+        android:drawablePadding="8dp"
+        android:drawableStart="@drawable/ic_cancel"
+        android:textSize="16sp"
+        android:text="@string/ready_to_charge"
         />
 
     <TextView
-        android:id="@+id/tv_payment_session_data"
+        android:id="@+id/tv_payment_method"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
         android:layout_margin="16dp"
-        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Medium"
+        android:drawablePadding="8dp"
+        android:drawableStart="@drawable/ic_credit_card"
+        android:textSize="16sp"
+        android:text="@string/not_selected"
+        />
+
+    <TextView
+        android:id="@+id/tv_shipping_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:drawablePadding="8dp"
+        android:drawableStart="@drawable/ic_home"
+        android:textSize="16sp"
+        android:text="@string/not_selected"
+        />
+
+    <TextView
+        android:id="@+id/tv_shipping_method"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:drawablePadding="8dp"
+        android:drawableStart="@drawable/ic_shipping_method"
+        android:textSize="16sp"
+        android:text="@string/not_selected"
         />
 
 </LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -65,4 +65,7 @@
     <string name="setup_intent_status">SetupIntent status: %s</string>
     <string name="payment_auth_intro">Tapping the button below will create a PaymentIntent then attempt to confirm it.</string>
     <string name="setup_auth_intro">Tapping the button below will create a SetupIntent then attempt to confirm it.</string>
+
+    <string name="ready_to_charge">Ready to charge?</string>
+    <string name="not_selected">Not selected</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/PaymentUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentUtils.kt
@@ -6,14 +6,14 @@ import java.util.Currency
 import java.util.Locale
 import kotlin.math.pow
 
-internal object PaymentUtils {
+object PaymentUtils {
 
     /**
      * Formats a monetary amount into a human friendly string where zero is returned
      * as free.
      */
-    @JvmSynthetic
-    internal fun formatPriceStringUsingFree(
+    @JvmStatic
+    fun formatPriceStringUsingFree(
         amount: Long,
         currency: Currency,
         free: String


### PR DESCRIPTION
Update the UI of this example to more clearly illustrate how
`PaymentSession` works.

Make `PaymentUtils` public, because it may be useful to
users for generating price strings.

![Screenshot_1573142643](https://user-images.githubusercontent.com/45020849/68406136-44690980-014f-11ea-8d2d-5815a50bf99d.png)
![Screenshot_1573142653](https://user-images.githubusercontent.com/45020849/68406137-4501a000-014f-11ea-8b92-421ea372484d.png)
