### PR TITLE
Add payment method type in analytics

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
+    testImplementation 'com.google.truth:truth:1.0.1'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.StringDef
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
 import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent
@@ -140,11 +141,13 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     internal fun createPaymentMethodCreationParams(
         publishableKey: String,
         paymentMethodId: String?,
-        productUsageTokens: Set<String>? = null
+        paymentMethodType: PaymentMethod.Type?,
+        productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.PaymentMethodCreate,
             publishableKey,
+            sourceType = paymentMethodType?.code,
             productUsageTokens = productUsageTokens,
             extraParams = paymentMethodId?.let {
                 mapOf(FIELD_PAYMENT_METHOD_ID to it)

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -418,6 +418,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 analyticsDataFactory.createPaymentMethodCreationParams(
                     options.apiKey,
                     paymentMethod?.id,
+                    paymentMethod?.type,
                     productUsageTokens = paymentMethodCreateParams.attribution
                 ),
                 options.apiKey

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
@@ -87,19 +88,32 @@ class AnalyticsDataFactoryTest {
 
     @Test
     fun getPaymentMethodCreationParams() {
-        val loggingParams = analyticsDataFactory
-            .createPaymentMethodCreationParams(API_KEY, "pm_12345")
-        assertNotNull(loggingParams)
-        assertEquals(API_KEY,
-            loggingParams[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
-        assertEquals("pm_12345",
-            loggingParams[AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID])
-        assertEquals(
-            AnalyticsEvent.PaymentMethodCreate.toString(),
-            loggingParams[AnalyticsDataFactory.FIELD_EVENT]
+        val expectedParams = mapOf(
+            "analytics_ua" to "analytics.stripe_android-1.0",
+            "event" to "stripe_android.payment_method_creation",
+            "publishable_key" to "pk_abc123",
+            "os_name" to "REL",
+            "os_release" to "9",
+            "os_version" to 28,
+            "device_type" to "unknown_Android_robolectric",
+            "bindings_version" to "13.1.3",
+            "app_name" to "com.stripe.android.test",
+            "app_version" to 0,
+            "product_usage" to ATTRIBUTION.toList(),
+            "source_type" to "card",
+            "payment_method_id" to "pm_12345"
         )
-        assertEquals(AnalyticsDataFactory.ANALYTICS_UA,
-            loggingParams[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
+
+        val actualParams = analyticsDataFactory
+            .createPaymentMethodCreationParams(
+                API_KEY,
+                "pm_12345",
+                PaymentMethod.Type.Card,
+                ATTRIBUTION
+            )
+
+        assertThat(actualParams)
+            .isEqualTo(expectedParams)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Add payment method type to `source_type` field
Add `com.google.truth:truth` library to improve testing

## Motivation
Improve analytics

## Testing
Add unit tests
