### PR TITLE
Update configuration of example app

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -15,6 +15,16 @@
         android:supportsRtl="true"
         tools:ignore="AllowBackup">
 
+        <meta-data
+            android:name="com.stripe.example.metadata.backend_url"
+            android:value="${BACKEND_URL}" />
+        <meta-data
+            android:name="com.stripe.example.metadata.publishable_key"
+            android:value="${PUBLISHABLE_KEY}" />
+        <meta-data
+            android:name="com.stripe.example.metadata.stripe_account_id"
+            android:value="${STRIPE_ACCOUNT_ID}" />
+
         <!-- Enables the Google Payment API -->
         <meta-data
             android:name="com.google.android.gms.wallet.api.enabled"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,21 +11,26 @@ configurations {
 
 // Read values from gradle.properties or system environment variable
 def getBackendUrl() {
-    return hasProperty('STRIPE_EXAMPLE_BACKEND_URL') ?
-            STRIPE_EXAMPLE_BACKEND_URL :
-            System.getenv('STRIPE_EXAMPLE_BACKEND_URL')
+    return readProperty('STRIPE_EXAMPLE_BACKEND_URL')
 }
 
 def getPublishableKey() {
-    return hasProperty('STRIPE_EXAMPLE_PUBLISHABLE_KEY') ?
-            STRIPE_EXAMPLE_PUBLISHABLE_KEY :
-            System.getenv('STRIPE_EXAMPLE_PUBLISHABLE_KEY')
+    return readProperty('STRIPE_EXAMPLE_PUBLISHABLE_KEY')
 }
 
 def getAccountId() {
-    return hasProperty('STRIPE_ACCOUNT_ID') ?
-            STRIPE_ACCOUNT_ID :
-            System.getenv('STRIPE_ACCOUNT_ID')
+    return readProperty('STRIPE_ACCOUNT_ID')
+}
+
+private def readProperty(name) {
+    final String propValue
+    if (hasProperty(name)) {
+        propValue = property(name)
+    } else {
+        propValue = System.getenv(name)
+    }
+
+    return propValue?.trim() ? propValue : ""
 }
 
 dependencies {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,6 +9,25 @@ configurations {
     ktlint
 }
 
+// Read values from gradle.properties or system environment variable
+def getBackendUrl() {
+    return hasProperty('STRIPE_EXAMPLE_BACKEND_URL') ?
+            STRIPE_EXAMPLE_BACKEND_URL :
+            System.getenv('STRIPE_EXAMPLE_BACKEND_URL')
+}
+
+def getPublishableKey() {
+    return hasProperty('STRIPE_EXAMPLE_PUBLISHABLE_KEY') ?
+            STRIPE_EXAMPLE_PUBLISHABLE_KEY :
+            System.getenv('STRIPE_EXAMPLE_PUBLISHABLE_KEY')
+}
+
+def getAccountId() {
+    return hasProperty('STRIPE_ACCOUNT_ID') ?
+            STRIPE_ACCOUNT_ID :
+            System.getenv('STRIPE_ACCOUNT_ID')
+}
+
 dependencies {
     implementation project(':stripe')
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -62,6 +81,12 @@ android {
         minSdkVersion 19
         targetSdkVersion rootProject.ext.compileSdkVersion
         multiDexEnabled true
+
+        manifestPlaceholders = [
+                BACKEND_URL: getBackendUrl(),
+                PUBLISHABLE_KEY: getPublishableKey(),
+                STRIPE_ACCOUNT_ID: getAccountId()
+        ]
     }
     packagingOptions {
         exclude 'LICENSE.txt'

--- a/example/src/main/java/com/stripe/example/Settings.kt
+++ b/example/src/main/java/com/stripe/example/Settings.kt
@@ -1,26 +1,66 @@
 package com.stripe.example
 
+import android.content.Context
+import android.content.pm.PackageManager
+
 /**
  * See [Configuring the example app](https://github.com/stripe/stripe-android#building-the-example-project)
  * for instructions on how to configure the app before running it.
  */
-internal object Settings {
-    /**
-     * Set to the base URL of your test backend. If you are using
-     * [example-ios-backend](https://github.com/stripe/example-ios-backend),
-     * the URL will be something like `https://hidden-beach-12345.herokuapp.com/`.
-     */
-    const val BASE_URL = "put your base url here"
+class Settings(context: Context) {
+    private val appContext = context.applicationContext
+    private val backendMetadata = getMetadata(METADATA_KEY_BACKEND_URL_KEY)
+    private val publishableKeyMetadata = getMetadata(METADATA_KEY_PUBLISHABLE_KEY)
+    private val stripeAccountIdMetadata = getMetadata(METADATA_KEY_STRIPE_ACCOUNT_ID)
 
-    /**
-     * Set to publishable key from https://dashboard.stripe.com/test/apikeys
-     */
-    const val PUBLISHABLE_KEY = "pk_test_your_key_goes_here"
+    val backendUrl: String
+        get() {
+            return backendMetadata ?: BASE_URL
+        }
 
-    /**
-     * Optionally, set to a Connect Account id to use for API requests to test Connect
-     *
-     * See https://dashboard.stripe.com/test/connect/accounts/overview
-     */
-    val STRIPE_ACCOUNT_ID: String? = null
+    val publishableKey: String
+        get() {
+            return publishableKeyMetadata ?: PUBLISHABLE_KEY
+        }
+
+    val stripeAccountId: String?
+        get() {
+            return stripeAccountIdMetadata ?: STRIPE_ACCOUNT_ID
+        }
+
+    private fun getMetadata(key: String): String? {
+        return appContext.packageManager
+            .getApplicationInfo(appContext.packageName, PackageManager.GET_META_DATA)
+            .metaData
+            .getString(key)
+            .takeIf { it?.isNotBlank() == true }
+    }
+
+    private companion object {
+        /**
+         * Set to the base URL of your test backend. If you are using
+         * [example-ios-backend](https://github.com/stripe/example-ios-backend),
+         * the URL will be something like `https://hidden-beach-12345.herokuapp.com/`.
+         */
+        private const val BASE_URL = "put your base url here"
+
+        /**
+         * Set to publishable key from https://dashboard.stripe.com/test/apikeys
+         */
+        private const val PUBLISHABLE_KEY = "pk_test_your_key_goes_here"
+
+        /**
+         * Optionally, set to a Connect Account id to use for API requests to test Connect
+         *
+         * See https://dashboard.stripe.com/test/connect/accounts/overview
+         */
+        private val STRIPE_ACCOUNT_ID: String? = null
+
+        private const val METADATA_KEY_BACKEND_URL_KEY =
+            "com.stripe.example.metadata.backend_url"
+        private const val METADATA_KEY_PUBLISHABLE_KEY =
+            "com.stripe.example.metadata.publishable_key"
+        private const val METADATA_KEY_STRIPE_ACCOUNT_ID =
+            "com.stripe.example.metadata.stripe_account_id"
+    }
 }

--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -30,7 +30,7 @@ class CustomerSessionActivity : AppCompatActivity() {
         errorDialogHandler = ErrorDialogHandler(this)
         CustomerSession.initCustomerSession(
             this,
-            ExampleEphemeralKeyProvider(),
+            ExampleEphemeralKeyProvider(this),
             false
         )
 

--- a/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
@@ -32,7 +32,7 @@ public class FpxPaymentActivity extends AppCompatActivity {
         setContentView(R.layout.activity_fpx_payment);
         setTitle(R.string.fpx_payment_example);
 
-        PaymentConfiguration.init(this, Settings.PUBLISHABLE_KEY);
+        PaymentConfiguration.init(this, new Settings(this).getPublishableKey());
 
         findViewById(R.id.btn_select_payment_method)
                 .setOnClickListener(view -> launchAddPaymentMethod());

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -10,6 +10,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentConfiguration
@@ -25,7 +26,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.example.R
-import com.stripe.example.module.RetrofitFactory
+import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
 import com.stripe.example.service.ExampleEphemeralKeyProvider
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -54,7 +55,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
             .commit()
     }
 
-    class LauncherFragment : androidx.fragment.app.Fragment() {
+    class LauncherFragment : Fragment() {
 
         private val compositeDisposable = CompositeDisposable()
 
@@ -71,7 +72,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
         override fun onActivityCreated(savedInstanceState: Bundle?) {
             super.onActivityCreated(savedInstanceState)
 
-            backendApi = RetrofitFactory.instance.create(BackendApi::class.java)
+            backendApi = BackendApiFactory(requireContext()).create()
             stripe = Stripe(
                 requireContext(),
                 PaymentConfiguration.getInstance(requireContext()).publishableKey
@@ -274,7 +275,10 @@ class FragmentExamplesActivity : AppCompatActivity() {
         }
 
         private fun createCustomerSession(): CustomerSession {
-            CustomerSession.initCustomerSession(requireContext(), ExampleEphemeralKeyProvider())
+            CustomerSession.initCustomerSession(
+                requireContext(),
+                ExampleEphemeralKeyProvider(requireContext())
+            )
             val customerSession = CustomerSession.getInstance()
             customerSession.retrieveCurrentCustomer(
                 object : CustomerSession.CustomerRetrievalListener {

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -20,7 +20,7 @@ class LauncherActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_launcher)
 
-        PaymentConfiguration.init(this, Settings.PUBLISHABLE_KEY)
+        PaymentConfiguration.init(this, Settings(this).publishableKey)
 
         val linearLayoutManager = LinearLayoutManager(this)
             .apply {

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -16,7 +16,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
 import com.stripe.example.Settings
-import com.stripe.example.module.RetrofitFactory
+import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -39,11 +39,11 @@ class PaymentAuthActivity : AppCompatActivity() {
     private lateinit var backendApi: BackendApi
     private lateinit var statusTextView: TextView
 
-    private val stripeAccountId: String? = Settings.STRIPE_ACCOUNT_ID
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_payment_auth)
+
+        val stripeAccountId = Settings(this).stripeAccountId
 
         val uiCustomization =
             PaymentAuthConfig.Stripe3ds2UiCustomization.Builder().build()
@@ -59,7 +59,7 @@ class PaymentAuthActivity : AppCompatActivity() {
             statusTextView.text = savedInstanceState.getString(STATE_STATUS)
         }
 
-        backendApi = RetrofitFactory.instance.create(BackendApi::class.java)
+        backendApi = BackendApiFactory(this).create()
         val publishableKey = PaymentConfiguration.getInstance(this).publishableKey
         stripe = Stripe(this, publishableKey,
             stripeAccountId = stripeAccountId,

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -94,7 +94,7 @@ class PaymentSessionActivity : AppCompatActivity() {
     private fun createCustomerSession(): CustomerSession {
         CustomerSession.initCustomerSession(
             this,
-            ExampleEphemeralKeyProvider(),
+            ExampleEphemeralKeyProvider(this),
             false
         )
         return CustomerSession.getInstance()

--- a/example/src/main/java/com/stripe/example/module/BackendApiFactory.kt
+++ b/example/src/main/java/com/stripe/example/module/BackendApiFactory.kt
@@ -1,8 +1,10 @@
 package com.stripe.example.module
 
+import android.content.Context
 import com.facebook.stetho.okhttp3.StethoInterceptor
 import com.google.gson.GsonBuilder
 import com.stripe.example.Settings
+import com.stripe.example.service.BackendApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -12,10 +14,11 @@ import retrofit2.converter.gson.GsonConverterFactory
 /**
  * Factory to generate our Retrofit instance.
  */
-object RetrofitFactory {
-    val instance: Retrofit
+class BackendApiFactory internal constructor(private val backendUrl: String) {
 
-    init {
+    constructor(context: Context) : this(Settings(context).backendUrl)
+
+    fun create(): BackendApi {
         // Set your desired log level. Use Level.BODY for debugging errors.
         // Adding Rx so the calls can be Observable, and adding a Gson converter with
         // leniency to make parsing the results simple.
@@ -31,11 +34,12 @@ object RetrofitFactory {
             .setLenient()
             .create()
 
-        instance = Retrofit.Builder()
+        return Retrofit.Builder()
             .addConverterFactory(GsonConverterFactory.create(gson))
             .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-            .baseUrl(Settings.BASE_URL)
+            .baseUrl(backendUrl)
             .client(httpClient)
             .build()
+            .create(BackendApi::class.java)
     }
 }

--- a/example/src/main/java/com/stripe/example/service/ExampleEphemeralKeyProvider.kt
+++ b/example/src/main/java/com/stripe/example/service/ExampleEphemeralKeyProvider.kt
@@ -1,10 +1,12 @@
 package com.stripe.example.service
 
+import android.content.Context
 import android.util.Log
 import androidx.annotation.Size
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.EphemeralKeyUpdateListener
-import com.stripe.example.module.RetrofitFactory
+import com.stripe.example.Settings
+import com.stripe.example.module.BackendApiFactory
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -14,11 +16,14 @@ import java.io.IOException
  * An implementation of [EphemeralKeyProvider] that can be used to generate
  * ephemeral keys on the backend.
  */
-class ExampleEphemeralKeyProvider : EphemeralKeyProvider {
+internal class ExampleEphemeralKeyProvider constructor(
+    backendUrl: String
+) : EphemeralKeyProvider {
+
+    constructor(context: Context) : this(Settings(context).backendUrl)
 
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
-    private val backendApi: BackendApi =
-        RetrofitFactory.instance.create(BackendApi::class.java)
+    private val backendApi: BackendApi = BackendApiFactory(backendUrl).create()
 
     override fun createEphemeralKey(
         @Size(min = 4) apiVersion: String,


### PR DESCRIPTION
**Summary**
- Add logic to read configuration settings from local
  `gradle.properties` or environment variables and write out
  to `AndroidManifest.xml` at build time.
- Update `Settings` to be a class that takes a `Context`
  to read metadata from `AndroidManifest.xml`.
  Retain constants in `Settings` to preserve existing
  functionality.
- Update `RetrofitFactory` accordingly.

**Motivation**
Enable Espresso testing of the example app without
hardcoding config values by setting them in Travis
environment variables [0].

[0] https://docs.travis-ci.com/user/environment-variables/