### PR TITLE
Improve Espresso testing

### DIFF
--- a/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
@@ -25,6 +25,9 @@ class CreateCardTokenActivityTest {
     @get:Rule
     val activityScenarioRule: ActivityScenarioRule<LauncherActivity> = activityScenarioRule()
 
+    @get:Rule
+    val idlingResourceRule: IdlingResourceRule = IdlingResourceRule("CreateCardTokenActivityTest")
+
     @Before
     fun setup() {
         Intents.init()
@@ -53,9 +56,6 @@ class CreateCardTokenActivityTest {
         // click create card button
         onView(withId(R.id.create_token_button))
             .perform(click())
-
-        // don't use Thread.sleep in Espresso tests - figure out how to use IdlingResource
-        Thread.sleep(2000)
 
         // check that card token info has been added to the tokens list
         onView(withId(R.id.tokens_list))

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/IdlingResourceRule.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/IdlingResourceRule.kt
@@ -1,0 +1,24 @@
+package com.stripe.example.activity
+
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.idling.CountingIdlingResource
+import org.junit.rules.ExternalResource
+
+class IdlingResourceRule(name: String) : ExternalResource() {
+    private val countingResource = CountingIdlingResource(name)
+
+    override fun before() {
+        IdlingRegistry.getInstance().register(countingResource)
+        BackgroundTaskTracker.onStart = {
+            countingResource.increment()
+        }
+        BackgroundTaskTracker.onStop = {
+            countingResource.decrement()
+        }
+    }
+
+    override fun after() {
+        BackgroundTaskTracker.reset()
+        IdlingRegistry.getInstance().unregister(countingResource)
+    }
+}

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/PaymentSessionActivityTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/PaymentSessionActivityTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.example.activity
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.stripe.example.R
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class PaymentSessionActivityTest {
+
+    @get:Rule
+    val activityScenarioRule: ActivityScenarioRule<LauncherActivity> = activityScenarioRule()
+
+    @get:Rule
+    val idlingResourceRule: IdlingResourceRule = IdlingResourceRule("PaymentSessionActivityTest")
+
+    @Before
+    fun setup() {
+        Intents.init()
+    }
+
+    @After
+    fun cleanup() {
+        Intents.release()
+    }
+
+    @Test
+    fun test() {
+        // launch PaymentSessionActivity
+        Espresso.onView(ViewMatchers.withId(R.id.examples)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(5, click())
+        )
+
+        // on PaymentSessionActivity
+        Espresso.onView(ViewMatchers.withId(R.id.btn_select_payment_method))
+            .perform(click())
+
+        // on PaymentMethodsActivity
+        Espresso.onView(ViewMatchers.withId(R.id.payment_methods_recycler)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+        )
+    }
+}

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/PaymentSessionActivityTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/PaymentSessionActivityTest.kt
@@ -38,7 +38,7 @@ class PaymentSessionActivityTest {
     }
 
     @Test
-    fun test() {
+    fun testSelectPaymentMethod() {
         // launch PaymentSessionActivity
         Espresso.onView(ViewMatchers.withId(R.id.examples)).perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(5, click())

--- a/example/src/main/java/com/stripe/example/ExampleApplication.kt
+++ b/example/src/main/java/com/stripe/example/ExampleApplication.kt
@@ -3,6 +3,7 @@ package com.stripe.example
 import android.os.StrictMode
 import androidx.multidex.MultiDexApplication
 import com.facebook.stetho.Stetho
+import com.stripe.android.PaymentConfiguration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -10,6 +11,8 @@ import kotlinx.coroutines.launch
 class ExampleApplication : MultiDexApplication() {
 
     override fun onCreate() {
+        PaymentConfiguration.init(this, Settings(this).publishableKey)
+
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy.Builder()
                 .detectDiskReads()

--- a/example/src/main/java/com/stripe/example/activity/BackgroundTaskTracker.kt
+++ b/example/src/main/java/com/stripe/example/activity/BackgroundTaskTracker.kt
@@ -1,0 +1,11 @@
+package com.stripe.example.activity
+
+internal object BackgroundTaskTracker {
+    internal var onStart: () -> Unit = {}
+    internal var onStop: () -> Unit = {}
+
+    internal fun reset() {
+        onStart = {}
+        onStop = {}
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -42,6 +42,8 @@ class CreateCardTokenActivity : AppCompatActivity() {
         )[CreateCardTokenViewModel::class.java]
 
         create_token_button.setOnClickListener {
+            BackgroundTaskTracker.onStart()
+
             val card = card_input_widget.card
 
             if (card != null) {
@@ -120,10 +122,12 @@ class CreateCardTokenActivity : AppCompatActivity() {
 
             stripe.createCardToken(card, callback = object : ApiResultCallback<Token> {
                 override fun onSuccess(result: Token) {
+                    BackgroundTaskTracker.onStop()
                     data.value = result
                 }
 
                 override fun onError(e: Exception) {
+                    BackgroundTaskTracker.onStop()
                     Log.e("StripeExample", "Error while creating card token", e)
                 }
             })

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -9,9 +9,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.stripe.android.PaymentConfiguration
 import com.stripe.example.R
-import com.stripe.example.Settings
 import kotlinx.android.synthetic.main.activity_launcher.*
 
 class LauncherActivity : AppCompatActivity() {
@@ -19,8 +17,6 @@ class LauncherActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_launcher)
-
-        PaymentConfiguration.init(this, Settings(this).publishableKey)
 
         val linearLayoutManager = LinearLayoutManager(this)
             .apply {

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -220,6 +220,10 @@ class PaymentSessionActivity : AppCompatActivity() {
     ) : PaymentSession.ActivityPaymentSessionListener<PaymentSessionActivity>(activity) {
 
         override fun onCommunicatingStateChanged(isCommunicating: Boolean) {
+            if (isCommunicating) {
+                BackgroundTaskTracker.onStart()
+            }
+
             listenerActivity?.progress_bar?.visibility = if (isCommunicating) {
                 View.VISIBLE
             } else {
@@ -228,10 +232,12 @@ class PaymentSessionActivity : AppCompatActivity() {
         }
 
         override fun onError(errorCode: Int, errorMessage: String) {
+            BackgroundTaskTracker.onStop()
             listenerActivity?.showError(errorMessage)
         }
 
         override fun onPaymentSessionDataChanged(data: PaymentSessionData) {
+            BackgroundTaskTracker.onStop()
             listenerActivity?.onPaymentSessionDataChanged(customerSession, data)
         }
     }
@@ -240,11 +246,17 @@ class PaymentSessionActivity : AppCompatActivity() {
         activity: PaymentSessionActivity
     ) : CustomerSession.ActivityCustomerRetrievalListener<PaymentSessionActivity>(activity) {
 
+        init {
+            BackgroundTaskTracker.onStart()
+        }
+
         override fun onCustomerRetrieved(customer: Customer) {
+            BackgroundTaskTracker.onStop()
             activity?.onCustomerRetrieved()
         }
 
         override fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?) {
+            BackgroundTaskTracker.onStop()
             activity?.progress_bar?.visibility = View.INVISIBLE
         }
     }


### PR DESCRIPTION
Create `BackgroundTaskTracker` as a way to report background
task events to an `IdlingResource`.

Create `IdlingResourceRule` to manage creating and registering
a `CountingIdlingResource` as well as configuring
`ActiveIdlingResource`.

Remove `Thread.sleep()` from `CreateCardTokenActivityTest`

Create `PaymentSessionActivityTest`