### PR TITLE
Update CardInputWidget EditText size

### DIFF
--- a/stripe/res/values-xhdpi/dimens.xml
+++ b/stripe/res/values-xhdpi/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
+    <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 </resources>

--- a/stripe/res/values-xxhdpi/dimens.xml
+++ b/stripe/res/values-xxhdpi/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
+    <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 </resources>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -30,5 +30,5 @@
     <dimen name="stripe_shipping_widget_outer_margin">12dp</dimen>
 
     <!-- Text size of CardInputWidget EditText views -->
-    <dimen name="ciw_stripe_edit_text_size">19sp</dimen>
+    <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 </resources>


### PR DESCRIPTION
Prevents "Postal Code" field from being cut off on some screens.

Fixes #2052