### PR TITLE
Add mandate data to confirm params whenever it is specified

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
@@ -113,6 +112,10 @@ data class ConfirmPaymentIntentParams internal constructor(
         ).plus(
             mandateId?.let { mapOf(PARAM_MANDATE_ID to it) }.orEmpty()
         ).plus(
+            mandateDataParams?.let {
+                mapOf(ConfirmStripeIntentParams.PARAM_MANDATE_DATA to it)
+            }.orEmpty()
+        ).plus(
             returnUrl?.let { mapOf(PARAM_RETURN_URL to it) }.orEmpty()
         ).plus(
             paymentMethodOptions?.let {
@@ -129,11 +132,7 @@ data class ConfirmPaymentIntentParams internal constructor(
         get() {
             return when {
                 paymentMethodCreateParams != null -> {
-                    mapOf(
-                        PARAM_PAYMENT_METHOD_DATA to paymentMethodCreateParams.toParamMap()
-                    ).plus(
-                        mandateDataParams?.let { mapOf(PARAM_MANDATE_DATA to it) }.orEmpty()
-                    )
+                    mapOf(PARAM_PAYMENT_METHOD_DATA to paymentMethodCreateParams.toParamMap())
                 }
                 paymentMethodId != null -> {
                     mapOf(PARAM_PAYMENT_METHOD_ID to paymentMethodId)

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -53,6 +53,8 @@ data class ConfirmSetupIntentParams internal constructor(
             returnUrl?.let { mapOf(PARAM_RETURN_URL to it) }.orEmpty()
         ).plus(
             mandateId?.let { mapOf(PARAM_MANDATE_ID to it) }.orEmpty()
+        ).plus(
+            mandateDataParams?.let { mapOf(PARAM_MANDATE_DATA to it) }.orEmpty()
         ).plus(paymentMethodParamMap)
     }
 
@@ -60,11 +62,7 @@ data class ConfirmSetupIntentParams internal constructor(
         get() {
             return when {
                 paymentMethodCreateParams != null -> {
-                    mapOf(
-                        PARAM_PAYMENT_METHOD_DATA to paymentMethodCreateParams.toParamMap()
-                    ).plus(
-                        mandateDataParams?.let { mapOf(PARAM_MANDATE_DATA to it) }.orEmpty()
-                    )
+                    mapOf(PARAM_PAYMENT_METHOD_DATA to paymentMethodCreateParams.toParamMap())
                 }
                 paymentMethodId != null -> {
                     mapOf(PARAM_PAYMENT_METHOD_ID to paymentMethodId)

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -263,6 +263,32 @@ class ConfirmPaymentIntentParamsTest {
     }
 
     @Test
+    fun create_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "save_payment_method" to false,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "ip_address" to "127.0.0.1",
+                        "user_agent" to "my_user_agent"
+                    )
+                )
+            ),
+            "payment_method" to "pm_12345"
+        )
+        val actualParams =
+            ConfirmPaymentIntentParams.createWithPaymentMethodId(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodId = "pm_12345",
+                mandateData = MandateDataParamsFixtures.DEFAULT
+            ).toParamMap()
+        assertEquals(expectedParams, actualParams)
+    }
+
+    @Test
     fun create_withPaymentMethodOptions() {
         val params = ConfirmPaymentIntentParams(
             paymentMethodId = "pm_123",

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -127,6 +127,31 @@ class ConfirmSetupIntentParamsTest {
     }
 
     @Test
+    fun create_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
+        val expectedParams = mapOf(
+            "client_secret" to CLIENT_SECRET,
+            "use_stripe_sdk" to false,
+            "mandate_data" to mapOf(
+                "customer_acceptance" to mapOf(
+                    "type" to "online",
+                    "online" to mapOf(
+                        "ip_address" to "127.0.0.1",
+                        "user_agent" to "my_user_agent"
+                    )
+                )
+            ),
+            "payment_method" to "pm_12345"
+        )
+
+        val actualParams = ConfirmSetupIntentParams.create(
+            clientSecret = CLIENT_SECRET,
+            paymentMethodId = "pm_12345",
+            mandateData = MandateDataParamsFixtures.DEFAULT
+        ).toParamMap()
+        assertEquals(expectedParams, actualParams)
+    }
+
+    @Test
     fun create_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
         val expectedParams = mapOf(
             "client_secret" to CLIENT_SECRET,


### PR DESCRIPTION
## Motivation
Mandate data was only being included when a new payment method
was being created, not when a payment method id was used.

## Testing
Added unit tests