### PR TITLE
Prepare for calling cancel source endpoint

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AppInfo.kt
+++ b/stripe/src/main/java/com/stripe/android/AppInfo.kt
@@ -1,22 +1,25 @@
 package com.stripe.android
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
  * Data for identifying your plug-in or library.
  *
- * See [
- * Building Stripe Plug-ins and Libraries - Setting the API version](https://stripe.com/docs/building-plugins#setappinfo).
+ * See [Building Stripe Plug-ins and Libraries - Setting the API version](https://stripe.com/docs/building-plugins#setappinfo).
  *
  * @param name Name of your application (e.g. "MyAwesomeApp")
  * @param version Version of your application (e.g. "1.2.34")
  * @param url Website for your application (e.g. "https://myawesomeapp.info")
  * @param partnerId Your Stripe Partner ID (e.g. "pp_partner_1234")
  */
-data class AppInfo private constructor(
+@Parcelize
+data class AppInfo internal constructor(
     private val name: String,
     private val version: String?,
     private val url: String?,
     private val partnerId: String?
-) {
+) : Parcelable {
 
     internal fun toUserAgent(): String {
         return listOfNotNull(

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -9,7 +9,7 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  * A class that manages starting a [PaymentAuthWebViewActivity] instance with the correct
  * arguments.
  */
-internal class PaymentAuthWebViewStarter @JvmOverloads internal constructor(
+internal class PaymentAuthWebViewStarter internal constructor(
     private val host: AuthActivityStarter.Host,
     private val requestCode: Int,
     private val toolbarCustomization: StripeToolbarCustomization? = null,
@@ -18,13 +18,13 @@ internal class PaymentAuthWebViewStarter @JvmOverloads internal constructor(
 
     override fun start(data: Data) {
         Logger.getInstance(enableLogging).debug("PaymentAuthWebViewStarter#start()")
-        val extras = Bundle()
-        extras.putString(EXTRA_CLIENT_SECRET, data.clientSecret)
-        extras.putString(EXTRA_AUTH_URL, data.url)
-        extras.putString(EXTRA_RETURN_URL, data.returnUrl)
-        extras.putBoolean(EXTRA_ENABLE_LOGGING, enableLogging)
-        extras.putParcelable(EXTRA_UI_CUSTOMIZATION, toolbarCustomization)
-
+        val extras = Bundle().apply {
+            putString(EXTRA_CLIENT_SECRET, data.clientSecret)
+            putString(EXTRA_AUTH_URL, data.url)
+            putString(EXTRA_RETURN_URL, data.returnUrl)
+            putBoolean(EXTRA_ENABLE_LOGGING, enableLogging)
+            putParcelable(EXTRA_UI_CUSTOMIZATION, toolbarCustomization)
+        }
         host.startActivityForResult(PaymentAuthWebViewActivity::class.java, extras, requestCode)
     }
 

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -92,7 +92,11 @@ class Stripe internal constructor(
     ) : this(
         stripeRepository,
         stripeNetworkUtils,
-        StripePaymentController.create(context.applicationContext, stripeRepository, enableLogging),
+        StripePaymentController.create(
+            context.applicationContext,
+            stripeRepository,
+            enableLogging
+        ),
         publishableKey,
         stripeAccountId
     )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -88,10 +88,16 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         logger.debug("PaymentAuthWebViewActivity#onOptionsItemSelected()")
         if (item.itemId == R.id.action_close) {
-            finish()
+            onCloseButtonClicked()
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun onCloseButtonClicked() {
+        // TODO(mshafrir-stripe): call cancel source endpoint - ANDROID-427
+
+        finish()
     }
 
     private fun customizeToolbar(toolbar: Toolbar) {


### PR DESCRIPTION
- Make `AppInfo` a `Parcelable` so that it can easily be passed to
  `PaymentAuthWebViewActivity`
- Indicate where in `PaymentAuthWebViewActivity` the cancel source
  endpoint should be called