### PR TITLE
Use StripeException instead of Exception internally

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiOperation.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.exception.APIConnectionException
+import com.stripe.android.exception.APIException
 import com.stripe.android.exception.StripeException
 import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
@@ -23,7 +24,7 @@ internal abstract class ApiOperation<ResultType>(
             } catch (e: StripeException) {
                 ResultWrapper.create(e)
             } catch (e: JSONException) {
-                ResultWrapper.create(e)
+                ResultWrapper.create(APIException(e))
             } catch (e: IOException) {
                 ResultWrapper.create(APIConnectionException.create(e))
             }
@@ -38,8 +39,9 @@ internal abstract class ApiOperation<ResultType>(
         when {
             resultWrapper.result != null -> callback.onSuccess(resultWrapper.result)
             resultWrapper.error != null -> callback.onError(resultWrapper.error)
-            else -> callback.onError(RuntimeException(
-                "The API operation returned neither a result or exception"))
+            else -> callback.onError(
+                RuntimeException("The API operation returned neither a result or exception")
+            )
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import com.stripe.android.exception.StripeException
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
@@ -96,7 +97,7 @@ internal interface PaymentController {
     data class Result internal constructor(
         internal val clientSecret: String? = null,
         @StripeIntentResult.Outcome internal val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
-        internal val exception: Exception? = null,
+        internal val exception: StripeException? = null,
         internal val shouldCancelSource: Boolean = false,
         internal val sourceId: String? = null,
         internal val source: Source? = null

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import android.os.Parcelable
+import com.stripe.android.exception.StripeException
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarter
@@ -37,7 +38,7 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
     data class Args internal constructor(
         val stripeIntent: StripeIntent? = null,
         val source: Source? = null,
-        val exception: Exception? = null
+        val exception: StripeException? = null
     ) : Parcelable {
         internal companion object {
             @JvmSynthetic
@@ -51,7 +52,7 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             }
 
             @JvmSynthetic
-            internal fun create(exception: Exception): Args {
+            internal fun create(exception: StripeException): Args {
                 return Args(exception = exception)
             }
         }

--- a/stripe/src/main/java/com/stripe/android/ResultWrapper.kt
+++ b/stripe/src/main/java/com/stripe/android/ResultWrapper.kt
@@ -1,8 +1,10 @@
 package com.stripe.android
 
+import com.stripe.android.exception.StripeException
+
 internal data class ResultWrapper<ResultType> internal constructor(
     val result: ResultType? = null,
-    val error: Exception? = null
+    val error: StripeException? = null
 ) {
     internal companion object {
         @JvmSynthetic
@@ -11,7 +13,7 @@ internal data class ResultWrapper<ResultType> internal constructor(
         }
 
         @JvmSynthetic
-        internal fun <ResultType> create(error: Exception): ResultWrapper<ResultType> {
+        internal fun <ResultType> create(error: StripeException): ResultWrapper<ResultType> {
             return ResultWrapper(error = error)
         }
     }

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Handler
 import android.os.HandlerThread
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.exception.APIException
 import com.stripe.android.exception.StripeException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -603,7 +604,12 @@ internal class StripePaymentController internal constructor(
         }
 
         override fun onError(e: Exception) {
-            paymentRelayStarter.start(PaymentRelayStarter.Args.create(e))
+            paymentRelayStarter.start(PaymentRelayStarter.Args.create(
+                when (e) {
+                    is StripeException -> e
+                    else -> APIException(e)
+                }
+            ))
         }
 
         private fun startFrictionlessFlow() {
@@ -896,7 +902,12 @@ internal class StripePaymentController internal constructor(
             exception: Exception
         ) {
             PaymentRelayStarter.create(host, requestCode)
-                .start(PaymentRelayStarter.Args.create(exception))
+                .start(PaymentRelayStarter.Args.create(
+                    when (exception) {
+                        is StripeException -> exception
+                        else -> APIException(exception)
+                    }
+                ))
         }
 
         @JvmStatic

--- a/stripe/src/main/java/com/stripe/android/StripeRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRequest.kt
@@ -69,7 +69,7 @@ internal abstract class StripeRequest {
                 throw InvalidRequestException(
                     message = "Unable to encode parameters to ${Charsets.UTF_8.name()}. " +
                         "Please contact support@stripe.com for assistance.",
-                    e = e
+                    cause = e
                 )
             }
         }

--- a/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIConnectionException.kt
@@ -7,9 +7,9 @@ import java.io.IOException
  */
 class APIConnectionException(
     message: String? = null,
-    e: Throwable? = null
+    cause: Throwable? = null
 ) : StripeException(
-    e = e,
+    cause = cause,
     message = message
 ) {
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/exception/APIException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIException.kt
@@ -10,14 +10,19 @@ class APIException(
     requestId: String? = null,
     statusCode: Int = 0,
     message: String? = stripeError?.message,
-    e: Throwable? = null
+    cause: Throwable? = null
 ) : StripeException(
     stripeError = stripeError,
     requestId = requestId,
     statusCode = statusCode,
-    e = e,
+    cause = cause,
     message = message
 ) {
+    internal constructor(exception: Exception) : this(
+        message = exception.message,
+        cause = exception
+    )
+
     internal companion object {
         @JvmSynthetic
         internal fun create(e: CardException): APIException {
@@ -26,7 +31,7 @@ class APIException(
                 requestId = e.requestId,
                 statusCode = e.statusCode,
                 message = e.message,
-                e = e
+                cause = e
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.kt
@@ -11,12 +11,12 @@ open class InvalidRequestException(
     statusCode: Int = 0,
     message: String? = stripeError?.message,
     val param: String? = stripeError?.param,
-    e: Throwable? = null
+    cause: Throwable? = null
 ) : StripeException(
     stripeError,
     requestId,
     statusCode,
-    e,
+    cause,
     message
 ) {
     val errorCode: String? = stripeError?.code

--- a/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
@@ -10,9 +10,9 @@ abstract class StripeException(
     val stripeError: StripeError? = null,
     val requestId: String? = null,
     val statusCode: Int = 0,
-    e: Throwable? = null,
+    cause: Throwable? = null,
     message: String? = stripeError?.message
-) : Exception(message, e) {
+) : Exception(message, cause) {
     override fun toString(): String {
         return listOfNotNull(
             requestId?.let { "Request-id: $it" },

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.exception.APIException
 import com.stripe.android.exception.PermissionException
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.view.AuthActivityStarter
@@ -45,7 +46,7 @@ class PaymentRelayStarterTest {
 
     @Test
     fun start_withException_shouldSetCorrectIntentExtras() {
-        val exception = RuntimeException()
+        val exception = APIException(RuntimeException())
         starter.start(PaymentRelayStarter.Args.create(exception))
         verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.stripe.android.exception.APIException
 import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -448,7 +449,7 @@ class StripePaymentControllerTest {
 
     @Test
     fun handlePaymentResult_withAuthException_shouldCallCallbackOnError() {
-        val exception = RuntimeException()
+        val exception = APIException(RuntimeException())
         val intent = Intent().putExtras(
             PaymentController.Result(
                 exception = exception
@@ -463,7 +464,7 @@ class StripePaymentControllerTest {
 
     @Test
     fun handleSetupResult_withAuthException_shouldCallCallbackOnError() {
-        val exception = RuntimeException()
+        val exception = APIException(RuntimeException())
         val intent = Intent().putExtras(
             PaymentController.Result(
                 exception = exception

--- a/stripe/src/test/java/com/stripe/android/exception/InvalidRequestExceptionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/exception/InvalidRequestExceptionTest.kt
@@ -26,7 +26,7 @@ class InvalidRequestExceptionTest {
     fun toString_withRequestId() {
         val actual = InvalidRequestException(
             requestId = "req_123",
-            e = IllegalArgumentException()
+            cause = IllegalArgumentException()
         ).toString()
         val expected = """
             Request-id: req_123
@@ -38,7 +38,7 @@ class InvalidRequestExceptionTest {
     @Test
     fun toString_withoutRequestId() {
         val actual = InvalidRequestException(
-            e = IllegalArgumentException()
+            cause = IllegalArgumentException()
         ).toString()
         val expected = "com.stripe.android.exception.InvalidRequestException"
         assertEquals(expected, actual)

--- a/stripe/src/test/java/com/stripe/android/exception/StripeExceptionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/exception/StripeExceptionTest.kt
@@ -12,12 +12,12 @@ class StripeExceptionTest {
             InvalidRequestException(
                 stripeError = StripeErrorFixtures.INVALID_REQUEST_ERROR,
                 requestId = "req_123",
-                e = RuntimeException()
+                cause = RuntimeException()
             ),
             InvalidRequestException(
                 stripeError = StripeErrorFixtures.INVALID_REQUEST_ERROR,
                 requestId = "req_123",
-                e = RuntimeException()
+                cause = RuntimeException()
             )
         )
     }


### PR DESCRIPTION
## Summary
- Change `PaymentController.Result#exception` to
  be a `StripeException`
- Convert `Exception` instances to `APIException`
  in `StripePaymentController`
- Convert `JSONException` instances to `APIException`
  in `ApiOperation`
- Rename `StripeException#e` to `StripeException#cause`

## Motivation
There is a bug in parceling of `PaymentController.Result`
related to the `exception` property. This PR simplifies
the solution, which will involve parceling the
individual components of the `exception` property.

The bug will be fixed in a follow-up PR.

## Testing
Unit tests