### PR TITLE
Update PostalCodeEditText input rules

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.InputFilter
 import android.text.InputType
 import android.text.method.DigitsKeyListener
+import android.text.method.TextKeyListener
 import android.util.AttributeSet
 import com.stripe.android.R
 
@@ -14,11 +15,8 @@ class PostalCodeEditText @JvmOverloads constructor(
 ) : StripeEditText(context, attrs, defStyleAttr) {
 
     init {
-        configureForUs()
-
         maxLines = 1
-        inputType = InputType.TYPE_CLASS_NUMBER
-        keyListener = DigitsKeyListener.getInstance(false, true)
+        configureForUs()
     }
 
     /**
@@ -28,6 +26,8 @@ class PostalCodeEditText @JvmOverloads constructor(
     internal fun configureForUs() {
         setHint(R.string.address_label_zip_code)
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH_US))
+        keyListener = DigitsKeyListener.getInstance(false, true)
+        inputType = InputType.TYPE_CLASS_NUMBER
     }
 
     /**
@@ -37,6 +37,8 @@ class PostalCodeEditText @JvmOverloads constructor(
     internal fun configureForGlobal() {
         setHint(R.string.address_label_postal_code)
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH_GLOBAL))
+        keyListener = TextKeyListener.getInstance()
+        inputType = InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS
     }
 
     private companion object {


### PR DESCRIPTION
For global postal codes, allow text input (previously digits-only)