### PR TITLE
Create PaymentAuthWebViewActivityViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.view
+
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.PaymentAuthWebViewStarter
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
+
+internal class PaymentAuthWebViewActivityViewModel(
+    private val args: PaymentAuthWebViewStarter.Args
+) : ViewModel() {
+    @JvmSynthetic
+    internal val buttonText = args.toolbarCustomization?.let { toolbarCustomization ->
+        toolbarCustomization.buttonText.takeUnless { it.isNullOrBlank() }
+    }
+
+    @JvmSynthetic
+    internal val toolbarTitle = args.toolbarCustomization?.let { toolbarCustomization ->
+        toolbarCustomization.headerText.takeUnless { it.isNullOrBlank() }?.let {
+            ToolbarTitleData(it, toolbarCustomization)
+        }
+    }
+
+    @JvmSynthetic
+    internal val toolbarBackgroundColor = args.toolbarCustomization?.backgroundColor
+
+    internal val resultIntent: Intent
+        @JvmSynthetic
+        get() {
+            return Intent()
+                .putExtra(StripeIntentResultExtras.CLIENT_SECRET, args.clientSecret)
+                .putExtra(StripeIntentResultExtras.SOURCE_ID,
+                    Uri.parse(args.url).lastPathSegment.orEmpty()
+                )
+        }
+
+    @JvmSynthetic
+    internal fun cancelIntentSource(): LiveData<Intent> {
+        val resultData = MutableLiveData<Intent>()
+        resultData.value = resultIntent.apply {
+            putExtra(StripeIntentResultExtras.FLOW_OUTCOME, StripeIntentResult.Outcome.CANCELED)
+            putExtra(StripeIntentResultExtras.SHOULD_CANCEL_SOURCE, true)
+        }
+        return resultData
+    }
+
+    internal data class ToolbarTitleData(
+        internal val text: String,
+        internal val toolbarCustomization: StripeToolbarCustomization
+    )
+
+    internal class Factory(
+        private val args: PaymentAuthWebViewStarter.Args
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return PaymentAuthWebViewActivityViewModel(args) as T
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.view
+
+import com.stripe.android.PaymentAuthWebViewStarter
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentAuthWebViewActivityViewModelTest {
+    @Test
+    fun cancelIntentSource() {
+        val viewModel = PaymentAuthWebViewActivityViewModel(
+            PaymentAuthWebViewStarter.Args(
+                clientSecret = "client_secret",
+                url = "https://example.com"
+            )
+        )
+
+        val intent = requireNotNull(viewModel.cancelIntentSource().value)
+
+        assertEquals(
+            StripeIntentResult.Outcome.CANCELED,
+            intent.getIntExtra(StripeIntentResultExtras.FLOW_OUTCOME, StripeIntentResult.Outcome.UNKNOWN)
+        )
+    }
+
+    @Test
+    fun toolbarBackgroundColor_returnsCorrectValue() {
+        val viewModel = PaymentAuthWebViewActivityViewModel(
+            PaymentAuthWebViewStarter.Args(
+                clientSecret = "client_secret",
+                url = "https://example.com",
+                toolbarCustomization = StripeToolbarCustomization().apply {
+                    setBackgroundColor("#ffffff")
+                }
+            )
+        )
+        assertEquals("#ffffff", viewModel.toolbarBackgroundColor)
+    }
+
+    @Test
+    fun buttonText_returnsCorrectValue() {
+        val viewModel = PaymentAuthWebViewActivityViewModel(
+            PaymentAuthWebViewStarter.Args(
+                clientSecret = "client_secret",
+                url = "https://example.com",
+                toolbarCustomization = StripeToolbarCustomization().apply {
+                    setButtonText("close")
+                }
+            )
+        )
+        assertEquals("close", viewModel.buttonText)
+    }
+
+    @Test
+    fun toolbarTitle_returnsCorrectValue() {
+        val toolbarCustomization = StripeToolbarCustomization().apply {
+            setHeaderText("auth webview")
+        }
+        val viewModel = PaymentAuthWebViewActivityViewModel(
+            PaymentAuthWebViewStarter.Args(
+                clientSecret = "client_secret",
+                url = "https://example.com",
+                toolbarCustomization = toolbarCustomization
+            )
+        )
+        assertEquals(PaymentAuthWebViewActivityViewModel.ToolbarTitleData(
+            "auth webview",
+            toolbarCustomization
+        ), viewModel.toolbarTitle)
+    }
+}


### PR DESCRIPTION
Create `PaymentAuthWebViewActivityViewModel` to manage business logic
of `PaymentAuthWebViewActivity`

Set `Outcome` to `Outcome.CANCELED` when "Close" button is closed
to fix regression

Fixes #1903