### PR TITLE
Fix PaymentAuthWebViewActivity layout

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import com.stripe.android.model.Address
 import com.stripe.android.model.KlarnaSourceParams
 import com.stripe.android.model.SourceParams
 import com.stripe.example.R
@@ -34,10 +35,20 @@ class KlarnaSourceActivity : AppCompatActivity() {
     private fun createKlarnaSource() {
         viewModel.createSource(SourceParams.createKlarna(
             returnUrl = RETURN_URL,
-            currency = "eur",
+            currency = "gbp",
             klarnaParams = KlarnaSourceParams(
-                purchaseCountry = "DE",
-                lineItems = LINE_ITEMS
+                purchaseCountry = "UK",
+                lineItems = LINE_ITEMS,
+                billingFirstName = "Arthur",
+                billingLastName = "Dent",
+                billingAddress = Address.Builder()
+                    .setLine1("29 Arlington Avenue")
+                    .setCity("London")
+                    .setCountry("UK")
+                    .setPostalCode("N1 7BE")
+                    .build(),
+                billingEmail = "test@example.com",
+                billingPhone = "02012267709"
             )
         ))
     }

--- a/stripe/res/layout/payment_auth_web_view_layout.xml
+++ b/stripe/res/layout/payment_auth_web_view_layout.xml
@@ -17,7 +17,7 @@
         android:id="@+id/auth_web_view_container"
         android:layout_below="@id/payment_auth_web_view_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
         <com.stripe.android.view.PaymentAuthWebView
             android:id="@+id/auth_web_view"
             android:layout_width="match_parent"


### PR DESCRIPTION
The `PaymentAuthWebView` should take up the full height
of the screen.

Also add better example for Klarna integration.

| Before | After |
|-------------------|-----------------|
| ![before](https://user-images.githubusercontent.com/45020849/71123027-c9fcc200-21af-11ea-8044-1f1cf1f60b30.png) | ![after](https://user-images.githubusercontent.com/45020849/71123028-c9fcc200-21af-11ea-9ff0-7f50a6f9d9f1.png) |
