### PR TITLE
Update CardBrand usage

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -546,31 +546,6 @@ data class Card internal constructor(
     }
 
     companion object {
-        const val CVC_LENGTH_AMERICAN_EXPRESS: Int = 4
-        const val CVC_LENGTH_COMMON: Int = 3
-
-        /**
-         * Based on [Issuer identification number table](http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29)
-         */
-        @Deprecated("Use CardBrand.AmericanExpress.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
-        val PREFIXES_AMERICAN_EXPRESS: Array<String> = CardBrand.AmericanExpress.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.Discover.prefixes", ReplaceWith("CardBrand.Discover.prefixes"))
-        val PREFIXES_DISCOVER: Array<String> = CardBrand.Discover.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.JCB.prefixes", ReplaceWith("CardBrand.JCB.prefixes"))
-        val PREFIXES_JCB: Array<String> = CardBrand.JCB.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.DinersClub.prefixes", ReplaceWith("CardBrand.DinersClub.prefixes"))
-        val PREFIXES_DINERS_CLUB: Array<String> = CardBrand.DinersClub.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.Visa.prefixes", ReplaceWith("CardBrand.Visa.prefixes"))
-        val PREFIXES_VISA: Array<String> = CardBrand.Visa.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.MasterCard.prefixes", ReplaceWith("CardBrand.MasterCard.prefixes"))
-        val PREFIXES_MASTERCARD: Array<String> = CardBrand.MasterCard.prefixes.toTypedArray()
-        @Deprecated("Use CardBrand.UnionPay.prefixes", ReplaceWith("CardBrand.AmericanExpress.prefixes"))
-        val PREFIXES_UNIONPAY: Array<String> = CardBrand.UnionPay.prefixes.toTypedArray()
-
-        const val MAX_LENGTH_STANDARD: Int = 16
-        const val MAX_LENGTH_AMERICAN_EXPRESS: Int = 15
-        const val MAX_LENGTH_DINERS_CLUB: Int = 14
-
         internal const val OBJECT_TYPE = "card"
 
         /**

--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -17,7 +17,14 @@ enum class CardBrand(
      */
     val cvcLength: Set<Int> = setOf(3),
 
+    /**
+     * The max length when the card number is formatted with spaces (e.g. "4242 4242 4242 4242")
+     */
     val maxLengthWithSpaces: Int = 19,
+
+    /**
+     * The max length when the card number is formatted without spaces (e.g. "4242424242424242")
+     */
     val maxLengthWithoutSpaces: Int = 16,
 
     /**
@@ -101,6 +108,11 @@ enum class CardBrand(
         cvcLength = setOf(3, 4)
     );
 
+    val maxCvcLength: Int
+        get() {
+            return cvcLength.max() ?: CVC_COMMON_LENGTH
+        }
+
     /**
      * Checks to see whether the input number is of the correct length, given the assumed brand of
      * the card. This function does not perform a Luhn check.
@@ -115,6 +127,11 @@ enum class CardBrand(
 
     fun isValidCvc(cvc: String): Boolean {
         return cvcLength.contains(cvc.length)
+    }
+
+    fun isMaxCvc(cvcText: String?): Boolean {
+        val cvcLength = cvcText?.trim()?.length ?: 0
+        return maxCvcLength == cvcLength
     }
 
     companion object {
@@ -142,5 +159,7 @@ enum class CardBrand(
         fun fromCode(code: String?): CardBrand {
             return values().firstOrNull { it.code.equals(code, ignoreCase = true) } ?: Unknown
         }
+
+        private const val CVC_COMMON_LENGTH: Int = 3
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -642,7 +642,7 @@ class CardInputWidget @JvmOverloads constructor(
         cvcNumberEditText.setAfterTextChangedListener(
             object : StripeEditText.AfterTextChangedListener {
                 override fun onTextChanged(text: String) {
-                    if (ViewUtils.isCvcMaximalLength(brand, text)) {
+                    if (brand.isMaxCvc(text)) {
                         cardInputListener?.onCvcComplete()
                     }
                     updateIconCvc(cvcNumberEditText.hasFocus(), text)
@@ -1257,7 +1257,7 @@ class CardInputWidget @JvmOverloads constructor(
             cvcHasFocus: Boolean,
             cvcText: String?
         ): Boolean {
-            return !cvcHasFocus || ViewUtils.isCvcMaximalLength(brand, cvcText)
+            return !cvcHasFocus || brand.isMaxCvc(cvcText)
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -233,7 +233,7 @@ class CardMultilineWidget @JvmOverloads constructor(
         cvcEditText.setAfterTextChangedListener(
             object : StripeEditText.AfterTextChangedListener {
                 override fun onTextChanged(text: String) {
-                    if (ViewUtils.isCvcMaximalLength(cardBrand, text)) {
+                    if (cardBrand.isMaxCvc(text)) {
                         updateBrandUi()
                         if (shouldShowPostalCode) {
                             postalCodeEditText.requestFocus()
@@ -460,7 +460,7 @@ class CardMultilineWidget @JvmOverloads constructor(
     }
 
     private fun flipToCvcIconIfNotFinished() {
-        if (ViewUtils.isCvcMaximalLength(cardBrand, cvcEditText.text?.toString())) {
+        if (cardBrand.isMaxCvc(cvcEditText.text?.toString())) {
             return
         }
 

--- a/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ViewUtils.kt
@@ -1,26 +1,11 @@
 package com.stripe.android.view
 
-import com.stripe.android.model.Card.Companion.CVC_LENGTH_AMERICAN_EXPRESS
-import com.stripe.android.model.Card.Companion.CVC_LENGTH_COMMON
 import com.stripe.android.model.CardBrand
 
 /**
  * Static utility functions needed for View classes.
  */
 internal object ViewUtils {
-    @JvmStatic
-    fun isCvcMaximalLength(
-        cardBrand: CardBrand,
-        cvcText: String?
-    ): Boolean {
-        val cvcLength = cvcText?.trim { it <= ' ' }?.length ?: 0
-        return if (CardBrand.AmericanExpress == cardBrand) {
-            cvcLength == CVC_LENGTH_AMERICAN_EXPRESS
-        } else {
-            cvcLength == CVC_LENGTH_COMMON
-        }
-    }
-
     /**
      * Separates a card number according to the brand requirements, including prefixes of card
      * numbers, so that the groups can be easily displayed if the user is typing them in.

--- a/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
@@ -66,4 +66,55 @@ class CardBrandTest {
             CardBrand.Unknown.isValidCardNumberLength(CardNumberFixtures.VALID_VISA_NO_SPACES)
         )
     }
+
+    @Test
+    fun isMaxCvc_whenThreeDigitsAndNotAmEx_returnsTrue() {
+        assertTrue(CardBrand.Visa.isMaxCvc("123"))
+        assertTrue(CardBrand.MasterCard.isMaxCvc("345"))
+        assertTrue(CardBrand.JCB.isMaxCvc("678"))
+        assertTrue(CardBrand.DinersClub.isMaxCvc("910"))
+        assertTrue(CardBrand.Discover.isMaxCvc("234"))
+        assertTrue(CardBrand.Unknown.isMaxCvc("3333"))
+    }
+
+    @Test
+    fun isMaxCvc_whenThreeDigitsAndIsAmEx_returnsFalse() {
+        assertFalse(CardBrand.AmericanExpress.isMaxCvc("123"))
+    }
+
+    @Test
+    fun isMaxCvc_whenFourDigitsAndIsAmEx_returnsTrue() {
+        assertTrue(CardBrand.AmericanExpress.isMaxCvc("1234"))
+    }
+
+    @Test
+    fun isMaxCvc_whenTooManyDigits_returnsFalse() {
+        assertFalse(CardBrand.AmericanExpress.isMaxCvc("12345"))
+        assertFalse(CardBrand.Visa.isMaxCvc("1234"))
+        assertFalse(CardBrand.MasterCard.isMaxCvc("123456"))
+        assertFalse(CardBrand.DinersClub.isMaxCvc("1234567"))
+        assertFalse(CardBrand.Discover.isMaxCvc("12345678"))
+        assertFalse(CardBrand.JCB.isMaxCvc("123456789012345"))
+    }
+
+    @Test
+    fun isMaxCvc_whenNotEnoughDigits_returnsFalse() {
+        assertFalse(CardBrand.AmericanExpress.isMaxCvc(""))
+        assertFalse(CardBrand.Visa.isMaxCvc("1"))
+        assertFalse(CardBrand.MasterCard.isMaxCvc("12"))
+        assertFalse(CardBrand.DinersClub.isMaxCvc(""))
+        assertFalse(CardBrand.Discover.isMaxCvc("8"))
+        assertFalse(CardBrand.JCB.isMaxCvc("1"))
+    }
+
+    @Test
+    fun isMaxCvc_whenWhitespaceAndNotEnoughDigits_returnsFalse() {
+        assertFalse(CardBrand.AmericanExpress.isMaxCvc("   "))
+        assertFalse(CardBrand.Visa.isMaxCvc("  1"))
+    }
+
+    @Test
+    fun isMaxCvc_whenNull_returnsFalse() {
+        assertFalse(CardBrand.AmericanExpress.isMaxCvc(null))
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -639,13 +639,13 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun onUpdateIcon_forCommonLengthBrand_setsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.
-        cardNumberEditText.append(Card.PREFIXES_VISA[0])
+        cardNumberEditText.append(CardBrand.Visa.prefixes.first())
         assertTrue(ViewTestUtils.hasMaxLength(cvcEditText, 3))
     }
 
     @Test
     fun onUpdateText_forAmExPrefix_setsLengthOnCvc() {
-        cardNumberEditText.append(Card.PREFIXES_AMERICAN_EXPRESS[0])
+        cardNumberEditText.append(CardBrand.AmericanExpress.prefixes.first())
         assertTrue(ViewTestUtils.hasMaxLength(cvcEditText, 4))
     }
 
@@ -1029,6 +1029,7 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @Test
     fun setCvcCode_withLongString_truncatesValue() {
+        cvcEditText.updateBrand(CardBrand.Visa)
         cardInputWidget.setCvcCode(CVC_VALUE_AMEX)
         assertEquals(CVC_VALUE_COMMON, cvcEditText.text.toString())
     }
@@ -1209,7 +1210,11 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         assertTrue(shouldIconShowBrand(CardBrand.JCB, true, "555"))
         assertTrue(shouldIconShowBrand(CardBrand.MasterCard, true, "919"))
         assertTrue(shouldIconShowBrand(CardBrand.DinersClub, true, "415"))
-        assertTrue(shouldIconShowBrand(CardBrand.Unknown, true, "212"))
+    }
+
+    @Test
+    fun shouldIconShowBrand_whenUnknownBrandAndCvcStringLengthIsFour_isTrue() {
+        assertTrue(shouldIconShowBrand(CardBrand.Unknown, true, "2124"))
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CvcEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CvcEditTextTest.kt
@@ -58,8 +58,10 @@ class CvcEditTextTest {
     }
 
     @Test
-    fun completionCallback_isInvoked_whenValid() {
+    fun completionCallback_whenVisa_isInvoked_whenMax() {
         var hasCompleted = false
+
+        cvcEditText.updateBrand(CardBrand.Visa)
         cvcEditText.completionCallback = { hasCompleted = true }
 
         cvcEditText.setText("1")
@@ -69,6 +71,26 @@ class CvcEditTextTest {
         assertFalse(hasCompleted)
 
         cvcEditText.setText("123")
+        assertTrue(hasCompleted)
+    }
+
+    @Test
+    fun completionCallback_whenAmex_isInvoked_whenMax() {
+        var hasCompleted = false
+
+        cvcEditText.updateBrand(CardBrand.AmericanExpress)
+        cvcEditText.completionCallback = { hasCompleted = true }
+
+        cvcEditText.setText("1")
+        assertFalse(hasCompleted)
+
+        cvcEditText.setText("12")
+        assertFalse(hasCompleted)
+
+        cvcEditText.setText("123")
+        assertFalse(hasCompleted)
+
+        cvcEditText.setText("1234")
         assertTrue(hasCompleted)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ViewUtilsTest.kt
@@ -3,9 +3,7 @@ package com.stripe.android.view
 import com.stripe.android.model.CardBrand
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -121,57 +119,6 @@ internal class ViewUtilsTest {
         assertEquals("0566", groups[1])
         assertEquals("5566", groups[2])
         assertEquals("555", groups[3])
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenThreeDigitsAndNotAmEx_returnsTrue() {
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "123"))
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "345"))
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "678"))
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, "910"))
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "234"))
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.Unknown, "333"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenThreeDigitsAndIsAmEx_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "123"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenFourDigitsAndIsAmEx_returnsTrue() {
-        assertTrue(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "1234"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenTooManyDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "12345"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "1234"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "123456"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, "1234567"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "12345678"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "123456789012345"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenNotEnoughDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, ""))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "1"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.MasterCard, "12"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.DinersClub, ""))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Discover, "8"))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.JCB, "1"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenWhitespaceAndNotEnoughDigits_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, "   "))
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.Visa, "  1"))
-    }
-
-    @Test
-    fun isCvcMaximalLength_whenNull_returnsFalse() {
-        assertFalse(ViewUtils.isCvcMaximalLength(CardBrand.AmericanExpress, null))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove max length, cvc, and prefix constants from `Card`
- Add `CardBrand.isMaxCvc()`
- Replace `ViewUtils.isCvcMaximalLength()` with `CardBrand.isMaxCvc()`
- Fire `CvcEditText` completion callback when at max CVC length
  instead of when first valid

## Motivation
Consolidate logic into `CardBrand`

## Testing
Update tests