### PR TITLE
Stop broadcasting error in CustomerSessionRunnableFactory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.Handler
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.PaymentConfiguration.Companion.getInstance
 import com.stripe.android.Stripe.Companion.appInfo
 import com.stripe.android.exception.StripeException
@@ -50,7 +49,6 @@ class CustomerSession @VisibleForTesting internal constructor(
             CustomerSessionRunnableFactory(
                 stripeRepository,
                 createHandler(),
-                LocalBroadcastManager.getInstance(context),
                 publishableKey,
                 stripeAccountId,
                 productUsage
@@ -411,9 +409,6 @@ class CustomerSession @VisibleForTesting internal constructor(
     }
 
     companion object {
-        internal const val ACTION_API_EXCEPTION = "action_api_exception"
-        internal const val EXTRA_EXCEPTION = "exception"
-
         internal const val ACTION_ADD_SOURCE = "add_source"
         internal const val ACTION_DELETE_SOURCE = "delete_source"
         internal const val ACTION_ATTACH_PAYMENT_METHOD = "attach_payment_method"

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -195,9 +195,8 @@ class AddPaymentMethodActivity : StripeActivity() {
             errorMessage: String,
             stripeError: StripeError?
         ) {
-            // No need to show this error, because it will be broadcast
-            // from the CustomerSession
             activity?.setCommunicatingProgress(false)
+            activity?.showError(errorMessage)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AlertDisplayer.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AlertDisplayer.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.view
+
+import android.app.Activity
+import androidx.appcompat.app.AlertDialog
+import com.stripe.android.R
+
+internal interface AlertDisplayer {
+    fun show(message: String)
+
+    class DefaultAlertDisplayer(
+        private val activity: Activity
+    ) : AlertDisplayer {
+        override fun show(message: String) {
+            AlertDialog.Builder(activity, R.style.AlertDialogStyle)
+                .setMessage(message)
+                .setCancelable(true)
+                .setPositiveButton(android.R.string.ok) { dialogInterface, _ ->
+                    dialogInterface.dismiss()
+                }
+                .create()
+                .show()
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -34,6 +33,10 @@ class PaymentMethodsActivity : AppCompatActivity() {
     private var startedFromPaymentSession: Boolean = false
     private lateinit var customerSession: CustomerSession
     private lateinit var cardDisplayTextFactory: CardDisplayTextFactory
+
+    private val alertDisplayer: AlertDisplayer by lazy {
+        AlertDisplayer.DefaultAlertDisplayer(this)
+    }
 
     private lateinit var viewModel: PaymentMethodsViewModel
 
@@ -68,7 +71,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
                     val exception = it.data as StripeException
                     val displayedError = TranslatorManager.getErrorMessageTranslator()
                         .translate(exception.statusCode, exception.message, exception.stripeError)
-                    showError(displayedError)
+                    alertDisplayer.show(displayedError)
                 }
             }
             setCommunicatingProgress(false)
@@ -199,17 +202,6 @@ class PaymentMethodsActivity : AppCompatActivity() {
         )
 
         finish()
-    }
-
-    private fun showError(error: String) {
-        AlertDialog.Builder(this, R.style.AlertDialogStyle)
-            .setMessage(error)
-            .setCancelable(true)
-            .setPositiveButton(android.R.string.ok) { dialogInterface, _ ->
-                dialogInterface.dismiss()
-            }
-            .create()
-            .show()
     }
 
     override fun onDestroy() {

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -4,10 +4,8 @@ import android.app.Activity.RESULT_OK
 import android.app.Instrumentation
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
@@ -18,8 +16,6 @@ import com.stripe.android.AbsFakeStripeRepository
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.ApiRequest
 import com.stripe.android.CustomerSession
-import com.stripe.android.CustomerSession.Companion.ACTION_API_EXCEPTION
-import com.stripe.android.CustomerSession.Companion.EXTRA_EXCEPTION
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSession.Companion.TOKEN_PAYMENT_SESSION
 import com.stripe.android.R
@@ -60,15 +56,21 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(RobolectricTestRunner::class)
 class AddPaymentMethodActivityTest {
 
-    private lateinit var paymentMethodIdCaptor: KArgumentCaptor<String>
-    private lateinit var listenerArgumentCaptor:
-        KArgumentCaptor<CustomerSession.PaymentMethodRetrievalListener>
-
     @Mock
-    private lateinit var mockStripeRepository: StripeRepository
+    private lateinit var stripeRepository: StripeRepository
 
     @Mock
     private lateinit var customerSession: CustomerSession
+
+    @Mock
+    private lateinit var alertDisplayer: AlertDisplayer
+
+    private val paymentMethodIdCaptor: KArgumentCaptor<String> by lazy {
+        argumentCaptor<String>()
+    }
+    private val listenerArgumentCaptor: KArgumentCaptor<CustomerSession.PaymentMethodRetrievalListener> by lazy {
+        argumentCaptor<CustomerSession.PaymentMethodRetrievalListener>()
+    }
 
     private val context: Context by lazy {
         ApplicationProvider.getApplicationContext<Context>()
@@ -83,9 +85,6 @@ class AddPaymentMethodActivityTest {
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         MockitoAnnotations.initMocks(this)
-
-        paymentMethodIdCaptor = argumentCaptor()
-        listenerArgumentCaptor = argumentCaptor()
 
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
@@ -131,8 +130,8 @@ class AddPaymentMethodActivityTest {
             activityScenario.onActivity { activity ->
                 val progressBar: ProgressBar = activity.findViewById(R.id.progress_bar_as)
                 assertEquals(View.GONE, progressBar.visibility)
-                activity.createPaymentMethod(createStripe(mockStripeRepository), null)
-                verify(mockStripeRepository, never()).createPaymentMethod(
+                activity.createPaymentMethod(createStripe(stripeRepository), null)
+                verify(stripeRepository, never()).createPaymentMethod(
                     any(), any()
                 )
             }
@@ -244,8 +243,7 @@ class AddPaymentMethodActivityTest {
             activityScenario.onActivity { activity ->
                 val progressBar: ProgressBar = activity.findViewById(R.id.progress_bar_as)
 
-                val alertMessageListener: StripeActivity.AlertMessageListener = mock()
-                activity.setAlertMessageListener(alertMessageListener)
+                activity.alertDisplayer = alertDisplayer
 
                 assertEquals(View.GONE, progressBar.visibility)
                 activity.createPaymentMethod(stripe, PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
@@ -253,7 +251,7 @@ class AddPaymentMethodActivityTest {
                 assertNull(shadowOf(activity).resultIntent)
                 assertFalse(activity.isFinishing)
                 assertEquals(View.GONE, progressBar.visibility)
-                verify(alertMessageListener).onAlertMessageDisplayed(errorMessage)
+                verify(alertDisplayer).show(errorMessage)
             }
         }
     }
@@ -270,8 +268,7 @@ class AddPaymentMethodActivityTest {
                 val cardMultilineWidget: CardMultilineWidget = activity.findViewById(R.id.card_multiline_widget)
                 activity.initCustomerSessionTokens(customerSession)
 
-                val alertMessageListener: StripeActivity.AlertMessageListener = mock()
-                activity.setAlertMessageListener(alertMessageListener)
+                activity.alertDisplayer = alertDisplayer
 
                 assertEquals(View.GONE, progressBar.visibility)
                 assertTrue(cardMultilineWidget.isEnabled)
@@ -297,19 +294,11 @@ class AddPaymentMethodActivityTest {
                 `when`(error.localizedMessage).thenReturn(errorMessage)
                 listenerArgumentCaptor.firstValue.onError(400, errorMessage, null)
 
-                // We're mocking the CustomerSession, so we have to replicate its broadcast behavior.
-                val bundle = Bundle()
-                bundle.putSerializable(EXTRA_EXCEPTION, error)
-                LocalBroadcastManager.getInstance(activity)
-                    .sendBroadcast(Intent(ACTION_API_EXCEPTION)
-                        .putExtras(bundle))
-
                 val intent = shadowOf(activity).resultIntent
                 assertNull(intent)
                 assertFalse(activity.isFinishing)
                 assertEquals(View.GONE, progressBar.visibility)
-                verify(alertMessageListener)
-                    .onAlertMessageDisplayed(errorMessage)
+                verify(alertDisplayer).show(errorMessage)
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.Bundle
 import android.view.View
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.core.app.ApplicationProvider
@@ -17,8 +16,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CustomerSession
-import com.stripe.android.CustomerSession.Companion.ACTION_API_EXCEPTION
-import com.stripe.android.CustomerSession.Companion.EXTRA_EXCEPTION
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSession.Companion.EXTRA_PAYMENT_SESSION_DATA
@@ -26,7 +23,6 @@ import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionData
 import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
-import com.stripe.android.exception.APIException
 import com.stripe.android.model.ShippingMethod
 import com.stripe.android.view.PaymentFlowExtras.EVENT_SHIPPING_INFO_PROCESSED
 import com.stripe.android.view.PaymentFlowExtras.EXTRA_IS_SHIPPING_INFO_VALID
@@ -43,7 +39,6 @@ import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -161,34 +156,6 @@ class PaymentFlowActivityTest {
                     ),
                     SHIPPING_INFO
                 )
-            }
-        }
-    }
-
-    @Test
-    fun onErrorBroadcast_displaysAlertDialog() {
-        activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity { paymentFlowActivity ->
-                val listener =
-                    mock(StripeActivity.AlertMessageListener::class.java)
-                paymentFlowActivity.setAlertMessageListener(listener)
-
-                val bundle = Bundle()
-                bundle.putSerializable(EXTRA_EXCEPTION,
-                    APIException("Something's wrong", "ID123", 400, null, null))
-
-                localBroadcastManager.sendBroadcast(
-                    Intent(ACTION_API_EXCEPTION)
-                        .putExtras(bundle)
-                )
-
-                verify(listener).onAlertMessageDisplayed("Something's wrong")
             }
         }
     }


### PR DESCRIPTION
`CustomerSessionRunnableFactory` would previously report
errors both through a listener callback method and through
a `LocalBroadcastManager` broadcast.

The latter was used to show an `AlertDialog` on `StripeActivity`
subclasses. However, this is unnecessary because the alert
dialogs can be shown when the callback happens.

Also consolidate `AlertDialog` displaying logic into
`AlertDisplayer` interface and implementation.