### PR TITLE
Create PaymentSessionConfig.shouldPrefetchCustomer

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -90,9 +90,9 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setShippingMethodsFactory(ShippingMethodsFactory())
                 .setWindowFlags(WindowManager.LayoutParams.FLAG_SECURE)
                 .setBillingAddressFields(BillingAddressFields.Full)
+                .setShouldPrefetchCustomer(shouldPrefetchCustomer)
                 .build(),
-            savedInstanceState = savedInstanceState,
-            shouldPrefetchCustomer = shouldPrefetchCustomer
+            savedInstanceState = savedInstanceState
         )
         if (paymentSessionInitialized) {
             paymentSession.setCartTotal(2000L)

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -146,8 +146,6 @@ class PaymentSession @VisibleForTesting internal constructor(
      * necessary in the PaymentSession.
      * @param savedInstanceState a `Bundle` containing the saved state of a
      * PaymentSession that was stored in [savePaymentSessionInstanceState]
-     * @param shouldPrefetchCustomer If true, will immediately fetch the [Customer] associated
-     * with this session. Otherwise, will only fetch when needed.
      *
      * @return `true` if the PaymentSession is initialized, `false` if a state error
      * occurs. Failure can only occur if there is no initialized [CustomerSession].
@@ -156,10 +154,35 @@ class PaymentSession @VisibleForTesting internal constructor(
     fun init(
         listener: PaymentSessionListener,
         paymentSessionConfig: PaymentSessionConfig,
-        savedInstanceState: Bundle? = null,
-        shouldPrefetchCustomer: Boolean = true
+        savedInstanceState: Bundle? = null
     ): Boolean {
+        return init(listener, paymentSessionConfig, savedInstanceState, true)
+    }
 
+    /**
+     * Initialize the PaymentSession with a [PaymentSessionListener] to be notified of
+     * data changes.
+     *
+     * @param listener a [PaymentSessionListener] that will receive notifications of changes
+     * in payment session status, including networking status
+     * @param paymentSessionConfig a [PaymentSessionConfig] used to decide which items are
+     * necessary in the PaymentSession.
+     * @param savedInstanceState a `Bundle` containing the saved state of a
+     * PaymentSession that was stored in [savePaymentSessionInstanceState]
+     * @param shouldPrefetchCustomer If true, will immediately fetch the [Customer] associated
+     * with this session. Otherwise, will only fetch when needed.
+     *
+     * @return `true` if the PaymentSession is initialized, `false` if a state error
+     * occurs. Failure can only occur if there is no initialized [CustomerSession].
+     */
+    @Deprecated("Use PaymentSessionConfig.Builder.setShouldPrefetchCustomer() to specify shouldPrefetchCustomer.")
+    @JvmOverloads
+    fun init(
+        listener: PaymentSessionListener,
+        paymentSessionConfig: PaymentSessionConfig,
+        savedInstanceState: Bundle? = null,
+        shouldPrefetchCustomer: Boolean
+    ): Boolean {
         // Checking to make sure that there is a valid CustomerSession -- the getInstance() call
         // will throw a runtime exception if none is ready.
         try {
@@ -178,7 +201,7 @@ class PaymentSession @VisibleForTesting internal constructor(
         paymentSessionData = savedInstanceState?.getParcelable(STATE_PAYMENT_SESSION_DATA)
             ?: PaymentSessionData(paymentSessionConfig)
 
-        if (shouldPrefetchCustomer) {
+        if (shouldPrefetchCustomer || paymentSessionConfig.shouldPrefetchCustomer) {
             fetchCustomer()
         }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import android.os.Parcelable
 import androidx.annotation.LayoutRes
 import androidx.annotation.WorkerThread
+import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
@@ -34,6 +35,7 @@ data class PaymentSessionConfig internal constructor(
     val allowedShippingCountryCodes: Set<String> = emptySet(),
     val billingAddressFields: BillingAddressFields = BillingAddressFields.None,
 
+    internal val shouldPrefetchCustomer: Boolean = true,
     internal val shippingInformationValidator: ShippingInformationValidator? = null,
     internal val shippingMethodsFactory: ShippingMethodsFactory? = null,
     internal val windowFlags: Int? = null
@@ -97,6 +99,7 @@ data class PaymentSessionConfig internal constructor(
         private var shippingInformationValidator: ShippingInformationValidator? = null
         private var shippingMethodsFactory: ShippingMethodsFactory? = null
         private var windowFlags: Int? = null
+        private var shouldPrefetchCustomer: Boolean = true
 
         @LayoutRes
         private var addPaymentMethodFooterLayoutId: Int = 0
@@ -228,6 +231,16 @@ data class PaymentSessionConfig internal constructor(
             this.shippingMethodsFactory = shippingMethodsFactory
         }
 
+        /**
+         * @param shouldPrefetchCustomer If true, will immediately fetch the [Customer] associated
+         * with this session. Otherwise, will only fetch when needed.
+         *
+         * Defaults to true.
+         */
+        fun setShouldPrefetchCustomer(shouldPrefetchCustomer: Boolean): Builder = apply {
+            this.shouldPrefetchCustomer = shouldPrefetchCustomer
+        }
+
         override fun build(): PaymentSessionConfig {
             return PaymentSessionConfig(
                 hiddenShippingInfoFields = hiddenShippingInfoFields.orEmpty(),
@@ -241,7 +254,8 @@ data class PaymentSessionConfig internal constructor(
                 shippingInformationValidator = shippingInformationValidator,
                 shippingMethodsFactory = shippingMethodsFactory,
                 windowFlags = windowFlags,
-                billingAddressFields = billingAddressFields
+                billingAddressFields = billingAddressFields,
+                shouldPrefetchCustomer = shouldPrefetchCustomer
             )
         }
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -51,6 +51,8 @@ internal object PaymentSessionFixtures {
 
         .setBillingAddressFields(BillingAddressFields.Full)
 
+        .setShouldPrefetchCustomer(true)
+
         .build()
 
     internal val PAYMENT_SESSION_DATA = PaymentSessionData(PAYMENT_SESSION_CONFIG)


### PR DESCRIPTION
## Summary
Use this instead of passing `shouldPrefetchCustomer` to `PaymentSession#init()`

## Motivation
Simplify `PaymentSession.init()` for eventual removal in the next major release