### PR TITLE
Add support for authenticating a Source via in-app WebView

### DIFF
--- a/example/res/layout/activity_klarna_source.xml
+++ b/example/res/layout/activity_klarna_source.xml
@@ -19,11 +19,20 @@
 
         <Button
             android:id="@+id/btn_create_klarna_source"
-            android:layout_width="200dp"
+            android:layout_width="360dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginTop="@dimen/example_vertical_spacing"
             android:text="@string/create_klarna_source"
+            />
+
+        <Button
+            android:id="@+id/btn_fetch_klarna_source"
+            android:layout_width="360dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="@dimen/example_vertical_spacing"
+            android:text="@string/fetch_klarna_source"
             />
 
         <TextView

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -64,7 +64,8 @@
     <string name="ready_to_charge">Ready to charge?</string>
     <string name="not_selected">Not selected</string>
 
-    <string name="create_klarna_source">Create Klarna Source</string>
+    <string name="create_klarna_source">Create and Authenticate Klarna Source</string>
+    <string name="fetch_klarna_source">Fetch Klarna Source</string>
 
     <!-- SEPA Debit -->
     <string name="sepa_debit_mandate">By providing your IBAN and confirming this payment, you are authorizing EXAMPLE COMPANY NAME and Stripe, our payment service provider, to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.</string>

--- a/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
@@ -1,14 +1,20 @@
 package com.stripe.example.activity
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import com.stripe.android.ApiResultCallback
+import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.KlarnaSourceParams
+import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.example.R
+import com.stripe.example.Settings
 import kotlinx.android.synthetic.main.activity_klarna_source.*
 
 class KlarnaSourceActivity : AppCompatActivity() {
@@ -16,24 +22,98 @@ class KlarnaSourceActivity : AppCompatActivity() {
         ViewModelProviders.of(this)[SourceViewModel::class.java]
     }
 
+    private val stripe: Stripe by lazy {
+        Stripe(
+            applicationContext,
+            Settings(applicationContext).publishableKey,
+            enableLogging = true
+        )
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_klarna_source)
 
-        viewModel.createdSource.observe(this, Observer {
-            progress_bar.visibility = View.INVISIBLE
-            source_result.text = it.toString()
-        })
-
         btn_create_klarna_source.setOnClickListener {
+            source_result.text = ""
             progress_bar.visibility = View.VISIBLE
-            createKlarnaSource()
+            createKlarnaSource().observe(this, Observer { result ->
+                progress_bar.visibility = View.INVISIBLE
+                when (result) {
+                    is SourceViewModel.SourceResult.Success -> {
+                        val source = result.source
+                        logSource(source)
+                        stripe.authenticateSource(this, source)
+                    }
+                    is SourceViewModel.SourceResult.Error -> {
+                        source_result.text = result.e.localizedMessage
+                    }
+                }
+            })
+        }
+
+        btn_fetch_klarna_source.setOnClickListener {
+            progress_bar.visibility = View.VISIBLE
+            viewModel.fetchSource(viewModel.source).observe(this, Observer { result ->
+                progress_bar.visibility = View.INVISIBLE
+                when (result) {
+                    is SourceViewModel.SourceResult.Success -> {
+                        logSource(result.source)
+                    }
+                    is SourceViewModel.SourceResult.Error -> {
+                        logException(result.e)
+                    }
+                }
+            })
         }
     }
 
-    private fun createKlarnaSource() {
-        viewModel.createSource(SourceParams.createKlarna(
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (data != null && stripe.isAuthenticateSourceResult(requestCode, data)) {
+            stripe.onAuthenticateSourceResult(data, object : ApiResultCallback<Source> {
+                override fun onSuccess(result: Source) {
+                    viewModel.source = result
+                    logSource(result)
+                }
+
+                override fun onError(e: Exception) {
+                    logException(e)
+                }
+            })
+        }
+    }
+
+    private fun logSource(source: Source) {
+        source_result.text = """
+            Source ID
+            ${source.id}
+            
+            Flow
+            ${source.flow}
+            
+            Status
+            ${source.status}
+
+            Redirect Status
+            ${source.redirect?.status}
+                
+            Authenticate URL
+            ${source.redirect?.url}
+                
+            Return URL
+            ${source.redirect?.returnUrl}
+        """.trimIndent()
+    }
+
+    private fun logException(ex: Exception) {
+        source_result.text = ex.localizedMessage
+    }
+
+    private fun createKlarnaSource(): LiveData<SourceViewModel.SourceResult> {
+        return viewModel.createSource(SourceParams.createKlarna(
             returnUrl = RETURN_URL,
             currency = "gbp",
             klarnaParams = KlarnaSourceParams(

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import android.content.Intent
 import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarter
 
@@ -21,6 +22,12 @@ internal interface PaymentController {
         requestOptions: ApiRequest.Options
     )
 
+    fun startAuthenticateSource(
+        host: AuthActivityStarter.Host,
+        source: Source,
+        requestOptions: ApiRequest.Options
+    )
+
     /**
      * Decide whether [handlePaymentResult] should be called.
      */
@@ -30,6 +37,8 @@ internal interface PaymentController {
      * Decide whether [handleSetupResult] should be called.
      */
     fun shouldHandleSetupResult(requestCode: Int, data: Intent?): Boolean
+
+    fun shouldHandleSourceResult(requestCode: Int, data: Intent?): Boolean
 
     /**
      * If payment authentication triggered an exception, get the exception object and pass to
@@ -59,6 +68,12 @@ internal interface PaymentController {
         data: Intent,
         requestOptions: ApiRequest.Options,
         callback: ApiResultCallback<SetupIntentResult>
+    )
+
+    fun handleSourceResult(
+        data: Intent,
+        requestOptions: ApiRequest.Options,
+        callback: ApiResultCallback<Source>
     )
 
     /**

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import android.os.Bundle
+import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.PaymentRelayActivity
@@ -20,10 +21,15 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             return object : PaymentRelayStarter {
                 override fun start(args: Args) {
                     val extras = Bundle()
-                    extras.putString(StripeIntentResultExtras.CLIENT_SECRET,
-                        args.stripeIntent?.clientSecret)
-                    extras.putSerializable(StripeIntentResultExtras.AUTH_EXCEPTION,
-                        args.exception)
+                    args.stripeIntent?.let {
+                        extras.putString(StripeIntentResultExtras.CLIENT_SECRET, it.clientSecret)
+                    }
+                    args.source?.let {
+                        extras.putParcelable(StripeIntentResultExtras.SOURCE, it)
+                    }
+                    args.exception?.let {
+                        extras.putSerializable(StripeIntentResultExtras.AUTH_EXCEPTION, it)
+                    }
                     host.startActivityForResult(
                         PaymentRelayActivity::class.java, extras, requestCode
                     )
@@ -34,12 +40,18 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
 
     data class Args internal constructor(
         val stripeIntent: StripeIntent? = null,
+        val source: Source? = null,
         val exception: Exception? = null
     ) {
         internal companion object {
             @JvmSynthetic
             internal fun create(stripeIntent: StripeIntent): Args {
                 return Args(stripeIntent = stripeIntent)
+            }
+
+            @JvmSynthetic
+            internal fun create(source: Source): Args {
+                return Args(source = source)
             }
 
             @JvmSynthetic

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -607,6 +607,72 @@ class Stripe internal constructor(
     //
 
     /**
+     * Authenticate a [Source] that requires user action via a redirect (i.e. [Source.flow] is
+     * [Source.SourceFlow.REDIRECT].
+     *
+     * The result of this operation will be returned via `Activity#onActivityResult(int, int, Intent)}}`
+     *
+     * @param activity the `Activity` that is launching the [Source] authentication flow
+     * @param source the [Source] to confirm
+     */
+    fun authenticateSource(
+        activity: Activity,
+        source: Source
+    ) {
+        paymentController.startAuthenticateSource(
+            AuthActivityStarter.Host.create(activity),
+            source,
+            ApiRequest.Options(publishableKey, stripeAccountId)
+        )
+    }
+
+    /**
+     * Authenticate a [Source] that requires user action via a redirect (i.e. [Source.flow] is
+     * [Source.SourceFlow.REDIRECT].
+     *
+     * The result of this operation will be returned via `Activity#onActivityResult(int, int, Intent)}}`
+     *
+     * @param fragment the `Fragment` that is launching the [Source] authentication flow
+     * @param source the [Source] to confirm
+     */
+    fun authenticateSource(
+        fragment: Fragment,
+        source: Source
+    ) {
+        paymentController.startAuthenticateSource(
+            AuthActivityStarter.Host.create(fragment),
+            source,
+            ApiRequest.Options(publishableKey, stripeAccountId)
+        )
+    }
+
+    /**
+     * Should be called in `onActivityResult()` to determine if the result is for Source authentication
+     */
+    fun isAuthenticateSourceResult(
+        requestCode: Int,
+        data: Intent?
+    ): Boolean {
+        return data != null && paymentController.shouldHandleSourceResult(requestCode, data)
+    }
+
+    /**
+     * The result of a call to [authenticateSource].
+     *
+     * Use [isAuthenticateSourceResult] before calling this method.
+     */
+    fun onAuthenticateSourceResult(
+        data: Intent,
+        callback: ApiResultCallback<Source>
+    ) {
+        paymentController.handleSourceResult(
+            data,
+            ApiRequest.Options(publishableKey, stripeAccountId),
+            callback
+        )
+    }
+
+    /**
      * Create a [Source] asynchronously.
      *
      * See [Create a source](https://stripe.com/docs/api/sources/create).

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -368,6 +368,15 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         }
     }
 
+    override fun retrieveSource(
+        sourceId: String,
+        clientSecret: String,
+        options: ApiRequest.Options,
+        callback: ApiResultCallback<Source>
+    ) {
+        RetrieveSourceTask(this, sourceId, clientSecret, options, callback).execute()
+    }
+
     @Throws(AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class, APIException::class)
     override fun createPaymentMethod(
@@ -991,6 +1000,20 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     )
                 else -> null
             }
+        }
+    }
+
+    private class RetrieveSourceTask constructor(
+        private val stripeRepository: StripeRepository,
+        private val sourceId: String,
+        private val clientSecret: String,
+        private val requestOptions: ApiRequest.Options,
+        callback: ApiResultCallback<Source>
+    ) : ApiOperation<Source>(callback = callback) {
+
+        @Throws(StripeException::class)
+        override suspend fun getResult(): Source? {
+            return stripeRepository.retrieveSource(sourceId, clientSecret, requestOptions)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -98,6 +98,16 @@ internal interface StripeRepository {
         options: ApiRequest.Options
     ): Source?
 
+    /**
+     * Retrieve a [Source] asynchronously
+     */
+    fun retrieveSource(
+        sourceId: String,
+        clientSecret: String,
+        options: ApiRequest.Options,
+        callback: ApiResultCallback<Source>
+    )
+
     @Throws(AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class, APIException::class)
     fun createPaymentMethod(

--- a/stripe/src/main/java/com/stripe/android/view/StripeIntentResultExtras.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeIntentResultExtras.kt
@@ -19,4 +19,6 @@ internal object StripeIntentResultExtras {
     const val SHOULD_CANCEL_SOURCE = "should_cancel_source"
 
     const val SOURCE_ID = "source_id"
+
+    const val SOURCE = "source"
 }

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -92,6 +92,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
+    override fun retrieveSource(
+        sourceId: String,
+        clientSecret: String,
+        options: ApiRequest.Options,
+        callback: ApiResultCallback<Source>
+    ) {
+    }
+
     override fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options


### PR DESCRIPTION
## Summary
Add `Stripe.authenticateSource()` for both `Activity` and `Fragment`
hosts. Result is returned through `Activity#onActivityResult()`
or `Fragment#onActivityResult()`.

Add example of using new functionality in `KlarnaSourceActivity`
example.

## Motivation
Simplify Source authentication flow.

## Testing
Add tests and manually verify

![klarna_auth](https://user-images.githubusercontent.com/45020849/71417476-7bc64380-2633-11ea-83cf-87054ebffc29.gif)

