### PR TITLE
Make PaymentMethodsActivityStarter.Result.paymentMethod nullable

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -168,7 +168,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
      */
     @Parcelize
     data class Result internal constructor(
-        @JvmField val paymentMethod: PaymentMethod,
+        @JvmField val paymentMethod: PaymentMethod?,
         private val useGooglePay: Boolean = false
     ) : ActivityStarter.Result {
         override fun toBundle(): Bundle {


### PR DESCRIPTION
This enables supporting Google Pay as a payment method