### PR TITLE
Make StripeEditText errors accessible

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -36,6 +36,7 @@
             android:nextFocusForward="@+id/tl_expiry_date"
             android:nextFocusDown="@+id/tl_expiry_date"
             android:contentDescription="@string/acc_label_card_number"
+            android:accessibilityLiveRegion="polite"
             app:hintEnabled="false"
             style="@style/Stripe.CardInputWidget.TextInputLayout">
             <com.stripe.android.view.CardNumberEditText
@@ -69,6 +70,7 @@
             android:nextFocusLeft="@id/tl_card_number"
             android:nextFocusUp="@id/tl_card_number"
             android:contentDescription="@string/acc_label_expiry_date"
+            android:accessibilityLiveRegion="polite"
             app:hintEnabled="false"
             style="@style/Stripe.CardInputWidget.TextInputLayout">
             <com.stripe.android.view.ExpiryDateEditText
@@ -97,6 +99,7 @@
             android:nextFocusLeft="@id/tl_expiry_date"
             android:nextFocusUp="@id/tl_expiry_date"
             android:contentDescription="@string/cvc_number_hint"
+            android:accessibilityLiveRegion="polite"
             app:hintEnabled="false"
             style="@style/Stripe.CardInputWidget.TextInputLayout">
             <com.stripe.android.view.CvcEditText
@@ -123,6 +126,7 @@
             android:nextFocusLeft="@id/tl_cvc"
             android:nextFocusUp="@id/tl_cvc"
             android:contentDescription="@string/address_label_postal_code"
+            android:accessibilityLiveRegion="polite"
             app:hintEnabled="false"
             style="@style/Stripe.CardInputWidget.TextInputLayout">
             <com.stripe.android.view.PostalCodeEditText

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -163,6 +163,10 @@ class CardInputWidget @JvmOverloads constructor(
             val cardDate = expiryDateEditText.validDateFields
             val cvcValue = this.cvcValue
 
+            cardNumberEditText.shouldShowError = cardNumber == null
+            expiryDateEditText.shouldShowError = cardDate == null
+            cvcNumberEditText.shouldShowError = cvcValue == null
+
             // Announce error messages for accessibility
             if (cardNumber == null) {
                 cardNumberEditText.errorMessage?.let {
@@ -591,21 +595,6 @@ class CardInputWidget @JvmOverloads constructor(
 
                     // Avoid reading out "1234 1234 1234 1234"
                     info.hintText = null
-                }
-            })
-
-        ViewCompat.setAccessibilityDelegate(
-            cvcNumberEditText,
-            object : AccessibilityDelegateCompat() {
-                override fun onInitializeAccessibilityNodeInfo(
-                    host: View,
-                    info: AccessibilityNodeInfoCompat
-                ) {
-                    super.onInitializeAccessibilityNodeInfo(host, info)
-                    info.text = resources.getString(
-                        R.string.acc_label_cvc_node,
-                        cvcNumberEditText.text
-                    )
                 }
             })
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.text.Editable
 import android.text.InputFilter
 import android.util.AttributeSet
-import android.view.accessibility.AccessibilityNodeInfo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.CardUtils
 import com.stripe.android.R
@@ -70,10 +69,10 @@ class CardNumberEditText @JvmOverloads constructor(
         listenForTextChanges()
     }
 
-    override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
-        super.onInitializeAccessibilityNodeInfo(info)
-        info.text = resources.getString(R.string.acc_label_card_number_node, text)
-    }
+    override val accessibilityText: String?
+        get() {
+            return resources.getString(R.string.acc_label_card_number_node, text)
+        }
 
     @JvmSynthetic
     internal fun updateLengthFilter() {

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -68,6 +68,11 @@ class CvcEditText @JvmOverloads constructor(
         })
     }
 
+    override val accessibilityText: String?
+        get() {
+            return resources.getString(R.string.acc_label_cvc_node, text)
+        }
+
     /**
      * @param cardBrand the [CardBrand] used to update the view
      * @param customHintText optional user-specified hint text

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -3,7 +3,6 @@ package com.stripe.android.view
 import android.content.Context
 import android.text.Editable
 import android.util.AttributeSet
-import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.EditText
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.R
@@ -61,10 +60,10 @@ class ExpiryDateEditText @JvmOverloads constructor(
             }
         }
 
-    override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
-        super.onInitializeAccessibilityNodeInfo(info)
-        info.text = resources.getString(R.string.acc_label_expiry_date_node, text)
-    }
+    override val accessibilityText: String?
+        get() {
+            return resources.getString(R.string.acc_label_expiry_date_node, text)
+        }
 
     private fun listenForTextChanges() {
         addTextChangedListener(object : StripeTextWatcher() {

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.os.Build
 import android.os.Handler
 import android.text.Editable
 import android.util.AttributeSet
@@ -92,6 +93,8 @@ open class StripeEditText @JvmOverloads constructor(
         cachedColorStateList = textColors
     }
 
+    protected open val accessibilityText: String? = null
+
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
         val inputConnection = super.onCreateInputConnection(outAttrs)
         return inputConnection?.let {
@@ -171,6 +174,10 @@ open class StripeEditText @JvmOverloads constructor(
     override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
         super.onInitializeAccessibilityNodeInfo(info)
         info.isContentInvalid = shouldShowError
+        accessibilityText?.let { info.text = it }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            info.error = errorMessage.takeIf { shouldShowError }
+        }
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
In `StripeEditText#onInitializeAccessibilityNodeInfo()`,
conditionally set `info.error` so that the field's
error message is read when a user focuses on it.

Fixes #1562