### PR TITLE
Create GooglePayJsonFactory

### DIFF
--- a/example/res/layout/activity_pay_with_google.xml
+++ b/example/res/layout/activity_pay_with_google.xml
@@ -1,22 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:indeterminate="true"
-        android:visibility="invisible"
-        />
+        android:layout_height="wrap_content">
 
-    <include android:id="@+id/btn_buy_pwg"
-             android:layout_width="200dp"
-             android:layout_height="48sp"
-             android:layout_gravity="center_horizontal"
-             layout="@layout/pay_with_google_button"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-</LinearLayout>
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:visibility="invisible"
+                />
+
+            <include android:id="@+id/google_pay_button"
+                     android:layout_width="200dp"
+                     android:layout_height="48sp"
+                     android:layout_gravity="center_horizontal"
+                     layout="@layout/pay_with_google_button"/>
+
+            <TextView
+                android:id="@+id/google_pay_result"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:fontFamily="monospace"
+                android:textSize="12sp"/>
+
+        </LinearLayout>
+    </ScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -1,0 +1,351 @@
+package com.stripe.android
+
+import android.content.Context
+import java.util.Currency
+import java.util.Locale
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A factory for generating [Google Pay JSON request objects](https://developers.google.com/pay/api/android/reference/request-objects)
+ * for Google Pay API version 2.0.
+ */
+class GooglePayJsonFactory constructor(
+    private val googlePayConfig: GooglePayConfig
+) {
+    /**
+     * [PaymentConfiguration] must be instantiated before calling this.
+     */
+    constructor(context: Context) : this(GooglePayConfig(context))
+
+    /**
+     * [IsReadyToPayRequest](https://developers.google.com/pay/api/android/reference/request-objects#IsReadyToPayRequest)
+     */
+    fun createIsReadyToPayRequest(
+        /**
+         * Configure additional fields to be returned for a requested billing address.
+         */
+        billingAddressParameters: BillingAddressParameters? = null,
+
+        /**
+         * If set to true, then the `isReadyToPay()` class method will return `true` if the current
+         * viewer is ready to pay with one or more payment methods specified in
+         * `allowedPaymentMethods`.
+         */
+        existingPaymentMethodRequired: Boolean? = null
+    ): JSONObject {
+        return JSONObject()
+            .put("apiVersion", API_VERSION)
+            .put("apiVersionMinor", API_VERSION_MINOR)
+            .put("allowedPaymentMethods",
+                JSONArray()
+                    .put(createCardPaymentMethod(billingAddressParameters))
+            )
+            .apply {
+                if (existingPaymentMethodRequired != null) {
+                    put("existingPaymentMethodRequired", existingPaymentMethodRequired)
+                }
+            }
+    }
+
+    /**
+     * [PaymentDataRequest](https://developers.google.com/pay/api/android/reference/request-objects#PaymentDataRequest)
+     */
+    fun createPaymentDataRequest(
+        /**
+         * Details about the authorization of the transaction based upon whether the user agrees to
+         * the transaction or not. Includes total price and price status.
+         */
+        transactionInfo: TransactionInfo,
+
+        /**
+         * Configure additional fields to be returned for a requested billing address.
+         */
+        billingAddressParameters: BillingAddressParameters? = null,
+
+        /**
+         * Specify shipping address restrictions.
+         */
+        shippingAddressParameters: ShippingAddressParameters? = null,
+
+        /**
+         * Set to true to request an email address.
+         */
+        isEmailRequired: Boolean = false,
+
+        /**
+         * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
+         * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant” message is displayed in the payment sheet.
+         */
+        merchantInfo: MerchantInfo? = null
+    ): JSONObject {
+        return JSONObject()
+            .put("apiVersion", API_VERSION)
+            .put("apiVersionMinor", API_VERSION_MINOR)
+            .put("allowedPaymentMethods",
+                JSONArray()
+                    .put(createCardPaymentMethod(billingAddressParameters))
+            )
+            .put("transactionInfo", createTransactionInfo(transactionInfo))
+            .put("emailRequired", isEmailRequired)
+            .apply {
+                if (shippingAddressParameters?.isRequired == true) {
+                    put("shippingAddressRequired", true)
+                    put("shippingAddressParameters",
+                        createShippingAddressParameters(shippingAddressParameters)
+                    )
+                }
+
+                if (merchantInfo != null && !merchantInfo.merchantName.isNullOrEmpty()) {
+                    put("merchantInfo", JSONObject()
+                        .put("merchantName", merchantInfo.merchantName)
+                    )
+                }
+            }
+    }
+
+    private fun createTransactionInfo(
+        transactionInfo: TransactionInfo
+    ): JSONObject {
+        return JSONObject()
+            .put("currencyCode", transactionInfo.currencyCode)
+            .put("totalPriceStatus", transactionInfo.totalPriceStatus.code)
+            .apply {
+                transactionInfo.countryCode?.let {
+                    put("countryCode", it)
+                }
+
+                transactionInfo.transactionId?.let {
+                    put("transactionId", it)
+                }
+
+                transactionInfo.totalPrice?.let {
+                    put("totalPrice",
+                        PayWithGoogleUtils.getPriceString(
+                            it, Currency.getInstance(transactionInfo.currencyCode)
+                        )
+                    )
+                }
+
+                transactionInfo.totalPriceLabel?.let {
+                    put("totalPriceLabel", it)
+                }
+
+                transactionInfo.checkoutOption?.let {
+                    put("checkoutOption", it.code)
+                }
+            }
+    }
+
+    private fun createShippingAddressParameters(
+        shippingAddressParameters: ShippingAddressParameters
+    ): JSONObject {
+        return JSONObject()
+            .put("allowedCountryCodes",
+                JSONArray(shippingAddressParameters.allowedCountryCodes))
+            .put("phoneNumberRequired",
+                shippingAddressParameters.phoneNumberRequired)
+    }
+
+    private fun createCardPaymentMethod(
+        billingAddressParameters: BillingAddressParameters?
+    ): JSONObject {
+        val cardPaymentMethodParams = createBaseCardPaymentMethodParams()
+            .apply {
+                if (billingAddressParameters?.isRequired == true) {
+                    put("billingAddressRequired", true)
+                    put("billingAddressParameters",
+                        JSONObject()
+                            .put("phoneNumberRequired",
+                                billingAddressParameters.isPhoneNumberRequired)
+                            .put("format", billingAddressParameters.format.code)
+                    )
+                }
+            }
+
+        return JSONObject()
+            .put("type", CARD_PAYMENT_METHOD)
+            .put("parameters", cardPaymentMethodParams)
+            .put("tokenizationSpecification", googlePayConfig.tokenizationSpecification)
+    }
+
+    private fun createBaseCardPaymentMethodParams(): JSONObject {
+        return JSONObject()
+            .put("allowedAuthMethods", JSONArray(ALLOWED_AUTH_METHODS))
+            .put("allowedCardNetworks", JSONArray(ALLOWED_CARD_NETWORKS))
+    }
+
+    /**
+     * [BillingAddressParameters](https://developers.google.com/pay/api/android/reference/request-objects#BillingAddressParameters)
+     *
+     * Configure additional fields to be returned for a requested billing address.
+     */
+    data class BillingAddressParameters @JvmOverloads constructor(
+        internal val isRequired: Boolean = false,
+
+        /**
+         * Billing address format required to complete the transaction.
+         */
+        internal val format: Format = Format.Min,
+
+        /**
+         * Set to true if a phone number is required to process the transaction.
+         */
+        internal val isPhoneNumberRequired: Boolean = false
+    ) {
+        /**
+         * Billing address format required to complete the transaction.
+         */
+        enum class Format(internal val code: String) {
+            /**
+             * Name, country code, and postal code (default).
+             */
+            Min("MIN"),
+
+            /**
+             * Name, street address, locality, region, country code, and postal code.
+             */
+            Full("FULL")
+        }
+    }
+
+    /**
+     * [TransactionInfo](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo)
+     */
+    data class TransactionInfo @JvmOverloads constructor(
+        /**
+         * ISO 4217 alphabetic currency code.
+         */
+        internal val currencyCode: String,
+
+        /**
+         * The status of the total price used.
+         */
+        internal val totalPriceStatus: TotalPriceStatus,
+
+        /**
+         * ISO 3166-1 alpha-2 country code where the transaction is processed.
+         * This is required for merchants based in European Economic Area (EEA) countries.
+         */
+        internal val countryCode: String? = null,
+
+        /**
+         * A unique ID that identifies a transaction attempt. Merchants may use an existing ID or
+         * generate a specific one for Google Pay transaction attempts. This field is required
+         * when you send callbacks to the Google Transaction Events API.
+         */
+        internal val transactionId: String? = null,
+
+        /**
+         * Total monetary value of the transaction with an optional decimal precision of two
+         * decimal places. This field is required unless totalPriceStatus is set to
+         * NOT_CURRENTLY_KNOWN.
+         *
+         * The format of the string should follow the regex format: ^[0-9]+(\.[0-9][0-9])?$
+         */
+        internal val totalPrice: Int? = null,
+
+        /**
+         * Custom label for the total price within the display items.
+         */
+        internal val totalPriceLabel: String? = null,
+
+        /**
+         * Affects the submit button text displayed in the Google Pay payment sheet.
+         */
+        internal val checkoutOption: CheckoutOption? = null
+    ) {
+        /**
+         * The status of the total price used.
+         */
+        enum class TotalPriceStatus(internal val code: String) {
+            /**
+             * Used for a capability check. Do not use this property if the transaction is
+             * processed in an EEA country.
+             */
+            NotCurrentlyKnown("NOT_CURRENTLY_KNOWN"),
+
+            /**
+             * Total price may adjust based on the details of the response, such as sales tax
+             * collected based on a billing address.
+             */
+            Estimated("ESTIMATED"),
+
+            /**
+             * Total price doesn't change from the amount presented to the shopper.
+             */
+            Final("FINAL")
+        }
+
+        /**
+         * Affects the submit button text displayed in the Google Pay payment sheet.
+         */
+        enum class CheckoutOption(internal val code: String) {
+            /**
+             * Standard text applies for the given totalPriceStatus (default).
+             */
+            Default("DEFAULT"),
+
+            /**
+             * The selected payment method is charged immediately after the payer confirms their
+             * selections. This option is only available when totalPriceStatus is set to FINAL.
+             */
+            CompleteImmediatePurchase("COMPLETE_IMMEDIATE_PURCHASE")
+        }
+    }
+
+    /**
+     * [ShippingAddressParameters](https://developers.google.com/pay/api/android/reference/request-objects#ShippingAddressParameters)
+     */
+    data class ShippingAddressParameters @JvmOverloads constructor(
+        /**
+         * Set to true to request a full shipping address.
+         */
+        internal val isRequired: Boolean = false,
+
+        /**
+         * ISO 3166-1 alpha-2 country code values of the countries where shipping is allowed.
+         * If this object isn't specified, all shipping address countries are allowed.
+         */
+        internal val allowedCountryCodes: Set<String> = emptySet(),
+
+        /**
+         * Set to true if a phone number is required for the provided shipping address.
+         */
+        internal val phoneNumberRequired: Boolean = false
+    ) {
+        init {
+            val countryCodes = Locale.getISOCountries()
+            allowedCountryCodes.forEach { allowedShippingCountryCode ->
+                require(
+                    countryCodes.any { allowedShippingCountryCode == it }
+                ) {
+                    "'$allowedShippingCountryCode' is not a valid country code"
+                }
+            }
+        }
+    }
+
+    /**
+     * [MerchantInfo](https://developers.google.com/pay/api/android/reference/request-objects#MerchantInfo)
+     */
+    data class MerchantInfo(
+        /**
+         * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
+         * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant”
+         * message is displayed in the payment sheet.
+         */
+        internal val merchantName: String? = null
+    )
+
+    companion object {
+        private const val API_VERSION = 2
+        private const val API_VERSION_MINOR = 0
+
+        private const val CARD_PAYMENT_METHOD = "CARD"
+
+        private val ALLOWED_AUTH_METHODS = listOf("PAN_ONLY", "CRYPTOGRAM_3DS")
+        private val ALLOWED_CARD_NETWORKS =
+            listOf("AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA")
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
@@ -18,7 +18,7 @@ object PayWithGoogleUtils {
      * @return a String that can be used as a Pay with Google price string
      */
     @JvmStatic
-    fun getPriceString(price: Long, currency: Currency): String {
+    fun getPriceString(price: Int, currency: Currency): String {
         val fractionDigits = currency.defaultFractionDigits
         val totalLength = price.toString().length
         val builder = StringBuilder()

--- a/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -1,0 +1,158 @@
+package com.stripe.android
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.json.JSONObject
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GooglePayJsonFactoryTest {
+
+    private val googlePayConfig = GooglePayConfig(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+    private val factory = GooglePayJsonFactory(googlePayConfig)
+
+    @Test
+    fun testCreateIsReadyToPayRequestJson_withoutArgs() {
+        val isReadyToPayRequestJson = factory.createIsReadyToPayRequest()
+        val expectedJson = JSONObject("""
+            {
+                "apiVersion": 2,
+                "apiVersionMinor": 0,
+                "allowedPaymentMethods": [{
+                    "type": "CARD",
+                    "parameters": {
+                        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"]
+                    },
+                    "tokenizationSpecification": {
+                        "type": "PAYMENT_GATEWAY",
+                        "parameters": {
+                            "gateway": "stripe",
+                            "stripe:version": "2019-11-05",
+                            "stripe:publishableKey": "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
+                        }
+                    }
+                }]
+            }
+        """.trimIndent())
+        assertEquals(expectedJson.toString(), isReadyToPayRequestJson.toString())
+    }
+
+    @Test
+    fun testCreateIsReadyToPayRequestJson_withArgs() {
+        val isReadyToPayRequestJson = factory.createIsReadyToPayRequest(
+            billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(
+                isRequired = true,
+                format = GooglePayJsonFactory.BillingAddressParameters.Format.Full,
+                isPhoneNumberRequired = true
+            ),
+            existingPaymentMethodRequired = true
+        )
+        val expectedJson = JSONObject("""
+            {
+                "apiVersion": 2,
+                "apiVersionMinor": 0,
+                "allowedPaymentMethods": [{
+                    "type": "CARD",
+                    "parameters": {
+                        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+                        "billingAddressRequired": true,
+                        "billingAddressParameters": {
+                            "phoneNumberRequired": true,
+                            "format": "FULL"
+                        }
+                    },
+                    "tokenizationSpecification": {
+                        "type": "PAYMENT_GATEWAY",
+                        "parameters": {
+                            "gateway": "stripe",
+                            "stripe:version": "2019-11-05",
+                            "stripe:publishableKey": "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
+                        }
+                    }
+                }],
+                "existingPaymentMethodRequired": true
+            }
+        """.trimIndent())
+        assertEquals(expectedJson.toString(), isReadyToPayRequestJson.toString())
+    }
+
+    @Test
+    fun testCreatePaymentMethodRequestJson() {
+        val transactionId = UUID.randomUUID().toString()
+        val expectedJson = JSONObject("""
+            {
+                "apiVersion": 2,
+                "apiVersionMinor": 0,
+                "allowedPaymentMethods": [{
+                    "type": "CARD",
+                    "parameters": {
+                        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+                        "billingAddressRequired": true,
+                        "billingAddressParameters": {
+                            "phoneNumberRequired": true,
+                            "format": "FULL"
+                        }
+                    },
+                    "tokenizationSpecification": {
+                        "type": "PAYMENT_GATEWAY",
+                        "parameters": {
+                            "gateway": "stripe",
+                            "stripe:version": "2019-11-05",
+                            "stripe:publishableKey": "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
+                        }
+                    }
+                }],
+                "transactionInfo": {
+                    "currencyCode": "USD",
+                    "totalPriceStatus": "ESTIMATED",
+                    "countryCode": "US",
+                    "transactionId": "$transactionId",
+                    "totalPrice": "5.00",
+                    "totalPriceLabel": "Your total price",
+                    "checkoutOption": "COMPLETE_IMMEDIATE_PURCHASE"
+                },
+                "emailRequired": false,
+                "shippingAddressRequired": true,
+                "shippingAddressParameters": {
+                    "allowedCountryCodes": ["US", "DE"],
+                    "phoneNumberRequired": true
+                },
+                "merchantInfo": {
+                    "merchantName": "Widget Store"
+                }
+            }
+        """.trimIndent())
+
+        val createPaymentDataRequestJson = factory.createPaymentDataRequest(
+            transactionInfo = GooglePayJsonFactory.TransactionInfo(
+                currencyCode = "USD",
+                totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+                totalPrice = 500,
+                countryCode = "US",
+                transactionId = transactionId,
+                totalPriceLabel = "Your total price",
+                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
+            ),
+            billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(
+                isRequired = true,
+                format = GooglePayJsonFactory.BillingAddressParameters.Format.Full,
+                isPhoneNumberRequired = true
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                merchantName = "Widget Store"
+            ),
+            shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
+                isRequired = true,
+                allowedCountryCodes = setOf("US", "DE"),
+                phoneNumberRequired = true
+            )
+        )
+
+        assertEquals(expectedJson.toString(), createPaymentDataRequestJson.toString())
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
@@ -19,38 +19,38 @@ class PayWithGoogleUtilsTest {
 
     @Test
     fun getPriceString_whenCurrencyWithDecimals_returnsExpectedValue() {
-        val priceString = getPriceString(100L, Currency.getInstance("USD"))
+        val priceString = getPriceString(100, Currency.getInstance("USD"))
         assertEquals("1.00", priceString)
 
-        val littlePrice = getPriceString(8L, Currency.getInstance("EUR"))
+        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
         assertEquals("0.08", littlePrice)
 
-        val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
+        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
         assertEquals("200000.00", bigPrice)
     }
 
     @Test
     fun getPriceString_whenLocaleWithCommas_returnsExpectedValue() {
         Locale.setDefault(Locale.FRENCH)
-        val priceString = getPriceString(100L, Currency.getInstance("USD"))
+        val priceString = getPriceString(100, Currency.getInstance("USD"))
         assertEquals("1.00", priceString)
 
-        val littlePrice = getPriceString(8L, Currency.getInstance("EUR"))
+        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
         assertEquals("0.08", littlePrice)
 
-        val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
+        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
         assertEquals("200000.00", bigPrice)
     }
 
     @Test
     fun getPriceString_whenCurrencyWithoutDecimals_returnsExpectedValue() {
-        val priceString = getPriceString(250L, Currency.getInstance("JPY"))
+        val priceString = getPriceString(250, Currency.getInstance("JPY"))
         assertEquals("250", priceString)
 
-        val bigPrice = getPriceString(250000L, Currency.getInstance("KRW"))
+        val bigPrice = getPriceString(250000, Currency.getInstance("KRW"))
         assertEquals("250000", bigPrice)
 
-        val littlePrice = getPriceString(7L, Currency.getInstance("CLP"))
+        val littlePrice = getPriceString(7, Currency.getInstance("CLP"))
         assertEquals("7", littlePrice)
     }
 }


### PR DESCRIPTION
## Summary
Create JSON representation of Google Pay Requests
https://developers.google.com/pay/api/android/reference/request-objects

- IsReadyToPayRequest
- PaymentMethodDataRequest

Update `PayWithGoogleActivity` to use `GooglePayJsonFactory`

## Motivation
Simplify creation of Google Pay JSON requests

## Testing
Added unit tests and manually verified via Google Pay example activity