### PR TITLE
Reduce visibility of many companion objects

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -142,7 +142,7 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
         }
     }
 
-    companion object {
+    private companion object {
         private val BILLING_DETAILS =
             PaymentMethod.BillingDetails.Builder()
                 .setName("Jenny Rosen")

--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -201,7 +201,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
             .show()
     }
 
-    companion object {
+    private companion object {
 
         private const val RETURN_SCHEMA = "stripe://"
         private const val RETURN_HOST_ASYNC = "async"

--- a/example/src/main/java/com/stripe/example/activity/CreateSepaDebitActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateSepaDebitActivity.kt
@@ -59,7 +59,7 @@ class CreateSepaDebitActivity : AppCompatActivity() {
         }
     }
 
-    companion object {
+    private companion object {
         private const val CUSTOMER_NAME = "Jenny Rosen"
         private const val CUSTOMER_EMAIl = "jrosen@example.com"
     }

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -339,7 +339,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
             }
         }
 
-        companion object {
+        private companion object {
             private const val PAYMENT_METHOD_3DS2_REQUIRED = "pm_card_threeDSecure2Required"
             private const val RETURN_URL = "stripe://payment_auth"
         }

--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
@@ -232,7 +232,7 @@ class PayWithGoogleActivity : AppCompatActivity() {
             )
     }
 
-    companion object {
+    private companion object {
         private const val LOAD_PAYMENT_DATA_REQUEST_CODE = 53
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -265,12 +265,11 @@ class PaymentAuthActivity : AppCompatActivity() {
         }
     }
 
-    companion object {
+    private companion object {
 
         /**
          * See https://stripe.com/docs/payments/3d-secure#three-ds-cards for more options.
          */
-
         private fun create3ds2ConfirmParams(
             paymentIntentClientSecret: String
         ): ConfirmPaymentIntentParams {

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -257,7 +257,7 @@ class PaymentSessionActivity : AppCompatActivity() {
         }
     }
 
-    companion object {
+    private companion object {
         private val EXAMPLE_SHIPPING_INFO = ShippingInformation(
             Address.Builder()
                 .setCity("San Francisco")

--- a/example/src/main/java/com/stripe/example/dialog/ErrorDialogFragment.kt
+++ b/example/src/main/java/com/stripe/example/dialog/ErrorDialogFragment.kt
@@ -18,8 +18,8 @@ class ErrorDialogFragment : androidx.fragment.app.DialogFragment() {
             .create()
     }
 
-    companion object {
-        fun newInstance(title: String, message: String): ErrorDialogFragment {
+    internal companion object {
+        internal fun newInstance(title: String, message: String): ErrorDialogFragment {
             val fragment = ErrorDialogFragment()
 
             val args = Bundle()

--- a/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.kt
+++ b/example/src/main/java/com/stripe/example/dialog/ProgressDialogFragment.kt
@@ -15,8 +15,8 @@ class ProgressDialogFragment : androidx.fragment.app.DialogFragment() {
         return dialog
     }
 
-    companion object {
-        fun newInstance(message: String): ProgressDialogFragment {
+    internal companion object {
+        internal fun newInstance(message: String): ProgressDialogFragment {
             val fragment = ProgressDialogFragment()
 
             val args = Bundle()

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -33,34 +33,34 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         EventName.AUTH_3DS2_FALLBACK, EventName.AUTH_REDIRECT, EventName.AUTH_ERROR)
     internal annotation class EventName {
         companion object {
-            const val TOKEN_CREATION = "token_creation"
-            const val CREATE_PAYMENT_METHOD = "payment_method_creation"
-            const val ATTACH_PAYMENT_METHOD = "attach_payment_method"
-            const val DETACH_PAYMENT_METHOD = "detach_payment_method"
-            const val SOURCE_CREATION = "source_creation"
-            const val ADD_SOURCE = "add_source"
-            const val DEFAULT_SOURCE = "default_source"
-            const val DELETE_SOURCE = "delete_source"
-            const val SET_SHIPPING_INFO = "set_shipping_info"
-            const val CONFIRM_PAYMENT_INTENT = "payment_intent_confirmation"
-            const val RETRIEVE_PAYMENT_INTENT = "payment_intent_retrieval"
-            const val CONFIRM_SETUP_INTENT = "setup_intent_confirmation"
-            const val RETRIEVE_SETUP_INTENT = "setup_intent_retrieval"
+            internal const val TOKEN_CREATION = "token_creation"
+            internal const val CREATE_PAYMENT_METHOD = "payment_method_creation"
+            internal const val ATTACH_PAYMENT_METHOD = "attach_payment_method"
+            internal const val DETACH_PAYMENT_METHOD = "detach_payment_method"
+            internal const val SOURCE_CREATION = "source_creation"
+            internal const val ADD_SOURCE = "add_source"
+            internal const val DEFAULT_SOURCE = "default_source"
+            internal const val DELETE_SOURCE = "delete_source"
+            internal const val SET_SHIPPING_INFO = "set_shipping_info"
+            internal const val CONFIRM_PAYMENT_INTENT = "payment_intent_confirmation"
+            internal const val RETRIEVE_PAYMENT_INTENT = "payment_intent_retrieval"
+            internal const val CONFIRM_SETUP_INTENT = "setup_intent_confirmation"
+            internal const val RETRIEVE_SETUP_INTENT = "setup_intent_retrieval"
 
-            const val AUTH_3DS1_SDK = "3ds1_sdk"
+            internal const val AUTH_3DS1_SDK = "3ds1_sdk"
 
-            const val AUTH_3DS2_FINGERPRINT = "3ds2_fingerprint"
-            const val AUTH_3DS2_START = "3ds2_authenticate"
-            const val AUTH_3DS2_FRICTIONLESS = "3ds2_frictionless_flow"
-            const val AUTH_3DS2_CHALLENGE_PRESENTED = "3ds2_challenge_flow_presented"
-            const val AUTH_3DS2_CHALLENGE_CANCELED = "3ds2_challenge_flow_canceled"
-            const val AUTH_3DS2_CHALLENGE_COMPLETED = "3ds2_challenge_flow_completed"
-            const val AUTH_3DS2_CHALLENGE_ERRORED = "3ds2_challenge_flow_errored"
-            const val AUTH_3DS2_CHALLENGE_TIMEDOUT = "3ds2_challenge_flow_timed_out"
-            const val AUTH_3DS2_FALLBACK = "3ds2_fallback"
+            internal const val AUTH_3DS2_FINGERPRINT = "3ds2_fingerprint"
+            internal const val AUTH_3DS2_START = "3ds2_authenticate"
+            internal const val AUTH_3DS2_FRICTIONLESS = "3ds2_frictionless_flow"
+            internal const val AUTH_3DS2_CHALLENGE_PRESENTED = "3ds2_challenge_flow_presented"
+            internal const val AUTH_3DS2_CHALLENGE_CANCELED = "3ds2_challenge_flow_canceled"
+            internal const val AUTH_3DS2_CHALLENGE_COMPLETED = "3ds2_challenge_flow_completed"
+            internal const val AUTH_3DS2_CHALLENGE_ERRORED = "3ds2_challenge_flow_errored"
+            internal const val AUTH_3DS2_CHALLENGE_TIMEDOUT = "3ds2_challenge_flow_timed_out"
+            internal const val AUTH_3DS2_FALLBACK = "3ds2_fallback"
 
-            const val AUTH_REDIRECT = "url_redirect_next_action"
-            const val AUTH_ERROR = "auth_error"
+            internal const val AUTH_REDIRECT = "url_redirect_next_action"
+            internal const val AUTH_ERROR = "auth_error"
         }
     }
 
@@ -346,7 +346,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
             .plus(FIELD_APP_VERSION to info.versionCode)
     }
 
-    companion object {
+    internal companion object {
         internal const val UNKNOWN = "unknown"
         internal const val NO_CONTEXT = "no_context"
 

--- a/stripe/src/main/java/com/stripe/android/ApiKeyValidator.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiKeyValidator.kt
@@ -18,11 +18,11 @@ internal class ApiKeyValidator {
         return apiKey
     }
 
-    companion object {
+    internal companion object {
         private val DEFAULT = ApiKeyValidator()
 
         @JvmStatic
-        fun get(): ApiKeyValidator {
+        internal fun get(): ApiKeyValidator {
             return DEFAULT
         }
     }

--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -105,7 +105,7 @@ internal class ApiRequest internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal const val MIME_TYPE = "application/x-www-form-urlencoded"
         internal const val API_HOST = "https://api.stripe.com"
 

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -15,7 +15,7 @@ internal data class ApiVersion internal constructor(internal val code: String) {
         return code
     }
 
-    companion object {
+    internal companion object {
         private const val API_VERSION_CODE: String = "2019-11-05"
 
         private val INSTANCE = ApiVersion(API_VERSION_CODE)

--- a/stripe/src/main/java/com/stripe/android/ConnectionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/ConnectionFactory.kt
@@ -52,7 +52,7 @@ internal class ConnectionFactory {
         }
     }
 
-    companion object {
+    private companion object {
         private val SSL_SOCKET_FACTORY = StripeSSLSocketFactory()
         private val CONNECT_TIMEOUT = TimeUnit.SECONDS.toMillis(30).toInt()
         private val READ_TIMEOUT = TimeUnit.SECONDS.toMillis(80).toInt()

--- a/stripe/src/main/java/com/stripe/android/CustomerSessionProductUsage.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSessionProductUsage.kt
@@ -21,7 +21,7 @@ internal class CustomerSessionProductUsage {
         return data.toSet()
     }
 
-    companion object {
+    private companion object {
         private val VALID_TOKENS = setOf(
             AddPaymentMethodActivity.TOKEN_ADD_PAYMENT_METHOD_ACTIVITY,
             PaymentMethodsActivity.TOKEN_PAYMENT_METHODS_ACTIVITY,

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.kt
@@ -29,7 +29,7 @@ internal data class EphemeralKey internal constructor(
     internal val type: String
 ) : StripeModel(), Parcelable {
 
-    companion object {
+    internal companion object {
         private const val FIELD_CREATED = "created"
         private const val FIELD_EXPIRES = "expires"
         private const val FIELD_SECRET = "secret"

--- a/stripe/src/main/java/com/stripe/android/FingerprintRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintRequest.kt
@@ -50,7 +50,7 @@ internal class FingerprintRequest(
         return super.typedEquals(obj) && guid == obj.guid
     }
 
-    companion object {
+    private companion object {
         private const val MIME_TYPE = "application/json"
         private const val URL = "https://m.stripe.com/4"
 

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -34,7 +34,7 @@ internal class PaymentAuthWebViewStarter @JvmOverloads internal constructor(
         val returnUrl: String? = null
     )
 
-    companion object {
+    internal companion object {
         internal const val EXTRA_AUTH_URL = "auth_url"
         internal const val EXTRA_CLIENT_SECRET = "client_secret"
         internal const val EXTRA_RETURN_URL = "return_url"

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -340,7 +340,7 @@ class PaymentSession @VisibleForTesting internal constructor(
             get() = activityRef.get()
     }
 
-    companion object {
+    internal companion object {
         internal const val TOKEN_PAYMENT_SESSION: String = "PaymentSession"
         internal const val EXTRA_PAYMENT_SESSION_ACTIVE: String = "payment_session_active"
         internal const val STATE_PAYMENT_SESSION_DATA: String = "payment_session_data"

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -125,7 +125,7 @@ data class PaymentSessionConfig internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal val EMPTY = PaymentSessionConfig()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/ResultWrapper.kt
+++ b/stripe/src/main/java/com/stripe/android/ResultWrapper.kt
@@ -1,10 +1,10 @@
 package com.stripe.android
 
-internal data class ResultWrapper<ResultType> private constructor(
+internal data class ResultWrapper<ResultType> internal constructor(
     val result: ResultType? = null,
     val error: Exception? = null
 ) {
-    companion object {
+    internal companion object {
         @JvmSynthetic
         internal fun <ResultType> create(result: ResultType?): ResultWrapper<ResultType> {
             return ResultWrapper(result = result)

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2AuthParams.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2AuthParams.kt
@@ -55,10 +55,10 @@ internal class Stripe3ds2AuthParams(
         }
     }
 
-    companion object {
-        const val FIELD_APP = "app"
-        const val FIELD_SOURCE = "source"
-        const val FIELD_FALLBACK_RETURN_URL = "fallback_return_url"
+    internal companion object {
+        internal const val FIELD_APP = "app"
+        internal const val FIELD_SOURCE = "source"
+        internal const val FIELD_FALLBACK_RETURN_URL = "fallback_return_url"
 
         private const val FIELD_SDK_APP_ID = "sdkAppID"
         private const val FIELD_SDK_TRANS_ID = "sdkTransID"

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.kt
@@ -26,12 +26,12 @@ internal class Stripe3ds2CompletionStarter(
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class ChallengeFlowOutcome {
         companion object {
-            const val COMPLETE_SUCCESSFUL = 0
-            const val COMPLETE_UNSUCCESSFUL = 1
-            const val CANCEL = 2
-            const val TIMEOUT = 3
-            const val PROTOCOL_ERROR = 4
-            const val RUNTIME_ERROR = 5
+            internal const val COMPLETE_SUCCESSFUL = 0
+            internal const val COMPLETE_UNSUCCESSFUL = 1
+            internal const val CANCEL = 2
+            internal const val TIMEOUT = 3
+            internal const val PROTOCOL_ERROR = 4
+            internal const val RUNTIME_ERROR = 5
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -949,8 +949,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         }
     }
 
-    companion object {
-
+    internal companion object {
         private const val DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl"
 
         private fun createVerificationParam(

--- a/stripe/src/main/java/com/stripe/android/StripeConnection.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeConnection.kt
@@ -68,7 +68,7 @@ internal class StripeConnection internal constructor(
         conn.disconnect()
     }
 
-    companion object {
+    private companion object {
         private val CHARSET = StandardCharsets.UTF_8.name()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -613,10 +613,10 @@ internal class StripePaymentController internal constructor(
         internal interface Complete3ds2AuthCallbackFactory :
             Factory<Stripe3ds2CompletionStarter.StartData, ApiResultCallback<Boolean>>
 
-        companion object {
+        internal companion object {
             private const val VALUE_YES = "Y"
 
-            fun create(
+            internal fun create(
                 host: AuthActivityStarter.Host,
                 stripeRepository: StripeRepository,
                 stripeIntent: StripeIntent,
@@ -677,10 +677,10 @@ internal class StripePaymentController internal constructor(
             }, TimeUnit.SECONDS.toMillis(DELAY_SECONDS))
         }
 
-        companion object {
+        private companion object {
             private const val DELAY_SECONDS = 2L
 
-            fun createHandler(handlerThread: HandlerThread): Handler {
+            private fun createHandler(handlerThread: HandlerThread): Handler {
                 handlerThread.start()
                 return Handler(handlerThread.looper)
             }
@@ -691,7 +691,7 @@ internal class StripePaymentController internal constructor(
         fun start(runnable: Runnable)
     }
 
-    companion object {
+    internal companion object {
         internal const val PAYMENT_REQUEST_CODE = 50000
         internal const val SETUP_REQUEST_CODE = 50001
 

--- a/stripe/src/main/java/com/stripe/android/StripeRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRequest.kt
@@ -155,7 +155,7 @@ internal abstract class StripeRequest(
         internal val value: String
     )
 
-    companion object {
+    internal companion object {
         const val HEADER_USER_AGENT = "User-Agent"
         const val CHARSET = "UTF-8"
 

--- a/stripe/src/main/java/com/stripe/android/StripeSSLSocketFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeSSLSocketFactory.kt
@@ -92,12 +92,12 @@ internal class StripeSSLSocketFactory constructor(
         ).filterNotNull().toTypedArray()
     }
 
-    companion object {
+    internal companion object {
         private const val TLS_V11_PROTO = "TLSv1.1"
         private const val TLS_V12_PROTO = "TLSv1.2"
 
         // For Android prior to 4.1, TLSv1.1 and TLSv1.2 might not be supported
-        fun getSupportedProtocols(): Array<String> {
+        internal fun getSupportedProtocols(): Array<String> {
             return try {
                 SSLContext.getDefault().supportedSSLParameters.protocols
             } catch (e: NoSuchAlgorithmException) {

--- a/stripe/src/main/java/com/stripe/android/StripeUid.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeUid.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
-internal data class StripeUid private constructor(val value: String) {
-    companion object {
+internal data class StripeUid internal constructor(val value: String) {
+    internal companion object {
         @JvmSynthetic
         internal fun create(uid: String): StripeUid {
             return StripeUid(uid)

--- a/stripe/src/main/java/com/stripe/android/TelemetryClientUtil.kt
+++ b/stripe/src/main/java/com/stripe/android/TelemetryClientUtil.kt
@@ -107,7 +107,7 @@ internal class TelemetryClientUtil @VisibleForTesting internal constructor(
         return mapOf("v" to value)
     }
 
-    companion object {
+    private companion object {
         private fun createTimezone(): String {
             val minutes = TimeUnit.MINUTES.convert(TimeZone.getDefault().rawOffset.toLong(),
                 TimeUnit.MILLISECONDS).toInt()

--- a/stripe/src/main/java/com/stripe/android/UidParamsFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/UidParamsFactory.kt
@@ -35,9 +35,8 @@ internal class UidParamsFactory constructor(
         }
     }
 
-    companion object {
-        @JvmStatic
-        fun create(context: Context): UidParamsFactory {
+    internal companion object {
+        internal fun create(context: Context): UidParamsFactory {
             return UidParamsFactory(context.packageName, UidSupplier(context))
         }
 

--- a/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
@@ -29,7 +29,7 @@ abstract class StripeException @JvmOverloads constructor(
         return super.toString() + reqIdStr
     }
 
-    companion object {
+    internal companion object {
         protected const val serialVersionUID = 1L
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
+++ b/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
@@ -13,7 +13,7 @@ internal class FpxBankStatuses private constructor(
         return statuses?.get(bankId) ?: true
     }
 
-    companion object {
+    internal companion object {
         @JvmSynthetic
         internal fun fromJson(json: JSONObject?): FpxBankStatuses {
             return if (json == null) {

--- a/stripe/src/main/java/com/stripe/android/model/MandateData.kt
+++ b/stripe/src/main/java/com/stripe/android/model/MandateData.kt
@@ -8,7 +8,7 @@ internal class MandateData : StripeParamsModel {
         ))
     }
 
-    companion object {
+    internal companion object {
         internal const val API_PARAM_MANDATE_DATA = "mandate_data"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
  *
  * See [PaymentMethod] for API object.
  */
-data class PaymentMethodCreateParams private constructor(
+data class PaymentMethodCreateParams internal constructor(
     internal val type: Type,
     private val card: Card? = null,
     private val ideal: Ideal? = null,
@@ -107,7 +107,7 @@ data class PaymentMethodCreateParams private constructor(
         SepaDebit("sepa_debit", true)
     }
 
-    data class Card private constructor(
+    data class Card internal constructor(
         private val number: String? = null,
         private val expiryMonth: Int? = null,
         private val expiryYear: Int? = null,
@@ -182,7 +182,7 @@ data class PaymentMethodCreateParams private constructor(
         }
     }
 
-    data class Ideal private constructor(private val bank: String?) : StripeParamsModel {
+    data class Ideal internal constructor(private val bank: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return bank?.let { mapOf(FIELD_BANK to it) }.orEmpty()
         }
@@ -205,7 +205,7 @@ data class PaymentMethodCreateParams private constructor(
         }
     }
 
-    data class Fpx private constructor(private val bank: String?) : StripeParamsModel {
+    data class Fpx internal constructor(private val bank: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return bank?.let {
                 mapOf(FIELD_BANK to it)
@@ -230,7 +230,7 @@ data class PaymentMethodCreateParams private constructor(
         }
     }
 
-    data class SepaDebit private constructor(private val iban: String?) : StripeParamsModel {
+    data class SepaDebit internal constructor(private val iban: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return iban?.let {
                 mapOf(FIELD_IBAN to it)

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -230,7 +230,7 @@ data class SetupIntent private constructor(
         RequestedByCustomer("requested_by_customer"),
         Abandoned("abandoned");
 
-        companion object {
+        internal companion object {
             internal fun fromCode(code: String?): CancellationReason? {
                 return values().firstOrNull { it.code == code }
             }
@@ -261,6 +261,7 @@ data class SetupIntent private constructor(
                 .dropLastWhile { it.isEmpty() }.toTypedArray()[0]
         }
 
+        @JvmStatic
         fun fromString(jsonString: String?): SetupIntent? {
             return if (jsonString == null) {
                 null
@@ -273,6 +274,7 @@ data class SetupIntent private constructor(
             }
         }
 
+        @JvmStatic
         fun fromJson(jsonObject: JSONObject?): SetupIntent? {
             val objectType = optString(jsonObject, FIELD_OBJECT)
             if (jsonObject == null || VALUE_SETUP_INTENT != objectType) {

--- a/stripe/src/main/java/com/stripe/android/model/SourceOwner.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOwner.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
  * Model for a [owner](https://stripe.com/docs/api#source_object-owner) object
  * in the Source api.
  */
-data class SourceOwner private constructor(
+data class SourceOwner internal constructor(
     val address: Address?,
     val email: String?,
     val name: String?,
@@ -48,9 +48,8 @@ data class SourceOwner private constructor(
                 return null
             }
 
-            val address: Address?
             val addressJsonOpt = jsonObject.optJSONObject(FIELD_ADDRESS)
-            address = if (addressJsonOpt != null) {
+            val address = if (addressJsonOpt != null) {
                 Address.fromJson(addressJsonOpt)
             } else {
                 null

--- a/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceSepaDebitData.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
 /**
  * Model for the SourceTypeData contained in a SEPA Debit Source object.
  */
-data class SourceSepaDebitData private constructor(
+data class SourceSepaDebitData internal constructor(
     val bankCode: String?,
     val branchCode: String?,
     val country: String?,

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -178,7 +178,7 @@ internal data class Stripe3ds2AuthResult private constructor(
             }
         }
 
-        companion object {
+        internal companion object {
             private const val FIELD_ACS_CHALLENGE_MANDATED = "acsChallengeMandated"
             private const val FIELD_ACS_SIGNED_CONTENT = "acsSignedContent"
             private const val FIELD_ACS_TRANS_ID = "acsTransID"
@@ -218,7 +218,7 @@ internal data class Stripe3ds2AuthResult private constructor(
         }
     }
 
-    data class MessageExtension private constructor(
+    data class MessageExtension internal constructor(
         // The name of the extension data set as defined by the extension owner.
         val name: String?,
 
@@ -266,7 +266,7 @@ internal data class Stripe3ds2AuthResult private constructor(
             }
         }
 
-        companion object {
+        internal companion object {
             private const val FIELD_NAME = "name"
             private const val FIELD_ID = "id"
             private const val FIELD_CRITICALITY_INDICATOR = "criticalityIndicator"
@@ -307,7 +307,7 @@ internal data class Stripe3ds2AuthResult private constructor(
         }
     }
 
-    data class ThreeDS2Error private constructor(
+    data class ThreeDS2Error internal constructor(
         val threeDSServerTransId: String?,
         val acsTransId: String?,
         val dsTransId: String?,
@@ -396,7 +396,7 @@ internal data class Stripe3ds2AuthResult private constructor(
             }
         }
 
-        companion object {
+        internal companion object {
             private const val FIELD_THREE_DS_SERVER_TRANS_ID = "threeDSServerTransID"
             private const val FIELD_ACS_TRANS_ID = "acsTransID"
             private const val FIELD_DS_TRANS_ID = "dsTransID"
@@ -429,7 +429,7 @@ internal data class Stripe3ds2AuthResult private constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         private const val FIELD_ID = "id"
         private const val FIELD_OBJECT = "object"
         private const val FIELD_ARES = "ares"

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2Fingerprint.kt
@@ -36,7 +36,7 @@ internal class Stripe3ds2Fingerprint private constructor(
             return certificate as X509Certificate
         }
 
-        companion object {
+        internal companion object {
             private const val FIELD_DIRECTORY_SERVER_ID = "directory_server_id"
             private const val FIELD_CERTIFICATE = "certificate"
             private const val FIELD_KEY_ID = "key_id"
@@ -65,7 +65,7 @@ internal class Stripe3ds2Fingerprint private constructor(
         Mastercard("mastercard", "A000000004"),
         Amex("american_express", "A000000025");
 
-        companion object {
+        internal companion object {
             @JvmSynthetic
             internal fun lookup(networkName: String): DirectoryServer {
                 return values().find { it.networkName == networkName }
@@ -74,7 +74,7 @@ internal class Stripe3ds2Fingerprint private constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         private const val FIELD_THREE_D_SECURE_2_SOURCE = "three_d_secure_2_source"
         private const val FIELD_DIRECTORY_SERVER_NAME = "directory_server_name"
         private const val FIELD_SERVER_TRANSACTION_ID = "server_transaction_id"

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -70,7 +70,7 @@ interface StripeIntent {
             return code
         }
 
-        companion object {
+        internal companion object {
             internal fun fromCode(code: String?): Status? {
                 return values().firstOrNull { it.code == code }
             }
@@ -90,7 +90,7 @@ interface StripeIntent {
             return code
         }
 
-        companion object {
+        internal companion object {
             internal fun fromCode(code: String?): Usage? {
                 return values().firstOrNull { it.code == code }
             }
@@ -106,7 +106,7 @@ interface StripeIntent {
         val is3ds1: Boolean
             get() = TYPE_3DS1 == type
 
-        companion object {
+        private companion object {
             private const val FIELD_TYPE = "type"
 
             private const val TYPE_3DS2 = "stripe_3ds2_fingerprint"
@@ -125,11 +125,11 @@ interface StripeIntent {
          */
         val returnUrl: String?
     ) {
-        companion object {
+        internal companion object {
             internal const val FIELD_URL = "url"
             internal const val FIELD_RETURN_URL = "return_url"
 
-            @JvmStatic
+            @JvmSynthetic
             internal fun create(redirectToUrlHash: Map<*, *>): RedirectData? {
                 val urlObj = redirectToUrlHash[FIELD_URL]
                 val returnUrlObj = redirectToUrlHash[FIELD_RETURN_URL]

--- a/stripe/src/main/java/com/stripe/android/model/StripeModel.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeModel.kt
@@ -11,9 +11,8 @@ abstract class StripeModel {
 
     abstract override fun equals(other: Any?): Boolean
 
-    companion object {
-        @JvmStatic
-        fun jsonArrayToList(jsonArray: JSONArray?): List<String> {
+    internal companion object {
+        internal fun jsonArrayToList(jsonArray: JSONArray?): List<String> {
             return jsonArray?.let {
                 (0 until jsonArray.length()).map { jsonArray.getString(it) }
             } ?: emptyList()

--- a/stripe/src/main/java/com/stripe/android/model/WeChat.kt
+++ b/stripe/src/main/java/com/stripe/android/model/WeChat.kt
@@ -16,7 +16,7 @@ data class WeChat internal constructor(
     val timestamp: String?,
     val qrCodeUrl: String? = null
 ) : StripeModel() {
-    companion object {
+    internal companion object {
         private const val FIELD_APPID = "android_appId"
         private const val FIELD_NONCE = "android_nonceStr"
         private const val FIELD_PACKAGE = "android_package"

--- a/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/AmexExpressCheckoutWallet.kt
@@ -13,7 +13,7 @@ data class AmexExpressCheckoutWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal fun fromJson(): Builder {
             return Builder()
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/ApplePayWallet.kt
@@ -13,7 +13,7 @@ data class ApplePayWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal fun fromJson(): Builder {
             return Builder()
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/GooglePayWallet.kt
@@ -13,7 +13,7 @@ data class GooglePayWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal fun fromJson(): Builder {
             return Builder()
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/MasterpassWallet.kt
@@ -48,7 +48,7 @@ data class MasterpassWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         private const val FIELD_BILLING_ADDRESS = "billing_address"
         private const val FIELD_EMAIL = "email"
         private const val FIELD_NAME = "name"

--- a/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/SamsungPayWallet.kt
@@ -12,7 +12,7 @@ data class SamsungPayWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal fun fromJson(): Builder {
             return Builder()
         }

--- a/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/VisaCheckoutWallet.kt
@@ -50,7 +50,7 @@ data class VisaCheckoutWallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         private const val FIELD_BILLING_ADDRESS = "billing_address"
         private const val FIELD_EMAIL = "email"
         private const val FIELD_NAME = "name"

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.kt
@@ -29,8 +29,8 @@ abstract class Wallet internal constructor(
         SamsungPay("samsung_pay"),
         VisaCheckout("visa_checkout");
 
-        companion object {
-            fun fromCode(code: String?): Type? {
+        internal companion object {
+            internal fun fromCode(code: String?): Type? {
                 return values().firstOrNull { it.code == code }
             }
         }
@@ -95,7 +95,7 @@ abstract class Wallet internal constructor(
             }
         }
 
-        companion object {
+        internal companion object {
             private const val FIELD_CITY = "city"
             private const val FIELD_COUNTRY = "country"
             private const val FIELD_LINE1 = "line1"
@@ -120,7 +120,7 @@ abstract class Wallet internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         internal const val FIELD_DYNAMIC_LAST4 = "dynamic_last4"
         internal const val FIELD_TYPE = "type"
     }

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
@@ -52,7 +52,7 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
 
     interface Args : Parcelable {
         companion object {
-            const val EXTRA: String = "extra_activity_args"
+            internal const val EXTRA: String = "extra_activity_args"
         }
     }
 
@@ -60,7 +60,7 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
         fun toBundle(): Bundle
 
         companion object {
-            const val EXTRA: String = "extra_activity_result"
+            internal const val EXTRA: String = "extra_activity_result"
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -214,7 +214,7 @@ open class AddPaymentMethodActivity : StripeActivity() {
             get() = activityRef.get()
     }
 
-    companion object {
-        const val TOKEN_ADD_PAYMENT_METHOD_ACTIVITY: String = "AddPaymentMethodActivity"
+    internal companion object {
+        internal const val TOKEN_ADD_PAYMENT_METHOD_ACTIVITY: String = "AddPaymentMethodActivity"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -116,7 +116,7 @@ class AddPaymentMethodActivityStarter constructor(
             }
         }
 
-        companion object {
+        internal companion object {
             internal val DEFAULT = Builder().build()
 
             @JvmSynthetic

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -213,7 +213,7 @@ internal class AddPaymentMethodFpxView @JvmOverloads internal constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         @JvmSynthetic
         internal fun create(activity: FragmentActivity): AddPaymentMethodFpxView {
             return AddPaymentMethodFpxView(activity)

--- a/stripe/src/main/java/com/stripe/android/view/CardDisplayTextFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardDisplayTextFactory.kt
@@ -105,7 +105,7 @@ internal class CardDisplayTextFactory internal constructor(
         )
     }
 
-    companion object {
+    internal companion object {
         private val BRAND_RESOURCE_MAP = mapOf(
             PaymentMethod.Card.Brand.AMERICAN_EXPRESS to R.string.amex_short,
             PaymentMethod.Card.Brand.DINERS_CLUB to R.string.diners_club,

--- a/stripe/src/main/java/com/stripe/android/view/CardInputListener.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputListener.kt
@@ -14,10 +14,10 @@ interface CardInputListener {
         FocusField.FOCUS_POSTAL)
     annotation class FocusField {
         companion object {
-            const val FOCUS_CARD = "focus_card"
-            const val FOCUS_EXPIRY = "focus_expiry"
-            const val FOCUS_CVC = "focus_cvc"
-            const val FOCUS_POSTAL = "focus_postal"
+            const val FOCUS_CARD: String = "focus_card"
+            const val FOCUS_EXPIRY: String = "focus_expiry"
+            const val FOCUS_CVC: String = "focus_cvc"
+            const val FOCUS_POSTAL: String = "focus_postal"
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -635,7 +635,7 @@ class CardMultilineWidget @JvmOverloads constructor(
         cardNumberEditText.setCompoundDrawablesRelative(compatIcon, null, null, null)
     }
 
-    companion object {
+    internal companion object {
 
         internal const val CARD_MULTILINE_TOKEN = "CardMultilineView"
         internal const val CARD_NUMBER_HINT_DELAY = 120L

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -267,7 +267,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
         fun onExpiryDateComplete()
     }
 
-    companion object {
+    private companion object {
         private const val INVALID_INPUT = -1
         private const val MAX_INPUT_LENGTH = 5
     }

--- a/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/IconTextInputLayout.kt
@@ -68,7 +68,7 @@ class IconTextInputLayout @JvmOverloads constructor(
         return collapsingTextHelper != null && bounds != null && recalculateMethod != null
     }
 
-    companion object {
+    private companion object {
         private val BOUNDS_FIELD_NAMES =
             setOf("mCollapsedBounds", "collapsedBounds")
         private val TEXT_FIELD_NAMES =

--- a/stripe/src/main/java/com/stripe/android/view/MaskedCardView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/MaskedCardView.kt
@@ -100,9 +100,8 @@ internal class MaskedCardView @JvmOverloads constructor(
         imageView: ImageView,
         isCheckMark: Boolean
     ) {
-        val icon = DrawableCompat.wrap(
-            ContextCompat.getDrawable(context, resourceId)!!
-        )
+        val drawable = ContextCompat.getDrawable(context, resourceId) ?: return
+        val icon = DrawableCompat.wrap(drawable)
         DrawableCompat.setTint(
             icon.mutate(),
             themeConfig.getTintColor(isSelected || isCheckMark)
@@ -122,7 +121,7 @@ internal class MaskedCardView @JvmOverloads constructor(
         }
     }
 
-    companion object {
+    private companion object {
         private val ICON_RESOURCE_MAP = mapOf(
             PaymentMethod.Card.Brand.AMERICAN_EXPRESS to R.drawable.ic_amex_template_32,
             PaymentMethod.Card.Brand.DINERS_CLUB to R.drawable.ic_diners_template_32,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -94,14 +94,14 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
         settings.domStorageEnabled = true
     }
 
-    companion object {
+    private companion object {
         /**
          * Fix for crash in API 21 and 22
          *
          * See <a href="https://stackoverflow.com/q/41025200/">https://stackoverflow.com/q/41025200/</a>
          * for more context.
          */
-        fun createContext(context: Context): Context {
+        private fun createContext(context: Context): Context {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 context.createConfigurationContext(Configuration())
             } else {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -259,7 +259,7 @@ class PaymentFlowActivity : StripeActivity() {
         }
     }
 
-    companion object {
+    internal companion object {
         internal const val TOKEN_PAYMENT_FLOW_ACTIVITY: String = "PaymentFlowActivity"
         internal const val TOKEN_SHIPPING_INFO_SCREEN: String = "ShippingInfoScreen"
         internal const val TOKEN_SHIPPING_METHOD_SCREEN: String = "ShippingMethodScreen"

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
@@ -148,7 +148,7 @@ internal class PaymentMethodSwipeCallback(
         trashIcon.draw(canvas)
     }
 
-    companion object {
+    internal companion object {
         // calculate the background color while transitioning from start to end threshold
         internal fun calculateTransitionColor(
             fraction: Float,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -220,7 +220,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
         outState.putString(STATE_SELECTED_PAYMENT_METHOD_ID, adapter.selectedPaymentMethod?.id)
     }
 
-    companion object {
+    internal companion object {
         private const val STATE_SELECTED_PAYMENT_METHOD_ID = "state_selected_payment_method_id"
         internal const val TOKEN_PAYMENT_METHODS_ACTIVITY: String = "PaymentMethodsActivity"
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -112,7 +112,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             }
         }
 
-        companion object {
+        internal companion object {
             internal val DEFAULT = Builder().build()
 
             @JvmSynthetic

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -177,7 +177,7 @@ internal class PaymentMethodsAdapter @JvmOverloads internal constructor(
         fun onClick(paymentMethod: PaymentMethod)
     }
 
-    companion object {
+    private companion object {
         private const val TYPE_CARD = 1
         private const val TYPE_ADD_CARD = 2
         private const val TYPE_ADD_FPX = 3

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -48,7 +48,7 @@ internal class PaymentMethodsViewModel : ViewModel() {
             SUCCESS, ERROR
         }
 
-        companion object {
+        internal companion object {
             @JvmSynthetic
             internal fun create(paymentMethods: List<PaymentMethod>): Result<List<PaymentMethod>> {
                 return Result(Status.SUCCESS, paymentMethods)

--- a/stripe/src/main/java/com/stripe/android/view/ShippingPostalCodeValidator.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingPostalCodeValidator.kt
@@ -26,7 +26,7 @@ internal class ShippingPostalCodeValidator {
             }
     }
 
-    companion object {
+    private companion object {
         private val POSTAL_CODE_PATTERNS = mapOf(
             Locale.US.country to
                 Pattern.compile("^[0-9]{5}(?:-[0-9]{4})?$"),
@@ -43,7 +43,7 @@ internal class ShippingPostalCodeValidator {
             return optionalShippingInfoFields
                 .contains(ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD) ||
                 hiddenShippingInfoFields
-                .contains(ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD)
+                    .contains(ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD)
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -228,7 +228,7 @@ class AnalyticsDataFactoryTest {
         assertEquals(androidAnalyticsUserAgent, AnalyticsDataFactory.analyticsUa)
     }
 
-    companion object {
+    private companion object {
         private const val API_KEY = "pk_abc123"
         private val EXPECTED_SINGLE_TOKEN_LIST = listOf("CardInputView")
     }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -208,7 +208,7 @@ internal class ApiRequestTest {
         assertNull(createGetRequest().languageTag)
     }
 
-    companion object {
+    private companion object {
         private fun createGetRequest(): ApiRequest {
             return ApiRequest.createGet(
                 StripeApiRepository.paymentMethodsUrl,

--- a/stripe/src/test/java/com/stripe/android/AppInfoTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AppInfoTest.kt
@@ -60,7 +60,7 @@ class AppInfoTest {
             ))
     }
 
-    companion object {
+    internal companion object {
         internal val APP_INFO = AppInfo.create(
             "MyAwesomePlugin",
             "1.2.34",

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -969,7 +969,7 @@ class CustomerSessionTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowActivit
             "acct_abc123", true)
     }
 
-    companion object {
+    private companion object {
         private val FIRST_SAMPLE_KEY_RAW = CustomerFixtures.EPHEMERAL_KEY_FIRST.toString()
         private val SECOND_SAMPLE_KEY_RAW = CustomerFixtures.EPHEMERAL_KEY_SECOND.toString()
 

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
@@ -309,7 +309,7 @@ class EphemeralKeyManagerTest {
             expires, "ephkey_123", false, "customer", "", "")
     }
 
-    companion object {
+    private companion object {
         private const val TEST_SECONDS_BUFFER = 10L
         private const val DEFAULT_EXPIRES = 1501199335L
     }

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
@@ -31,7 +31,7 @@ class EphemeralKeyTest {
         assertEquals(EPHEMERAL_KEY, ParcelUtils.create(EPHEMERAL_KEY))
     }
 
-    companion object {
+    private companion object {
         private val EPHEMERAL_KEY = EphemeralKey.fromJson(JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/ErrorParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ErrorParserTest.kt
@@ -33,7 +33,7 @@ class ErrorParserTest {
         assertEquals("invalid_request_error", type)
     }
 
-    companion object {
+    private companion object {
         private val RAW_INVALID_REQUEST_ERROR =
             """
             {

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
@@ -160,7 +160,7 @@ class IssuingCardPinServiceTest {
         )
     }
 
-    companion object {
+    private companion object {
 
         private val EPHEMERAL_KEY = JSONObject(
             """

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
@@ -69,7 +69,7 @@ class PaymentAuthWebViewStarterTest {
             extras.getString(PaymentAuthWebViewStarter.EXTRA_CLIENT_SECRET))
     }
 
-    companion object {
+    private companion object {
         private const val CLIENT_SECRET = "pi_1EceMnCRMbs6FrXfCXdF8dnx_secret_vew0L3IGaO0x9o0eyRMGzKr0k"
         private val DATA = PaymentAuthWebViewStarter.Data(
             CLIENT_SECRET,

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -78,8 +78,7 @@ class PaymentSessionDataTest {
         assertEquals(data, ParcelUtils.create(data))
     }
 
-    companion object {
-
+    private companion object {
         private val PAYMENT_METHOD = PaymentMethod.fromJson(PaymentMethodTest.PM_CARD_JSON)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -383,7 +383,7 @@ class PaymentSessionTest {
         }
     }
 
-    companion object {
+    private companion object {
         private val FIRST_CUSTOMER = CustomerFixtures.CUSTOMER
         private val SECOND_CUSTOMER = CustomerFixtures.OTHER_CUSTOMER
     }

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2AuthParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2AuthParamsTest.kt
@@ -44,7 +44,7 @@ class Stripe3ds2AuthParamsTest {
             paramsMap[Stripe3ds2AuthParams.FIELD_FALLBACK_RETURN_URL].toString())
     }
 
-    companion object {
+    private companion object {
         private const val RETURN_URL = "stripe://payment-auth-return"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -584,7 +584,7 @@ class StripeApiRepositoryTest {
         )
     }
 
-    companion object {
+    private companion object {
         private const val STRIPE_ACCOUNT_RESPONSE_HEADER = "Stripe-Account"
         private val CARD =
             Card.create("4242424242424242", 1, 2050, "123")

--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
@@ -87,7 +87,7 @@ class StripeNetworkUtilsTest {
         return cardTokenParams["card"] as Map<String, Any>?
     }
 
-    companion object {
+    private companion object {
         private const val CARD_ADDRESS_L1 = "123 Main Street"
         private const val CARD_ADDRESS_L2 = "906"
         private const val CARD_CITY = "San Francisco"

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -147,7 +147,7 @@ class StripePaymentAuthTest {
         )
     }
 
-    companion object {
+    private companion object {
         private val REQUEST_OPTIONS =
             ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
     }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -571,7 +571,7 @@ class StripePaymentControllerTest {
         }
     }
 
-    companion object {
+    private companion object {
         private const val MESSAGE_VERSION = Stripe3ds2Fixtures.MESSAGE_VERSION
         private val REQUEST_OPTIONS =
             ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)

--- a/stripe/src/test/java/com/stripe/android/model/AddressTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/AddressTest.kt
@@ -45,7 +45,7 @@ class AddressTest {
         assertEquals(ADDRESS, ParcelUtils.create(ADDRESS))
     }
 
-    companion object {
+    private companion object {
         private val MAP_ADDRESS = mapOf(
             "city" to "San Francisco",
             "country" to "US",

--- a/stripe/src/test/java/com/stripe/android/model/BankAccountTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/BankAccountTest.kt
@@ -54,7 +54,7 @@ class BankAccountTest {
         return params["bank_account"] as Map<String, Any>
     }
 
-    companion object {
+    private companion object {
         private const val BANK_ACCOUNT_NUMBER = "000123456789"
         private const val BANK_ROUTING_NUMBER = "110000000"
         private const val BANK_ACCOUNT_HOLDER_NAME = "Lily Thomas"

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.kt
@@ -663,7 +663,7 @@ class CardTest {
         assertEquals(expected, actual)
     }
 
-    companion object {
+    internal companion object {
         private const val YEAR_IN_FUTURE: Int = 2100
 
         internal val JSON_CARD_USD = JSONObject(

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -197,7 +197,7 @@ class ConfirmPaymentIntentParamsTest {
         assertTrue(params.containsKey(MandateData.API_PARAM_MANDATE_DATA))
     }
 
-    companion object {
+    private companion object {
         private val FULL_FIELDS_VISA_CARD =
             Card.Builder(VALID_VISA_NO_SPACES, 12, 2050, "123")
                 .name("Captain Cardholder")

--- a/stripe/src/test/java/com/stripe/android/model/CustomerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerTest.kt
@@ -91,7 +91,7 @@ class CustomerTest {
         return rawJsonCustomer.toString()
     }
 
-    companion object {
+    private companion object {
 
         private val NON_CUSTOMER_OBJECT = JSONObject(
             """

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -119,7 +119,7 @@ class PaymentIntentTest {
             PaymentIntentFixtures.CANCELLED.canceledAt)
     }
 
-    companion object {
+    private companion object {
         private const val BAD_URL: String = "nonsense-blahblah"
 
         private val PAYMENT_INTENT_WITH_SOURCE_WITH_BAD_AUTH_URL_JSON = JSONObject(

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodTest.kt
@@ -137,8 +137,8 @@ class PaymentMethodTest {
         )
     }
 
-    companion object {
-        val PM_CARD_JSON: JSONObject = JSONObject(
+    internal companion object {
+        internal val PM_CARD_JSON: JSONObject = JSONObject(
             """
             {
                 "id": "pm_123456789",

--- a/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ShippingMethodTest.kt
@@ -22,7 +22,7 @@ class ShippingMethodTest {
         assertEquals(SHIPPING_METHOD, ParcelUtils.create(SHIPPING_METHOD))
     }
 
-    companion object {
+    private companion object {
         private val SHIPPING_METHOD = createShippingMethod()
 
         private fun createShippingMethod(): ShippingMethod {

--- a/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SourceCardDataTest.kt
@@ -55,7 +55,7 @@ class SourceCardDataTest {
         assertNull(SourceCardData.asThreeDSecureStatus(""))
     }
 
-    companion object {
+    private companion object {
         private val CARD_DATA =
             SourceCardData.fromJson(SOURCE_CARD_DATA_WITH_APPLE_PAY_JSON)!!
     }

--- a/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SourceParamsTest.kt
@@ -723,27 +723,23 @@ class SourceParamsTest {
         return owner["address"] as Map<String, Any>
     }
 
-    companion object {
-
-        private val FULL_FIELDS_VISA_CARD: Card
+    private companion object {
 
         private val METADATA = mapOf(
             "color" to "blue",
             "animal" to "dog"
         )
 
-        init {
-            FULL_FIELDS_VISA_CARD = Card.Builder(VALID_VISA_NO_SPACES, 12, 2050, "123")
-                .name("Captain Cardholder")
-                .addressLine1("1 ABC Street")
-                .addressLine2("Apt. 123")
-                .addressCity("San Francisco")
-                .addressState("CA")
-                .addressZip("94107")
-                .addressCountry("US")
-                .currency("usd")
-                .metadata(METADATA)
-                .build()
-        }
+        private val FULL_FIELDS_VISA_CARD: Card = Card.Builder(VALID_VISA_NO_SPACES, 12, 2050, "123")
+            .name("Captain Cardholder")
+            .addressLine1("1 ABC Street")
+            .addressLine2("Apt. 123")
+            .addressCity("San Francisco")
+            .addressState("CA")
+            .addressZip("94107")
+            .addressCountry("US")
+            .currency("usd")
+            .metadata(METADATA)
+            .build()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/SourceSepaDebitDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SourceSepaDebitDataTest.kt
@@ -38,7 +38,7 @@ class SourceSepaDebitDataTest {
         )
     }
 
-    companion object {
+    private companion object {
         private val EXAMPLE_SEPA_JSON_DATA = JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.kt
@@ -51,15 +51,14 @@ class SourceTest {
         assertNotNull(source)
 
         assertEquals(Source.USD, source.currency)
-        assertTrue(source.isLiveMode!!)
+        assertTrue(source.isLiveMode == true)
 
         val weChat = source.weChat
         assertNotNull(weChat)
         assertEquals("wxa0df8has9d78ce", weChat.appId)
     }
 
-    companion object {
-        @JvmField
+    internal companion object {
         internal val EXAMPLE_JSON_SOURCE_WITHOUT_NULLS = JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.kt
@@ -153,7 +153,7 @@ class Stripe3ds2AuthResultTest {
         )
     }
 
-    companion object {
+    private companion object {
         private val AUTH_RESULT_JSON = JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.kt
@@ -69,8 +69,8 @@ class Stripe3ds2FingerprintTest {
         assertFailsWith<IllegalArgumentException> { Stripe3ds2Fingerprint.create(sdkData) }
     }
 
-    companion object {
-        internal val DS_CERT_DATA_RSA =
+    internal companion object {
+        private val DS_CERT_DATA_RSA =
             """
             -----BEGIN CERTIFICATE-----
             MIIE0TCCA7mgAwIBAgIUXbeqM1duFcHk4dDBwT8o7Ln5wX8wDQYJKoZIhvcNAQEL
@@ -102,7 +102,7 @@ class Stripe3ds2FingerprintTest {
             -----END CERTIFICATE-----
             """.trimIndent()
 
-        val DS_RSA_PUBLIC_KEY: PublicKey = generateCertificate(DS_CERT_DATA_RSA).publicKey
+        internal val DS_RSA_PUBLIC_KEY: PublicKey = generateCertificate(DS_CERT_DATA_RSA).publicKey
 
         private fun generateCertificate(certificateData: String): X509Certificate {
             try {

--- a/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/StripeJsonUtilsTest.kt
@@ -156,7 +156,7 @@ class StripeJsonUtilsTest {
         JsonTestUtils.assertListEquals(expectedList, convertedJsonArray)
     }
 
-    companion object {
+    private companion object {
 
         private val SIMPLE_JSON_TEST_OBJECT = JSONObject(
             """

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
@@ -63,7 +63,7 @@ class TokenTest {
         assertNull(token)
     }
 
-    companion object {
+    private companion object {
         private val CARD = Card.Builder(null, 8, 2017, null)
             .id("card_189fi32eZvKYlo2CHK8NPRME")
             .brand(Card.CardBrand.VISA)

--- a/stripe/src/test/java/com/stripe/android/model/WeChatTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/WeChatTest.kt
@@ -26,7 +26,7 @@ class WeChatTest {
         assertEquals(expected, actual)
     }
 
-    companion object {
+    private companion object {
         private val WE_CHAT_PAY_JSON = JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/wallets/WalletFactoryTest.kt
@@ -61,7 +61,7 @@ class WalletFactoryTest {
         assertEquals(visaWallet, ParcelUtils.create(visaWallet))
     }
 
-    companion object {
+    private companion object {
         private val VISA_WALLET_JSON = JSONObject(
             """
             {

--- a/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.kt
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.kt
@@ -39,8 +39,7 @@ internal class TestEphemeralKeyProvider : EphemeralKeyProvider {
         this.errorMessage = errorMessage
     }
 
-    companion object {
-
+    private companion object {
         private const val INVALID_ERROR_CODE = -1
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -334,7 +334,7 @@ class AddPaymentMethodActivityTest :
         )
     }
 
-    companion object {
+    private companion object {
         private fun createFakeRepository(paymentMethod: PaymentMethod): StripeRepository {
             return object : AbsFakeStripeRepository() {
                 override fun createPaymentMethod(

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -811,7 +811,7 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         assertTrue(shouldIconShowBrand(Card.CardBrand.UNKNOWN, true, "212"))
     }
 
-    companion object {
+    private companion object {
 
         // Every Card made by the CardInputView should have the card widget token.
         private val EXPECTED_LOGGING_ARRAY = arrayOf(LOGGING_TOKEN)

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -748,7 +748,7 @@ internal class CardMultilineWidgetTest : BaseViewTest<CardInputTestActivity>(
             parentWidget.findViewById(R.id.second_row_layout)
     }
 
-    companion object {
+    private companion object {
         // Every Card made by the CardInputView should have the card widget token.
         private val EXPECTED_LOGGING_ARRAY = arrayOf(CARD_MULTILINE_TOKEN)
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -256,7 +256,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
         assertEquals(resultSessionData?.shippingInformation, SHIPPING_INFO)
     }
 
-    companion object {
+    private companion object {
         private val SHIPPING_INFO = ShippingInformation(
             Address.Builder()
                 .setCity("San Francisco")

--- a/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
@@ -34,7 +34,7 @@ class SelectShippingMethodWidgetTest {
         assertEquals(shippingMethodAdapter.selectedShippingMethod, FEDEX)
     }
 
-    companion object {
+    private companion object {
         private val UPS = ShippingMethod(
             "UPS Ground",
             "ups-ground",

--- a/stripe/src/test/java/com/stripe/android/view/ShippingPostalCodeValidatorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingPostalCodeValidatorTest.kt
@@ -61,7 +61,7 @@ class ShippingPostalCodeValidatorTest {
             emptyList(), emptyList())
     }
 
-    companion object {
+    private companion object {
         private val VALIDATOR = ShippingPostalCodeValidator()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/i18n/TranslatorManagerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/i18n/TranslatorManagerTest.kt
@@ -38,7 +38,7 @@ class TranslatorManagerTest {
                 .translate(0, "original message", STRIPE_ERROR))
     }
 
-    companion object {
+    private companion object {
         private val STRIPE_ERROR = StripeErrorFixtures.INVALID_REQUEST_ERROR
     }
 }


### PR DESCRIPTION
Companion objects with non-public fields or methods end up
filling the SDK reference with empty entries, such as

https://stripe.dev/stripe-android/com/stripe/android/model/WeChat.Companion.html