### PR TITLE
Add PaymentSessionConfig.allowedShippingCountryCodes

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -121,6 +121,7 @@ class PaymentSessionActivity : AppCompatActivity() {
                 // Optionally specify the `PaymentMethod.Type` values to use.
                 // Defaults to `PaymentMethod.Type.Card`
                 .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card))
+                .setAllowedShippingCountryCodes(setOf("US", "CA"))
                 .build(),
             savedInstanceState = savedInstanceState,
             shouldPrefetchCustomer = shouldPrefetchCustomer

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -60,7 +60,8 @@ class PaymentFlowActivity : StripeActivity() {
             paymentSessionConfig,
             customerSession,
             shippingInformation,
-            savedInstanceState?.getParcelable(STATE_SHIPPING_METHOD)
+            savedInstanceState?.getParcelable(STATE_SHIPPING_METHOD),
+            paymentSessionConfig.allowedShippingCountryCodes
         )
         shipping_flow_viewpager.adapter = paymentFlowPagerAdapter
         shipping_flow_viewpager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
@@ -19,7 +19,8 @@ internal class PaymentFlowPagerAdapter(
     private val paymentSessionConfig: PaymentSessionConfig,
     private val customerSession: CustomerSession,
     private val shippingInformation: ShippingInformation?,
-    private val shippingMethod: ShippingMethod?
+    private val shippingMethod: ShippingMethod?,
+    private val allowedShippingCountryCodes: Set<String> = emptySet()
 ) : PagerAdapter() {
     private val pages: MutableList<PaymentFlowPagerEnum>
 
@@ -92,6 +93,8 @@ internal class PaymentFlowPagerAdapter(
                     .setOptionalFields(paymentSessionConfig.optionalShippingInfoFields)
                 shippingInfoWidget
                     .populateShippingInfo(shippingInformation)
+                shippingInfoWidget
+                    .setAllowedCountryCodes(allowedShippingCountryCodes)
             }
         }
         collection.addView(layout)

--- a/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -174,6 +174,10 @@ class ShippingInfoWidget @JvmOverloads constructor(
         phoneNumberEditText.setText(shippingInformation.phone)
     }
 
+    fun setAllowedCountryCodes(allowedCountryCodes: Set<String>) {
+        countryAutoCompleteTextView.setAllowedCountryCodes(allowedCountryCodes)
+    }
+
     /**
      * Validates all fields and shows error messages if appropriate.
      *

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
@@ -4,6 +4,8 @@ import com.stripe.android.PaymentSessionFixtures.PAYMENT_SESSION_CONFIG
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -13,5 +15,39 @@ class PaymentSessionConfigTest {
     @Test
     fun testParcel() {
         assertEquals(PAYMENT_SESSION_CONFIG, ParcelUtils.create(PAYMENT_SESSION_CONFIG))
+        assertEquals(
+            PaymentSessionFixtures.PAYMENT_SESSION_CONFIG,
+            ParcelUtils.create(PaymentSessionFixtures.PAYMENT_SESSION_CONFIG)
+        )
+    }
+
+    @Test
+    fun create_withValidCountryCode_succeeds() {
+        val allowedShippingCountryCodes = setOf("us", "CA")
+        val config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+            allowedShippingCountryCodes = allowedShippingCountryCodes
+        )
+        assertEquals(allowedShippingCountryCodes, config.allowedShippingCountryCodes)
+    }
+
+    @Test
+    fun create_withEmptyCountryCodesList_succeeds() {
+        val config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+            allowedShippingCountryCodes = emptySet()
+        )
+        assertTrue(config.allowedShippingCountryCodes.isEmpty())
+    }
+
+    @Test
+    fun create_withInvalidCountryCode_throwsException() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+                allowedShippingCountryCodes = setOf("invalid_country_code")
+            )
+        }
+        assertEquals(
+            "'invalid_country_code' is not a valid country code",
+            exception.message
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -43,6 +43,11 @@ internal object PaymentSessionFixtures {
             listOf(PaymentMethod.Type.Card)
         )
 
+        // only allowed US and Canada shipping addresses
+        .setAllowedShippingCountryCodes(
+            setOf("US", "CA")
+        )
+
         .build()
 
     internal val PAYMENT_SESSION_DATA = PaymentSessionData(PAYMENT_SESSION_CONFIG)


### PR DESCRIPTION
## Summary
- Add `PaymentSessionConfig.allowedShippingCountryCodes`
- Pass through to `PaymentFlowActivity` and UI components

## Motivation
Allow users to configured shipping address form

## Testing
Unit tests + manual verification
