### PR TITLE
Feature/fix country selection from prepopulated info

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
@@ -162,9 +162,9 @@ internal class PaymentFlowPagerAdapter(
                 shippingInfoWidget
                     .setOptionalFields(paymentSessionConfig.optionalShippingInfoFields)
                 shippingInfoWidget
-                    .populateShippingInfo(shippingInformation)
-                shippingInfoWidget
                     .setAllowedCountryCodes(allowedShippingCountryCodes)
+                shippingInfoWidget
+                    .populateShippingInfo(shippingInformation)
             }
         }
 

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -258,6 +258,20 @@ class ShippingInfoWidgetTest {
         assertEquals(countryAutoCompleteTextView.selectedCountry?.code, "US")
     }
 
+    @Test
+    fun getSelectedShippingCountry_whenShippingInfoProvided_returnsExpected() {
+        shippingInfoWidget.setAllowedCountryCodes(setOf("US", "CA"))
+        shippingInfoWidget.populateShippingInfo(SHIPPING_INFO_CA)
+        assertEquals("Ontario", stateEditText.text.toString())
+        assertEquals("Ontario", cityEditText.text.toString())
+        assertEquals("185 Berry St", addressLine1EditText.text.toString())
+        assertEquals("10th Floor", addressLine2EditText.text.toString())
+        assertEquals("416-759-0260", phoneEditText.text.toString())
+        assertEquals("M4B1B5", postalEditText.text.toString())
+        assertEquals("Fake Name", nameEditText.text.toString())
+        assertEquals("CA", countryAutoCompleteTextView.selectedCountry?.code)
+    }
+
     private companion object {
         private const val NO_POSTAL_CODE_COUNTRY_CODE = "ZW" // Zimbabwe
 
@@ -272,6 +286,19 @@ class ShippingInfoWidgetTest {
                 .build(),
             "Fake Name",
             "(123) 456 - 7890"
+        )
+
+        private val SHIPPING_INFO_CA = ShippingInformation(
+            Address.Builder()
+                .setCity("Ontario")
+                .setState("Ontario")
+                .setCountry("CA")
+                .setLine1("185 Berry St")
+                .setLine2("10th Floor")
+                .setPostalCode("M4B1B5")
+                .build(),
+            "Fake Name",
+            "416-759-0260"
         )
     }
 }


### PR DESCRIPTION
## Summary
Add an Address page's country list wasn't showing prepopulated selectedCountry. The fix was just placing `shippingInfoWidget.populateShippingInfo(shippingInformation)` at the last of `fun bind()` method of `PaymentFlowPagerAdapter` class as calling `setAllowedCountryCodes()` refreshes selected country with first item.

## Motivation
To fix this open issue https://github.com/stripe/stripe-android/issues/2010

## Testing
I have written the following test.
```
  @Test
    fun getSelectedShippingCountry_whenShippingInfoProvided_returnsExpected() {
        shippingInfoWidget.setAllowedCountryCodes(setOf("US", "CA"))
        shippingInfoWidget.populateShippingInfo(SHIPPING_INFO_CA)
        assertEquals(stateEditText.text.toString(), "Ontario")
        assertEquals(cityEditText.text.toString(), "Ontario")
        assertEquals(addressLine1EditText.text.toString(), "185 Berry St")
        assertEquals(addressLine2EditText.text.toString(), "10th Floor")
        assertEquals(phoneEditText.text.toString(), "416-759-0260")
        assertEquals(postalEditText.text.toString(), "M4B1B5")
        assertEquals(nameEditText.text.toString(), "Fake Name")
        assertEquals(countryAutoCompleteTextView.selectedCountry?.code, "CA")
    }
```
