### PR TITLE
Use CardBrand enum to represent the card brand

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,6 +1,9 @@
 # Migration Guide
 
 ## Migrating from versions < 13.0.0
+- Changes to `Card` and `SourceCard`
+    - Make `brand` property a `CardBrand` instead of `String?`
+    - Remove `Card.CardBrand`
 - Changes to `CardInputWidget`
     - The postal code field is now displayed by default
     - The postal code input is not validated

--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -12,6 +12,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.SourceParams
@@ -210,12 +211,12 @@ class CreateCardSourceActivity : AppCompatActivity() {
         private var alertDialog: AlertDialog? = null
 
         fun showDialog(redirectUrl: String, sourceCardData: Map<String, *>) {
-            val brand = sourceCardData["brand"] as String?
+            val brand = CardBrand.fromCode(sourceCardData["brand"] as String?)
             val alertDialog = AlertDialog.Builder(activity, R.style.AlertDialogStyle)
                 .setTitle(activity.getString(R.string.authentication_dialog_title))
                 .setMessage(activity.getString(R.string.authentication_dialog_message,
                     brand, sourceCardData["last4"]))
-                .setIcon(Card.getBrandIcon(brand))
+                .setIcon(brand.icon)
                 .setPositiveButton(android.R.string.yes) { _, _ ->
                     activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(redirectUrl)))
                 }

--- a/stripe/src/main/java/com/stripe/android/CardUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.kt
@@ -1,29 +1,19 @@
 package com.stripe.android
 
-import com.stripe.android.model.Card
-import com.stripe.android.model.Card.CardBrand
-import com.stripe.android.model.CardBrand.Companion.fromCardNumber
+import com.stripe.android.model.CardBrand
 
 /**
  * Utility class for functions to do with cards.
  */
 object CardUtils {
 
-    private const val LENGTH_COMMON_CARD = 16
-    private const val LENGTH_AMERICAN_EXPRESS = 15
-    private const val LENGTH_DINERS_CLUB = 14
-
     /**
-     * Returns a [CardBrand] corresponding to a partial card number,
-     * or [Card.CardBrand.UNKNOWN] if the card brand can't be determined from the input value.
-     *
-     * @param cardNumber a credit card number or partial card number
-     * @return the [Card.CardBrand] corresponding to that number,
-     * or [CardBrand.UNKNOWN] if it can't be determined
+     * @param cardNumber a full or partial card number
+     * @return the [CardBrand] that matches the card number based on prefixes,
+     * or [CardBrand.Unknown] if it can't be determined
      */
     @JvmStatic
-    @Card.CardBrand
-    fun getPossibleCardType(cardNumber: String?): String {
+    fun getPossibleCardType(cardNumber: String?): CardBrand {
         return getPossibleCardType(cardNumber, true)
     }
 
@@ -85,44 +75,13 @@ object CardUtils {
      * @return `true` if the card number is of known type and the correct length
      */
     internal fun isValidCardLength(cardNumber: String?): Boolean {
-        return cardNumber != null && isValidCardLength(cardNumber,
-            getPossibleCardType(cardNumber, false))
+        return cardNumber != null &&
+            getPossibleCardType(cardNumber, false).isValidCardNumberLength(cardNumber)
     }
 
-    /**
-     * Checks to see whether the input number is of the correct length, given the assumed brand of
-     * the card. This function does not perform a Luhn check.
-     *
-     * @param cardNumber the card number with no spaces or dashes
-     * @param cardBrand a [Card.CardBrand] used to get the correct size
-     * @return `true` if the card number is the correct length for the assumed brand
-     */
-    internal fun isValidCardLength(
-        cardNumber: String?,
-        @CardBrand cardBrand: String
-    ): Boolean {
-        if (cardNumber == null || CardBrand.UNKNOWN == cardBrand) {
-            return false
-        }
-
-        val length = cardNumber.length
-        return when (cardBrand) {
-            CardBrand.AMERICAN_EXPRESS -> {
-                length == LENGTH_AMERICAN_EXPRESS
-            }
-            CardBrand.DINERS_CLUB -> {
-                length == LENGTH_DINERS_CLUB
-            }
-            else -> {
-                length == LENGTH_COMMON_CARD
-            }
-        }
-    }
-
-    @CardBrand
-    private fun getPossibleCardType(cardNumber: String?, shouldNormalize: Boolean): String {
+    private fun getPossibleCardType(cardNumber: String?, shouldNormalize: Boolean): CardBrand {
         if (cardNumber.isNullOrBlank()) {
-            return CardBrand.UNKNOWN
+            return CardBrand.Unknown
         }
 
         val spacelessCardNumber =
@@ -132,6 +91,6 @@ object CardUtils {
                 cardNumber
             }
 
-        return fromCardNumber(spacelessCardNumber).displayName
+        return CardBrand.fromCardNumber(spacelessCardNumber)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.IntRange
 import androidx.annotation.Size
 import androidx.annotation.StringDef
@@ -13,7 +12,7 @@ import org.json.JSONException
 import org.json.JSONObject
 
 /**
- * A model object representing a Card in the Android SDK.
+ * A representation of a [Card API object](https://stripe.com/docs/api/cards/object).
  */
 @Parcelize
 data class Card internal constructor(
@@ -29,141 +28,176 @@ data class Card internal constructor(
     val cvc: String?,
 
     /**
-     * @return the [expMonth] for this card
+     * @return Two-digit number representing the card’s expiration month.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-exp_month)
      */
     @get:IntRange(from = 1, to = 12)
     val expMonth: Int?,
 
     /**
-     * @return the [expYear] for this card
+     * @return Four-digit number representing the card’s expiration year.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-exp_year)
      */
     val expYear: Int?,
 
     /**
-     * @return the cardholder [name] for this card
+     * @return Cardholder name.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-name)
      */
     val name: String?,
 
     /**
-     * @return the [addressLine1] of this card
+     * @return Address line 1 (Street address/PO Box/Company name).
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_line1)
      */
     val addressLine1: String?,
 
     /**
-     * @return If address_line1 was provided, results of the check:
-     * pass, fail, unavailable, or unchecked.
+     * @return If address_line1 was provided, results of the check: `pass`, `fail`, `unavailable`,
+     * or `unchecked`.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_line1_check)
      */
     val addressLine1Check: String?,
 
     /**
-     * @return the [addressLine2] of this card
+     * @return Address line 2 (Apartment/Suite/Unit/Building).
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_line2)
      */
     val addressLine2: String?,
 
     /**
-     * @return the [addressCity] for this card
+     * @return City/District/Suburb/Town/Village.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_city)
      */
     val addressCity: String?,
 
     /**
-     * @return the [addressState] of this card
+     * @return State/County/Province/Region.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_state)
      */
     val addressState: String?,
 
     /**
-     * @return the [addressZip] of this card
+     * @return ZIP or postal code.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_zip)
      */
     val addressZip: String?,
 
     /**
-     * @return If address_zip was provided, results of the check:
-     * pass, fail, unavailable, or unchecked.
+     * @return If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`,
+     * or `unchecked`.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_zip_check)
      */
     val addressZipCheck: String?,
 
     /**
-     * @return the [addressCountry] of this card
+     * @return Billing address country, if provided when creating card.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-address_country)
      */
     val addressCountry: String?,
 
     /**
-     * @return the [last4] digits of this card.
+     * @return The last four digits of the card.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-last4)
      */
     @Size(4)
     val last4: String?,
 
     /**
-     * Gets the [brand] of this card. Updates the value if none has yet been set, or
-     * if the [number] has been changed.
+     * @return Card brand. Can be `"American Express"`, `"Diners Club"`, `"Discover"`, `"JCB"`,
+     * `"MasterCard"`, `"UnionPay"`, `"Visa"`, or `"Unknown"`.
      *
-     * @return the [brand] of this card
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-brand)
      */
-    @CardBrand
-    @get:CardBrand
-    val brand: String?,
+    val brand: CardBrand,
 
     /**
-     * @return the [funding] type of this card
+     * @return Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-funding)
      */
     @FundingType
     @get:FundingType
     val funding: String?,
 
     /**
-     * @return the [fingerprint] of this card
+     * @return Uniquely identifies this particular card number. You can use this attribute to
+     * check whether two customers who’ve signed up with you are using the same card number,
+     * for example.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-fingerprint)
      */
     val fingerprint: String?,
 
     /**
-     * @return the [country] of this card
+     * @return Two-letter ISO code representing the country of the card. You could use this
+     * attribute to get a sense of the international breakdown of cards you’ve collected.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-country)
      */
     val country: String?,
 
     /**
-     * @return the [currency] of this card. Only supported for Managed accounts.
+     * @return Three-letter [ISO code for currency](https://stripe.com/docs/payouts). Only
+     * applicable on accounts (not customers or recipients). The card can be used as a transfer
+     * destination for funds in this currency.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-currency)
      */
     val currency: String?,
 
     /**
      * @return The ID of the customer that this card belongs to.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-customer)
      */
     val customerId: String?,
 
     /**
-     * @return If a CVC was provided, results of the check:
-     * pass, fail, unavailable, or unchecked.
+     * @return If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`,
+     * or `unchecked`.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-cvc_check)
      */
     val cvcCheck: String?,
 
     /**
-     * @return the [id] of this card
+     * @return Unique identifier for the object.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-id)
      */
     override val id: String?,
+
     internal val loggingTokens: MutableList<String> = mutableListOf(),
+
+    /**
+     * @return If the card number is tokenized, this is the method that was used.
+     * Can be `apple_pay` or `google_pay`.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-tokenization_method)
+     */
     internal val tokenizationMethod: String?,
 
     /**
-     * @return the [metadata] of this card
+     * @return Set of key-value pairs that you can attach to an object. This can be useful fo
+     * storing additional information about the object in a structured format.
+     *
+     * [API Reference](https://stripe.com/docs/api/cards/object#card_object-metadata)
      */
     val metadata: Map<String, String>?
 ) : StripeModel, StripePaymentSource, StripeParamsModel {
-
-    @Retention(AnnotationRetention.SOURCE)
-    @StringDef(CardBrand.AMERICAN_EXPRESS, CardBrand.DISCOVER, CardBrand.JCB,
-        CardBrand.DINERS_CLUB, CardBrand.VISA, CardBrand.MASTERCARD,
-        CardBrand.UNIONPAY, CardBrand.UNKNOWN)
-    annotation class CardBrand {
-        companion object {
-            const val AMERICAN_EXPRESS: String = "American Express"
-            const val DISCOVER: String = "Discover"
-            const val JCB: String = "JCB"
-            const val DINERS_CLUB: String = "Diners Club"
-            const val VISA: String = "Visa"
-            const val MASTERCARD: String = "MasterCard"
-            const val UNIONPAY: String = "UnionPay"
-            const val UNKNOWN: String = "Unknown"
-        }
-    }
 
     @Retention(AnnotationRetention.SOURCE)
     @StringDef(FundingType.CREDIT, FundingType.DEBIT, FundingType.PREPAID, FundingType.UNKNOWN)
@@ -273,11 +307,7 @@ data class Card internal constructor(
             return false
         }
         val cvcValue = cvc.trim()
-        val updatedType = brand
-        val validLength =
-            updatedType == null && cvcValue.length >= 3 && cvcValue.length <= 4 ||
-                CardBrand.AMERICAN_EXPRESS == updatedType && cvcValue.length == 4 ||
-                cvcValue.length == 3
+        val validLength = brand.isValidCvc(cvc)
 
         return ModelUtils.isWholePositiveNumber(cvcValue) && validLength
     }
@@ -353,10 +383,10 @@ data class Card internal constructor(
      * @param cvc the card CVC number
      */
     class Builder(
-        internal val number: String?,
-        @param:IntRange(from = 1, to = 12) internal val expMonth: Int?,
-        @param:IntRange(from = 0) internal val expYear: Int?,
-        internal val cvc: String?
+        internal val number: String? = null,
+        @param:IntRange(from = 1, to = 12) internal val expMonth: Int? = null,
+        @param:IntRange(from = 0) internal val expYear: Int? = null,
+        internal val cvc: String? = null
     ) : ObjectBuilder<Card> {
         private var name: String? = null
         private var addressLine1: String? = null
@@ -367,8 +397,7 @@ data class Card internal constructor(
         private var addressZip: String? = null
         private var addressZipCheck: String? = null
         private var addressCountry: String? = null
-        @CardBrand
-        private var brand: String? = null
+        private var brand: CardBrand? = null
         @FundingType
         private var funding: String? = null
         @Size(4)
@@ -383,109 +412,89 @@ data class Card internal constructor(
         private var metadata: Map<String, String>? = null
         private var loggingTokens: List<String>? = null
 
-        fun name(name: String?): Builder {
+        fun name(name: String?): Builder = apply {
             this.name = name
-            return this
         }
 
-        fun addressLine1(address: String?): Builder {
+        fun addressLine1(address: String?): Builder = apply {
             this.addressLine1 = address
-            return this
         }
 
-        fun addressLine1Check(addressLine1Check: String?): Builder {
+        fun addressLine1Check(addressLine1Check: String?): Builder = apply {
             this.addressLine1Check = addressLine1Check
-            return this
         }
 
-        fun addressLine2(address: String?): Builder {
+        fun addressLine2(address: String?): Builder = apply {
             this.addressLine2 = address
-            return this
         }
 
-        fun addressCity(city: String?): Builder {
+        fun addressCity(city: String?): Builder = apply {
             this.addressCity = city
-            return this
         }
 
-        fun addressState(state: String?): Builder {
+        fun addressState(state: String?): Builder = apply {
             this.addressState = state
-            return this
         }
 
-        fun addressZip(zip: String?): Builder {
+        fun addressZip(zip: String?): Builder = apply {
             this.addressZip = zip
-            return this
         }
 
-        fun addressZipCheck(zipCheck: String?): Builder {
+        fun addressZipCheck(zipCheck: String?): Builder = apply {
             this.addressZipCheck = zipCheck
-            return this
         }
 
-        fun addressCountry(country: String?): Builder {
+        fun addressCountry(country: String?): Builder = apply {
             this.addressCountry = country
-            return this
         }
 
-        fun brand(@CardBrand brand: String?): Builder {
+        fun brand(brand: CardBrand?): Builder = apply {
             this.brand = brand
-            return this
         }
 
-        fun fingerprint(fingerprint: String?): Builder {
+        fun fingerprint(fingerprint: String?): Builder = apply {
             this.fingerprint = fingerprint
             return this
         }
 
-        fun funding(@FundingType funding: String?): Builder {
+        fun funding(@FundingType funding: String?): Builder = apply {
             this.funding = funding
-            return this
         }
 
-        fun country(country: String?): Builder {
+        fun country(country: String?): Builder = apply {
             this.country = country
-            return this
         }
 
-        fun currency(currency: String?): Builder {
+        fun currency(currency: String?): Builder = apply {
             this.currency = currency
-            return this
         }
 
-        fun customer(customerId: String?): Builder {
+        fun customer(customerId: String?): Builder = apply {
             this.customerId = customerId
-            return this
         }
 
-        fun cvcCheck(cvcCheck: String?): Builder {
+        fun cvcCheck(cvcCheck: String?): Builder = apply {
             this.cvcCheck = cvcCheck
-            return this
         }
 
-        fun last4(last4: String?): Builder {
+        fun last4(last4: String?): Builder = apply {
             this.last4 = last4
-            return this
         }
 
-        fun id(id: String?): Builder {
+        fun id(id: String?): Builder = apply {
             this.id = id
-            return this
         }
 
-        fun tokenizationMethod(tokenizationMethod: String?): Builder {
+        fun tokenizationMethod(tokenizationMethod: String?): Builder = apply {
             this.tokenizationMethod = tokenizationMethod
-            return this
         }
 
-        fun metadata(metadata: Map<String, String>?): Builder {
+        fun metadata(metadata: Map<String, String>?): Builder = apply {
             this.metadata = metadata
-            return this
         }
 
-        fun loggingTokens(loggingTokens: List<String>): Builder {
+        fun loggingTokens(loggingTokens: List<String>): Builder = apply {
             this.loggingTokens = loggingTokens
-            return this
         }
 
         /**
@@ -511,11 +520,7 @@ data class Card internal constructor(
                 addressZipCheck = addressZipCheck.takeUnless { it.isNullOrBlank() },
                 addressCountry = addressCountry.takeUnless { it.isNullOrBlank() },
                 last4 = last4,
-                brand = if (asCardBrand(brand) == null) {
-                    calculateBrand(brand)
-                } else {
-                    brand
-                },
+                brand = brand ?: CardUtils.getPossibleCardType(number),
                 fingerprint = fingerprint.takeUnless { it.isNullOrBlank() },
                 funding = asFundingType(funding).takeUnless { it.isNullOrBlank() },
                 country = country.takeUnless { it.isNullOrBlank() },
@@ -540,14 +545,6 @@ data class Card internal constructor(
                 null
             }
         }
-
-        private fun calculateBrand(brand: String?): String? {
-            return if (brand.isNullOrBlank() && !number.isNullOrBlank()) {
-                CardUtils.getPossibleCardType(number)
-            } else {
-                brand
-            }
-        }
     }
 
     companion object {
@@ -558,60 +555,25 @@ data class Card internal constructor(
          * Based on [Issuer identification number table](http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29)
          */
         @Deprecated("Use CardBrand.AmericanExpress.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
-        val PREFIXES_AMERICAN_EXPRESS: Array<String> = arrayOf("34", "37")
+        val PREFIXES_AMERICAN_EXPRESS: Array<String> = CardBrand.AmericanExpress.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.Discover.prefixes", ReplaceWith("CardBrand.Discover.prefixes"))
-        val PREFIXES_DISCOVER: Array<String> = arrayOf("60", "64", "65")
+        val PREFIXES_DISCOVER: Array<String> = CardBrand.Discover.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.JCB.prefixes", ReplaceWith("CardBrand.JCB.prefixes"))
-        val PREFIXES_JCB: Array<String> = arrayOf("35")
+        val PREFIXES_JCB: Array<String> = CardBrand.JCB.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.DinersClub.prefixes", ReplaceWith("CardBrand.DinersClub.prefixes"))
-        val PREFIXES_DINERS_CLUB: Array<String> = arrayOf(
-            "300", "301", "302", "303", "304", "305", "309", "36", "38", "39"
-        )
+        val PREFIXES_DINERS_CLUB: Array<String> = CardBrand.DinersClub.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.Visa.prefixes", ReplaceWith("CardBrand.Visa.prefixes"))
-        val PREFIXES_VISA: Array<String> = arrayOf("4")
+        val PREFIXES_VISA: Array<String> = CardBrand.Visa.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.MasterCard.prefixes", ReplaceWith("CardBrand.MasterCard.prefixes"))
-        val PREFIXES_MASTERCARD: Array<String> = arrayOf(
-            "2221", "2222", "2223", "2224", "2225", "2226", "2227", "2228", "2229", "223", "224",
-            "225", "226", "227", "228", "229", "23", "24", "25", "26", "270", "271", "2720",
-            "50", "51", "52", "53", "54", "55", "67"
-        )
+        val PREFIXES_MASTERCARD: Array<String> = CardBrand.MasterCard.prefixes.toTypedArray()
         @Deprecated("Use CardBrand.UnionPay.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
-        val PREFIXES_UNIONPAY: Array<String> = arrayOf("62")
+        val PREFIXES_UNIONPAY: Array<String> = CardBrand.UnionPay.prefixes.toTypedArray()
 
         const val MAX_LENGTH_STANDARD: Int = 16
         const val MAX_LENGTH_AMERICAN_EXPRESS: Int = 15
         const val MAX_LENGTH_DINERS_CLUB: Int = 14
 
         internal const val OBJECT_TYPE = "card"
-
-        /**
-         * Converts an unchecked String value to a [CardBrand] or `null`.
-         *
-         * @param possibleCardType a String that might match a [CardBrand] or be empty.
-         * @return `null` if the input is blank, else the appropriate [CardBrand].
-         */
-        @JvmStatic
-        @CardBrand
-        fun asCardBrand(possibleCardType: String?): String? {
-            if (possibleCardType.isNullOrBlank()) {
-                return null
-            }
-
-            val cardBrand = com.stripe.android.model.CardBrand.values().firstOrNull {
-                it.displayName.equals(possibleCardType, ignoreCase = true)
-            } ?: com.stripe.android.model.CardBrand.Unknown
-
-            return when (cardBrand.displayName) {
-                CardBrand.AMERICAN_EXPRESS -> CardBrand.AMERICAN_EXPRESS
-                CardBrand.MASTERCARD -> CardBrand.MASTERCARD
-                CardBrand.DINERS_CLUB -> CardBrand.DINERS_CLUB
-                CardBrand.DISCOVER -> CardBrand.DISCOVER
-                CardBrand.JCB -> CardBrand.JCB
-                CardBrand.VISA -> CardBrand.VISA
-                CardBrand.UNIONPAY -> CardBrand.UNIONPAY
-                else -> CardBrand.UNKNOWN
-            }
-        }
 
         /**
          * Converts an unchecked String value to a [FundingType] or `null`.
@@ -635,16 +597,6 @@ data class Card internal constructor(
                     FundingType.PREPAID
                 else -> FundingType.UNKNOWN
             }
-        }
-
-        @JvmStatic
-        @DrawableRes
-        fun getBrandIcon(brand: String?): Int {
-            val cardBrand = com.stripe.android.model.CardBrand.values()
-                .firstOrNull {
-                    it.displayName == brand
-                } ?: com.stripe.android.model.CardBrand.Unknown
-            return cardBrand.icon
         }
 
         /**
@@ -681,10 +633,10 @@ data class Card internal constructor(
          */
         @JvmStatic
         fun create(
-            number: String?,
-            expMonth: Int?,
-            expYear: Int?,
-            cvc: String?
+            number: String? = null,
+            expMonth: Int? = null,
+            expYear: Int? = null,
+            cvc: String? = null
         ): Card {
             return Builder(number, expMonth, expYear, cvc)
                 .build()

--- a/stripe/src/main/java/com/stripe/android/model/SourceCardData.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCardData.kt
@@ -11,9 +11,7 @@ data class SourceCardData internal constructor(
     val addressLine1Check: String?,
     val addressZipCheck: String?,
 
-    @Card.CardBrand
-    @get:Card.CardBrand
-    val brand: String?,
+    val brand: CardBrand,
 
     val country: String?,
     val cvcCheck: String?,

--- a/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.model.Card
-import com.stripe.android.model.Card.CardBrand
 import com.stripe.android.model.Card.FundingType
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
@@ -21,7 +21,7 @@ internal class CardJsonParser : ModelJsonParser<Card> {
             .takeUnless { it < 0 }
 
         // Note that we'll never get the CVC or card number in JSON, so those values are null
-        return Card.Builder(null, expMonth, expYear, null)
+        return Card.Builder(expMonth = expMonth, expYear = expYear)
             .addressCity(StripeJsonUtils.optString(json, FIELD_ADDRESS_CITY))
             .addressLine1(StripeJsonUtils.optString(json, FIELD_ADDRESS_LINE1))
             .addressLine1Check(StripeJsonUtils.optString(json, FIELD_ADDRESS_LINE1_CHECK))
@@ -30,7 +30,7 @@ internal class CardJsonParser : ModelJsonParser<Card> {
             .addressState(StripeJsonUtils.optString(json, FIELD_ADDRESS_STATE))
             .addressZip(StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP))
             .addressZipCheck(StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP_CHECK))
-            .brand(asCardBrand(StripeJsonUtils.optString(json, FIELD_BRAND)))
+            .brand(CardBrand.fromCode(StripeJsonUtils.optString(json, FIELD_BRAND)))
             .country(StripeJsonUtils.optCountryCode(json, FIELD_COUNTRY))
             .customer(StripeJsonUtils.optString(json, FIELD_CUSTOMER))
             .currency(StripeJsonUtils.optCurrency(json, FIELD_CURRENCY))
@@ -72,38 +72,6 @@ internal class CardJsonParser : ModelJsonParser<Card> {
         private const val FIELD_LAST4 = "last4"
         private const val FIELD_ID = "id"
         private const val FIELD_TOKENIZATION_METHOD = "tokenization_method"
-
-        /**
-         * Converts an unchecked String value to a [CardBrand] or `null`.
-         *
-         * @param possibleCardType a String that might match a [CardBrand] or be empty.
-         * @return `null` if the input is blank, else the appropriate [CardBrand].
-         */
-        @JvmStatic
-        @CardBrand
-        fun asCardBrand(possibleCardType: String?): String? {
-            if (possibleCardType.isNullOrBlank()) {
-                return null
-            }
-
-            return when {
-                CardBrand.AMERICAN_EXPRESS.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.AMERICAN_EXPRESS
-                CardBrand.MASTERCARD.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.MASTERCARD
-                CardBrand.DINERS_CLUB.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.DINERS_CLUB
-                CardBrand.DISCOVER.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.DISCOVER
-                CardBrand.JCB.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.JCB
-                CardBrand.VISA.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.VISA
-                CardBrand.UNIONPAY.equals(possibleCardType, ignoreCase = true) ->
-                    CardBrand.UNIONPAY
-                else -> CardBrand.UNKNOWN
-            }
-        }
 
         /**
          * Converts an unchecked String value to a [FundingType] or `null`.

--- a/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model.parsers
 
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.StripeJsonUtils
 import java.util.Locale
@@ -12,7 +13,7 @@ internal class SourceCardDataJsonParser : ModelJsonParser<SourceCardData> {
         return SourceCardData(
             addressLine1Check = StripeJsonUtils.optString(json, FIELD_ADDRESS_LINE1_CHECK),
             addressZipCheck = StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP_CHECK),
-            brand = Card.asCardBrand(StripeJsonUtils.optString(json, FIELD_BRAND)),
+            brand = CardBrand.fromCode(StripeJsonUtils.optString(json, FIELD_BRAND)),
             country = StripeJsonUtils.optString(json, FIELD_COUNTRY),
             cvcCheck = StripeJsonUtils.optString(json, FIELD_CVC_CHECK),
             dynamicLast4 = StripeJsonUtils.optString(json, FIELD_DYNAMIC_LAST4),

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -22,7 +22,6 @@ import androidx.annotation.ColorInt
 import androidx.annotation.IdRes
 import androidx.annotation.IntRange
 import androidx.annotation.VisibleForTesting
-import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
@@ -30,7 +29,7 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.Card
-import com.stripe.android.model.Card.CardBrand
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CARD
@@ -61,7 +60,6 @@ class CardInputWidget @JvmOverloads constructor(
     @ColorInt
     private var tintColorInt: Int = 0
 
-    private var isAmEx: Boolean = false
     private var initFlag: Boolean = false
 
     @JvmSynthetic
@@ -81,6 +79,11 @@ class CardInputWidget @JvmOverloads constructor(
     private val cvcValue: String?
         get() {
             return cvcNumberEditText.cvcValue
+        }
+
+    private val brand: CardBrand
+        get() {
+            return cardNumberEditText.cardBrand
         }
 
     @VisibleForTesting
@@ -501,13 +504,12 @@ class CardInputWidget @JvmOverloads constructor(
             FULL_SIZING_DATE_TEXT, expiryDateEditText
         )
 
-        @Card.CardBrand val brand = cardNumberEditText.cardBrand
         placementParameters.hiddenCardWidth = getDesiredWidthInPixels(
-            getHiddenTextForBrand(brand), cardNumberEditText
+            hiddenCardText, cardNumberEditText
         )
 
         placementParameters.cvcWidth = getDesiredWidthInPixels(
-            getCvcPlaceHolderForBrand(brand), cvcNumberEditText
+            cvcPlaceHolder, cvcNumberEditText
         )
 
         placementParameters.postalCodeWidth = getDesiredWidthInPixels(
@@ -515,7 +517,7 @@ class CardInputWidget @JvmOverloads constructor(
         )
 
         placementParameters.peekCardWidth = getDesiredWidthInPixels(
-            getPeekCardTextForBrand(brand), cardNumberEditText
+            peekCardText, cardNumberEditText
         )
 
         placementParameters.updateSpacing(isCardViewed, postalCodeEnabled, frameStart, frameWidth)
@@ -606,22 +608,16 @@ class CardInputWidget @JvmOverloads constructor(
                 scrollRight()
                 cardInputListener?.onFocusChange(FOCUS_CVC)
             }
-            updateIconCvc(
-                cardNumberEditText.cardBrand,
-                hasFocus,
-                cvcValue
-            )
+            updateIconCvc(hasFocus, cvcValue)
         }
 
         cvcNumberEditText.setAfterTextChangedListener(
             object : StripeEditText.AfterTextChangedListener {
                 override fun onTextChanged(text: String) {
-                    if (ViewUtils.isCvcMaximalLength(cardNumberEditText.cardBrand, text)) {
+                    if (ViewUtils.isCvcMaximalLength(brand, text)) {
                         cardInputListener?.onCvcComplete()
                     }
-                    updateIconCvc(cardNumberEditText.cardBrand,
-                        cvcNumberEditText.hasFocus(),
-                        text)
+                    updateIconCvc(cvcNumberEditText.hasFocus(), text)
                 }
             }
         )
@@ -632,8 +628,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         cardNumberEditText.brandChangeCallback = { brand ->
-            isAmEx = CardBrand.AMERICAN_EXPRESS == brand
-            updateIcon(brand)
+            updateIcon()
             cvcNumberEditText.updateBrand(brand)
         }
 
@@ -824,38 +819,35 @@ class CardInputWidget @JvmOverloads constructor(
         }
     }
 
-    private fun getHiddenTextForBrand(@CardBrand brand: String): String {
-        return if (CardBrand.AMERICAN_EXPRESS == brand) {
-            HIDDEN_TEXT_AMEX
-        } else {
-            HIDDEN_TEXT_COMMON
+    private val hiddenCardText: String
+        get() {
+            return if (CardBrand.AmericanExpress == brand) {
+                HIDDEN_TEXT_AMEX
+            } else {
+                HIDDEN_TEXT_COMMON
+            }
         }
-    }
 
-    private fun getCvcPlaceHolderForBrand(@Card.CardBrand brand: String): String {
-        return if (CardBrand.AMERICAN_EXPRESS == brand) {
-            CVC_PLACEHOLDER_AMEX
-        } else {
-            CVC_PLACEHOLDER_COMMON
+    private val cvcPlaceHolder: String
+        get() {
+            return if (CardBrand.AmericanExpress == brand) {
+                CVC_PLACEHOLDER_AMEX
+            } else {
+                CVC_PLACEHOLDER_COMMON
+            }
         }
-    }
 
-    private fun getPeekCardTextForBrand(@Card.CardBrand brand: String): String {
-        return when (brand) {
-            CardBrand.AMERICAN_EXPRESS -> {
-                PEEK_TEXT_AMEX
-            }
-            CardBrand.DINERS_CLUB -> {
-                PEEK_TEXT_DINERS
-            }
-            else -> {
-                PEEK_TEXT_COMMON
+    private val peekCardText: String
+        get() {
+            return when (brand) {
+                CardBrand.AmericanExpress -> PEEK_TEXT_AMEX
+                CardBrand.DinersClub -> PEEK_TEXT_DINERS
+                else -> PEEK_TEXT_COMMON
             }
         }
-    }
 
     private fun applyTint(isCvc: Boolean) {
-        if (isCvc || CardBrand.UNKNOWN == cardNumberEditText.cardBrand) {
+        if (isCvc || CardBrand.Unknown == brand) {
             val icon = cardIconImageView.drawable
             val compatIcon = DrawableCompat.wrap(icon)
             DrawableCompat.setTint(compatIcon.mutate(), tintColorInt)
@@ -863,34 +855,26 @@ class CardInputWidget @JvmOverloads constructor(
         }
     }
 
-    private fun updateIcon(@Card.CardBrand brand: String) {
-        if (CardBrand.UNKNOWN == brand) {
-            val icon = ContextCompat.getDrawable(context, R.drawable.stripe_ic_unknown)
-            cardIconImageView.setImageDrawable(icon)
+    private fun updateIcon() {
+        cardIconImageView.setImageResource(brand.icon)
+        if (brand == CardBrand.Unknown) {
             applyTint(false)
-        } else {
-            cardIconImageView.setImageResource(Card.getBrandIcon(brand))
         }
     }
 
     private fun updateIconCvc(
-        @CardBrand brand: String,
         hasFocus: Boolean,
         cvcText: String?
     ) {
         if (shouldIconShowBrand(brand, hasFocus, cvcText)) {
-            updateIcon(brand)
+            updateIcon()
         } else {
-            updateIconForCvcEntry(CardBrand.AMERICAN_EXPRESS == brand)
+            updateIconForCvcEntry()
         }
     }
 
-    private fun updateIconForCvcEntry(isAmEx: Boolean) {
-        cardIconImageView.setImageResource(if (isAmEx) {
-            R.drawable.stripe_ic_cvc_amex
-        } else {
-            R.drawable.stripe_ic_cvc
-        })
+    private fun updateIconForCvcEntry() {
+        cardIconImageView.setImageResource(brand.cvcIcon)
         applyTint(true)
     }
 
@@ -1232,15 +1216,16 @@ class CardInputWidget @JvmOverloads constructor(
          * Determines whether or not the icon should show the card brand instead of the
          * CVC helper icon.
          *
-         * @param brand the [Card.CardBrand] in question, used for determining max length
+         * @param brand the [CardBrand] of the card number
          * @param cvcHasFocus `true` if the CVC entry field has focus, `false` otherwise
          * @param cvcText the current content of [cvcNumberEditText]
+         *
          * @return `true` if we should show the brand of the card, or `false` if we
          * should show the CVC helper icon instead
          */
         @VisibleForTesting
         internal fun shouldIconShowBrand(
-            @Card.CardBrand brand: String,
+            brand: CardBrand,
             cvcHasFocus: Boolean,
             cvcText: String?
         ): Boolean {

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build
-import android.text.TextUtils
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.View
@@ -23,6 +22,7 @@ import com.stripe.android.CardUtils
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CARD
@@ -57,8 +57,7 @@ class CardMultilineWidget @JvmOverloads constructor(
     private var hasAdjustedDrawable: Boolean = false
     private var customCvcLabel: String? = null
 
-    @Card.CardBrand
-    private var cardBrand: String = Card.CardBrand.UNKNOWN
+    private var cardBrand: CardBrand = CardBrand.Unknown
     @ColorInt
     private val tintColorInt: Int
 
@@ -153,19 +152,13 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private val isCvcLengthValid: Boolean
         get() {
-            val cvcLength = cvcEditText.text?.toString()?.trim()?.length
-            return if (TextUtils.equals(Card.CardBrand.AMERICAN_EXPRESS, cardBrand) &&
-                cvcLength == Card.CVC_LENGTH_AMERICAN_EXPRESS) {
-                true
-            } else {
-                cvcLength == Card.CVC_LENGTH_COMMON
-            }
+            return cardBrand.isValidCvc(cvcEditText.rawCvcValue)
         }
 
     private val cvcHelperText: Int
         @StringRes
         get() {
-            return if (Card.CardBrand.AMERICAN_EXPRESS == cardBrand) {
+            return if (CardBrand.AmericanExpress == cardBrand) {
                 R.string.cvc_multiline_helper_amex
             } else {
                 R.string.cvc_multiline_helper
@@ -257,7 +250,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
         cardNumberEditText.updateLengthFilter()
 
-        cardBrand = Card.CardBrand.UNKNOWN
+        cardBrand = CardBrand.Unknown
         updateBrandUi()
 
         isEnabled = true
@@ -276,7 +269,7 @@ class CardMultilineWidget @JvmOverloads constructor(
         cvcEditText.shouldShowError = false
         postalCodeEditText.shouldShowError = false
 
-        cardBrand = Card.CardBrand.UNKNOWN
+        cardBrand = CardBrand.Unknown
         updateBrandUi()
     }
 
@@ -471,13 +464,7 @@ class CardMultilineWidget @JvmOverloads constructor(
             return
         }
 
-        @DrawableRes val resourceId = if (Card.CardBrand.AMERICAN_EXPRESS == cardBrand) {
-            R.drawable.stripe_ic_cvc_amex
-        } else {
-            R.drawable.stripe_ic_cvc
-        }
-
-        updateDrawable(resourceId, true)
+        updateDrawable(cardBrand.cvcIcon, true)
     }
 
     private fun initDeleteEmptyListeners() {
@@ -557,7 +544,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private fun updateBrandUi() {
         updateCvc()
-        updateDrawable(Card.getBrandIcon(cardBrand), Card.CardBrand.UNKNOWN == cardBrand)
+        updateDrawable(cardBrand.icon, CardBrand.Unknown == cardBrand)
     }
 
     private fun updateCvc() {

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -11,6 +11,7 @@ import android.view.View
 import com.google.android.material.textfield.TextInputLayout
 import com.stripe.android.R
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 
 class CvcEditText @JvmOverloads constructor(
     context: Context,
@@ -26,7 +27,8 @@ class CvcEditText @JvmOverloads constructor(
             return rawCvcValue.takeIf { isValid }
         }
 
-    private val rawCvcValue: String
+    internal val rawCvcValue: String
+        @JvmSynthetic
         get() {
             return text.toString().trim()
         }
@@ -69,18 +71,18 @@ class CvcEditText @JvmOverloads constructor(
     }
 
     /**
-     * @param brand - the [Card.CardBrand] used to update the view
-     * @param customHintText - optional user-specified hint text
-     * @param textInputLayout - if specified, hint text will be set on this [TextInputLayout]
+     * @param cardBrand the [CardBrand] used to update the view
+     * @param customHintText optional user-specified hint text
+     * @param textInputLayout if specified, hint text will be set on this [TextInputLayout]
      * instead of directly on the [CvcEditText]
      */
     @JvmSynthetic
     internal fun updateBrand(
-        @Card.CardBrand brand: String,
+        cardBrand: CardBrand,
         customHintText: String? = null,
         textInputLayout: TextInputLayout? = null
     ) {
-        isAmex = Card.CardBrand.AMERICAN_EXPRESS == brand
+        isAmex = CardBrand.AmericanExpress == cardBrand
         filters = if (isAmex) {
             INPUT_FILTER_AMEX
         } else {

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.view
 
-import com.stripe.android.model.Card
 import com.stripe.android.model.Card.Companion.CVC_LENGTH_AMERICAN_EXPRESS
 import com.stripe.android.model.Card.Companion.CVC_LENGTH_COMMON
+import com.stripe.android.model.CardBrand
 
 /**
  * Static utility functions needed for View classes.
@@ -10,11 +10,11 @@ import com.stripe.android.model.Card.Companion.CVC_LENGTH_COMMON
 internal object ViewUtils {
     @JvmStatic
     fun isCvcMaximalLength(
-        @Card.CardBrand cardBrand: String,
+        cardBrand: CardBrand,
         cvcText: String?
     ): Boolean {
         val cvcLength = cvcText?.trim { it <= ' ' }?.length ?: 0
-        return if (Card.CardBrand.AMERICAN_EXPRESS == cardBrand) {
+        return if (CardBrand.AmericanExpress == cardBrand) {
             cvcLength == CVC_LENGTH_AMERICAN_EXPRESS
         } else {
             cvcLength == CVC_LENGTH_COMMON
@@ -27,23 +27,25 @@ internal object ViewUtils {
      * Note that this does not verify that the card number is valid, or even that it is a number.
      *
      * @param spacelessCardNumber the raw card number, without spaces
-     * @param brand the [Card.CardBrand] to use as a separating scheme
+     * @param brand the [CardBrand] to use as a separating scheme
      * @return an array of strings with the number groups, in order. If the number is not complete,
      * some of the array entries may be `null`.
      */
     @JvmStatic
     fun separateCardNumberGroups(
         spacelessCardNumber: String,
-        @Card.CardBrand brand: String
+        brand: CardBrand
     ): Array<String?> {
-        return if (brand == Card.CardBrand.AMERICAN_EXPRESS) {
+        return if (brand == CardBrand.AmericanExpress) {
             separateAmexCardNumberGroups(spacelessCardNumber.take(16))
         } else {
             separateDefaultCardNumberGroups(spacelessCardNumber.take(16))
         }
     }
 
-    private fun separateDefaultCardNumberGroups(spacelessCardNumber: String): Array<String?> {
+    private fun separateDefaultCardNumberGroups(
+        spacelessCardNumber: String
+    ): Array<String?> {
         val numberGroups = arrayOfNulls<String?>(4)
         var i = 0
         var previousStart = 0

--- a/stripe/src/test/java/com/stripe/android/CardUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CardUtilsTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android
 
-import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -13,62 +13,62 @@ class CardUtilsTest {
 
     @Test
     fun getPossibleCardType_withEmptyCard_returnsUnknown() {
-        assertEquals(Card.CardBrand.UNKNOWN, CardUtils.getPossibleCardType("   "))
+        assertEquals(CardBrand.Unknown, CardUtils.getPossibleCardType("   "))
     }
 
     @Test
     fun getPossibleCardType_withNullCardNumber_returnsUnknown() {
-        assertEquals(Card.CardBrand.UNKNOWN, CardUtils.getPossibleCardType(null))
+        assertEquals(CardBrand.Unknown, CardUtils.getPossibleCardType(null))
     }
 
     @Test
     fun getPossibleCardType_withVisaPrefix_returnsVisa() {
-        assertEquals(Card.CardBrand.VISA, CardUtils.getPossibleCardType("4899 99"))
-        assertEquals(Card.CardBrand.VISA, CardUtils.getPossibleCardType("4"))
+        assertEquals(CardBrand.Visa, CardUtils.getPossibleCardType("4899 99"))
+        assertEquals(CardBrand.Visa, CardUtils.getPossibleCardType("4"))
     }
 
     @Test
     fun getPossibleCardType_withAmexPrefix_returnsAmex() {
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, CardUtils.getPossibleCardType("345"))
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, CardUtils.getPossibleCardType("37999999999"))
+        assertEquals(CardBrand.AmericanExpress, CardUtils.getPossibleCardType("345"))
+        assertEquals(CardBrand.AmericanExpress, CardUtils.getPossibleCardType("37999999999"))
     }
 
     @Test
     fun getPossibleCardType_withJCBPrefix_returnsJCB() {
-        assertEquals(Card.CardBrand.JCB, CardUtils.getPossibleCardType("3535 3535"))
+        assertEquals(CardBrand.JCB, CardUtils.getPossibleCardType("3535 3535"))
     }
 
     @Test
     fun getPossibleCardType_withMasterCardPrefix_returnsMasterCard() {
-        assertEquals(Card.CardBrand.MASTERCARD, CardUtils.getPossibleCardType("2222 452"))
-        assertEquals(Card.CardBrand.MASTERCARD, CardUtils.getPossibleCardType("5050"))
+        assertEquals(CardBrand.MasterCard, CardUtils.getPossibleCardType("2222 452"))
+        assertEquals(CardBrand.MasterCard, CardUtils.getPossibleCardType("5050"))
     }
 
     @Test
     fun getPossibleCardType_withDinersClubPrefix_returnsDinersClub() {
-        assertEquals(Card.CardBrand.DINERS_CLUB, CardUtils.getPossibleCardType("303922 2234"))
-        assertEquals(Card.CardBrand.DINERS_CLUB, CardUtils.getPossibleCardType("36778 9098"))
+        assertEquals(CardBrand.DinersClub, CardUtils.getPossibleCardType("303922 2234"))
+        assertEquals(CardBrand.DinersClub, CardUtils.getPossibleCardType("36778 9098"))
     }
 
     @Test
     fun getPossibleCardType_withDiscoverPrefix_returnsDiscover() {
-        assertEquals(Card.CardBrand.DISCOVER, CardUtils.getPossibleCardType("60355"))
-        assertEquals(Card.CardBrand.DISCOVER, CardUtils.getPossibleCardType("6433 8 90923"))
+        assertEquals(CardBrand.Discover, CardUtils.getPossibleCardType("60355"))
+        assertEquals(CardBrand.Discover, CardUtils.getPossibleCardType("6433 8 90923"))
         // This one has too many numbers on purpose. Checking for length is not part of the
         // function under test.
-        assertEquals(Card.CardBrand.DISCOVER, CardUtils.getPossibleCardType("6523452309209340293423"))
+        assertEquals(CardBrand.Discover, CardUtils.getPossibleCardType("6523452309209340293423"))
     }
 
     @Test
     fun getPossibleCardType_withUnionPayPrefix_returnsUnionPay() {
-        assertEquals(Card.CardBrand.UNIONPAY, CardUtils.getPossibleCardType("62"))
+        assertEquals(CardBrand.UnionPay, CardUtils.getPossibleCardType("62"))
     }
 
     @Test
     fun getPossibleCardType_withNonsenseNumber_returnsUnknown() {
-        assertEquals(Card.CardBrand.UNKNOWN, CardUtils.getPossibleCardType("1234567890123456"))
-        assertEquals(Card.CardBrand.UNKNOWN, CardUtils.getPossibleCardType("9999 9999 9999 9999"))
-        assertEquals(Card.CardBrand.UNKNOWN, CardUtils.getPossibleCardType("3"))
+        assertEquals(CardBrand.Unknown, CardUtils.getPossibleCardType("1234567890123456"))
+        assertEquals(CardBrand.Unknown, CardUtils.getPossibleCardType("9999 9999 9999 9999"))
+        assertEquals(CardBrand.Unknown, CardUtils.getPossibleCardType("3"))
     }
 
     @Test
@@ -139,14 +139,6 @@ class CardUtilsTest {
     @Test
     fun isValidCardLength_whenDinersClubStyleNumberStyleNumberButAmexLength_returnsFalse() {
         assertFalse(CardUtils.isValidCardLength("305693090259040"))
-    }
-
-    @Test
-    fun isValidCardLengthWithBrand_whenBrandUnknown_alwaysReturnsFalse() {
-        val validVisa = "4242424242424242"
-        // Adding this check to ensure the input number is correct
-        assertTrue(CardUtils.isValidCardLength(validVisa))
-        assertFalse(CardUtils.isValidCardLength(validVisa, Card.CardBrand.UNKNOWN))
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -13,6 +13,7 @@ import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardBrand;
 import com.stripe.android.model.CardFixtures;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.PaymentMethodCreateParams;
@@ -160,7 +161,7 @@ public class StripeTest {
         assertNull(token.getBankAccount());
         assertEquals(Token.TokenType.CARD, token.getType());
         assertEquals(CARD.getLast4(), returnedCard.getLast4());
-        assertEquals(Card.CardBrand.VISA, returnedCard.getBrand());
+        assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
         assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
         assertEquals(Card.FundingType.CREDIT, returnedCard.getFunding());
@@ -183,7 +184,7 @@ public class StripeTest {
         assertNull(token.getBankAccount());
         assertEquals(Token.TokenType.CARD, token.getType());
         assertEquals(CARD.getLast4(), returnedCard.getLast4());
-        assertEquals(Card.CardBrand.VISA, returnedCard.getBrand());
+        assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
         assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
         assertEquals(Card.FundingType.CREDIT, returnedCard.getFunding());

--- a/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeTextUtilsTest.kt
@@ -11,19 +11,28 @@ class StripeTextUtilsTest {
     @Test
     fun removeSpacesAndHyphens_withSpacesInInterior_returnsSpacelessNumber() {
         val testCardNumber = "4242 4242 4242 4242"
-        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber))
+        assertEquals(
+            CardNumberFixtures.VALID_VISA_NO_SPACES,
+            StripeTextUtils.removeSpacesAndHyphens(testCardNumber)
+        )
     }
 
     @Test
     fun removeSpacesAndHyphens_withExcessiveSpacesInInterior_returnsSpacelessNumber() {
         val testCardNumber = "4  242                  4 242 4  242 42 4   2"
-        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber))
+        assertEquals(
+            CardNumberFixtures.VALID_VISA_NO_SPACES,
+            StripeTextUtils.removeSpacesAndHyphens(testCardNumber)
+        )
     }
 
     @Test
     fun removeSpacesAndHyphens_withSpacesOnExterior_returnsSpacelessNumber() {
         val testCardNumber = "      42424242 4242 4242    "
-        assertEquals("4242424242424242", StripeTextUtils.removeSpacesAndHyphens(testCardNumber))
+        assertEquals(
+            CardNumberFixtures.VALID_VISA_NO_SPACES,
+            StripeTextUtils.removeSpacesAndHyphens(testCardNumber)
+        )
     }
 
     @Test
@@ -38,14 +47,19 @@ class StripeTextUtilsTest {
 
     @Test
     fun removeSpacesAndHyphens_withHyphenatedCardNumber_returnsCardNumber() {
-        assertEquals("4242424242424242",
-            StripeTextUtils.removeSpacesAndHyphens("4242-4242-4242-4242"))
+        assertEquals(
+            CardNumberFixtures.VALID_VISA_NO_SPACES,
+            StripeTextUtils.removeSpacesAndHyphens("4242-4242-4242-4242")
+        )
     }
 
     @Test
     fun removeSpacesAndHyphens_removesMultipleSpacesAndHyphens() {
         assertEquals("123",
-            StripeTextUtils.removeSpacesAndHyphens(" -    1-  --- 2   3- - - -------- "))
+            StripeTextUtils.removeSpacesAndHyphens(
+                " -    1-  --- 2   3- - - -------- "
+            )
+        )
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.model
 import com.stripe.android.CardNumberFixtures
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CardBrandTest {
 
@@ -51,6 +53,17 @@ class CardBrandTest {
         assertEquals(
             CardBrand.Unknown,
             CardBrand.fromCardNumber("1" + CardNumberFixtures.VALID_VISA_NO_SPACES)
+        )
+    }
+
+    @Test
+    fun isValidCardLengthWithBrand_whenBrandUnknown_alwaysReturnsFalse() {
+        // Adding this check to ensure the input number is correct
+        assertTrue(
+            CardBrand.Visa.isValidCardNumberLength(CardNumberFixtures.VALID_VISA_NO_SPACES)
+        )
+        assertFalse(
+            CardBrand.Unknown.isValidCardNumberLength(CardNumberFixtures.VALID_VISA_NO_SPACES)
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import com.stripe.android.model.Card.Companion.asCardBrand
+import com.stripe.android.CardNumberFixtures
 import com.stripe.android.model.Card.Companion.asFundingType
 import com.stripe.android.model.parsers.CardJsonParser
 import java.util.Calendar
@@ -25,57 +25,6 @@ class CardTest {
         calendar.set(Calendar.YEAR, 1997)
         calendar.set(Calendar.MONTH, Calendar.AUGUST)
         calendar.set(Calendar.DAY_OF_MONTH, 29)
-    }
-
-    @Test
-    fun asCardBrand_whenBlank_returnsNull() {
-        assertNull(asCardBrand("   "))
-        assertNull(asCardBrand(null))
-    }
-
-    @Test
-    fun asCardBrand_whenNonemptyButWeird_returnsUnknown() {
-        assertEquals(Card.CardBrand.UNKNOWN, asCardBrand("Awesome New CardBrand"))
-    }
-
-    @Test
-    fun asCardBrand_whenMastercard_returnsMasterCard() {
-        assertEquals(Card.CardBrand.MASTERCARD, asCardBrand("MasterCard"))
-    }
-
-    @Test
-    fun asCardBrand_whenCapitalizedStrangely_stillRecognizesCard() {
-        assertEquals(Card.CardBrand.MASTERCARD, asCardBrand("Mastercard"))
-    }
-
-    @Test
-    fun asCardBrand_whenVisa_returnsVisa() {
-        assertEquals(Card.CardBrand.VISA, asCardBrand("visa"))
-    }
-
-    @Test
-    fun asCardBrand_whenJcb_returnsJcb() {
-        assertEquals(Card.CardBrand.JCB, asCardBrand("Jcb"))
-    }
-
-    @Test
-    fun asCardBrand_whenDiscover_returnsDiscover() {
-        assertEquals(Card.CardBrand.DISCOVER, asCardBrand("Discover"))
-    }
-
-    @Test
-    fun asCardBrand_whenDinersClub_returnsDinersClub() {
-        assertEquals(Card.CardBrand.DINERS_CLUB, asCardBrand("Diners Club"))
-    }
-
-    @Test
-    fun asCardBrand_whenAmericanExpress_returnsAmericanExpress() {
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, asCardBrand("American express"))
-    }
-
-    @Test
-    fun asCardBrand_whenUnionPay_returnsUnionPay() {
-        assertEquals(Card.CardBrand.UNIONPAY, asCardBrand("UnionPay"))
     }
 
     @Test
@@ -115,141 +64,141 @@ class CardTest {
 
     @Test
     fun canInitializeWithMinimalArguments() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, "123")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050, cvc = "123")
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun testTypeReturnsCorrectlyForAmexCard() {
-        val card = Card.create("3412123412341234", null, null, null)
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, card.brand)
+        val card = Card.create(number = "3412123412341234")
+        assertEquals(CardBrand.AmericanExpress, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForDiscoverCard() {
-        val card = Card.create("6452123412341234", null, null, null)
-        assertEquals(Card.CardBrand.DISCOVER, card.brand)
+        val card = Card.create(number = "6452123412341234")
+        assertEquals(CardBrand.Discover, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForJCBCard() {
-        val card = Card.create("3512123412341234", null, null, null)
-        assertEquals(Card.CardBrand.JCB, card.brand)
+        val card = Card.create(number = "3512123412341234")
+        assertEquals(CardBrand.JCB, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForDinersClubCard() {
-        val card = Card.create("3612123412341234", null, null, null)
-        assertEquals(Card.CardBrand.DINERS_CLUB, card.brand)
+        val card = Card.create(number = "3612123412341234")
+        assertEquals(CardBrand.DinersClub, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForVisaCard() {
-        val card = Card.create("4112123412341234", null, null, null)
-        assertEquals(Card.CardBrand.VISA, card.brand)
+        val card = Card.create(number = "4112123412341234")
+        assertEquals(CardBrand.Visa, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForMasterCard() {
-        val card = Card.create("5112123412341234", null, null, null)
-        assertEquals(Card.CardBrand.MASTERCARD, card.brand)
+        val card = Card.create(number = "5112123412341234")
+        assertEquals(CardBrand.MasterCard, card.brand)
     }
 
     @Test
     fun testTypeReturnsCorrectlyForUnionPay() {
-        val card = Card.create("6200000000000005", null, null, null)
-        assertEquals(Card.CardBrand.UNIONPAY, card.brand)
+        val card = Card.create(number = "6200000000000005")
+        assertEquals(CardBrand.UnionPay, card.brand)
     }
 
     @Test
     fun shouldPassValidateNumberIfLuhnNumber() {
-        val card = Card.create("4242-4242-4242-4242", null, null, null)
+        val card = Card.create(number = "4242-4242-4242-4242")
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfNotLuhnNumber() {
-        val card = Card.create("4242-4242-4242-4241", null, null, null)
+        val card = Card.create(number = "4242-4242-4242-4241")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldPassValidateNumberIfLuhnNumberAmex() {
-        val card = Card.create("378282246310005", null, null, null)
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, card.brand)
+        val card = Card.create(number = "378282246310005")
+        assertEquals(CardBrand.AmericanExpress, card.brand)
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfNull() {
-        val card = Card.create(null, null, null, null)
+        val card = Card.create(cvc = null)
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfBlank() {
-        val card = Card.create("", null, null, null)
+        val card = Card.create(number = "")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfJustSpaces() {
-        val card = Card.create("    ", null, null, null)
+        val card = Card.create(number = "    ")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfTooShort() {
-        val card = Card.create("0", null, null, null)
+        val card = Card.create(number = "0")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfContainsLetters() {
-        val card = Card.create("424242424242a4242", null, null, null)
+        val card = Card.create(number = "424242424242a4242")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfTooLong() {
-        val card = Card.create("4242 4242 4242 4242 6", null, null, null)
-        assertEquals(Card.CardBrand.VISA, card.brand)
+        val card = Card.create(number = "4242 4242 4242 4242 6")
+        assertEquals(CardBrand.Visa, card.brand)
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldPassValidateNumber() {
-        val card = Card.create("4242424242424242", null, null, null)
+        val card = Card.create(CardNumberFixtures.VALID_VISA_NO_SPACES)
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldPassValidateNumberSpaces() {
-        val card = Card.create("4242 4242 4242 4242", null, null, null)
+        val card = Card.create(CardNumberFixtures.VALID_VISA_WITH_SPACES)
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldPassValidateNumberDashes() {
-        val card = Card.create("4242-4242-4242-4242", null, null, null)
+        val card = Card.create(number = "4242-4242-4242-4242")
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldPassValidateNumberWithMixedSeparators() {
-        val card = Card.create("4242-4   242 424-24 242", null, null, null)
+        val card = Card.create(number = "4242-4   242 424-24 242")
         assertTrue(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateNumberIfWithDot() {
-        val card = Card.create("4242.4242.4242.4242", null, null, null)
+        val card = Card.create(number = "4242.4242.4242.4242")
         assertFalse(card.validateNumber())
     }
 
     @Test
     fun shouldFailValidateExpiryDateIfNull() {
-        val card = Card.create(null, null, null, null)
+        val card = Card.create(cvc = null)
         assertFalse(card.validateExpMonth())
         assertFalse(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -257,7 +206,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfNullMonth() {
-        val card = Card.create(null, null, YEAR_IN_FUTURE, null)
+        val card = Card.create(expYear = YEAR_IN_FUTURE)
         assertFalse(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -265,7 +214,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfZeroMonth() {
-        val card = Card.create(null, 0, YEAR_IN_FUTURE, null)
+        val card = Card.create(expMonth = 0, expYear = YEAR_IN_FUTURE)
         assertFalse(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -273,7 +222,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfNegativeMonth() {
-        val card = Card.create(null, -1, YEAR_IN_FUTURE, null)
+        val card = Card.create(expMonth = -1, expYear = YEAR_IN_FUTURE)
         assertFalse(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -281,7 +230,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfMonthToLarge() {
-        val card = Card.create(null, 13, YEAR_IN_FUTURE, null)
+        val card = Card.create(expMonth = 13, expYear = YEAR_IN_FUTURE)
         assertFalse(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -289,13 +238,13 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfNullYear() {
-        val card = Card.create(null, 1, null, null)
+        val card = Card.create(expMonth = 1)
         assertFalse(card.validateExpiryDate(calendar))
     }
 
     @Test
     fun shouldFailValidateExpiryDateIfZeroYear() {
-        val card = Card.create(null, 12, 0, null)
+        val card = Card.create(expMonth = 12, expYear = 0)
         assertTrue(card.validateExpMonth())
         assertFalse(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -303,7 +252,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfNegativeYear() {
-        val card = Card.create(null, 12, -1, null)
+        val card = Card.create(expMonth = 12, expYear = -1)
         assertTrue(card.validateExpMonth())
         assertFalse(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -311,7 +260,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateForDecemberOfThisYear() {
-        val card = Card.create(null, 12, 1997, null)
+        val card = Card.create(expMonth = 12, expYear = 1997)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertTrue(card.validateExpiryDate(calendar))
@@ -319,7 +268,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateIfCurrentMonth() {
-        val card = Card.create(null, 8, 1997, null)
+        val card = Card.create(expMonth = 8, expYear = 1997)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertTrue(card.validateExpiryDate(calendar))
@@ -327,7 +276,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateIfCurrentMonthTwoDigitYear() {
-        val card = Card.create(null, 8, 97, null)
+        val card = Card.create(expMonth = 8, expYear = 97)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertTrue(card.validateExpiryDate(calendar))
@@ -335,7 +284,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateExpiryDateIfLastMonth() {
-        val card = Card.create(null, 7, 1997, null)
+        val card = Card.create(expMonth = 7, expYear = 1997)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -343,7 +292,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateIfNextMonth() {
-        val card = Card.create(null, 9, 1997, null)
+        val card = Card.create(expMonth = 9, expYear = 1997)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertTrue(card.validateExpiryDate(calendar))
@@ -351,7 +300,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateForJanuary00() {
-        val card = Card.create(null, 1, 0, null)
+        val card = Card.create(expMonth = 1, expYear = 0)
         assertTrue(card.validateExpMonth())
         assertFalse(card.validateExpYear(calendar))
         assertFalse(card.validateExpiryDate(calendar))
@@ -359,7 +308,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateExpiryDateForDecember99() {
-        val card = Card.create(null, 12, 99, null)
+        val card = Card.create(expMonth = 12, expYear = 99)
         assertTrue(card.validateExpMonth())
         assertTrue(card.validateExpYear(calendar))
         assertTrue(card.validateExpiryDate(calendar))
@@ -367,103 +316,103 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCVCIfNull() {
-        val card = Card.create(null, null, null, null)
+        val card = Card.create(cvc = null)
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfBlank() {
-        val card = Card.create(null, null, null, "")
+        val card = Card.create(cvc = "")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfUnknownTypeAndLength2() {
-        val card = Card.create(null, null, null, "12")
+        val card = Card.create(cvc = "12")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfUnknownTypeAndLength3() {
-        val card = Card.create(null, null, null, "123")
+        val card = Card.create(cvc = "123")
         assertTrue(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfUnknownTypeAndLength4() {
-        val card = Card.create(null, null, null, "1234")
+        val card = Card.create(cvc = "1234")
         assertTrue(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfUnknownTypeAndLength5() {
-        val card = Card.create(null, null, null, "12345")
+        val card = Card.create(cvc = "12345")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfVisaAndLength2() {
-        val card = Card.create("4242 4242 4242 4242", null, null, "12")
+        val card = Card.create(number = "4242 4242 4242 4242", cvc = "12")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfVisaAndLength3() {
-        val card = Card.create("4242 4242 4242 4242", null, null, "123")
+        val card = Card.create(number = "4242 4242 4242 4242", cvc = "123")
         assertTrue(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfVisaAndLength4() {
-        val card = Card.create("4242 4242 4242 4242", null, null, "1234")
+        val card = Card.create(number = "4242 4242 4242 4242", cvc = "1234")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfVisaAndLength5() {
-        val card = Card.create("4242 4242 4242 4242", null, null, "12345")
+        val card = Card.create(number = "4242 4242 4242 4242", cvc = "12345")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfVisaAndNotNumeric() {
-        val card = Card.create("4242 4242 4242 4242", null, null, "12a")
+        val card = Card.create(number = "4242 4242 4242 4242", cvc = "12a")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfAmexAndLength2() {
-        val card = Card.create("378282246310005", null, null, "12")
+        val card = Card.create(number = "378282246310005", cvc = "12")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfAmexAndLength3() {
-        val card = Card.create("378282246310005", null, null, "123")
+        val card = Card.create(number = "378282246310005", cvc = "123")
         assertTrue(card.validateCVC())
     }
 
     @Test
     fun shouldPassValidateCVCIfAmexAndLength4() {
-        val card = Card.create("378282246310005", null, null, "1234")
+        val card = Card.create(number = "378282246310005", cvc = "1234")
         assertTrue(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfAmexAndLength5() {
-        val card = Card.create("378282246310005", null, null, "12345")
+        val card = Card.create(number = "378282246310005", cvc = "12345")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCVCIfAmexAndNotNumeric() {
-        val card = Card.create("378282246310005", null, null, "123d")
+        val card = Card.create(number = "378282246310005", cvc = "123d")
         assertFalse(card.validateCVC())
     }
 
     @Test
     fun shouldFailValidateCardIfNotLuhnNumber() {
-        val card = Card.create("4242-4242-4242-4241", 12, 2050, "123")
+        val card = Card.create(number = "4242-4242-4242-4241", expMonth = 12, expYear = 2050, cvc = "123")
         assertFalse(card.validateCard())
         assertFalse(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -472,7 +421,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardInvalidMonth() {
-        val card = Card.create("4242-4242-4242-4242", 13, 2050, "123")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 13, expYear = 2050, cvc = "123")
         assertFalse(card.validateCard())
         assertTrue(card.validateNumber())
         assertFalse(card.validateExpiryDate(calendar))
@@ -481,7 +430,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardInvalidYear() {
-        val card = Card.create("4242-4242-4242-4242", 1, 1990, "123")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 1, expYear = 1990, cvc = "123")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertFalse(card.validateExpiryDate(calendar))
@@ -490,7 +439,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateCardWithNullCVC() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, null)
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050)
         assertTrue(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -499,7 +448,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateCardVisa() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, "123")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050, cvc = "123")
         assertTrue(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -508,7 +457,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardVisaWithShortCVC() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, "12")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050, cvc = "12")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -517,7 +466,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardVisaWithLongCVC() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, "1234")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050, cvc = "1234")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -526,7 +475,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardVisaWithBadCVC() {
-        val card = Card.create("4242-4242-4242-4242", 12, 2050, "bad")
+        val card = Card.create(number = "4242-4242-4242-4242", expMonth = 12, expYear = 2050, cvc = "bad")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -535,7 +484,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateCardAmex() {
-        val card = Card.create("378282246310005", 12, 2050, "1234")
+        val card = Card.create(number = "378282246310005", expMonth = 12, expYear = 2050, cvc = "1234")
         assertTrue(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -544,7 +493,7 @@ class CardTest {
 
     @Test
     fun shouldPassValidateCardAmexWithNullCVC() {
-        val card = Card.create("378282246310005", 12, 2050, null)
+        val card = Card.create(number = "378282246310005", expMonth = 12, expYear = 2050)
         assertTrue(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -553,7 +502,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardAmexWithShortCVC() {
-        val card = Card.create("378282246310005", 12, 2050, "12")
+        val card = Card.create(number = "378282246310005", expMonth = 12, expYear = 2050, cvc = "12")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -562,7 +511,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardAmexWithLongCVC() {
-        val card = Card.create("378282246310005", 12, 2050, "12345")
+        val card = Card.create(number = "378282246310005", expMonth = 12, expYear = 2050, cvc = "12345")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -571,7 +520,7 @@ class CardTest {
 
     @Test
     fun shouldFailValidateCardAmexWithBadCVC() {
-        val card = Card.create("378282246310005", 12, 2050, "bad")
+        val card = Card.create(number = "378282246310005", expMonth = 12, expYear = 2050, cvc = "bad")
         assertFalse(card.validateCard(calendar))
         assertTrue(card.validateNumber())
         assertTrue(card.validateExpiryDate(calendar))
@@ -580,13 +529,13 @@ class CardTest {
 
     @Test
     fun testLast4() {
-        val card = Card.create("42 42 42 42 42 42 42 42", null, null, null)
+        val card = Card.create(number = "42 42 42 42 42 42 42 42")
         assertEquals("4242", card.last4)
     }
 
     @Test
     fun last4ShouldBeNullWhenNumberIsNull() {
-        val card = Card.create(null, null, null, null)
+        val card = Card.create(cvc = null)
         assertNull(card.last4)
     }
 
@@ -603,9 +552,9 @@ class CardTest {
     fun getBrand_whenNumberIsNullButBrandIsSet_returnsCorrectValue() {
         val card = Card.Builder(null, 2, 2020, "123")
             .name("John Q Public")
-            .brand(Card.CardBrand.AMERICAN_EXPRESS)
+            .brand(CardBrand.AmericanExpress)
             .build()
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, card.brand)
+        assertEquals(CardBrand.AmericanExpress, card.brand)
     }
 
     @Test
@@ -701,8 +650,8 @@ class CardTest {
 
         private const val BAD_JSON: String = "{ \"id\": "
 
-        internal val CARD_USD = Card.Builder(null, 8, 2017, null)
-            .brand(Card.CardBrand.VISA)
+        internal val CARD_USD = Card.Builder(expMonth = 8, expYear = 2017)
+            .brand(CardBrand.Visa)
             .funding(Card.FundingType.CREDIT)
             .last4("4242")
             .id("card_189fi32eZvKYlo2CHK8NPRME")

--- a/stripe/src/test/java/com/stripe/android/model/SourceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SourceTest.kt
@@ -47,7 +47,7 @@ class SourceTest {
         assertTrue(source.sourceTypeModel is SourceCardData)
 
         val sourceCardData = source.sourceTypeModel as SourceCardData?
-        assertEquals(Card.CardBrand.VISA, sourceCardData?.brand)
+        assertEquals(CardBrand.Visa, sourceCardData?.brand)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
@@ -62,9 +62,9 @@ class TokenTest {
     }
 
     private companion object {
-        private val CARD = Card.Builder(null, 8, 2017, null)
+        private val CARD = Card.Builder(expMonth = 8, expYear = 2017)
             .id("card_189fi32eZvKYlo2CHK8NPRME")
-            .brand(Card.CardBrand.VISA)
+            .brand(CardBrand.Visa)
             .country("US")
             .last4("4242")
             .funding(Card.FundingType.CREDIT)

--- a/stripe/src/test/java/com/stripe/android/model/parsers/SourceCardDataJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/SourceCardDataJsonParserTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.SourceFixtures
 import kotlin.test.Test
@@ -26,7 +27,7 @@ class SourceCardDataJsonParserTest {
 
     @Test
     fun fromExampleJsonCard_createsExpectedObject() {
-        assertEquals(Card.CardBrand.VISA, CARD_DATA.brand)
+        assertEquals(CardBrand.Visa, CARD_DATA.brand)
         assertEquals(Card.FundingType.CREDIT, CARD_DATA.funding)
         assertEquals("4242", CARD_DATA.last4)
         assertNotNull(CARD_DATA.expiryMonth)

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.CardNumberFixtures.VALID_VISA_WITH_SPACES
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.TestFocusChangeListener
@@ -1097,7 +1098,7 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         assertEquals(12, card.expMonth)
         assertEquals(2079, card.expYear)
         assertEquals("1234", card.cvc)
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, card.brand)
+        assertEquals(CardBrand.AmericanExpress, card.brand)
 
         val paymentMethodCard = cardInputWidget.paymentMethodCard
         assertNotNull(paymentMethodCard)
@@ -1127,7 +1128,7 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         assertEquals(12, card.expMonth)
         assertEquals(2079, card.expYear)
         assertEquals("1234", card.cvc)
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, card.brand)
+        assertEquals(CardBrand.AmericanExpress, card.brand)
 
         val paymentMethodCard = cardInputWidget.paymentMethodCard
         assertNotNull(paymentMethodCard)
@@ -1172,45 +1173,45 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @Test
     fun shouldIconShowBrand_whenCvcNotFocused_isAlwaysTrue() {
-        assertTrue(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, false, CVC_VALUE_AMEX))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, false, ""))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.VISA, false, "333"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.DINERS_CLUB, false, "12"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.DISCOVER, false, null))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.JCB, false, "7"))
+        assertTrue(shouldIconShowBrand(CardBrand.AmericanExpress, false, CVC_VALUE_AMEX))
+        assertTrue(shouldIconShowBrand(CardBrand.AmericanExpress, false, ""))
+        assertTrue(shouldIconShowBrand(CardBrand.Visa, false, "333"))
+        assertTrue(shouldIconShowBrand(CardBrand.DinersClub, false, "12"))
+        assertTrue(shouldIconShowBrand(CardBrand.Discover, false, null))
+        assertTrue(shouldIconShowBrand(CardBrand.JCB, false, "7"))
     }
 
     @Test
     fun shouldIconShowBrand_whenAmexAndCvCStringLengthNotFour_isFalse() {
-        assertFalse(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, true, ""))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, true, "1"))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, true, "22"))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, true, "333"))
+        assertFalse(shouldIconShowBrand(CardBrand.AmericanExpress, true, ""))
+        assertFalse(shouldIconShowBrand(CardBrand.AmericanExpress, true, "1"))
+        assertFalse(shouldIconShowBrand(CardBrand.AmericanExpress, true, "22"))
+        assertFalse(shouldIconShowBrand(CardBrand.AmericanExpress, true, "333"))
     }
 
     @Test
     fun shouldIconShowBrand_whenAmexAndCvcStringLengthIsFour_isTrue() {
-        assertTrue(shouldIconShowBrand(Card.CardBrand.AMERICAN_EXPRESS, true, CVC_VALUE_AMEX))
+        assertTrue(shouldIconShowBrand(CardBrand.AmericanExpress, true, CVC_VALUE_AMEX))
     }
 
     @Test
     fun shouldIconShowBrand_whenNotAmexAndCvcStringLengthIsNotThree_isFalse() {
-        assertFalse(shouldIconShowBrand(Card.CardBrand.VISA, true, ""))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.DISCOVER, true, "12"))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.JCB, true, "55"))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.MASTERCARD, true, "9"))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.DINERS_CLUB, true, null))
-        assertFalse(shouldIconShowBrand(Card.CardBrand.UNKNOWN, true, "12"))
+        assertFalse(shouldIconShowBrand(CardBrand.Visa, true, ""))
+        assertFalse(shouldIconShowBrand(CardBrand.Discover, true, "12"))
+        assertFalse(shouldIconShowBrand(CardBrand.JCB, true, "55"))
+        assertFalse(shouldIconShowBrand(CardBrand.MasterCard, true, "9"))
+        assertFalse(shouldIconShowBrand(CardBrand.DinersClub, true, null))
+        assertFalse(shouldIconShowBrand(CardBrand.Unknown, true, "12"))
     }
 
     @Test
     fun shouldIconShowBrand_whenNotAmexAndCvcStringLengthIsThree_isTrue() {
-        assertTrue(shouldIconShowBrand(Card.CardBrand.VISA, true, "999"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.DISCOVER, true, "123"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.JCB, true, "555"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.MASTERCARD, true, "919"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.DINERS_CLUB, true, "415"))
-        assertTrue(shouldIconShowBrand(Card.CardBrand.UNKNOWN, true, "212"))
+        assertTrue(shouldIconShowBrand(CardBrand.Visa, true, "999"))
+        assertTrue(shouldIconShowBrand(CardBrand.Discover, true, "123"))
+        assertTrue(shouldIconShowBrand(CardBrand.JCB, true, "555"))
+        assertTrue(shouldIconShowBrand(CardBrand.MasterCard, true, "919"))
+        assertTrue(shouldIconShowBrand(CardBrand.DinersClub, true, "415"))
+        assertTrue(shouldIconShowBrand(CardBrand.Unknown, true, "212"))
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.CardNumberFixtures.VALID_DINERS_CLUB_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VALID_DINERS_CLUB_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.VALID_VISA_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VALID_VISA_WITH_SPACES
-import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import com.stripe.android.testharness.ViewTestUtils
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -28,8 +28,10 @@ class CardNumberEditTextTest {
     private var completionCallbackInvocations = 0
     private val completionCallback: () -> Unit = { completionCallbackInvocations++ }
 
-    private var lastBrandChangeCallbackInvocation: String? = null
-    private val brandChangeCallback: (String) -> Unit = { lastBrandChangeCallbackInvocation = it }
+    private var lastBrandChangeCallbackInvocation: CardBrand? = null
+    private val brandChangeCallback: (CardBrand) -> Unit = {
+        lastBrandChangeCallbackInvocation = it
+    }
 
     private lateinit var cardNumberEditText: CardNumberEditText
 
@@ -46,7 +48,7 @@ class CardNumberEditTextTest {
     @Test
     fun updateSelectionIndex_whenVisa_increasesIndexWhenGoingPastTheSpaces() {
         // Directly setting card brand as a testing hack (annotated in source)
-        cardNumberEditText.cardBrand = Card.CardBrand.VISA
+        cardNumberEditText.cardBrand = CardBrand.Visa
 
         // Adding 1 character, starting at position 4, with a final string length 6
         assertEquals(6, cardNumberEditText.updateSelectionIndex(6, 4, 1))
@@ -57,14 +59,14 @@ class CardNumberEditTextTest {
 
     @Test
     fun updateSelectionIndex_whenAmEx_increasesIndexWhenGoingPastTheSpaces() {
-        cardNumberEditText.cardBrand = Card.CardBrand.AMERICAN_EXPRESS
+        cardNumberEditText.cardBrand = CardBrand.AmericanExpress
         assertEquals(6, cardNumberEditText.updateSelectionIndex(6, 4, 1))
         assertEquals(13, cardNumberEditText.updateSelectionIndex(13, 11, 1))
     }
 
     @Test
     fun updateSelectionIndex_whenDinersClub_decreasesIndexWhenDeletingPastTheSpaces() {
-        cardNumberEditText.cardBrand = Card.CardBrand.DINERS_CLUB
+        cardNumberEditText.cardBrand = CardBrand.DinersClub
         assertEquals(4, cardNumberEditText.updateSelectionIndex(6, 5, 0))
         assertEquals(9, cardNumberEditText.updateSelectionIndex(13, 10, 0))
         assertEquals(14, cardNumberEditText.updateSelectionIndex(17, 15, 0))
@@ -72,38 +74,38 @@ class CardNumberEditTextTest {
 
     @Test
     fun updateSelectionIndex_whenDeletingNotOnGaps_doesNotDecreaseIndex() {
-        cardNumberEditText.cardBrand = Card.CardBrand.DINERS_CLUB
+        cardNumberEditText.cardBrand = CardBrand.DinersClub
         assertEquals(7, cardNumberEditText.updateSelectionIndex(12, 7, 0))
     }
 
     @Test
     fun updateSelectionIndex_whenAmEx_decreasesIndexWhenDeletingPastTheSpaces() {
-        cardNumberEditText.cardBrand = Card.CardBrand.AMERICAN_EXPRESS
+        cardNumberEditText.cardBrand = CardBrand.AmericanExpress
         assertEquals(4, cardNumberEditText.updateSelectionIndex(10, 5, 0))
         assertEquals(11, cardNumberEditText.updateSelectionIndex(13, 12, 0))
     }
 
     @Test
     fun updateSelectionIndex_whenSelectionInTheMiddle_increasesIndexOverASpace() {
-        cardNumberEditText.cardBrand = Card.CardBrand.VISA
+        cardNumberEditText.cardBrand = CardBrand.Visa
         assertEquals(6, cardNumberEditText.updateSelectionIndex(10, 4, 1))
     }
 
     @Test
     fun updateSelectionIndex_whenPastingIntoAGap_includesTheGapJump() {
-        cardNumberEditText.cardBrand = Card.CardBrand.UNKNOWN
+        cardNumberEditText.cardBrand = CardBrand.Unknown
         assertEquals(11, cardNumberEditText.updateSelectionIndex(12, 8, 2))
     }
 
     @Test
     fun updateSelectionIndex_whenPastingOverAGap_includesTheGapJump() {
-        cardNumberEditText.cardBrand = Card.CardBrand.UNKNOWN
+        cardNumberEditText.cardBrand = CardBrand.Unknown
         assertEquals(9, cardNumberEditText.updateSelectionIndex(12, 3, 5))
     }
 
     @Test
     fun updateSelectionIndex_whenIndexWouldGoOutOfBounds_setsToEndOfString() {
-        cardNumberEditText.cardBrand = Card.CardBrand.VISA
+        cardNumberEditText.cardBrand = CardBrand.Visa
         // This case could happen when you paste over 5 digits with only 2
         assertEquals(3, cardNumberEditText.updateSelectionIndex(3, 3, 2))
     }
@@ -224,7 +226,7 @@ class CardNumberEditTextTest {
 
     @Test
     fun setCardBrandChangeListener_callsSetCardBrand() {
-        assertEquals(Card.CardBrand.UNKNOWN, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.Unknown, lastBrandChangeCallbackInvocation)
     }
 
     @Test
@@ -232,35 +234,35 @@ class CardNumberEditTextTest {
         // We reset because just attaching the listener calls the method once.
         lastBrandChangeCallbackInvocation = null
         // There is only one Visa Prefix.
-        cardNumberEditText.setText(cardNumberEditText.text?.toString() + Card.PREFIXES_VISA[0])
-        assertEquals(Card.CardBrand.VISA, lastBrandChangeCallbackInvocation)
+        cardNumberEditText.setText(cardNumberEditText.text?.toString() + CardBrand.Visa.prefixes[0])
+        assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun addAmExPrefix_callsBrandListener() {
-        Card.PREFIXES_AMERICAN_EXPRESS.forEach(
-            verifyCardBrandPrefix(Card.CardBrand.AMERICAN_EXPRESS)
+        CardBrand.AmericanExpress.prefixes.forEach(
+            verifyCardBrandPrefix(CardBrand.AmericanExpress)
         )
     }
 
     @Test
     fun addDinersClubPrefix_callsBrandListener() {
-        Card.PREFIXES_DINERS_CLUB.forEach(verifyCardBrandPrefix(Card.CardBrand.DINERS_CLUB))
+        CardBrand.DinersClub.prefixes.forEach(verifyCardBrandPrefix(CardBrand.DinersClub))
     }
 
     @Test
     fun addDiscoverPrefix_callsBrandListener() {
-        Card.PREFIXES_DISCOVER.forEach(verifyCardBrandPrefix(Card.CardBrand.DISCOVER))
+        CardBrand.Discover.prefixes.forEach(verifyCardBrandPrefix(CardBrand.Discover))
     }
 
     @Test
     fun addMasterCardPrefix_callsBrandListener() {
-        Card.PREFIXES_MASTERCARD.forEach(verifyCardBrandPrefix(Card.CardBrand.MASTERCARD))
+        CardBrand.MasterCard.prefixes.forEach(verifyCardBrandPrefix(CardBrand.MasterCard))
     }
 
     @Test
     fun addJCBPrefix_callsBrandListener() {
-        Card.PREFIXES_JCB.forEach(verifyCardBrandPrefix(Card.CardBrand.JCB))
+        CardBrand.JCB.prefixes.forEach(verifyCardBrandPrefix(CardBrand.JCB))
     }
 
     @Test
@@ -270,31 +272,31 @@ class CardNumberEditTextTest {
         val suffix = VALID_AMEX_WITH_SPACES.substring(2)
         cardNumberEditText.setText(cardNumberEditText.text?.toString() + prefix)
         cardNumberEditText.setText(cardNumberEditText.text?.toString() + suffix)
-        assertEquals(Card.CardBrand.AMERICAN_EXPRESS, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.AmericanExpress, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun enterBrandPrefix_thenDelete_callsUpdateWithUnknown() {
         lastBrandChangeCallbackInvocation = null
-        val dinersPrefix = Card.PREFIXES_DINERS_CLUB[0]
+        val dinersPrefix = CardBrand.DinersClub.prefixes[0]
         // All the Diners Club prefixes are longer than one character, but I specifically want
         // to test that a nonempty string still triggers this action, so this test will fail if
         // the Diners Club prefixes are ever changed.
         assertTrue(dinersPrefix.length > 1)
 
         cardNumberEditText.setText(cardNumberEditText.text?.toString() + dinersPrefix)
-        assertEquals(Card.CardBrand.DINERS_CLUB, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.DinersClub, lastBrandChangeCallbackInvocation)
 
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
-        assertEquals(Card.CardBrand.UNKNOWN, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.Unknown, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun enterBrandPrefix_thenClearAllText_callsUpdateWithUnknown() {
         lastBrandChangeCallbackInvocation = null
-        val prefixVisa = Card.PREFIXES_VISA[0]
+        val prefixVisa = CardBrand.Visa.prefixes[0]
         cardNumberEditText.setText(cardNumberEditText.text?.toString() + prefixVisa)
-        assertEquals(Card.CardBrand.VISA, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
 
         // Just adding some other text. Not enough to invalidate the card or complete it.
         lastBrandChangeCallbackInvocation = null
@@ -304,7 +306,7 @@ class CardNumberEditTextTest {
         // This simulates the user selecting all text and deleting it.
         cardNumberEditText.setText("")
 
-        assertEquals(Card.CardBrand.UNKNOWN, lastBrandChangeCallbackInvocation)
+        assertEquals(CardBrand.Unknown, lastBrandChangeCallbackInvocation)
     }
 
     @Test
@@ -351,7 +353,15 @@ class CardNumberEditTextTest {
         )
     }
 
-    private fun verifyCardBrandPrefix(cardBrand: String): (String) -> Unit {
+    @Test
+    fun testUpdateCardBrandFromNumber() {
+        cardNumberEditText.updateCardBrandFromNumber(VALID_DINERS_CLUB_NO_SPACES)
+        assertEquals(CardBrand.DinersClub, lastBrandChangeCallbackInvocation)
+        cardNumberEditText.updateCardBrandFromNumber(VALID_AMEX_NO_SPACES)
+        assertEquals(CardBrand.AmericanExpress, lastBrandChangeCallbackInvocation)
+    }
+
+    private fun verifyCardBrandPrefix(cardBrand: CardBrand): (String) -> Unit {
         return { prefix ->
             // Reset inside the loop so we don't count each prefix
             lastBrandChangeCallbackInvocation = null

--- a/stripe/src/test/java/com/stripe/android/view/CvcEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CvcEditTextTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.view
 
 import androidx.test.core.app.ApplicationProvider
-import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -25,35 +25,35 @@ class CvcEditTextTest {
     @Test
     fun cvcValue_withValidVisaValue_returnsCvcValue() {
         cvcEditText.setText("123")
-        cvcEditText.updateBrand(Card.CardBrand.VISA)
+        cvcEditText.updateBrand(CardBrand.Visa)
         assertEquals("123", cvcEditText.cvcValue)
     }
 
     @Test
     fun cvcValue_withValidInvalidVisaValue_returnsCvcValue() {
         cvcEditText.setText("1234")
-        cvcEditText.updateBrand(Card.CardBrand.VISA)
+        cvcEditText.updateBrand(CardBrand.Visa)
         assertNull(cvcEditText.cvcValue)
     }
 
     @Test
     fun cvcValue_withInvalidAmexValue_returnsCvcValue() {
         cvcEditText.setText("12")
-        cvcEditText.updateBrand(Card.CardBrand.AMERICAN_EXPRESS)
+        cvcEditText.updateBrand(CardBrand.AmericanExpress)
         assertNull(cvcEditText.cvcValue)
     }
 
     @Test
     fun cvcValue_withValid3DigitAmexValue_returnsCvcValue() {
         cvcEditText.setText("123")
-        cvcEditText.updateBrand(Card.CardBrand.AMERICAN_EXPRESS)
+        cvcEditText.updateBrand(CardBrand.AmericanExpress)
         assertEquals("123", cvcEditText.cvcValue)
     }
 
     @Test
     fun cvcValue_withValid4DigitAmexValue_returnsCvcValue() {
         cvcEditText.setText("1234")
-        cvcEditText.updateBrand(Card.CardBrand.AMERICAN_EXPRESS)
+        cvcEditText.updateBrand(CardBrand.AmericanExpress)
         assertEquals("1234", cvcEditText.cvcValue)
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.view
 
-import com.stripe.android.model.Card
+import com.stripe.android.model.CardBrand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +19,7 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withVisa_returnsCorrectCardGroups() {
         val testCardNumber = "4000056655665556"
         val groups =
-            ViewUtils.separateCardNumberGroups(testCardNumber, Card.CardBrand.VISA)
+            ViewUtils.separateCardNumberGroups(testCardNumber, CardBrand.Visa)
         assertEquals(4, groups.size)
         assertEquals("4000", groups[0])
         assertEquals("0566", groups[1])
@@ -31,7 +31,7 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withAmex_returnsCorrectCardGroups() {
         val testCardNumber = "378282246310005"
         val groups =
-            ViewUtils.separateCardNumberGroups(testCardNumber, Card.CardBrand.AMERICAN_EXPRESS)
+            ViewUtils.separateCardNumberGroups(testCardNumber, CardBrand.AmericanExpress)
         assertEquals(3, groups.size)
         assertEquals("3782", groups[0])
         assertEquals("822463", groups[1])
@@ -42,7 +42,7 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withDinersClub_returnsCorrectCardGroups() {
         val testCardNumber = "38520000023237"
         val groups =
-            ViewUtils.separateCardNumberGroups(testCardNumber, Card.CardBrand.DINERS_CLUB)
+            ViewUtils.separateCardNumberGroups(testCardNumber, CardBrand.DinersClub)
         assertEquals(4, groups.size)
         assertEquals("3852", groups[0])
         assertEquals("0000", groups[1])
@@ -54,7 +54,7 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withInvalid_returnsCorrectCardGroups() {
         val testCardNumber = "1234056655665556"
         val groups =
-            ViewUtils.separateCardNumberGroups(testCardNumber, Card.CardBrand.UNKNOWN)
+            ViewUtils.separateCardNumberGroups(testCardNumber, CardBrand.Unknown)
         assertEquals(4, groups.size)
         assertEquals("1234", groups[0])
         assertEquals("0566", groups[1])
@@ -66,21 +66,21 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withAmexPrefix_returnsPrefixGroups() {
         val testCardNumber = "378282246310005"
         var groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 2), Card.CardBrand.AMERICAN_EXPRESS)
+            testCardNumber.substring(0, 2), CardBrand.AmericanExpress)
         assertEquals(3, groups.size)
         assertEquals("37", groups[0])
         assertNull(groups[1])
         assertNull(groups[2])
 
         groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 5), Card.CardBrand.AMERICAN_EXPRESS)
+            testCardNumber.substring(0, 5), CardBrand.AmericanExpress)
         assertEquals(3, groups.size)
         assertEquals("3782", groups[0])
         assertEquals("8", groups[1])
         assertNull(groups[2])
 
         groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 11), Card.CardBrand.AMERICAN_EXPRESS)
+            testCardNumber.substring(0, 11), CardBrand.AmericanExpress)
         assertEquals(3, groups.size)
         assertEquals("3782", groups[0])
         assertEquals("822463", groups[1])
@@ -91,7 +91,7 @@ internal class ViewUtilsTest {
     fun separateCardNumberGroups_withVisaPrefix_returnsCorrectGroups() {
         val testCardNumber = "4000056655665556"
         var groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 2), Card.CardBrand.VISA)
+            testCardNumber.substring(0, 2), CardBrand.Visa)
         assertEquals(4, groups.size)
         assertEquals("40", groups[0])
         assertNull(groups[1])
@@ -99,7 +99,7 @@ internal class ViewUtilsTest {
         assertNull(groups[3])
 
         groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 5), Card.CardBrand.VISA)
+            testCardNumber.substring(0, 5), CardBrand.Visa)
         assertEquals(4, groups.size)
         assertEquals("4000", groups[0])
         assertEquals("0", groups[1])
@@ -107,7 +107,7 @@ internal class ViewUtilsTest {
         assertNull(groups[3])
 
         groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 9), Card.CardBrand.VISA)
+            testCardNumber.substring(0, 9), CardBrand.Visa)
         assertEquals(4, groups.size)
         assertEquals("4000", groups[0])
         assertEquals("0566", groups[1])
@@ -115,7 +115,7 @@ internal class ViewUtilsTest {
         assertNull(groups[3])
 
         groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber.substring(0, 15), Card.CardBrand.VISA)
+            testCardNumber.substring(0, 15), CardBrand.Visa)
         assertEquals(4, groups.size)
         assertEquals("4000", groups[0])
         assertEquals("0566", groups[1])
@@ -125,60 +125,60 @@ internal class ViewUtilsTest {
 
     @Test
     fun isCvcMaximalLength_whenThreeDigitsAndNotAmEx_returnsTrue() {
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.VISA, "123"))
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.MASTERCARD, "345"))
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.JCB, "678"))
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.DINERS_CLUB, "910"))
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.DISCOVER, "234"))
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.UNKNOWN, "333"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "123"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "345"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "678"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, "910"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "234"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Unknown, "333"))
     }
 
     @Test
     fun isCvcMaximalLength_whenThreeDigitsAndIsAmEx_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, "123"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "123"))
     }
 
     @Test
     fun isCvcMaximalLength_whenFourDigitsAndIsAmEx_returnsTrue() {
-        assertTrue(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, "1234"))
+        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "1234"))
     }
 
     @Test
     fun isCvcMaximalLength_whenTooManyDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, "12345"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.VISA, "1234"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.MASTERCARD, "123456"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.DINERS_CLUB, "1234567"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.DISCOVER, "12345678"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.JCB, "123456789012345"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "12345"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "1234"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "123456"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, "1234567"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "12345678"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "123456789012345"))
     }
 
     @Test
     fun isCvcMaximalLength_whenNotEnoughDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, ""))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.VISA, "1"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.MASTERCARD, "12"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.DINERS_CLUB, ""))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.DISCOVER, "8"))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.JCB, "1"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, ""))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "1"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "12"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, ""))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "8"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "1"))
     }
 
     @Test
     fun isCvcMaximalLength_whenWhitespaceAndNotEnoughDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, "   "))
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.VISA, "  1"))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "   "))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "  1"))
     }
 
     @Test
     fun isCvcMaximalLength_whenNull_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(Card.CardBrand.AMERICAN_EXPRESS, null))
+        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, null))
     }
 
     @Test
     fun separateCardNumberGroups_forLongInputs_doesNotCrash() {
         val testCardNumber = "1234567890123456789"
         val groups = ViewUtils.separateCardNumberGroups(
-            testCardNumber, Card.CardBrand.VISA)
+            testCardNumber, CardBrand.Visa)
         assertEquals(4, groups.size)
     }
 }


### PR DESCRIPTION
## Summary
This is a breaking change.

- Make `Card#brand` a `CardBrand` instead of `String?`
- Make `SourceCardData#brand` a `CardBrand` instead of `String?`
- Update `CardUtils` methods to take a `CardBrand` instead of `String`
- Remove `Card.CardBrand`
- Remove `Card#asCardBrand()`; use `CardBrand.fromCode()` instead
- Use `CardBrand` internally in `CardInputWidget` and `CardMultilineWidget`

## Motivation
Consolidate logic related to the card brand.

## Testing
Unit tests and manual verification