### PR TITLE
Create AccountParams.BusinessTypeParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
@@ -1,13 +1,41 @@
 package com.stripe.android.model
 
+import android.os.Parcelable
+import com.stripe.android.ObjectBuilder
+import com.stripe.android.model.AccountParams.BusinessTypeParams
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.parcel.RawValue
+
 /**
- * Represents a grouping of parameters needed to create a Token for a Connect account on the server.
+ * [Create an account token](https://stripe.com/docs/api/tokens/create_account)
+ *
+ * Creates a single-use token that wraps a user’s legal entity information. Use this when creating
+ * or updating a Connect account. See the
+ * [account tokens documentation](https://stripe.com/docs/connect/account-tokens) to learn more.
  */
-data class AccountParams private constructor(
-    private val businessType: BusinessType?,
-    private val businessData: Map<String, Any>?,
-    private val tosShownAndAccepted: Boolean
-) : StripeParamsModel {
+@Parcelize
+data class AccountParams internal constructor(
+    /**
+     * Whether the user described by the data in the token has been shown the
+     * [Stripe Connected Account Agreement](https://stripe.com/docs/connect/account-tokens#stripe-connected-account-agreement).
+     * When creating an account token to create a new Connect account, this value must be `true`.
+     *
+     * [account.tos_shown_and_accepted](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted)
+     */
+    private val tosShownAndAccepted: Boolean,
+
+    /**
+     * The business type.
+     *
+     * [account.business_type](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-business_type)
+     */
+    private val businessType: BusinessType? = null,
+
+    /**
+     * See [BusinessTypeParams]
+     */
+    private val businessData: Map<String, @RawValue Any>? = null
+) : StripeParamsModel, Parcelable {
 
     /**
      * Create a string-keyed map representing this object that is ready to be sent over the network.
@@ -16,10 +44,10 @@ data class AccountParams private constructor(
      */
     override fun toParamMap(): Map<String, Any> {
         return mapOf("account" to
-            mapOf(API_TOS_SHOWN_AND_ACCEPTED to tosShownAndAccepted)
+            mapOf(PARAM_TOS_SHOWN_AND_ACCEPTED to tosShownAndAccepted)
                 .plus(
                     businessType?.code?.let { code ->
-                        mapOf(API_BUSINESS_TYPE to code)
+                        mapOf(PARAM_BUSINESS_TYPE to code)
                             .plus(
                                 businessData?.let { mapOf(code to it) }.orEmpty()
                             )
@@ -29,39 +57,989 @@ data class AccountParams private constructor(
     }
 
     /**
-     * See [Account creation API docs](https://stripe.com/docs/api/accounts/create#create_account-business_type)
+     * The business type.
+     *
+     * [account.business_type](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-business_type)
      */
     enum class BusinessType constructor(val code: String) {
         Individual("individual"),
         Company("company")
     }
 
-    companion object {
-        internal const val API_BUSINESS_TYPE = "business_type"
-        internal const val API_TOS_SHOWN_AND_ACCEPTED = "tos_shown_and_accepted"
+    sealed class BusinessTypeParams : StripeParamsModel, Parcelable {
+        /**
+         * Information about the company or business.
+         *
+         * [account.company](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company)
+         */
+        @Parcelize
+        data class Company(
+            /**
+             * The company’s primary address.
+             *
+             * [account.company.address](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address)
+             */
+            val address: Address? = null,
+
+            /**
+             * The Kana variation of the company’s primary address (Japan only).
+             *
+             * [account.company.address_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address_kana)
+             */
+            val addressKana: AddressJapanParams? = null,
+
+            /**
+             * The Kanji variation of the company’s primary address (Japan only).
+             *
+             * [account.company.address_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address_kanji)
+             */
+            val addressKanji: AddressJapanParams? = null,
+
+            /**
+             * Whether the company’s directors have been provided. Set this Boolean to `true` after
+             * creating all the company’s directors with the
+             * [Persons API](https://stripe.com/docs/api/persons) for accounts with a
+             * `relationship.director` requirement. This value is not automatically set to `true`
+             * after creating directors, so it needs to be updated to indicate all directors have
+             * been provided.
+             *
+             * [account.company.directors_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-directors_provided)
+             */
+            val directorsProvided: Boolean? = null,
+
+            /**
+             * Whether the company’s executives have been provided. Set this Boolean to `true` after
+             * creating all the company’s executives with the
+             * [Persons API](https://stripe.com/docs/api/persons) for accounts with a
+             * `relationship.executive` requirement.
+             *
+             * [account.company.executives_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-executives_provided)
+             */
+            val executivesProvided: Boolean? = null,
+
+            /**
+             * The company’s legal name.
+             *
+             * [account.company.name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name)
+             */
+            val name: String? = null,
+
+            /**
+             * The Kana variation of the company’s legal name (Japan only).
+             *
+             * [account.company.name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name_kana)
+             */
+            val nameKana: String? = null,
+
+            /**
+             * The Kanji variation of the company’s legal name (Japan only).
+             *
+             * [account.company.name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name_kanji)
+             */
+            val nameKanji: String? = null,
+
+            /**
+             * Whether the company’s owners have been provided. Set this Boolean to `true` after
+             * creating all the company’s owners with the
+             * [Persons API](https://stripe.com/docs/api/persons)
+             * for accounts with a `relationship.owner` requirement.
+             *
+             * [account.company.owners_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-owners_provided)
+             */
+            val ownersProvided: Boolean? = false,
+
+            /**
+             * The company’s phone number (used for verification).
+             *
+             * [account.company.phone](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-phone)
+             */
+            val phone: String? = null,
+
+            /**
+             * The business ID number of the company, as appropriate for the company’s country.
+             * (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a
+             * Company Number in the UK.)
+             *
+             * [account.company.tax_id](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-tax_id)
+             */
+            val taxId: String? = null,
+
+            /**
+             * The jurisdiction in which the `tax_id` is registered (Germany-based companies only).
+             *
+             * [account.company.tax_id_registrar](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-tax_id_registrar)
+             */
+            val taxIdRegistrar: String? = null,
+
+            /**
+             * The VAT number of the company.
+             *
+             * [account.company.vat_id](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-vat_id)
+             */
+            val vatId: String? = null,
+
+            /**
+             * Information on the verification state of the company.
+             *
+             * [account.company.verification](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-verification)
+             */
+            val verification: Verification? = null
+        ) : BusinessTypeParams() {
+            override fun toParamMap(): Map<String, Any> {
+                val params = listOf(
+                    PARAM_ADDRESS to address?.toParamMap(),
+                    PARAM_ADDRESS_KANA to addressKana?.toParamMap(),
+                    PARAM_ADDRESS_KANJI to addressKanji?.toParamMap(),
+                    PARAM_DIRECTORS_PROVIDED to directorsProvided,
+                    PARAM_EXECUTIVES_PROVIDED to executivesProvided,
+                    PARAM_NAME to name,
+                    PARAM_NAME_KANA to nameKana,
+                    PARAM_NAME_KANJI to nameKanji,
+                    PARAM_OWNERS_PROVIDED to ownersProvided,
+                    PARAM_PHONE to phone,
+                    PARAM_TAX_ID to taxId,
+                    PARAM_TAX_ID_REGISTRAR to taxIdRegistrar,
+                    PARAM_VAT_ID to vatId,
+                    PARAM_VERIFICATION to verification?.toParamMap()
+                )
+
+                return params.fold(emptyMap()) { acc, (key, value) ->
+                    acc.plus(
+                        value?.let { mapOf(key to it) }.orEmpty()
+                    )
+                }
+            }
+
+            @Parcelize
+            data class Verification(
+                /**
+                 * A document verifying the business.
+                 */
+                val document: Document? = null
+            ) : StripeParamsModel, Parcelable {
+                override fun toParamMap(): Map<String, Any> {
+                    return document?.let {
+                        mapOf(PARAM_DOCUMENT to it.toParamMap())
+                    }.orEmpty()
+                }
+
+                private companion object {
+                    private const val PARAM_DOCUMENT = "document"
+                }
+            }
+
+            @Parcelize
+            data class Document @JvmOverloads constructor(
+                /**
+                 * The front of a document returned by a
+                 * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file)
+                 * with a `purpose` value of `additional_verification`. The uploaded file needs to
+                 * be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and
+                 * less than 10 MB in size.
+                 *
+                 * [account.company.verification.document.front](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-verification-document-front)
+                 */
+                private val front: String? = null,
+
+                /**
+                 * The back of a document returned by a
+                 * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file)
+                 * with a `purpose` value of `additional_verification`. The uploaded file needs to
+                 * be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and
+                 * less than 10 MB in size.
+                 *
+                 * [account.company.verification.document.back](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-verification-document-back)
+                 */
+                private val back: String? = null
+            ) : StripeParamsModel, Parcelable {
+                override fun toParamMap(): Map<String, Any> {
+                    return listOf(
+                        PARAM_FRONT to front,
+                        PARAM_BACK to back
+                    ).fold(emptyMap()) { acc, (key, value) ->
+                        acc.plus(
+                            value?.let { mapOf(key to it) }.orEmpty()
+                        )
+                    }
+                }
+
+                private companion object {
+                    private const val PARAM_BACK = "back"
+                    private const val PARAM_FRONT = "front"
+                }
+            }
+
+            class Builder : ObjectBuilder<Company> {
+                private var address: Address? = null
+                private var addressKana: AddressJapanParams? = null
+                private var addressKanji: AddressJapanParams? = null
+                private var directorsProvided: Boolean? = null
+                private var executivesProvided: Boolean? = null
+                private var name: String? = null
+                private var nameKana: String? = null
+                private var nameKanji: String? = null
+                private var ownersProvided: Boolean? = null
+                private var phone: String? = null
+                private var taxId: String? = null
+                private var taxIdRegistrar: String? = null
+                private var vatId: String? = null
+                private var verification: Verification? = null
+
+                /**
+                 * @param address The company’s primary address.
+                 *
+                 * [account.company.address](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address)
+                 */
+                fun setAddress(address: Address?): Builder = apply {
+                    this.address = address
+                }
+
+                /**
+                 * @param addressKana The Kana variation of the company’s primary address (Japan only).
+                 *
+                 * [account.company.address_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address_kana)
+                 */
+                fun setAddressKana(addressKana: AddressJapanParams?): Builder = apply {
+                    this.addressKana = addressKana
+                }
+
+                /**
+                 * @param addressKanji The Kanji variation of the company’s primary address (Japan only).
+                 *
+                 * [account.company.address_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-address_kanji)
+                 */
+                fun setAddressKanji(addressKanji: AddressJapanParams?): Builder = apply {
+                    this.addressKanji = addressKanji
+                }
+
+                /**
+                 * @param directorsProvided Whether the company’s directors have been provided. Set
+                 * this Boolean to `true` after creating all the company’s directors with the
+                 * [Persons API](https://stripe.com/docs/api/persons) for accounts with a
+                 * `relationship.director` requirement. This value is not automatically set to
+                 * `true` after creating directors, so it needs to be updated to indicate all
+                 * directors have been provided.
+                 *
+                 * [account.company.directors_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-directors_provided)
+                 */
+                fun setDirectorsProvided(directorsProvided: Boolean?): Builder = apply {
+                    this.directorsProvided = directorsProvided
+                }
+
+                /**
+                 * @param executivesProvided Whether the company’s executives have been provided.
+                 * Set this Boolean to `true` after creating all the company’s executives with the
+                 * [Persons API](https://stripe.com/docs/api/persons) for accounts with a
+                 * `relationship.executive` requirement.
+                 *
+                 * [account.company.executives_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-executives_provided)
+                 */
+                fun setExecutivesProvided(executivesProvided: Boolean?): Builder = apply {
+                    this.executivesProvided = executivesProvided
+                }
+
+                /**
+                 * @param name The company’s legal name.
+                 *
+                 * [account.company.name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name)
+                 */
+                fun setName(name: String?): Builder = apply {
+                    this.name = name
+                }
+
+                /**
+                 * @param nameKana The Kana variation of the company’s legal name (Japan only).
+                 *
+                 * [account.company.name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name_kana)
+                 */
+                fun setNameKana(nameKana: String?): Builder = apply {
+                    this.nameKana = nameKana
+                }
+
+                /**
+                 * @param nameKanji The Kanji variation of the company’s legal name (Japan only).
+                 *
+                 * [account.company.name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-name_kanji)
+                 */
+                fun setNameKanji(nameKanji: String?): Builder = apply {
+                    this.nameKanji = nameKanji
+                }
+
+                /**
+                 * @param ownersProvided Whether the company’s owners have been provided. Set this
+                 * Boolean to `true` after creating all the company’s owners with the
+                 * [Persons API](https://stripe.com/docs/api/persons) for accounts with a
+                 * `relationship.owner` requirement.
+                 *
+                 * [account.company.owners_provided](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-owners_provided)
+                 */
+                fun setOwnersProvided(ownersProvided: Boolean?): Builder = apply {
+                    this.ownersProvided = ownersProvided
+                }
+
+                /**
+                 * @param phone The company’s phone number (used for verification).
+                 *
+                 * [account.company.phone](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-phone)
+                 */
+                fun setPhone(phone: String?): Builder = apply {
+                    this.phone = phone
+                }
+
+                /**
+                 * @param taxId The business ID number of the company, as appropriate for the
+                 * company’s country. (Examples are an Employer ID Number in the U.S.,
+                 * a Business Number in Canada, or a Company Number in the UK.)
+                 *
+                 * [account.company.tax_id](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-tax_id)
+                 */
+                fun setTaxId(taxId: String?): Builder = apply {
+                    this.taxId = taxId
+                }
+
+                /**
+                 * @param taxIdRegistrar The jurisdiction in which the `tax_id` is registered
+                 * (Germany-based companies only).
+                 *
+                 * [account.company.tax_id_registrar](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-tax_id_registrar)
+                 */
+                fun setTaxIdRegistrar(taxIdRegistrar: String?): Builder = apply {
+                    this.taxIdRegistrar = taxIdRegistrar
+                }
+
+                /**
+                 * @param vatId The VAT number of the company.
+                 *
+                 * [account.company.vat_id](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-vat_id)
+                 */
+                fun setVatId(vatId: String?): Builder = apply {
+                    this.vatId = vatId
+                }
+
+                /**
+                 * @param verification Information on the verification state of the company.
+                 *
+                 * [account.company.verification](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company-verification)
+                 */
+                fun setVerification(verification: Verification?): Builder = apply {
+                    this.verification = verification
+                }
+
+                override fun build(): Company {
+                    return Company(
+                        address = address,
+                        addressKana = addressKana,
+                        addressKanji = addressKanji,
+                        directorsProvided = directorsProvided,
+                        executivesProvided = executivesProvided,
+                        name = name,
+                        nameKana = nameKana,
+                        nameKanji = nameKanji,
+                        ownersProvided = ownersProvided,
+                        phone = phone,
+                        taxId = taxId,
+                        taxIdRegistrar = taxIdRegistrar,
+                        vatId = vatId,
+                        verification = verification
+                    )
+                }
+            }
+
+            private companion object {
+                private const val PARAM_ADDRESS = "address"
+                private const val PARAM_ADDRESS_KANA = "address_kana"
+                private const val PARAM_ADDRESS_KANJI = "address_kanji"
+                private const val PARAM_DIRECTORS_PROVIDED = "directors_provided"
+                private const val PARAM_EXECUTIVES_PROVIDED = "executives_provided"
+                private const val PARAM_NAME = "name"
+                private const val PARAM_NAME_KANA = "name_kana"
+                private const val PARAM_NAME_KANJI = "name_kanji"
+                private const val PARAM_OWNERS_PROVIDED = "owners_provided"
+                private const val PARAM_PHONE = "phone"
+                private const val PARAM_TAX_ID = "tax_id"
+                private const val PARAM_TAX_ID_REGISTRAR = "tax_id_registrar"
+                private const val PARAM_VAT_ID = "vat_id"
+                private const val PARAM_VERIFICATION = "verification"
+            }
+        }
 
         /**
-         * Create an [AccountParams] instance for a [BusinessType.Individual] or
-         * [BusinessType.Company].
+         * Information about the person represented by the account.
          *
-         * @param tosShownAndAccepted Whether the user described by the data in the token has been shown
-         * the [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
-         * When creating an account token to create a new Connect account,
-         * this value must be `true`.
+         * [account.individual](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual)
+         */
+        @Parcelize
+        data class Individual(
+            /**
+             * The individual’s primary address.
+             *
+             * [account.individual.address](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address)
+             */
+            val address: Address? = null,
+
+            /**
+             * The Kana variation of the the individual’s primary address (Japan only).
+             *
+             * [account.individual.address_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address_kana)
+             */
+            val addressKana: AddressJapanParams? = null,
+
+            /**
+             * The Kanji variation of the the individual’s primary address (Japan only).
+             *
+             * [account.individual.address_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address_kanji)
+             */
+            val addressKanji: AddressJapanParams? = null,
+
+            /**
+             * The individual’s date of birth.
+             *
+             * [account.individual.dob](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-dob)
+             */
+            val dateOfBirth: DateOfBirth? = null,
+
+            /**
+             * The individual’s email.
+             *
+             * [account.individual.email](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-email)
+             */
+            val email: String? = null,
+
+            /**
+             * The individual’s first name.
+             *
+             * [account.individual.first_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name)
+             */
+            val firstName: String? = null,
+
+            /**
+             * The Kana variation of the the individual’s first name (Japan only).
+             *
+             * [account.individual.first_name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name_kana)
+             */
+            val firstNameKana: String? = null,
+
+            /**
+             * The Kanji variation of the individual’s first name (Japan only).
+             *
+             * [account.individual.first_name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name_kanji)
+             */
+            val firstNameKanji: String? = null,
+
+            /**
+             * The individual’s gender (International regulations require either “male” or “female”).
+             *
+             * [account.individual.gender](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-gender)
+             */
+            val gender: String? = null,
+
+            /**
+             * The government-issued ID number of the individual, as appropriate for the
+             * representative’s country. (Examples are a Social Security Number in the U.S., or a
+             * Social Insurance Number in Canada). Instead of the number itself, you can also
+             * provide a PII token.
+             *
+             * [account.individual.id_number](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-id_number)
+             */
+            val idNumber: String? = null,
+
+            /**
+             * The individual’s last name.
+             *
+             * [account.individual.last_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name)
+             */
+            val lastName: String? = null,
+
+            /**
+             * The Kana varation of the individual’s last name (Japan only).
+             *
+             * [account.individual.last_name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name_kana)
+             */
+            val lastNameKana: String? = null,
+
+            /**
+             * The Kanji varation of the individual’s last name (Japan only).
+             *
+             * [account.individual.last_name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name_kanji)
+             */
+            val lastNameKanji: String? = null,
+
+            /**
+             * The individual’s maiden name.
+             *
+             * [account.individual.maiden_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-maiden_name)
+             */
+            val maidenName: String? = null,
+
+            /**
+             * Set of key-value pairs that you can attach to an object. This can be useful for
+             * storing additional information about the object in a structured format. Individual keys
+             * can be unset by posting an empty value to them. All keys can be unset by posting an
+             * empty value to `metadata`.
+             *
+             * [account.individual.metadata](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-metadata)
+             */
+            val metadata: Map<String, String>? = null,
+
+            /**
+             * The individual’s phone number.
+             *
+             * [account.individual.phone](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-phone)
+             */
+            val phone: String? = null,
+
+            /**
+             * The last four digits of the individual’s Social Security Number (U.S. only).
+             *
+             * [account.individual.ssn_last_4](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-ssn_last_4)
+             */
+            val ssnLast4: String? = null,
+
+            /**
+             * The individual’s verification document information.
+             *
+             * [account.individual.verification](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-verification)
+             */
+            val verification: Verification? = null
+        ) : BusinessTypeParams() {
+            override fun toParamMap(): Map<String, Any> {
+                return listOf(
+                    PARAM_ADDRESS to address?.toParamMap(),
+                    PARAM_ADDRESS_KANA to addressKana?.toParamMap(),
+                    PARAM_ADDRESS_KANJI to addressKanji?.toParamMap(),
+                    PARAM_DOB to dateOfBirth?.toParamMap(),
+                    PARAM_EMAIL to email,
+                    PARAM_FIRST_NAME to firstName,
+                    PARAM_FIRST_NAME_KANA to firstNameKana,
+                    PARAM_FIRST_NAME_KANJI to firstNameKanji,
+                    PARAM_GENDER to gender,
+                    PARAM_ID_NUMBER to idNumber,
+                    PARAM_LAST_NAME to lastName,
+                    PARAM_LAST_NAME_KANA to lastNameKana,
+                    PARAM_LAST_NAME_KANJI to lastNameKanji,
+                    PARAM_MAIDEN_NAME to maidenName,
+                    PARAM_METADATA to metadata,
+                    PARAM_PHONE to phone,
+                    PARAM_SSN_LAST_4 to ssnLast4,
+                    PARAM_VERIFICATION to verification?.toParamMap()
+                ).fold(emptyMap()) { acc, (key, value) ->
+                    acc.plus(
+                        value?.let { mapOf(key to it) }.orEmpty()
+                    )
+                }
+            }
+
+            @Parcelize
+            data class Verification @JvmOverloads constructor(
+                /**
+                 * An identifying document, either a passport or local ID card.
+                 */
+                val document: Document? = null,
+
+                /**
+                 * A document showing address, either a passport, local ID card, or utility bill from
+                 * a well-known utility company.
+                 */
+                val additionalDocument: Document? = null
+            ) : StripeParamsModel, Parcelable {
+                override fun toParamMap(): Map<String, Any> {
+                    return listOf(
+                        PARAM_ADDITIONAL_DOCUMENT to additionalDocument?.toParamMap(),
+                        PARAM_DOCUMENT to document?.toParamMap()
+                    ).fold(emptyMap()) { acc, (key, value) ->
+                        acc.plus(
+                            value?.let { mapOf(key to it) }.orEmpty()
+                        )
+                    }
+                }
+
+                private companion object {
+                    private const val PARAM_ADDITIONAL_DOCUMENT = "additional_document"
+                    private const val PARAM_DOCUMENT = "document"
+                }
+            }
+
+            @Parcelize
+            data class Document @JvmOverloads constructor(
+                /**
+                 * The front of an ID returned by a
+                 * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file) with
+                 * a `purpose` value of `identity_document`. The uploaded file needs to be a color
+                 * image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than
+                 * 10 MB in size.
+                 */
+                private val front: String? = null,
+
+                /**
+                 * The back of an ID returned by a
+                 * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file)
+                 * with a `purpose` value of `identity_document`. The uploaded file needs to be a
+                 * color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less
+                 * than 10 MB in size.
+                 */
+                private val back: String? = null
+            ) : StripeParamsModel, Parcelable {
+                override fun toParamMap(): Map<String, Any> {
+                    return listOf(
+                        PARAM_FRONT to front,
+                        PARAM_BACK to back
+                    ).fold(emptyMap()) { acc, (key, value) ->
+                        acc.plus(
+                            value?.let { mapOf(key to it) }.orEmpty()
+                        )
+                    }
+                }
+
+                private companion object {
+                    private const val PARAM_BACK = "back"
+                    private const val PARAM_FRONT = "front"
+                }
+            }
+
+            class Builder : ObjectBuilder<Individual> {
+                private var address: Address? = null
+                private var addressKana: AddressJapanParams? = null
+                private var addressKanji: AddressJapanParams? = null
+                private var dateOfBirth: DateOfBirth? = null
+                private var email: String? = null
+                private var firstName: String? = null
+                private var firstNameKana: String? = null
+                private var firstNameKanji: String? = null
+                private var gender: String? = null
+                private var idNumber: String? = null
+                private var lastName: String? = null
+                private var lastNameKana: String? = null
+                private var lastNameKanji: String? = null
+                private var maidenName: String? = null
+                private var metadata: Map<String, String>? = null
+                private var phone: String? = null
+                private var ssnLast4: String? = null
+                private var verification: Verification? = null
+
+                /**
+                 * @param address The individual’s primary address.
+                 *
+                 * [account.individual.address](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address)
+                 */
+                fun setAddress(address: Address?): Builder = apply {
+                    this.address = address
+                }
+
+                /**
+                 * @param addressKana The Kana variation of the the individual’s primary address (Japan only).
+                 *
+                 * [account.individual.address_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address_kana)
+                 */
+                fun setAddressKana(addressKana: AddressJapanParams?): Builder = apply {
+                    this.addressKana = addressKana
+                }
+
+                /**
+                 * @param addressKanji The Kanji variation of the the individual’s primary address (Japan only).
+                 *
+                 * [account.individual.address_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-address_kanji)
+                 */
+                fun setAddressKanji(addressKanji: AddressJapanParams?): Builder = apply {
+                    this.addressKanji = addressKanji
+                }
+
+                /**
+                 * @param dateOfBirth The individual’s date of birth.
+                 *
+                 * [account.individual.dob](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-dob)
+                 */
+                fun setDateOfBirth(dateOfBirth: DateOfBirth?): Builder = apply {
+                    this.dateOfBirth = dateOfBirth
+                }
+
+                /**
+                 * @param email The individual’s email.
+                 *
+                 * [account.individual.email](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-email)
+                 */
+                fun setEmail(email: String?): Builder = apply {
+                    this.email = email
+                }
+
+                /**
+                 * @param firstName The individual’s first name.
+                 *
+                 * [account.individual.first_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name)
+                 */
+                fun setFirstName(firstName: String?): Builder = apply {
+                    this.firstName = firstName
+                }
+
+                /**
+                 * @param firstNameKana The Kana variation of the the individual’s first name (Japan only).
+                 *
+                 * [account.individual.first_name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name_kana)
+                 */
+                fun setFirstNameKana(firstNameKana: String?): Builder = apply {
+                    this.firstNameKana = firstNameKana
+                }
+
+                /**
+                 * @param firstNameKanji The Kanji variation of the individual’s first name (Japan only).
+                 *
+                 * [account.individual.first_name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-first_name_kanji)
+                 */
+                fun setFirstNameKanji(firstNameKanji: String?): Builder = apply {
+                    this.firstNameKanji = firstNameKanji
+                }
+
+                /**
+                 * @param gender The individual’s gender (International regulations require either “male” or “female”).
+                 *
+                 * [account.individual.gender](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-gender)
+                 */
+                fun setGender(gender: String?): Builder = apply {
+                    this.gender = gender
+                }
+
+                /**
+                 * @param idNumber The government-issued ID number of the individual, as appropriate
+                 * for the representative’s country. (Examples are a Social Security Number in the
+                 * U.S., or a Social Insurance Number in Canada). Instead of the number itself, you
+                 * can also provide a PII token.
+                 *
+                 * [account.individual.id_number](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-id_number)
+                 */
+                fun setIdNumber(idNumber: String?): Builder = apply {
+                    this.idNumber = idNumber
+                }
+
+                /**
+                 * @param lastName The individual’s last name.
+                 *
+                 * [account.individual.last_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name)
+                 */
+                fun setLastName(lastName: String?): Builder = apply {
+                    this.lastName = lastName
+                }
+
+                /**
+                 * @param lastNameKana The Kana varation of the individual’s last name (Japan only).
+                 *
+                 * [account.individual.last_name_kana](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name_kana)
+                 */
+                fun setLastNameKana(lastNameKana: String?): Builder = apply {
+                    this.lastNameKana = lastNameKana
+                }
+
+                /**
+                 * @param lastNameKanji The Kanji varation of the individual’s last name (Japan only).
+                 *
+                 * [account.individual.last_name_kanji](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-last_name_kanji)
+                 */
+                fun setLastNameKanji(lastNameKanji: String?): Builder = apply {
+                    this.lastNameKanji = lastNameKanji
+                }
+
+                /**
+                 * @param maidenName The individual’s maiden name.
+                 *
+                 * [account.individual.maiden_name](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-maiden_name)
+                 */
+                fun setMaidenName(maidenName: String?): Builder = apply {
+                    this.maidenName = maidenName
+                }
+
+                /**
+                 * @param metadata Set of key-value pairs that you can attach to an object. This
+                 * can be useful for storing additional information about the object in a
+                 * structured format. Individual keys can be unset by posting an empty value to
+                 * them. All keys can be unset by posting an empty value to `metadata`.
+                 *
+                 * [account.individual.metadata](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-metadata)
+                 */
+                fun setMetadata(metadata: Map<String, String>?): Builder = apply {
+                    this.metadata = metadata
+                }
+
+                /**
+                 * @param phone The individual’s phone number.
+                 *
+                 * [account.individual.phone](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-phone)
+                 */
+                fun setPhone(phone: String?): Builder = apply {
+                    this.phone = phone
+                }
+
+                /**
+                 * @param ssnLast4 The last four digits of the individual’s Social Security Number (U.S. only).
+                 *
+                 * [account.individual.ssn_last_4](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-ssn_last_4)
+                 */
+                fun setSsnLast4(ssnLast4: String?): Builder = apply {
+                    this.ssnLast4 = ssnLast4
+                }
+
+                /**
+                 * @param verification The individual’s verification document information.
+                 *
+                 * [account.individual.verification](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-verification)
+                 */
+                fun setVerification(verification: Verification?): Builder = apply {
+                    this.verification = verification
+                }
+
+                override fun build(): Individual {
+                    return Individual(
+                        address = address,
+                        addressKana = addressKana,
+                        addressKanji = addressKanji,
+                        dateOfBirth = dateOfBirth,
+                        email = email,
+                        firstName = firstName,
+                        firstNameKana = firstNameKana,
+                        firstNameKanji = firstNameKanji,
+                        gender = gender,
+                        idNumber = idNumber,
+                        lastName = lastName,
+                        lastNameKana = lastNameKana,
+                        lastNameKanji = lastNameKanji,
+                        maidenName = maidenName,
+                        metadata = metadata,
+                        phone = phone,
+                        ssnLast4 = ssnLast4,
+                        verification = verification
+                    )
+                }
+            }
+
+            private companion object {
+                private const val PARAM_ADDRESS = "address"
+                private const val PARAM_ADDRESS_KANA = "address_kana"
+                private const val PARAM_ADDRESS_KANJI = "address_kanji"
+                private const val PARAM_DOB = "dob"
+                private const val PARAM_EMAIL = "email"
+                private const val PARAM_FIRST_NAME = "first_name"
+                private const val PARAM_FIRST_NAME_KANA = "first_name_kana"
+                private const val PARAM_FIRST_NAME_KANJI = "first_name_kanji"
+                private const val PARAM_GENDER = "gender"
+                private const val PARAM_ID_NUMBER = "id_number"
+                private const val PARAM_LAST_NAME = "last_name"
+                private const val PARAM_LAST_NAME_KANA = "last_name_kana"
+                private const val PARAM_LAST_NAME_KANJI = "last_name_kanji"
+                private const val PARAM_MAIDEN_NAME = "maiden_name"
+                private const val PARAM_METADATA = "metadata"
+                private const val PARAM_PHONE = "phone"
+                private const val PARAM_SSN_LAST_4 = "ssn_last_4"
+                private const val PARAM_VERIFICATION = "verification"
+            }
+        }
+    }
+
+    companion object {
+        internal const val PARAM_BUSINESS_TYPE = "business_type"
+        internal const val PARAM_TOS_SHOWN_AND_ACCEPTED = "tos_shown_and_accepted"
+
+        /**
+         * Create an [AccountParams] instance for a [BusinessType.Individual] or BusinessType.Company].
+         *
+         * @param tosShownAndAccepted Whether the user described by the data in the token has been
+         * shown the
+         * [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
+         * When creating an account token to create a new Connect account, this value must be `true`.
          * @param businessType See [BusinessType]
          * @param businessData A map of [company](https://stripe.com/docs/api/accounts/create#create_account-company)
          * or [individual](https://stripe.com/docs/api/accounts/create#create_account-individual) params.
          *
+         * @deprecated Use a [create] method.
          *
          * @return [AccountParams]
          */
+        @Deprecated("Use a create() method", ReplaceWith("create()"))
         @JvmStatic
         fun createAccountParams(
             tosShownAndAccepted: Boolean,
             businessType: BusinessType?,
             businessData: Map<String, Any>?
         ): AccountParams {
-            return AccountParams(businessType, businessData, tosShownAndAccepted)
+            return AccountParams(tosShownAndAccepted, businessType, businessData)
+        }
+
+        /**
+         * Create an [AccountParams] instance with information about the person represented by the account.
+         *
+         * @param tosShownAndAccepted Whether the user described by the data in the token has been
+         * shown the
+         * [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
+         * When creating an account token to create a new Connect account, this value must be `true`.
+         * @param individual Information about the person represented by the account.
+         *
+         * @return [AccountParams]
+         */
+        @JvmStatic
+        fun create(
+            tosShownAndAccepted: Boolean,
+            individual: BusinessTypeParams.Individual
+        ): AccountParams {
+            return AccountParams(
+                tosShownAndAccepted,
+                BusinessType.Individual,
+                individual.toParamMap()
+            )
+        }
+
+        /**
+         * Create an [AccountParams] instance with information about the company or business.
+         *
+         * @param tosShownAndAccepted Whether the user described by the data in the token has been
+         * shown the
+         * [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
+         * When creating an account token to create a new Connect account, this value must be `true`.
+         * @param company Information about the company or business.
+         *
+         * @return [AccountParams]
+         */
+        @JvmStatic
+        fun create(
+            tosShownAndAccepted: Boolean,
+            company: BusinessTypeParams.Company
+        ): AccountParams {
+            return AccountParams(
+                tosShownAndAccepted,
+                BusinessType.Company,
+                company.toParamMap()
+            )
+        }
+
+        /**
+         * Create an [AccountParams] instance.
+         *
+         * @param tosShownAndAccepted Whether the user described by the data in the token has been
+         * shown the
+         * [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
+         * When creating an account token to create a new Connect account, this value must be `true`.
+         * @param businessType The business type.
+         *
+         * @return [AccountParams]
+         */
+        @JvmStatic
+        fun create(
+            tosShownAndAccepted: Boolean,
+            businessType: BusinessType
+        ): AccountParams {
+            return AccountParams(tosShownAndAccepted, businessType)
+        }
+
+        /**
+         * Create an [AccountParams] instance.
+         *
+         * @param tosShownAndAccepted Whether the user described by the data in the token has been
+         * shown the
+         * [Stripe Connected Account Agreement](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-tos_shown_and_accepted).
+         * When creating an account token to create a new Connect account, this value must be `true`.
+         *
+         * @return [AccountParams]
+         */
+        @JvmStatic
+        fun create(
+            tosShownAndAccepted: Boolean
+        ): AccountParams {
+            return AccountParams(tosShownAndAccepted)
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
@@ -67,30 +67,51 @@ data class AddressJapanParams(
         private var state: String? = null
         private var town: String? = null
 
+        /**
+         * @param city City or ward.
+         */
         fun setCity(city: String?): Builder = apply {
             this.city = city
         }
 
+        /**
+         * @param country Two-letter country code (ISO 3166-1 alpha-2).
+         */
         fun setCountry(country: String?): Builder = apply {
             this.country = country?.toUpperCase(Locale.ROOT)
         }
 
+        /**
+         * @param line1 Block or building number.
+         */
         fun setLine1(line1: String?): Builder = apply {
             this.line1 = line1
         }
 
+        /**
+         * @param line2 Building details.
+         */
         fun setLine2(line2: String?): Builder = apply {
             this.line2 = line2
         }
 
+        /**
+         * @param postalCode Postal code.
+         */
         fun setPostalCode(postalCode: String?): Builder = apply {
             this.postalCode = postalCode
         }
 
+        /**
+         * @param state Prefecture.
+         */
         fun setState(state: String?): Builder = apply {
             this.state = state
         }
 
+        /**
+         * @param town Town or cho-me.
+         */
         fun setTown(town: String?): Builder = apply {
             this.town = town
         }

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -1,0 +1,33 @@
+package com.stripe.android
+
+import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.model.AccountParams
+import com.stripe.android.model.AddressFixtures
+import com.stripe.android.model.Token
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StripeEndToEndTest {
+
+    private val stripe: Stripe by lazy {
+        Stripe(ApplicationProvider.getApplicationContext(), ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+    }
+
+    @Test
+    fun testCreateAccountToken() {
+        val token = stripe.createAccountTokenSynchronous(
+            accountParams = AccountParams.create(
+                tosShownAndAccepted = true,
+                individual = AccountParams.BusinessTypeParams.Individual(
+                    firstName = "Jenny",
+                    lastName = "Rosen",
+                    address = AddressFixtures.ADDRESS
+                )
+            )
+        )
+        assertEquals(Token.TokenType.ACCOUNT, token?.type)
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -11,6 +11,7 @@ import com.stripe.android.exception.InvalidRequestException;
 import com.stripe.android.exception.StripeException;
 import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.Address;
+import com.stripe.android.model.AddressFixtures;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.CardBrand;
@@ -969,23 +970,18 @@ public class StripeTest {
     @Test
     public void createAccountTokenSynchronous_withIndividualEntity_passesIntegrationTest()
             throws StripeException {
-        final Address exampleAddress = new Address
-                .Builder()
-                .setCity("SF")
-                .setCountry("US")
-                .setState("CA")
-                .build();
-        final Map<String, Object> businessData = new HashMap<String, Object>() {{
-            put("address", exampleAddress.toParamMap());
-            put("ssn_last_4", "1234");
-            put("first_name", "Kathy");
-            put("last_name", "Sun");
-        }};
-
         final Stripe stripe = createStripe();
         final Token token = stripe.createAccountTokenSynchronous(
-                AccountParams.createAccountParams(true,
-                        AccountParams.BusinessType.Individual, businessData));
+                AccountParams.create(
+                        true,
+                        new AccountParams.BusinessTypeParams.Individual.Builder()
+                                .setAddress(AddressFixtures.ADDRESS)
+                                .setFirstName("Kathy")
+                                .setLastName("Sun")
+                                .setSsnLast4("1234")
+                                .build()
+                )
+        );
         assertNotNull(token);
         assertEquals(Token.TokenType.ACCOUNT, token.getType());
         assertFalse(token.getLivemode());
@@ -996,21 +992,17 @@ public class StripeTest {
     @Test
     public void createAccountTokenSynchronous_withCompanyEntity_isSuccessful()
             throws StripeException {
-        final Address exampleAddress = new Address
-                .Builder()
-                .setCity("SF")
-                .setCountry("US")
-                .setState("CA").build();
-        final Map<String, Object> businessData = new HashMap<String, Object>() {{
-            put("address", exampleAddress.toParamMap());
-            put("tax_id", "123-23-1234");
-            put("name", "My Corp.");
-        }};
-
         final Stripe stripe = createStripe();
         final Token token = stripe.createAccountTokenSynchronous(
-                AccountParams.createAccountParams(true,
-                        AccountParams.BusinessType.Company, businessData));
+                AccountParams.create(
+                        true,
+                        new AccountParams.BusinessTypeParams.Company.Builder()
+                                .setAddress(AddressFixtures.ADDRESS)
+                                .setTaxId("123-23-1234")
+                                .setName("My Corp.")
+                                .build()
+                )
+        );
         assertNotNull(token);
         assertEquals(Token.TokenType.ACCOUNT, token.getType());
         assertFalse(token.getLivemode());
@@ -1021,21 +1013,17 @@ public class StripeTest {
     @Test
     public void createAccountTokenSynchronous_withoutTosShown_isSuccessful()
             throws StripeException {
-        final Address address = new Address.Builder()
-                .setCity("SF")
-                .setCountry("US")
-                .setState("CA").build();
-        final Map<String, Object> businessData = new HashMap<String, Object>() {{
-            put("address", address.toParamMap());
-            put("ssn_last_4", "1234");
-            put("first_name", "Kathy");
-            put("last_name", "Sun");
-        }};
-
         final Stripe stripe = createStripe();
-        Token token = stripe.createAccountTokenSynchronous(
-                AccountParams.createAccountParams(false,
-                        AccountParams.BusinessType.Individual, businessData));
+        final Token token = stripe.createAccountTokenSynchronous(
+                AccountParams.create(false,
+                        new AccountParams.BusinessTypeParams.Individual.Builder()
+                                .setAddress(AddressFixtures.ADDRESS)
+                                .setFirstName("Kathy")
+                                .setLastName("Sun")
+                                .setSsnLast4("1234")
+                                .build()
+                )
+        );
         assertNotNull(token);
         assertEquals(Token.TokenType.ACCOUNT, token.getType());
         assertFalse(token.getLivemode());
@@ -1048,8 +1036,11 @@ public class StripeTest {
             throws StripeException {
         final Stripe stripe = createStripe();
         final Token token = stripe.createAccountTokenSynchronous(
-                AccountParams.createAccountParams(false,
-                        AccountParams.BusinessType.Individual, null));
+                AccountParams.create(
+                        false,
+                        AccountParams.BusinessType.Individual
+                )
+        );
         assertNotNull(token);
         assertEquals(Token.TokenType.ACCOUNT, token.getType());
         assertFalse(token.getLivemode());
@@ -1061,9 +1052,7 @@ public class StripeTest {
     public void createAccountTokenSynchronous_withoutBusinessType_isValid()
             throws StripeException {
         final Stripe stripe = createStripe();
-        final Token token = stripe.createAccountTokenSynchronous(
-                AccountParams.createAccountParams(false,
-                        null, null));
+        final Token token = stripe.createAccountTokenSynchronous(AccountParams.create(false));
         assertNotNull(token);
         assertEquals(Token.TokenType.ACCOUNT, token.getType());
         assertFalse(token.getLivemode());

--- a/stripe/src/test/java/com/stripe/android/model/AccountParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/AccountParamsTest.kt
@@ -8,34 +8,32 @@ class AccountParamsTest {
 
     @Test
     fun toParamMap_withBusinessData() {
-        val businessData = mapOf("name" to "Stripe")
-        val params = AccountParams
-            .createAccountParams(
-                true,
-                AccountParams.BusinessType.Company,
-                businessData
-            )
+        val company = AccountParams.BusinessTypeParams.Company(name = "Stripe")
+        val params = AccountParams.create(
+            true,
+            company
+        )
             .toParamMap()
 
         val accountData = params["account"] as Map<String, *>?
         assertNotNull(accountData)
         assertEquals(3, accountData.size)
-        assertEquals(java.lang.Boolean.TRUE, accountData[AccountParams.API_TOS_SHOWN_AND_ACCEPTED])
+        assertEquals(java.lang.Boolean.TRUE, accountData[AccountParams.PARAM_TOS_SHOWN_AND_ACCEPTED])
         assertEquals(AccountParams.BusinessType.Company.code,
-            accountData[AccountParams.API_BUSINESS_TYPE])
-        assertEquals(businessData,
-            accountData[AccountParams.BusinessType.Company.code])
+            accountData[AccountParams.PARAM_BUSINESS_TYPE])
+        assertEquals(
+            company.toParamMap(),
+            accountData[AccountParams.BusinessType.Company.code]
+        )
     }
 
     @Test
     fun toParamMap_withNoBusinessData() {
-        val params =
-            AccountParams.createAccountParams(true, null, null)
-                .toParamMap()
+        val params = AccountParams.create(true).toParamMap()
 
         val accountData = params["account"] as Map<String, *>?
         assertNotNull(accountData)
         assertEquals(1, accountData.size)
-        assertEquals(java.lang.Boolean.TRUE, accountData[AccountParams.API_TOS_SHOWN_AND_ACCEPTED])
+        assertEquals(java.lang.Boolean.TRUE, accountData[AccountParams.PARAM_TOS_SHOWN_AND_ACCEPTED])
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/AddressFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/AddressFixtures.kt
@@ -3,8 +3,9 @@ package com.stripe.android.model
 import com.stripe.android.model.parsers.AddressJsonParser
 import org.json.JSONObject
 
-internal object AddressFixtures {
-    val ADDRESS = AddressJsonParser().parse(JSONObject(
+object AddressFixtures {
+    @JvmField
+    val ADDRESS: Address = AddressJsonParser().parse(JSONObject(
         """
         {
             "city": "San Francisco",


### PR DESCRIPTION
`BusinessTypeParams.Company` and `BusinessTypeParams.Individual`
model the parameters for creating a company or individual account
token. Use these instead of creating raw maps representing
the data.

`AccountParams.createAccountParams()` is now deprecated. Use the
appropriate `AccountParams.create()` method.