### PR TITLE
Add support for PaymentMethodOptions and PaymentIntent CVC recollection

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -6,18 +6,19 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 
-data class ConfirmPaymentIntentParams private constructor(
-    val paymentMethodCreateParams: PaymentMethodCreateParams?,
-    val paymentMethodId: String?,
-    val sourceParams: SourceParams?,
-    val sourceId: String?,
+data class ConfirmPaymentIntentParams internal constructor(
+    val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
+    val paymentMethodId: String? = null,
+    val sourceParams: SourceParams? = null,
+    val sourceId: String? = null,
 
-    val extraParams: Map<String, Any>?,
+    val extraParams: Map<String, Any>? = null,
     override val clientSecret: String,
-    val returnUrl: String?,
+    val returnUrl: String? = null,
 
-    private val savePaymentMethod: Boolean,
-    private val useStripeSdk: Boolean
+    private val savePaymentMethod: Boolean = false,
+    private val useStripeSdk: Boolean = false,
+    private val paymentMethodOptions: PaymentMethodOptionsParams? = null
 ) : ConfirmStripeIntentParams {
 
     fun shouldSavePaymentMethod(): Boolean {
@@ -63,6 +64,9 @@ data class ConfirmPaymentIntentParams private constructor(
         if (extraParams != null) {
             params.putAll(extraParams)
         }
+        paymentMethodOptions?.let {
+            params[PARAM_PAYMENT_METHOD_OPTIONS] = it.toParamMap()
+        }
 
         return params.toMap()
     }
@@ -74,6 +78,7 @@ data class ConfirmPaymentIntentParams private constructor(
             .setSourceId(sourceId)
             .setSavePaymentMethod(savePaymentMethod)
             .setExtraParams(extraParams)
+            .setPaymentMethodOptions(paymentMethodOptions)
             .also { builder ->
                 paymentMethodId?.let { builder.setPaymentMethodId(it) }
                 paymentMethodCreateParams?.let { builder.setPaymentMethodCreateParams(it) }
@@ -99,6 +104,7 @@ data class ConfirmPaymentIntentParams private constructor(
 
         private var savePaymentMethod: Boolean = false
         private var shouldUseSdk: Boolean = false
+        private var paymentMethodOptions: PaymentMethodOptionsParams? = null
 
         /**
          * Sets the PaymentMethod data that will be included with this PaymentIntent
@@ -169,6 +175,12 @@ data class ConfirmPaymentIntentParams private constructor(
             this.shouldUseSdk = shouldUseSdk
         }
 
+        internal fun setPaymentMethodOptions(
+            paymentMethodOptions: PaymentMethodOptionsParams?
+        ): Builder = apply {
+            this.paymentMethodOptions = paymentMethodOptions
+        }
+
         override fun build(): ConfirmPaymentIntentParams {
             return ConfirmPaymentIntentParams(
                 clientSecret = clientSecret,
@@ -179,7 +191,8 @@ data class ConfirmPaymentIntentParams private constructor(
                 sourceParams = sourceParams,
                 savePaymentMethod = savePaymentMethod,
                 extraParams = extraParams,
-                useStripeSdk = shouldUseSdk
+                useStripeSdk = shouldUseSdk,
+                paymentMethodOptions = paymentMethodOptions
             )
         }
     }
@@ -189,6 +202,7 @@ data class ConfirmPaymentIntentParams private constructor(
 
         internal const val PARAM_SOURCE_ID = "source"
         internal const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
+        internal const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
 
         /**
          * Create a [ConfirmPaymentIntentParams] without a payment method.
@@ -221,6 +235,7 @@ data class ConfirmPaymentIntentParams private constructor(
          * in the same request or the current payment method attached to the
          * PaymentIntent and must be specified again if a new payment method is
          * added.
+         * @param paymentMethodOptions Optional [PaymentMethodOptionsParams]
          */
         @JvmOverloads
         @JvmStatic
@@ -229,14 +244,17 @@ data class ConfirmPaymentIntentParams private constructor(
             clientSecret: String,
             returnUrl: String? = null,
             savePaymentMethod: Boolean = false,
-            extraParams: Map<String, Any>? = null
+            extraParams: Map<String, Any>? = null,
+            paymentMethodOptions: PaymentMethodOptionsParams? = null
         ): ConfirmPaymentIntentParams {
-            return Builder(clientSecret)
-                .setPaymentMethodId(paymentMethodId)
-                .setReturnUrl(returnUrl)
-                .setSavePaymentMethod(savePaymentMethod)
-                .setExtraParams(extraParams)
-                .build()
+            return ConfirmPaymentIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodId = paymentMethodId,
+                returnUrl = returnUrl,
+                savePaymentMethod = savePaymentMethod,
+                extraParams = extraParams,
+                paymentMethodOptions = paymentMethodOptions
+            )
         }
 
         /**

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+sealed class PaymentMethodOptionsParams(
+    val type: PaymentMethod.Type
+) : StripeParamsModel, Parcelable {
+
+    @Parcelize
+    data class Card(
+        val cvc: String? = null
+    ) : PaymentMethodOptionsParams(PaymentMethod.Type.Card) {
+        override fun toParamMap(): Map<String, Any> {
+            return mapOf(type.code to
+                cvc?.let {
+                    mapOf(PARAM_CVC to it)
+                }.orEmpty()
+            )
+        }
+
+        private companion object {
+            private const val PARAM_CVC = "cvc"
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.model
 
 import com.stripe.android.CardNumberFixtures.VALID_VISA_NO_SPACES
+import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SAVE_PAYMENT_METHOD
 import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SOURCE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -195,6 +197,28 @@ class ConfirmPaymentIntentParamsTest {
             RETURN_URL
         ).toParamMap()
         assertTrue(params.containsKey(MandateData.PARAM_MANDATE_DATA))
+    }
+
+    @Test
+    fun create_withPaymentMethodOptions() {
+        val params = ConfirmPaymentIntentParams(
+            paymentMethodId = "pm_123",
+            paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                cvc = "123"
+            ),
+            clientSecret = "client_secret"
+        ).toParamMap()
+
+        assertEquals(
+            mapOf(
+                PARAM_PAYMENT_METHOD_ID to "pm_123",
+                PARAM_PAYMENT_METHOD_OPTIONS to mapOf("card" to mapOf("cvc" to "123")),
+                PARAM_CLIENT_SECRET to "client_secret",
+                PARAM_SAVE_PAYMENT_METHOD to false,
+                PARAM_USE_STRIPE_SDK to false
+            ),
+            params
+        )
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Add `PaymentMethodOptionsParams` sealed class and
  `PaymentMethodOptionsParams.Card` subclass
- Update `ConfirmPaymentIntentParams.createWithPaymentMethodId()`
  with optional `PaymentMethodOptionsParams?` argument

## Motivation
Enable users to recollect and update the CVC of a card payment method
when confirming a `PaymentIntent`

ANDROID-464

## Testing
Added unit tests + verified manually end to end