### PR TITLE
Enable optionally requiring postal code in CardInputWidget and CardMultilineWidget

### DIFF
--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -8,5 +8,6 @@
 
     <declare-styleable name="CardElement">
         <attr name="shouldShowPostalCode" format="boolean" />
+        <attr name="shouldRequirePostalCode" format="boolean" />
     </declare-styleable>
 </resources>

--- a/stripe/res/values/public.xml
+++ b/stripe/res/values/public.xml
@@ -2,13 +2,14 @@
 <resources>
 
     <!-- Public Styles -->
-    <public name='StripeDefaultTheme' type='style'/>
-    <public name='StripeToolBarStyle' type='style'/>
+    <public name="StripeDefaultTheme" type="style"/>
+    <public name="StripeToolBarStyle" type="style"/>
 
     <!-- Styleable Attributes should all be public -->
-    <public name='cardTextErrorColor' type='attr' />
-    <public name='cardHintText' type='attr' />
-    <public name='cardTint' type='attr'/>
-    <public name='shouldShowPostalCode' type='attr'/>
+    <public name="cardTextErrorColor" type="attr" />
+    <public name="cardHintText" type="attr" />
+    <public name="cardTint" type="attr"/>
+    <public name="shouldShowPostalCode" type="attr"/>
+    <public name="shouldRequirePostalCode" type="attr"/>
 
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
@@ -40,4 +40,9 @@ internal interface CardWidget {
     )
 
     fun setCvcCode(cvcCode: String?)
+
+    companion object {
+        internal const val DEFAULT_POSTAL_CODE_ENABLED = true
+        internal const val DEFAULT_POSTAL_CODE_REQUIRED = false
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -61,7 +61,7 @@ open class StripeEditText @JvmOverloads constructor(
 
     internal var errorMessage: String? = null
 
-    protected val fieldText: String
+    internal val fieldText: String
         get() {
             return text?.toString().orEmpty()
         }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -68,6 +68,9 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @BeforeTest
     fun setup() {
+        // The input date here will be invalid after 2050. Please update the test.
+        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
+
         cardInputWidget.setCardNumberTextWatcher(object : StripeTextWatcher() {})
         cardInputWidget.setExpiryDateTextWatcher(object : StripeTextWatcher() {})
         cardInputWidget.setCvcNumberTextWatcher(object : StripeTextWatcher() {})
@@ -107,9 +110,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun getCard_whenInputIsValidVisa_withPostalCodeDisabled_returnsCardObjectWithLoggingToken() {
         cardInputWidget.postalCodeEnabled = false
 
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -143,9 +143,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun getCard_whenInputIsValidVisa_withPostalCodeEnabled_returnsCardObjectWithLoggingToken() {
         cardInputWidget.postalCodeEnabled = true
-
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         expiryEditText.append("12")
@@ -185,8 +182,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun getCard_whenInputIsValidAmEx_withPostalCodeDisabled_createsExpectedObjects() {
         cardInputWidget.postalCodeEnabled = false
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         expiryEditText.append("12")
@@ -219,8 +214,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun getCard_whenInputIsValidAmEx_withPostalCodeEnabled_createsExpectedObjects() {
         cardInputWidget.postalCodeEnabled = true
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         expiryEditText.append("12")
@@ -262,9 +255,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun getCard_whenInputIsValidDinersClub_withPostalCodeDisabled_returnsCardObjectWithLoggingToken() {
         cardInputWidget.postalCodeEnabled = false
 
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_DINERS_CLUB_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -296,9 +286,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun getCard_whenInputIsValidDinersClub_withPostalCodeEnabled_returnsCardObjectWithLoggingToken() {
         cardInputWidget.postalCodeEnabled = true
 
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_DINERS_CLUB_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -327,10 +314,25 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     }
 
     @Test
-    fun getCard_whenInputHasIncompleteCardNumber_returnsNull() {
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
+    fun getCard_whenPostalCodeIsEnabledAndRequired_andValueIsBlank_returnsNull() {
+        cardInputWidget.postalCodeEnabled = true
+        cardInputWidget.postalCodeRequired = true
 
+        cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
+        expiryEditText.append("12")
+        expiryEditText.append("50")
+        cvcEditText.append(CVC_VALUE_COMMON)
+        postalCodeEditText.append("")
+
+        val card = cardInputWidget.card
+        assertNull(card)
+
+        val paymentMethodCard = cardInputWidget.paymentMethodCard
+        assertNull(paymentMethodCard)
+    }
+
+    @Test
+    fun getCard_whenInputHasIncompleteCardNumber_returnsNull() {
         // This will be 242 4242 4242 4242
         cardNumberEditText.setText(VALID_VISA_WITH_SPACES.substring(1))
         expiryEditText.append("12")
@@ -364,9 +366,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @Test
     fun getCard_whenIncompleteCvCForVisa_returnsNull() {
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -382,9 +381,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun getCard_doesNotValidatePostalCode() {
         cardInputWidget.postalCodeEnabled = true
-
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         expiryEditText.append("12")
@@ -403,9 +399,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun getCard_when3DigitCvCForAmEx_withPostalCodeDisabled_returnsCard() {
         cardInputWidget.postalCodeEnabled = false
 
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -422,9 +415,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun getCard_when3DigitCvCForAmEx_withPostalCodeEnabled_returnsCard() {
         cardInputWidget.postalCodeEnabled = true
 
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -440,9 +430,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @Test
     fun getCard_whenIncompleteCvCForAmEx_returnsNull() {
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")
@@ -458,9 +445,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun getPaymentMethodCreateParams_shouldReturnExpectedObject() {
         cardInputWidget.postalCodeEnabled = true
-
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
 
         cardInputWidget.setCardNumber(VALID_VISA_NO_SPACES)
         cardInputWidget.setExpiryDate(12, 2030)
@@ -488,9 +472,6 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
 
     @Test
     fun getCard_whenIncompleteCvCForDiners_returnsNull() {
-        // The test will be testing the wrong variable after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         cardNumberEditText.setText(VALID_DINERS_CLUB_WITH_SPACES)
         expiryEditText.append("12")
         expiryEditText.append("50")

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -25,7 +25,6 @@ import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CARD
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CVC
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_EXPIRY
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_POSTAL
-import com.stripe.android.view.CardMultilineWidget.Companion.CARD_MULTILINE_TOKEN
 import java.util.Calendar
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -61,6 +60,9 @@ internal class CardMultilineWidgetTest {
 
     @BeforeTest
     fun setup() {
+        // The input date here will be invalid after 2050. Please update the test.
+        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
+
         CustomerSession.instance = mock()
 
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
@@ -139,9 +141,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getCard_whenInputIsValidVisaWithZip_returnsCardObjectWithLoggingToken() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
@@ -162,9 +161,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getCard_whenInputIsValidVisaButInputHasNoZip_returnsValidCard() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
@@ -176,9 +172,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getCard_whenInputIsValidVisaAndNoZipRequired_returnsFullCardAndExpectedLogging() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         noZipGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -198,9 +191,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getCard_whenInputIsValidAmexAndNoZipRequiredAnd4DigitCvc_returnsFullCardAndExpectedLogging() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         noZipGroup.cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -220,9 +210,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getCard_whenInputIsValidAmexAndNoZipRequiredAnd3DigitCvc_returnsFullCardAndExpectedLogging() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         noZipGroup.cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -242,9 +229,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun getPaymentMethodCreateParams_shouldReturnExpectedObject() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
@@ -272,10 +256,7 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun getPaymentMethodCard_whenInputIsValidVisaWithZip_returnsCardAndBillingDetails() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
+    fun paymentMethodCard_whenInputIsValidVisaWithZip_returnsCardAndBillingDetails() {
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
@@ -300,24 +281,46 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun getPaymentMethodCard_whenInputIsValidVisaButInputHasNoZip_returnsNull() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
+    fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsBlank_returnsNull() {
+        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.postalCodeRequired = true
 
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
         fullGroup.cvcEditText.append("123")
 
-        val card = noZipCardMultilineWidget.paymentMethodCard
-        assertNull(card)
+        assertNull(cardMultilineWidget.paymentMethodCreateParams)
     }
 
     @Test
-    fun getPaymentMethodCard_whenInputIsValidVisaAndNoZipRequired_returnsFullCard() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
+    fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsNotBlank_returnsNotNull() {
+        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.postalCodeRequired = false
 
+        fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append("123")
+
+        assertNotNull(cardMultilineWidget.paymentMethodCreateParams)
+    }
+
+    @Test
+    fun paymentMethodCreateParams_whenPostalCodeIsNotRequiredAndValueIsBlank_returnsNotNull() {
+        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.postalCodeRequired = false
+
+        fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append("123")
+
+        assertNotNull(cardMultilineWidget.paymentMethodCreateParams)
+    }
+
+    @Test
+    fun paymentMethodCard_whenInputIsValidVisaAndNoZipRequired_returnsFullCard() {
         noZipGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -337,10 +340,7 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun getPaymentMethodCard_whenInputIsValidAmexAndNoZipRequiredAnd4DigitCvc_returnsFullCard() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
+    fun paymentMethodCard_whenInputIsValidAmexAndNoZipRequiredAnd4DigitCvc_returnsFullCard() {
         noZipGroup.cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -362,10 +362,7 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun getPaymentMethodCard_whenInputIsValidAmexAndNoZipRequiredAnd3DigitCvc_returnsFullCard() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
+    fun paymentMethodCard_whenInputIsValidAmexAndNoZipRequiredAnd3DigitCvc_returnsFullCard() {
         noZipGroup.cardNumberEditText.setText(VALID_AMEX_WITH_SPACES)
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
@@ -394,9 +391,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun clear_whenZipRequiredAndAllFieldsEntered_clearsAllfields() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
         fullGroup.cardNumberEditText.setText(VALID_VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
@@ -413,11 +407,9 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun clear_whenFieldsInErrorState_clearsFieldsAndHidesErrors() {
-        // The input date here will be invalid after 2050. Please update the test.
-        assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-
-        var badVisa = VALID_VISA_WITH_SPACES.substring(VALID_VISA_WITH_SPACES.length - 1)
-        badVisa += 3 // Makes this 4242 4242 4242 4243
+        // Makes this 4242 4242 4242 4243
+        val badVisa = VALID_VISA_WITH_SPACES
+            .substring(VALID_VISA_WITH_SPACES.length - 1) + "3"
         fullGroup.cardNumberEditText.setText(badVisa)
 
         fullGroup.expiryDateEditText.append("01")
@@ -756,30 +748,21 @@ internal class CardMultilineWidgetTest {
         )
     }
 
-    internal class WidgetControlGroup(parentWidget: CardMultilineWidget) {
-        val cardNumberEditText: CardNumberEditText =
-            parentWidget.findViewById(R.id.et_card_number)
-        val cardInputLayout: TextInputLayout =
-            parentWidget.findViewById(R.id.tl_card_number)
-        val expiryDateEditText: ExpiryDateEditText =
-            parentWidget.findViewById(R.id.et_expiry)
-        val expiryInputLayout: TextInputLayout =
-            parentWidget.findViewById(R.id.tl_expiry)
-        val cvcEditText: StripeEditText =
-            parentWidget.findViewById(R.id.et_cvc)
-        val cvcInputLayout: TextInputLayout =
-            parentWidget.findViewById(R.id.tl_cvc)
-        val postalCodeEditText: StripeEditText =
-            parentWidget.findViewById(R.id.et_postal_code)
-        val postalCodeInputLayout: TextInputLayout =
-            parentWidget.findViewById(R.id.tl_postal_code)
-        val secondRowLayout: LinearLayout =
-            parentWidget.findViewById(R.id.second_row_layout)
+    internal class WidgetControlGroup(widget: CardMultilineWidget) {
+        val cardNumberEditText: CardNumberEditText = widget.findViewById(R.id.et_card_number)
+        val cardInputLayout: TextInputLayout = widget.findViewById(R.id.tl_card_number)
+        val expiryDateEditText: ExpiryDateEditText = widget.findViewById(R.id.et_expiry)
+        val expiryInputLayout: TextInputLayout = widget.findViewById(R.id.tl_expiry)
+        val cvcEditText: StripeEditText = widget.findViewById(R.id.et_cvc)
+        val cvcInputLayout: TextInputLayout = widget.findViewById(R.id.tl_cvc)
+        val postalCodeEditText: StripeEditText = widget.findViewById(R.id.et_postal_code)
+        val postalCodeInputLayout: TextInputLayout = widget.findViewById(R.id.tl_postal_code)
+        val secondRowLayout: LinearLayout = widget.findViewById(R.id.second_row_layout)
     }
 
     private companion object {
         // Every Card made by the CardInputView should have the card widget token.
-        private val EXPECTED_LOGGING_ARRAY = arrayOf(CARD_MULTILINE_TOKEN)
+        private val EXPECTED_LOGGING_ARRAY = arrayOf("CardMultilineView")
 
         private val EMPTY_WATCHER = object : StripeTextWatcher() {}
     }


### PR DESCRIPTION
## Summary
By default, postal code is an optional field in `CardInputWidget`
and `CardMultilineWidget` because some countries do not have
postal codes.

For apps that are certain their customers are from a country
that has a postal code (e.g. US), postal code can be set to a
required field. If required, the postal code value must be
non-blank. No other validation is applied.

If the postal code field is not enabled (i.e. it is not visible),
then the postal code will never be required.

Note that because some countries do not have postal codes, requiring
a postal code will prevent users with cards from those countries
from submitting the form successfully.

Postal code can either be required via XML:
```
<com.stripe.android.view.CardInputWidget
    app:shouldRequirePostalCode="true" />

<com.stripe.android.view.CardMultilineWidget
    app:shouldRequirePostalCode="true" />
```

or code:
```
val cardWidget: CardInlineWidget = ...
cardWidget.postalCodeRequired = true

val cardWidget: CardMultilineWidget = ...
cardWidget.postalCodeRequired = true
```

## Motivation
Fixes #2111

## Testing
- Added unit tests
- Tested in example app
- Tested with TalkBack
