### PR TITLE
Enable adding mandate information to confirm params

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import androidx.annotation.VisibleForTesting
-import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
@@ -18,7 +16,7 @@ data class ConfirmSetupIntentParams internal constructor(
     @get:JvmSynthetic internal val paymentMethodId: String? = null,
     @get:JvmSynthetic internal val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     private val returnUrl: String? = null,
-    private val useStripeSdk: Boolean,
+    private val useStripeSdk: Boolean = false,
 
     /**
      * ID of the mandate to be used for this payment.
@@ -38,9 +36,7 @@ data class ConfirmSetupIntentParams internal constructor(
     }
 
     override fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmSetupIntentParams {
-        return toBuilder()
-            .setShouldUseSdk(shouldUseStripeSdk)
-            .build()
+        return copy(useStripeSdk = shouldUseStripeSdk)
     }
 
     /**
@@ -96,55 +92,6 @@ data class ConfirmSetupIntentParams internal constructor(
                 }
         }
 
-    @VisibleForTesting
-    internal fun toBuilder(): Builder {
-        val builder = Builder(clientSecret)
-            .setReturnUrl(returnUrl)
-            .setShouldUseSdk(useStripeSdk)
-
-        paymentMethodId?.let { builder.setPaymentMethodId(it) }
-        paymentMethodCreateParams?.let { builder.setPaymentMethodCreateParams(it) }
-
-        return builder
-    }
-
-    internal class Builder internal constructor(
-        private val clientSecret: String
-    ) : ObjectBuilder<ConfirmSetupIntentParams> {
-        private var paymentMethodId: String? = null
-        private var paymentMethodCreateParams: PaymentMethodCreateParams? = null
-        private var returnUrl: String? = null
-        private var useStripeSdk: Boolean = false
-
-        internal fun setPaymentMethodId(paymentMethodId: String): Builder = apply {
-            this.paymentMethodId = paymentMethodId
-        }
-
-        internal fun setPaymentMethodCreateParams(
-            paymentMethodCreateParams: PaymentMethodCreateParams
-        ): Builder = apply {
-            this.paymentMethodCreateParams = paymentMethodCreateParams
-        }
-
-        internal fun setReturnUrl(returnUrl: String?): Builder = apply {
-            this.returnUrl = returnUrl
-        }
-
-        internal fun setShouldUseSdk(useStripeSdk: Boolean): Builder = apply {
-            this.useStripeSdk = useStripeSdk
-        }
-
-        override fun build(): ConfirmSetupIntentParams {
-            return ConfirmSetupIntentParams(
-                clientSecret = clientSecret,
-                returnUrl = returnUrl,
-                paymentMethodId = paymentMethodId,
-                paymentMethodCreateParams = paymentMethodCreateParams,
-                useStripeSdk = useStripeSdk
-            )
-        }
-    }
-
     companion object {
         /**
          * Create the parameters necessary for confirming a SetupIntent, without specifying a payment method
@@ -164,9 +111,10 @@ data class ConfirmSetupIntentParams internal constructor(
             clientSecret: String,
             returnUrl: String? = null
         ): ConfirmSetupIntentParams {
-            return Builder(clientSecret)
-                .setReturnUrl(returnUrl)
-                .build()
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                returnUrl = returnUrl
+            )
         }
 
         /**
@@ -179,6 +127,8 @@ data class ConfirmSetupIntentParams internal constructor(
          * @param returnUrl The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
          * If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
          * This parameter is only used for cards and other redirect-based payment methods.
+         * @param mandateId optional ID of the Mandate to be used for this payment.
+         * @param mandateData optional details about the Mandate to create.
          *
          * @return params that can be use to confirm a SetupIntent
          */
@@ -187,12 +137,17 @@ data class ConfirmSetupIntentParams internal constructor(
         fun create(
             paymentMethodId: String,
             clientSecret: String,
-            returnUrl: String? = null
+            returnUrl: String? = null,
+            mandateId: String? = null,
+            mandateData: MandateDataParams? = null
         ): ConfirmSetupIntentParams {
-            return Builder(clientSecret)
-                .setReturnUrl(returnUrl)
-                .setPaymentMethodId(paymentMethodId)
-                .build()
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodId = paymentMethodId,
+                returnUrl = returnUrl,
+                mandateId = mandateId,
+                mandateData = mandateData
+            )
         }
 
         /**
@@ -204,6 +159,8 @@ data class ConfirmSetupIntentParams internal constructor(
          * @param returnUrl The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
          * If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
          * This parameter is only used for cards and other redirect-based payment methods.
+         * @param mandateId optional ID of the Mandate to be used for this payment.
+         * @param mandateData optional details about the Mandate to create.
          *
          * @return params that can be use to confirm a SetupIntent
          */
@@ -212,12 +169,17 @@ data class ConfirmSetupIntentParams internal constructor(
         fun create(
             paymentMethodCreateParams: PaymentMethodCreateParams,
             clientSecret: String,
-            returnUrl: String? = null
+            returnUrl: String? = null,
+            mandateId: String? = null,
+            mandateData: MandateDataParams? = null
         ): ConfirmSetupIntentParams {
-            return Builder(clientSecret)
-                .setPaymentMethodCreateParams(paymentMethodCreateParams)
-                .setReturnUrl(returnUrl)
-                .build()
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                returnUrl = returnUrl,
+                mandateId = mandateId,
+                mandateData = mandateData
+            )
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/MandateDataParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/MandateDataParams.kt
@@ -9,7 +9,7 @@ import kotlinx.android.parcel.Parcelize
  * or [confirming a SetupIntent](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data)
  */
 @Parcelize
-internal data class MandateDataParams internal constructor(
+data class MandateDataParams internal constructor(
     private val type: Type = Type.Online,
     private val typeData: TypeData? = null
 ) : StripeParamsModel, Parcelable {

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -180,40 +180,86 @@ class ConfirmPaymentIntentParamsTest {
     }
 
     @Test
-    fun toBuilder_withPaymentMethodCreateParams_shouldCreateEqualObject() {
-        val extraParams = mapOf("key" to "value")
-        val params = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-            PaymentMethodCreateParamsFixtures.DEFAULT_CARD, CLIENT_SECRET, RETURN_URL, true, extraParams
-        )
-
-        assertEquals(params, params.toBuilder().build())
-    }
-
-    @Test
     fun create_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
-        val params = ConfirmPaymentIntentParams(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT
-        ).toParamMap()
-        assertEquals(
-            MandateDataParams(MandateDataParams.TypeData.Online(
-                inferFromClient = true
-            )).toParamMap(),
-            params[ConfirmStripeIntentParams.PARAM_MANDATE_DATA]
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "save_payment_method" to false,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "infer_from_client" to true
+                    )
+                )
+            ),
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
         )
+        val actualParams =
+            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT
+            ).toParamMap()
+        assertEquals(expectedParams, actualParams)
     }
 
     @Test
     fun create_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
-        val params = ConfirmPaymentIntentParams(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
-            mandateData = MandateDataParamsFixtures.DEFAULT
-        ).toParamMap()
-        assertEquals(
-            MandateDataParamsFixtures.DEFAULT.toParamMap(),
-            params[ConfirmStripeIntentParams.PARAM_MANDATE_DATA]
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "save_payment_method" to false,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "ip_address" to "127.0.0.1",
+                        "user_agent" to "my_user_agent"
+                    )
+                )
+            ),
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
         )
+        val actualParams =
+            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+                mandateData = MandateDataParamsFixtures.DEFAULT
+            ).toParamMap()
+        assertEquals(expectedParams, actualParams)
+    }
+
+    @Test
+    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "save_payment_method" to false,
+            "use_stripe_sdk" to false,
+            "mandate" to "mandate_123456789",
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
+        )
+        val actualParams =
+            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+                mandateId = "mandate_123456789"
+            ).toParamMap()
+        assertEquals(expectedParams, actualParams)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -35,23 +35,6 @@ class ConfirmSetupIntentParamsTest {
     }
 
     @Test
-    fun toBuilder_withPaymentMethodId_shouldCreateEqualObject() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            "pm_123", "client_secret", "return_url")
-        assertEquals(confirmSetupIntentParams,
-            confirmSetupIntentParams.toBuilder().build())
-    }
-
-    @Test
-    fun toBuilder_withPaymentMethodCreateParams_shouldCreateEqualObject() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            "client_secret", "return_url")
-        assertEquals(confirmSetupIntentParams,
-            confirmSetupIntentParams.toBuilder().build())
-    }
-
-    @Test
     fun create_withPaymentMethodId_shouldPopulateParamMapCorrectly() {
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
             "pm_12345",
@@ -87,31 +70,82 @@ class ConfirmSetupIntentParamsTest {
 
     @Test
     fun create_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
-        val params = ConfirmSetupIntentParams(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
-            useStripeSdk = true
-        ).toParamMap()
-        assertEquals(
-            MandateDataParams(MandateDataParams.TypeData.Online(
-                inferFromClient = true
-            )).toParamMap(),
-            params[ConfirmStripeIntentParams.PARAM_MANDATE_DATA]
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "infer_from_client" to true
+                    )
+                )
+            ),
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
         )
+
+        val actualParams = ConfirmSetupIntentParams.create(
+            clientSecret = CLIENT_SECRET,
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT
+        ).toParamMap()
+        assertEquals(expectedParams, actualParams)
     }
 
     @Test
     fun create_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
-        val params = ConfirmSetupIntentParams(
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "ip_address" to "127.0.0.1",
+                        "user_agent" to "my_user_agent"
+                    )
+                )
+            ),
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
+        )
+
+        val actualParams = ConfirmSetupIntentParams.create(
             clientSecret = CLIENT_SECRET,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
-            mandateData = MandateDataParamsFixtures.DEFAULT,
-            useStripeSdk = true
+            mandateData = MandateDataParamsFixtures.DEFAULT
         ).toParamMap()
-        assertEquals(
-            MandateDataParamsFixtures.DEFAULT.toParamMap(),
-            params[ConfirmStripeIntentParams.PARAM_MANDATE_DATA]
+        assertEquals(expectedParams, actualParams)
+    }
+
+    @Test
+    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "use_stripe_sdk" to false,
+            "mandate" to "mandate_123456789",
+            "payment_method_data" to mapOf(
+                "type" to "sepa_debit",
+                "sepa_debit" to mapOf(
+                    "iban" to "my_iban"
+                )
+            )
         )
+        val actualParams =
+            ConfirmSetupIntentParams.create(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+                mandateId = "mandate_123456789"
+            ).toParamMap()
+        assertEquals(expectedParams, actualParams)
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Update confirm params creation methods to take an
  optional mandate id or mandate data
- Remove `ConfirmPaymentIntentParams.Builder`
- Remove `ConfirmSetupIntentParams.Builder`

## Motivation
Fixes #2103

## Testing
Add unit tests