### PR TITLE
Remove deprecated methods from PaymentSession and ActivityStarters

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -15,6 +15,8 @@
       If you need to specify `shouldPrefetchCustomer`, use `PaymentSessionConfig.Builder.setShouldPrefetchCustomer()`.
     - `PaymentSession#presentPaymentMethodSelection(shouldRequirePostalCode, userSelectedPaymentMethodId)` is deleted.
       If you need to specify billing details, use `PaymentSessionConfig.Builder#setBillingAddressFields()`.
+    - `setShouldRequirePostalCode()` has been removed from `AddPaymentMethodActivityStarter.Args` and
+      `PaymentMethodsActivityStarter.Args`. Use `setBillingAddressFields()` instead.
     - Shipping information validation and shipping methods creation logic when using `PaymentSession` has been improved.
       Previously, this was accomplished by creating a `BroadcastReceiver` and registering it for a
       particular `Intent`. This has been greatly simplified by providing `ShippingInformationValidator`

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -156,33 +156,6 @@ class PaymentSession @VisibleForTesting internal constructor(
         paymentSessionConfig: PaymentSessionConfig,
         savedInstanceState: Bundle? = null
     ): Boolean {
-        return init(listener, paymentSessionConfig, savedInstanceState, true)
-    }
-
-    /**
-     * Initialize the PaymentSession with a [PaymentSessionListener] to be notified of
-     * data changes.
-     *
-     * @param listener a [PaymentSessionListener] that will receive notifications of changes
-     * in payment session status, including networking status
-     * @param paymentSessionConfig a [PaymentSessionConfig] used to decide which items are
-     * necessary in the PaymentSession.
-     * @param savedInstanceState a `Bundle` containing the saved state of a
-     * PaymentSession that was stored in [savePaymentSessionInstanceState]
-     * @param shouldPrefetchCustomer If true, will immediately fetch the [Customer] associated
-     * with this session. Otherwise, will only fetch when needed.
-     *
-     * @return `true` if the PaymentSession is initialized, `false` if a state error
-     * occurs. Failure can only occur if there is no initialized [CustomerSession].
-     */
-    @Deprecated("Use PaymentSessionConfig.Builder.setShouldPrefetchCustomer() to specify shouldPrefetchCustomer.")
-    @JvmOverloads
-    fun init(
-        listener: PaymentSessionListener,
-        paymentSessionConfig: PaymentSessionConfig,
-        savedInstanceState: Bundle? = null,
-        shouldPrefetchCustomer: Boolean
-    ): Boolean {
         // Checking to make sure that there is a valid CustomerSession -- the getInstance() call
         // will throw a runtime exception if none is ready.
         try {
@@ -201,7 +174,7 @@ class PaymentSession @VisibleForTesting internal constructor(
         paymentSessionData = savedInstanceState?.getParcelable(STATE_PAYMENT_SESSION_DATA)
             ?: PaymentSessionData(paymentSessionConfig)
 
-        if (shouldPrefetchCustomer || paymentSessionConfig.shouldPrefetchCustomer) {
+        if (paymentSessionConfig.shouldPrefetchCustomer) {
             fetchCustomer()
         }
 
@@ -225,37 +198,10 @@ class PaymentSession @VisibleForTesting internal constructor(
      * initially selected on the Payment Method selection screen
      */
     fun presentPaymentMethodSelection(selectedPaymentMethodId: String? = null) {
-        presentPaymentMethodSelection(false, selectedPaymentMethodId)
-    }
-
-    /**
-     * Launch the [PaymentMethodsActivity] to allow the user to select a payment method,
-     * or to add a new one.
-     *
-     * The initial selected Payment Method ID uses the following logic.
-     *
-     *  1. If {@param userSelectedPaymentMethodId} is specified, use that
-     *  2. If the instance's [PaymentSessionData.paymentMethod] is non-null, use that
-     *  3. If the instance's [PaymentSessionPrefs.getSelectedPaymentMethodId] is non-null, use that
-     *  4. Otherwise, choose the most recently added Payment Method
-     *
-     * See [getSelectedPaymentMethodId]
-     *
-     * @param shouldRequirePostalCode if true, require postal code when adding a payment method
-     * @param userSelectedPaymentMethodId if non-null, the ID of the Payment Method that should be
-     * initially selected on the Payment Method selection screen
-     */
-    @Deprecated("Use presentPaymentMethodSelection(selectedPaymentMethodId) and configure billing fields using PaymentSessionConfig.Builder.setBillingAddressFields()")
-    @JvmOverloads
-    fun presentPaymentMethodSelection(
-        shouldRequirePostalCode: Boolean,
-        userSelectedPaymentMethodId: String? = null
-    ) {
         paymentMethodsActivityStarter.startForResult(
             PaymentMethodsActivityStarter.Args.Builder()
                 .setInitialPaymentMethodId(
-                    getSelectedPaymentMethodId(userSelectedPaymentMethodId))
-                .setShouldRequirePostalCode(shouldRequirePostalCode)
+                    getSelectedPaymentMethodId(selectedPaymentMethodId))
                 .setAddPaymentMethodFooter(config?.addPaymentMethodFooterLayoutId ?: 0)
                 .setIsPaymentSessionActive(true)
                 .setPaymentConfiguration(PaymentConfiguration.getInstance(context))

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -30,7 +30,6 @@ class AddPaymentMethodActivityStarter constructor(
     data class Args internal constructor(
         internal val billingAddressFields: BillingAddressFields,
         internal val shouldAttachToCustomer: Boolean,
-        internal val shouldRequirePostalCode: Boolean,
         internal val isPaymentSessionActive: Boolean,
         internal val shouldInitCustomerSessionTokens: Boolean,
         internal val paymentMethodType: PaymentMethod.Type,
@@ -42,7 +41,6 @@ class AddPaymentMethodActivityStarter constructor(
         class Builder : ObjectBuilder<Args> {
             private var billingAddressFields: BillingAddressFields = BillingAddressFields.None
             private var shouldAttachToCustomer: Boolean = false
-            private var shouldRequirePostalCode: Boolean = false
             private var isPaymentSessionActive = false
             private var shouldInitCustomerSessionTokens = true
             private var paymentMethodType: PaymentMethod.Type? = PaymentMethod.Type.Card
@@ -66,19 +64,6 @@ class AddPaymentMethodActivityStarter constructor(
                 billingAddressFields: BillingAddressFields
             ): Builder = apply {
                 this.billingAddressFields = billingAddressFields
-            }
-
-            /**
-             * If true, a postal code field will be shown and validated.
-             * Currently, only US ZIP Codes are supported.
-             */
-            @Deprecated("Use setBillingAddressFields()",
-                ReplaceWith("setBillingAddressFields(BillingAddressFields.PostalCode"))
-            fun setShouldRequirePostalCode(shouldRequirePostalCode: Boolean): Builder = apply {
-                this.shouldRequirePostalCode = shouldRequirePostalCode
-                if (shouldRequirePostalCode) {
-                    this.billingAddressFields = BillingAddressFields.PostalCode
-                }
             }
 
             /**
@@ -135,7 +120,6 @@ class AddPaymentMethodActivityStarter constructor(
                 return Args(
                     billingAddressFields = billingAddressFields,
                     shouldAttachToCustomer = shouldAttachToCustomer,
-                    shouldRequirePostalCode = shouldRequirePostalCode,
                     isPaymentSessionActive = isPaymentSessionActive,
                     shouldInitCustomerSessionTokens = shouldInitCustomerSessionTokens,
                     paymentMethodType = paymentMethodType ?: PaymentMethod.Type.Card,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -40,7 +40,6 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
     @Parcelize
     data class Args internal constructor(
         internal val initialPaymentMethodId: String?,
-        val shouldRequirePostalCode: Boolean,
         @LayoutRes val addPaymentMethodFooterLayoutId: Int,
         internal val isPaymentSessionActive: Boolean,
         internal val paymentMethodTypes: List<PaymentMethod.Type>,
@@ -52,7 +51,6 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
         class Builder : ObjectBuilder<Args> {
             private var billingAddressFields: BillingAddressFields = BillingAddressFields.None
             private var initialPaymentMethodId: String? = null
-            private var shouldRequirePostalCode = false
             private var isPaymentSessionActive = false
             private var paymentMethodTypes: List<PaymentMethod.Type>? = null
             private var shouldShowGooglePay: Boolean = false
@@ -72,12 +70,6 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
 
             fun setInitialPaymentMethodId(initialPaymentMethodId: String?): Builder = apply {
                 this.initialPaymentMethodId = initialPaymentMethodId
-            }
-
-            @Deprecated("Use setBillingAddressFields()",
-                ReplaceWith("setBillingAddressFields(BillingAddressFields.PostalCode"))
-            fun setShouldRequirePostalCode(shouldRequirePostalCode: Boolean): Builder = apply {
-                this.shouldRequirePostalCode = shouldRequirePostalCode
             }
 
             fun setIsPaymentSessionActive(isPaymentSessionActive: Boolean): Builder = apply {
@@ -139,7 +131,6 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             override fun build(): Args {
                 return Args(
                     initialPaymentMethodId = initialPaymentMethodId,
-                    shouldRequirePostalCode = shouldRequirePostalCode,
                     isPaymentSessionActive = isPaymentSessionActive,
                     paymentMethodTypes = paymentMethodTypes ?: listOf(PaymentMethod.Type.Card),
                     shouldShowGooglePay = shouldShowGooglePay,

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -157,7 +157,7 @@ class PaymentSessionTest {
         assertEquals(PaymentMethodsActivity::class.java.name, component?.className)
 
         val args = PaymentMethodsActivityStarter.Args.create(intent)
-        assertFalse(args.shouldRequirePostalCode)
+        assertEquals(BillingAddressFields.None, args.billingAddressFields)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
@@ -25,7 +25,6 @@ class PaymentMethodsActivityStarterTest {
         val args = PaymentMethodsActivityStarter.Args.Builder()
             .setInitialPaymentMethodId("pm_12345")
             .setIsPaymentSessionActive(true)
-            .setShouldRequirePostalCode(true)
             .setPaymentMethodTypes(listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Fpx))
             .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
             .setAddPaymentMethodFooter(R.layout.activity_payment_methods)


### PR DESCRIPTION
See [MIGRATING.md](https://github.com/stripe/stripe-android/blob/master/MIGRATING.md) for more details.

This is a breaking change.
