### PR TITLE
Guard against IndexOutOfBoundsException in CardNumberEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -174,7 +174,7 @@ class CardNumberEditText @JvmOverloads constructor(
                 if (formattedNumber != null) {
                     setText(formattedNumber)
                     newCursorPosition?.let {
-                        setSelection(it)
+                        setSelection(it.coerceIn(0, fieldText.length))
                     }
                 }
                 formattedNumber = null

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -161,7 +161,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 if (formattedDate != null) {
                     setText(formattedDate)
                     newCursorPosition?.let {
-                        setSelection(it)
+                        setSelection(it.coerceIn(0, fieldText.length))
                     }
                 }
 


### PR DESCRIPTION
Calling `setSelection()` in `CardNumberEditText` may throw
`IndexOutOfBoundsException`. Coerce the selection to be
within a valid range.

Fixes #2023
