### PR TITLE
Add CardValidCallback and add support in card forms

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -39,6 +40,15 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
         rv_payment_methods.setHasFixedSize(false)
         rv_payment_methods.layoutManager = LinearLayoutManager(this)
         rv_payment_methods.adapter = adapter
+
+        card_multiline_widget.setCardValidCallback(object : CardValidCallback {
+            override fun onInputChanged(
+                isValid: Boolean,
+                invalidFields: Set<CardValidCallback.Fields>
+            ) {
+                // added as an example - no-op
+            }
+        })
 
         btn_create_payment_method.setOnClickListener { createPaymentMethod() }
     }

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -20,6 +20,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.Card
 import com.stripe.android.model.Token
+import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
 import kotlinx.android.synthetic.main.card_token_activity.*
 
@@ -59,6 +60,15 @@ class CreateCardTokenActivity : AppCompatActivity() {
                 snackbarController.show(getString(R.string.invalid_card_details))
             }
         }
+
+        card_input_widget.setCardValidCallback(object : CardValidCallback {
+            override fun onInputChanged(
+                isValid: Boolean,
+                invalidFields: Set<CardValidCallback.Fields>
+            ) {
+                // added as an example - no-op
+            }
+        })
 
         card_input_widget.requestFocus()
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardValidCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardValidCallback.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.view
+
+interface CardValidCallback {
+    /**
+     * @param isValid if the current input is valid
+     * @param invalidFields if the current input is invalid, this [Set] will be populated with the
+     * fields that are invalid, represented by [Fields]; if the current input is valid,
+     * this [Set] will be empty
+     */
+    fun onInputChanged(isValid: Boolean, invalidFields: Set<Fields>)
+
+    enum class Fields {
+        Number,
+        Expiry,
+        Cvc
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
@@ -24,6 +24,8 @@ internal interface CardWidget {
      */
     val paymentMethodCreateParams: PaymentMethodCreateParams?
 
+    fun setCardValidCallback(callback: CardValidCallback?)
+
     fun setCardInputListener(listener: CardInputListener?)
 
     fun setCardHint(cardHint: String)


### PR DESCRIPTION
## Summary
Add `CardInputWidget#setCardValidCallback()` and
`CardMultilineWidget#setCardValidCallback()`

Setting a callback instance will allow the integrating
app to determine if the current form input is valid
and which fields are invalid, if any.

For example, when none of the fields are valid,
`CardValidCallback#onInputChanged()` will be called with
```
false,
setOf(
  CardValidCallback.Fields.Number,
  CardValidCallback.Fields.Expiry,
  CardValidCallback.Fields.Cvc
)
```

When all of the fields are valid,
`CardValidCallback#onInputChanged()` will be called with
```
true, emptySet()
```

## Testing
Add unit tests and manually verified

## Motivation
Fixes #1808
