### PR TITLE
Fix crash related to Add Proguard rules for Kotlin Coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     compileSdkVersion = 29
 
     javaAnnotationVersion = "1.0"
-    coroutineVersion = '1.3.2'
+    coroutineVersion = '1.3.0'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -8,3 +8,15 @@
 
 -keep class com.stripe.android.** { *; }
 -dontwarn com.stripe.android.view.**
+
+
+# Rules for Kotlin Coroutines
+# https://github.com/Kotlin/kotlinx.coroutines/blob/master/ui/kotlinx-coroutines-android/example-app/app/proguard-rules.pro
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {}
+-keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {}
+
+-keepclassmembernames class kotlinx.** {
+    volatile <fields>;
+}


### PR DESCRIPTION
User reported crash:
```
java.lang.IllegalStateException: Module with the Main
dispatcher is missing. Add dependency providing the
Main dispatcher, e.g. 'kotlinx-coroutines-android'
```

Based on comments in related GitHub ticket,
attempting to see if downgrading
`kotlinx-coroutines` to `1.3.0` [0] and
adding Proguard rules [1] fixes the issue.

[0] https://github.com/Kotlin/kotlinx.coroutines/issues/1532#issuecomment-536299897
[1] https://github.com/Kotlin/kotlinx.coroutines/issues/1532#issue-493167262

Fixes #1856