### PR TITLE
Convert ApiOperation from AsyncTask to Coroutines

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiOperation.kt
@@ -1,31 +1,40 @@
 package com.stripe.android
 
-import android.os.AsyncTask
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.StripeException
 import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONException
 
 internal abstract class ApiOperation<ResultType>(
+    private val workScope: CoroutineScope = CoroutineScope(IO),
     private val callback: ApiResultCallback<ResultType>
-) : AsyncTask<Void, Void, ResultWrapper<ResultType>>() {
+) {
+    internal abstract suspend fun getResult(): ResultType?
 
-    internal abstract fun getResult(): ResultType?
+    internal fun execute() {
+        workScope.launch {
+            val resultWrapper: ResultWrapper<ResultType> = try {
+                ResultWrapper.create(getResult())
+            } catch (e: StripeException) {
+                ResultWrapper.create(e)
+            } catch (e: JSONException) {
+                ResultWrapper.create(e)
+            } catch (e: IOException) {
+                ResultWrapper.create(APIConnectionException.create(e))
+            }
 
-    override fun doInBackground(vararg voids: Void): ResultWrapper<ResultType> {
-        return try {
-            ResultWrapper.create(getResult())
-        } catch (e: StripeException) {
-            ResultWrapper.create(e)
-        } catch (e: JSONException) {
-            ResultWrapper.create(e)
-        } catch (e: IOException) {
-            ResultWrapper.create(APIConnectionException.create(e))
+            withContext(Main) {
+                dispatchResult(resultWrapper)
+            }
         }
     }
 
-    override fun onPostExecute(resultWrapper: ResultWrapper<ResultType>) {
-        super.onPostExecute(resultWrapper)
+    private fun dispatchResult(resultWrapper: ResultWrapper<ResultType>) {
         when {
             resultWrapper.result != null -> callback.onSuccess(resultWrapper.result)
             resultWrapper.error != null -> callback.onError(resultWrapper.error)

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -930,9 +930,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         private val mStripeIntentId: String,
         private val mRequestOptions: ApiRequest.Options,
         callback: ApiResultCallback<Stripe3ds2AuthResult>
-    ) : ApiOperation<Stripe3ds2AuthResult>(callback) {
+    ) : ApiOperation<Stripe3ds2AuthResult>(callback = callback) {
         @Throws(StripeException::class, JSONException::class)
-        override fun getResult(): Stripe3ds2AuthResult {
+        override suspend fun getResult(): Stripe3ds2AuthResult {
             return mStripeApiRepository.start3ds2Auth(mParams, mStripeIntentId, mRequestOptions)
         }
     }
@@ -942,9 +942,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         private val mSourceId: String,
         private val mRequestOptions: ApiRequest.Options,
         callback: ApiResultCallback<Boolean>
-    ) : ApiOperation<Boolean>(callback) {
+    ) : ApiOperation<Boolean>(callback = callback) {
         @Throws(StripeException::class)
-        override fun getResult(): Boolean {
+        override suspend fun getResult(): Boolean {
             return mStripeApiRepository.complete3ds2Auth(mSourceId, mRequestOptions)
         }
     }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -35,6 +35,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlinx.coroutines.MainScope
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -109,7 +110,8 @@ class StripePaymentControllerTest {
             threeDs2Service,
             fireAndForgetRequestExecutor,
             analyticsDataFactory,
-            challengeFlowStarter
+            challengeFlowStarter,
+            MainScope()
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -45,6 +45,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.MainScope
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -329,7 +330,7 @@ class AddPaymentMethodActivityTest :
             StripeNetworkUtils(context),
             StripePaymentController.create(context, stripeRepository),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            null
+            workScope = MainScope()
         )
     }
 


### PR DESCRIPTION
Refactor `ApiOperation` to use coroutines to handle making
IO requests (i.e. Stripe API requests) on a background thread
(i.e. `Dispatchers.IO`) and dispatch the result to the
main thread (i.e. `MainScope()`).

`ApiOperation` takes a `workScope: CoroutineScope` param
that defaults to `Dispatchers.IO` but can be set to
`MainScope()` for testing purposes, as is shown in `StripeTest`.