### PR TITLE
Refactor CountryAutoCompleteTextView logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/Country.kt
+++ b/stripe/src/main/java/com/stripe/android/view/Country.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.view
+
+internal data class Country(
+    val code: String,
+    val name: String
+) {
+
+    /**
+     * @return display value for [CountryAutoCompleteTextView] text view
+     */
+    override fun toString(): String = name
+}

--- a/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
@@ -18,20 +18,20 @@ import java.util.Locale
  */
 internal class CountryAdapter(
     context: Context,
-    initialCountries: List<String>
-) : ArrayAdapter<String>(context, R.layout.country_text_view) {
+    initialCountries: List<Country>
+) : ArrayAdapter<Country>(context, R.layout.country_text_view) {
     private val countryFilter: Filter = CountryFilter(
         initialCountries,
         this,
         context as? Activity
     )
-    private var suggestions: List<String> = initialCountries
+    private var suggestions: List<Country> = initialCountries
 
     override fun getCount(): Int {
         return suggestions.size
     }
 
-    override fun getItem(i: Int): String {
+    override fun getItem(i: Int): Country {
         return suggestions[i]
     }
 
@@ -41,12 +41,12 @@ internal class CountryAdapter(
 
     override fun getView(i: Int, view: View?, viewGroup: ViewGroup): View {
         return if (view is TextView) {
-            view.text = getItem(i)
+            view.text = getItem(i).name
             view
         } else {
             val countryText = LayoutInflater.from(context).inflate(
                 R.layout.country_text_view, viewGroup, false) as TextView
-            countryText.text = getItem(i)
+            countryText.text = getItem(i).name
             countryText
         }
     }
@@ -56,7 +56,7 @@ internal class CountryAdapter(
     }
 
     private class CountryFilter(
-        private val initialCountries: List<String>,
+        private val initialCountries: List<Country>,
         private val adapter: CountryAdapter,
         activity: Activity?
     ) : Filter() {
@@ -74,10 +74,10 @@ internal class CountryAdapter(
             constraint: CharSequence?,
             filterResults: FilterResults?
         ) {
-            val suggestions = filterResults?.values as List<String>
+            val suggestions = filterResults?.values as List<Country>
 
             activityRef.get()?.let { activity ->
-                if (suggestions.any { it == constraint }) {
+                if (suggestions.any { it.name == constraint }) {
                     hideKeyboard(activity)
                 }
             }
@@ -86,7 +86,7 @@ internal class CountryAdapter(
             adapter.notifyDataSetChanged()
         }
 
-        private fun filteredSuggestedCountries(constraint: CharSequence?): List<String> {
+        private fun filteredSuggestedCountries(constraint: CharSequence?): List<Country> {
             val suggestedCountries = getSuggestedCountries(constraint)
 
             return if (suggestedCountries.isEmpty() || isMatch(suggestedCountries, constraint)) {
@@ -96,17 +96,17 @@ internal class CountryAdapter(
             }
         }
 
-        private fun getSuggestedCountries(constraint: CharSequence?): List<String> {
+        private fun getSuggestedCountries(constraint: CharSequence?): List<Country> {
             return initialCountries
                 .filter {
-                    it.toLowerCase(Locale.ROOT).startsWith(
+                    it.name.toLowerCase(Locale.ROOT).startsWith(
                         constraint.toString().toLowerCase(Locale.ROOT)
                     )
                 }
         }
 
-        private fun isMatch(countries: List<String>, constraint: CharSequence?): Boolean {
-            return countries.size == 1 && countries[0] == constraint.toString()
+        private fun isMatch(countries: List<Country>, constraint: CharSequence?): Boolean {
+            return countries.size == 1 && countries[0].name == constraint.toString()
         }
 
         private fun hideKeyboard(activity: Activity) {

--- a/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -4,34 +4,42 @@ import java.util.Locale
 
 internal object CountryUtils {
 
-    private val NO_POSTAL_CODE_COUNTRIES =
-        arrayOf("AE", "AG", "AN", "AO", "AW", "BF", "BI", "BJ", "BO", "BS", "BW", "BZ", "CD", "CF", "CG", "CI", "CK", "CM", "DJ", "DM", "ER", "FJ", "GD", "GH", "GM", "GN", "GQ", "GY", "HK", "IE", "JM", "KE", "KI", "KM", "KN", "KP", "LC", "ML", "MO", "MR", "MS", "MU", "MW", "NR", "NU", "PA", "QA", "RW", "SB", "SC", "SL", "SO", "SR", "ST", "SY", "TF", "TK", "TL", "TO", "TT", "TV", "TZ", "UG", "VU", "YE", "ZA", "ZW")
-    private val NO_POSTAL_CODE_COUNTRIES_SET = setOf(*NO_POSTAL_CODE_COUNTRIES)
+    private val NO_POSTAL_CODE_COUNTRIES = setOf(
+        "AE", "AG", "AN", "AO", "AW", "BF", "BI", "BJ", "BO", "BS", "BW", "BZ", "CD", "CF", "CG",
+        "CI", "CK", "CM", "DJ", "DM", "ER", "FJ", "GD", "GH", "GM", "GN", "GQ", "GY", "HK", "IE",
+        "JM", "KE", "KI", "KM", "KN", "KP", "LC", "ML", "MO", "MR", "MS", "MU", "MW", "NR", "NU",
+        "PA", "QA", "RW", "SB", "SC", "SL", "SO", "SR", "ST", "SY", "TF", "TK", "TL", "TO", "TT",
+        "TV", "TZ", "UG", "VU", "YE", "ZA", "ZW"
+    )
 
-    private val COUNTRY_NAMES_TO_CODES: Map<String, String>
-        get() {
-            return Locale.getISOCountries()
-                .associateBy { Locale("", it).displayCountry }
+    private val COUNTRIES: List<Country> =
+        Locale.getISOCountries().map { code ->
+            Country(code, Locale("", code).displayCountry)
         }
 
     @JvmSynthetic
-    internal fun getCountryCode(countryName: String?): String? {
-        return COUNTRY_NAMES_TO_CODES[countryName]
+    internal fun getCountryByName(countryName: String): Country? {
+        return COUNTRIES.firstOrNull { it.name == countryName }
     }
 
     @JvmSynthetic
-    internal fun getOrderedCountries(currentLocale: Locale): List<String> {
+    internal fun getCountryByCode(countryCode: String): Country? {
+        return COUNTRIES.firstOrNull { it.code == countryCode }
+    }
+
+    @JvmSynthetic
+    internal fun getOrderedCountries(currentLocale: Locale): List<Country> {
         // Show user's current locale first, followed by countries alphabetized by display name
-        return listOf(currentLocale.displayCountry)
+        return listOfNotNull(getCountryByCode(currentLocale.country))
             .plus(
-                COUNTRY_NAMES_TO_CODES.keys.toList()
-                    .sortedWith(compareBy { it.toLowerCase(Locale.ROOT) })
-                    .minus(currentLocale.displayCountry)
+                COUNTRIES
+                    .sortedBy { it.name.toLowerCase(Locale.ROOT) }
+                    .filterNot { it.code == currentLocale.country }
             )
     }
 
     @JvmSynthetic
     internal fun doesCountryUsePostalCode(countryCode: String): Boolean {
-        return !NO_POSTAL_CODE_COUNTRIES_SET.contains(countryCode)
+        return !NO_POSTAL_CODE_COUNTRIES.contains(countryCode)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -61,7 +61,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
         get() {
             val address = Address.Builder()
                 .setCity(cityEditText.text?.toString())
-                .setCountry(countryAutoCompleteTextView.selectedCountryCode)
+                .setCountry(countryAutoCompleteTextView.selectedCountry.code)
                 .setLine1(addressEditText.text?.toString())
                 .setLine2(addressEditText2.text?.toString())
                 .setPostalCode(postalCodeEditText.text?.toString())
@@ -136,9 +136,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
         optionalShippingInfoFields = optionalAddressFields.orEmpty()
         renderLabels()
 
-        countryAutoCompleteTextView.selectedCountryCode?.let { selectedCountryCode ->
-            renderCountrySpecificLabels(selectedCountryCode)
-        }
+        countryAutoCompleteTextView.selectedCountry.let(::renderCountrySpecificLabels)
     }
 
     /**
@@ -149,9 +147,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
         hiddenShippingInfoFields = hiddenAddressFields.orEmpty()
         renderLabels()
 
-        countryAutoCompleteTextView.selectedCountryCode?.let { selectedCountryCode ->
-            renderCountrySpecificLabels(selectedCountryCode)
-        }
+        countryAutoCompleteTextView.selectedCountry.let(::renderCountrySpecificLabels)
     }
 
     /**
@@ -193,7 +189,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
         val isPostalCodeValid = shippingPostalCodeValidator.isValid(
             postalCode,
-            countryAutoCompleteTextView.selectedCountryCode.orEmpty(),
+            countryAutoCompleteTextView.selectedCountry.code,
             optionalShippingInfoFields,
             hiddenShippingInfoFields
         )
@@ -235,20 +231,13 @@ class ShippingInfoWidget @JvmOverloads constructor(
     }
 
     private fun initView() {
-        countryAutoCompleteTextView.setCountryChangeListener(
-            object : CountryAutoCompleteTextView.CountryChangeListener {
-                override fun onCountryChanged(countryCode: String) {
-                    renderCountrySpecificLabels(countryCode)
-                }
-            }
-        )
+        countryAutoCompleteTextView.countryChangeCallback = ::renderCountrySpecificLabels
+
         phoneNumberEditText.addTextChangedListener(PhoneNumberFormattingTextWatcher())
         setupErrorHandling()
         renderLabels()
 
-        countryAutoCompleteTextView.selectedCountryCode?.let { selectedCountryCode ->
-            renderCountrySpecificLabels(selectedCountryCode)
-        }
+        countryAutoCompleteTextView.selectedCountry.let(::renderCountrySpecificLabels)
     }
 
     private fun setupErrorHandling() {
@@ -303,8 +292,8 @@ class ShippingInfoWidget @JvmOverloads constructor(
         }
     }
 
-    private fun renderCountrySpecificLabels(countrySelected: String) {
-        when (countrySelected) {
+    private fun renderCountrySpecificLabels(country: Country) {
+        when (country.code) {
             Locale.US.country -> renderUSForm()
             Locale.UK.country -> renderGreatBritainForm()
             Locale.CANADA.country -> renderCanadianForm()
@@ -312,7 +301,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
         }
 
         postalCodeTextInputLayout.visibility =
-            if (CountryUtils.doesCountryUsePostalCode(countrySelected) &&
+            if (CountryUtils.doesCountryUsePostalCode(country.code) &&
                 !isFieldHidden(CustomizableShippingField.POSTAL_CODE_FIELD)) {
                 View.VISIBLE
             } else {

--- a/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
@@ -17,9 +17,9 @@ import org.robolectric.RobolectricTestRunner
 class CountryAdapterTest {
 
     private lateinit var countryAdapter: CountryAdapter
-    private lateinit var orderedCountries: List<String>
+    private lateinit var orderedCountries: List<Country>
 
-    private val suggestions: List<String>
+    private val suggestions: List<Country>
         get() {
             return (0 until countryAdapter.count).mapNotNull {
                 countryAdapter.getItem(it)
@@ -66,7 +66,7 @@ class CountryAdapterTest {
                 "United Kingdom",
                 "United States Minor Outlying Islands"
             ),
-            suggestions
+            suggestions.map { it.name }
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
@@ -37,13 +37,13 @@ class CountryAutoCompleteTextViewTest : BaseViewTest<ShippingInfoTestActivity>(
 
     @Test
     fun countryAutoCompleteTextView_whenInitialized_displaysDefaultLocaleDisplayName() {
-        assertEquals(Locale.US.country, countryAutoCompleteTextView.selectedCountryCode)
+        assertEquals(Locale.US.country, countryAutoCompleteTextView.selectedCountry.code)
         assertEquals(Locale.US.displayCountry, autoCompleteTextView.text.toString())
     }
 
     @Test
     fun updateUIForCountryEntered_whenInvalidCountry_revertsToLastCountry() {
-        val previousValidCountryCode = countryAutoCompleteTextView.selectedCountryCode.orEmpty()
+        val previousValidCountryCode = countryAutoCompleteTextView.selectedCountry.code
         countryAutoCompleteTextView.setCountrySelected("FAKE COUNTRY CODE")
         assertNull(autoCompleteTextView.error)
         assertEquals(autoCompleteTextView.text.toString(),
@@ -56,9 +56,9 @@ class CountryAutoCompleteTextViewTest : BaseViewTest<ShippingInfoTestActivity>(
 
     @Test
     fun updateUIForCountryEntered_whenValidCountry_UIUpdates() {
-        assertEquals(Locale.US.country, countryAutoCompleteTextView.selectedCountryCode)
+        assertEquals(Locale.US.country, countryAutoCompleteTextView.selectedCountry.code)
         countryAutoCompleteTextView.setCountrySelected(Locale.UK.country)
-        assertEquals(Locale.UK.country, countryAutoCompleteTextView.selectedCountryCode)
+        assertEquals(Locale.UK.country, countryAutoCompleteTextView.selectedCountry.code)
     }
 
     @Test
@@ -67,13 +67,6 @@ class CountryAutoCompleteTextViewTest : BaseViewTest<ShippingInfoTestActivity>(
         assertFalse(autoCompleteTextView.isPopupShowing)
         autoCompleteTextView.requestFocus()
         assertTrue(autoCompleteTextView.isPopupShowing)
-    }
-
-    @Test
-    fun updateUIForCountryEntered_whenCountrySelectedNullAndNoLocale_doesNotCrash() {
-        Locale.setDefault(Locale.CHINA)
-        countryAutoCompleteTextView.selectedCountryCode = null
-        countryAutoCompleteTextView.updateUiForCountryEntered(null)
     }
 
     @AfterTest

--- a/stripe/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
@@ -22,8 +22,8 @@ class CountryUtilsTest {
     @Test
     fun getOrderedCountries() {
         assertEquals(
-            Locale.getDefault().displayCountry,
-            CountryUtils.getOrderedCountries(Locale.getDefault())[0]
+            Locale.getDefault().country,
+            CountryUtils.getOrderedCountries(Locale.getDefault())[0].code
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -40,9 +40,6 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
     private lateinit var phoneEditText: StripeEditText
     private lateinit var countryAutoCompleteTextView: CountryAutoCompleteTextView
 
-    private val mNoPostalCodeCountry = "ZW" // Zimbabwe
-    private var mShippingInfo: ShippingInformation? = null
-
     @BeforeTest
     fun setup() {
         MockitoAnnotations.initMocks(this)
@@ -62,15 +59,6 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         stateEditText = shippingInfoWidget.findViewById(R.id.et_state_aaw)
         phoneEditText = shippingInfoWidget.findViewById(R.id.et_phone_number_aaw)
         countryAutoCompleteTextView = shippingInfoWidget.findViewById(R.id.country_autocomplete_aaw)
-        val address = Address.Builder()
-            .setCity("San Francisco")
-            .setState("CA")
-            .setCountry("US")
-            .setLine1("185 Berry St")
-            .setLine2("10th Floor")
-            .setPostalCode("12345")
-            .build()
-        mShippingInfo = ShippingInformation(address, "Fake Name", "(123) 456 - 7890")
     }
 
     @AfterTest
@@ -98,7 +86,7 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         assertEquals(postalCodeTextInputLayout.hint, shippingInfoWidget.resources.getString(R.string.address_label_postcode))
         assertEquals(stateTextInputLayout.hint, shippingInfoWidget.resources.getString(R.string.address_label_county))
 
-        countryAutoCompleteTextView.updateUiForCountryEntered(Locale("", mNoPostalCodeCountry).displayCountry)
+        countryAutoCompleteTextView.updateUiForCountryEntered(Locale("", NO_POSTAL_CODE_COUNTRY_CODE).displayCountry)
         assertEquals(addressLine1TextInputLayout.hint, shippingInfoWidget.resources.getString(R.string.address_label_address_line1))
         assertEquals(addressLine2TextInputLayout.hint, shippingInfoWidget.resources.getString(R.string.address_label_address_line2_optional))
         assertEquals(postalCodeTextInputLayout.visibility, View.GONE)
@@ -121,7 +109,7 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         postalEditText.setText("ABCDEF")
         assertFalse(shippingInfoWidget.validateAllFields())
         countryAutoCompleteTextView
-            .updateUiForCountryEntered(Locale("", mNoPostalCodeCountry).displayCountry)
+            .updateUiForCountryEntered(Locale("", NO_POSTAL_CODE_COUNTRY_CODE).displayCountry)
         assertTrue(shippingInfoWidget.validateAllFields())
     }
 
@@ -149,7 +137,7 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         shippingInfoWidget.validateAllFields()
         assertTrue(postalCodeTextInputLayout.isErrorEnabled)
         countryAutoCompleteTextView
-            .updateUiForCountryEntered(Locale("", mNoPostalCodeCountry).displayCountry)
+            .updateUiForCountryEntered(Locale("", NO_POSTAL_CODE_COUNTRY_CODE).displayCountry)
         shippingInfoWidget.validateAllFields()
         assertFalse(stateTextInputLayout.isErrorEnabled)
     }
@@ -172,7 +160,7 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         assertEquals(postalCodeTextInputLayout.error, shippingInfoWidget.resources.getString(R.string.address_postal_code_invalid))
 
         countryAutoCompleteTextView
-            .updateUiForCountryEntered(Locale("", mNoPostalCodeCountry).displayCountry)
+            .updateUiForCountryEntered(Locale("", NO_POSTAL_CODE_COUNTRY_CODE).displayCountry)
         shippingInfoWidget.validateAllFields()
         assertEquals(stateTextInputLayout.error, shippingInfoWidget.resources.getString(R.string.address_region_generic_required))
     }
@@ -225,12 +213,12 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         postalEditText.setText("12345")
         countryAutoCompleteTextView.updateUiForCountryEntered(Locale.US.displayCountry)
         val inputShippingInfo = shippingInfoWidget.shippingInformation
-        assertEquals(inputShippingInfo, mShippingInfo)
+        assertEquals(inputShippingInfo, SHIPPING_INFO)
     }
 
     @Test
     fun populateShippingInfo_whenShippingInfoProvided_populates() {
-        shippingInfoWidget.populateShippingInfo(mShippingInfo)
+        shippingInfoWidget.populateShippingInfo(SHIPPING_INFO)
         assertEquals(stateEditText.text.toString(), "CA")
         assertEquals(cityEditText.text.toString(), "San Francisco")
         assertEquals(addressLine1EditText.text.toString(), "185 Berry St")
@@ -238,6 +226,23 @@ class ShippingInfoWidgetTest : BaseViewTest<ShippingInfoTestActivity>(
         assertEquals(phoneEditText.text.toString(), "(123) 456 - 7890")
         assertEquals(postalEditText.text.toString(), "12345")
         assertEquals(nameEditText.text.toString(), "Fake Name")
-        assertEquals(countryAutoCompleteTextView.selectedCountryCode, "US")
+        assertEquals(countryAutoCompleteTextView.selectedCountry.code, "US")
+    }
+
+    private companion object {
+        private const val NO_POSTAL_CODE_COUNTRY_CODE = "ZW" // Zimbabwe
+
+        private val SHIPPING_INFO = ShippingInformation(
+            Address.Builder()
+                .setCity("San Francisco")
+                .setState("CA")
+                .setCountry("US")
+                .setLine1("185 Berry St")
+                .setLine2("10th Floor")
+                .setPostalCode("12345")
+                .build(),
+            "Fake Name",
+            "(123) 456 - 7890"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Create `Country` model to use in `CountryAutoCompleteTextView`
  and `CountryAdapter` to simplify logic
- Make `CountryAutoCompleteTextView.selectedCountry` non-null
- Avoid redundant `setText()` calls in `CountryAutoCompleteTextView`
  after a user selects a dropdown item
- Make `CountryAutoCompleteTextView.CountryChangeListener` a
  function type `(Country) -> Unit`

## Motivation
Refactor `CountryAutoCompleteTextView` to make it easier to add future logic, such as filtering the initial country list

## Testing
Manually verified