### PR TITLE
Improve AddPaymentMethodActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardView.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.view
 
-import android.app.Activity
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
@@ -17,20 +15,16 @@ import com.stripe.android.model.PaymentMethodCreateParams
  *
  * See [AddPaymentMethodActivity] for usage.
  */
-internal class AddPaymentMethodCardView private constructor(
+internal class AddPaymentMethodCardView @JvmOverloads internal constructor(
     context: Context,
-    attrs: AttributeSet?,
-    defStyleAttr: Int,
-    shouldShowPostalCode: Boolean
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    shouldShowPostalCode: Boolean = false
 ) : AddPaymentMethodView(context, attrs, defStyleAttr) {
     private val cardMultilineWidget: CardMultilineWidget
 
     override val createParams: PaymentMethodCreateParams?
         get() = cardMultilineWidget.paymentMethodCreateParams
-
-    @JvmOverloads
-    constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
-        this(context, attrs, defStyleAttr, false)
 
     init {
         View.inflate(getContext(), R.layout.add_payment_method_card_layout, this)
@@ -45,8 +39,7 @@ internal class AddPaymentMethodCardView private constructor(
         val listener = OnEditorActionListenerImpl(
             activity,
             this,
-            activity
-                .getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+            KeyboardController(activity)
         )
 
         cardMultilineWidget.findViewById<TextView>(R.id.et_card_number)
@@ -66,13 +59,13 @@ internal class AddPaymentMethodCardView private constructor(
     internal class OnEditorActionListenerImpl(
         private val activity: AddPaymentMethodActivity,
         private val addPaymentMethodCardView: AddPaymentMethodCardView,
-        private val inputMethodManager: InputMethodManager
+        private val keyboardController: KeyboardController
     ) : TextView.OnEditorActionListener {
 
         override fun onEditorAction(v: TextView?, actionId: Int, event: KeyEvent?): Boolean {
             if (actionId == EditorInfo.IME_ACTION_DONE) {
                 if (addPaymentMethodCardView.createParams != null) {
-                    inputMethodManager.hideSoftInputFromWindow(activity.windowToken, 0)
+                    keyboardController.hide()
                 }
                 activity.onActionSave()
                 return true

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodCardViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodCardViewTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.view
 
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import kotlin.test.BeforeTest
@@ -21,7 +20,7 @@ class AddPaymentMethodCardViewTest {
     @Mock
     private lateinit var addPaymentMethodCardView: AddPaymentMethodCardView
     @Mock
-    private lateinit var inputMethodManager: InputMethodManager
+    private lateinit var keyboardController: KeyboardController
 
     @BeforeTest
     fun setup() {
@@ -33,9 +32,9 @@ class AddPaymentMethodCardViewTest {
         `when`<PaymentMethodCreateParams>(addPaymentMethodCardView.createParams)
             .thenReturn(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
         AddPaymentMethodCardView.OnEditorActionListenerImpl(
-            activity, addPaymentMethodCardView, inputMethodManager)
+            activity, addPaymentMethodCardView, keyboardController)
             .onEditorAction(null, EditorInfo.IME_ACTION_DONE, null)
-        verify(inputMethodManager).hideSoftInputFromWindow(null, 0)
+        verify(keyboardController).hide()
         verify(activity).onActionSave()
     }
 }


### PR DESCRIPTION
- Don't explicitly show the keyboard. Instead, call `requestFocus()`
  on the `AddPaymentMethodView`.
- Use `KeyboardController` to hide keyboard in `AddPaymentMethodCardView`
- Use `by lazy` instead of `lateinit var`

Fixes #1904

![addpm](https://user-images.githubusercontent.com/45020849/70346337-1ea55200-182c-11ea-86d8-ffa8d5f92126.gif)
