### PR TITLE
Update postal code logic for CardMultilineWidget

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,7 +2,12 @@
 
 ## Migrating from versions < 13.0.0
 - Changes to `CardInputWidget`
-    - The postal code field is now displayed by default. The postal code input is not validated.
+    - The postal code field is now displayed by default
+    - The postal code input is not validated
+- Changes to `CardMultilineWidget`
+    - The postal code field is now displayed by default
+    - The postal code input is not validated
+    - `CardInputListener.onPostalCodeComplete()` has been removed
 - Changes to `Stripe`
     - Bindings for API POST methods now take an optional `idempotencyKey`.
       Read about [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests) for more details.

--- a/example/res/layout/activity_card_payment_methods.xml
+++ b/example/res/layout/activity_card_payment_methods.xml
@@ -24,8 +24,7 @@
     <com.stripe.android.view.CardMultilineWidget
         android:id="@+id/card_multiline_widget"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:shouldShowPostalCode="true" />
+        android:layout_height="wrap_content" />
 
     <Button
         android:id="@+id/btn_create_payment_method"

--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -13,7 +13,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -47,15 +46,13 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
     }
 
     private fun createPaymentMethod() {
-        val paymentMethodCard =
-            card_multiline_widget.paymentMethodCard ?: return
+        val paymentMethodCreateParams =
+            card_multiline_widget.paymentMethodCreateParams ?: return
 
-        val createPaymentMethodParams =
-            PaymentMethodCreateParams.create(paymentMethodCard, BILLING_DETAILS)
         // Note: using this style of Observable creation results in us having a method that
         // will not be called until we subscribe to it.
         val createPaymentMethodObservable = Observable.fromCallable {
-            stripe.createPaymentMethodSynchronous(createPaymentMethodParams)
+            stripe.createPaymentMethodSynchronous(paymentMethodCreateParams)
         }
 
         compositeDisposable.add(createPaymentMethodObservable

--- a/stripe/src/main/java/com/stripe/android/view/CardInputListener.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputListener.kt
@@ -47,10 +47,4 @@ interface CardInputListener {
      * the user edits the CVC.
      */
     fun onCvcComplete()
-
-    /**
-     * Called when a potentially valid postal code or zip code has been entered.
-     * May be called multiple times.
-     */
-    fun onPostalCodeComplete()
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -56,8 +56,11 @@ internal class CardMultilineWidgetTest {
     @Mock
     private lateinit var noZipCardListener: CardInputListener
 
+    private val context: Context by lazy {
+        ApplicationProvider.getApplicationContext<Context>()
+    }
     private val activityScenarioFactory: ActivityScenarioFactory by lazy {
-        ActivityScenarioFactory(ApplicationProvider.getApplicationContext())
+        ActivityScenarioFactory(context)
     }
 
     @BeforeTest
@@ -66,7 +69,6 @@ internal class CardMultilineWidgetTest {
 
         CustomerSession.instance = mock()
 
-        val context: Context = ApplicationProvider.getApplicationContext()
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
         activityScenarioFactory.create<AddPaymentMethodActivity>(
@@ -99,6 +101,7 @@ internal class CardMultilineWidgetTest {
         ).use { activityScenario ->
             activityScenario.onActivity {
                 noZipCardMultilineWidget = it.findViewById(R.id.card_multiline_widget)
+                noZipCardMultilineWidget.setShouldShowPostalCode(false)
                 noZipGroup = WidgetControlGroup(noZipCardMultilineWidget)
             }
         }
@@ -164,36 +167,7 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun isPostalCodeMaximalLength_whenZipEnteredAndIsMaximalLength_returnsTrue() {
-        assertTrue(CardMultilineWidget.isPostalCodeMaximalLength("12345"))
-    }
-
-    @Test
-    fun isPostalCodeMaximalLength_whenZipEnteredAndIsNotMaximalLength_returnsFalse() {
-        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength("123"))
-    }
-
-    @Test
-    fun isPostalCodeMaximalLength_whenZipEnteredAndIsEmpty_returnsFalse() {
-        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(""))
-    }
-
-    @Test
-    fun isPostalCodeMaximalLength_whenZipEnteredAndIsNull_returnsFalse() {
-        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength(null))
-    }
-
-    /**
-     * This test should change when we allow and validate postal codes outside of the US
-     * in this control.
-     */
-    @Test
-    fun isPostalCodeMaximalLength_whenNotZip_returnsFalse() {
-        assertFalse(CardMultilineWidget.isPostalCodeMaximalLength("12345", 10))
-    }
-
-    @Test
-    fun getCard_whenInputIsValidVisaButInputHasNoZip_returnsNull() {
+    fun getCard_whenInputIsValidVisaButInputHasNoZip_returnsValidCard() {
         // The input date here will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
@@ -203,7 +177,7 @@ internal class CardMultilineWidgetTest {
         fullGroup.cvcEditText.append("123")
 
         val card = cardMultilineWidget.card
-        assertNull(card)
+        assertNotNull(card)
     }
 
     @Test
@@ -462,7 +436,7 @@ internal class CardMultilineWidgetTest {
         assertTrue(fullGroup.cardNumberEditText.shouldShowError)
         assertTrue(fullGroup.expiryDateEditText.shouldShowError)
         assertTrue(fullGroup.cvcEditText.shouldShowError)
-        assertTrue(fullGroup.postalCodeEditText.shouldShowError)
+        assertFalse(fullGroup.postalCodeEditText.shouldShowError)
 
         cardMultilineWidget.clear()
 
@@ -649,7 +623,6 @@ internal class CardMultilineWidgetTest {
         fullGroup.postalCodeEditText.append("12345")
 
         val card = cardMultilineWidget.card
-
         assertEquals(VALID_VISA_NO_SPACES, card?.number)
     }
 


### PR DESCRIPTION
- Default to showing postal code (i.e. `shouldShowPostalCode = true`)
- Change postal code hint field to be "Postal Code" instead of "Zip Code"
- Remove all validation from postal code field
- Remove `CardInputListener.onPostalCodeComplete()` - we no longer
  have a way to determine when the postal code has been completed, because
  this field supports all postal codes

Fixes #1778 

| Postal Code enabled (default) | Postal Code disabled |
| - | - |
| ![Screenshot_1576878348](https://user-images.githubusercontent.com/45020849/71295011-4d511b80-2348-11ea-957b-2da4d866a7d2.png) | ![Screenshot_1576878339](https://user-images.githubusercontent.com/45020849/71295019-54782980-2348-11ea-8a86-070febb56dbe.png) |