### PR TITLE
Expose ability to enable postal code on CardInputWidget

### DIFF
--- a/example/res/layout/card_token_activity.xml
+++ b/example/res/layout/card_token_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -28,7 +29,7 @@
             android:id="@+id/card_input_widget"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            />
+            app:shouldShowPostalCode="true" />
 
         <Button
             android:id="@+id/create_token_button"

--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -6,7 +6,7 @@
         <attr name="cardTextErrorColor" format="color"/>
     </declare-styleable>
 
-    <declare-styleable name="CardMultilineWidget">
+    <declare-styleable name="CardElement">
         <attr name="shouldShowPostalCode" format="boolean" />
     </declare-styleable>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -173,8 +173,7 @@ class CardInputWidget @JvmOverloads constructor(
     @JvmSynthetic
     internal var frameWidthSupplier: () -> Int
 
-    @JvmSynthetic
-    internal var postalCodeEnabled: Boolean = false
+    var postalCodeEnabled: Boolean = false
         set(value) {
             updatePostalCodeEditText(value)
             field = value
@@ -534,6 +533,8 @@ class CardInputWidget @JvmOverloads constructor(
     }
 
     private fun initView(attrs: AttributeSet?) {
+        attrs?.let { applyAttributes(it) }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             cardNumberEditText.setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_NUMBER)
             expiryDateEditText.setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE)
@@ -648,6 +649,19 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         cardNumberEditText.requestFocus()
+    }
+
+    private fun applyAttributes(attrs: AttributeSet) {
+        val typedArray = context.theme.obtainStyledAttributes(
+            attrs, R.styleable.CardElement, 0, 0
+        )
+
+        try {
+            postalCodeEnabled =
+                typedArray.getBoolean(R.styleable.CardElement_shouldShowPostalCode, false)
+        } finally {
+            typedArray.recycle()
+        }
     }
 
     // reveal the full card number field

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -473,12 +473,12 @@ class CardMultilineWidget @JvmOverloads constructor(
     private fun checkAttributeSet(attrs: AttributeSet) {
         val a = context.theme.obtainStyledAttributes(
             attrs,
-            R.styleable.CardMultilineWidget,
+            R.styleable.CardElement,
             0, 0)
 
         try {
             shouldShowPostalCode =
-                a.getBoolean(R.styleable.CardMultilineWidget_shouldShowPostalCode, false)
+                a.getBoolean(R.styleable.CardElement_shouldShowPostalCode, false)
         } finally {
             a.recycle()
         }


### PR DESCRIPTION
Postal code can either be enabled via layout or code.

1. Layout
```
        <com.stripe.android.view.CardInputWidget
            android:id="@+id/card_input_widget"
            android:layout_width="match_parent"
            android:layout_height="wrap_content"
            app:shouldShowPostalCode="true" />
```

2. Code
  a. Java: `cardInputWidget.setPostalCodeEnabled(true)`
  b. Kotlin: `cardInputWidget.postalCodeEnabled = true`

Fixes: #1807
