### PR TITLE
Create StripeFile and StripeFileParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/StripeFile.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeFile.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.model
+
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * [The file object](https://stripe.com/docs/api/files/object)
+ */
+@Parcelize
+internal data class StripeFile internal constructor(
+    /**
+     * Unique identifier for the object.
+     *
+     * [id](https://stripe.com/docs/api/files/object#file_object-id)
+     */
+    val id: String? = null,
+
+    /**
+     * Time at which the object was created. Measured in seconds since the Unix epoch.
+     *
+     * [created](https://stripe.com/docs/api/files/object#file_object-created)
+     */
+    val created: Long? = null,
+
+    /**
+     * A filename for the file, suitable for saving to a filesystem.
+     *
+     * [filename](https://stripe.com/docs/api/files/object#file_object-filename)
+     */
+    val filename: String? = null,
+
+    /**
+     * The purpose of the file. Possible values are `business_icon`, `business_logo`,
+     * `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`,
+     * or `tax_document_user_upload`.
+     *
+     * [purpose](https://stripe.com/docs/api/files/object#file_object-purpose)
+     */
+    val purpose: StripeFilePurpose? = null,
+
+    /**
+     * The size in bytes of the file object.
+     *
+     * [size](https://stripe.com/docs/api/files/object#file_object-size)
+     */
+    val size: Int? = null,
+
+    /**
+     * A user friendly title for the document.
+     *
+     * [title](https://stripe.com/docs/api/files/object#file_object-title)
+     */
+    val title: String? = null,
+
+    /**
+     * The type of the file returned (e.g., csv, pdf, jpg, or png).
+     *
+     * [type](https://stripe.com/docs/api/files/object#file_object-type)
+     */
+    val type: String? = null
+) : StripeModel

--- a/stripe/src/main/java/com/stripe/android/model/StripeFileParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeFileParams.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import java.io.File
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * [Create a file](https://stripe.com/docs/api/files/create)
+ *
+ * To upload a file to Stripe, you’ll need to send a request of type `multipart/form-data`.
+ * The request should contain the file you would like to upload, as well as the parameters for
+ * creating a file.
+ */
+internal data class StripeFileParams(
+    /**
+     * A file to upload. The file should follow the specifications of RFC 2388 (which defines file
+     * transfers for the `multipart/form-data` protocol).
+     */
+    private val file: File,
+
+    /**
+     * The purpose of the uploaded file. Possible values are `business_icon`, `business_logo`,
+     * `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`,
+     * or `tax_document_user_upload`.
+     *
+     * [purpose](https://stripe.com/docs/api/files/create#create_file-purpose)
+     */
+    private val purpose: StripeFilePurpose,
+
+    /**
+     * Optional parameters to automatically create a
+     * [file link](https://stripe.com/docs/api/files/create#file_links) for the newly created file.
+     *
+     * [file_link_data]](https://stripe.com/docs/api/files/create#create_file-file_link_data)
+     */
+    private val fileLink: FileLink? = null
+) {
+    /**
+     * Optional parameters to automatically create a
+     * [file link](https://stripe.com/docs/api/files/create#file_links) for the newly created file.
+     *
+     * [file_link_data]](https://stripe.com/docs/api/files/create#create_file-file_link_data)
+     */
+    @Parcelize
+    data class FileLink(
+        /**
+         * Set this to `true` to create a file link for the newly created file. Creating a link is
+         * only possible when the file’s `purpose` is one of the following: `business_icon`,
+         * `business_logo`, `customer_signature`, `dispute_evidence`, `pci_document`, or
+         * `tax_document_user_upload`.
+         *
+         * [file_link_data.create](https://stripe.com/docs/api/files/create#create_file-file_link_data-create)
+         */
+        private val create: Boolean = false,
+
+        /**
+         * A future timestamp after which the link will no longer be usable.
+         *
+         * [file_link_data.expires_at](https://stripe.com/docs/api/files/create#create_file-file_link_data-expires_at)
+         */
+        private val expiresAt: Long? = null,
+
+        /**
+         * Set of key-value pairs that you can attach to an object. This can be useful for storing
+         * additional information about the object in a structured format. Individual keys can be
+         * unset by posting an empty value to them. All keys can be unset by posting an empty value
+         * to metadata.
+         *
+         * [file_link_data.metadata](https://stripe.com/docs/api/files/create#create_file-file_link_data-metadata)
+         */
+        private val metadata: Map<String, String>? = null
+    ) : Parcelable
+}

--- a/stripe/src/main/java/com/stripe/android/model/StripeFilePurpose.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeFilePurpose.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.model
+
+/**
+ * The purpose of the uploaded file. Possible values are `business_icon`, `business_logo`,
+ * `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`,
+ * or `tax_document_user_upload`.
+ *
+ * [purpose](https://stripe.com/docs/api/files/create#create_file-purpose)
+*/
+internal enum class StripeFilePurpose(private val code: String) {
+    BusinessIcon("business_icon"),
+    BusinessLogo("business_logo"),
+    CustomerSignature("customer_signature"),
+    DisputeEvidence("dispute_evidence"),
+    IdentityDocument("identity_document"),
+    PciDocument("pci_document"),
+    TaxDocumentUserUpload("tax_document_user_upload");
+
+    internal companion object {
+        fun fromCode(code: String?): StripeFilePurpose? {
+            return values().first { it.code == code }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/model/parsers/StripeFileJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/StripeFileJsonParser.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.model.StripeFile
+import com.stripe.android.model.StripeFilePurpose
+import com.stripe.android.model.StripeJsonUtils.optInteger
+import com.stripe.android.model.StripeJsonUtils.optLong
+import com.stripe.android.model.StripeJsonUtils.optString
+import org.json.JSONObject
+
+internal class StripeFileJsonParser : ModelJsonParser<StripeFile> {
+    override fun parse(json: JSONObject): StripeFile {
+        return StripeFile(
+            id = optString(json, FIELD_ID),
+            created = optLong(json, FIELD_CREATED),
+            filename = optString(json, FIELD_FILENAME),
+            purpose = StripeFilePurpose.fromCode(optString(json, FIELD_PURPOSE)),
+            size = optInteger(json, FIELD_SIZE),
+            title = optString(json, FIELD_TITLE),
+            type = optString(json, FIELD_TYPE)
+        )
+    }
+
+    private companion object {
+        private const val FIELD_ID = "id"
+        private const val FIELD_CREATED = "created"
+        private const val FIELD_FILENAME = "filename"
+        private const val FIELD_PURPOSE = "purpose"
+        private const val FIELD_SIZE = "size"
+        private const val FIELD_TITLE = "title"
+        private const val FIELD_TYPE = "type"
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/parsers/StripeFileJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/StripeFileJsonParserTest.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.model.StripeFile
+import com.stripe.android.model.StripeFilePurpose
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.json.JSONObject
+
+class StripeFileJsonParserTest {
+
+    @Test
+    fun testParse() {
+        assertEquals(FILE, StripeFileJsonParser().parse(FILE_JSON))
+    }
+
+    private companion object {
+        private val FILE = StripeFile(
+            id = "file_1FzRQ6CRMbs6FrXfgjerzyUQ",
+            created = 1578677834L,
+            filename = "upload.png",
+            purpose = StripeFilePurpose.IdentityDocument,
+            size = 25722,
+            title = null,
+            type = "png"
+        )
+
+        private val FILE_JSON = JSONObject("""
+            {
+                "id": "file_1FzRQ6CRMbs6FrXfgjerzyUQ",
+                "object": "file",
+                "created": 1578677834,
+                "filename": "upload.png",
+                "purpose": "identity_document",
+                "size": 25722,
+                "title": null,
+                "type": "png"
+            }
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
Upload functionality will be implemented in a future PR

- `StripeFile` represents a file object [0]
- `StripeFileParams` represents parameters for creating a file [1]

[0] https://stripe.com/docs/api/files/object
[1] https://stripe.com/docs/api/files/create

