### PR TITLE
Fixed country is not selected from prepopulated shipping info

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAutoCompleteTextView.kt
@@ -89,7 +89,7 @@ internal class CountryAutoCompleteTextView @JvmOverloads constructor(
     private fun updateInitialCountry() {
         val initialCountry = countryAdapter.firstItem
         countryAutocomplete.setText(initialCountry.name)
-        selectedCountry = initialCountry
+        selectedCountry = selectedCountry ?: initialCountry
         countryChangeCallback(initialCountry)
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
@@ -162,9 +162,9 @@ internal class PaymentFlowPagerAdapter(
                 shippingInfoWidget
                     .setOptionalFields(paymentSessionConfig.optionalShippingInfoFields)
                 shippingInfoWidget
-                    .populateShippingInfo(shippingInformation)
-                shippingInfoWidget
                     .setAllowedCountryCodes(allowedShippingCountryCodes)
+                shippingInfoWidget
+                        .populateShippingInfo(shippingInformation)
             }
         }
 

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -258,6 +258,20 @@ class ShippingInfoWidgetTest {
         assertEquals(countryAutoCompleteTextView.selectedCountry?.code, "US")
     }
 
+    @Test
+    fun getSelectedShippingCountry_whenShippingInfoProvided_returnsExpected() {
+        shippingInfoWidget.populateShippingInfo(SHIPPING_INFO_CA)
+        shippingInfoWidget.setAllowedCountryCodes(setOf("US", "CA"))
+        assertEquals(stateEditText.text.toString(), "Ontario")
+        assertEquals(cityEditText.text.toString(), "Ontario")
+        assertEquals(addressLine1EditText.text.toString(), "185 Berry St")
+        assertEquals(addressLine2EditText.text.toString(), "10th Floor")
+        assertEquals(phoneEditText.text.toString(), "416-759-0260")
+        assertEquals(postalEditText.text.toString(), "M4B1B5")
+        assertEquals(nameEditText.text.toString(), "Fake Name")
+        assertEquals(countryAutoCompleteTextView.selectedCountry?.code, "CA")
+    }
+
     private companion object {
         private const val NO_POSTAL_CODE_COUNTRY_CODE = "ZW" // Zimbabwe
 
@@ -272,6 +286,19 @@ class ShippingInfoWidgetTest {
                 .build(),
             "Fake Name",
             "(123) 456 - 7890"
+        )
+
+        private val SHIPPING_INFO_CA = ShippingInformation(
+                Address.Builder()
+                        .setCity("Ontario")
+                        .setState("Ontario")
+                        .setCountry("CA")
+                        .setLine1("185 Berry St")
+                        .setLine2("10th Floor")
+                        .setPostalCode("M4B1B5")
+                        .build(),
+                "Fake Name",
+                "416-759-0260"
         )
     }
 }


### PR DESCRIPTION
## Summary
Preloaded country was not set to `Add an Address` page's  country drop down list due to not considering `selectedCountry` when updating the `CountryAutoCompleteTextView` ui. To fix this problem I have made two changes in actual code base. In `private fun updateInitialCountry()` method of `CountryAutoCompleteTextView` I have considered selected country before putting `initialCountry` as `selectedCountry` like `selectedCountry = selectedCountry ?: initialCountry` and in `PaymentFlowPagerAdapter ` I have called `shippingInfoWidget.populateShippingInfo(shippingInformation)` at last to not mess with `selectedCountry` as it was happening before.

## Motivation
To solve the issue mentioned in this link
https://github.com/stripe/stripe-android/issues/2010
## Testing
<!-- How was the code tested? Be as specific as possible. -->
The following test was added in `ShippingInfoWidgetTest` class
```
  @Test
    fun getSelectedShippingCountry_whenShippingInfoProvided_returnsExpected() {
        shippingInfoWidget.populateShippingInfo(SHIPPING_INFO_CA)
        shippingInfoWidget.setAllowedCountryCodes(setOf("US", "CA"))
        assertEquals(stateEditText.text.toString(), "Ontario")
        assertEquals(cityEditText.text.toString(), "Ontario")
        assertEquals(addressLine1EditText.text.toString(), "185 Berry St")
        assertEquals(addressLine2EditText.text.toString(), "10th Floor")
        assertEquals(phoneEditText.text.toString(), "416-759-0260")
        assertEquals(postalEditText.text.toString(), "M4B1B5")
        assertEquals(nameEditText.text.toString(), "Fake Name")
        assertEquals(countryAutoCompleteTextView.selectedCountry?.code, "CA")
    }
```
