### PR TITLE
Fix backspace functionality in CardNumberEditText and ExpiryDateEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -171,7 +171,7 @@ class CardNumberEditText @JvmOverloads constructor(
                 }
 
                 ignoreChanges = true
-                if (formattedNumber != null) {
+                if (!isLastKeyDelete && formattedNumber != null) {
                     setText(formattedNumber)
                     newCursorPosition?.let {
                         setSelection(it.coerceIn(0, fieldText.length))
@@ -183,10 +183,10 @@ class CardNumberEditText @JvmOverloads constructor(
                 ignoreChanges = false
 
                 if (fieldText.length == lengthMax) {
-                    val before = isCardNumberValid
+                    val wasCardNumberValid = isCardNumberValid
                     isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
                     shouldShowError = !isCardNumberValid
-                    if (!before && isCardNumberValid) {
+                    if (!wasCardNumberValid && isCardNumberValid) {
                         completionCallback()
                     }
                 } else {

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -158,7 +158,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 }
 
                 ignoreChanges = true
-                if (formattedDate != null) {
+                if (!isLastKeyDelete && formattedDate != null) {
                     setText(formattedDate)
                     newCursorPosition?.let {
                         setSelection(it.coerceIn(0, fieldText.length))

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -33,13 +33,12 @@ class CardNumberEditTextTest {
         lastBrandChangeCallbackInvocation = it
     }
 
-    private lateinit var cardNumberEditText: CardNumberEditText
+    private val cardNumberEditText: CardNumberEditText by lazy {
+        CardNumberEditText(ApplicationProvider.getApplicationContext<Context>())
+    }
 
     @BeforeTest
     fun setup() {
-        cardNumberEditText = CardNumberEditText(
-            ApplicationProvider.getApplicationContext<Context>()
-        )
         cardNumberEditText.setText("")
         cardNumberEditText.completionCallback = completionCallback
         cardNumberEditText.brandChangeCallback = brandChangeCallback

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -19,11 +19,12 @@ import org.robolectric.RobolectricTestRunner
  */
 @RunWith(RobolectricTestRunner::class)
 class ExpiryDateEditTextTest {
-    private lateinit var expiryDateEditText: ExpiryDateEditText
+    private val expiryDateEditText: ExpiryDateEditText by lazy {
+        ExpiryDateEditText(ApplicationProvider.getApplicationContext<Context>())
+    }
 
     @BeforeTest
     fun setup() {
-        expiryDateEditText = ExpiryDateEditText(ApplicationProvider.getApplicationContext<Context>())
         expiryDateEditText.setText("")
     }
 
@@ -72,13 +73,13 @@ class ExpiryDateEditTextTest {
     }
 
     @Test
-    fun afterInputThreeDigits_whenDeletingOne_textDoesNotContainSlash() {
+    fun afterInputThreeDigits_whenDeletingOne_textDoesContainSlash() {
         expiryDateEditText.append("1")
         expiryDateEditText.append("2")
         expiryDateEditText.append("3")
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
         val text = expiryDateEditText.text.toString()
-        assertEquals("12", text)
+        assertEquals("12/", text)
     }
 
     @Test
@@ -171,12 +172,12 @@ class ExpiryDateEditTextTest {
     }
 
     @Test
-    fun delete_whenAcrossSeparator_alwaysDeletesNumber() {
+    fun delete_whenAcrossSeparator_deletesSeparator() {
         expiryDateEditText.append("12")
         assertEquals("12/", expiryDateEditText.text.toString())
 
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
-        assertEquals("1", expiryDateEditText.text.toString())
+        assertEquals("12", expiryDateEditText.text.toString())
     }
 
     @Test


### PR DESCRIPTION
When backspace is pressed on `CardNumberEditText` and
`ExpiryDateEditText`, skip the `setText()` logic in
`afterTextChanged()`.

This slightly modifies backspace behavior, because it does
not automatically delete automatically added characters.

For example, if the content of `ExpiryDateEditText` is "12/2",
previously tapping backspace would update the content to "12".
Now, tapping backspace would result in content being "12/".

Fixes #2035

| Before | After |
|--------|-------|
| ![backspace_before](https://user-images.githubusercontent.com/45020849/71988515-0dba7880-31fe-11ea-8aea-6586735c75d9.gif)    | ![backspace_after](https://user-images.githubusercontent.com/45020849/71988523-114dff80-31fe-11ea-9024-5ffc39f4e315.gif)   |
