### PR TITLE
Fix bug in highlighting StripeEditText fields with errors

### DIFF
--- a/example/res/layout/card_token_activity.xml
+++ b/example/res/layout/card_token_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -27,7 +28,8 @@
         <com.stripe.android.view.CardInputWidget
             android:id="@+id/card_input_widget"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            app:cardTextErrorColor="@android:color/holo_red_dark"/>
 
         <Button
             android:id="@+id/create_token_button"

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -657,7 +657,7 @@ class CardInputWidget @JvmOverloads constructor(
             cardNumberEditText.hint = it
         }
 
-        standardFields.forEach { it.setErrorColor(errorColorInt) }
+        allFields.forEach { it.setErrorColor(errorColorInt) }
 
         cardNumberEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -61,6 +61,7 @@ class CvcEditText @JvmOverloads constructor(
 
         addTextChangedListener(object : StripeTextWatcher() {
             override fun afterTextChanged(s: Editable?) {
+                shouldShowError = false
                 if (cardBrand.isMaxCvc(rawCvcValue)) {
                     completionCallback()
                 }

--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import android.content.Context
+import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
 import android.text.method.DigitsKeyListener
@@ -18,6 +19,12 @@ class PostalCodeEditText @JvmOverloads constructor(
         setErrorMessage(resources.getString(R.string.invalid_zip))
         maxLines = 1
         configureForUs()
+
+        addTextChangedListener(object : StripeTextWatcher() {
+            override fun afterTextChanged(s: Editable?) {
+                shouldShowError = false
+            }
+        })
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -44,19 +44,22 @@ open class StripeEditText @JvmOverloads constructor(
      * the text in an error color determined by the original text color.
      */
     var shouldShowError: Boolean = false
-        set(shouldShowError) = if (errorMessage != null) {
-            val errorMessage = errorMessage.takeIf { shouldShowError }
-            errorMessageListener?.displayErrorMessage(errorMessage)
-            field = shouldShowError
-        } else {
-            field = shouldShowError
-            if (this.shouldShowError) {
-                setTextColor(errorColor ?: defaultErrorColor)
-            } else {
-                setTextColor(cachedColorStateList)
+        set(shouldShowError) {
+            errorMessage?.let {
+                errorMessageListener?.displayErrorMessage(it.takeIf { shouldShowError })
             }
 
-            refreshDrawableState()
+            if (field != shouldShowError) {
+                // only update the view's UI if the property's value is changing
+                if (shouldShowError) {
+                    setTextColor(errorColor ?: defaultErrorColor)
+                } else {
+                    setTextColor(cachedColorStateList)
+                }
+                refreshDrawableState()
+            }
+
+            field = shouldShowError
         }
 
     internal var errorMessage: String? = null

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.R
 import com.stripe.android.testharness.ViewTestUtils
@@ -12,7 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
@@ -24,11 +24,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StripeEditTextTest {
 
-    @Mock
-    private lateinit var afterTextChangedListener: StripeEditText.AfterTextChangedListener
-    @Mock
-    private lateinit var deleteEmptyListener: StripeEditText.DeleteEmptyListener
-    private lateinit var editText: StripeEditText
+    private val afterTextChangedListener: StripeEditText.AfterTextChangedListener = mock()
+    private val deleteEmptyListener: StripeEditText.DeleteEmptyListener = mock()
+    private val editText: StripeEditText by lazy {
+        StripeEditText(context)
+    }
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
@@ -36,8 +36,6 @@ class StripeEditTextTest {
     fun setup() {
         MockitoAnnotations.initMocks(this)
 
-        // Note that the CVC EditText is a StripeEditText
-        editText = StripeEditText(context)
         editText.setText("")
         editText.setDeleteEmptyListener(deleteEmptyListener)
         editText.setAfterTextChangedListener(afterTextChangedListener)
@@ -54,7 +52,8 @@ class StripeEditTextTest {
     fun addText_callsAppropriateListeners() {
         editText.append("1")
         verifyNoMoreInteractions(deleteEmptyListener)
-        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener).onTextChanged("1")
+        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener)
+            .onTextChanged("1")
     }
 
     @Test
@@ -64,13 +63,15 @@ class StripeEditTextTest {
 
         ViewTestUtils.sendDeleteKeyEvent(editText)
         verifyNoMoreInteractions(deleteEmptyListener)
-        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener).onTextChanged("")
+        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener)
+            .onTextChanged("")
     }
 
     @Test
     fun deleteText_whenSelectionAtBeginningButLengthNonZero_doesNotCallListener() {
         editText.append("12")
-        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener).onTextChanged("12")
+        verify<StripeEditText.AfterTextChangedListener>(afterTextChangedListener)
+            .onTextChanged("12")
         editText.setSelection(0)
         ViewTestUtils.sendDeleteKeyEvent(editText)
         verifyNoMoreInteractions(deleteEmptyListener)
@@ -81,6 +82,7 @@ class StripeEditTextTest {
     fun deleteText_whenDeletingMultipleItems_onlyCallsListenerOneTime() {
         editText.append("123")
         // Doing this four times because we need to delete all three items, then jump back.
+
         for (i in 0..3) {
             ViewTestUtils.sendDeleteKeyEvent(editText)
         }
@@ -90,8 +92,7 @@ class StripeEditTextTest {
 
     @Test
     fun getDefaultErrorColorInt_onDarkTheme_returnsDarkError() {
-        editText.setTextColor(context.resources
-            .getColor(android.R.color.primary_text_dark))
+        editText.setTextColor(ContextCompat.getColor(context, android.R.color.primary_text_dark))
         @ColorInt val colorInt = editText.defaultErrorColorInt
         @ColorInt val expectedErrorInt = ContextCompat.getColor(context,
             R.color.stripe_error_text_dark_theme)
@@ -100,11 +101,10 @@ class StripeEditTextTest {
 
     @Test
     fun getDefaultErrorColorInt_onLightTheme_returnsLightError() {
-        editText.setTextColor(context.resources
-            .getColor(android.R.color.primary_text_light))
+        editText.setTextColor(ContextCompat.getColor(context, android.R.color.primary_text_light))
         @ColorInt val colorInt = editText.defaultErrorColorInt
-        @ColorInt val expectedErrorInt = ContextCompat.getColor(context,
-            R.color.stripe_error_text_light_theme)
+        @ColorInt val expectedErrorInt =
+            ContextCompat.getColor(context, R.color.stripe_error_text_light_theme)
         assertEquals(expectedErrorInt, colorInt)
     }
 
@@ -128,5 +128,16 @@ class StripeEditTextTest {
         editText.shouldShowError = true
         assertEquals(ContextCompat.getColor(context, R.color.stripe_error_text_light_theme),
             editText.textColors.defaultColor)
+    }
+
+    @Test
+    fun shouldShowError_whenChanged_changesTextColor() {
+        editText.errorMessage = "There was an error!"
+
+        editText.shouldShowError = true
+        assertEquals(-1369050, editText.currentTextColor)
+
+        editText.shouldShowError = false
+        assertEquals(-570425344, editText.currentTextColor)
     }
 }


### PR DESCRIPTION
## Summary
The text color was not being updated correctly. It should
be updated whenever `StripeEditText#shouldShowError`'s
value changes.

| Before | After |
|-------------------------------|-----------------|
| ![Screenshot_1580317780](https://user-images.githubusercontent.com/45020849/73381108-354bb080-4293-11ea-83ad-0ae715d41760.png) | ![Screenshot_1580317672](https://user-images.githubusercontent.com/45020849/73381138-409edc00-4293-11ea-8145-703b1c676211.png) |

## Motivation
ANDROID-480

## Testing
- Add tests
- Manually verify
