### PR TITLE
Update ClientSecret validation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -265,7 +265,7 @@ data class PaymentIntent internal constructor(
         }
 
         private companion object {
-            private val PATTERN = Pattern.compile("^pi_(\\w)+_secret_(\\w)+$")
+            private val PATTERN = Pattern.compile("^pi_([a-zA-Z0-9])+_secret_([a-zA-Z0-9])+$")
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -212,7 +212,7 @@ data class SetupIntent internal constructor(
         }
 
         private companion object {
-            private val PATTERN = Pattern.compile("^seti_(\\w)+_secret_(\\w)+$")
+            private val PATTERN = Pattern.compile("^seti_([a-zA-Z0-9])+_secret_([a-zA-Z0-9])+$")
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -130,10 +130,22 @@ class PaymentIntentTest {
         assertFailsWith<IllegalArgumentException> {
             PaymentIntent.ClientSecret("pi_12345_secret_")
         }
+
+        assertFailsWith<IllegalArgumentException> {
+            SetupIntent.ClientSecret("pi_secret")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            SetupIntent.ClientSecret("pi_secret_a")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            PaymentIntent.ClientSecret("pi_a1b2c3_secret_x7y8z9pi_a1b2c3_secret_x7y8z9")
+        }
     }
 
     @Test
-    fun clientSecret_withValidKeys_throwsException() {
+    fun clientSecret_withValidKeys_succeeds() {
         assertEquals(
             "pi_a1b2c3_secret_x7y8z9",
             PaymentIntent.ClientSecret("pi_a1b2c3_secret_x7y8z9").value

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentTest.kt
@@ -79,10 +79,22 @@ class SetupIntentTest {
         assertFailsWith<IllegalArgumentException> {
             SetupIntent.ClientSecret("seti_12345_secret_")
         }
+
+        assertFailsWith<IllegalArgumentException> {
+            SetupIntent.ClientSecret("seti_secret")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            SetupIntent.ClientSecret("seti_secret_a")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            PaymentIntent.ClientSecret("seti_a1b2c3_secret_x7y8z9pi_a1b2c3_secret_x7y8z9")
+        }
     }
 
     @Test
-    fun clientSecret_withValidKeys_throwsException() {
+    fun clientSecret_withValidKeys_succeeds() {
         assertEquals(
             "seti_a1b2c3_secret_x7y8z9",
             SetupIntent.ClientSecret("seti_a1b2c3_secret_x7y8z9").value


### PR DESCRIPTION
`\w` matches alphanumeric and underscore, but we only want
to match alphanumberic