### PR TITLE
Add initial logic for postal code field in CardInputWidget

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -116,5 +116,23 @@
             android:layout_gravity="start"
             />
 
+        <com.stripe.android.view.PostalCodeEditText
+            android:id="@+id/et_postal_code"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:ignore="UnusedAttribute"
+            tools:importantForAccessibility="yes"
+            android:accessibilityTraversalAfter="@+id/et_cvc"
+            android:nextFocusLeft="@id/et_cvc"
+            android:nextFocusUp="@id/et_cvc"
+            android:background="@android:color/transparent"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:layout_marginStart="@dimen/stripe_card_cvc_initial_margin"
+            android:layout_gravity="start"
+            android:visibility="gone"
+            android:enabled="false"
+            />
+
     </FrameLayout>
 </merge>

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -780,6 +780,11 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         assertTrue(shouldIconShowBrand(Card.CardBrand.UNKNOWN, true, "212"))
     }
 
+    @Test
+    fun allFields_whenPostalCodeDisabled() {
+        assertEquals(cardInputWidget.standardFields, cardInputWidget.allFields)
+    }
+
     private companion object {
         // Every Card made by the CardInputView should have the card widget token.
         private val EXPECTED_LOGGING_ARRAY = arrayOf(LOGGING_TOKEN)


### PR DESCRIPTION
The `PostalCodeEditText` view is not visible in this PR
and the layout/animation logic will be added in a future PR