### PR TITLE
Refactor PaymentSessionData and update PaymentSession

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -57,7 +57,6 @@ class PaymentSessionActivity : AppCompatActivity() {
         progress_bar.visibility = View.VISIBLE
         errorDialogHandler = ErrorDialogHandler(this)
 
-        // CustomerSession only needs to be initialized once per app.
         paymentSession = createPaymentSession(savedInstanceState)
 
         val localBroadcastManager = LocalBroadcastManager.getInstance(this)
@@ -101,8 +100,13 @@ class PaymentSessionActivity : AppCompatActivity() {
         return CustomerSession.getInstance()
     }
 
-    private fun createPaymentSession(savedInstanceState: Bundle?): PaymentSession {
+    private fun createPaymentSession(
+        savedInstanceState: Bundle?,
+        shouldPrefetchCustomer: Boolean = true
+    ): PaymentSession {
+        // CustomerSession only needs to be initialized once per app.
         val customerSession = createCustomerSession()
+
         val paymentSession = PaymentSession(this)
         val paymentSessionInitialized = paymentSession.init(
             listener = PaymentSessionListenerImpl(this, customerSession),
@@ -118,7 +122,8 @@ class PaymentSessionActivity : AppCompatActivity() {
                 // Defaults to `PaymentMethod.Type.Card`
                 .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card))
                 .build(),
-            savedInstanceState = savedInstanceState
+            savedInstanceState = savedInstanceState,
+            shouldPrefetchCustomer = shouldPrefetchCustomer
         )
         if (paymentSessionInitialized) {
             paymentSession.setCartTotal(2000L)
@@ -204,10 +209,14 @@ class PaymentSessionActivity : AppCompatActivity() {
         )
     }
 
-    private fun onCustomerRetrieved() {
+    private fun enableUi() {
         progress_bar.visibility = View.INVISIBLE
         btn_select_payment_method.isEnabled = true
         btn_start_payment_flow.isEnabled = true
+    }
+
+    private fun onCustomerRetrieved() {
+        enableUi()
 
         paymentSessionData?.let { paymentSessionData ->
             tv_ready_to_charge.setCompoundDrawablesRelativeWithIntrinsicBounds(

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -124,8 +124,4 @@ data class PaymentSessionConfig internal constructor(
             )
         }
     }
-
-    internal companion object {
-        internal val EMPTY = PaymentSessionConfig()
-    }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
@@ -1,124 +1,51 @@
 package com.stripe.android
 
-import android.os.Parcel
 import android.os.Parcelable
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
-import java.util.Objects
+import kotlinx.android.parcel.Parcelize
 
 /**
  * A data class representing the state of the associated [PaymentSession].
  */
-class PaymentSessionData : Parcelable {
+@Parcelize
+data class PaymentSessionData internal constructor(
+    private val config: PaymentSessionConfig? = null,
 
     /**
      * The cart total value, excluding shipping and tax items.
      */
-    var cartTotal: Long = 0L
-        internal set
+    val cartTotal: Long = 0L,
+
+    /**
+     * The current value of the shipping items in the associated [PaymentSession]
+     */
+    val shippingTotal: Long = 0L,
+
+    /**
+     * Where the items being purchased should be shipped.
+     */
+    val shippingInformation: ShippingInformation? = null,
+
+    /**
+     * How the items being purchased should be shipped.
+     */
+    val shippingMethod: ShippingMethod? = null,
+
+    /**
+     * @return the selected payment method for the associated [PaymentSession]
+     */
+    val paymentMethod: PaymentMethod? = null
+) : Parcelable {
 
     /**
      * Whether the payment data is ready for making a charge. This can be used to
      * set a buy button to enabled for prompt a user to fill in more information.
      */
-    var isPaymentReadyToCharge: Boolean = false
-
-    /**
-     * The current value of the shipping items in the associated [PaymentSession]
-     */
-    var shippingTotal: Long = 0L
-        internal set
-
-    /**
-     * Where the items being purchased should be shipped.
-     */
-    var shippingInformation: ShippingInformation? = null
-
-    /**
-     * How the items being purchased should be shipped.
-     */
-    var shippingMethod: ShippingMethod? = null
-
-    /**
-     * @return the selected payment method for the associated [PaymentSession]
-     */
-    var paymentMethod: PaymentMethod? = null
-        internal set
-
-    constructor()
-
-    /**
-     * Function that looks at the [PaymentSessionConfig] and determines whether the data is
-     * ready to charge.
-     *
-     * @param config specifies what data is required
-     * @return whether the data is ready to charge
-     */
-    fun updateIsPaymentReadyToCharge(config: PaymentSessionConfig): Boolean {
-        isPaymentReadyToCharge = paymentMethod != null &&
-            (!config.isShippingInfoRequired || shippingInformation != null) &&
-            (!config.isShippingMethodRequired || shippingMethod != null)
-        return isPaymentReadyToCharge
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return when {
-            this === other -> true
-            other is PaymentSessionData -> typedEquals(other)
-            else -> false
-        }
-    }
-
-    private fun typedEquals(data: PaymentSessionData): Boolean {
-        return cartTotal == data.cartTotal &&
-            isPaymentReadyToCharge == data.isPaymentReadyToCharge &&
-            shippingTotal == data.shippingTotal &&
-            shippingInformation == data.shippingInformation &&
-            shippingMethod == data.shippingMethod &&
-            paymentMethod == data.paymentMethod
-    }
-
-    override fun hashCode(): Int {
-        return Objects.hash(
-            cartTotal, isPaymentReadyToCharge, paymentMethod, shippingTotal, shippingInformation,
-            shippingMethod
-        )
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    override fun writeToParcel(parcel: Parcel, i: Int) {
-        parcel.writeLong(cartTotal)
-        parcel.writeInt(if (isPaymentReadyToCharge) 1 else 0)
-        parcel.writeParcelable(paymentMethod, i)
-        parcel.writeParcelable(shippingInformation, i)
-        parcel.writeParcelable(shippingMethod, i)
-        parcel.writeLong(shippingTotal)
-    }
-
-    private constructor(parcel: Parcel) {
-        cartTotal = parcel.readLong()
-        isPaymentReadyToCharge = parcel.readInt() == 1
-        paymentMethod = parcel.readParcelable(PaymentMethod::class.java.classLoader)
-        shippingInformation = parcel.readParcelable(ShippingInformation::class.java.classLoader)
-        shippingMethod = parcel.readParcelable(ShippingMethod::class.java.classLoader)
-        shippingTotal = parcel.readLong()
-    }
-
-    companion object {
-        @JvmField
-        val CREATOR: Parcelable.Creator<PaymentSessionData> =
-            object : Parcelable.Creator<PaymentSessionData> {
-                override fun createFromParcel(parcel: Parcel): PaymentSessionData {
-                    return PaymentSessionData(parcel)
-                }
-
-                override fun newArray(size: Int): Array<PaymentSessionData?> {
-                    return arrayOfNulls(size)
-                }
-            }
-    }
+    val isPaymentReadyToCharge: Boolean
+        get() =
+            paymentMethod != null && config != null &&
+                (!config.isShippingInfoRequired || shippingInformation != null) &&
+                (!config.isShippingMethodRequired || shippingMethod != null)
 }

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -644,7 +644,7 @@ class CustomerSessionTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowActivit
         createActivity(PaymentFlowActivityStarter.Args.Builder()
             .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                 .build())
-            .setPaymentSessionData(PaymentSessionData())
+            .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
             .build())
 
         assertTrue(customerSession.productUsageTokens.contains("ShippingInfoScreen"))
@@ -659,7 +659,7 @@ class CustomerSessionTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowActivit
             .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                 .setShippingInfoRequired(false)
                 .build())
-            .setPaymentSessionData(PaymentSessionData())
+            .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
             .build())
 
         assertTrue(customerSession.productUsageTokens.contains("ShippingMethodScreen"))

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
@@ -1,10 +1,7 @@
 package com.stripe.android
 
-import com.stripe.android.model.Address
-import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.ShippingInformation
+import com.stripe.android.PaymentSessionFixtures.PAYMENT_SESSION_CONFIG
 import com.stripe.android.utils.ParcelUtils
-import com.stripe.android.view.ShippingInfoWidget
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
@@ -15,45 +12,6 @@ class PaymentSessionConfigTest {
 
     @Test
     fun testParcel() {
-        val paymentSessionConfig = PaymentSessionConfig.Builder()
-
-            // hide the phone field on the shipping information form
-            .setHiddenShippingInfoFields(
-                ShippingInfoWidget.CustomizableShippingField.ADDRESS_LINE_TWO_FIELD
-            )
-
-            // make the address line 2 field optional
-            .setOptionalShippingInfoFields(
-                ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD
-            )
-
-            // specify an address to pre-populate the shipping information form
-            .setPrepopulatedShippingInfo(ShippingInformation(
-                Address.Builder()
-                    .setLine1("123 Market St")
-                    .setCity("San Francisco")
-                    .setState("CA")
-                    .setPostalCode("94107")
-                    .setCountry("US")
-                    .build(),
-                "Jenny Rosen",
-                "4158675309"
-            ))
-
-            // collect shipping information
-            .setShippingInfoRequired(true)
-
-            // collect shipping method
-            .setShippingMethodsRequired(true)
-
-            // specify the payment method types that the customer can use;
-            // defaults to PaymentMethod.Type.Card
-            .setPaymentMethodTypes(
-                listOf(PaymentMethod.Type.Card)
-            )
-
-            .build()
-
-        assertEquals(paymentSessionConfig, ParcelUtils.create(paymentSessionConfig))
+        assertEquals(PAYMENT_SESSION_CONFIG, ParcelUtils.create(PAYMENT_SESSION_CONFIG))
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -22,13 +22,11 @@ class PaymentSessionDataTest {
             .setShippingMethodsRequired(false)
             .build()
 
-        val data = PaymentSessionData()
-        assertFalse(data.updateIsPaymentReadyToCharge(config))
+        val data = PaymentSessionData(config)
         assertFalse(data.isPaymentReadyToCharge)
-
-        data.paymentMethod = PAYMENT_METHOD
-        assertTrue(data.updateIsPaymentReadyToCharge(config))
-        assertTrue(data.isPaymentReadyToCharge)
+        assertTrue(
+            data.copy(paymentMethod = PAYMENT_METHOD).isPaymentReadyToCharge
+        )
     }
 
     @Test
@@ -38,42 +36,46 @@ class PaymentSessionDataTest {
             .setShippingMethodsRequired(true)
             .build()
 
-        val data = PaymentSessionData()
-        assertFalse(data.updateIsPaymentReadyToCharge(config))
-        assertFalse(data.isPaymentReadyToCharge)
+        assertFalse(PaymentSessionData(config).isPaymentReadyToCharge)
 
-        data.paymentMethod = PAYMENT_METHOD
-        assertFalse(data.updateIsPaymentReadyToCharge(config))
-        assertFalse(data.isPaymentReadyToCharge)
+        assertFalse(PaymentSessionData(
+            config,
+            paymentMethod = PAYMENT_METHOD
+        ).isPaymentReadyToCharge)
 
-        data.shippingInformation = ShippingInformation(null, null, null)
-        assertFalse(data.updateIsPaymentReadyToCharge(config))
-        assertFalse(data.isPaymentReadyToCharge)
+        assertFalse(PaymentSessionData(
+            config,
+            paymentMethod = PAYMENT_METHOD,
+            shippingInformation = ShippingInformation(null, null, null)
+        ).isPaymentReadyToCharge)
 
-        data.shippingMethod = ShippingMethod("label", "id", 0, "USD")
-        assertTrue(data.updateIsPaymentReadyToCharge(config))
-        assertTrue(data.isPaymentReadyToCharge)
+        assertTrue(PaymentSessionData(
+            config,
+            paymentMethod = PAYMENT_METHOD,
+            shippingInformation = ShippingInformation(null, null, null),
+            shippingMethod = ShippingMethod("label", "id", 0, "USD")
+        ).isPaymentReadyToCharge)
     }
 
     @Test
     fun writeToParcel_withNulls_readsFromParcelCorrectly() {
-        val data = PaymentSessionData()
-        data.cartTotal = 100L
-        data.shippingTotal = 150L
-        data.isPaymentReadyToCharge = false
+        val data = PaymentSessionData(
+            cartTotal = 100L,
+            shippingTotal = 150L
+        )
 
         assertEquals(data, ParcelUtils.create(data))
     }
 
     @Test
     fun writeToParcel_withoutNulls_readsFromParcelCorrectly() {
-        val data = PaymentSessionData()
-        data.cartTotal = 100L
-        data.shippingTotal = 150L
-        data.paymentMethod = PAYMENT_METHOD
-        data.isPaymentReadyToCharge = false
-        data.shippingInformation = ShippingInformation(null, null, null)
-        data.shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "USD")
+        val data = PaymentSessionData(
+            cartTotal = 100L,
+            shippingTotal = 150L,
+            paymentMethod = PAYMENT_METHOD,
+            shippingInformation = ShippingInformation(null, null, null),
+            shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "USD")
+        )
 
         assertEquals(data, ParcelUtils.create(data))
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -1,0 +1,49 @@
+package com.stripe.android
+
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
+import com.stripe.android.view.ShippingInfoWidget
+
+internal object PaymentSessionFixtures {
+    internal val PAYMENT_SESSION_CONFIG = PaymentSessionConfig.Builder()
+
+        // hide the phone field on the shipping information form
+        .setHiddenShippingInfoFields(
+            ShippingInfoWidget.CustomizableShippingField.ADDRESS_LINE_TWO_FIELD
+        )
+
+        // make the address line 2 field optional
+        .setOptionalShippingInfoFields(
+            ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD
+        )
+
+        // specify an address to pre-populate the shipping information form
+        .setPrepopulatedShippingInfo(ShippingInformation(
+            Address.Builder()
+                .setLine1("123 Market St")
+                .setCity("San Francisco")
+                .setState("CA")
+                .setPostalCode("94107")
+                .setCountry("US")
+                .build(),
+            "Jenny Rosen",
+            "4158675309"
+        ))
+
+        // collect shipping information
+        .setShippingInfoRequired(true)
+
+        // collect shipping method
+        .setShippingMethodsRequired(true)
+
+        // specify the payment method types that the customer can use;
+        // defaults to PaymentMethod.Type.Card
+        .setPaymentMethodTypes(
+            listOf(PaymentMethod.Type.Card)
+        )
+
+        .build()
+
+    internal val PAYMENT_SESSION_DATA = PaymentSessionData(PAYMENT_SESSION_CONFIG)
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -18,9 +18,10 @@ import com.stripe.android.CustomerSession.ACTION_API_EXCEPTION
 import com.stripe.android.CustomerSession.EXTRA_EXCEPTION
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.PaymentSession.Companion.STATE_PAYMENT_SESSION_DATA
+import com.stripe.android.PaymentSession.Companion.EXTRA_PAYMENT_SESSION_DATA
 import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionData
+import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
 import com.stripe.android.exception.APIException
 import com.stripe.android.model.Address
@@ -87,7 +88,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .setShippingInfoRequired(false)
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         assertNull(paymentFlowActivity.findViewById(R.id.shipping_info_widget))
@@ -100,7 +101,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
             PaymentFlowActivityStarter.Args.Builder()
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         shippingInfoWidget = paymentFlowActivity.findViewById(R.id.shipping_info_widget)
@@ -115,7 +116,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
             PaymentFlowActivityStarter.Args.Builder()
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         shippingInfoWidget = paymentFlowActivity.findViewById(R.id.shipping_info_widget)
@@ -132,7 +133,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         shippingInfoWidget = paymentFlowActivity.findViewById(R.id.shipping_info_widget)
@@ -156,7 +157,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
             PaymentFlowActivityStarter.Args.Builder()
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         paymentFlowActivity.setAlertMessageListener(mockListener)
@@ -181,7 +182,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
 
@@ -203,7 +204,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
                 .setPaymentSessionConfig(PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
 
@@ -233,7 +234,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .setShippingMethodsRequired(false)
                     .build())
-                .setPaymentSessionData(PaymentSessionData())
+                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
                 .build()
         )
         val shadowActivity = shadowOf(paymentFlowActivity)
@@ -252,7 +253,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
 
         val extras = shadowActivity.resultIntent.extras
         val resultSessionData =
-            extras?.getParcelable<PaymentSessionData>(STATE_PAYMENT_SESSION_DATA)
+            extras?.getParcelable<PaymentSessionData>(EXTRA_PAYMENT_SESSION_DATA)
         assertEquals(resultSessionData?.shippingInformation, SHIPPING_INFO)
     }
 


### PR DESCRIPTION
## Summary
- `PaymentSessionData`
  - Make all properties immutable and move to primary constructor
  - Make data class
  - Mark as `@Parcelizable`
  - Take `PaymentSessionData` in constructor and remove `updateIsPaymentReadyToCharge()`

- `PaymentSession`
  - Update logic to copy `PaymentSessionData` with
    updated property values

- `PaymentFlowActivity`
  - Update logic for saving state of updates to `PaymentSessionData`

## Motivation
Remove boilerplate from `PaymentSessionData` and make `PaymentSession` more readily refactorable

## Testing
Update unit tests and manually tested UI flow
