### PR TITLE
Update text size for CardInputWidget fields

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -72,6 +72,7 @@
             android:focusable="true"
             android:focusableInTouchMode="true"
             android:visibility="visible"
+            android:textSize="@dimen/ciw_stripe_edit_text_size"
             />
 
         <com.stripe.android.view.ExpiryDateEditText
@@ -97,6 +98,7 @@
             android:focusableInTouchMode="true"
             android:layout_marginStart="@dimen/stripe_card_expiry_initial_margin"
             android:layout_gravity="start"
+            android:textSize="@dimen/ciw_stripe_edit_text_size"
             />
 
         <com.stripe.android.view.CvcEditText
@@ -114,6 +116,7 @@
             android:focusableInTouchMode="true"
             android:layout_marginStart="@dimen/stripe_card_cvc_initial_margin"
             android:layout_gravity="start"
+            android:textSize="@dimen/ciw_stripe_edit_text_size"
             />
 
         <com.stripe.android.view.PostalCodeEditText
@@ -132,6 +135,7 @@
             android:layout_gravity="start"
             android:visibility="gone"
             android:enabled="false"
+            android:textSize="@dimen/ciw_stripe_edit_text_size"
             />
 
     </FrameLayout>

--- a/stripe/res/values-hdpi/dimens.xml
+++ b/stripe/res/values-hdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ciw_stripe_edit_text_size">15sp</dimen>
+</resources>

--- a/stripe/res/values-mdpi/dimens.xml
+++ b/stripe/res/values-mdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ciw_stripe_edit_text_size">15sp</dimen>
+</resources>

--- a/stripe/res/values-xhdpi/dimens.xml
+++ b/stripe/res/values-xhdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
+</resources>

--- a/stripe/res/values-xxhdpi/dimens.xml
+++ b/stripe/res/values-xxhdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
+</resources>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -28,4 +28,7 @@
     <dimen name="stripe_shipping_widget_vertical_margin">4dp</dimen>
     <dimen name="stripe_shipping_widget_horizontal_margin">16dp</dimen>
     <dimen name="stripe_shipping_widget_outer_margin">12dp</dimen>
+
+    <!-- Text size of CardInputWidget EditText views -->
+    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
 </resources>


### PR DESCRIPTION
For lower-density screens, the text size needs to be reduced

![ciw_text_small](https://user-images.githubusercontent.com/45020849/70341429-e6e4dd00-1820-11ea-9f20-80b495b351fb.gif)

![ciw_text_normal](https://user-images.githubusercontent.com/45020849/70341413-df253880-1820-11ea-94bb-a19b4790f477.gif)
