### PR TITLE
Consolidate StripeApiRepository request/response logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -169,9 +169,9 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     }
 
     internal fun getSourceCreationParams(
-        productUsageTokens: List<String>?,
         publishableKey: String,
-        @Source.SourceType sourceType: String
+        @Source.SourceType sourceType: String,
+        productUsageTokens: List<String>? = null
     ): Map<String, Any> {
         return getEventLoggingParams(
             EventName.SOURCE_CREATION,

--- a/stripe/src/main/java/com/stripe/android/ApiRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequestExecutor.kt
@@ -2,8 +2,9 @@ package com.stripe.android
 
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.InvalidRequestException
+import java.net.UnknownHostException
 
 internal interface ApiRequestExecutor {
-    @Throws(APIConnectionException::class, InvalidRequestException::class)
+    @Throws(APIConnectionException::class, InvalidRequestException::class, UnknownHostException::class)
     fun execute(request: ApiRequest): StripeResponse
 }

--- a/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRequestExecutor.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.InvalidRequestException
 import java.io.IOException
+import java.net.UnknownHostException
 
 /**
  * Used by [StripeApiRepository] to make HTTP requests
@@ -15,7 +16,7 @@ internal class StripeApiRequestExecutor internal constructor(
     /**
      * Make the request and return the response as a [StripeResponse]
      */
-    @Throws(APIConnectionException::class, InvalidRequestException::class)
+    @Throws(APIConnectionException::class, InvalidRequestException::class, UnknownHostException::class)
     override fun execute(request: ApiRequest): StripeResponse {
         logger.info(request.toString())
 

--- a/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
@@ -9,11 +9,11 @@ class APIConnectionException(
     message: String?,
     e: Throwable?
 ) : StripeException(null, message, null, STATUS_CODE, e) {
-    companion object {
+    internal companion object {
         private const val STATUS_CODE = 0
 
-        @JvmStatic
-        fun create(e: IOException, url: String? = null): APIConnectionException {
+        @JvmSynthetic
+        internal fun create(e: IOException, url: String? = null): APIConnectionException {
             val displayUrl = listOfNotNull(
                 "Stripe",
                 "($url)".takeUnless { url.isNullOrBlank() }

--- a/stripe/src/main/java/com/stripe/android/exception/APIException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIException.kt
@@ -9,6 +9,18 @@ class APIException(
     message: String?,
     requestId: String? = null,
     statusCode: Int,
-    stripeError: StripeError?,
+    stripeError: StripeError? = null,
     e: Throwable? = null
-) : StripeException(stripeError, message, requestId, statusCode, e)
+) : StripeException(stripeError, message, requestId, statusCode, e) {
+    internal companion object {
+        @JvmSynthetic
+        internal fun create(e: StripeException): APIException {
+            return APIException(
+                message = e.message,
+                requestId = e.requestId,
+                statusCode = e.statusCode,
+                e = e
+            )
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -62,9 +62,9 @@ class AnalyticsDataFactoryTest {
         val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1
         val tokens = listOf("CardInputView")
         val loggingParams = analyticsDataFactory.getSourceCreationParams(
-            tokens,
             API_KEY,
-            Source.SourceType.SEPA_DEBIT)
+            Source.SourceType.SEPA_DEBIT,
+            tokens)
         assertEquals(expectedSize.toLong(), loggingParams.size.toLong())
         assertEquals(Source.SourceType.SEPA_DEBIT,
             loggingParams[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
@@ -175,7 +175,7 @@ class AnalyticsDataFactoryTest {
         val expectedTokenName = AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.SOURCE_CREATION)
         val expectedUaName = AnalyticsDataFactory.analyticsUa
 
-        val params = analyticsDataFactory.getSourceCreationParams(null, API_KEY, Token.TokenType.BANK_ACCOUNT)
+        val params = analyticsDataFactory.getSourceCreationParams(API_KEY, Token.TokenType.BANK_ACCOUNT)
         assertEquals((AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2).toLong(), params.size.toLong())
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(Token.TokenType.BANK_ACCOUNT, params[AnalyticsDataFactory.FIELD_SOURCE_TYPE])


### PR DESCRIPTION
## Summary
- Make all API methods call `makeApiRequest()`
- Remove redundant
  `StripeApiRepository#convertErrorsToExceptionsAndThrowIfNecessary()`
- In `StripeApiRepository#makeApiRequest()`, convert
  `UnknownHostException` to `APIConnectionException`

## Motivation
Fixes #1899

## Testing
Unit test
