### PR TITLE
Refactor token creation logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeNetworkUtils.kt
@@ -2,7 +2,6 @@ package com.stripe.android
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.model.Card
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 
@@ -15,21 +14,6 @@ internal class StripeNetworkUtils @VisibleForTesting constructor(
     constructor(context: Context) : this(
         UidParamsFactory.create(context)
     )
-
-    /**
-     * A utility function to map the fields of a [Card] object into a [Map] we
-     * can use in network communications.
-     *
-     * @param card the [Card] to be read
-     * @return a [Map] containing the appropriate values read from the card
-     */
-    fun createCardTokenParams(card: Card): Map<String, Any> {
-        return card.toParamMap()
-            // We store the logging items in this field, which is extracted from the parameters
-            // sent to the API.
-            .plus(AnalyticsDataFactory.FIELD_PRODUCT_USAGE to card.loggingTokens)
-            .plus(uidParamsFactory.createParams())
-    }
 
     internal fun paramsWithUid(intentParams: Map<String, *>): Map<String, *> {
         return when {

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
+import com.stripe.android.model.TokenParams
 import org.json.JSONException
 
 /**
@@ -120,9 +121,8 @@ internal interface StripeRepository {
     @Throws(AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class, APIException::class, CardException::class)
     fun createToken(
-        tokenParams: Map<String, *>,
-        options: ApiRequest.Options,
-        @Token.TokenType tokenType: String
+        tokenParams: TokenParams,
+        options: ApiRequest.Options
     ): Token?
 
     @Throws(AuthenticationException::class, InvalidRequestException::class,

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
@@ -35,7 +35,7 @@ data class AccountParams internal constructor(
      * See [BusinessTypeParams]
      */
     private val businessData: Map<String, @RawValue Any>? = null
-) : StripeParamsModel, Parcelable {
+) : TokenParams(Token.TokenType.ACCOUNT) {
 
     /**
      * Create a string-keyed map representing this object that is ready to be sent over the network.

--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
@@ -96,7 +96,7 @@ data class BankAccount internal constructor(
      * [status](https://stripe.com/docs/api/customer_bank_accounts/object#customer_bank_account_object-status)
      */
     val status: Status? = null
-) : StripeModel, StripeParamsModel {
+) : StripeModel, TokenParams(Token.TokenType.BANK_ACCOUNT) {
 
     @Retention(AnnotationRetention.SOURCE)
     @StringDef(BankAccountType.COMPANY, BankAccountType.INDIVIDUAL)

--- a/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model
 
-import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -54,7 +53,7 @@ data class BankAccountTokenParams @JvmOverloads constructor(
      * [bank_account.routing_number](https://stripe.com/docs/api/tokens/create_bank_account#create_bank_account_token-bank_account-routing_number)
      */
     private val routingNumber: String? = null
-) : StripeParamsModel, Parcelable {
+) : TokenParams(Token.TokenType.BANK_ACCOUNT) {
     enum class Type(internal val code: String) {
         Individual("individual"),
         Company("company");

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -180,7 +180,7 @@ data class Card internal constructor(
      */
     override val id: String?,
 
-    internal val loggingTokens: MutableList<String> = mutableListOf(),
+    internal val loggingTokens: Set<String> = emptySet(),
 
     /**
      * @return If the card number is tokenized, this is the method that was used.
@@ -197,7 +197,7 @@ data class Card internal constructor(
      * [API Reference](https://stripe.com/docs/api/cards/object#card_object-metadata)
      */
     val metadata: Map<String, String>?
-) : StripeModel, StripePaymentSource, StripeParamsModel {
+) : StripeModel, StripePaymentSource, TokenParams(Token.TokenType.CARD, loggingTokens) {
 
     @Retention(AnnotationRetention.SOURCE)
     @StringDef(FundingType.CREDIT, FundingType.DEBIT, FundingType.PREPAID, FundingType.UNKNOWN)
@@ -408,7 +408,7 @@ data class Card internal constructor(
         private var id: String? = null
         private var tokenizationMethod: TokenizationMethod? = null
         private var metadata: Map<String, String>? = null
-        private var loggingTokens: List<String>? = null
+        private var loggingTokens: Set<String>? = null
 
         fun name(name: String?): Builder = apply {
             this.name = name
@@ -491,7 +491,7 @@ data class Card internal constructor(
             this.metadata = metadata
         }
 
-        fun loggingTokens(loggingTokens: List<String>): Builder = apply {
+        fun loggingTokens(loggingTokens: Set<String>): Builder = apply {
             this.loggingTokens = loggingTokens
         }
 
@@ -528,7 +528,7 @@ data class Card internal constructor(
                 id = id.takeUnless { it.isNullOrBlank() },
                 tokenizationMethod = tokenizationMethod,
                 metadata = metadata,
-                loggingTokens = loggingTokens.orEmpty().toMutableList()
+                loggingTokens = loggingTokens.orEmpty()
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.model
 
-import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class CvcTokenParams(private val cvc: String) : StripeParamsModel, Parcelable {
+data class CvcTokenParams(
+    private val cvc: String
+) : TokenParams(Token.TokenType.CVC_UPDATE) {
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
             Token.TokenType.CVC_UPDATE to mapOf("cvc" to cvc)

--- a/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
@@ -150,7 +150,7 @@ data class PersonTokenParams(
      * [person.verification](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification)
      */
     val verification: Verification? = null
-) : StripeParamsModel, Parcelable {
+) : TokenParams(Token.TokenType.BANK_ACCOUNT) {
     override fun toParamMap(): Map<String, Any> {
         return mapOf(PARAM_PERSON to
             listOf(

--- a/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
@@ -1,12 +1,11 @@
 package com.stripe.android.model
 
-import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class PiiTokenParams(
     private val personalId: String
-) : StripeParamsModel, Parcelable {
+) : TokenParams(Token.TokenType.PII) {
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
             Token.TokenType.PII to mapOf("personal_id_number" to personalId)

--- a/stripe/src/main/java/com/stripe/android/model/TokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/TokenParams.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+
+abstract class TokenParams(
+    @Token.TokenType internal val tokenType: String,
+    /**
+     * The SDK components that were involved in the creation of this token
+     */
+    internal val attribution: Collection<String> = emptySet()
+) : StripeParamsModel, Parcelable

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -216,7 +216,7 @@ class CardInputWidget @JvmOverloads constructor(
                 else -> {
                     return Card.Builder(cardNumber, cardDate.first, cardDate.second, cvcValue)
                         .addressZip(postalCodeValue)
-                        .loggingTokens(listOf(LOGGING_TOKEN))
+                        .loggingTokens(setOf(LOGGING_TOKEN))
                 }
             }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -178,7 +178,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
             return Card.Builder(cardNumber, cardDate.first, cardDate.second, cvcValue)
                 .addressZip(postalCode)
-                .loggingTokens(listOf(CARD_MULTILINE_TOKEN))
+                .loggingTokens(setOf(CARD_MULTILINE_TOKEN))
         }
 
     private val cardNumber: String?

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
+import com.stripe.android.model.TokenParams
 
 internal abstract class AbsFakeStripeRepository : StripeRepository {
 
@@ -110,9 +111,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     }
 
     override fun createToken(
-        tokenParams: Map<String, *>,
-        options: ApiRequest.Options,
-        tokenType: String
+        tokenParams: TokenParams,
+        options: ApiRequest.Options
     ): Token? {
         return null
     }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -14,14 +14,15 @@ internal class ApiRequestTest {
 
     @Test
     fun url_withCardData_createsProperQueryString() {
-        val cardMap = NETWORK_UTILS.createCardTokenParams(CardFixtures.MINIMUM_CARD)
+        val cardMap = CardFixtures.MINIMUM_CARD.toParamMap()
+            .plus(NETWORK_UTILS.createUidParams())
         val url = FACTORY.createGet(
             StripeApiRepository.sourcesUrl,
             OPTIONS,
             cardMap
         ).url
 
-        val expectedValue = "https://api.stripe.com/v1/sources?muid=BF3BF4D775100923AAAFA82884FB759001162E28&product_usage=&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123"
+        val expectedValue = "https://api.stripe.com/v1/sources?muid=BF3BF4D775100923AAAFA82884FB759001162E28&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123"
         assertEquals(expectedValue, url)
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
@@ -5,12 +5,10 @@ import com.stripe.android.model.CardFixtures
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
-import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 /**
@@ -22,11 +20,6 @@ class StripeNetworkUtilsTest {
     private val networkUtils = StripeNetworkUtils(
         UidParamsFactory("com.example.app", FakeUidSupplier())
     )
-
-    @BeforeTest
-    fun setup() {
-        MockitoAnnotations.initMocks(this)
-    }
 
     @Test
     fun paramsFromCard_mapsCorrectFields() {
@@ -83,7 +76,7 @@ class StripeNetworkUtilsTest {
     }
 
     private fun getCardTokenParamData(card: Card): Map<String, Any>? {
-        val cardTokenParams = networkUtils.createCardTokenParams(card)
+        val cardTokenParams = card.toParamMap()
         return cardTokenParams["card"] as Map<String, Any>?
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -7,19 +7,17 @@ import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.view.AuthActivityStarter
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -29,22 +27,11 @@ class StripePaymentAuthTest {
         ApplicationProvider.getApplicationContext<Context>()
     }
 
-    @Mock
-    private lateinit var activity: Activity
-    @Mock
-    private lateinit var paymentController: PaymentController
-    @Mock
-    private lateinit var paymentCallback: ApiResultCallback<PaymentIntentResult>
-    @Mock
-    private lateinit var setupCallback: ApiResultCallback<SetupIntentResult>
-
-    private lateinit var hostArgumentCaptor: KArgumentCaptor<AuthActivityStarter.Host>
-
-    @BeforeTest
-    fun setup() {
-        MockitoAnnotations.initMocks(this)
-        hostArgumentCaptor = argumentCaptor()
-    }
+    private val activity: Activity = mock()
+    private val paymentController: PaymentController = mock()
+    private val paymentCallback: ApiResultCallback<PaymentIntentResult> = mock()
+    private val setupCallback: ApiResultCallback<SetupIntentResult> = mock()
+    private val hostArgumentCaptor: KArgumentCaptor<AuthActivityStarter.Host> = argumentCaptor()
 
     @Test
     fun confirmPayment_shouldConfirmAndAuth() {
@@ -142,7 +129,6 @@ class StripePaymentAuthTest {
                 stripeApiRequestExecutor = ApiRequestExecutor.Default(),
                 fireAndForgetRequestExecutor = FakeFireAndForgetRequestExecutor()
             ),
-            StripeNetworkUtils(context),
             paymentController,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, null
         )

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1400,7 +1400,6 @@ public class StripeTest {
         final StripeRepository stripeRepository = createStripeRepository(fireAndForgetRequestExecutor);
         return new Stripe(
                 stripeRepository,
-                new StripeNetworkUtils(context),
                 StripePaymentController.create(context, stripeRepository),
                 publishableKey,
                 null
@@ -1413,7 +1412,6 @@ public class StripeTest {
                 new FakeFireAndForgetRequestExecutor());
         return new Stripe(
                 stripeRepository,
-                new StripeNetworkUtils(context),
                 StripePaymentController.create(context, stripeRepository),
                 NON_LOGGING_PK,
                 null,

--- a/stripe/src/test/java/com/stripe/android/model/CardFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardFixtures.kt
@@ -126,4 +126,8 @@ object CardFixtures {
         }
         """.trimIndent()
     )))
+
+    internal val CARD_WITH_ATTRIBUTION = Card.Builder()
+        .loggingTokens(setOf("CardInputView"))
+        .build()
 }

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.kt
@@ -585,7 +585,7 @@ class CardTest {
     fun toBuilder_withLoggingToken_whenUnchanged_isEquals() {
         val card = requireNotNull(CardJsonParser().parse(JSON_CARD_USD))
         card.toBuilder()
-            .loggingTokens(listOf("hello"))
+            .loggingTokens(setOf("hello"))
 
         assertEquals(card, card.toBuilder().build())
     }

--- a/stripe/src/test/java/com/stripe/android/model/TokenFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenFixtures.kt
@@ -6,7 +6,7 @@ import org.json.JSONObject
 internal object TokenFixtures {
     private val PARSER = TokenJsonParser()
 
-    val CARD_TOKEN = requireNotNull(PARSER.parse(JSONObject(
+    val CARD_TOKEN_JSON = JSONObject(
         """
         {
             "id": "tok_189fi32eZvKYlo2Ct0KZvU5Y",
@@ -41,9 +41,11 @@ internal object TokenFixtures {
             "used": false
         }
         """.trimIndent()
-    )))
+    )
 
-    val BANK_TOKEN = requireNotNull(PARSER.parse(JSONObject(
+    val CARD_TOKEN = requireNotNull(PARSER.parse(CARD_TOKEN_JSON))
+
+    val BANK_TOKEN_JSON = JSONObject(
         """
         {
             "id": "btok_9xJAbronBnS9bH",
@@ -68,5 +70,7 @@ internal object TokenFixtures {
             "used": false
         }
         """.trimIndent()
-    )))
+    )
+
+    val BANK_TOKEN = requireNotNull(PARSER.parse(BANK_TOKEN_JSON))
 }


### PR DESCRIPTION
## Summary
- Create `TokenParams` superclass with
  `tokenType` and `attribution` properties
- Make `StripeApiRepository#createToken()` take a
  `tokenParams: TokenParams` instead of
  `tokenParams: Map<String, *>`, which avoids
  awkward casting in that method
- Remove `StripeNetworkUtils#createCardTokenParams()`

## Motivation
Make token creation logic similar to how it
works for other objects. This greatly simplifies the
logic and removes the need to add analytics data
to the params map.

## Testing
Created unit tests
Manually tested
