### PR TITLE
Create CountryAutoCompleteTextView.setAllowedCountryCodes()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.kt
@@ -28,10 +28,12 @@ internal class CountryAutoCompleteTextView @JvmOverloads constructor(
     @JvmSynthetic
     internal var countryChangeCallback: (Country) -> Unit = {}
 
+    private val countryAdapter: CountryAdapter
+
     init {
         View.inflate(getContext(), R.layout.country_autocomplete_textview, this)
 
-        val countryAdapter = CountryAdapter(
+        countryAdapter = CountryAdapter(
             getContext(),
             CountryUtils.getOrderedCountries(
                 ConfigurationCompat.getLocales(context.resources.configuration)[0]
@@ -54,10 +56,25 @@ internal class CountryAutoCompleteTextView @JvmOverloads constructor(
             }
         }
 
-        val initialCountry = countryAdapter.getItem(0)
+        selectedCountry = countryAdapter.firstItem
+        updateInitialCountry()
+    }
+
+    private fun updateInitialCountry() {
+        val initialCountry = countryAdapter.firstItem
         countryAutocomplete.setText(initialCountry.name)
         selectedCountry = initialCountry
         countryChangeCallback(initialCountry)
+    }
+
+    /**
+     * @param allowedCountryCodes A set of allowed country codes. Will be ignored if empty.
+     */
+    internal fun setAllowedCountryCodes(allowedCountryCodes: Set<String>) {
+        val isUpdated = countryAdapter.updateUnfilteredCountries(allowedCountryCodes)
+        if (isUpdated) {
+            updateInitialCountry()
+        }
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
@@ -6,6 +6,8 @@ import java.util.Locale
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
@@ -21,7 +23,7 @@ class CountryAdapterTest {
 
     private val suggestions: List<Country>
         get() {
-            return (0 until countryAdapter.count).mapNotNull {
+            return (0 until countryAdapter.count).map {
                 countryAdapter.getItem(it)
             }
         }
@@ -76,6 +78,44 @@ class CountryAdapterTest {
         assertEquals(
             orderedCountries,
             suggestions
+        )
+    }
+
+    @Test
+    fun updateUnfilteredCountries_withPopulatedSet_shouldUpdateSuggestions() {
+        assertEquals("US", countryAdapter.firstItem.code)
+        assertTrue(countryAdapter.updateUnfilteredCountries(setOf("fr", "de")))
+        assertEquals("FR", countryAdapter.firstItem.code)
+    }
+
+    @Test
+    fun updateUnfilteredCountries_withEmptySet_shouldNotUpdateSuggestions() {
+        assertEquals("US", countryAdapter.firstItem.code)
+        assertFalse(countryAdapter.updateUnfilteredCountries(emptySet()))
+        assertEquals("US", countryAdapter.firstItem.code)
+    }
+
+    @Test
+    fun updateUnfilteredCountries_shouldUpdateFilter() {
+        countryAdapter.filter.filter("United")
+        assertEquals(
+            listOf(
+                "United States",
+                "United Arab Emirates",
+                "United Kingdom",
+                "United States Minor Outlying Islands"
+            ),
+            suggestions.map { it.name }
+        )
+
+        countryAdapter.updateUnfilteredCountries(setOf("gb", "ae"))
+        countryAdapter.filter.filter("United")
+        assertEquals(
+            listOf(
+                "United Arab Emirates",
+                "United Kingdom"
+            ),
+            suggestions.map { it.name }
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
@@ -69,6 +69,15 @@ class CountryAutoCompleteTextViewTest : BaseViewTest<ShippingInfoTestActivity>(
         assertTrue(autoCompleteTextView.isPopupShowing)
     }
 
+    @Test
+    fun setAllowedCountryCodes_withPopulatedSet_shouldUpdateSelectedCountry() {
+        countryAutoCompleteTextView.setAllowedCountryCodes(setOf("fr", "de"))
+        assertEquals(
+            "FR",
+            countryAutoCompleteTextView.selectedCountry.code
+        )
+    }
+
     @AfterTest
     fun teardown() {
         Locale.setDefault(Locale.US)


### PR DESCRIPTION
## Summary
Allow a set of whitelisted country codes to be passed to
`CountryAdapter` via `CountryAutoCompleteTextView`. If this
set is populated, only include countries in the set in the
unfiltered list.

## Motivation
Ultimately to give users the option of specifying a whitelist of countries they will ship to

## Testing
Added unit tests and manually verified behavior