### PR TITLE
Disable Klarna end-to-end tests

### DIFF
--- a/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -7,11 +7,14 @@ import com.stripe.android.model.DateOfBirth
 import com.stripe.android.model.KlarnaSourceParams
 import com.stripe.android.model.SourceOrder
 import com.stripe.android.model.SourceParams
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+// TODO(mshafrir-stripe): investigate test failures - ANDROID-461
+@Ignore("Klarna end-to-end tests are currently failing")
 @RunWith(RobolectricTestRunner::class)
 class SourceEndToEndTest {
     @Test


### PR DESCRIPTION
`SourceEndToEndTest` tests are currently failing. Disable for now to unblock CI. Investigate in ANDROID-461.