### PR TITLE
Create CardBrand enum

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -109,6 +109,9 @@
 
         <activity
             android:name=".activity.KlarnaSourceActivity" />
+
+        <activity
+            android:name=".activity.CardBrandsActivity" />
     </application>
 
 </manifest>

--- a/example/res/layout/activity_card_brands.xml
+++ b/example/res/layout/activity_card_brands.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <TextView
+        android:text="@string/card_brands"
+        style="@style/Header" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/card_brands"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+
+</LinearLayout>

--- a/example/res/layout/card_brand_item.xml
+++ b/example/res/layout/card_brand_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:paddingStart="3dp"
+    android:paddingEnd="3dp">
+
+    <ImageView
+        android:id="@+id/brand_logo"
+        android:layout_width="32dp"
+        android:layout_height="21dp"
+        android:contentDescription="@null"
+        />
+
+    <TextView
+        android:id="@+id/brand_name"
+        android:layout_width="wrap_content"
+        android:layout_height="21dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="15sp"
+        android:gravity="center_vertical"
+        android:layout_marginStart="12dp"
+        />
+</LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="launch_create_pm_sepa_debit">Create SEPA Debit Payment Method</string>
     <string name="fpx_payment_example">FPX Payment Example</string>
     <string name="klarna_source_example">Klarna Source Example</string>
+    <string name="card_brands">Card Brands</string>
 
     <string name="select_add_card">Select or add card</string>
     <string name="selected_card">Selected card:</string>

--- a/example/src/main/java/com/stripe/example/activity/CardBrandsActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardBrandsActivity.kt
@@ -1,0 +1,62 @@
+package com.stripe.example.activity
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.stripe.android.model.CardBrand
+import com.stripe.example.R
+import kotlinx.android.synthetic.main.activity_card_brands.*
+
+class CardBrandsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_card_brands)
+
+        card_brands.setHasFixedSize(true)
+        card_brands.layoutManager = LinearLayoutManager(this)
+        card_brands.adapter = Adapter(this)
+    }
+
+    internal class Adapter(
+        private val activity: Activity
+    ) : RecyclerView.Adapter<Adapter.CardBrandViewHolder>() {
+        init {
+            setHasStableIds(true)
+        }
+
+        override fun getItemCount(): Int {
+            return CardBrand.values().size
+        }
+
+        override fun onCreateViewHolder(
+            parent: ViewGroup,
+            viewType: Int
+        ): CardBrandViewHolder {
+            return CardBrandViewHolder(
+                activity.layoutInflater
+                    .inflate(R.layout.card_brand_item, parent, false)
+            )
+        }
+
+        override fun onBindViewHolder(holder: CardBrandViewHolder, position: Int) {
+            val brand = CardBrand.values()[position]
+            holder.nameView.text = brand.displayName
+            holder.logoView.setImageDrawable(
+                ContextCompat.getDrawable(activity, brand.icon)
+            )
+        }
+
+        internal class CardBrandViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+            val nameView: TextView = itemView.findViewById(R.id.brand_name)
+            val logoView: ImageView = itemView.findViewById(R.id.brand_logo)
+        }
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -55,7 +55,9 @@ class LauncherActivity : AppCompatActivity() {
             Item(activity.getString(R.string.fpx_payment_example),
                 FpxPaymentActivity::class.java),
             Item(activity.getString(R.string.klarna_source_example),
-                KlarnaSourceActivity::class.java)
+                KlarnaSourceActivity::class.java),
+            Item(activity.getString(R.string.card_brands),
+                CardBrandsActivity::class.java)
         )
 
         override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ExamplesViewHolder {

--- a/stripe/src/main/java/com/stripe/android/CardUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import com.stripe.android.model.Card
 import com.stripe.android.model.Card.CardBrand
+import com.stripe.android.model.CardBrand.Companion.fromCardNumber
 
 /**
  * Utility class for functions to do with cards.
@@ -131,22 +132,6 @@ object CardUtils {
                 cardNumber
             }
 
-        return when {
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_AMERICAN_EXPRESS) ->
-                CardBrand.AMERICAN_EXPRESS
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_DISCOVER) ->
-                CardBrand.DISCOVER
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_JCB) ->
-                CardBrand.JCB
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_DINERS_CLUB) ->
-                CardBrand.DINERS_CLUB
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_VISA) ->
-                CardBrand.VISA
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_MASTERCARD) ->
-                CardBrand.MASTERCARD
-            StripeTextUtils.hasAnyPrefix(spacelessCardNumber, *Card.PREFIXES_UNIONPAY) ->
-                CardBrand.UNIONPAY
-            else -> CardBrand.UNKNOWN
-        }
+        return fromCardNumber(spacelessCardNumber).displayName
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
@@ -25,17 +25,6 @@ object StripeTextUtils {
     }
 
     /**
-     * Check to see if the input number has any of the given prefixes.
-     *
-     * @param number the number to test
-     * @param prefixes the prefixes to test against
-     * @return `true` if number begins with any of the input prefixes
-     */
-    internal fun hasAnyPrefix(number: String?, vararg prefixes: String): Boolean {
-        return prefixes.any { number?.startsWith(it) == true }
-    }
-
-    /**
      * Calculate a hash value of a String input and convert the result to a hex string.
      *
      * @param toHash a value to hash

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -6,7 +6,6 @@ import androidx.annotation.Size
 import androidx.annotation.StringDef
 import com.stripe.android.CardUtils
 import com.stripe.android.ObjectBuilder
-import com.stripe.android.R
 import com.stripe.android.model.parsers.CardJsonParser
 import java.util.Calendar
 import kotlinx.android.parcel.Parcelize
@@ -558,18 +557,25 @@ data class Card internal constructor(
         /**
          * Based on [Issuer identification number table](http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29)
          */
+        @Deprecated("Use CardBrand.AmericanExpress.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
         val PREFIXES_AMERICAN_EXPRESS: Array<String> = arrayOf("34", "37")
+        @Deprecated("Use CardBrand.Discover.prefixes", ReplaceWith("CardBrand.Discover.prefixes"))
         val PREFIXES_DISCOVER: Array<String> = arrayOf("60", "64", "65")
+        @Deprecated("Use CardBrand.JCB.prefixes", ReplaceWith("CardBrand.JCB.prefixes"))
         val PREFIXES_JCB: Array<String> = arrayOf("35")
+        @Deprecated("Use CardBrand.DinersClub.prefixes", ReplaceWith("CardBrand.DinersClub.prefixes"))
         val PREFIXES_DINERS_CLUB: Array<String> = arrayOf(
             "300", "301", "302", "303", "304", "305", "309", "36", "38", "39"
         )
+        @Deprecated("Use CardBrand.Visa.prefixes", ReplaceWith("CardBrand.Visa.prefixes"))
         val PREFIXES_VISA: Array<String> = arrayOf("4")
+        @Deprecated("Use CardBrand.MasterCard.prefixes", ReplaceWith("CardBrand.MasterCard.prefixes"))
         val PREFIXES_MASTERCARD: Array<String> = arrayOf(
             "2221", "2222", "2223", "2224", "2225", "2226", "2227", "2228", "2229", "223", "224",
             "225", "226", "227", "228", "229", "23", "24", "25", "26", "270", "271", "2720",
             "50", "51", "52", "53", "54", "55", "67"
         )
+        @Deprecated("Use CardBrand.UnionPay.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
         val PREFIXES_UNIONPAY: Array<String> = arrayOf("62")
 
         const val MAX_LENGTH_STANDARD: Int = 16
@@ -577,17 +583,6 @@ data class Card internal constructor(
         const val MAX_LENGTH_DINERS_CLUB: Int = 14
 
         internal const val OBJECT_TYPE = "card"
-
-        private val BRAND_RESOURCE_MAP = mapOf(
-            CardBrand.AMERICAN_EXPRESS to R.drawable.stripe_ic_amex,
-            CardBrand.DINERS_CLUB to R.drawable.stripe_ic_diners,
-            CardBrand.DISCOVER to R.drawable.stripe_ic_discover,
-            CardBrand.JCB to R.drawable.stripe_ic_jcb,
-            CardBrand.MASTERCARD to R.drawable.stripe_ic_mastercard,
-            CardBrand.VISA to R.drawable.stripe_ic_visa,
-            CardBrand.UNIONPAY to R.drawable.stripe_ic_unionpay,
-            CardBrand.UNKNOWN to R.drawable.stripe_ic_unknown
-        )
 
         /**
          * Converts an unchecked String value to a [CardBrand] or `null`.
@@ -602,21 +597,18 @@ data class Card internal constructor(
                 return null
             }
 
-            return when {
-                CardBrand.AMERICAN_EXPRESS.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.AMERICAN_EXPRESS
-                CardBrand.MASTERCARD.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.MASTERCARD
-                CardBrand.DINERS_CLUB.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.DINERS_CLUB
-                CardBrand.DISCOVER.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.DISCOVER
-                CardBrand.JCB.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.JCB
-                CardBrand.VISA.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.VISA
-                CardBrand.UNIONPAY.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.UNIONPAY
+            val cardBrand = com.stripe.android.model.CardBrand.values().firstOrNull {
+                it.displayName.equals(possibleCardType, ignoreCase = true)
+            } ?: com.stripe.android.model.CardBrand.Unknown
+
+            return when (cardBrand.displayName) {
+                CardBrand.AMERICAN_EXPRESS -> CardBrand.AMERICAN_EXPRESS
+                CardBrand.MASTERCARD -> CardBrand.MASTERCARD
+                CardBrand.DINERS_CLUB -> CardBrand.DINERS_CLUB
+                CardBrand.DISCOVER -> CardBrand.DISCOVER
+                CardBrand.JCB -> CardBrand.JCB
+                CardBrand.VISA -> CardBrand.VISA
+                CardBrand.UNIONPAY -> CardBrand.UNIONPAY
                 else -> CardBrand.UNKNOWN
             }
         }
@@ -648,8 +640,11 @@ data class Card internal constructor(
         @JvmStatic
         @DrawableRes
         fun getBrandIcon(brand: String?): Int {
-            val brandIcon = BRAND_RESOURCE_MAP[brand]
-            return brandIcon ?: R.drawable.stripe_ic_unknown
+            val cardBrand = com.stripe.android.model.CardBrand.values()
+                .firstOrNull {
+                    it.displayName == brand
+                } ?: com.stripe.android.model.CardBrand.Unknown
+            return cardBrand.icon
         }
 
         /**

--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -1,0 +1,108 @@
+package com.stripe.android.model
+
+import androidx.annotation.DrawableRes
+import com.stripe.android.R
+
+enum class CardBrand(
+    val code: String,
+    val displayName: String,
+    @DrawableRes val icon: Int,
+    val maxLengthWithSpaces: Int = 19,
+    val maxLengthWithoutSpaces: Int = 16,
+
+    /**
+     * Based on [Issuer identification number table](http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29)
+     */
+    private val prefixes: Set<String> = emptySet()
+) {
+    AmericanExpress(
+        "amex",
+        "American Express",
+        R.drawable.stripe_ic_amex,
+        maxLengthWithSpaces = 17,
+        maxLengthWithoutSpaces = 15,
+        prefixes = setOf("34", "37")
+    ),
+
+    Discover(
+        "discover",
+        "Discover",
+        R.drawable.stripe_ic_discover,
+        prefixes = setOf("60", "64", "65")
+    ),
+
+    JCB(
+        "jcb",
+        "JCB",
+        R.drawable.stripe_ic_jcb,
+        prefixes = setOf("35")
+    ),
+
+    DinersClub(
+        "diners",
+        "Diners Club",
+        R.drawable.stripe_ic_diners,
+        maxLengthWithSpaces = 17,
+        maxLengthWithoutSpaces = 14,
+        prefixes = setOf(
+            "300", "301", "302", "303", "304", "305", "309", "36", "38", "39"
+        )
+    ),
+
+    Visa(
+        "visa",
+        "Visa",
+        R.drawable.stripe_ic_visa,
+        prefixes = setOf("4")
+    ),
+
+    MasterCard(
+        "mastercard",
+        "MasterCard",
+        R.drawable.stripe_ic_mastercard,
+        prefixes = setOf(
+            "2221", "2222", "2223", "2224", "2225", "2226", "2227", "2228", "2229", "223", "224",
+            "225", "226", "227", "228", "229", "23", "24", "25", "26", "270", "271", "2720",
+            "50", "51", "52", "53", "54", "55", "67"
+        )
+    ),
+
+    UnionPay(
+        "unionpay",
+        "UnionPay",
+        R.drawable.stripe_ic_unionpay,
+        prefixes = setOf("62")
+    ),
+
+    Unknown(
+        "unknown",
+        "Unknown",
+        R.drawable.stripe_ic_unknown
+    );
+
+    companion object {
+        /**
+         * @param cardNumber a card number
+         * @return the [CardBrand] that matches the [cardNumber]'s prefix, if one is found;
+         * otherwise, [CardBrand.Unknown]
+         */
+        fun fromCardNumber(cardNumber: String?): CardBrand {
+            return values()
+                .firstOrNull { cardBrand ->
+                    cardBrand.prefixes
+                        .takeIf {
+                            it.isNotEmpty()
+                        }?.any {
+                            cardNumber?.startsWith(it) == true
+                        } == true
+                } ?: Unknown
+        }
+
+        /**
+         * @param code a brand code, such as `visa` or `amex`. See [PaymentMethod.Card.brand].
+         */
+        fun fromCode(code: String?): CardBrand {
+            return values().firstOrNull { it.code == code } ?: Unknown
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.kt
@@ -2,60 +2,12 @@ package com.stripe.android
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Test class for [StripeTextUtils].
  */
 class StripeTextUtilsTest {
-
-    @Test
-    fun hasAnyPrefixShouldFailIfNull() {
-        assertFalse(StripeTextUtils.hasAnyPrefix(null))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldFailIfEmpty() {
-        assertFalse(StripeTextUtils.hasAnyPrefix(""))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldFailWithNullAndEmptyPrefix() {
-        assertFalse(StripeTextUtils.hasAnyPrefix(null, ""))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldFailWithNullAndSomePrefix() {
-        assertFalse(StripeTextUtils.hasAnyPrefix(null, "1"))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldMatch() {
-        assertTrue(StripeTextUtils.hasAnyPrefix("1234", "12"))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldMatchMultiple() {
-        assertTrue(StripeTextUtils.hasAnyPrefix("1234", "12", "1"))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldMatchSome() {
-        assertTrue(StripeTextUtils.hasAnyPrefix("abcd", "bc", "ab"))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldNotMatch() {
-        assertFalse(StripeTextUtils.hasAnyPrefix("1234", "23"))
-    }
-
-    @Test
-    fun hasAnyPrefixShouldNotMatchWithSpace() {
-        assertFalse(StripeTextUtils.hasAnyPrefix("xyz", " x"))
-    }
-
     @Test
     fun removeSpacesAndHyphens_withSpacesInInterior_returnsSpacelessNumber() {
         val testCardNumber = "4242 4242 4242 4242"

--- a/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.model
+
+import com.stripe.android.CardNumberFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CardBrandTest {
+
+    @Test
+    fun fromCardNumber_withNull() {
+        assertEquals(
+            CardBrand.Unknown,
+            CardBrand.fromCardNumber(null)
+        )
+    }
+
+    @Test
+    fun fromCardNumber_withEmpty() {
+        assertEquals(
+            CardBrand.Unknown,
+            CardBrand.fromCardNumber("")
+        )
+    }
+
+    @Test
+    fun fromCardNumber_withAmericanExpress() {
+        assertEquals(
+            CardBrand.AmericanExpress,
+            CardBrand.fromCardNumber(CardNumberFixtures.VALID_AMEX_NO_SPACES)
+        )
+    }
+
+    @Test
+    fun fromCardNumber_withDinersClub() {
+        assertEquals(
+            CardBrand.DinersClub,
+            CardBrand.fromCardNumber(CardNumberFixtures.VALID_DINERS_CLUB_NO_SPACES)
+        )
+    }
+
+    @Test
+    fun fromCardNumber_withVisa() {
+        assertEquals(
+            CardBrand.Visa,
+            CardBrand.fromCardNumber(CardNumberFixtures.VALID_VISA_NO_SPACES)
+        )
+    }
+
+    @Test
+    fun fromCardNumber_withInvalidVisa() {
+        assertEquals(
+            CardBrand.Unknown,
+            CardBrand.fromCardNumber("1" + CardNumberFixtures.VALID_VISA_NO_SPACES)
+        )
+    }
+}


### PR DESCRIPTION
This is the source of truth for Card Brand data

Add `CardBrandsActivity` to visually show information about
each `CardBrand`

Update some `Card` and `CardUtils` methods to use `CardBrand`

Fixes #1964

![Screenshot_1576858843](https://user-images.githubusercontent.com/45020849/71268367-c8034200-231a-11ea-9555-d79d46a63029.png)

