### PR TITLE
Pass PaymentSessionConfig instance to PaymentSession constructor

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -14,6 +14,7 @@
 - Changes to `PaymentMethodsActivityStarter.Result`
     - The type of `paymentMethod` has been changed from `PaymentMethod` to `PaymentMethod?` (i.e. it is nullable)
 - Changes to `PaymentSession`
+    - `PaymentSession` now takes the `PaymentSessionConfig` instance through its constructor, instead of `init()`
     - By default, users will be asked for their postal code (i.e. `BillingAddressFields.PostalCode`) when adding a new
       card payment method.
     - `PaymentSession#init(listener, paymentSessionConfig, savedInstanceState, shouldPrefetchCustomer)` is deleted.

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -236,7 +236,15 @@ class FragmentExamplesActivity : AppCompatActivity() {
         }
 
         private fun createPaymentSession(customerSession: CustomerSession): PaymentSession {
-            val paymentSession = PaymentSession(this)
+            val paymentSession = PaymentSession(
+                fragment = this,
+                config = PaymentSessionConfig.Builder()
+                    .setHiddenShippingInfoFields(
+                        ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD,
+                        ShippingInfoWidget.CustomizableShippingField.CITY_FIELD
+                    )
+                    .build()
+            )
             val paymentSessionInitialized = paymentSession.init(
                 object : PaymentSession.PaymentSessionListener {
                     override fun onCommunicatingStateChanged(isCommunicating: Boolean) {
@@ -260,13 +268,8 @@ class FragmentExamplesActivity : AppCompatActivity() {
                                 }
                             })
                     }
-                },
-                PaymentSessionConfig.Builder()
-                    .setHiddenShippingInfoFields(
-                        ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD,
-                        ShippingInfoWidget.CustomizableShippingField.CITY_FIELD
-                    )
-                    .build())
+                }
+            )
             if (paymentSessionInitialized) {
                 paymentSession.setCartTotal(2000L)
             }

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -71,10 +71,9 @@ class PaymentSessionActivity : AppCompatActivity() {
         // CustomerSession only needs to be initialized once per app.
         val customerSession = createCustomerSession()
 
-        val paymentSession = PaymentSession(this)
-        val paymentSessionInitialized = paymentSession.init(
-            listener = PaymentSessionListenerImpl(this, customerSession),
-            paymentSessionConfig = PaymentSessionConfig.Builder()
+        val paymentSession = PaymentSession(
+            activity = this,
+            config = PaymentSessionConfig.Builder()
                 .setAddPaymentMethodFooter(R.layout.add_payment_method_footer)
                 .setPrepopulatedShippingInfo(EXAMPLE_SHIPPING_INFO)
                 .setHiddenShippingInfoFields(
@@ -92,7 +91,10 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setWindowFlags(WindowManager.LayoutParams.FLAG_SECURE)
                 .setBillingAddressFields(BillingAddressFields.Full)
                 .setShouldPrefetchCustomer(shouldPrefetchCustomer)
-                .build(),
+                .build()
+        )
+        val paymentSessionInitialized = paymentSession.init(
+            listener = PaymentSessionListenerImpl(this, customerSession),
             savedInstanceState = savedInstanceState
         )
         if (paymentSessionInitialized) {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -93,8 +93,8 @@ class PaymentSessionTest {
         val customerSession = createCustomerSession()
         CustomerSession.instance = customerSession
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
 
         assertTrue(customerSession.productUsageTokens
             .contains(PaymentSession.TOKEN_PAYMENT_SESSION))
@@ -108,8 +108,8 @@ class PaymentSessionTest {
             .setNextRawEphemeralKey(CustomerFixtures.EPHEMERAL_KEY_FIRST.toString())
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
         verify(paymentSessionListener)
             .onCommunicatingStateChanged(eq(true))
         verify(paymentSessionListener)
@@ -122,8 +122,8 @@ class PaymentSessionTest {
     fun handlePaymentData_whenPaymentMethodSelected_notifiesListenerAndFetchesCustomer() {
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
 
         // We have already tested the functionality up to here.
         reset(paymentSessionListener)
@@ -147,8 +147,8 @@ class PaymentSessionTest {
     fun handlePaymentData_whenGooglePaySelected_notifiesListenerAndFetchesCustomer() {
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
 
         // We have already tested the functionality up to here.
         reset(paymentSessionListener)
@@ -172,8 +172,8 @@ class PaymentSessionTest {
     fun selectPaymentMethod_launchesPaymentMethodsActivityWithLog() {
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
 
         paymentSession.presentPaymentMethodSelection()
 
@@ -192,10 +192,12 @@ class PaymentSessionTest {
     fun presentPaymentMethodSelection_withShouldRequirePostalCode_shouldPassInIntent() {
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder()
-            .setBillingAddressFields(BillingAddressFields.PostalCode)
-            .build())
+        val paymentSession = PaymentSession(activity,
+            PaymentSessionConfig.Builder()
+                .setBillingAddressFields(BillingAddressFields.PostalCode)
+                .build()
+        )
+        paymentSession.init(paymentSessionListener)
         paymentSession.presentPaymentMethodSelection()
 
         verify(activity).startActivityForResult(intentArgumentCaptor.capture(),
@@ -259,8 +261,8 @@ class PaymentSessionTest {
             .addProductUsageTokenIfValid(PaymentMethodsActivity.TOKEN_PAYMENT_METHODS_ACTIVITY)
         assertEquals(1, customerSession.productUsageTokens.size)
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
 
         // The init removes PaymentMethodsActivity, but then adds PaymentSession
         val loggingTokens = customerSession.productUsageTokens
@@ -277,10 +279,9 @@ class PaymentSessionTest {
             .addProductUsageTokenIfValid(PaymentMethodsActivity.TOKEN_PAYMENT_METHODS_ACTIVITY)
         assertEquals(1, customerSession.productUsageTokens.size)
 
-        val paymentSession = PaymentSession(activity)
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
         // If it is given any saved state at all, the tokens are not cleared out.
-        paymentSession.init(paymentSessionListener,
-            PaymentSessionConfig.Builder().build(), Bundle())
+        paymentSession.init(paymentSessionListener, Bundle())
 
         val loggingTokens = customerSession.productUsageTokens
         assertEquals(2, loggingTokens.size)
@@ -296,10 +297,9 @@ class PaymentSessionTest {
             .addProductUsageTokenIfValid(PaymentMethodsActivity.TOKEN_PAYMENT_METHODS_ACTIVITY)
         assertEquals(1, customerSession.productUsageTokens.size)
 
-        val paymentSession = PaymentSession(activity)
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
         // If it is given any saved state at all, the tokens are not cleared out.
-        paymentSession.init(paymentSessionListener,
-            PaymentSessionConfig.Builder().build(), Bundle())
+        paymentSession.init(paymentSessionListener, Bundle())
 
         val loggingTokens = customerSession.productUsageTokens
         assertEquals(2, loggingTokens.size)
@@ -316,8 +316,8 @@ class PaymentSessionTest {
             .setNextRawEphemeralKey(CustomerFixtures.EPHEMERAL_KEY_FIRST.toString())
         CustomerSession.instance = createCustomerSession()
 
-        val paymentSession = PaymentSession(activity)
-        paymentSession.init(paymentSessionListener, PaymentSessionConfig.Builder().build())
+        val paymentSession = PaymentSession(activity, EMPTY_CONFIG)
+        paymentSession.init(paymentSessionListener)
         paymentSession.setCartTotal(300L)
 
         verify(paymentSessionListener)
@@ -329,7 +329,7 @@ class PaymentSessionTest {
         val secondListener =
             mock(PaymentSession.PaymentSessionListener::class.java)
 
-        paymentSession.init(secondListener, PaymentSessionConfig.Builder().build(), bundle)
+        paymentSession.init(secondListener, bundle)
         verify(secondListener)
             .onPaymentSessionDataChanged(paymentSessionDataArgumentCaptor.capture())
 
@@ -368,6 +368,7 @@ class PaymentSessionTest {
     ): PaymentSession {
         return PaymentSession(
             ApplicationProvider.getApplicationContext<Context>(),
+            EMPTY_CONFIG,
             customerSession,
             paymentMethodsActivityStarter,
             paymentFlowActivityStarter,
@@ -419,5 +420,7 @@ class PaymentSessionTest {
     private companion object {
         private val FIRST_CUSTOMER = CustomerFixtures.CUSTOMER
         private val SECOND_CUSTOMER = CustomerFixtures.OTHER_CUSTOMER
+
+        private val EMPTY_CONFIG = PaymentSessionConfig.Builder().build()
     }
 }


### PR DESCRIPTION
## Summary
This is a breaking change.

## Motivation
Simplify `PaymentSession` logic

## Testing
<!-- How was the code tested? Be as specific as possible. -->
