### PR TITLE
Create ApiRequest.Factory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsRequest.kt
@@ -9,6 +9,7 @@ internal object AnalyticsRequest {
         requestOptions: ApiRequest.Options,
         appInfo: AppInfo? = null
     ): ApiRequest {
-        return ApiRequest.createGet(HOST, requestOptions, params, appInfo)
+        return ApiRequest.Factory(appInfo = appInfo)
+            .createGet(HOST, requestOptions, params)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -14,14 +14,18 @@ internal data class ApiRequest internal constructor(
     override val params: Map<String, *>? = null,
     internal val options: Options,
     private val appInfo: AppInfo? = null,
-    private val systemPropertySupplier: (String) -> String = DEFAULT_SYSTEM_PROPERTY_SUPPLIER
+    private val systemPropertySupplier: (String) -> String = DEFAULT_SYSTEM_PROPERTY_SUPPLIER,
+    private val apiVersion: String = ApiVersion.get().code,
+    private val sdkVersion: String = Stripe.VERSION
 ) : StripeRequest() {
     override val mimeType: MimeType = MimeType.Form
 
     override val headersFactory = RequestHeadersFactory.Api(
         options = options,
         appInfo = appInfo,
-        systemPropertySupplier = systemPropertySupplier
+        systemPropertySupplier = systemPropertySupplier,
+        apiVersion = apiVersion,
+        sdkVersion = sdkVersion
     )
 
     override val body: String
@@ -48,38 +52,53 @@ internal data class ApiRequest internal constructor(
         }
     }
 
+    class Factory(
+        private val appInfo: AppInfo? = null,
+        private val apiVersion: String = ApiVersion.get().code,
+        private val sdkVersion: String = Stripe.VERSION
+    ) {
+        fun createGet(
+            url: String,
+            options: Options,
+            params: Map<String, *>? = null
+        ): ApiRequest {
+            return ApiRequest(
+                Method.GET, url, params, options, appInfo,
+                apiVersion = apiVersion,
+                sdkVersion = sdkVersion
+            )
+        }
+
+        fun createPost(
+            url: String,
+            options: Options,
+            params: Map<String, *>? = null
+        ): ApiRequest {
+            return ApiRequest(
+                Method.POST, url, params, options, appInfo,
+                apiVersion = apiVersion,
+                sdkVersion = sdkVersion
+            )
+        }
+
+        fun createDelete(
+            url: String,
+            options: Options
+        ): ApiRequest {
+            return ApiRequest(
+                Method.DELETE,
+                url,
+                options = options,
+                appInfo = appInfo,
+                apiVersion = apiVersion,
+                sdkVersion = sdkVersion
+            )
+        }
+    }
+
     internal companion object {
         internal const val API_HOST = "https://api.stripe.com"
 
         internal const val HEADER_STRIPE_CLIENT_USER_AGENT = "X-Stripe-Client-User-Agent"
-
-        @JvmSynthetic
-        internal fun createGet(
-            url: String,
-            options: Options,
-            params: Map<String, *>? = null,
-            appInfo: AppInfo? = null
-        ): ApiRequest {
-            return ApiRequest(Method.GET, url, params, options, appInfo)
-        }
-
-        @JvmSynthetic
-        internal fun createPost(
-            url: String,
-            options: Options,
-            params: Map<String, *>? = null,
-            appInfo: AppInfo? = null
-        ): ApiRequest {
-            return ApiRequest(Method.POST, url, params, options, appInfo)
-        }
-
-        @JvmSynthetic
-        internal fun createDelete(
-            url: String,
-            options: Options,
-            appInfo: AppInfo? = null
-        ): ApiRequest {
-            return ApiRequest(Method.DELETE, url, null, options, appInfo)
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
@@ -22,10 +22,10 @@ internal sealed class RequestHeadersFactory {
         private val options: ApiRequest.Options,
         private val appInfo: AppInfo? = null,
         private val locale: Locale = Locale.getDefault(),
-        private val systemPropertySupplier: (String) -> String = DEFAULT_SYSTEM_PROPERTY_SUPPLIER
+        private val systemPropertySupplier: (String) -> String = DEFAULT_SYSTEM_PROPERTY_SUPPLIER,
+        private val apiVersion: String = ApiVersion.get().code,
+        private val sdkVersion: String = Stripe.VERSION
     ) : RequestHeadersFactory() {
-        private val apiVersion: String = ApiVersion.get().code
-
         private val languageTag: String?
             get() {
                 return locale.toString().replace("_", "-")
@@ -35,7 +35,7 @@ internal sealed class RequestHeadersFactory {
         override val userAgent: String
             get() {
                 return listOfNotNull(
-                    DEFAULT_USER_AGENT, appInfo?.toUserAgent()
+                    getUserAgent(sdkVersion), appInfo?.toUserAgent()
                 ).joinToString(" ")
             }
 
@@ -86,13 +86,14 @@ internal sealed class RequestHeadersFactory {
     }
 
     class Default(
-        override val extraHeaders: Map<String, String> = emptyMap()
+        override val extraHeaders: Map<String, String> = emptyMap(),
+        sdkVersion: String = Stripe.VERSION
     ) : RequestHeadersFactory() {
-        override val userAgent: String = DEFAULT_USER_AGENT
+        override val userAgent: String = getUserAgent(sdkVersion)
     }
 
     internal companion object {
-        internal const val DEFAULT_USER_AGENT = "Stripe/v1 ${Stripe.VERSION}"
+        internal fun getUserAgent(sdkVersion: String = Stripe.VERSION) = "Stripe/v1 $sdkVersion"
 
         private const val HEADER_USER_AGENT = "User-Agent"
         private const val HEADER_ACCEPT_CHARSET = "Accept-Charset"

--- a/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
@@ -85,7 +85,7 @@ class ApiRequestHeadersFactoryTest {
     fun headers_withAppInfo() {
         val headers = createHeaders(appInfo = AppInfoTest.APP_INFO)
         assertEquals(
-            "${RequestHeadersFactory.DEFAULT_USER_AGENT} MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",
+            "${RequestHeadersFactory.getUserAgent()} MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",
             headers["User-Agent"]
         )
 

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -15,7 +15,7 @@ internal class ApiRequestTest {
     @Test
     fun url_withCardData_createsProperQueryString() {
         val cardMap = NETWORK_UTILS.createCardTokenParams(CardFixtures.MINIMUM_CARD)
-        val url = ApiRequest.createGet(
+        val url = FACTORY.createGet(
             StripeApiRepository.sourcesUrl,
             OPTIONS,
             cardMap
@@ -27,7 +27,7 @@ internal class ApiRequestTest {
 
     @Test
     fun getContentType() {
-        val contentType = ApiRequest.createGet(
+        val contentType = FACTORY.createGet(
             StripeApiRepository.sourcesUrl,
             OPTIONS
         ).contentType
@@ -37,7 +37,7 @@ internal class ApiRequestTest {
     @Test
     fun writeBody_withEmptyBody_shouldHaveZeroLength() {
         ByteArrayOutputStream().use {
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS
             ).writeBody(it)
@@ -48,7 +48,7 @@ internal class ApiRequestTest {
     @Test
     fun writeBody_withNonEmptyBody_shouldHaveNonZeroLength() {
         ByteArrayOutputStream().use {
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS,
                 mapOf("customer" to "cus_123")
@@ -62,12 +62,12 @@ internal class ApiRequestTest {
         val params = mapOf("customer" to "cus_123")
 
         assertEquals(
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS,
                 params
             ),
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS,
                 params
@@ -75,12 +75,12 @@ internal class ApiRequestTest {
         )
 
         assertNotEquals(
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 OPTIONS,
                 params
             ),
-            ApiRequest.createPost(
+            FACTORY.createPost(
                 StripeApiRepository.paymentMethodsUrl,
                 ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, "acct"),
                 params
@@ -97,5 +97,7 @@ internal class ApiRequestTest {
         )
 
         private val OPTIONS = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+
+        private val FACTORY = ApiRequest.Factory()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/FingerprintRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintRequestTest.kt
@@ -27,7 +27,7 @@ class FingerprintRequestTest {
     fun getHeaders() {
         val headers = FingerprintRequest(emptyMap(), "guid").headers
         assertEquals(
-            RequestHeadersFactory.DEFAULT_USER_AGENT,
+            RequestHeadersFactory.getUserAgent(),
             headers["User-Agent"]
         )
         assertEquals("m=guid", headers["Cookie"])


### PR DESCRIPTION
This allows passing in an optional custom
API version and SDK version for testing
purposes.

Add tests in `StripeApiRepositoryTest` to
validate that API error messages are
localized for supported SDK versions
(i.e. >= 14.0.0)