### PR TITLE
Fix payment methods screen accessibility

### DIFF
--- a/stripe/res/layout/add_payment_method_card_row.xml
+++ b/stripe/res/layout/add_payment_method_card_row.xml
@@ -11,15 +11,15 @@
     android:paddingTop="@dimen/stripe_add_payment_method_vertical_padding"
     android:paddingBottom="@dimen/stripe_add_payment_method_vertical_padding"
     android:background="@drawable/stripe_simple_button_background"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:focusable="true"
+    android:clickable="true">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:layout_width="wrap_content"
         android:layout_height="@dimen/stripe_masked_card_icon_width"
         android:src="@drawable/stripe_ic_add_black_32dp"
         android:tint="?attr/colorAccent"
-        android:focusableInTouchMode="false"
-        android:clickable="false"
         android:layout_gravity="center_vertical|start"
         />
 
@@ -31,8 +31,6 @@
         android:textAppearance="@android:style/TextAppearance.DeviceDefault.Medium"
         android:text="@string/payment_method_add_new_card"
         android:textColor="?attr/colorAccent"
-        android:focusableInTouchMode="false"
-        android:clickable="false"
         android:layout_gravity="center_vertical|start"
         />
 

--- a/stripe/res/layout/masked_card_row.xml
+++ b/stripe/res/layout/masked_card_row.xml
@@ -5,6 +5,8 @@
     android:layout_height="wrap_content"
     android:paddingEnd="@dimen/stripe_list_row_end_padding"
     android:paddingStart="@dimen/stripe_list_row_start_padding"
+    android:focusable="true"
+    android:clickable="true"
     >
 
     <com.stripe.android.view.MaskedCardView

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.kt
@@ -18,5 +18,9 @@ internal abstract class AddPaymentMethodRowView(
         id = idRes
         setOnClickListener { AddPaymentMethodActivityStarter(activity).startForResult(args) }
         layoutParams = ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+
+        isFocusable = true
+        isClickable = true
+        isFocusableInTouchMode = true
     }
 }


### PR DESCRIPTION
Mark views that can be clicked (i.e. payment methods,
add new payment method) as focusable and clickable.