### PR TITLE
Deprecate BankAccount for token creation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringDef
 import kotlinx.android.parcel.Parcelize
 
 /**
- * [Create a bank account token](https://stripe.com/docs/api/tokens/create_bank_account)
+ * [The bank account object](https://stripe.com/docs/api/customer_bank_accounts/object)
  */
 @Parcelize
 data class BankAccount internal constructor(
@@ -16,6 +16,7 @@ data class BankAccount internal constructor(
      */
     val id: String? = null,
 
+    @Deprecated("Use BankAccountTokenParams")
     val accountNumber: String? = null,
 
     /**
@@ -138,6 +139,7 @@ data class BankAccount internal constructor(
      * either `individual` or `company`. This field is required when attaching the bank account to
      * a `Customer` object.
      */
+    @Deprecated("Use BankAccountTokenParams")
     @JvmOverloads
     constructor(
         accountNumber: String,
@@ -192,19 +194,13 @@ data class BankAccount internal constructor(
     )
 
     override fun toParamMap(): Map<String, Any> {
-        val bankAccountParams: Map<String, String> = listOf(
-            "country" to countryCode,
-            "currency" to currency,
-            "account_number" to accountNumber,
-            "routing_number" to routingNumber,
-            "account_holder_name" to accountHolderName,
-            "account_holder_type" to accountHolderType
-        ).fold(emptyMap()) { acc, (key, value) ->
-            acc.plus(
-                value?.let { mapOf(key to it) }.orEmpty()
-            )
-        }
-
-        return mapOf(Token.TokenType.BANK_ACCOUNT to bankAccountParams)
+        return BankAccountTokenParams(
+            country = countryCode.orEmpty(),
+            currency = currency.orEmpty(),
+            accountNumber = accountNumber.orEmpty(),
+            routingNumber = routingNumber,
+            accountHolderName = accountHolderName,
+            accountHolderType = BankAccountTokenParams.Type.fromCode(accountHolderType)
+        ).toParamMap()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.model
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
  * [Create a bank account token](https://stripe.com/docs/api/tokens/create_bank_account)
  */
-private data class BankAccountTokenParams @JvmOverloads constructor(
+@Parcelize
+data class BankAccountTokenParams @JvmOverloads constructor(
     /**
      * The country in which the bank account is located.
      *
@@ -50,10 +54,17 @@ private data class BankAccountTokenParams @JvmOverloads constructor(
      * [bank_account.routing_number](https://stripe.com/docs/api/tokens/create_bank_account#create_bank_account_token-bank_account-routing_number)
      */
     private val routingNumber: String? = null
-) : StripeParamsModel {
+) : StripeParamsModel, Parcelable {
     enum class Type(internal val code: String) {
         Individual("individual"),
-        Company("company")
+        Company("company");
+
+        internal companion object {
+            @JvmSynthetic
+            internal fun fromCode(code: String?): Type? {
+                return values().firstOrNull { it.code == code }
+            }
+        }
     }
 
     override fun toParamMap(): Map<String, Any> {

--- a/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParamsFixtures.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParamsFixtures.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.model
+
+object BankAccountTokenParamsFixtures {
+    @JvmField
+    val DEFAULT: BankAccountTokenParams = BankAccountTokenParams(
+        country = "US",
+        currency = "usd",
+        accountNumber = "000123456789",
+        routingNumber = "110000000",
+        accountHolderName = "Jenny Rosen",
+        accountHolderType = BankAccountTokenParams.Type.Individual
+    )
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -13,6 +13,7 @@ import com.stripe.android.model.AccountParams;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.AddressFixtures;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParamsFixtures;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.CardBrand;
 import com.stripe.android.model.CardFixtures;
@@ -78,14 +79,7 @@ public class StripeTest {
 
     private static final int YEAR = Calendar.getInstance().get(Calendar.YEAR) + 1;
     private static final Card CARD = Card.create(TEST_CARD_NUMBER, 12, YEAR, "123");
-    private static final BankAccount BANK_ACCOUNT = new BankAccount(
-            "000123456789",
-            "US",
-            "usd",
-            "314074269",
-            "Jenny Rosen",
-            BankAccount.BankAccountType.INDIVIDUAL
-    );
+
     private static final SourceParams CARD_SOURCE_PARAMS = SourceParams.createCardParams(CARD);
 
     private Context context;
@@ -229,7 +223,7 @@ public class StripeTest {
     @Test
     public void createBankAccountToken() {
         createStripe().createBankAccountToken(
-                BANK_ACCOUNT,
+                BankAccountTokenParamsFixtures.DEFAULT,
                 new ApiResultCallback<Token>() {
                     @Override
                     public void onSuccess(@NonNull Token result) {
@@ -295,7 +289,9 @@ public class StripeTest {
             throws StripeException {
         final Stripe stripe = createStripe();
 
-        final Token token = stripe.createBankAccountTokenSynchronous(BANK_ACCOUNT);
+        final Token token = stripe.createBankAccountTokenSynchronous(
+                BankAccountTokenParamsFixtures.DEFAULT
+        );
         assertNotNull(token);
         assertEquals(Token.TokenType.BANK_ACCOUNT, token.getType());
         assertNull(token.getCard());
@@ -310,7 +306,7 @@ public class StripeTest {
         assertEquals("usd", returnedBankAccount.getCurrency());
         assertNull(returnedBankAccount.getFingerprint());
         assertEquals("6789", returnedBankAccount.getLast4());
-        assertEquals("314074269", returnedBankAccount.getRoutingNumber());
+        assertEquals("110000000", returnedBankAccount.getRoutingNumber());
         assertEquals(BankAccount.Status.New, returnedBankAccount.getStatus());
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/BankAccountTokenParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/BankAccountTokenParamsTest.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BankAccountTokenParamsTest {
+    @Test
+    fun toParamMap_createsExpectedMap() {
+        val bankAccountTokenParams = BankAccountTokenParams(
+            accountNumber = BANK_ACCOUNT_NUMBER,
+            country = "US",
+            currency = "usd",
+            routingNumber = BANK_ROUTING_NUMBER,
+            accountHolderType = BankAccountTokenParams.Type.Individual,
+            accountHolderName = BANK_ACCOUNT_HOLDER_NAME
+        )
+        val bankAccountMap =
+            bankAccountTokenParams.toParamMap()[Token.TokenType.BANK_ACCOUNT] as Map<String, String>
+        assertEquals(BANK_ACCOUNT_NUMBER, bankAccountMap["account_number"])
+        assertEquals(BANK_ROUTING_NUMBER, bankAccountMap["routing_number"])
+        assertEquals("US", bankAccountMap["country"])
+        assertEquals("usd", bankAccountMap["currency"])
+        assertEquals(BANK_ACCOUNT_HOLDER_NAME, bankAccountMap["account_holder_name"])
+        assertEquals(BankAccountTokenParams.Type.Individual.code, bankAccountMap["account_holder_type"])
+    }
+
+    private companion object {
+        private const val BANK_ACCOUNT_NUMBER = "000123456789"
+        private const val BANK_ROUTING_NUMBER = "110000000"
+        private const val BANK_ACCOUNT_HOLDER_NAME = "Lily Thomas"
+    }
+}


### PR DESCRIPTION
Create `Stripe#createBankAccountToken()` and
`Stripe#createBankAccountTokenSynchronous()` that take
a `BankAccountTokenParams` object.

Mark the corresponding `BankAccount` methods
as `@Deprecated`.