### PR TITLE
Update Jetpack Lifecycle to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
     javaAnnotationVersion = '1.0'
     kotlinVersion = '1.3.61'
     kotlinCoroutinesVersion = '1.3.0'
+    androidLifecycleVersion = '2.2.0'
     espressoVersion = '3.2.0'
     ktlintVersion = '0.36.0'
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -42,8 +42,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.1.0"
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel:$androidLifecycleVersion"
     implementation 'com.google.android.material:material:1.1.0-rc02'
 
     implementation 'com.google.android.gms:play-services-wallet:18.0.0'

--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -6,7 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
@@ -25,7 +25,7 @@ import kotlinx.android.synthetic.main.activity_card_sources.*
  */
 class CreateCardSourceActivity : AppCompatActivity() {
     private val viewModel: SourceViewModel by lazy {
-        ViewModelProviders.of(this)[SourceViewModel::class.java]
+        ViewModelProvider(this)[SourceViewModel::class.java]
     }
     private val sourcesAdapter: SourcesAdapter by lazy {
         SourcesAdapter()

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.ApiResultCallback
@@ -41,7 +41,7 @@ class CreateCardTokenActivity : AppCompatActivity() {
                 orientation = LinearLayoutManager.VERTICAL
             }
 
-        val viewModel = ViewModelProviders.of(
+        val viewModel = ViewModelProvider(
             this
         )[CreateCardTokenViewModel::class.java]
 

--- a/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
@@ -6,7 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
@@ -19,7 +19,7 @@ import kotlinx.android.synthetic.main.activity_klarna_source.*
 
 class KlarnaSourceActivity : AppCompatActivity() {
     private val viewModel: SourceViewModel by lazy {
-        ViewModelProviders.of(this)[SourceViewModel::class.java]
+        ViewModelProvider(this)[SourceViewModel::class.java]
     }
 
     private val stripe: Stripe by lazy {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -18,8 +18,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.1.0"
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel:$androidLifecycleVersion"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 
     // Api for this import because we use reflection to alter TextInputLayout

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -13,7 +13,7 @@ import androidx.annotation.StringRes
 import androidx.core.text.util.LinkifyCompat
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
@@ -60,7 +60,7 @@ class AddPaymentMethodActivity : StripeActivity() {
     }
 
     private val viewModel: AddPaymentMethodViewModel by lazy {
-        ViewModelProviders.of(this, AddPaymentMethodViewModel.Factory(
+        ViewModelProvider(this, AddPaymentMethodViewModel.Factory(
             stripe, customerSession, args
         ))[AddPaymentMethodViewModel::class.java]
     }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -13,7 +13,7 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.widget.ImageViewCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -52,7 +52,7 @@ internal class AddPaymentMethodFpxView @JvmOverloads internal constructor(
             itemAnimator = DefaultItemAnimator()
         }
 
-        viewModel = ViewModelProviders.of(
+        viewModel = ViewModelProvider(
             activity,
             FpxViewModel.Factory(activity.application)
         ).get(FpxViewModel::class.java)

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -9,7 +9,7 @@ import android.view.MenuItem
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.Logger
 import com.stripe.android.PaymentAuthWebViewStarter
@@ -34,7 +34,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
             return
         }
 
-        viewModel = ViewModelProviders.of(
+        viewModel = ViewModelProvider(
             this, PaymentAuthWebViewActivityViewModel.Factory(args)
         )[PaymentAuthWebViewActivityViewModel::class.java]
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession.Companion.EXTRA_PAYMENT_SESSION_DATA
@@ -44,7 +44,7 @@ class PaymentFlowActivity : StripeActivity() {
         viewStub.layoutResource = R.layout.activity_shipping_flow
         viewStub.inflate()
 
-        viewModel = ViewModelProviders.of(
+        viewModel = ViewModelProvider(
             this,
             PaymentFlowViewModel.Factory(customerSession, args.paymentSessionData)
         )[PaymentFlowViewModel::class.java]

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -7,7 +7,7 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession.Companion.TOKEN_PAYMENT_SESSION
@@ -46,7 +46,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
     }
 
     private val viewModel: PaymentMethodsViewModel by lazy {
-        ViewModelProviders.of(
+        ViewModelProvider(
             this,
             PaymentMethodsViewModel.Factory(customerSession, args.initialPaymentMethodId)
         )[PaymentMethodsViewModel::class.java]


### PR DESCRIPTION
## Summary
- `ViewModelProviders.of()` has been deprecated in favor of `ViewModelProvider`
- Remove unused `androidx.lifecycle:lifecycle-extensions`

See the [release notes](https://developer.android.com/jetpack/androidx/releases/lifecycle#version_220_3) for more details

## Testing
Manually verified
