### PR TITLE
Make PaymentSessionData take a non-null PaymentSessionConfig

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -28,7 +28,7 @@ class PaymentSession @VisibleForTesting internal constructor(
     private val paymentFlowActivityStarter:
     ActivityStarter<PaymentFlowActivity, PaymentFlowActivityStarter.Args>,
     private val paymentSessionPrefs: PaymentSessionPrefs,
-    paymentSessionData: PaymentSessionData = PaymentSessionData()
+    paymentSessionData: PaymentSessionData = PaymentSessionData(config)
 ) {
     /**
      * @return the data associated with the instance of this class.
@@ -51,7 +51,7 @@ class PaymentSession @VisibleForTesting internal constructor(
         config,
         CustomerSession.getInstance(),
         PaymentMethodsActivityStarter(activity),
-        PaymentFlowActivityStarter(activity),
+        PaymentFlowActivityStarter(activity, config),
         PaymentSessionPrefs.create(activity)
     )
 
@@ -68,7 +68,7 @@ class PaymentSession @VisibleForTesting internal constructor(
         config,
         CustomerSession.getInstance(),
         PaymentMethodsActivityStarter(fragment),
-        PaymentFlowActivityStarter(fragment),
+        PaymentFlowActivityStarter(fragment, config),
         PaymentSessionPrefs.create(fragment.requireActivity())
     )
 
@@ -264,12 +264,12 @@ class PaymentSession @VisibleForTesting internal constructor(
      */
     fun presentShippingFlow() {
         paymentFlowActivityStarter.startForResult(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(config)
-                .setPaymentSessionData(paymentSessionData)
-                .setIsPaymentSessionActive(true)
-                .setWindowFlags(config.windowFlags)
-                .build()
+            PaymentFlowActivityStarter.Args(
+                paymentSessionConfig = config,
+                paymentSessionData = paymentSessionData,
+                isPaymentSessionActive = true,
+                windowFlags = config.windowFlags
+            )
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -32,7 +32,7 @@ data class PaymentSessionConfig internal constructor(
     @get:LayoutRes
     val addPaymentMethodFooterLayoutId: Int = 0,
     val paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card),
-    val shouldShowGooglePay: Boolean,
+    val shouldShowGooglePay: Boolean = false,
     val allowedShippingCountryCodes: Set<String> = emptySet(),
     val billingAddressFields: BillingAddressFields = BillingAddressFields.None,
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
@@ -11,7 +11,7 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 data class PaymentSessionData internal constructor(
-    private val config: PaymentSessionConfig? = null,
+    private val config: PaymentSessionConfig,
 
     /**
      * The cart total value, excluding shipping and tax items.

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
@@ -11,19 +11,31 @@ import kotlinx.android.parcel.Parcelize
 class PaymentFlowActivityStarter :
     ActivityStarter<PaymentFlowActivity, PaymentFlowActivityStarter.Args> {
 
-    constructor(activity: Activity) : super(
-        activity, PaymentFlowActivity::class.java, Args.DEFAULT, REQUEST_CODE
+    constructor(activity: Activity, config: PaymentSessionConfig) : super(
+        activity,
+        PaymentFlowActivity::class.java,
+        Args(
+            paymentSessionConfig = config,
+            paymentSessionData = PaymentSessionData(config)
+        ),
+        REQUEST_CODE
     )
 
-    constructor(fragment: Fragment) : super(
-        fragment, PaymentFlowActivity::class.java, Args.DEFAULT, REQUEST_CODE
+    constructor(fragment: Fragment, config: PaymentSessionConfig) : super(
+        fragment,
+        PaymentFlowActivity::class.java,
+        Args(
+            paymentSessionConfig = config,
+            paymentSessionData = PaymentSessionData(config)
+        ),
+        REQUEST_CODE
     )
 
     @Parcelize
     data class Args internal constructor(
         internal val paymentSessionConfig: PaymentSessionConfig,
         internal val paymentSessionData: PaymentSessionData,
-        internal val isPaymentSessionActive: Boolean,
+        internal val isPaymentSessionActive: Boolean = false,
         internal val windowFlags: Int? = null
     ) : ActivityStarter.Args {
         class Builder : ObjectBuilder<Args> {
@@ -69,10 +81,6 @@ class PaymentFlowActivityStarter :
         }
 
         companion object {
-            internal val DEFAULT = Builder()
-                .setPaymentSessionData(PaymentSessionData())
-                .build()
-
             @JvmStatic
             fun create(intent: Intent): Args {
                 return requireNotNull(intent.getParcelableExtra(ActivityStarter.Args.EXTRA))

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -587,11 +587,7 @@ class CustomerSessionTest {
         CustomerSession.instance = customerSession
 
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity {
                 assertTrue(customerSession.productUsageTokens.contains("ShippingInfoScreen"))
@@ -604,13 +600,15 @@ class CustomerSessionTest {
         val customerSession = createCustomerSession(null)
         CustomerSession.instance = customerSession
 
+        val config = PaymentSessionConfig.Builder()
+            .setShippingInfoRequired(false)
+            .build()
+
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .setShippingInfoRequired(false)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentFlowActivityStarter.Args(
+                paymentSessionConfig = config,
+                paymentSessionData = PaymentSessionData(config)
+            )
         ).use { activityScenario ->
             activityScenario.onActivity {
                 assertTrue(customerSession.productUsageTokens.contains("ShippingMethodScreen"))

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthConfigTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.init.ui.UiCustomization
 import com.stripe.android.view.ActivityScenarioFactory
 import com.stripe.android.view.PaymentFlowActivity
-import com.stripe.android.view.PaymentFlowActivityStarter
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -242,11 +241,7 @@ class PaymentAuthConfigTest {
     @Test
     fun createWithAppTheme_shouldCreateExpectedToolbarCustomization() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity { activity ->
                 activity.setTheme(android.R.style.Theme)

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -60,6 +60,7 @@ class PaymentSessionDataTest {
     @Test
     fun writeToParcel_withNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData(
+            config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG,
             cartTotal = 100L,
             shippingTotal = 150L
         )
@@ -70,6 +71,7 @@ class PaymentSessionDataTest {
     @Test
     fun writeToParcel_withoutNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData(
+            config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG,
             cartTotal = 100L,
             shippingTotal = 150L,
             paymentMethod = PAYMENT_METHOD,

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -4,6 +4,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.view.BillingAddressFields
+import com.stripe.android.view.PaymentFlowActivityStarter
 import com.stripe.android.view.ShippingInfoWidget
 
 internal object PaymentSessionFixtures {
@@ -56,4 +57,9 @@ internal object PaymentSessionFixtures {
         .build()
 
     internal val PAYMENT_SESSION_DATA = PaymentSessionData(PAYMENT_SESSION_CONFIG)
+
+    internal val PAYMENT_FLOW_ARGS = PaymentFlowActivityStarter.Args(
+        paymentSessionConfig = PAYMENT_SESSION_CONFIG,
+        paymentSessionData = PAYMENT_SESSION_DATA
+    )
 }

--- a/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CustomerSession
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.PaymentSessionConfig
+import com.stripe.android.PaymentSessionData
 import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
 import java.util.Locale
@@ -49,12 +49,15 @@ class CountryAutoCompleteTextViewTest {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         CustomerSession.initCustomerSession(context, ephemeralKeyProvider)
 
+        val config = PaymentSessionFixtures.PAYMENT_SESSION_CONFIG.copy(
+            prepopulatedShippingInfo = null,
+            allowedShippingCountryCodes = emptySet()
+        )
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentFlowActivityStarter.Args(
+                paymentSessionConfig = config,
+                paymentSessionData = PaymentSessionData(config)
+            )
         ).use { activityScenario ->
             activityScenario.onActivity {
                 countryAutoCompleteTextView = it

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -86,12 +86,11 @@ class PaymentFlowActivityTest {
     @Test
     fun launchPaymentFlowActivity_withHideShippingInfoConfig_hidesShippingInfoView() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setShippingInfoRequired(false)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 assertNull(getShippingInfoWidget(paymentFlowActivity))
@@ -103,11 +102,7 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoSave_whenShippingNotPopulated_doesNotFinish() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 assertNotNull(getShippingInfoWidget(paymentFlowActivity))
@@ -120,11 +115,7 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoSave_whenShippingInfoNotPopulated_doesNotContinue() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 assertNotNull(getShippingInfoWidget(paymentFlowActivity))
@@ -138,12 +129,11 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoSave_whenShippingPopulated_sendsCorrectIntent() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 assertNotNull(getShippingInfoWidget(paymentFlowActivity))
@@ -163,12 +153,11 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoProcessed_whenInvalidShippingInfoSubmitted_rendersCorrectly() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 // invalid result
@@ -187,12 +176,11 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoProcessed_whenValidShippingInfoSubmitted_rendersCorrectly() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 // valid result
@@ -214,13 +202,12 @@ class PaymentFlowActivityTest {
     @Test
     fun onShippingInfoSaved_whenOnlyShippingInfo_finishWithSuccess() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .setShippingMethodsRequired(false)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 // valid result
@@ -252,14 +239,13 @@ class PaymentFlowActivityTest {
         `when`(shippingMethodsFactory.create(SHIPPING_INFO)).thenReturn(SHIPPING_METHODS)
 
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
+            createStarterArgs(
+                PaymentSessionConfig.Builder()
                     .setPrepopulatedShippingInfo(SHIPPING_INFO)
                     .setShippingInformationValidator(shippingInformationValidator)
                     .setShippingMethodsFactory(shippingMethodsFactory)
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+                    .build()
+            )
         ).use { activityScenario ->
             activityScenario.onActivity { paymentFlowActivity ->
                 // valid result
@@ -291,5 +277,14 @@ class PaymentFlowActivityTest {
             ShippingMethod("FedEx", "fedex",
                 599, "USD", "Arrives tomorrow")
         )
+
+        private fun createStarterArgs(
+            config: PaymentSessionConfig
+        ): PaymentFlowActivityStarter.Args {
+            return PaymentFlowActivityStarter.Args(
+                paymentSessionConfig = config,
+                paymentSessionData = PaymentSessionData(config)
+            )
+        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionData
+import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.model.CustomerFixtures
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
@@ -34,7 +35,7 @@ class PaymentFlowViewModelTest {
     private val viewModel: PaymentFlowViewModel by lazy {
         PaymentFlowViewModel(
             customerSession = customerSession,
-            paymentSessionData = PaymentSessionData(),
+            paymentSessionData = PaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_CONFIG),
             workScope = MainScope()
         )
     }

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.CustomerSession
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSessionConfig
-import com.stripe.android.PaymentSessionFixtures
+import com.stripe.android.PaymentSessionData
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.ShippingInformation
@@ -65,13 +65,15 @@ class ShippingInfoWidgetTest {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         CustomerSession.initCustomerSession(context, ephemeralKeyProvider)
 
-        val args = PaymentFlowActivityStarter.Args.Builder()
-            .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                .build())
-            .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-            .build()
+        val config = PaymentSessionConfig(
+            isShippingInfoRequired = true,
+            isShippingMethodRequired = true
+        )
         activityScenarioFactory.create<PaymentFlowActivity>(
-            args
+            PaymentFlowActivityStarter.Args(
+                paymentSessionConfig = config,
+                paymentSessionData = PaymentSessionData(config)
+            )
         ).use { activityScenario ->
             activityScenario.onActivity {
                 shippingInfoWidget = it.findViewById(R.id.shipping_info_widget)

--- a/stripe/src/test/java/com/stripe/android/view/StripeColorUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeColorUtilsTest.kt
@@ -5,7 +5,6 @@ import androidx.annotation.ColorInt
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.CustomerSession
-import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionFixtures
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -28,11 +27,7 @@ internal class StripeColorUtilsTest {
     @Test
     fun getThemeAccentColor_whenOnPostLollipopConfig_getsNonzeroColor() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity {
                 @ColorInt val color = StripeColorUtils(it).getThemeAccentColor().data
@@ -44,11 +39,7 @@ internal class StripeColorUtilsTest {
     @Test
     fun getThemeColorControlNormal_whenOnPostLollipopConfig_getsNonzeroColor() {
         activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentFlowActivityStarter.Args.Builder()
-                .setPaymentSessionConfig(PaymentSessionConfig.Builder()
-                    .build())
-                .setPaymentSessionData(PaymentSessionFixtures.PAYMENT_SESSION_DATA)
-                .build()
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
         ).use { activityScenario ->
             activityScenario.onActivity {
                 @ColorInt val color = StripeColorUtils(it).getThemeColorControlNormal().data


### PR DESCRIPTION
`PaymentSessionConfig` is a dependency of `PaymentSessionData`, and it can now be non-null