### PR TITLE
Move more logic from PaymentFlowActivity to PaymentFlowViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
@@ -22,7 +22,7 @@ class PaymentFlowActivityStarter :
     @Parcelize
     data class Args internal constructor(
         internal val paymentSessionConfig: PaymentSessionConfig,
-        internal val paymentSessionData: PaymentSessionData?,
+        internal val paymentSessionData: PaymentSessionData,
         internal val isPaymentSessionActive: Boolean
     ) : ActivityStarter.Args {
         class Builder : ObjectBuilder<Args> {
@@ -49,14 +49,18 @@ class PaymentFlowActivityStarter :
                 return Args(
                     paymentSessionConfig = paymentSessionConfig
                         ?: PaymentSessionConfig.Builder().build(),
-                    paymentSessionData = paymentSessionData,
+                    paymentSessionData = requireNotNull(paymentSessionData) {
+                        "PaymentFlowActivity launched without PaymentSessionData"
+                    },
                     isPaymentSessionActive = isPaymentSessionActive
                 )
             }
         }
 
         companion object {
-            internal val DEFAULT = Builder().build()
+            internal val DEFAULT = Builder()
+                .setPaymentSessionData(PaymentSessionData())
+                .build()
 
             @JvmStatic
             fun create(intent: Intent): Args {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
@@ -5,24 +5,32 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.CustomerSession
+import com.stripe.android.PaymentSessionConfig
+import com.stripe.android.PaymentSessionData
 import com.stripe.android.StripeError
 import com.stripe.android.model.Customer
 import com.stripe.android.model.ShippingInformation
+import com.stripe.android.model.ShippingMethod
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 internal class PaymentFlowViewModel(
-    private val customerSession: CustomerSession
+    private val customerSession: CustomerSession,
+    internal var paymentSessionData: PaymentSessionData,
+    private val workScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : ViewModel() {
 
     @JvmSynthetic
     internal fun saveCustomerShippingInformation(
         shippingInformation: ShippingInformation
-    ): LiveData<Result<*>> {
-        val resultData = MutableLiveData<Result<*>>()
+    ): LiveData<SaveCustomerShippingInfoResult<*>> {
+        val resultData = MutableLiveData<SaveCustomerShippingInfoResult<*>>()
         customerSession.setCustomerShippingInformation(
             shippingInformation,
             object : CustomerSession.CustomerRetrievalListener {
                 override fun onCustomerRetrieved(customer: Customer) {
-                    resultData.value = Result.create(customer)
+                    resultData.value = SaveCustomerShippingInfoResult.create(customer)
                 }
 
                 override fun onError(
@@ -30,39 +38,87 @@ internal class PaymentFlowViewModel(
                     errorMessage: String,
                     stripeError: StripeError?
                 ) {
-                    resultData.value = Result.create(errorMessage)
+                    resultData.value = SaveCustomerShippingInfoResult.create(errorMessage)
                 }
             }
         )
         return resultData
     }
 
-    internal data class Result<out T> internal constructor(
+    /**
+     * Validate [shippingInformation] using [shippingMethodsFactory]. If valid, use
+     * [shippingMethodsFactory] to create the [ShippingMethod] options.
+     */
+    @JvmSynthetic
+    internal fun validateShippingInformation(
+        shippingInfoValidator: PaymentSessionConfig.ShippingInformationValidator,
+        shippingMethodsFactory: PaymentSessionConfig.ShippingMethodsFactory?,
+        shippingInformation: ShippingInformation
+    ): LiveData<ValidateShippingInfoResult<*>> {
+        val resultData = MutableLiveData<ValidateShippingInfoResult<*>>()
+        workScope.launch {
+            val isValid = shippingInfoValidator.isValid(shippingInformation)
+            if (isValid) {
+                val shippingMethods =
+                    shippingMethodsFactory?.create(shippingInformation).orEmpty()
+                resultData.postValue(ValidateShippingInfoResult.create(shippingMethods))
+            } else {
+                val errorMessage = shippingInfoValidator.getErrorMessage(shippingInformation)
+                resultData.postValue(ValidateShippingInfoResult.create(errorMessage))
+            }
+        }
+        return resultData
+    }
+
+    internal data class SaveCustomerShippingInfoResult<out T> internal constructor(
         internal val status: Status,
         internal val data: T
     ) {
-        enum class Status {
-            SUCCESS, ERROR
-        }
-
         internal companion object {
             @JvmSynthetic
-            internal fun create(customer: Customer): Result<Customer> {
-                return Result(Status.SUCCESS, customer)
+            internal fun create(customer: Customer): SaveCustomerShippingInfoResult<Customer> {
+                return SaveCustomerShippingInfoResult(Status.SUCCESS, customer)
             }
 
             @JvmSynthetic
-            internal fun create(errorMessage: String): Result<String> {
-                return Result(Status.ERROR, errorMessage)
+            internal fun create(errorMessage: String): SaveCustomerShippingInfoResult<String> {
+                return SaveCustomerShippingInfoResult(Status.ERROR, errorMessage)
             }
         }
     }
 
+    internal data class ValidateShippingInfoResult<out T> internal constructor(
+        internal val status: Status,
+        internal val data: T
+    ) {
+        internal companion object {
+            @JvmSynthetic
+            internal fun create(
+                shippingMethods: List<ShippingMethod>
+            ): ValidateShippingInfoResult<List<ShippingMethod>> {
+                return ValidateShippingInfoResult(Status.SUCCESS, shippingMethods)
+            }
+
+            @JvmSynthetic
+            internal fun create(errorMessage: String): ValidateShippingInfoResult<String> {
+                return ValidateShippingInfoResult(Status.ERROR, errorMessage)
+            }
+        }
+    }
+
+    internal enum class Status {
+        SUCCESS, ERROR
+    }
+
     internal class Factory(
-        private val customerSession: CustomerSession
+        private val customerSession: CustomerSession,
+        private val paymentSessionData: PaymentSessionData
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return PaymentFlowViewModel(customerSession) as T
+            return PaymentFlowViewModel(
+                customerSession,
+                paymentSessionData
+            ) as T
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -27,8 +27,6 @@ import com.stripe.android.PaymentSessionData
 import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
 import com.stripe.android.exception.APIException
-import com.stripe.android.model.Address
-import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
 import com.stripe.android.view.PaymentFlowExtras.EVENT_SHIPPING_INFO_PROCESSED
 import com.stripe.android.view.PaymentFlowExtras.EXTRA_IS_SHIPPING_INFO_VALID
@@ -315,19 +313,7 @@ class PaymentFlowActivityTest {
     }
 
     private companion object {
-        private val SHIPPING_INFO = ShippingInformation(
-            Address.Builder()
-                .setCity("San Francisco")
-                .setCountry("US")
-                .setLine1("123 Market St")
-                .setLine2("#345")
-                .setPostalCode("94107")
-                .setState("CA")
-                .build(),
-            "Fake Name",
-            "(555) 555-5555"
-        )
-
+        private val SHIPPING_INFO = ShippingInfoFixtures.DEFAULT
         private val SHIPPING_METHODS = arrayListOf(
             ShippingMethod("UPS Ground", "ups-ground",
                 0, "USD", "Arrives in 3-5 days"),

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
@@ -1,0 +1,141 @@
+package com.stripe.android.view
+
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.CustomerSession
+import com.stripe.android.PaymentSessionConfig
+import com.stripe.android.PaymentSessionData
+import com.stripe.android.model.CustomerFixtures
+import com.stripe.android.model.ShippingInformation
+import com.stripe.android.model.ShippingMethod
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.MainScope
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentFlowViewModelTest {
+
+    @Mock
+    private lateinit var customerSession: CustomerSession
+
+    private val customerRetrievalListener: KArgumentCaptor<CustomerSession.CustomerRetrievalListener> by lazy {
+        argumentCaptor<CustomerSession.CustomerRetrievalListener>()
+    }
+
+    private val viewModel: PaymentFlowViewModel by lazy {
+        PaymentFlowViewModel(
+            customerSession = customerSession,
+            paymentSessionData = PaymentSessionData(),
+            workScope = MainScope()
+        )
+    }
+
+    @BeforeTest
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun saveCustomerShippingInformation_onSuccess_returnsExpectedData() {
+        val result =
+            viewModel.saveCustomerShippingInformation(ShippingInfoFixtures.DEFAULT)
+        verify(customerSession).setCustomerShippingInformation(
+            eq(ShippingInfoFixtures.DEFAULT),
+            customerRetrievalListener.capture()
+        )
+
+        customerRetrievalListener.firstValue.onCustomerRetrieved(CustomerFixtures.CUSTOMER)
+
+        val resultValue = requireNotNull(result.value)
+        assertEquals(PaymentFlowViewModel.Status.SUCCESS, resultValue.status)
+        assertEquals(CustomerFixtures.CUSTOMER, resultValue.data)
+    }
+
+    @Test
+    fun validateShippingInformation_withValidShippingInfo_createsExpectedShippingMethods() {
+        val result = viewModel.validateShippingInformation(
+            FakeShippingInformationValidator(),
+            FakeShippingMethodsFactory(),
+            ShippingInfoFixtures.DEFAULT
+        )
+
+        val resultValue = requireNotNull(result.value)
+        assertEquals(PaymentFlowViewModel.Status.SUCCESS, resultValue.status)
+        assertEquals(SHIPPING_METHODS, resultValue.data)
+    }
+
+    @Test
+    fun validateShippingInformation_withValidShippingInfoAndNoShippingMethodsFactory_createsEmptyShippingMethods() {
+        val result = viewModel.validateShippingInformation(
+            FakeShippingInformationValidator(),
+            null,
+            ShippingInfoFixtures.DEFAULT
+        )
+
+        val resultValue = requireNotNull(result.value)
+        assertEquals(PaymentFlowViewModel.Status.SUCCESS, resultValue.status)
+        assertEquals(emptyList<ShippingMethod>(), resultValue.data)
+    }
+
+    @Test
+    fun validateShippingInformation_withInvalidValidShippingInfo_createsEmptyShippingMethods() {
+        val result = viewModel.validateShippingInformation(
+            FailingShippingInformationValidator(),
+            ThrowingShippingMethodsFactory(),
+            ShippingInfoFixtures.DEFAULT
+        )
+
+        val resultValue = requireNotNull(result.value)
+        assertEquals(PaymentFlowViewModel.Status.ERROR, resultValue.status)
+        assertEquals(SHIPPING_ERROR_MESSAGE, resultValue.data)
+    }
+
+    private class FakeShippingInformationValidator : PaymentSessionConfig.ShippingInformationValidator {
+        override fun isValid(shippingInformation: ShippingInformation): Boolean {
+            return true
+        }
+
+        override fun getErrorMessage(shippingInformation: ShippingInformation): String {
+            throw IllegalStateException("Should not be called because shipping info is valid")
+        }
+    }
+
+    private class FakeShippingMethodsFactory : PaymentSessionConfig.ShippingMethodsFactory {
+        override fun create(shippingInformation: ShippingInformation): List<ShippingMethod> {
+            return SHIPPING_METHODS
+        }
+    }
+
+    private class FailingShippingInformationValidator : PaymentSessionConfig.ShippingInformationValidator {
+        override fun isValid(shippingInformation: ShippingInformation): Boolean {
+            return false
+        }
+
+        override fun getErrorMessage(shippingInformation: ShippingInformation): String {
+            return SHIPPING_ERROR_MESSAGE
+        }
+    }
+
+    private class ThrowingShippingMethodsFactory : PaymentSessionConfig.ShippingMethodsFactory {
+        override fun create(shippingInformation: ShippingInformation): List<ShippingMethod> {
+            throw RuntimeException("Always throws an exception")
+        }
+    }
+
+    private companion object {
+        private val SHIPPING_ERROR_MESSAGE = "Shipping info was invalid"
+        private val SHIPPING_METHODS = listOf(
+            ShippingMethod("UPS Ground", "ups-ground",
+                0, "USD", "Arrives in 3-5 days"),
+            ShippingMethod("FedEx", "fedex",
+                599, "USD", "Arrives tomorrow")
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoFixtures.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.view
+
+import com.stripe.android.model.Address
+import com.stripe.android.model.ShippingInformation
+
+internal object ShippingInfoFixtures {
+
+    val DEFAULT = ShippingInformation(
+        Address.Builder()
+            .setCity("San Francisco")
+            .setCountry("US")
+            .setLine1("123 Market St")
+            .setLine2("#345")
+            .setPostalCode("94107")
+            .setState("CA")
+            .build(),
+        "Jenny Rosen",
+        "(555) 555-5555"
+    )
+}


### PR DESCRIPTION
## Summary
- Move `paymentSessionData` to `PaymentFlowViewModel`
- Move `validateShippingInformation()` to `PaymentFlowViewModel`
- Create unit tests for `PaymentFlowViewModel`

## Motivation
Refactor `PaymentFlowActivity`

## Testing
Unit tests
