### PR TITLE
Simplify PaymentAuthWebViewStarter arg passing

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -1,11 +1,13 @@
 package com.stripe.android
 
 import android.os.Build
+import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.exception.InvalidRequestException
 import java.io.UnsupportedEncodingException
 import java.util.Locale
 import java.util.Objects
+import kotlinx.android.parcel.Parcelize
 import org.json.JSONObject
 
 /**
@@ -95,11 +97,12 @@ internal class ApiRequest internal constructor(
     /**
      * Data class representing options for a Stripe API request.
      */
+    @Parcelize
     internal data class Options internal constructor(
         val apiKey: String,
         internal val stripeAccount: String? = null,
         internal val idempotencyKey: String? = null
-    ) {
+    ) : Parcelable {
         init {
             ApiKeyValidator().requireValid(apiKey)
         }

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -1,9 +1,11 @@
 package com.stripe.android
 
 import android.os.Bundle
+import android.os.Parcelable
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.PaymentAuthWebViewActivity
+import kotlinx.android.parcel.Parcelize
 
 /**
  * A class that manages starting a [PaymentAuthWebViewActivity] instance with the correct
@@ -11,34 +13,28 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  */
 internal class PaymentAuthWebViewStarter internal constructor(
     private val host: AuthActivityStarter.Host,
-    private val requestCode: Int,
-    private val toolbarCustomization: StripeToolbarCustomization? = null,
-    private val enableLogging: Boolean = false
-) : AuthActivityStarter<PaymentAuthWebViewStarter.Data> {
+    private val requestCode: Int
+) : AuthActivityStarter<PaymentAuthWebViewStarter.Args> {
 
-    override fun start(data: Data) {
-        Logger.getInstance(enableLogging).debug("PaymentAuthWebViewStarter#start()")
+    override fun start(args: Args) {
         val extras = Bundle().apply {
-            putString(EXTRA_CLIENT_SECRET, data.clientSecret)
-            putString(EXTRA_AUTH_URL, data.url)
-            putString(EXTRA_RETURN_URL, data.returnUrl)
-            putBoolean(EXTRA_ENABLE_LOGGING, enableLogging)
-            putParcelable(EXTRA_UI_CUSTOMIZATION, toolbarCustomization)
+            putParcelable(EXTRA_ARGS, args)
         }
         host.startActivityForResult(PaymentAuthWebViewActivity::class.java, extras, requestCode)
     }
 
-    internal class Data(
+    @Parcelize
+    internal data class Args(
         val clientSecret: String,
         val url: String,
-        val returnUrl: String? = null
-    )
+        val returnUrl: String? = null,
+        val requestOptions: ApiRequest.Options,
+        val enableLogging: Boolean = false,
+        val appInfo: AppInfo? = null,
+        val toolbarCustomization: StripeToolbarCustomization? = null
+    ) : Parcelable
 
     internal companion object {
-        internal const val EXTRA_AUTH_URL = "auth_url"
-        internal const val EXTRA_CLIENT_SECRET = "client_secret"
-        internal const val EXTRA_RETURN_URL = "return_url"
-        internal const val EXTRA_UI_CUSTOMIZATION = "ui_customization"
-        internal const val EXTRA_ENABLE_LOGGING = "enable_logging"
+        internal const val EXTRA_ARGS = "extra_args"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
@@ -10,7 +10,7 @@ import com.stripe.android.view.StripeIntentResultExtras
  * Starts an instance of [PaymentRelayStarter].
  * Should only be called from [StripePaymentController].
  */
-internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter.Data> {
+internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter.Args> {
     companion object {
         @JvmSynthetic
         internal fun create(
@@ -18,12 +18,12 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             requestCode: Int
         ): PaymentRelayStarter {
             return object : PaymentRelayStarter {
-                override fun start(data: Data) {
+                override fun start(args: Args) {
                     val extras = Bundle()
                     extras.putString(StripeIntentResultExtras.CLIENT_SECRET,
-                        data.stripeIntent?.clientSecret)
+                        args.stripeIntent?.clientSecret)
                     extras.putSerializable(StripeIntentResultExtras.AUTH_EXCEPTION,
-                        data.exception)
+                        args.exception)
                     host.startActivityForResult(
                         PaymentRelayActivity::class.java, extras, requestCode
                     )
@@ -32,19 +32,19 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
         }
     }
 
-    data class Data internal constructor(
+    data class Args internal constructor(
         val stripeIntent: StripeIntent? = null,
         val exception: Exception? = null
     ) {
         internal companion object {
             @JvmSynthetic
-            internal fun create(stripeIntent: StripeIntent): Data {
-                return Data(stripeIntent = stripeIntent)
+            internal fun create(stripeIntent: StripeIntent): Args {
+                return Args(stripeIntent = stripeIntent)
             }
 
             @JvmSynthetic
-            internal fun create(exception: Exception): Data {
-                return Data(exception = exception)
+            internal fun create(exception: Exception): Args {
+                return Args(exception = exception)
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -79,7 +79,8 @@ class Stripe internal constructor(
         StripeNetworkUtils(context.applicationContext),
         ApiKeyValidator.get().requireValid(publishableKey),
         stripeAccountId,
-        enableLogging
+        enableLogging,
+        appInfo
     )
 
     private constructor(
@@ -88,7 +89,8 @@ class Stripe internal constructor(
         stripeNetworkUtils: StripeNetworkUtils,
         publishableKey: String,
         stripeAccountId: String?,
-        enableLogging: Boolean
+        enableLogging: Boolean,
+        appInfo: AppInfo?
     ) : this(
         stripeRepository,
         stripeNetworkUtils,

--- a/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe3ds2CompletionStarter.kt
@@ -10,13 +10,13 @@ import com.stripe.android.view.StripeIntentResultExtras
 internal class Stripe3ds2CompletionStarter(
     private val host: AuthActivityStarter.Host,
     private val requestCode: Int
-) : AuthActivityStarter<Stripe3ds2CompletionStarter.StartData> {
+) : AuthActivityStarter<Stripe3ds2CompletionStarter.Args> {
 
-    override fun start(data: StartData) {
+    override fun start(args: Args) {
         val extras = Bundle()
         extras.putString(StripeIntentResultExtras.CLIENT_SECRET,
-            data.stripeIntent.clientSecret)
-        extras.putInt(StripeIntentResultExtras.FLOW_OUTCOME, data.outcome)
+            args.stripeIntent.clientSecret)
+        extras.putInt(StripeIntentResultExtras.FLOW_OUTCOME, args.outcome)
         host.startActivityForResult(PaymentRelayActivity::class.java, extras, requestCode)
     }
 
@@ -35,7 +35,7 @@ internal class Stripe3ds2CompletionStarter(
         }
     }
 
-    internal data class StartData internal constructor(
+    internal data class Args internal constructor(
         val stripeIntent: StripeIntent,
         @param:ChallengeFlowOutcome @field:ChallengeFlowOutcome
         private val challengeFlowOutcome: Int

--- a/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
@@ -6,16 +6,15 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import java.lang.ref.WeakReference
 
-internal interface AuthActivityStarter<StartDataType> {
-    fun start(data: StartDataType)
+internal interface AuthActivityStarter<ArgsType> {
+    fun start(args: ArgsType)
 
     /**
      * A representation of an object (i.e. Activity or Fragment) that can start an activity.
      */
     class Host private constructor(activity: Activity, fragment: Fragment?) {
         private val activityRef: WeakReference<Activity> = WeakReference(activity)
-        private val fragmentRef: WeakReference<Fragment>? =
-            if (fragment != null) WeakReference(fragment) else null
+        private val fragmentRef: WeakReference<Fragment>? = fragment?.let { WeakReference(it) }
 
         internal val activity: Activity?
             get() = activityRef.get()

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Intent
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.StripeIntentResultExtras
@@ -13,9 +15,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -40,8 +40,8 @@ class PaymentRelayStarterTest {
 
     @Test
     fun start_withPaymentIntent_shouldSetCorrectIntentExtras() {
-        starter.start(PaymentRelayStarter.Data.create(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        starter.start(PaymentRelayStarter.Args.create(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret,
             intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))
@@ -52,8 +52,8 @@ class PaymentRelayStarterTest {
     @Test
     fun start_withException_shouldSetCorrectIntentExtras() {
         val exception = RuntimeException()
-        starter.start(PaymentRelayStarter.Data.create(exception))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        starter.start(PaymentRelayStarter.Args.create(exception))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertNull(intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))
         assertFalse(intent.hasExtra(StripeIntentResultExtras.FLOW_OUTCOME))

--- a/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/Stripe3ds2CompletionStarterTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.StripeIntentResultExtras
@@ -13,7 +14,6 @@ import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -37,10 +37,10 @@ class Stripe3ds2CompletionStarterTest {
 
     @Test
     fun start_withSuccessfulCompletion_shouldAddClientSecretAndOutcomeToIntent() {
-        starter.start(Stripe3ds2CompletionStarter.StartData(
+        starter.start(Stripe3ds2CompletionStarter.Args(
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_SUCCESSFUL))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret,
             intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))
@@ -51,10 +51,10 @@ class Stripe3ds2CompletionStarterTest {
 
     @Test
     fun start_withUnsuccessfulCompletion_shouldAddClientSecretAndOutcomeToIntent() {
-        starter.start(Stripe3ds2CompletionStarter.StartData(
+        starter.start(Stripe3ds2CompletionStarter.Args(
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             Stripe3ds2CompletionStarter.ChallengeFlowOutcome.COMPLETE_UNSUCCESSFUL))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret,
             intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))
@@ -65,10 +65,10 @@ class Stripe3ds2CompletionStarterTest {
 
     @Test
     fun start_withTimeout_shouldAddClientSecretAndOutcomeToIntent() {
-        starter.start(Stripe3ds2CompletionStarter.StartData(
+        starter.start(Stripe3ds2CompletionStarter.Args(
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             Stripe3ds2CompletionStarter.ChallengeFlowOutcome.TIMEOUT))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret,
             intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))
@@ -79,10 +79,10 @@ class Stripe3ds2CompletionStarterTest {
 
     @Test
     fun start_withProtocolError_shouldAddClientSecretAndOutcomeToIntent() {
-        starter.start(Stripe3ds2CompletionStarter.StartData(
+        starter.start(Stripe3ds2CompletionStarter.Args(
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             Stripe3ds2CompletionStarter.ChallengeFlowOutcome.PROTOCOL_ERROR))
-        verify<Activity>(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
         val intent = intentArgumentCaptor.firstValue
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret,
             intent.getStringExtra(StripeIntentResultExtras.CLIENT_SECRET))

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.APIException
@@ -35,7 +36,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -300,7 +300,7 @@ class StripeApiRepositoryTest {
         assertTrue(paymentMethodDataParams["guid"] is String)
         assertEquals("card", paymentMethodDataParams["type"])
 
-        verify<FireAndForgetRequestExecutor>(fireAndForgetRequestExecutor, times(2))
+        verify(fireAndForgetRequestExecutor, times(2))
             .executeAsync(stripeRequestArgumentCaptor.capture())
         val stripeRequests = stripeRequestArgumentCaptor.allValues
         val analyticsRequest = stripeRequests[1] as ApiRequest

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -7,16 +7,16 @@ import android.webkit.WebView
 import android.widget.ProgressBar
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.FakeLogger
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -48,7 +48,7 @@ class PaymentAuthWebViewTest {
             "stripe://payment_intent_return"
         )
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -56,7 +56,7 @@ class PaymentAuthWebViewTest {
         val url = "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("seti_1234_secret_5678", "stripe://payment_auth")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -64,7 +64,7 @@ class PaymentAuthWebViewTest {
         val url = "stripe://payment_intent_return?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -72,7 +72,7 @@ class PaymentAuthWebViewTest {
         val url = "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("seti_1234_secret_5678")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -80,7 +80,7 @@ class PaymentAuthWebViewTest {
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView,
             "https://example.com")
-        verify<Activity>(activity, never()).finish()
+        verify(activity, never()).finish()
     }
 
     @Test
@@ -88,7 +88,7 @@ class PaymentAuthWebViewTest {
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView,
             "stripejs://use_stripe_sdk/return_url")
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -96,7 +96,7 @@ class PaymentAuthWebViewTest {
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.onPageFinished(webView,
             "https://hooks.stripe.com/3d_secure/complete/tdsrc_1ExLWoCRMbs6FrXfjPJRYtng")
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -104,7 +104,7 @@ class PaymentAuthWebViewTest {
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.onPageFinished(webView,
             "https://hooks.stripe.com/redirect/complete/src_1ExLWoCRMbs6FrXfjPJRYtng")
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -119,7 +119,7 @@ class PaymentAuthWebViewTest {
         val url = "deep://link"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test
@@ -127,13 +127,13 @@ class PaymentAuthWebViewTest {
         val deepLink = "intent://example.com/#Intent;scheme=https;action=android.intent.action.VIEW;end"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, deepLink)
-        verify<PackageManager>(packageManager).resolveActivity(
+        verify(packageManager).resolveActivity(
             intentArgumentCaptor.capture(),
             eq(PackageManager.MATCH_DEFAULT_ONLY)
         )
         val intent = intentArgumentCaptor.firstValue
         assertEquals("https://example.com/", intent.dataString)
-        verify<Activity>(activity).finish()
+        verify(activity).finish()
     }
 
     @Test


### PR DESCRIPTION
## Summary
Pass `PaymentAuthWebViewStarter.Args` as the single intent extra
to `PaymentAuthWebViewActivity`.

## Motivation
Simplifies passing more fields necessary for implementing 3DS1 source cancel logic

## Testing
Unit + manual testing
