### PR TITLE
Add delete payment method accessibility action

### DIFF
--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -131,7 +131,9 @@
     <!-- TODO(mshafrir-stripe): translate string - ANDROID-413 -->
     <string name="added" tools:ignore="MissingTranslation">Added %s</string>
     <string name="removed" tools:ignore="MissingTranslation">Removed %s</string>
-    <string name="delete_payment_method" tools:ignore="MissingTranslation">Delete Payment Method?</string>
+
+    <string name="delete_payment_method_prompt_title" tools:ignore="MissingTranslation">Delete payment method?</string>
+    <string name="delete_payment_method" tools:ignore="MissingTranslation">Delete payment method</string>
 
     <!-- TODO(mshafrir-stripe): translate string - ANDROID-432 -->
     <!-- Label that will show that an FPX bank is offline. For example, "AmBank - Offline" -->

--- a/stripe/src/main/java/com/stripe/android/view/CardDisplayTextFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardDisplayTextFactory.kt
@@ -15,6 +15,8 @@ internal class CardDisplayTextFactory internal constructor(
     private val resources: Resources,
     private val themeConfig: ThemeConfig
 ) {
+    internal constructor(context: Context) : this(context.resources, ThemeConfig(context))
+
     @JvmSynthetic
     internal fun createStyled(
         brand: String?,
@@ -105,7 +107,7 @@ internal class CardDisplayTextFactory internal constructor(
         )
     }
 
-    internal companion object {
+    private companion object {
         private val BRAND_RESOURCE_MAP = mapOf(
             PaymentMethod.Card.Brand.AMERICAN_EXPRESS to R.string.amex_short,
             PaymentMethod.Card.Brand.DINERS_CLUB to R.string.diners_club,
@@ -116,9 +118,5 @@ internal class CardDisplayTextFactory internal constructor(
             PaymentMethod.Card.Brand.UNIONPAY to R.string.unionpay,
             PaymentMethod.Card.Brand.UNKNOWN to R.string.unknown
         )
-
-        @JvmSynthetic
-        internal fun create(context: Context) =
-            CardDisplayTextFactory(context.resources, ThemeConfig(context))
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/DeletePaymentMethodDialogFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/view/DeletePaymentMethodDialogFactory.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.view
+
+import androidx.appcompat.app.AlertDialog
+import com.stripe.android.CustomerSession
+import com.stripe.android.R
+import com.stripe.android.StripeError
+import com.stripe.android.model.PaymentMethod
+
+internal class DeletePaymentMethodDialogFactory internal constructor(
+    private val activity: PaymentMethodsActivity,
+    private val adapter: PaymentMethodsAdapter,
+    private val cardDisplayTextFactory: CardDisplayTextFactory,
+    private val customerSession: CustomerSession
+) {
+    @JvmSynthetic
+    fun create(paymentMethod: PaymentMethod): AlertDialog {
+        val message = paymentMethod.card?.let {
+            cardDisplayTextFactory.createUnstyled(it)
+        }
+        return AlertDialog.Builder(activity, R.style.AlertDialogStyle)
+            .setTitle(R.string.delete_payment_method_prompt_title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.yes) { _, _ ->
+                onDeletedPaymentMethod(paymentMethod)
+            }
+            .setNegativeButton(android.R.string.no) { _, _ ->
+                adapter.resetPaymentMethod(paymentMethod)
+            }
+            .setOnCancelListener {
+                adapter.resetPaymentMethod(paymentMethod)
+            }
+            .create()
+    }
+
+    private fun onDeletedPaymentMethod(paymentMethod: PaymentMethod) {
+        adapter.deletePaymentMethod(paymentMethod)
+
+        paymentMethod.id?.let { paymentMethodId ->
+            customerSession.detachPaymentMethod(paymentMethodId, PaymentMethodDeleteListener())
+        }
+
+        activity.showSnackbar(paymentMethod, R.string.removed)
+    }
+
+    private class PaymentMethodDeleteListener : CustomerSession.PaymentMethodRetrievalListener {
+        override fun onPaymentMethodRetrieved(paymentMethod: PaymentMethod) {
+        }
+
+        override fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?) {
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -6,6 +6,7 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
@@ -170,7 +171,17 @@ internal class PaymentMethodsAdapter constructor(
     ): ViewHolder.PaymentMethodViewHolder {
         val itemView = LayoutInflater.from(parent.context)
             .inflate(R.layout.masked_card_row, parent, false)
-        return ViewHolder.PaymentMethodViewHolder(itemView)
+        val viewHolder = ViewHolder.PaymentMethodViewHolder(itemView)
+        ViewCompat.addAccessibilityAction(
+            itemView,
+            parent.context.getString(R.string.delete_payment_method)
+        ) { _, _ ->
+            listener?.onDeletePaymentMethodAction(
+                paymentMethod = getPaymentMethodAtPosition(viewHolder.adapterPosition)
+            )
+            true
+        }
+        return viewHolder
     }
 
     private fun createGooglePayViewHolder(
@@ -240,6 +251,7 @@ internal class PaymentMethodsAdapter constructor(
     internal interface Listener {
         fun onPaymentMethodClick(paymentMethod: PaymentMethod)
         fun onGooglePayClick()
+        fun onDeletePaymentMethodAction(paymentMethod: PaymentMethod)
     }
 
     internal enum class ViewType {

--- a/stripe/src/main/java/com/stripe/android/view/SwipeToDeleteCallbackListener.kt
+++ b/stripe/src/main/java/com/stripe/android/view/SwipeToDeleteCallbackListener.kt
@@ -1,57 +1,14 @@
 package com.stripe.android.view
 
-import androidx.appcompat.app.AlertDialog
-import com.stripe.android.CustomerSession
-import com.stripe.android.R
-import com.stripe.android.StripeError
 import com.stripe.android.model.PaymentMethod
 
 internal class SwipeToDeleteCallbackListener internal constructor(
-    private val activity: PaymentMethodsActivity,
-    private val adapter: PaymentMethodsAdapter,
-    private val cardDisplayTextFactory: CardDisplayTextFactory,
-    private val customerSession: CustomerSession
+    private val deletePaymentMethodDialogFactory: DeletePaymentMethodDialogFactory
 ) : PaymentMethodSwipeCallback.Listener {
 
     override fun onSwiped(paymentMethod: PaymentMethod) {
-        confirmDeletePaymentMethod(paymentMethod)
-    }
-
-    private fun confirmDeletePaymentMethod(paymentMethod: PaymentMethod) {
-        val message = paymentMethod.card?.let {
-            cardDisplayTextFactory.createUnstyled(it)
-        }
-        AlertDialog.Builder(activity, R.style.AlertDialogStyle)
-            .setTitle(R.string.delete_payment_method)
-            .setMessage(message)
-            .setPositiveButton(android.R.string.yes) { _, _ ->
-                onDeletedPaymentMethod(paymentMethod)
-            }
-            .setNegativeButton(android.R.string.no) { _, _ ->
-                adapter.resetPaymentMethod(paymentMethod)
-            }
-            .setOnCancelListener {
-                adapter.resetPaymentMethod(paymentMethod)
-            }
-            .create()
+        deletePaymentMethodDialogFactory
+            .create(paymentMethod)
             .show()
-    }
-
-    private fun onDeletedPaymentMethod(paymentMethod: PaymentMethod) {
-        adapter.deletePaymentMethod(paymentMethod)
-
-        paymentMethod.id?.let { paymentMethodId ->
-            customerSession.detachPaymentMethod(paymentMethodId, PaymentMethodDeleteListener())
-        }
-
-        activity.showSnackbar(paymentMethod, R.string.removed)
-    }
-
-    private class PaymentMethodDeleteListener : CustomerSession.PaymentMethodRetrievalListener {
-        override fun onPaymentMethodRetrieved(paymentMethod: PaymentMethod) {
-        }
-
-        override fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?) {
-        }
     }
 }


### PR DESCRIPTION
## Summary
Use `ViewCompat.addAccessibilityAction()` that will be available
to accessibility services (e.g. TalkBack) to indicate extra
actions that can be done on the View.

## Motivation
Make payment method deletion accessible in `PaymentMethodsActivity`

## Testing
Manually tested
