### PR TITLE
Enable configuring billing fields on AddPaymentMethodActivity

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
+import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.PaymentUtils
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.example.R
@@ -46,7 +47,7 @@ class PaymentSessionActivity : AppCompatActivity() {
         paymentSession = createPaymentSession(savedInstanceState)
 
         btn_select_payment_method.setOnClickListener {
-            paymentSession.presentPaymentMethodSelection(true)
+            paymentSession.presentPaymentMethodSelection()
         }
         btn_start_payment_flow.setOnClickListener {
             paymentSession.presentShippingFlow()
@@ -86,6 +87,7 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setAllowedShippingCountryCodes(setOf("US", "CA"))
                 .setShippingInformationValidator(ShippingInformationValidator())
                 .setShippingMethodsFactory(ShippingMethodsFactory())
+                .setBillingAddressFields(BillingAddressFields.Full)
                 .build(),
             savedInstanceState = savedInstanceState,
             shouldPrefetchCustomer = shouldPrefetchCustomer

--- a/stripe/res/layout/add_payment_method_card_layout.xml
+++ b/stripe/res/layout/add_payment_method_card_layout.xml
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<com.stripe.android.view.CardMultilineWidget
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/card_multiline_widget"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/stripe_add_card_total_margin"
-    />
+    android:orientation="vertical">
+
+    <com.stripe.android.view.CardMultilineWidget
+        android:id="@+id/card_multiline_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <com.stripe.android.view.ShippingInfoWidget
+        android:id="@+id/billing_address_widget"
+        android:layout_marginTop="48dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        />
+</LinearLayout>

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
+import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.PaymentFlowActivity
 import com.stripe.android.view.PaymentFlowActivityStarter
 import com.stripe.android.view.PaymentMethodsActivity
@@ -185,9 +186,22 @@ class PaymentSession @VisibleForTesting internal constructor(
     }
 
     /**
-     * See [presentPaymentMethodSelection]
+     * Launch the [PaymentMethodsActivity] to allow the user to select a payment method,
+     * or to add a new one.
+     *
+     * The initial selected Payment Method ID uses the following logic.
+     *
+     *  1. If {@param userSelectedPaymentMethodId} is specified, use that
+     *  2. If the instance's [PaymentSessionData.paymentMethod] is non-null, use that
+     *  3. If the instance's [PaymentSessionPrefs.getSelectedPaymentMethodId] is non-null, use that
+     *  4. Otherwise, choose the most recently added Payment Method
+     *
+     * See [getSelectedPaymentMethodId]
+     *
+     * @param selectedPaymentMethodId if non-null, the ID of the Payment Method that should be
+     * initially selected on the Payment Method selection screen
      */
-    fun presentPaymentMethodSelection(selectedPaymentMethodId: String) {
+    fun presentPaymentMethodSelection(selectedPaymentMethodId: String? = null) {
         presentPaymentMethodSelection(false, selectedPaymentMethodId)
     }
 
@@ -208,9 +222,10 @@ class PaymentSession @VisibleForTesting internal constructor(
      * @param userSelectedPaymentMethodId if non-null, the ID of the Payment Method that should be
      * initially selected on the Payment Method selection screen
      */
+    @Deprecated("Use presentPaymentMethodSelection(selectedPaymentMethodId) and configure billing fields using PaymentSessionConfig.Builder.setBillingAddressFields()")
     @JvmOverloads
     fun presentPaymentMethodSelection(
-        shouldRequirePostalCode: Boolean = false,
+        shouldRequirePostalCode: Boolean,
         userSelectedPaymentMethodId: String? = null
     ) {
         paymentMethodsActivityStarter.startForResult(
@@ -222,6 +237,7 @@ class PaymentSession @VisibleForTesting internal constructor(
                 .setIsPaymentSessionActive(true)
                 .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
                 .setPaymentMethodTypes(config?.paymentMethodTypes.orEmpty())
+                .setBillingAddressFields(config?.billingAddressFields ?: BillingAddressFields.None)
                 .build()
         )
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
 import com.stripe.android.view.AddPaymentMethodActivity
+import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.PaymentFlowActivity
 import com.stripe.android.view.PaymentFlowExtras
 import com.stripe.android.view.SelectShippingMethodWidget
@@ -31,6 +32,7 @@ data class PaymentSessionConfig internal constructor(
     val addPaymentMethodFooterLayoutId: Int = 0,
     val paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card),
     val allowedShippingCountryCodes: Set<String> = emptySet(),
+    val billingAddressFields: BillingAddressFields = BillingAddressFields.None,
 
     internal val shippingInformationValidator: ShippingInformationValidator? = null,
     internal val shippingMethodsFactory: ShippingMethodsFactory? = null
@@ -83,6 +85,7 @@ data class PaymentSessionConfig internal constructor(
     }
 
     class Builder : ObjectBuilder<PaymentSessionConfig> {
+        private var billingAddressFields: BillingAddressFields = BillingAddressFields.None
         private var shippingInfoRequired = true
         private var shippingMethodsRequired = true
         private var hiddenShippingInfoFields: List<String>? = null
@@ -95,6 +98,15 @@ data class PaymentSessionConfig internal constructor(
 
         @LayoutRes
         private var addPaymentMethodFooterLayoutId: Int = 0
+
+        /**
+         * @param billingAddressFields the billing address fields to require on [AddPaymentMethodActivity]
+         */
+        fun setBillingAddressFields(
+            billingAddressFields: BillingAddressFields
+        ): Builder = apply {
+            this.billingAddressFields = billingAddressFields
+        }
 
         /**
          * @param hiddenShippingInfoFields [CustomizableShippingField] fields that should be
@@ -218,7 +230,8 @@ data class PaymentSessionConfig internal constructor(
                 paymentMethodTypes = paymentMethodTypes,
                 allowedShippingCountryCodes = allowedShippingCountryCodes,
                 shippingInformationValidator = shippingInformationValidator,
-                shippingMethodsFactory = shippingMethodsFactory
+                shippingMethodsFactory = shippingMethodsFactory,
+                billingAddressFields = billingAddressFields
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -208,6 +208,14 @@ data class PaymentMethod internal constructor(
             internal const val PARAM_EMAIL = "email"
             internal const val PARAM_NAME = "name"
             internal const val PARAM_PHONE = "phone"
+
+            fun create(shippingInformation: ShippingInformation): BillingDetails {
+                return BillingDetails(
+                    address = shippingInformation.address,
+                    name = shippingInformation.name,
+                    phone = shippingInformation.phone
+                )
+            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -114,7 +114,10 @@ class AddPaymentMethodActivity : StripeActivity() {
     ): AddPaymentMethodView {
         return when (paymentMethodType) {
             PaymentMethod.Type.Card -> {
-                AddPaymentMethodCardView.create(this, args.shouldRequirePostalCode)
+                AddPaymentMethodCardView(
+                    context = this,
+                    billingAddressFields = args.billingAddressFields
+                )
             }
             PaymentMethod.Type.Fpx -> {
                 AddPaymentMethodFpxView.create(this)

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -28,6 +28,7 @@ class AddPaymentMethodActivityStarter constructor(
 ) {
     @Parcelize
     data class Args internal constructor(
+        internal val billingAddressFields: BillingAddressFields,
         internal val shouldAttachToCustomer: Boolean,
         internal val shouldRequirePostalCode: Boolean,
         internal val isPaymentSessionActive: Boolean,
@@ -38,6 +39,7 @@ class AddPaymentMethodActivityStarter constructor(
     ) : ActivityStarter.Args {
 
         class Builder : ObjectBuilder<Args> {
+            private var billingAddressFields: BillingAddressFields = BillingAddressFields.None
             private var shouldAttachToCustomer: Boolean = false
             private var shouldRequirePostalCode: Boolean = false
             private var isPaymentSessionActive = false
@@ -56,11 +58,25 @@ class AddPaymentMethodActivityStarter constructor(
             }
 
             /**
+             * @param billingAddressFields the billing address fields to require on [AddPaymentMethodActivity]
+             */
+            fun setBillingAddressFields(
+                billingAddressFields: BillingAddressFields
+            ): Builder = apply {
+                this.billingAddressFields = billingAddressFields
+            }
+
+            /**
              * If true, a postal code field will be shown and validated.
              * Currently, only US ZIP Codes are supported.
              */
+            @Deprecated("Use setBillingAddressFields()",
+                ReplaceWith("setBillingAddressFields(BillingAddressFields.PostalCode"))
             fun setShouldRequirePostalCode(shouldRequirePostalCode: Boolean): Builder = apply {
                 this.shouldRequirePostalCode = shouldRequirePostalCode
+                if (shouldRequirePostalCode) {
+                    this.billingAddressFields = BillingAddressFields.PostalCode
+                }
             }
 
             /**
@@ -106,6 +122,7 @@ class AddPaymentMethodActivityStarter constructor(
 
             override fun build(): Args {
                 return Args(
+                    billingAddressFields = billingAddressFields,
                     shouldAttachToCustomer = shouldAttachToCustomer,
                     shouldRequirePostalCode = shouldRequirePostalCode,
                     isPaymentSessionActive = isPaymentSessionActive,

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardRowView.kt
@@ -14,8 +14,8 @@ internal class AddPaymentMethodCardRowView internal constructor(
     R.layout.add_payment_method_card_row,
     R.id.stripe_payment_methods_add_card,
     AddPaymentMethodActivityStarter.Args.Builder()
+        .setBillingAddressFields(args.billingAddressFields)
         .setShouldAttachToCustomer(true)
-        .setShouldRequirePostalCode(args.shouldRequirePostalCode)
         .setIsPaymentSessionActive(args.isPaymentSessionActive)
         .setPaymentMethodType(PaymentMethod.Type.Card)
         .setAddPaymentMethodFooter(args.addPaymentMethodFooterLayoutId)

--- a/stripe/src/main/java/com/stripe/android/view/BillingAddressFields.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BillingAddressFields.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.view
+
+/**
+ * Configure [AddPaymentMethodActivity]'s UI and validation logic for billing address fields
+ */
+enum class BillingAddressFields {
+    /**
+     * Do not require any customer billing details when adding a new Payment Method
+     */
+    None,
+
+    /**
+     * Require the customer's postal code when adding a new Payment Method
+     */
+    PostalCode,
+
+    /**
+     * Require the customer's full billing address when adding a new Payment Method
+     */
+    Full
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -330,10 +330,7 @@ class CardMultilineWidget @JvmOverloads constructor(
             }
         }
 
-        return (cardNumberIsValid &&
-            expiryIsValid &&
-            cvcIsValid &&
-            postalCodeIsValidOrGone)
+        return cardNumberIsValid && expiryIsValid && cvcIsValid && postalCodeIsValidOrGone
     }
 
     override fun onWindowFocusChanged(hasWindowFocus: Boolean) {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -44,9 +44,11 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
         @LayoutRes val addPaymentMethodFooterLayoutId: Int,
         internal val isPaymentSessionActive: Boolean,
         internal val paymentMethodTypes: List<PaymentMethod.Type>,
-        internal val paymentConfiguration: PaymentConfiguration?
+        internal val paymentConfiguration: PaymentConfiguration?,
+        internal val billingAddressFields: BillingAddressFields
     ) : ActivityStarter.Args {
         class Builder : ObjectBuilder<Args> {
+            private var billingAddressFields: BillingAddressFields = BillingAddressFields.None
             private var initialPaymentMethodId: String? = null
             private var shouldRequirePostalCode = false
             private var isPaymentSessionActive = false
@@ -55,10 +57,21 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             @LayoutRes
             private var addPaymentMethodFooterLayoutId: Int = 0
 
+            /**
+             * @param billingAddressFields the billing address fields to require on [AddPaymentMethodActivity]
+             */
+            fun setBillingAddressFields(
+                billingAddressFields: BillingAddressFields
+            ): Builder = apply {
+                this.billingAddressFields = billingAddressFields
+            }
+
             fun setInitialPaymentMethodId(initialPaymentMethodId: String?): Builder = apply {
                 this.initialPaymentMethodId = initialPaymentMethodId
             }
 
+            @Deprecated("Use setBillingAddressFields()",
+                ReplaceWith("setBillingAddressFields(BillingAddressFields.PostalCode"))
             fun setShouldRequirePostalCode(shouldRequirePostalCode: Boolean): Builder = apply {
                 this.shouldRequirePostalCode = shouldRequirePostalCode
             }
@@ -107,7 +120,8 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                     isPaymentSessionActive = isPaymentSessionActive,
                     paymentMethodTypes = paymentMethodTypes ?: listOf(PaymentMethod.Type.Card),
                     paymentConfiguration = paymentConfiguration,
-                    addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId
+                    addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId,
+                    billingAddressFields = billingAddressFields
                 )
             }
         }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
+import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.ShippingInfoWidget
 
 internal object PaymentSessionFixtures {
@@ -47,6 +48,8 @@ internal object PaymentSessionFixtures {
         .setAllowedShippingCountryCodes(
             setOf("US", "CA")
         )
+
+        .setBillingAddressFields(BillingAddressFields.Full)
 
         .build()
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentMethodTest
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.testharness.TestEphemeralKeyProvider
 import com.stripe.android.view.ActivityStarter
+import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.PaymentFlowActivity
 import com.stripe.android.view.PaymentFlowActivityStarter
 import com.stripe.android.view.PaymentMethodsActivity
@@ -164,13 +165,18 @@ class PaymentSessionTest {
         CustomerSession.instance = createCustomerSession()
 
         val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
-        paymentSession.presentPaymentMethodSelection(true)
+        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder()
+            .setBillingAddressFields(BillingAddressFields.PostalCode)
+            .build())
+        paymentSession.presentPaymentMethodSelection()
 
         verify(activity).startActivityForResult(intentArgumentCaptor.capture(),
             eq(PaymentMethodsActivityStarter.REQUEST_CODE))
-        assertTrue(PaymentMethodsActivityStarter.Args.create(intentArgumentCaptor.firstValue)
-            .shouldRequirePostalCode)
+        assertEquals(
+            BillingAddressFields.PostalCode,
+            PaymentMethodsActivityStarter.Args.create(intentArgumentCaptor.firstValue)
+                .billingAddressFields
+        )
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.kt
@@ -16,7 +16,7 @@ class AddPaymentMethodActivityStarterTest {
         val args = AddPaymentMethodActivityStarter.Args.Builder()
             .setPaymentMethodType(PaymentMethod.Type.Fpx)
             .setIsPaymentSessionActive(true)
-            .setShouldRequirePostalCode(true)
+            .setBillingAddressFields(BillingAddressFields.PostalCode)
             .build()
 
         assertEquals(args, ParcelUtils.create(args))

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -185,6 +185,81 @@ class AddPaymentMethodActivityTest {
     }
 
     @Test
+    fun addCardData_withFullBillingFieldsRequirement_shouldShowBillingAddressWidget() {
+        activityScenarioFactory.create<AddPaymentMethodActivity>(
+            createArgs(
+                PaymentMethod.Type.Card,
+                initCustomerSessionTokens = true,
+                billingAddressFields = BillingAddressFields.Full
+            )
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                assertEquals(
+                    View.VISIBLE,
+                    activity.findViewById<View>(R.id.billing_address_widget).visibility
+                )
+
+                val cardMultilineWidget: CardMultilineWidget =
+                    activity.findViewById(R.id.card_multiline_widget)
+                assertEquals(
+                    View.GONE,
+                    cardMultilineWidget.findViewById<View>(R.id.tl_postal_code).visibility
+                )
+            }
+        }
+    }
+
+    @Test
+    fun addCardData_withPostalCodeBillingFieldsRequirement_shouldHideBillingAddressWidget() {
+        activityScenarioFactory.create<AddPaymentMethodActivity>(
+            createArgs(
+                PaymentMethod.Type.Card,
+                initCustomerSessionTokens = true,
+                billingAddressFields = BillingAddressFields.PostalCode
+            )
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                assertEquals(
+                    View.GONE,
+                    activity.findViewById<View>(R.id.billing_address_widget).visibility
+                )
+
+                val cardMultilineWidget: CardMultilineWidget =
+                    activity.findViewById(R.id.card_multiline_widget)
+                assertEquals(
+                    View.VISIBLE,
+                    cardMultilineWidget.findViewById<View>(R.id.tl_postal_code).visibility
+                )
+            }
+        }
+    }
+
+    @Test
+    fun addCardData_withNoBillingFieldsRequirement_shouldHideBillingAddressWidgetAndPostalCode() {
+        activityScenarioFactory.create<AddPaymentMethodActivity>(
+            createArgs(
+                PaymentMethod.Type.Card,
+                initCustomerSessionTokens = true,
+                billingAddressFields = BillingAddressFields.None
+            )
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                assertEquals(
+                    View.GONE,
+                    activity.findViewById<View>(R.id.billing_address_widget).visibility
+                )
+
+                val cardMultilineWidget: CardMultilineWidget =
+                    activity.findViewById(R.id.card_multiline_widget)
+                assertEquals(
+                    View.GONE,
+                    cardMultilineWidget.findViewById<View>(R.id.tl_postal_code).visibility
+                )
+            }
+        }
+    }
+
+    @Test
     fun addCardData_whenServerReturnsSuccessAndUpdatesCustomer_finishesWithIntent() {
         activityScenarioFactory.create<AddPaymentMethodActivity>(
             createArgs(
@@ -325,15 +400,16 @@ class AddPaymentMethodActivityTest {
 
     private fun createArgs(
         paymentMethodType: PaymentMethod.Type,
-        initCustomerSessionTokens: Boolean = false
+        initCustomerSessionTokens: Boolean = false,
+        billingAddressFields: BillingAddressFields = BillingAddressFields.PostalCode
     ): AddPaymentMethodActivityStarter.Args {
         return AddPaymentMethodActivityStarter.Args.Builder()
             .setShouldAttachToCustomer(true)
-            .setShouldRequirePostalCode(true)
             .setIsPaymentSessionActive(true)
             .setShouldInitCustomerSessionTokens(initCustomerSessionTokens)
             .setPaymentMethodType(paymentMethodType)
             .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
+            .setBillingAddressFields(billingAddressFields)
             .build()
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
@@ -29,6 +29,7 @@ class PaymentMethodsActivityStarterTest {
             .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx))
             .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
             .setAddPaymentMethodFooter(R.layout.activity_payment_methods)
+            .setBillingAddressFields(BillingAddressFields.Full)
             .build()
 
         assertEquals(args, ParcelUtils.create(args))


### PR DESCRIPTION
## Summary
Add `BillingAddressFields` with three values - `None`, `PostalCode`, and `Full`

Add `setBillingAddressFields()` to `PaymentSessionConfig`,
`PaymentMethodsActivityStarter.Args`, and `AddPaymentMethodActivityStarter.Args`

```
PaymentSessionConfig.Builder()
    .setBillingAddressFields(BillingAddressFields.Full)
    .build()
```

```
AddPaymentMethodActivityStarter.Args.Builder()
    .setBillingAddressFields(BillingAddressFields.Full)
    .build()
```

Mark `setShouldRequirePostalCode()` as `@Deprecated`; use
`BillingAddressFields.PostalCode` instead.

## Motivation
Fixes #1878

## Testing
Added unit tests and manually verified

![add_billing_details](https://user-images.githubusercontent.com/45020849/71018178-0653f380-20c6-11ea-96ee-3de2dd8c3169.gif)
