### PR TITLE
Make all param keys have a prefix of PARAM_

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.Card
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 
 /**
  * Utility class for static functions useful for networking and data transfer.
@@ -32,15 +33,15 @@ internal class StripeNetworkUtils @VisibleForTesting constructor(
 
     internal fun paramsWithUid(intentParams: Map<String, *>): Map<String, *> {
         return when {
-            intentParams.containsKey(ConfirmPaymentIntentParams.API_PARAM_SOURCE_DATA) ->
+            intentParams.containsKey(ConfirmPaymentIntentParams.PARAM_SOURCE_DATA) ->
                 paramsWithUid(
                     intentParams,
-                    ConfirmPaymentIntentParams.API_PARAM_SOURCE_DATA
+                    ConfirmPaymentIntentParams.PARAM_SOURCE_DATA
                 )
-            intentParams.containsKey(ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_DATA) ->
+            intentParams.containsKey(PARAM_PAYMENT_METHOD_DATA) ->
                 paramsWithUid(
                     intentParams,
-                    ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_DATA
+                    PARAM_PAYMENT_METHOD_DATA
                 )
             else -> intentParams
         }

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -2,8 +2,9 @@ package com.stripe.android.model
 
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.ObjectBuilder
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_CLIENT_SECRET
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_USE_STRIPE_SDK
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 
 data class ConfirmPaymentIntentParams private constructor(
     val paymentMethodCreateParams: PaymentMethodCreateParams?,
@@ -39,26 +40,26 @@ data class ConfirmPaymentIntentParams private constructor(
      */
     override fun toParamMap(): Map<String, Any> {
         val params: MutableMap<String, Any> = mutableMapOf(
-            API_PARAM_CLIENT_SECRET to clientSecret,
-            API_PARAM_SAVE_PAYMENT_METHOD to savePaymentMethod,
-            API_PARAM_USE_STRIPE_SDK to useStripeSdk
+            PARAM_CLIENT_SECRET to clientSecret,
+            PARAM_SAVE_PAYMENT_METHOD to savePaymentMethod,
+            PARAM_USE_STRIPE_SDK to useStripeSdk
         )
 
         if (paymentMethodCreateParams != null) {
-            params[API_PARAM_PAYMENT_METHOD_DATA] = paymentMethodCreateParams.toParamMap().toMap()
+            params[PARAM_PAYMENT_METHOD_DATA] = paymentMethodCreateParams.toParamMap().toMap()
             if (paymentMethodCreateParams.type.hasMandate) {
-                params[MandateData.API_PARAM_MANDATE_DATA] = MandateData().toParamMap()
+                params[MandateData.PARAM_MANDATE_DATA] = MandateData().toParamMap()
             }
         } else if (paymentMethodId != null) {
-            params[ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_ID] = paymentMethodId
+            params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_ID] = paymentMethodId
         } else if (sourceParams != null) {
-            params[API_PARAM_SOURCE_DATA] = sourceParams.toParamMap().toMap()
+            params[PARAM_SOURCE_DATA] = sourceParams.toParamMap().toMap()
         } else if (sourceId != null) {
-            params[API_PARAM_SOURCE_ID] = sourceId
+            params[PARAM_SOURCE_ID] = sourceId
         }
 
         if (returnUrl != null) {
-            params[ConfirmStripeIntentParams.API_PARAM_RETURN_URL] = returnUrl
+            params[ConfirmStripeIntentParams.PARAM_RETURN_URL] = returnUrl
         }
         if (extraParams != null) {
             params.putAll(extraParams)
@@ -193,11 +194,10 @@ data class ConfirmPaymentIntentParams private constructor(
     }
 
     companion object {
-        const val API_PARAM_SOURCE_DATA: String = "source_data"
-        const val API_PARAM_PAYMENT_METHOD_DATA: String = "payment_method_data"
+        const val PARAM_SOURCE_DATA: String = "source_data"
 
-        internal const val API_PARAM_SOURCE_ID = "source"
-        internal const val API_PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
+        internal const val PARAM_SOURCE_ID = "source"
+        internal const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
 
         /**
          * Create a [ConfirmPaymentIntentParams] without a payment method.

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -2,11 +2,11 @@ package com.stripe.android.model
 
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.ObjectBuilder
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_CLIENT_SECRET
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_PAYMENT_METHOD_DATA
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_PAYMENT_METHOD_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_RETURN_URL
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_USE_STRIPE_SDK
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 
 data class ConfirmSetupIntentParams internal constructor(
     @get:JvmSynthetic override val clientSecret: String,
@@ -34,19 +34,19 @@ data class ConfirmSetupIntentParams internal constructor(
      */
     override fun toParamMap(): Map<String, Any> {
         val params = mapOf(
-            API_PARAM_CLIENT_SECRET to clientSecret,
-            API_PARAM_USE_STRIPE_SDK to useStripeSdk
+            PARAM_CLIENT_SECRET to clientSecret,
+            PARAM_USE_STRIPE_SDK to useStripeSdk
         ).plus(
-            returnUrl?.let { mapOf(API_PARAM_RETURN_URL to it) }.orEmpty()
+            returnUrl?.let { mapOf(PARAM_RETURN_URL to it) }.orEmpty()
         ).toMutableMap()
 
         if (paymentMethodCreateParams != null) {
-            params[API_PARAM_PAYMENT_METHOD_DATA] = paymentMethodCreateParams.toParamMap()
+            params[PARAM_PAYMENT_METHOD_DATA] = paymentMethodCreateParams.toParamMap()
             if (paymentMethodCreateParams.type.hasMandate) {
-                params[MandateData.API_PARAM_MANDATE_DATA] = MandateData().toParamMap()
+                params[MandateData.PARAM_MANDATE_DATA] = MandateData().toParamMap()
             }
         } else if (paymentMethodId != null) {
-            params[API_PARAM_PAYMENT_METHOD_ID] = paymentMethodId
+            params[PARAM_PAYMENT_METHOD_ID] = paymentMethodId
         }
 
         return params.toMap()

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -9,10 +9,10 @@ interface ConfirmStripeIntentParams : StripeParamsModel {
     fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmStripeIntentParams
 
     companion object {
-        internal const val API_PARAM_CLIENT_SECRET: String = "client_secret"
-        internal const val API_PARAM_RETURN_URL: String = "return_url"
-        internal const val API_PARAM_PAYMENT_METHOD_ID: String = "payment_method"
-        internal const val API_PARAM_PAYMENT_METHOD_DATA: String = "payment_method_data"
-        internal const val API_PARAM_USE_STRIPE_SDK: String = "use_stripe_sdk"
+        internal const val PARAM_CLIENT_SECRET: String = "client_secret"
+        internal const val PARAM_RETURN_URL: String = "return_url"
+        internal const val PARAM_PAYMENT_METHOD_ID: String = "payment_method"
+        internal const val PARAM_PAYMENT_METHOD_DATA: String = "payment_method_data"
+        internal const val PARAM_USE_STRIPE_SDK: String = "use_stripe_sdk"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/MandateData.kt
+++ b/stripe/src/main/java/com/stripe/android/model/MandateData.kt
@@ -9,6 +9,6 @@ internal class MandateData : StripeParamsModel {
     }
 
     internal companion object {
-        internal const val API_PARAM_MANDATE_DATA = "mandate_data"
+        internal const val PARAM_MANDATE_DATA = "mandate_data"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -73,29 +73,29 @@ data class PaymentMethodCreateParams internal constructor(
 
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
-            FIELD_TYPE to type.code
+            PARAM_TYPE to type.code
         ).plus(
             billingDetails?.let {
-                mapOf(FIELD_BILLING_DETAILS to it.toParamMap())
+                mapOf(PARAM_BILLING_DETAILS to it.toParamMap())
             }.orEmpty()
         ).plus(
             when (type) {
                 Type.Card -> {
-                    mapOf(FIELD_CARD to card?.toParamMap().orEmpty())
+                    mapOf(PARAM_CARD to card?.toParamMap().orEmpty())
                 }
                 Type.Ideal -> {
-                    mapOf(FIELD_IDEAL to ideal?.toParamMap().orEmpty())
+                    mapOf(PARAM_IDEAL to ideal?.toParamMap().orEmpty())
                 }
                 Type.Fpx -> {
-                    mapOf(FIELD_FPX to fpx?.toParamMap().orEmpty())
+                    mapOf(PARAM_FPX to fpx?.toParamMap().orEmpty())
                 }
                 Type.SepaDebit -> {
-                    mapOf(FIELD_SEPA_DEBIT to sepaDebit?.toParamMap().orEmpty())
+                    mapOf(PARAM_SEPA_DEBIT to sepaDebit?.toParamMap().orEmpty())
                 }
             }
         ).plus(
             metadata?.let {
-                mapOf(FIELD_METADATA to it)
+                mapOf(PARAM_METADATA to it)
             }.orEmpty()
         )
     }
@@ -116,11 +116,11 @@ data class PaymentMethodCreateParams internal constructor(
     ) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return listOf(
-                FIELD_NUMBER to number,
-                FIELD_EXP_MONTH to expiryMonth,
-                FIELD_EXP_YEAR to expiryYear,
-                FIELD_CVC to cvc,
-                FIELD_TOKEN to token
+                PARAM_NUMBER to number,
+                PARAM_EXP_MONTH to expiryMonth,
+                PARAM_EXP_YEAR to expiryYear,
+                PARAM_CVC to cvc,
+                PARAM_TOKEN to token
             ).mapNotNull {
                 it.second?.let { value ->
                     it.first to value
@@ -169,11 +169,11 @@ data class PaymentMethodCreateParams internal constructor(
         }
 
         companion object {
-            private const val FIELD_NUMBER: String = "number"
-            private const val FIELD_EXP_MONTH: String = "exp_month"
-            private const val FIELD_EXP_YEAR: String = "exp_year"
-            private const val FIELD_CVC: String = "cvc"
-            private const val FIELD_TOKEN: String = "token"
+            private const val PARAM_NUMBER: String = "number"
+            private const val PARAM_EXP_MONTH: String = "exp_month"
+            private const val PARAM_EXP_YEAR: String = "exp_year"
+            private const val PARAM_CVC: String = "cvc"
+            private const val PARAM_TOKEN: String = "token"
 
             @JvmStatic
             fun create(token: String): Card {
@@ -184,7 +184,7 @@ data class PaymentMethodCreateParams internal constructor(
 
     data class Ideal internal constructor(private val bank: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
-            return bank?.let { mapOf(FIELD_BANK to it) }.orEmpty()
+            return bank?.let { mapOf(PARAM_BANK to it) }.orEmpty()
         }
 
         class Builder : ObjectBuilder<Ideal> {
@@ -201,14 +201,14 @@ data class PaymentMethodCreateParams internal constructor(
         }
 
         companion object {
-            private const val FIELD_BANK: String = "bank"
+            private const val PARAM_BANK: String = "bank"
         }
     }
 
     data class Fpx internal constructor(private val bank: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return bank?.let {
-                mapOf(FIELD_BANK to it)
+                mapOf(PARAM_BANK to it)
             }.orEmpty()
         }
 
@@ -226,14 +226,14 @@ data class PaymentMethodCreateParams internal constructor(
         }
 
         companion object {
-            private const val FIELD_BANK: String = "bank"
+            private const val PARAM_BANK: String = "bank"
         }
     }
 
     data class SepaDebit internal constructor(private val iban: String?) : StripeParamsModel {
         override fun toParamMap(): Map<String, Any> {
             return iban?.let {
-                mapOf(FIELD_IBAN to it)
+                mapOf(PARAM_IBAN to it)
             }.orEmpty()
         }
 
@@ -251,19 +251,19 @@ data class PaymentMethodCreateParams internal constructor(
         }
 
         companion object {
-            private const val FIELD_IBAN: String = "iban"
+            private const val PARAM_IBAN: String = "iban"
         }
     }
 
     companion object {
-        private const val FIELD_TYPE = "type"
-        private const val FIELD_CARD = "card"
-        private const val FIELD_FPX = "fpx"
-        private const val FIELD_IDEAL = "ideal"
-        private const val FIELD_SEPA_DEBIT = "sepa_debit"
+        private const val PARAM_TYPE = "type"
+        private const val PARAM_CARD = "card"
+        private const val PARAM_FPX = "fpx"
+        private const val PARAM_IDEAL = "ideal"
+        private const val PARAM_SEPA_DEBIT = "sepa_debit"
 
-        private const val FIELD_BILLING_DETAILS = "billing_details"
-        private const val FIELD_METADATA = "metadata"
+        private const val PARAM_BILLING_DETAILS = "billing_details"
+        private const val PARAM_METADATA = "metadata"
 
         @JvmStatic
         @JvmOverloads

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
@@ -146,7 +146,7 @@ class SourceParams private constructor(
      */
     fun setReturnUrl(@Size(min = 1) returnUrl: String): SourceParams {
         this.redirect = redirect.orEmpty().plus(
-            mapOf(FIELD_RETURN_URL to returnUrl)
+            mapOf(PARAM_RETURN_URL to returnUrl)
         )
         return this
     }
@@ -197,7 +197,7 @@ class SourceParams private constructor(
      * @return a String-keyed map
      */
     override fun toParamMap(): Map<String, Any> {
-        return mapOf<String, Any>(API_PARAM_TYPE to typeRaw)
+        return mapOf<String, Any>(PARAM_TYPE to typeRaw)
             .plus(
                 apiParameterMap?.let {
                     mapOf(typeRaw to it)
@@ -205,43 +205,43 @@ class SourceParams private constructor(
             )
             .plus(
                 amount?.let {
-                    mapOf(API_PARAM_AMOUNT to it)
+                    mapOf(PARAM_AMOUNT to it)
                 }.orEmpty()
             )
             .plus(
                 currency?.let {
-                    mapOf(API_PARAM_CURRENCY to it)
+                    mapOf(PARAM_CURRENCY to it)
                 }.orEmpty()
             )
             .plus(
                 owner.takeUnless { it.isNullOrEmpty() }?.let {
-                    mapOf(API_PARAM_OWNER to it)
+                    mapOf(PARAM_OWNER to it)
                 }.orEmpty()
             )
             .plus(
                 redirect?.let {
-                    mapOf(API_PARAM_REDIRECT to it)
+                    mapOf(PARAM_REDIRECT to it)
                 }.orEmpty()
             )
             .plus(
                 metaData?.let {
-                    mapOf(API_PARAM_METADATA to it)
+                    mapOf(PARAM_METADATA to it)
                 }.orEmpty()
             )
             .plus(
                 token?.let {
-                    mapOf(API_PARAM_TOKEN to it)
+                    mapOf(PARAM_TOKEN to it)
                 }.orEmpty()
             )
             .plus(
                 usage?.let {
-                    mapOf(API_PARAM_USAGE to it)
+                    mapOf(PARAM_USAGE to it)
                 }.orEmpty()
             )
             .plus(extraParams)
             .plus(
                 weChatParams?.let {
-                    mapOf(API_PARAM_WECHAT to it.toParamMap())
+                    mapOf(PARAM_WECHAT to it.toParamMap())
                 }.orEmpty()
             )
     }
@@ -254,19 +254,19 @@ class SourceParams private constructor(
             return emptyMap<String, Any>()
                 .plus(
                     appId?.let {
-                        mapOf(FIELD_APPID to it)
+                        mapOf(PARAM_APPID to it)
                     }.orEmpty()
                 )
                 .plus(
                     statementDescriptor?.let {
-                        mapOf(FIELD_STATEMENT_DESCRIPTOR to it)
+                        mapOf(PARAM_STATEMENT_DESCRIPTOR to it)
                     }.orEmpty()
                 )
         }
 
         companion object {
-            private const val FIELD_APPID = "appid"
-            private const val FIELD_STATEMENT_DESCRIPTOR = "statement_descriptor"
+            private const val PARAM_APPID = "appid"
+            private const val PARAM_STATEMENT_DESCRIPTOR = "statement_descriptor"
         }
     }
 
@@ -331,66 +331,65 @@ class SourceParams private constructor(
             return emptyMap<String, Any>()
                 .plus(
                     address?.let {
-                        mapOf(FIELD_ADDRESS to it.toParamMap())
+                        mapOf(PARAM_ADDRESS to it.toParamMap())
                     }.orEmpty()
                 )
                 .plus(
                     email?.let {
-                        mapOf(FIELD_EMAIL to it)
+                        mapOf(PARAM_EMAIL to it)
                     }.orEmpty()
                 )
                 .plus(
                     name?.let {
-                        mapOf(FIELD_NAME to it)
+                        mapOf(PARAM_NAME to it)
                     }.orEmpty()
                 )
                 .plus(
                     phone?.let {
-                        mapOf(FIELD_PHONE to it)
+                        mapOf(PARAM_PHONE to it)
                     }.orEmpty()
                 )
         }
 
         private companion object {
-            private const val FIELD_ADDRESS = "address"
-            private const val FIELD_EMAIL = "email"
-            private const val FIELD_NAME = "name"
-            private const val FIELD_PHONE = "phone"
+            private const val PARAM_ADDRESS = "address"
+            private const val PARAM_EMAIL = "email"
+            private const val PARAM_NAME = "name"
+            private const val PARAM_PHONE = "phone"
         }
     }
 
     companion object {
-        private const val API_PARAM_AMOUNT = "amount"
-        private const val API_PARAM_CURRENCY = "currency"
-        private const val API_PARAM_METADATA = "metadata"
-        private const val API_PARAM_OWNER = "owner"
-        private const val API_PARAM_REDIRECT = "redirect"
-        private const val API_PARAM_TYPE = "type"
-        private const val API_PARAM_TOKEN = "token"
-        private const val API_PARAM_USAGE = "usage"
-        private const val API_PARAM_WECHAT = "wechat"
-        private const val API_PARAM_CLIENT_SECRET = "client_secret"
-        private const val API_PARAM_FLOW = "flow"
-        private const val API_PARAM_KLARNA = "klarna"
-        private const val API_PARAM_SOURCE_ORDER = "source_order"
+        private const val PARAM_AMOUNT = "amount"
+        private const val PARAM_CURRENCY = "currency"
+        private const val PARAM_METADATA = "metadata"
+        private const val PARAM_OWNER = "owner"
+        private const val PARAM_REDIRECT = "redirect"
+        private const val PARAM_TYPE = "type"
+        private const val PARAM_TOKEN = "token"
+        private const val PARAM_USAGE = "usage"
+        private const val PARAM_WECHAT = "wechat"
+        private const val PARAM_CLIENT_SECRET = "client_secret"
+        private const val PARAM_FLOW = "flow"
+        private const val PARAM_KLARNA = "klarna"
+        private const val PARAM_SOURCE_ORDER = "source_order"
+        private const val PARAM_BANK = "bank"
+        private const val PARAM_CARD = "card"
+        private const val PARAM_COUNTRY = "country"
+        private const val PARAM_CVC = "cvc"
+        private const val PARAM_EXP_MONTH = "exp_month"
+        private const val PARAM_EXP_YEAR = "exp_year"
+        private const val PARAM_IBAN = "iban"
+        private const val PARAM_NUMBER = "number"
+        private const val PARAM_RETURN_URL = "return_url"
+        private const val PARAM_STATEMENT_DESCRIPTOR = "statement_descriptor"
+        private const val PARAM_PREFERRED_LANGUAGE = "preferred_language"
 
-        private const val FIELD_BANK = "bank"
-        private const val FIELD_CARD = "card"
-        private const val FIELD_COUNTRY = "country"
-        private const val FIELD_CVC = "cvc"
-        private const val FIELD_EXP_MONTH = "exp_month"
-        private const val FIELD_EXP_YEAR = "exp_year"
-        private const val FIELD_IBAN = "iban"
-        private const val FIELD_NUMBER = "number"
-        private const val FIELD_RETURN_URL = "return_url"
-        private const val FIELD_STATEMENT_DESCRIPTOR = "statement_descriptor"
-        private const val FIELD_PREFERRED_LANGUAGE = "preferred_language"
-
-        private const val VISA_CHECKOUT = "visa_checkout"
-        private const val CALL_ID = "callid"
-        private const val MASTERPASS = "masterpass"
-        private const val TRANSACTION_ID = "transaction_id"
-        private const val CART_ID = "cart_id"
+        private const val PARAM_VISA_CHECKOUT = "visa_checkout"
+        private const val PARAM_CALL_ID = "callid"
+        private const val PARAM_MASTERPASS = "masterpass"
+        private const val PARAM_TRANSACTION_ID = "transaction_id"
+        private const val PARAM_CART_ID = "cart_id"
 
         /**
          * Create P24 Source params.
@@ -418,7 +417,7 @@ class SourceParams private constructor(
             return SourceParams(SourceType.P24)
                 .setAmount(amount)
                 .setCurrency(currency)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setOwner(Owner(
                     email = email,
                     name = name
@@ -452,7 +451,7 @@ class SourceParams private constructor(
             ).toParamMap()
             return SourceParams(SourceType.ALIPAY)
                 .setCurrency(currency)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setUsage(Source.Usage.REUSABLE)
                 .setOwner(ownerMap)
         }
@@ -488,7 +487,7 @@ class SourceParams private constructor(
             return SourceParams(SourceType.ALIPAY)
                 .setCurrency(currency)
                 .setAmount(amount)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setOwner(ownerMap)
         }
 
@@ -548,9 +547,9 @@ class SourceParams private constructor(
                 .setReturnUrl(returnUrl)
                 .setExtraParams(
                     mapOf(
-                        API_PARAM_KLARNA to KlarnaParams(purchaseCountry).toParamMap(),
-                        API_PARAM_FLOW to Source.SourceFlow.REDIRECT,
-                        API_PARAM_SOURCE_ORDER to sourceOrderParams.toParamMap()
+                        PARAM_KLARNA to KlarnaParams(purchaseCountry).toParamMap(),
+                        PARAM_FLOW to Source.SourceFlow.REDIRECT,
+                        PARAM_SOURCE_ORDER to sourceOrderParams.toParamMap()
                     )
                 )
         }
@@ -586,16 +585,16 @@ class SourceParams private constructor(
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
                 .setOwner(ownerMap)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
             val additionalParamsMap = emptyMap<String, Any>()
                 .plus(
                     statementDescriptor?.let {
-                        mapOf(FIELD_STATEMENT_DESCRIPTOR to it)
+                        mapOf(PARAM_STATEMENT_DESCRIPTOR to it)
                     }.orEmpty()
                 )
                 .plus(
                     preferredLanguage?.let {
-                        mapOf(FIELD_PREFERRED_LANGUAGE to it)
+                        mapOf(PARAM_PREFERRED_LANGUAGE to it)
                     }.orEmpty()
                 )
             if (additionalParamsMap.isNotEmpty()) {
@@ -642,10 +641,10 @@ class SourceParams private constructor(
             // Not enforcing all fields to exist at this level.
             // Instead, the server will return an error for invalid data.
             val cardParams = mapOf(
-                FIELD_NUMBER to card.number,
-                FIELD_EXP_MONTH to card.expMonth,
-                FIELD_EXP_YEAR to card.expYear,
-                FIELD_CVC to card.cvc
+                PARAM_NUMBER to card.number,
+                PARAM_EXP_MONTH to card.expMonth,
+                PARAM_EXP_YEAR to card.expYear,
+                PARAM_CVC to card.cvc
             )
             params.setApiParameterMap(cardParams)
             params.setOwner(
@@ -743,10 +742,10 @@ class SourceParams private constructor(
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
                 .setOwner(ownerMap)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
             if (statementDescriptor != null) {
                 params.setApiParameterMap(
-                    mapOf(FIELD_STATEMENT_DESCRIPTOR to statementDescriptor)
+                    mapOf(PARAM_STATEMENT_DESCRIPTOR to statementDescriptor)
                 )
             }
             return params
@@ -778,10 +777,10 @@ class SourceParams private constructor(
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
                 .setOwner(ownerMap)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
             if (statementDescriptor != null) {
                 params.setApiParameterMap(
-                    mapOf(FIELD_STATEMENT_DESCRIPTOR to statementDescriptor)
+                    mapOf(PARAM_STATEMENT_DESCRIPTOR to statementDescriptor)
                 )
             }
             return params
@@ -814,18 +813,18 @@ class SourceParams private constructor(
             val params = SourceParams(SourceType.IDEAL)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setOwner(ownerMap)
 
             val additionalParamsMap = emptyMap<String, Any>()
                 .plus(
                     statementDescriptor?.let {
-                        mapOf(FIELD_STATEMENT_DESCRIPTOR to it)
+                        mapOf(PARAM_STATEMENT_DESCRIPTOR to it)
                     }.orEmpty()
                 )
                 .plus(
                     bank?.let {
-                        mapOf(FIELD_BANK to it)
+                        mapOf(PARAM_BANK to it)
                     }.orEmpty()
                 )
             if (additionalParamsMap.isNotEmpty()) {
@@ -858,7 +857,7 @@ class SourceParams private constructor(
             return SourceParams(SourceType.MULTIBANCO)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setOwner(ownerMap)
         }
 
@@ -924,7 +923,7 @@ class SourceParams private constructor(
             return SourceParams(SourceType.SEPA_DEBIT)
                 .setCurrency(Source.EURO)
                 .setOwner(ownerMap)
-                .setApiParameterMap(mapOf(FIELD_IBAN to iban))
+                .setApiParameterMap(mapOf(PARAM_IBAN to iban))
         }
 
         /**
@@ -947,16 +946,16 @@ class SourceParams private constructor(
             @Size(2) country: String,
             statementDescriptor: String?
         ): SourceParams {
-            val sofortMap = mapOf(FIELD_COUNTRY to country)
+            val sofortMap = mapOf(PARAM_COUNTRY to country)
                 .plus(
                     statementDescriptor?.let {
-                        mapOf(FIELD_STATEMENT_DESCRIPTOR to it)
+                        mapOf(PARAM_STATEMENT_DESCRIPTOR to it)
                     }.orEmpty()
                 )
             return SourceParams(SourceType.SOFORT)
                 .setCurrency(Source.EURO)
                 .setAmount(amount)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
                 .setApiParameterMap(sofortMap)
         }
 
@@ -982,8 +981,8 @@ class SourceParams private constructor(
             return SourceParams(SourceType.THREE_D_SECURE)
                 .setCurrency(currency)
                 .setAmount(amount)
-                .setRedirect(mapOf(FIELD_RETURN_URL to returnUrl))
-                .setApiParameterMap(mapOf(FIELD_CARD to cardId))
+                .setRedirect(mapOf(PARAM_RETURN_URL to returnUrl))
+                .setApiParameterMap(mapOf(PARAM_CARD to cardId))
         }
 
         /**
@@ -1000,7 +999,7 @@ class SourceParams private constructor(
         fun createVisaCheckoutParams(callId: String): SourceParams {
             return SourceParams(SourceType.CARD)
                 .setApiParameterMap(
-                    mapOf(VISA_CHECKOUT to mapOf(CALL_ID to callId)))
+                    mapOf(PARAM_VISA_CHECKOUT to mapOf(PARAM_CALL_ID to callId)))
         }
 
         /**
@@ -1024,11 +1023,11 @@ class SourceParams private constructor(
             cartId: String
         ): SourceParams {
             val map = mapOf(
-                TRANSACTION_ID to transactionId,
-                CART_ID to cartId
+                PARAM_TRANSACTION_ID to transactionId,
+                PARAM_CART_ID to cartId
             )
             return SourceParams(SourceType.CARD)
-                .setApiParameterMap(mapOf(MASTERPASS to map))
+                .setApiParameterMap(mapOf(PARAM_MASTERPASS to map))
         }
 
         /**
@@ -1043,7 +1042,7 @@ class SourceParams private constructor(
         fun createRetrieveSourceParams(
             @Size(min = 1) clientSecret: String
         ): Map<String, String> {
-            return mapOf(API_PARAM_CLIENT_SECRET to clientSecret)
+            return mapOf(PARAM_CLIENT_SECRET to clientSecret)
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardFixtures
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -59,11 +60,11 @@ class StripeNetworkUtilsTest {
     @Test
     fun addUidParamsToPaymentIntent_withSource_addsParamsAtRightLevel() {
         val updatedParams = networkUtils.paramsWithUid(
-            mapOf(ConfirmPaymentIntentParams.API_PARAM_SOURCE_DATA to emptyMap<String, Any>())
+            mapOf(ConfirmPaymentIntentParams.PARAM_SOURCE_DATA to emptyMap<String, Any>())
         )
 
         val updatedData =
-            updatedParams[ConfirmPaymentIntentParams.API_PARAM_SOURCE_DATA] as Map<String, *>
+            updatedParams[ConfirmPaymentIntentParams.PARAM_SOURCE_DATA] as Map<String, *>
         assertEquals(1, updatedParams.size)
         assertTrue(updatedData.containsKey("muid"))
         assertTrue(updatedData.containsKey("guid"))
@@ -72,11 +73,10 @@ class StripeNetworkUtilsTest {
     @Test
     fun addUidParamsToPaymentIntent_withPaymentMethodParams_addsUidAtRightLevel() {
         val updatedParams = networkUtils.paramsWithUid(
-            mapOf(ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_DATA to
+            mapOf(PARAM_PAYMENT_METHOD_DATA to
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap())
         )
-        val updatedData =
-            updatedParams[ConfirmPaymentIntentParams.API_PARAM_PAYMENT_METHOD_DATA] as Map<String, *>
+        val updatedData = updatedParams[PARAM_PAYMENT_METHOD_DATA] as Map<String, *>
         assertEquals(1, updatedParams.size)
         assertTrue(updatedData.containsKey("muid"))
         assertTrue(updatedData.containsKey("guid"))

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.model
 
 import com.stripe.android.CardNumberFixtures.VALID_VISA_NO_SPACES
-import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.API_PARAM_SAVE_PAYMENT_METHOD
-import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.API_PARAM_SOURCE_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_CLIENT_SECRET
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_PAYMENT_METHOD_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.API_PARAM_RETURN_URL
+import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SAVE_PAYMENT_METHOD
+import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SOURCE_ID
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -46,7 +46,7 @@ class ConfirmPaymentIntentParamsTest {
         assertEquals(SOURCE_ID, params.sourceId)
         assertTrue(params.shouldSavePaymentMethod())
 
-        assertTrue(params.toParamMap()[API_PARAM_SAVE_PAYMENT_METHOD] == true)
+        assertTrue(params.toParamMap()[PARAM_SAVE_PAYMENT_METHOD] == true)
     }
 
     @Test
@@ -95,7 +95,7 @@ class ConfirmPaymentIntentParamsTest {
         assertEquals(PM_ID, params.paymentMethodId)
         assertTrue(params.shouldSavePaymentMethod())
 
-        assertTrue(params.toParamMap()[API_PARAM_SAVE_PAYMENT_METHOD] == true)
+        assertTrue(params.toParamMap()[PARAM_SAVE_PAYMENT_METHOD] == true)
     }
 
     @Test
@@ -104,10 +104,10 @@ class ConfirmPaymentIntentParamsTest {
             .createWithSourceId(SOURCE_ID, CLIENT_SECRET, RETURN_URL)
 
         val paramMap = confirmPaymentIntentParams.toParamMap()
-        assertEquals(paramMap[API_PARAM_SOURCE_ID], SOURCE_ID)
-        assertEquals(paramMap[API_PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertEquals(paramMap[API_PARAM_RETURN_URL], RETURN_URL)
-        assertEquals(false, paramMap[API_PARAM_SAVE_PAYMENT_METHOD])
+        assertEquals(paramMap[PARAM_SOURCE_ID], SOURCE_ID)
+        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
+        assertEquals(paramMap[PARAM_RETURN_URL], RETURN_URL)
+        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
     }
 
     @Test
@@ -117,10 +117,10 @@ class ConfirmPaymentIntentParamsTest {
 
         val paramMap = confirmPaymentIntentParams.toParamMap()
 
-        assertEquals(paramMap[API_PARAM_PAYMENT_METHOD_ID], PM_ID)
-        assertEquals(paramMap[API_PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertFalse(paramMap.containsKey(API_PARAM_RETURN_URL))
-        assertEquals(false, paramMap[API_PARAM_SAVE_PAYMENT_METHOD])
+        assertEquals(paramMap[PARAM_PAYMENT_METHOD_ID], PM_ID)
+        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
+        assertFalse(paramMap.containsKey(PARAM_RETURN_URL))
+        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
     }
 
     @Test
@@ -130,10 +130,10 @@ class ConfirmPaymentIntentParamsTest {
 
         val paramMap = confirmPaymentIntentParams.toParamMap()
 
-        assertEquals(paramMap[API_PARAM_PAYMENT_METHOD_ID], PM_ID)
-        assertEquals(paramMap[API_PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertEquals(paramMap[API_PARAM_RETURN_URL], RETURN_URL)
-        assertEquals(false, paramMap[API_PARAM_SAVE_PAYMENT_METHOD])
+        assertEquals(paramMap[PARAM_PAYMENT_METHOD_ID], PM_ID)
+        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
+        assertEquals(paramMap[PARAM_RETURN_URL], RETURN_URL)
+        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
     }
 
     @Test
@@ -153,10 +153,10 @@ class ConfirmPaymentIntentParamsTest {
 
         val paramMap = confirmPaymentIntentParams.toParamMap()
 
-        assertEquals(paramMap[API_PARAM_CLIENT_SECRET], CLIENT_SECRET)
+        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
         assertEquals(paramMap[extraParamKey1], extraParamValue1)
         assertEquals(paramMap[extraParamKey2], extraParamValue2)
-        assertEquals(false, paramMap[API_PARAM_SAVE_PAYMENT_METHOD])
+        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
     }
 
     @Test
@@ -194,7 +194,7 @@ class ConfirmPaymentIntentParamsTest {
             CLIENT_SECRET,
             RETURN_URL
         ).toParamMap()
-        assertTrue(params.containsKey(MandateData.API_PARAM_MANDATE_DATA))
+        assertTrue(params.containsKey(MandateData.PARAM_MANDATE_DATA))
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -59,9 +59,9 @@ class ConfirmSetupIntentParamsTest {
             null
         )
         val params = confirmSetupIntentParams.toParamMap()
-        assertNull(params[ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_DATA])
+        assertNull(params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_DATA])
         assertEquals("pm_12345",
-            params[ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_ID])
+            params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_ID])
     }
 
     @Test
@@ -71,9 +71,9 @@ class ConfirmSetupIntentParamsTest {
             "client_secret", null
         )
         val params = confirmSetupIntentParams.toParamMap()
-        assertNull(params[ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_ID])
+        assertNull(params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_ID])
         val paymentMethodData =
-            params[ConfirmStripeIntentParams.API_PARAM_PAYMENT_METHOD_DATA] as Map<String, Any>
+            params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_DATA] as Map<String, Any>
         assertEquals("card", paymentMethodData["type"])
         assertNotNull(paymentMethodData["card"])
     }


### PR DESCRIPTION
Constants previously had a prefix of `PARAM_`,
`FIELD_`, or `API_PARAM_`.