### PR TITLE
Update PaymentFlowActivity to support ShippingInformationValidator

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -31,7 +31,6 @@ import com.stripe.example.R
 import com.stripe.example.controller.ErrorDialogHandler
 import com.stripe.example.service.ExampleEphemeralKeyProvider
 import kotlinx.android.synthetic.main.activity_payment_session.*
-import java.util.ArrayList
 import java.util.Currency
 import java.util.Locale
 
@@ -68,11 +67,10 @@ class PaymentSessionActivity : AppCompatActivity() {
                 if (!isValidShippingInfo(shippingInformation)) {
                     shippingInfoProcessedIntent.putExtra(EXTRA_IS_SHIPPING_INFO_VALID, false)
                 } else {
-                    val shippingMethods = createSampleShippingMethods()
                     shippingInfoProcessedIntent
                         .putExtra(EXTRA_IS_SHIPPING_INFO_VALID, true)
-                        .putParcelableArrayListExtra(EXTRA_VALID_SHIPPING_METHODS, shippingMethods)
-                        .putExtra(EXTRA_DEFAULT_SHIPPING_METHOD, shippingMethods.last())
+                        .putParcelableArrayListExtra(EXTRA_VALID_SHIPPING_METHODS, SHIPPING_METHODS)
+                        .putExtra(EXTRA_DEFAULT_SHIPPING_METHOD, SHIPPING_METHODS.last())
                 }
                 localBroadcastManager.sendBroadcast(shippingInfoProcessedIntent)
             }
@@ -172,15 +170,6 @@ class PaymentSessionActivity : AppCompatActivity() {
         } else {
             notSelectedText
         }
-    }
-
-    private fun createSampleShippingMethods(): ArrayList<ShippingMethod> {
-        return arrayListOf(
-            ShippingMethod("UPS Ground", "ups-ground",
-                0, "USD", "Arrives in 3-5 days"),
-            ShippingMethod("FedEx", "fedex",
-                599, "USD", "Arrives tomorrow")
-        )
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -286,6 +275,13 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .build(),
             "Fake Name",
             "(555) 555-5555"
+        )
+
+        private val SHIPPING_METHODS = arrayListOf(
+            ShippingMethod("UPS Ground", "ups-ground",
+                0, "USD", "Arrives in 3-5 days"),
+            ShippingMethod("FedEx", "fedex",
+                599, "USD", "Arrives tomorrow")
         )
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -6,6 +6,8 @@ import androidx.annotation.WorkerThread
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
+import com.stripe.android.view.PaymentFlowActivity
+import com.stripe.android.view.PaymentFlowExtras
 import com.stripe.android.view.SelectShippingMethodWidget
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.android.view.ShippingInfoWidget.CustomizableShippingField
@@ -23,13 +25,12 @@ data class PaymentSessionConfig internal constructor(
     val prepopulatedShippingInfo: ShippingInformation? = null,
     val isShippingInfoRequired: Boolean = false,
     val isShippingMethodRequired: Boolean = false,
-
     @LayoutRes
     @get:LayoutRes
     val addPaymentMethodFooter: Int = 0,
-
     val paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card),
     val allowedShippingCountryCodes: Set<String> = emptySet(),
+
     internal val shippingInformationValidator: ShippingInformationValidator? = null,
     internal val shippingMethodsFactory: ShippingMethodsFactory? = null
 ) : Parcelable {
@@ -79,6 +80,8 @@ data class PaymentSessionConfig internal constructor(
         private var shippingInformation: ShippingInformation? = null
         private var paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card)
         private var allowedShippingCountryCodes: Set<String> = emptySet()
+        private var shippingInformationValidator: ShippingInformationValidator? = null
+        private var shippingMethodsFactory: ShippingMethodsFactory? = null
 
         @LayoutRes
         private var addPaymentMethodFooter: Int = 0
@@ -169,6 +172,32 @@ data class PaymentSessionConfig internal constructor(
             return this
         }
 
+        /**
+         * @param shippingInformationValidator if specified, will be used to validate
+         * [ShippingInformation] in [PaymentFlowActivity] instead of sending a broadcast with
+         * [PaymentFlowExtras.EVENT_SHIPPING_INFO_SUBMITTED].
+         */
+        @JvmSynthetic
+        internal fun setShippingInformationValidator(
+            shippingInformationValidator: ShippingInformationValidator?
+        ): Builder {
+            this.shippingInformationValidator = shippingInformationValidator
+            return this
+        }
+
+        /**
+         * @param shippingMethodsFactory required if [shippingInformationValidator] is specified
+         * and [shippingMethodsRequired] is `true`. Used to create the [ShippingMethod] options
+         * to be displayed in [PaymentFlowActivity].
+         */
+        @JvmSynthetic
+        internal fun setShippingMethodsFactory(
+            shippingMethodsFactory: ShippingMethodsFactory?
+        ): Builder {
+            this.shippingMethodsFactory = shippingMethodsFactory
+            return this
+        }
+
         override fun build(): PaymentSessionConfig {
             return PaymentSessionConfig(
                 hiddenShippingInfoFields = hiddenShippingInfoFields.orEmpty(),
@@ -178,7 +207,9 @@ data class PaymentSessionConfig internal constructor(
                 isShippingMethodRequired = shippingMethodsRequired,
                 addPaymentMethodFooter = addPaymentMethodFooter,
                 paymentMethodTypes = paymentMethodTypes,
-                allowedShippingCountryCodes = allowedShippingCountryCodes
+                allowedShippingCountryCodes = allowedShippingCountryCodes,
+                shippingInformationValidator = shippingInformationValidator,
+                shippingMethodsFactory = shippingMethodsFactory
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -43,6 +43,15 @@ data class PaymentSessionConfig internal constructor(
                 "'$allowedShippingCountryCode' is not a valid country code"
             }
         }
+
+        if (shippingInformationValidator != null && isShippingMethodRequired) {
+            requireNotNull(shippingMethodsFactory) {
+                """
+                If isShippingMethodRequired is true and a ShippingInformationValidator is provided,
+                a ShippingMethodsFactory must also be provided.
+                """.trimIndent()
+            }
+        }
     }
 
     internal interface ShippingInformationValidator : Serializable {
@@ -129,9 +138,8 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
-         * @param shippingMethodsRequired whether a [com.stripe.android.model.ShippingMethod]
-         * should be required. If it is required, a screen with a [SelectShippingMethodWidget]
-         * is shown to collect it.
+         * @param shippingMethodsRequired whether a [ShippingMethod] should be required.
+         * If it is required, a screen with a [SelectShippingMethodWidget] is shown to collect it.
          *
          * Default is `true`.
          */

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -12,6 +12,7 @@ import androidx.viewpager.widget.ViewPager
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession.Companion.EXTRA_PAYMENT_SESSION_DATA
 import com.stripe.android.PaymentSession.Companion.TOKEN_PAYMENT_SESSION
+import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionData
 import com.stripe.android.R
 import com.stripe.android.StripeError
@@ -20,6 +21,10 @@ import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
 import java.lang.ref.WeakReference
 import kotlinx.android.synthetic.main.activity_shipping_flow.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Activity containing a two-part payment flow that allows users to provide a shipping address
@@ -27,16 +32,19 @@ import kotlinx.android.synthetic.main.activity_shipping_flow.*
  */
 class PaymentFlowActivity : StripeActivity() {
 
-    private lateinit var shippingInfoSubmittedBroadcastReceiver: BroadcastReceiver
     private lateinit var paymentFlowPagerAdapter: PaymentFlowPagerAdapter
     private lateinit var paymentSessionData: PaymentSessionData
+    private lateinit var paymentSessionConfig: PaymentSessionConfig
+    private lateinit var customerSession: CustomerSession
+
+    private var shippingInfoSubmittedBroadcastReceiver: BroadcastReceiver? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val args = PaymentFlowActivityStarter.Args.create(intent)
 
-        val customerSession = CustomerSession.getInstance()
+        customerSession = CustomerSession.getInstance()
         customerSession.addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION)
         customerSession.addProductUsageTokenIfValid(TOKEN_PAYMENT_FLOW_ACTIVITY)
         viewStub.layoutResource = R.layout.activity_shipping_flow
@@ -47,7 +55,7 @@ class PaymentFlowActivity : StripeActivity() {
                 "PaymentFlowActivity launched without PaymentSessionData"
             }
 
-        val paymentSessionConfig = args.paymentSessionConfig
+        paymentSessionConfig = args.paymentSessionConfig
 
         val shippingInformation =
             savedInstanceState?.getParcelable(STATE_SHIPPING_INFO)
@@ -75,7 +83,16 @@ class PaymentFlowActivity : StripeActivity() {
             override fun onPageScrollStateChanged(i: Int) {
             }
         })
-        shippingInfoSubmittedBroadcastReceiver = object : BroadcastReceiver() {
+
+        if (paymentSessionConfig.shippingInformationValidator == null) {
+            shippingInfoSubmittedBroadcastReceiver = createShippingInfoSubmittedBroadcastReceiver()
+        }
+
+        title = paymentFlowPagerAdapter.getPageTitle(shipping_flow_viewpager.currentItem)
+    }
+
+    private fun createShippingInfoSubmittedBroadcastReceiver(): BroadcastReceiver {
+        return object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 val isShippingInfoValid = intent.getBooleanExtra(
                     PaymentFlowExtras.EXTRA_IS_SHIPPING_INFO_VALID,
@@ -100,8 +117,6 @@ class PaymentFlowActivity : StripeActivity() {
                 }
             }
         }
-
-        title = paymentFlowPagerAdapter.getPageTitle(shipping_flow_viewpager.currentItem)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -120,16 +135,21 @@ class PaymentFlowActivity : StripeActivity() {
 
     override fun onPause() {
         super.onPause()
-        LocalBroadcastManager.getInstance(this)
-            .unregisterReceiver(shippingInfoSubmittedBroadcastReceiver)
+
+        shippingInfoSubmittedBroadcastReceiver?.let {
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(it)
+        }
     }
 
     override fun onResume() {
         super.onResume()
-        LocalBroadcastManager.getInstance(this).registerReceiver(
-            shippingInfoSubmittedBroadcastReceiver,
-            IntentFilter(PaymentFlowExtras.EVENT_SHIPPING_INFO_PROCESSED)
-        )
+
+        shippingInfoSubmittedBroadcastReceiver?.let {
+            LocalBroadcastManager.getInstance(this).registerReceiver(
+                it,
+                IntentFilter(PaymentFlowExtras.EVENT_SHIPPING_INFO_PROCESSED)
+            )
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -155,7 +175,7 @@ class PaymentFlowActivity : StripeActivity() {
     private fun onShippingInfoValidated(
         customerSession: CustomerSession,
         shippingMethods: List<ShippingMethod>,
-        defaultShippingMethod: ShippingMethod?
+        defaultShippingMethod: ShippingMethod? = null
     ) {
         paymentSessionData.shippingInformation?.let {
             customerSession.setCustomerShippingInformation(it,
@@ -167,11 +187,11 @@ class PaymentFlowActivity : StripeActivity() {
     }
 
     private fun onShippingMethodsReady(
-        validShippingMethods: List<ShippingMethod>,
+        shippingMethods: List<ShippingMethod>,
         defaultShippingMethod: ShippingMethod?
     ) {
         setCommunicatingProgress(false)
-        paymentFlowPagerAdapter.setShippingMethods(validShippingMethods, defaultShippingMethod)
+        paymentFlowPagerAdapter.setShippingMethods(shippingMethods, defaultShippingMethod)
         paymentFlowPagerAdapter.setShippingInfoSaved(true)
         if (hasNextPage()) {
             shipping_flow_viewpager.currentItem = shipping_flow_viewpager.currentItem + 1
@@ -186,7 +206,18 @@ class PaymentFlowActivity : StripeActivity() {
         shippingInfo?.let { shippingInfo ->
             paymentSessionData = paymentSessionData.copy(shippingInformation = shippingInfo)
             setCommunicatingProgress(true)
-            broadcastShippingInfoSubmitted(shippingInfo)
+
+            val shippingInfoValidator =
+                paymentSessionConfig.shippingInformationValidator
+            if (shippingInfoValidator != null) {
+                validateShippingInformation(
+                    shippingInfoValidator,
+                    paymentSessionConfig.shippingMethodsFactory,
+                    shippingInfo
+                )
+            } else {
+                broadcastShippingInfoSubmitted(shippingInfo)
+            }
         }
     }
 
@@ -240,6 +271,42 @@ class PaymentFlowActivity : StripeActivity() {
             shippingMethod = selectShippingMethodWidget.selectedShippingMethod
         ))
         finish()
+    }
+
+    /**
+     * Validate [shippingInformation] using [shippingMethodsFactory]. If valid, use
+     * [shippingMethodsFactory] to create the [ShippingMethod] options.
+     */
+    private fun validateShippingInformation(
+        shippingInfoValidator: PaymentSessionConfig.ShippingInformationValidator,
+        shippingMethodsFactory: PaymentSessionConfig.ShippingMethodsFactory?,
+        shippingInformation: ShippingInformation
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val isValid = shippingInfoValidator.isValid(shippingInformation)
+
+            val errorMessage = if (isValid) {
+                null
+            } else {
+                shippingInfoValidator.getErrorMessage(shippingInformation)
+            }
+
+            val shippingMethods =
+                shippingMethodsFactory?.create(shippingInformation).orEmpty()
+
+            withContext(Dispatchers.Main) {
+                if (isValid) {
+                    // show shipping methods screen
+                    onShippingInfoValidated(
+                        customerSession,
+                        shippingMethods
+                    )
+                } else {
+                    // show error on current screen
+                    onShippingInfoError(errorMessage)
+                }
+            }
+        }
     }
 
     private fun onShippingInfoError(errorMessage: String?) {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionConfigTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.PaymentSessionFixtures.PAYMENT_SESSION_CONFIG
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,16 +16,12 @@ class PaymentSessionConfigTest {
     @Test
     fun testParcel() {
         assertEquals(PAYMENT_SESSION_CONFIG, ParcelUtils.create(PAYMENT_SESSION_CONFIG))
-        assertEquals(
-            PaymentSessionFixtures.PAYMENT_SESSION_CONFIG,
-            ParcelUtils.create(PaymentSessionFixtures.PAYMENT_SESSION_CONFIG)
-        )
     }
 
     @Test
     fun create_withValidCountryCode_succeeds() {
         val allowedShippingCountryCodes = setOf("us", "CA")
-        val config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+        val config = PAYMENT_SESSION_CONFIG.copy(
             allowedShippingCountryCodes = allowedShippingCountryCodes
         )
         assertEquals(allowedShippingCountryCodes, config.allowedShippingCountryCodes)
@@ -32,7 +29,7 @@ class PaymentSessionConfigTest {
 
     @Test
     fun create_withEmptyCountryCodesList_succeeds() {
-        val config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+        val config = PAYMENT_SESSION_CONFIG.copy(
             allowedShippingCountryCodes = emptySet()
         )
         assertTrue(config.allowedShippingCountryCodes.isEmpty())
@@ -40,8 +37,8 @@ class PaymentSessionConfigTest {
 
     @Test
     fun create_withInvalidCountryCode_throwsException() {
-        val exception = assertFailsWith<IllegalArgumentException> {
-            PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+        val exception: IllegalArgumentException = assertFailsWith {
+            PAYMENT_SESSION_CONFIG.copy(
                 allowedShippingCountryCodes = setOf("invalid_country_code")
             )
         }
@@ -49,5 +46,26 @@ class PaymentSessionConfigTest {
             "'invalid_country_code' is not a valid country code",
             exception.message
         )
+    }
+
+    @Test
+    fun create_withShippingMethodsRequiredAndShippingInformationValidatorProvided_withoutShippingMethodsFactory_throwsException() {
+        assertFailsWith<IllegalArgumentException> {
+            PaymentSessionConfig.Builder()
+                .setShippingInfoRequired(true)
+                .setShippingMethodsRequired(true)
+                .setShippingInformationValidator(FakeShippingInfoValidator())
+                .build()
+        }
+    }
+
+    private class FakeShippingInfoValidator : PaymentSessionConfig.ShippingInformationValidator {
+        override fun isValid(shippingInformation: ShippingInformation): Boolean {
+            return true
+        }
+
+        override fun getErrorMessage(shippingInformation: ShippingInformation): String {
+            return ""
+        }
     }
 }


### PR DESCRIPTION
## Summary
If `ShippingInformationValidator` is specified, use that instead
of sending a broadcast to validate the shipping info and
create the `ShippingMethod` options.

By default, `ShippingInformationValidator` and
`ShippingMethodsFactory` are null, and the broadcast mechanism
will be used to do validation and create
`ShippingMethod` options.

## Motivation
Introduce a better mechanism for validating shipping information
and creating shipping methods.

## Testing
Added tests and manually verified via example app
