### PR TITLE
Remove redundant instance fields from PaymentFlowActivity

### DIFF
--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -222,7 +222,7 @@ class PaymentFlowActivityTest : BaseViewTest<PaymentFlowActivity>(PaymentFlowAct
             .sendBroadcast(onShippingInfoProcessedValid)
         assertEquals(View.VISIBLE, paymentFlowActivity.progressBar.visibility)
 
-        paymentFlowActivity.onShippingInfoSaved(SHIPPING_INFO)
+        paymentFlowActivity.onShippingInfoSaved(SHIPPING_INFO, shippingMethods)
         assertEquals(View.GONE, paymentFlowActivity.progressBar.visibility)
     }
 


### PR DESCRIPTION
`shippingMethods` and `defaultShippingMethod` can be passed as
method arguments instead of made into instance fields