### PR TITLE
Fix regression in CardInputWidget styling

### DIFF
--- a/example/res/layout/card_token_activity.xml
+++ b/example/res/layout/card_token_activity.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -28,7 +27,7 @@
         <com.stripe.android.view.CardInputWidget
             android:id="@+id/card_input_widget"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"/>
 
         <Button
             android:id="@+id/create_token_button"

--- a/example/res/values/styles.xml
+++ b/example/res/values/styles.xml
@@ -13,4 +13,7 @@
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
+    <style name="Stripe.CardInputWidget.EditText" parent="Stripe.Base.CardInputWidget.EditText">
+        <!-- Customize CardInputWidget's individual fields -->
+    </style>
 </resources>

--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -72,7 +72,7 @@
             android:focusable="true"
             android:focusableInTouchMode="true"
             android:visibility="visible"
-            android:textSize="@dimen/ciw_stripe_edit_text_size"
+            style="@style/Stripe.CardInputWidget.EditText"
             />
 
         <com.stripe.android.view.ExpiryDateEditText
@@ -98,7 +98,7 @@
             android:focusableInTouchMode="true"
             android:layout_marginStart="@dimen/stripe_card_expiry_initial_margin"
             android:layout_gravity="start"
-            android:textSize="@dimen/ciw_stripe_edit_text_size"
+            style="@style/Stripe.CardInputWidget.EditText"
             />
 
         <com.stripe.android.view.CvcEditText
@@ -116,7 +116,7 @@
             android:focusableInTouchMode="true"
             android:layout_marginStart="@dimen/stripe_card_cvc_initial_margin"
             android:layout_gravity="start"
-            android:textSize="@dimen/ciw_stripe_edit_text_size"
+            style="@style/Stripe.CardInputWidget.EditText"
             />
 
         <com.stripe.android.view.PostalCodeEditText
@@ -135,7 +135,7 @@
             android:layout_gravity="start"
             android:visibility="gone"
             android:enabled="false"
-            android:textSize="@dimen/ciw_stripe_edit_text_size"
+            style="@style/Stripe.CardInputWidget.EditText"
             />
 
     </FrameLayout>

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -29,4 +29,10 @@
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 
     <style name="AlertDialogStyle" parent="Theme.AppCompat.DayNight.Dialog" />
+
+    <style name="Stripe.Base.CardInputWidget.EditText" parent="Widget.AppCompat.EditText">
+        <item name="android:textSize">@dimen/ciw_stripe_edit_text_size</item>
+    </style>
+
+    <style name="Stripe.CardInputWidget.EditText" parent="Stripe.Base.CardInputWidget.EditText" />
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -39,6 +39,9 @@ import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_EXPI
 
 /**
  * A card input widget that handles all animation on its own.
+ *
+ * The individual `EditText` views of this widget can be styled by defining a style
+ * `Stripe.CardInputWidget.EditText` that extends `Stripe.Base.CardInputWidget.EditText`.
  */
 class CardInputWidget @JvmOverloads constructor(
     context: Context,


### PR DESCRIPTION
The `android:textSize` attribute in `card_input_widget.xml` was
hardcoded in #1930, preventing styling of the `CardInputWidget`'s
EditText fields.

Introduce a base style `Stripe.Base.CardInputWidget.EditText`, and
override it with `Stripe.CardInputWidget.EditText` to allow for
user customization.

For example, in your app's `style.xml`, if you add the following:

```
<style name="Stripe.CardInputWidget.EditText" parent="Stripe.Base.CardInputWidget.EditText">
    <item name="android:textSize">22sp</item>
    <item name="android:textColor">@android:color/holo_blue_light</item>
    <item name="android:textColorHint">@android:color/holo_orange_light</item>
</style>
```

![Screenshot_1577132333](https://user-images.githubusercontent.com/45020849/71379877-158de200-259b-11ea-8163-4693ddfd05b5.png)

Fixes #1997
