### PR TITLE
Update analytics logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
@@ -1,0 +1,62 @@
+package com.stripe.android
+
+internal enum class AnalyticsEvent(private val code: String) {
+    TokenCreate("token_creation"),
+
+    // Payment Methods
+    PaymentMethodCreate("payment_method_creation"),
+
+    // Customer Methods
+    CustomerRetrieve("retrieve_customer"),
+    CustomerRetrievePaymentMethods("retrieve_payment_methods"),
+    CustomerAttachPaymentMethod("attach_payment_method"),
+    CustomerDetachPaymentMethod("detach_payment_method"),
+    CustomerDeleteSource("delete_source"),
+    CustomerSetShippingInfo("set_shipping_info"),
+    CustomerAddSource("add_source"),
+    CustomerSetDefaultSource("default_source"),
+
+    // Issuing
+    IssuingRetrievePin("issuing_retrieve_pin"),
+    IssuingUpdatePin("issuing_update_pin"),
+
+    // Source
+    SourceCreate("source_creation"),
+
+    // Payment Intents
+    PaymentIntentConfirm("payment_intent_confirmation"),
+    PaymentIntentRetrieve("payment_intent_retrieval"),
+    PaymentIntentCancelSource("payment_intent_cancel_source"),
+
+    // Setup Intents
+    SetupIntentConfirm("setup_intent_confirmation"),
+    SetupIntentRetrieve("setup_intent_retrieval"),
+    SetupIntentCancelSource("setup_intent_cancel_source"),
+
+    // File
+    FileCreate("create_file"),
+
+    Auth3ds1Sdk("3ds1_sdk"),
+
+    // 3DS2
+    Auth3ds2Fingerprint("3ds2_fingerprint"),
+    Auth3ds2Start("3ds2_authenticate"),
+    Auth3ds2Frictionless("3ds2_frictionless_flow"),
+    Auth3ds2ChallengePresented("3ds2_challenge_flow_presented"),
+    Auth3ds2ChallengeCanceled("3ds2_challenge_flow_canceled"),
+    Auth3ds2ChallengeCompleted("3ds2_challenge_flow_completed"),
+    Auth3ds2ChallengeErrored("3ds2_challenge_flow_errored"),
+    Auth3ds2ChallengeTimedOut("3ds2_challenge_flow_timed_out"),
+    Auth3ds2Fallback("3ds2_fallback"),
+
+    AuthRedirect("url_redirect_next_action"),
+    AuthError("auth_error");
+
+    override fun toString(): String {
+        return "$PREFIX.$code"
+    }
+
+    private companion object {
+        private const val PREFIX = "stripe_android"
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -52,7 +52,7 @@ internal class StripePaymentController internal constructor(
     private val analyticsRequestExecutor: FireAndForgetRequestExecutor =
         StripeFireAndForgetRequestExecutor(Logger.getInstance(enableLogging)),
     private val analyticsDataFactory: AnalyticsDataFactory =
-        AnalyticsDataFactory.create(context.applicationContext),
+        AnalyticsDataFactory(context.applicationContext),
     private val challengeFlowStarter: ChallengeFlowStarter =
         ChallengeFlowStarterImpl(),
     private val workScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
@@ -347,7 +347,7 @@ internal class StripePaymentController internal constructor(
                             analyticsRequestExecutor.executeAsync(
                                 AnalyticsRequest.create(
                                     analyticsDataFactory.createAuthParams(
-                                        AnalyticsDataFactory.EventName.AUTH_3DS2_FINGERPRINT,
+                                        AnalyticsEvent.Auth3ds2Fingerprint,
                                         stripeIntent.id.orEmpty(),
                                         requestOptions.apiKey
                                     ),
@@ -366,7 +366,7 @@ internal class StripePaymentController internal constructor(
                             analyticsRequestExecutor.executeAsync(
                                 AnalyticsRequest.create(
                                     analyticsDataFactory.createAuthParams(
-                                        AnalyticsDataFactory.EventName.AUTH_3DS1_SDK,
+                                        AnalyticsEvent.Auth3ds1Sdk,
                                         stripeIntent.id.orEmpty(),
                                         requestOptions.apiKey
                                     ),
@@ -389,9 +389,10 @@ internal class StripePaymentController internal constructor(
                     analyticsRequestExecutor.executeAsync(
                         AnalyticsRequest.create(
                             analyticsDataFactory.createAuthParams(
-                                AnalyticsDataFactory.EventName.AUTH_REDIRECT,
+                                AnalyticsEvent.AuthRedirect,
                                 stripeIntent.id.orEmpty(),
-                                requestOptions.apiKey),
+                                requestOptions.apiKey
+                            ),
                             requestOptions
                         )
                     )
@@ -543,7 +544,7 @@ internal class StripePaymentController internal constructor(
                 analyticsRequestExecutor.executeAsync(
                     AnalyticsRequest.create(
                         analyticsDataFactory.createAuthParams(
-                            AnalyticsDataFactory.EventName.AUTH_3DS2_FALLBACK,
+                            AnalyticsEvent.Auth3ds2Fallback,
                             stripeIntent.id.orEmpty(),
                             requestOptions.apiKey
                         ),
@@ -582,9 +583,10 @@ internal class StripePaymentController internal constructor(
             analyticsRequestExecutor.executeAsync(
                 AnalyticsRequest.create(
                     analyticsDataFactory.createAuthParams(
-                        AnalyticsDataFactory.EventName.AUTH_3DS2_FRICTIONLESS,
+                        AnalyticsEvent.Auth3ds2Frictionless,
                         stripeIntent.id.orEmpty(),
-                        requestOptions.apiKey),
+                        requestOptions.apiKey
+                    ),
                     requestOptions
                 )
             )
@@ -626,7 +628,7 @@ internal class StripePaymentController internal constructor(
             analyticsRequestExecutor.executeAsync(
                 AnalyticsRequest.create(
                     analyticsDataFactory.create3ds2ChallengeParams(
-                        AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_COMPLETED,
+                        AnalyticsEvent.Auth3ds2ChallengeCompleted,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode,
                         requestOptions.apiKey
@@ -647,7 +649,7 @@ internal class StripePaymentController internal constructor(
             analyticsRequestExecutor.executeAsync(
                 AnalyticsRequest.create(
                     analyticsDataFactory.create3ds2ChallengeParams(
-                        AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_CANCELED,
+                        AnalyticsEvent.Auth3ds2ChallengeCanceled,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode,
                         requestOptions.apiKey
@@ -664,7 +666,7 @@ internal class StripePaymentController internal constructor(
             analyticsRequestExecutor.executeAsync(
                 AnalyticsRequest.create(
                     analyticsDataFactory.create3ds2ChallengeParams(
-                        AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_TIMEDOUT,
+                        AnalyticsEvent.Auth3ds2ChallengeTimedOut,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode,
                         requestOptions.apiKey
@@ -712,7 +714,7 @@ internal class StripePaymentController internal constructor(
             analyticsRequestExecutor.executeAsync(
                 AnalyticsRequest.create(
                     analyticsDataFactory.create3ds2ChallengeParams(
-                        AnalyticsDataFactory.EventName.AUTH_3DS2_CHALLENGE_PRESENTED,
+                        AnalyticsEvent.Auth3ds2ChallengePresented,
                         stripeIntent.id.orEmpty(),
                         transaction.initialChallengeUiType.orEmpty(),
                         requestOptions.apiKey

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
 import kotlin.test.Test
@@ -21,22 +22,27 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class AnalyticsDataFactoryTest {
 
-    private val analyticsDataFactory =
-        AnalyticsDataFactory.create(ApplicationProvider.getApplicationContext<Context>())
+    private val analyticsDataFactory = AnalyticsDataFactory(
+        ApplicationProvider.getApplicationContext<Context>()
+    )
 
     @Test
     fun getTokenCreationParams_withValidInput_createsCorrectMap() {
         val tokens = listOf("CardInputView")
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
-        val expectedTokenName = AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.TOKEN_CREATION)
+        val expectedEvent = AnalyticsEvent.TokenCreate.toString()
 
-        val params = analyticsDataFactory.getTokenCreationParams(
+        val params = analyticsDataFactory.createTokenCreationParams(
             tokens,
             API_KEY,
-            Token.TokenType.PII)
+            Token.TokenType.PII
+        )
         // Size is SIZE-1 because tokens don't have a source_type field
-        assertEquals((AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1).toLong(), params.size.toLong())
-        assertEquals(expectedTokenName, params[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1,
+            params.size
+        )
+        assertEquals(expectedEvent, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(Token.TokenType.PII, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
     }
 
@@ -44,15 +50,19 @@ class AnalyticsDataFactoryTest {
     fun getCvcUpdateTokenCreationParams_withValidInput_createsCorrectMap() {
         val tokens = listOf("CardInputView")
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
-        val expectedTokenName = AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.TOKEN_CREATION)
+        val expectedEventName = AnalyticsEvent.TokenCreate.toString()
 
-        val params = analyticsDataFactory.getTokenCreationParams(
+        val params = analyticsDataFactory.createTokenCreationParams(
             tokens,
             API_KEY,
-            Token.TokenType.CVC_UPDATE)
+            Token.TokenType.CVC_UPDATE
+        )
         // Size is SIZE-1 because tokens don't have a source_type field
-        assertEquals((AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1).toLong(), params.size.toLong())
-        assertEquals(expectedTokenName, params[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1,
+            params.size
+        )
+        assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(Token.TokenType.CVC_UPDATE, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
     }
 
@@ -61,17 +71,19 @@ class AnalyticsDataFactoryTest {
         // Size is SIZE-1 because tokens don't have a token_type field
         val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1
         val tokens = listOf("CardInputView")
-        val loggingParams = analyticsDataFactory.getSourceCreationParams(
+        val loggingParams = analyticsDataFactory.createSourceCreationParams(
             API_KEY,
             Source.SourceType.SEPA_DEBIT,
             tokens)
-        assertEquals(expectedSize.toLong(), loggingParams.size.toLong())
+        assertEquals(expectedSize, loggingParams.size)
         assertEquals(Source.SourceType.SEPA_DEBIT,
             loggingParams[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
         assertEquals(API_KEY, loggingParams[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
-        assertEquals(AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.SOURCE_CREATION),
-            loggingParams[AnalyticsDataFactory.FIELD_EVENT])
-        assertEquals(AnalyticsDataFactory.analyticsUa,
+        assertEquals(
+            AnalyticsEvent.SourceCreate.toString(),
+            loggingParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
+        assertEquals(AnalyticsDataFactory.ANALYTICS_UA,
             loggingParams[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
     }
 
@@ -85,49 +97,55 @@ class AnalyticsDataFactoryTest {
         assertEquals("pm_12345",
             loggingParams[AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID])
         assertEquals(
-            AnalyticsDataFactory.getEventParamName(
-                AnalyticsDataFactory.EventName.CREATE_PAYMENT_METHOD),
-            loggingParams[AnalyticsDataFactory.FIELD_EVENT])
-        assertEquals(AnalyticsDataFactory.analyticsUa,
+            AnalyticsEvent.PaymentMethodCreate.toString(),
+            loggingParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
+        assertEquals(AnalyticsDataFactory.ANALYTICS_UA,
             loggingParams[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
     }
 
     @Test
-    fun getPaymentIntentConfirmationParams_withValidInput_createsCorrectMap() {
-        val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1
-        val tokens = listOf("CardInputView")
-        val loggingParams = analyticsDataFactory.getPaymentIntentConfirmationParams(
-            tokens,
-            API_KEY, null)
-        assertEquals(expectedSize.toLong(), loggingParams.size.toLong())
+    fun createPaymentIntentConfirmationParams_withValidInput_createsCorrectMap() {
+        val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2
+        val loggingParams =
+            analyticsDataFactory.createPaymentIntentConfirmationParams(
+                API_KEY,
+                PaymentMethod.Type.Card.code
+            )
+        assertEquals(expectedSize, loggingParams.size)
         assertEquals(API_KEY, loggingParams[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(
-            AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.CONFIRM_PAYMENT_INTENT),
+            AnalyticsEvent.PaymentIntentConfirm.toString(),
             loggingParams[AnalyticsDataFactory.FIELD_EVENT]
         )
-        assertEquals(AnalyticsDataFactory.analyticsUa,
+        assertEquals(AnalyticsDataFactory.ANALYTICS_UA,
             loggingParams[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
     }
 
     @Test
     fun getPaymentIntentRetrieveParams_withValidInput_createsCorrectMap() {
-        val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1
-        val tokens = listOf("CardInputView")
-        val loggingParams = analyticsDataFactory.getPaymentIntentRetrieveParams(
-            tokens,
-            API_KEY)
-        assertEquals(expectedSize.toLong(), loggingParams.size.toLong())
+        val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2
+        val loggingParams = analyticsDataFactory.createParams(
+            AnalyticsEvent.PaymentIntentRetrieve,
+            API_KEY
+        )
+        assertEquals(expectedSize, loggingParams.size)
         assertEquals(API_KEY, loggingParams[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
-        assertEquals(AnalyticsDataFactory.getEventParamName(
-            AnalyticsDataFactory.EventName.RETRIEVE_PAYMENT_INTENT),
-            loggingParams[AnalyticsDataFactory.FIELD_EVENT])
-        assertEquals(AnalyticsDataFactory.analyticsUa,
+        assertEquals(
+            AnalyticsEvent.PaymentIntentRetrieve.toString(),
+            loggingParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
+        assertEquals(AnalyticsDataFactory.ANALYTICS_UA,
             loggingParams[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
     }
 
     @Test
     fun getSetupIntentConfirmationParams_withValidInput_createsCorrectMap() {
-        val params = analyticsDataFactory.getSetupIntentConfirmationParams(API_KEY, "card")
+        val params = analyticsDataFactory.createSetupIntentConfirmationParams(
+            API_KEY,
+            PaymentMethod.Type.Card.code,
+            "seti_12345"
+        )
         assertEquals("card", params[AnalyticsDataFactory.FIELD_PAYMENT_METHOD_TYPE])
     }
 
@@ -136,21 +154,22 @@ class AnalyticsDataFactoryTest {
     fun getEventLoggingParams_withProductUsage_createsAllFields() {
         val tokens = listOf("CardInputView")
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
-        val expectedTokenName = AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.TOKEN_CREATION)
-        val expectedUaName = AnalyticsDataFactory.analyticsUa
+        val expectedEventName = AnalyticsEvent.TokenCreate.toString()
+        val expectedUaName = AnalyticsDataFactory.ANALYTICS_UA
 
         val versionCode = 20
-        val packageName = BuildConfig.APPLICATION_ID
+        val packageName = BuildConfig.LIBRARY_PACKAGE_NAME
         val packageManager = mock(PackageManager::class.java)
-        val packageInfo = PackageInfo()
-        packageInfo.versionCode = versionCode
-        packageInfo.packageName = BuildConfig.APPLICATION_ID
+        val packageInfo = PackageInfo().also {
+            it.versionCode = versionCode
+            it.packageName = BuildConfig.LIBRARY_PACKAGE_NAME
+        }
         `when`(packageManager.getPackageInfo(packageName, 0))
             .thenReturn(packageInfo)
 
         val params = AnalyticsDataFactory(packageManager, packageName)
-            .getTokenCreationParams(tokens, API_KEY, Token.TokenType.CARD)
-        assertEquals((AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1).toLong(), params.size.toLong())
+            .createTokenCreationParams(tokens, API_KEY, Token.TokenType.CARD)
+        assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1, params.size)
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(EXPECTED_SINGLE_TOKEN_LIST, params[AnalyticsDataFactory.FIELD_PRODUCT_USAGE])
         assertEquals(Token.TokenType.CARD, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
@@ -158,11 +177,11 @@ class AnalyticsDataFactoryTest {
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_RELEASE])
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_NAME])
         assertEquals(versionCode, params[AnalyticsDataFactory.FIELD_APP_VERSION])
-        assertEquals(BuildConfig.APPLICATION_ID, params[AnalyticsDataFactory.FIELD_APP_NAME])
+        assertEquals(BuildConfig.LIBRARY_PACKAGE_NAME, params[AnalyticsDataFactory.FIELD_APP_NAME])
 
         // The @Config constants param means BuildConfig constants are the same in prod as in test.
         assertEquals(BuildConfig.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
-        assertEquals(expectedTokenName, params[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(expectedUaName, params[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
 
         assertEquals("unknown_Android_robolectric",
@@ -172,11 +191,13 @@ class AnalyticsDataFactoryTest {
     @Test
     fun getEventLoggingParams_withoutProductUsage_createsOnlyNeededFields() {
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
-        val expectedTokenName = AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.SOURCE_CREATION)
-        val expectedUaName = AnalyticsDataFactory.analyticsUa
+        val expectedEventName = AnalyticsEvent.SourceCreate.toString()
+        val expectedUaName = AnalyticsDataFactory.ANALYTICS_UA
 
-        val params = analyticsDataFactory.getSourceCreationParams(API_KEY, Token.TokenType.BANK_ACCOUNT)
-        assertEquals((AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2).toLong(), params.size.toLong())
+        val params = analyticsDataFactory.createSourceCreationParams(
+            API_KEY, Token.TokenType.BANK_ACCOUNT
+        )
+        assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2, params.size)
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(Token.TokenType.BANK_ACCOUNT, params[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
 
@@ -186,7 +207,7 @@ class AnalyticsDataFactoryTest {
 
         // The @Config constants param means BuildConfig constants are the same in prod as in test.
         assertEquals(BuildConfig.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
-        assertEquals(expectedTokenName, params[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(expectedUaName, params[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
 
         assertEquals("unknown_Android_robolectric", params[AnalyticsDataFactory.FIELD_DEVICE_TYPE])
@@ -218,14 +239,16 @@ class AnalyticsDataFactoryTest {
     @Test
     fun getEventParamName_withTokenCreation_createsExpectedParameter() {
         val expectedEventParam = "stripe_android.token_creation"
-        assertEquals(expectedEventParam,
-            AnalyticsDataFactory.getEventParamName(AnalyticsDataFactory.EventName.TOKEN_CREATION))
+        assertEquals(
+            expectedEventParam,
+            AnalyticsEvent.TokenCreate.toString()
+        )
     }
 
     @Test
     fun getAnalyticsUa_returnsExpectedValue() {
         val androidAnalyticsUserAgent = "analytics.stripe_android-1.0"
-        assertEquals(androidAnalyticsUserAgent, AnalyticsDataFactory.analyticsUa)
+        assertEquals(androidAnalyticsUserAgent, AnalyticsDataFactory.ANALYTICS_UA)
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -83,7 +83,7 @@ class StripePaymentControllerTest {
         createController()
     }
     private val analyticsDataFactory: AnalyticsDataFactory by lazy {
-        AnalyticsDataFactory.create(context)
+        AnalyticsDataFactory(context)
     }
     private val host: AuthActivityStarter.Host by lazy {
         AuthActivityStarter.Host.create(activity)
@@ -98,23 +98,16 @@ class StripePaymentControllerTest {
             }
         }
 
-    private lateinit var relayStarterArgsArgumentCaptor: KArgumentCaptor<PaymentRelayStarter.Args>
-    private lateinit var intentArgumentCaptor: KArgumentCaptor<Intent>
-    private lateinit var apiRequestArgumentCaptor: KArgumentCaptor<StripeRequest>
-    private lateinit var setupIntentResultArgumentCaptor: KArgumentCaptor<SetupIntentResult>
-    private lateinit var apiResultStripeIntentArgumentCaptor: KArgumentCaptor<ApiResultCallback<StripeIntent>>
-    private lateinit var sourceArgumentCaptor: KArgumentCaptor<Source>
+    private val relayStarterArgsArgumentCaptor: KArgumentCaptor<PaymentRelayStarter.Args> = argumentCaptor()
+    private val intentArgumentCaptor: KArgumentCaptor<Intent> = argumentCaptor()
+    private val apiRequestArgumentCaptor: KArgumentCaptor<StripeRequest> = argumentCaptor()
+    private val setupIntentResultArgumentCaptor: KArgumentCaptor<SetupIntentResult> = argumentCaptor()
+    private val apiResultStripeIntentArgumentCaptor: KArgumentCaptor<ApiResultCallback<StripeIntent>> = argumentCaptor()
+    private val sourceArgumentCaptor: KArgumentCaptor<Source> = argumentCaptor()
 
     @BeforeTest
     fun setup() {
         MockitoAnnotations.initMocks(this)
-
-        relayStarterArgsArgumentCaptor = argumentCaptor()
-        intentArgumentCaptor = argumentCaptor()
-        apiRequestArgumentCaptor = argumentCaptor()
-        setupIntentResultArgumentCaptor = argumentCaptor()
-        apiResultStripeIntentArgumentCaptor = argumentCaptor()
-        sourceArgumentCaptor = argumentCaptor()
 
         `when`<AuthenticationRequestParameters>(transaction.authenticationRequestParameters)
             .thenReturn(Stripe3ds2Fixtures.AREQ_PARAMS)
@@ -158,8 +151,10 @@ class StripePaymentControllerTest {
         verify(fireAndForgetRequestExecutor)
             .executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsParams = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
-        assertEquals("stripe_android.3ds2_fingerprint",
-            analyticsParams[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2Fingerprint.toString(),
+            analyticsParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
         assertEquals(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.id,
             analyticsParams[AnalyticsDataFactory.FIELD_INTENT_ID])
     }
@@ -209,8 +204,10 @@ class StripePaymentControllerTest {
 
         verify(fireAndForgetRequestExecutor)
             .executeAsync(apiRequestArgumentCaptor.capture())
-        assertEquals("stripe_android.3ds1_sdk",
-            requireNotNull(apiRequestArgumentCaptor.firstValue.params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds1Sdk.toString(),
+            requireNotNull(apiRequestArgumentCaptor.firstValue.params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test
@@ -231,8 +228,10 @@ class StripePaymentControllerTest {
         verify(fireAndForgetRequestExecutor)
             .executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsParams = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
-        assertEquals("stripe_android.url_redirect_next_action",
-            analyticsParams[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.AuthRedirect.toString(),
+            analyticsParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
         assertEquals("pi_1EZlvVCRMbs6FrXfKpq2xMmy",
             analyticsParams[AnalyticsDataFactory.FIELD_INTENT_ID])
     }
@@ -289,12 +288,16 @@ class StripePaymentControllerTest {
             .executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsRequests = apiRequestArgumentCaptor.allValues
 
-        assertEquals("stripe_android.3ds2_challenge_flow_completed",
-            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengeCompleted.toString(),
+            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
 
         val analyticsParamsSecond = requireNotNull(analyticsRequests[1].params)
-        assertEquals("stripe_android.3ds2_challenge_flow_presented",
-            analyticsParamsSecond[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengePresented.toString(),
+            analyticsParamsSecond[AnalyticsDataFactory.FIELD_EVENT]
+        )
         assertEquals("oob",
             analyticsParamsSecond[AnalyticsDataFactory.FIELD_3DS2_UI_TYPE])
     }
@@ -311,11 +314,15 @@ class StripePaymentControllerTest {
             .executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsRequests = apiRequestArgumentCaptor.allValues
 
-        assertEquals("stripe_android.3ds2_challenge_flow_timed_out",
-            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengeTimedOut.toString(),
+            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
 
-        assertEquals("stripe_android.3ds2_challenge_flow_presented",
-            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengePresented.toString(),
+            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test
@@ -331,11 +338,15 @@ class StripePaymentControllerTest {
             .executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsRequests = apiRequestArgumentCaptor.allValues
 
-        assertEquals("stripe_android.3ds2_challenge_flow_canceled",
-            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengeCanceled.toString(),
+            requireNotNull(analyticsRequests[0].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
 
-        assertEquals("stripe_android.3ds2_challenge_flow_presented",
-            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengePresented.toString(),
+            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test
@@ -357,8 +368,10 @@ class StripePaymentControllerTest {
         val analyticsRequests = apiRequestArgumentCaptor.allValues
 
         val analyticsParamsFirst = requireNotNull(analyticsRequests[0].params)
-        assertEquals("stripe_android.3ds2_challenge_flow_errored",
-            analyticsParamsFirst[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengeErrored.toString(),
+            analyticsParamsFirst[AnalyticsDataFactory.FIELD_EVENT]
+        )
 
         val errorData =
             analyticsParamsFirst[AnalyticsDataFactory.FIELD_ERROR_DATA] as Map<String, String>
@@ -366,8 +379,10 @@ class StripePaymentControllerTest {
         assertEquals("404", errorData["error_code"])
         assertEquals("Resource not found", errorData["error_message"])
 
-        assertEquals("stripe_android.3ds2_challenge_flow_presented",
-            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengePresented.toString(),
+            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test
@@ -395,16 +410,20 @@ class StripePaymentControllerTest {
         val analyticsRequests = apiRequestArgumentCaptor.allValues
 
         val analyticsParamsFirst = requireNotNull(analyticsRequests[0].params)
-        assertEquals("stripe_android.3ds2_challenge_flow_errored",
-            analyticsParamsFirst[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengeErrored.toString(),
+            analyticsParamsFirst[AnalyticsDataFactory.FIELD_EVENT]
+        )
 
         val errorData =
             analyticsParamsFirst[AnalyticsDataFactory.FIELD_ERROR_DATA] as Map<String, String>
 
         assertEquals("201", errorData["error_code"])
 
-        assertEquals("stripe_android.3ds2_challenge_flow_presented",
-            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2ChallengePresented.toString(),
+            requireNotNull(analyticsRequests[1].params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test
@@ -505,8 +524,10 @@ class StripePaymentControllerTest {
         verify(fireAndForgetRequestExecutor).executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsRequest = apiRequestArgumentCaptor.firstValue
         val analyticsParams = requireNotNull(analyticsRequest.params)
-        assertEquals("stripe_android.3ds2_frictionless_flow",
-            analyticsParams[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2Frictionless.toString(),
+            analyticsParams[AnalyticsDataFactory.FIELD_EVENT]
+        )
         assertEquals("pi_1ExkUeAWhjPjYwPiXph9ouXa",
             analyticsParams[AnalyticsDataFactory.FIELD_INTENT_ID])
     }
@@ -534,8 +555,10 @@ class StripePaymentControllerTest {
 
         verify(fireAndForgetRequestExecutor).executeAsync(apiRequestArgumentCaptor.capture())
         val analyticsRequest = apiRequestArgumentCaptor.firstValue
-        assertEquals("stripe_android.3ds2_fallback",
-            requireNotNull(analyticsRequest.params)[AnalyticsDataFactory.FIELD_EVENT])
+        assertEquals(
+            AnalyticsEvent.Auth3ds2Fallback.toString(),
+            requireNotNull(analyticsRequest.params)[AnalyticsDataFactory.FIELD_EVENT]
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace `AnalyticsDataFactory.EventName` with
  `AnalyticsEvent` enum to better represent
  possible analytics events
- Add missing analytics events to `AnalyticsEvent` enum
  - `CustomerRetrievePaymentMethods`
  - `CustomerRetrieve`
  - `IssuingRetrievePin`
  - `IssuingUpdatePin`

## Motivation
Simplify logic and add missing analytics

## Testing
Add unit tests
