### PR TITLE
Remove builders from Stripe3ds2AuthResult

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -161,10 +161,10 @@ internal data class Stripe3ds2AuthResult internal constructor(
             @JvmSynthetic
             @Throws(JSONException::class)
             internal fun fromJson(errorJson: JSONObject?): ThreeDS2Error? {
-                if (errorJson == null) {
-                    return null
+                return if (errorJson == null) {
+                    null
                 } else {
-                    return ThreeDS2Error(
+                    ThreeDS2Error(
                         threeDSServerTransId = errorJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID),
                         acsTransId = optString(errorJson, FIELD_ACS_TRANS_ID),
                         dsTransId = optString(errorJson, FIELD_DS_TRANS_ID),

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -1,182 +1,36 @@
 package com.stripe.android.model
 
-import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-internal data class Stripe3ds2AuthResult private constructor(
+internal data class Stripe3ds2AuthResult internal constructor(
     val id: String?,
     private val objectType: String?,
-    val ares: Ares?,
+    val ares: Ares? = null,
     val created: Long?,
     val source: String?,
-    val state: String?,
-    private val liveMode: Boolean,
-    val error: ThreeDS2Error?,
-    val fallbackRedirectUrl: String?
+    val state: String? = null,
+    private val liveMode: Boolean = false,
+    val error: ThreeDS2Error? = null,
+    val fallbackRedirectUrl: String? = null
 ) {
-    internal class Builder : ObjectBuilder<Stripe3ds2AuthResult> {
-        private var id: String? = null
-        private var objectType: String? = null
-        private var ares: Ares? = null
-        private var created: Long? = null
-        private var source: String? = null
-        private var state: String? = null
-        private var liveMode: Boolean = false
-        private var error: ThreeDS2Error? = null
-        private var fallbackRedirectUrl: String? = null
-
-        fun setId(id: String): Builder {
-            this.id = id
-            return this
-        }
-
-        fun setObjectType(objectType: String): Builder {
-            this.objectType = objectType
-            return this
-        }
-
-        fun setAres(ares: Ares?): Builder {
-            this.ares = ares
-            return this
-        }
-
-        fun setCreated(created: Long): Builder {
-            this.created = created
-            return this
-        }
-
-        fun setSource(source: String): Builder {
-            this.source = source
-            return this
-        }
-
-        fun setState(state: String?): Builder {
-            this.state = state
-            return this
-        }
-
-        fun setLiveMode(liveMode: Boolean): Builder {
-            this.liveMode = liveMode
-            return this
-        }
-
-        fun setError(error: ThreeDS2Error?): Builder {
-            this.error = error
-            return this
-        }
-
-        fun setFallbackRedirectUrl(fallbackRedirectUrl: String?): Builder {
-            this.fallbackRedirectUrl = fallbackRedirectUrl
-            return this
-        }
-
-        override fun build(): Stripe3ds2AuthResult {
-            return Stripe3ds2AuthResult(id, objectType, ares, created, source, state,
-                liveMode, error, fallbackRedirectUrl)
-        }
-    }
-
-    data class Ares private constructor(
-        val threeDSServerTransId: String?,
+    internal data class Ares internal constructor(
+        internal val threeDSServerTransId: String?,
         private val acsChallengeMandated: String?,
-        val acsSignedContent: String?,
-        val acsTransId: String?,
-        private val acsUrl: String?,
-        private val authenticationType: String?,
-        private val cardholderInfo: String?,
-        private val messageExtension: List<MessageExtension>?,
+        internal val acsSignedContent: String? = null,
+        internal val acsTransId: String?,
+        private val acsUrl: String? = null,
+        private val authenticationType: String? = null,
+        private val cardholderInfo: String? = null,
+        private val messageExtension: List<MessageExtension>? = null,
         private val messageType: String?,
         private val messageVersion: String?,
         private val sdkTransId: String?,
-        private val transStatus: String?
+        private val transStatus: String? = null
     ) {
         val isChallenge = VALUE_CHALLENGE == transStatus
-
-        internal class Builder : ObjectBuilder<Ares> {
-            private var threeDSServerTransId: String? = null
-            private var acsChallengeMandated: String? = null
-            private var acsSignedContent: String? = null
-            private var acsTransId: String? = null
-            private var acsUrl: String? = null
-            private var authenticationType: String? = null
-            private var cardholderInfo: String? = null
-            private var messageExtension: List<MessageExtension>? = null
-            private var messageType: String? = null
-            private var messageVersion: String? = null
-            private var sdkTransId: String? = null
-            private var transStatus: String? = null
-
-            fun setThreeDSServerTransId(threeDSServerTransId: String?): Builder {
-                this.threeDSServerTransId = threeDSServerTransId
-                return this
-            }
-
-            fun setAcsChallengeMandated(acsChallengeMandated: String?): Builder {
-                this.acsChallengeMandated = acsChallengeMandated
-                return this
-            }
-
-            fun setAcsSignedContent(acsSignedContent: String?): Builder {
-                this.acsSignedContent = acsSignedContent
-                return this
-            }
-
-            fun setAcsTransId(acsTransId: String?): Builder {
-                this.acsTransId = acsTransId
-                return this
-            }
-
-            fun setAcsUrl(acsUrl: String?): Builder {
-                this.acsUrl = acsUrl
-                return this
-            }
-
-            fun setAuthenticationType(authenticationType: String?): Builder {
-                this.authenticationType = authenticationType
-                return this
-            }
-
-            fun setCardholderInfo(cardholderInfo: String?): Builder {
-                this.cardholderInfo = cardholderInfo
-                return this
-            }
-
-            fun setMessageExtension(messageExtension: List<MessageExtension>?): Builder {
-                this.messageExtension = messageExtension
-                return this
-            }
-
-            fun setMessageType(messageType: String?): Builder {
-                this.messageType = messageType
-                return this
-            }
-
-            fun setMessageVersion(messageVersion: String?): Builder {
-                this.messageVersion = messageVersion
-                return this
-            }
-
-            fun setSdkTransId(sdkTransId: String?): Builder {
-                this.sdkTransId = sdkTransId
-                return this
-            }
-
-            fun setTransStatus(transStatus: String?): Builder {
-                this.transStatus = transStatus
-                return this
-            }
-
-            override fun build(): Ares {
-                return Ares(
-                    threeDSServerTransId, acsChallengeMandated, acsSignedContent, acsTransId,
-                    acsUrl, authenticationType, cardholderInfo, messageExtension, messageType,
-                    messageVersion, sdkTransId, transStatus
-                )
-            }
-        }
 
         internal companion object {
             private const val FIELD_ACS_CHALLENGE_MANDATED = "acsChallengeMandated"
@@ -199,26 +53,29 @@ internal data class Stripe3ds2AuthResult private constructor(
             internal fun fromJson(aresJson: JSONObject?): Ares? {
                 return if (aresJson == null) {
                     null
-                } else Builder()
-                    .setThreeDSServerTransId(aresJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID))
-                    .setAcsChallengeMandated(optString(aresJson, FIELD_ACS_CHALLENGE_MANDATED))
-                    .setAcsSignedContent(optString(aresJson, FIELD_ACS_SIGNED_CONTENT))
-                    .setAcsTransId(aresJson.getString(FIELD_ACS_TRANS_ID))
-                    .setAcsUrl(optString(aresJson, FIELD_ACS_URL))
-                    .setAuthenticationType(optString(aresJson, FIELD_AUTHENTICATION_TYPE))
-                    .setCardholderInfo(optString(aresJson, FIELD_CARDHOLDER_INFO))
-                    .setMessageType(aresJson.getString(FIELD_MESSAGE_TYPE))
-                    .setMessageVersion(aresJson.getString(FIELD_MESSAGE_VERSION))
-                    .setSdkTransId(optString(aresJson, FIELD_SDK_TRANS_ID))
-                    .setTransStatus(optString(aresJson, FIELD_TRANS_STATUS))
-                    .setMessageExtension(MessageExtension.fromJson(
-                        aresJson.optJSONArray(FIELD_MESSAGE_EXTENSION)))
-                    .build()
+                } else {
+                    Ares(
+                        threeDSServerTransId = aresJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID),
+                        acsChallengeMandated = optString(aresJson, FIELD_ACS_CHALLENGE_MANDATED),
+                        acsSignedContent = optString(aresJson, FIELD_ACS_SIGNED_CONTENT),
+                        acsTransId = aresJson.getString(FIELD_ACS_TRANS_ID),
+                        acsUrl = optString(aresJson, FIELD_ACS_URL),
+                        authenticationType = optString(aresJson, FIELD_AUTHENTICATION_TYPE),
+                        cardholderInfo = optString(aresJson, FIELD_CARDHOLDER_INFO),
+                        messageType = aresJson.getString(FIELD_MESSAGE_TYPE),
+                        messageVersion = aresJson.getString(FIELD_MESSAGE_VERSION),
+                        sdkTransId = optString(aresJson, FIELD_SDK_TRANS_ID),
+                        transStatus = optString(aresJson, FIELD_TRANS_STATUS),
+                        messageExtension = MessageExtension.fromJson(
+                            aresJson.optJSONArray(FIELD_MESSAGE_EXTENSION)
+                        )
+                    )
+                }
             }
         }
     }
 
-    data class MessageExtension internal constructor(
+    internal data class MessageExtension internal constructor(
         // The name of the extension data set as defined by the extension owner.
         val name: String?,
 
@@ -234,38 +91,6 @@ internal data class Stripe3ds2AuthResult private constructor(
         // The data carried in the extension.
         val data: Map<String, String>?
     ) {
-
-        internal class Builder : ObjectBuilder<MessageExtension> {
-            private var name: String? = null
-            private var criticalityIndicator: Boolean = false
-            private var id: String? = null
-            private var data: Map<String, String>? = null
-
-            fun setName(name: String?): Builder {
-                this.name = name
-                return this
-            }
-
-            fun setCriticalityIndicator(criticalityIndicator: Boolean): Builder {
-                this.criticalityIndicator = criticalityIndicator
-                return this
-            }
-
-            fun setId(id: String?): Builder {
-                this.id = id
-                return this
-            }
-
-            fun setData(data: Map<String, String>?): Builder {
-                this.data = data
-                return this
-            }
-
-            override fun build(): MessageExtension {
-                return MessageExtension(name, criticalityIndicator, id, data)
-            }
-        }
-
         internal companion object {
             private const val FIELD_NAME = "name"
             private const val FIELD_ID = "id"
@@ -314,88 +139,12 @@ internal data class Stripe3ds2AuthResult private constructor(
         val errorCode: String?,
         val errorComponent: String?,
         val errorDescription: String?,
-        val errorDetail: String?,
+        val errorDetail: String? = null,
         val errorMessageType: String?,
         val messageType: String?,
         val messageVersion: String?,
         val sdkTransId: String?
     ) {
-        internal class Builder : ObjectBuilder<ThreeDS2Error> {
-            private var threeDSServerTransId: String? = null
-            private var acsTransId: String? = null
-            private var dsTransId: String? = null
-            private var errorCode: String? = null
-            private var errorComponent: String? = null
-            private var errorDescription: String? = null
-            private var errorDetail: String? = null
-            private var errorMessageType: String? = null
-            private var messageType: String? = null
-            private var messageVersion: String? = null
-            private var sdkTransId: String? = null
-
-            fun setThreeDSServerTransId(threeDSServerTransId: String?): Builder {
-                this.threeDSServerTransId = threeDSServerTransId
-                return this
-            }
-
-            fun setAcsTransId(acsTransId: String?): Builder {
-                this.acsTransId = acsTransId
-                return this
-            }
-
-            fun setDsTransId(dsTransId: String?): Builder {
-                this.dsTransId = dsTransId
-                return this
-            }
-
-            fun setErrorCode(errorCode: String?): Builder {
-                this.errorCode = errorCode
-                return this
-            }
-
-            fun setErrorComponent(errorComponent: String?): Builder {
-                this.errorComponent = errorComponent
-                return this
-            }
-
-            fun setErrorDescription(errorDescription: String?): Builder {
-                this.errorDescription = errorDescription
-                return this
-            }
-
-            fun setErrorDetail(errorDetail: String?): Builder {
-                this.errorDetail = errorDetail
-                return this
-            }
-
-            fun setErrorMessageType(errorMessageType: String?): Builder {
-                this.errorMessageType = errorMessageType
-                return this
-            }
-
-            fun setMessageType(messageType: String?): Builder {
-                this.messageType = messageType
-                return this
-            }
-
-            fun setMessageVersion(messageVersion: String?): Builder {
-                this.messageVersion = messageVersion
-                return this
-            }
-
-            fun setSdkTransId(sdkTransId: String?): Builder {
-                this.sdkTransId = sdkTransId
-                return this
-            }
-
-            override fun build(): ThreeDS2Error {
-                return ThreeDS2Error(threeDSServerTransId, acsTransId,
-                    dsTransId, errorCode, errorComponent, errorDescription,
-                    errorDetail,
-                    errorMessageType, messageType, messageVersion, sdkTransId)
-            }
-        }
-
         internal companion object {
             private const val FIELD_THREE_DS_SERVER_TRANS_ID = "threeDSServerTransID"
             private const val FIELD_ACS_TRANS_ID = "acsTransID"
@@ -411,20 +160,24 @@ internal data class Stripe3ds2AuthResult private constructor(
 
             @JvmSynthetic
             @Throws(JSONException::class)
-            internal fun fromJson(errorJson: JSONObject): ThreeDS2Error {
-                return Builder()
-                    .setThreeDSServerTransId(errorJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID))
-                    .setAcsTransId(optString(errorJson, FIELD_ACS_TRANS_ID))
-                    .setDsTransId(optString(errorJson, FIELD_DS_TRANS_ID))
-                    .setErrorCode(errorJson.getString(FIELD_ERROR_CODE))
-                    .setErrorComponent(errorJson.getString(FIELD_ERROR_COMPONENT))
-                    .setErrorDescription(errorJson.getString(FIELD_ERROR_DESCRIPTION))
-                    .setErrorDetail(errorJson.getString(FIELD_ERROR_DETAIL))
-                    .setErrorMessageType(optString(errorJson, FIELD_ERROR_MESSAGE_TYPE))
-                    .setMessageType(errorJson.getString(FIELD_MESSAGE_TYPE))
-                    .setMessageVersion(errorJson.getString(FIELD_MESSAGE_VERSION))
-                    .setSdkTransId(optString(errorJson, FIELD_SDK_TRANS_ID))
-                    .build()
+            internal fun fromJson(errorJson: JSONObject?): ThreeDS2Error? {
+                if (errorJson == null) {
+                    return null
+                } else {
+                    return ThreeDS2Error(
+                        threeDSServerTransId = errorJson.getString(FIELD_THREE_DS_SERVER_TRANS_ID),
+                        acsTransId = optString(errorJson, FIELD_ACS_TRANS_ID),
+                        dsTransId = optString(errorJson, FIELD_DS_TRANS_ID),
+                        errorCode = errorJson.getString(FIELD_ERROR_CODE),
+                        errorComponent = errorJson.getString(FIELD_ERROR_COMPONENT),
+                        errorDescription = errorJson.getString(FIELD_ERROR_DESCRIPTION),
+                        errorDetail = errorJson.getString(FIELD_ERROR_DETAIL),
+                        errorMessageType = optString(errorJson, FIELD_ERROR_MESSAGE_TYPE),
+                        messageType = errorJson.getString(FIELD_MESSAGE_TYPE),
+                        messageVersion = errorJson.getString(FIELD_MESSAGE_VERSION),
+                        sdkTransId = optString(errorJson, FIELD_SDK_TRANS_ID)
+                    )
+                }
             }
         }
     }
@@ -443,32 +196,35 @@ internal data class Stripe3ds2AuthResult private constructor(
         @JvmSynthetic
         @Throws(JSONException::class)
         internal fun fromJson(authResultJson: JSONObject): Stripe3ds2AuthResult {
-            return Builder()
-                .setId(authResultJson.getString(FIELD_ID))
-                .setObjectType(authResultJson.getString(FIELD_OBJECT))
-                .setCreated(authResultJson.getLong(FIELD_CREATED))
-                .setLiveMode(authResultJson.getBoolean(FIELD_LIVEMODE))
-                .setSource(authResultJson.getString(FIELD_SOURCE))
-                .setState(authResultJson.optString(FIELD_STATE))
-                .setAres(
-                    if (authResultJson.isNull(FIELD_ARES))
-                        null
-                    else
-                        Ares.fromJson(authResultJson.optJSONObject(FIELD_ARES))
-                )
-                .setError(
-                    if (authResultJson.isNull(FIELD_ERROR)) {
-                        null
-                    } else {
-                        ThreeDS2Error.fromJson(authResultJson.optJSONObject(FIELD_ERROR))
-                    }
-                )
-                .setFallbackRedirectUrl(
-                    if (authResultJson.isNull(FIELD_FALLBACK_REDIRECT_URL))
-                        null
-                    else
-                        authResultJson.optString(FIELD_FALLBACK_REDIRECT_URL))
-                .build()
+            val ares =
+                if (authResultJson.isNull(FIELD_ARES)) {
+                    null
+                } else {
+                    Ares.fromJson(authResultJson.optJSONObject(FIELD_ARES))
+                }
+            val error =
+                if (authResultJson.isNull(FIELD_ERROR)) {
+                    null
+                } else {
+                    ThreeDS2Error.fromJson(authResultJson.optJSONObject(FIELD_ERROR))
+                }
+            val fallbackRedirectUrl =
+                if (authResultJson.isNull(FIELD_FALLBACK_REDIRECT_URL)) {
+                    null
+                } else {
+                    authResultJson.optString(FIELD_FALLBACK_REDIRECT_URL)
+                }
+            return Stripe3ds2AuthResult(
+                id = authResultJson.getString(FIELD_ID),
+                objectType = authResultJson.getString(FIELD_OBJECT),
+                created = authResultJson.getLong(FIELD_CREATED),
+                liveMode = authResultJson.getBoolean(FIELD_LIVEMODE),
+                source = authResultJson.getString(FIELD_SOURCE),
+                state = authResultJson.optString(FIELD_STATE),
+                ares = ares,
+                error = error,
+                fallbackRedirectUrl = fallbackRedirectUrl
+            )
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.kt
@@ -3,54 +3,62 @@ package com.stripe.android.model
 import java.util.UUID
 
 internal object Stripe3ds2AuthResultFixtures {
+    internal val ARES_CHALLENGE_FLOW = Stripe3ds2AuthResult(
+        id = "threeds2_1FDy0vCRMbs6",
+        objectType = "three_d_secure_2",
+        source = "src_1FDy0uCRMb",
+        created = 1567363381,
+        ares = Stripe3ds2AuthResult.Ares(
+            acsChallengeMandated = "Y",
+            acsTransId = UUID.randomUUID().toString(),
+            sdkTransId = UUID.randomUUID().toString(),
+            threeDSServerTransId = UUID.randomUUID().toString(),
+            transStatus = Stripe3ds2AuthResult.Ares.VALUE_CHALLENGE,
+            messageType = "ARes",
+            messageVersion = "2.1.0"
+        )
+    )
 
-    // TODO(mshafrir): fully hydrate fixtures
+    internal val ARES_FRICTIONLESS_FLOW = Stripe3ds2AuthResult(
+        id = "threeds2_1Ecwz3CRMbs6FrXfThtfogua",
+        objectType = "three_d_secure_2",
+        liveMode = false,
+        created = 1558541285L,
+        source = "src_1Ecwz1CRMbs6FrXfUwt98lxf",
+        ares = Stripe3ds2AuthResult.Ares(
+            acsChallengeMandated = "N",
+            acsTransId = UUID.randomUUID().toString(),
+            sdkTransId = UUID.randomUUID().toString(),
+            threeDSServerTransId = UUID.randomUUID().toString(),
+            messageVersion = "2.1.0",
+            messageType = "ARes"
+        )
+    )
 
-    @JvmField
-    val ARES_CHALLENGE_FLOW = Stripe3ds2AuthResult.Builder()
-        .setAres(Stripe3ds2AuthResult.Ares.Builder()
-            .setAcsChallengeMandated("Y")
-            .setAcsTransId(UUID.randomUUID().toString())
-            .setSdkTransId(UUID.randomUUID().toString())
-            .setThreeDSServerTransId(UUID.randomUUID().toString())
-            .setTransStatus(Stripe3ds2AuthResult.Ares.VALUE_CHALLENGE)
-            .setMessageVersion("2.1.0")
-            .setMessageType("ARes")
-            .build())
-        .build()
+    internal val ERROR = Stripe3ds2AuthResult(
+        id = "threeds2_1FDy0vCRMbs6",
+        objectType = "three_d_secure_2",
+        source = "src_1FDy0uCRMb",
+        created = 1567363381,
+        error = Stripe3ds2AuthResult.ThreeDS2Error(
+            acsTransId = UUID.randomUUID().toString(),
+            dsTransId = UUID.randomUUID().toString(),
+            sdkTransId = UUID.randomUUID().toString(),
+            threeDSServerTransId = UUID.randomUUID().toString(),
+            messageVersion = "2.1.0",
+            messageType = "Erro",
+            errorComponent = "D",
+            errorCode = "302",
+            errorDescription = "Data could not be decrypted by the receiving system due to technical or other reason.",
+            errorMessageType = "AReq"
+        )
+    )
 
-    @JvmField
-    val ARES_FRICTIONLESS_FLOW = Stripe3ds2AuthResult.Builder()
-        .setAres(Stripe3ds2AuthResult.Ares.Builder()
-            .setAcsChallengeMandated("N")
-            .setAcsTransId(UUID.randomUUID().toString())
-            .setSdkTransId(UUID.randomUUID().toString())
-            .setThreeDSServerTransId(UUID.randomUUID().toString())
-            .setMessageVersion("2.1.0")
-            .setMessageType("ARes")
-            .build())
-        .build()
-
-    @JvmField
-    val ERROR = Stripe3ds2AuthResult.Builder()
-        .setError(Stripe3ds2AuthResult.ThreeDS2Error.Builder()
-            .setAcsTransId(UUID.randomUUID().toString())
-            .setDsTransId(UUID.randomUUID().toString())
-            .setSdkTransId(UUID.randomUUID().toString())
-            .setThreeDSServerTransId(UUID.randomUUID().toString())
-            .setErrorComponent("D")
-            .setErrorCode("302")
-            .setErrorDescription("Data could not be decrypted by the receiving system due to technical or other reason.")
-            .setErrorMessageType("Erro")
-            .build())
-        .build()
-
-    @JvmField
-    val FALLBACK_REDIRECT_URL = Stripe3ds2AuthResult.Builder()
-        .setId("threeds2_1FDy0vCRMbs6")
-        .setObjectType("three_d_secure_2")
-        .setSource("src_1FDy0uCRMb")
-        .setCreated(1567363381)
-        .setFallbackRedirectUrl("https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW")
-        .build()
+    internal val FALLBACK_REDIRECT_URL = Stripe3ds2AuthResult(
+        id = "threeds2_1FDy0vCRMbs6",
+        objectType = "three_d_secure_2",
+        source = "src_1FDy0uCRMb",
+        created = 1567363381,
+        fallbackRedirectUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW"
+    )
 }

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultTest.kt
@@ -16,25 +16,25 @@ class Stripe3ds2AuthResultTest {
         val result = Stripe3ds2AuthResult.fromJson(AUTH_RESULT_JSON)
         assertTrue(result.ares?.isChallenge == true)
 
-        val expectedResult = Stripe3ds2AuthResult.Builder()
-            .setId("threeds2_1Ecwz3CRMbs6FrXfThtfogua")
-            .setObjectType("three_d_secure_2")
-            .setLiveMode(false)
-            .setCreated(1558541285L)
-            .setSource("src_1Ecwz1CRMbs6FrXfUwt98lxf")
-            .setState("challenge_required")
-            .setAres(Stripe3ds2AuthResult.Ares.Builder()
-                .setAcsChallengeMandated("Y")
-                .setAcsTransId("dd23c757-211a-4c1b-add5-06a1450a642e")
-                .setAcsSignedContent("eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa")
-                .setAuthenticationType("02")
-                .setMessageType("ARes")
-                .setMessageVersion("2.1.0")
-                .setSdkTransId("20158862-9d9d-4d71-83d4-9e65554ed92c")
-                .setThreeDSServerTransId("e8ea0b42-0e74-42b2-92b4-1b27005f0596")
-                .setTransStatus("C")
-                .build())
-            .build()
+        val expectedResult = Stripe3ds2AuthResult(
+            id = "threeds2_1Ecwz3CRMbs6FrXfThtfogua",
+            objectType = "three_d_secure_2",
+            liveMode = false,
+            created = 1558541285L,
+            source = "src_1Ecwz1CRMbs6FrXfUwt98lxf",
+            state = "challenge_required",
+            ares = Stripe3ds2AuthResult.Ares(
+                acsChallengeMandated = "Y",
+                acsTransId = "dd23c757-211a-4c1b-add5-06a1450a642e",
+                acsSignedContent = "eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa",
+                authenticationType = "02",
+                messageType = "ARes",
+                messageVersion = "2.1.0",
+                sdkTransId = "20158862-9d9d-4d71-83d4-9e65554ed92c",
+                threeDSServerTransId = "e8ea0b42-0e74-42b2-92b4-1b27005f0596",
+                transStatus = "C"
+            )
+        )
 
         assertEquals(expectedResult, result)
     }
@@ -44,48 +44,48 @@ class Stripe3ds2AuthResultTest {
         val jsonResult = Stripe3ds2AuthResult.fromJson(AUTH_RESULT_WITH_EXTENSIONS_JSON)
 
         val extensions = listOf(
-            Stripe3ds2AuthResult.MessageExtension.Builder()
-                .setName("extension1")
-                .setId("ID1")
-                .setCriticalityIndicator(true)
-                .setData(mapOf("key1" to "value1"))
-                .build(),
-            Stripe3ds2AuthResult.MessageExtension.Builder()
-                .setName("extension2")
-                .setId("ID2")
-                .setCriticalityIndicator(true)
-                .setData(mapOf(
+            Stripe3ds2AuthResult.MessageExtension(
+                name = "extension1",
+                id = "ID1",
+                criticalityIndicator = true,
+                data = mapOf("key1" to "value1")
+            ),
+            Stripe3ds2AuthResult.MessageExtension(
+                name = "extension2",
+                id = "ID2",
+                criticalityIndicator = true,
+                data = mapOf(
                     "key1" to "value1",
                     "key2" to "value2"
-                ))
-                .build(),
-            Stripe3ds2AuthResult.MessageExtension.Builder()
-                .setName("sharedData")
-                .setId("ID3")
-                .setCriticalityIndicator(false)
-                .setData(mapOf("key" to "IkpTT05EYXRhIjogew0KImRhdGExIjogInNkYXRhIg0KfQ=="))
-                .build()
+                )
+            ),
+            Stripe3ds2AuthResult.MessageExtension(
+                name = "sharedData",
+                id = "ID3",
+                criticalityIndicator = false,
+                data = mapOf("key" to "IkpTT05EYXRhIjogew0KImRhdGExIjogInNkYXRhIg0KfQ==")
+            )
         )
 
-        val expectedResult = Stripe3ds2AuthResult.Builder()
-            .setId("threeds2_1Ecwz3CRMbs6FrXfThtfogua")
-            .setObjectType("three_d_secure_2")
-            .setLiveMode(false)
-            .setCreated(1558541285L)
-            .setSource("src_1Ecwz1CRMbs6FrXfUwt98lxf")
-            .setState("challenge_required")
-            .setAres(Stripe3ds2AuthResult.Ares.Builder()
-                .setAcsChallengeMandated("Y")
-                .setAcsTransId("dd23c757-211a-4c1b-add5-06a1450a642e")
-                .setAcsSignedContent("eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa")
-                .setAuthenticationType("02")
-                .setMessageType("ARes")
-                .setMessageVersion("2.1.0")
-                .setMessageExtension(extensions)
-                .setSdkTransId("20158862-9d9d-4d71-83d4-9e65554ed92c")
-                .setThreeDSServerTransId("e8ea0b42-0e74-42b2-92b4-1b27005f0596")
-                .build())
-            .build()
+        val expectedResult = Stripe3ds2AuthResult(
+            id = "threeds2_1Ecwz3CRMbs6FrXfThtfogua",
+            objectType = "three_d_secure_2",
+            liveMode = false,
+            created = 1558541285L,
+            source = "src_1Ecwz1CRMbs6FrXfUwt98lxf",
+            state = "challenge_required",
+            ares = Stripe3ds2AuthResult.Ares(
+                acsChallengeMandated = "Y",
+                acsTransId = "dd23c757-211a-4c1b-add5-06a1450a642e",
+                acsSignedContent = "eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa",
+                authenticationType = "02",
+                messageType = "ARes",
+                messageVersion = "2.1.0",
+                messageExtension = extensions,
+                sdkTransId = "20158862-9d9d-4d71-83d4-9e65554ed92c",
+                threeDSServerTransId = "e8ea0b42-0e74-42b2-92b4-1b27005f0596"
+            )
+        )
 
         assertEquals(expectedResult, jsonResult)
     }
@@ -94,37 +94,37 @@ class Stripe3ds2AuthResultTest {
     fun fromJSON_errorData_createsObjectWithError() {
         val jsonResult = Stripe3ds2AuthResult.fromJson(AUTH_RESULT_ERROR_JSON)
 
-        val expectedResult = Stripe3ds2AuthResult.Builder()
-            .setId("threeds2_1Ecwz3CRMbs6FrXfThtfogua")
-            .setObjectType("three_d_secure_2")
-            .setLiveMode(false)
-            .setCreated(1558541285L)
-            .setSource("src_1Ecwz1CRMbs6FrXfUwt98lxf")
-            .setState("challenge_required")
-            .setAres(Stripe3ds2AuthResult.Ares.Builder()
-                .setAcsChallengeMandated("Y")
-                .setAcsTransId("dd23c757-211a-4c1b-add5-06a1450a642e")
-                .setAcsSignedContent("eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa")
-                .setAuthenticationType("02")
-                .setMessageType("ARes")
-                .setMessageVersion("2.1.0")
-                .setSdkTransId("20158862-9d9d-4d71-83d4-9e65554ed92c")
-                .setThreeDSServerTransId("e8ea0b42-0e74-42b2-92b4-1b27005f0596")
-                .build())
-            .setError(Stripe3ds2AuthResult.ThreeDS2Error.Builder()
-                .setThreeDSServerTransId("e8ea0b42-0e74-42b2-92b4-1b27005f0596")
-                .setAcsTransId("dd23c757-211a-4c1b-add5-06a1450a642e")
-                .setDsTransId("ff23c757-211a-4c1b-add5-06a1450a642e")
-                .setErrorCode("error code 1234")
-                .setErrorComponent("error component")
-                .setErrorDetail("error detail")
-                .setErrorDescription("error description")
-                .setErrorMessageType("error message type")
-                .setMessageType("Error")
-                .setMessageVersion("2.1.0")
-                .setSdkTransId("20158862-9d9d-4d71-83d4-9e65554ed92c")
-                .build())
-            .build()
+        val expectedResult = Stripe3ds2AuthResult(
+            id = "threeds2_1Ecwz3CRMbs6FrXfThtfogua",
+            objectType = "three_d_secure_2",
+            liveMode = false,
+            created = 1558541285L,
+            source = "src_1Ecwz1CRMbs6FrXfUwt98lxf",
+            state = "challenge_required",
+            ares = Stripe3ds2AuthResult.Ares(
+                acsChallengeMandated = "Y",
+                acsTransId = "dd23c757-211a-4c1b-add5-06a1450a642e",
+                acsSignedContent = "eyJhbGciOiJFUzI1NiJ9.asdfasf.asdfasdfa",
+                authenticationType = "02",
+                messageType = "ARes",
+                messageVersion = "2.1.0",
+                sdkTransId = "20158862-9d9d-4d71-83d4-9e65554ed92c",
+                threeDSServerTransId = "e8ea0b42-0e74-42b2-92b4-1b27005f0596"
+            ),
+            error = Stripe3ds2AuthResult.ThreeDS2Error(
+                threeDSServerTransId = "e8ea0b42-0e74-42b2-92b4-1b27005f0596",
+                acsTransId = "dd23c757-211a-4c1b-add5-06a1450a642e",
+                dsTransId = "ff23c757-211a-4c1b-add5-06a1450a642e",
+                errorCode = "error code 1234",
+                errorComponent = "error component",
+                errorDetail = "error detail",
+                errorDescription = "error description",
+                errorMessageType = "error message type",
+                messageType = "Error",
+                messageVersion = "2.1.0",
+                sdkTransId = "20158862-9d9d-4d71-83d4-9e65554ed92c"
+            )
+        )
 
         assertEquals(expectedResult, jsonResult)
     }
@@ -134,11 +134,12 @@ class Stripe3ds2AuthResultTest {
         val result = Stripe3ds2AuthResult.fromJson(AUTH_RESULT_ERROR_INVALID_ELEMENT_FORMAT_JSON)
         assertNull(result.ares)
         assertNull(result.fallbackRedirectUrl)
-        val error = result.error!!
-        assertEquals("sdkMaxTimeout", error.errorDetail)
+        val error = result.error
+        assertEquals("sdkMaxTimeout", error?.errorDetail)
         assertEquals(
             "Format or value of one or more Data Elements is Invalid according to the Specification",
-            error.errorDescription)
+            error?.errorDescription
+        )
     }
 
     @Test


### PR DESCRIPTION
With Kotlin, builders are unnecessary for creating a `Stripe3ds2AuthResult`