### PR TITLE
Create StripeRequest.writeBody(OutputStream)

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ConnectionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/ConnectionFactory.kt
@@ -25,7 +25,7 @@ internal class ConnectionFactory {
             if (StripeRequest.Method.POST == request.method) {
                 doOutput = true
                 setRequestProperty(HEADER_CONTENT_TYPE, request.contentType)
-                outputStream.use { output -> output.write(request.bodyBytes) }
+                outputStream.use { output -> request.writeBody(output) }
             }
         }
 

--- a/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
@@ -33,13 +33,11 @@ class ApiRequestHeadersFactoryTest {
 
     @Test
     fun headers_withAllRequestOptions_properlyMapsRequestOptions() {
-        Locale.setDefault(Locale.US)
-
         val stripeAccount = "acct_123abc"
-        val headers = ApiRequest.createGet(
-            StripeApiRepository.sourcesUrl,
-            ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccount)
-        ).headers
+        val headers = createHeaders(
+            locale = Locale.US,
+            options = ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccount)
+        )
 
         assertEquals(
             "Bearer ${ApiKeyFixtures.FAKE_PUBLISHABLE_KEY}",
@@ -111,10 +109,11 @@ class ApiRequestHeadersFactoryTest {
 
     private fun createHeaders(
         locale: Locale = Locale.getDefault(),
+        options: ApiRequest.Options = OPTIONS,
         appInfo: AppInfo? = null
     ): Map<String, String> {
         return RequestHeadersFactory.Api(
-            options = OPTIONS,
+            options = options,
             appInfo = appInfo,
             locale = locale,
             systemPropertySupplier = { UUID.randomUUID().toString() }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -34,25 +34,26 @@ internal class ApiRequestTest {
     }
 
     @Test
-    fun body_withEmptyBody_shouldHaveZeroLength() {
-        val bodyBytes = ApiRequest.createPost(
-            StripeApiRepository.paymentMethodsUrl,
-            OPTIONS
-        ).bodyBytes
-        assertTrue(bodyBytes.isEmpty())
+    fun writeBody_withEmptyBody_shouldHaveZeroLength() {
+        FakeOutputStream().use {
+            ApiRequest.createPost(
+                StripeApiRepository.paymentMethodsUrl,
+                OPTIONS
+            ).writeBody(it)
+            assertTrue(it.writtenBytesSize == 0)
+        }
     }
 
     @Test
-    fun bodyBytes_withNonEmptyBody_shouldHaveNonZeroLength() {
-        val params = mapOf("customer" to "cus_123")
-
-        val bodyBytes =
+    fun writeBody_withNonEmptyBody_shouldHaveNonZeroLength() {
+        FakeOutputStream().use {
             ApiRequest.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS,
-                params
-            ).bodyBytes
-        assertEquals(16, bodyBytes.size)
+                mapOf("customer" to "cus_123")
+            ).writeBody(it)
+            assertEquals(16, it.writtenBytesSize)
+        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/FakeOutputStream.kt
+++ b/stripe/src/test/java/com/stripe/android/FakeOutputStream.kt
@@ -1,0 +1,14 @@
+package com.stripe.android
+
+import java.io.OutputStream
+
+internal class FakeOutputStream : OutputStream() {
+    var writtenBytesSize: Int = 0
+
+    override fun write(b: Int) {
+    }
+
+    override fun write(b: ByteArray) {
+        writtenBytesSize += b.size
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/FingerprintRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintRequestTest.kt
@@ -33,10 +33,11 @@ class FingerprintRequestTest {
     }
 
     @Test
-    fun testBody() {
-        val body =
+    fun writeBody_shouldWriteNonEmptyBytes() {
+        FakeOutputStream().use {
             FingerprintRequest(telemetryClientUtil.createTelemetryMap(), "guid")
-                .body
-        assertTrue(body.isNotEmpty())
+                .writeBody(it)
+            assertTrue(it.writtenBytesSize > 0)
+        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRequestExecutorTest.kt
@@ -25,7 +25,9 @@ class StripeApiRequestExecutorTest {
         }
 
         assertFailsWith<InvalidRequestException> {
-            stripeRequest.bodyBytes
+            FakeOutputStream().use {
+                stripeRequest.writeBody(it)
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation
This will be used in an upcoming PR to write file contents.
The prior implementation of overriding `val body: String` was
not sufficient for writing a file to a stream.

## Testing
Added unit tests.