### PR TITLE
Use ViewHolders in PaymentFlowPagerAdapter

### DIFF
--- a/stripe/res/layout/activity_enter_shipping_info.xml
+++ b/stripe/res/layout/activity_enter_shipping_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
 


### PR DESCRIPTION
This further prepares `PaymentFlowPagerAdapter` for migration to ViewPager2.

In addition, fix a layout bug in `activity_enter_shipping_info.xml`.
