### PR TITLE
Update PaymentMethodsActivity result and PaymentSession.handlePaymentData() logic

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -58,8 +58,7 @@ class PaymentSessionActivity : AppCompatActivity() {
         errorDialogHandler = ErrorDialogHandler(this)
 
         // CustomerSession only needs to be initialized once per app.
-        val customerSession = createCustomerSession()
-        paymentSession = createPaymentSession(customerSession)
+        paymentSession = createPaymentSession(createCustomerSession())
 
         val localBroadcastManager = LocalBroadcastManager.getInstance(this)
         broadcastReceiver = object : BroadcastReceiver() {
@@ -117,7 +116,8 @@ class PaymentSessionActivity : AppCompatActivity() {
                 // Optionally specify the `PaymentMethod.Type` values to use.
                 // Defaults to `PaymentMethod.Type.Card`
                 .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card))
-                .build())
+                .build()
+        )
         if (paymentSessionInitialized) {
             paymentSession.setCartTotal(2000L)
         }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -99,7 +99,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
         payment_methods_recycler.adapter = adapter
         payment_methods_recycler.listener = object : PaymentMethodsRecyclerView.Listener {
             override fun onPaymentMethodSelected(paymentMethod: PaymentMethod) {
-                setSelectionAndFinish(paymentMethod)
+                finishWithPaymentMethod(paymentMethod)
             }
         }
 
@@ -119,7 +119,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        setSelectionAndFinish(adapter.selectedPaymentMethod)
+        finishWithPaymentMethod(adapter.selectedPaymentMethod, Activity.RESULT_CANCELED)
         return true
     }
 
@@ -163,7 +163,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        setSelectionAndFinish(adapter.selectedPaymentMethod)
+        finishWithPaymentMethod(adapter.selectedPaymentMethod, Activity.RESULT_CANCELED)
     }
 
     private fun fetchCustomerPaymentMethods() {
@@ -186,14 +186,12 @@ class PaymentMethodsActivity : AppCompatActivity() {
         }
     }
 
-    @JvmSynthetic
-    internal fun setSelectionAndFinish(paymentMethod: PaymentMethod?) {
-        finishWithPaymentMethod(paymentMethod)
-    }
-
-    private fun finishWithPaymentMethod(paymentMethod: PaymentMethod?) {
+    private fun finishWithPaymentMethod(
+        paymentMethod: PaymentMethod?,
+        resultCode: Int = Activity.RESULT_OK
+    ) {
         setResult(
-            Activity.RESULT_OK,
+            resultCode,
             Intent().also {
                 if (paymentMethod != null) {
                     it.putExtras(PaymentMethodsActivityStarter.Result(paymentMethod).toBundle())

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -193,9 +193,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
         paymentMethodsAdapter.selectedPaymentMethodId =
             PaymentMethodFixtures.CARD_PAYMENT_METHODS[0].id
 
-        paymentMethodsActivity.setSelectionAndFinish(
-            PaymentMethodFixtures.CARD_PAYMENT_METHODS[0]
-        )
+        paymentMethodsActivity.onBackPressed()
 
         // Now it should be gone.
         assertEquals(View.GONE, progressBar.visibility)

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import android.app.Activity.RESULT_CANCELED
 import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
@@ -188,8 +189,7 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
         listenerArgumentCaptor.firstValue
             .onPaymentMethodsRetrieved(PaymentMethodFixtures.CARD_PAYMENT_METHODS)
         val paymentMethodsAdapter =
-            recyclerView.adapter as PaymentMethodsAdapter?
-        assertNotNull(paymentMethodsAdapter)
+            recyclerView.adapter as PaymentMethodsAdapter
         paymentMethodsAdapter.selectedPaymentMethodId =
             PaymentMethodFixtures.CARD_PAYMENT_METHODS[0].id
 
@@ -198,12 +198,12 @@ class PaymentMethodsActivityTest : BaseViewTest<PaymentMethodsActivity>(PaymentM
         // Now it should be gone.
         assertEquals(View.GONE, progressBar.visibility)
         assertTrue(paymentMethodsActivity.isFinishing)
-        assertEquals(RESULT_OK, shadowActivity.resultCode)
-        val intent = shadowActivity.resultIntent
-        assertNotNull(intent)
+
+        // `resultCode` is `RESULT_CANCELED` because back was pressed
+        assertEquals(RESULT_CANCELED, shadowActivity.resultCode)
 
         val result =
-            PaymentMethodsActivityStarter.Result.fromIntent(intent)
+            PaymentMethodsActivityStarter.Result.fromIntent(shadowActivity.resultIntent)
         assertEquals(PaymentMethodFixtures.CARD_PAYMENT_METHODS[0], result?.paymentMethod)
     }
 }


### PR DESCRIPTION
## Summary
`PaymentMethodsActivity` should use `Activity.RESULT_CANCELED`
when the user taps back via the toolbar or back button;
`Activity.RESULT_OK` otherwise.

This signals to the user what happened during in
`PaymentMethodsActivity`.

## Motivation
Fixes #1806

## Testing
Manually verified