### PR TITLE
Create EphemeralOperation sealed class

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -172,7 +172,10 @@ class CustomerSession @VisibleForTesting internal constructor(
      */
     fun updateCurrentCustomer(listener: CustomerRetrievalListener) {
         customer = null
-        startOperation(null, null, listener)
+        startOperation(
+            EphemeralOperation.RetrieveKey(operationIdFactory.create()),
+            listener
+        )
     }
 
     /**
@@ -198,11 +201,14 @@ class CustomerSession @VisibleForTesting internal constructor(
         @SourceType sourceType: String,
         listener: SourceRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_SOURCE to sourceId,
-            KEY_SOURCE_TYPE to sourceType
+        startOperation(
+            EphemeralOperation.Customer.AddSource(
+                sourceId = sourceId,
+                sourceType = sourceType,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_ADD_SOURCE, arguments, listener)
     }
 
     /**
@@ -216,10 +222,13 @@ class CustomerSession @VisibleForTesting internal constructor(
         sourceId: String,
         listener: SourceRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_SOURCE to sourceId
+        startOperation(
+            EphemeralOperation.Customer.DeleteSource(
+                sourceId = sourceId,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_DELETE_SOURCE, arguments, listener)
     }
 
     /**
@@ -233,10 +242,13 @@ class CustomerSession @VisibleForTesting internal constructor(
         paymentMethodId: String,
         listener: PaymentMethodRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_PAYMENT_METHOD to paymentMethodId
+        startOperation(
+            EphemeralOperation.Customer.AttachPaymentMethod(
+                paymentMethodId = paymentMethodId,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_ATTACH_PAYMENT_METHOD, arguments, listener)
     }
 
     /**
@@ -250,10 +262,13 @@ class CustomerSession @VisibleForTesting internal constructor(
         paymentMethodId: String,
         listener: PaymentMethodRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_PAYMENT_METHOD to paymentMethodId
+        startOperation(
+            EphemeralOperation.Customer.DetachPaymentMethod(
+                paymentMethodId = paymentMethodId,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_DETACH_PAYMENT_METHOD, arguments, listener)
     }
 
     /**
@@ -268,10 +283,13 @@ class CustomerSession @VisibleForTesting internal constructor(
         paymentMethodType: PaymentMethod.Type,
         listener: PaymentMethodsRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_PAYMENT_METHOD_TYPE to paymentMethodType.code
+        startOperation(
+            EphemeralOperation.Customer.PaymentMethods(
+                type = paymentMethodType,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_GET_PAYMENT_METHODS, arguments, listener)
     }
 
     /**
@@ -283,10 +301,13 @@ class CustomerSession @VisibleForTesting internal constructor(
         shippingInformation: ShippingInformation,
         listener: CustomerRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_SHIPPING_INFO to shippingInformation
+        startOperation(
+            EphemeralOperation.Customer.UpdateShipping(
+                shippingInformation = shippingInformation,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_SET_CUSTOMER_SHIPPING_INFO, arguments, listener)
     }
 
     /**
@@ -301,21 +322,22 @@ class CustomerSession @VisibleForTesting internal constructor(
         @SourceType sourceType: String,
         listener: CustomerRetrievalListener
     ) {
-        val arguments = mapOf(
-            KEY_SOURCE to sourceId,
-            KEY_SOURCE_TYPE to sourceType
+        startOperation(
+            EphemeralOperation.Customer.UpdateDefaultSource(
+                sourceId = sourceId,
+                sourceType = sourceType,
+                id = operationIdFactory.create()
+            ),
+            listener
         )
-        startOperation(ACTION_SET_DEFAULT_SOURCE, arguments, listener)
     }
 
     private fun startOperation(
-        action: String?,
-        arguments: Map<String, Any>?,
+        operation: EphemeralOperation,
         listener: RetrievalListener?
     ) {
-        val operationId = operationIdFactory.create()
-        listeners[operationId] = listener
-        ephemeralKeyManager.retrieveEphemeralKey(operationId, action, arguments)
+        listeners[operation.id] = listener
+        ephemeralKeyManager.retrieveEphemeralKey(operation)
     }
 
     @JvmSynthetic
@@ -410,19 +432,6 @@ class CustomerSession @VisibleForTesting internal constructor(
     }
 
     companion object {
-        internal const val ACTION_ADD_SOURCE = "add_source"
-        internal const val ACTION_DELETE_SOURCE = "delete_source"
-        internal const val ACTION_ATTACH_PAYMENT_METHOD = "attach_payment_method"
-        internal const val ACTION_DETACH_PAYMENT_METHOD = "detach_payment_method"
-        internal const val ACTION_GET_PAYMENT_METHODS = "get_payment_methods"
-        internal const val ACTION_SET_DEFAULT_SOURCE = "default_source"
-        internal const val ACTION_SET_CUSTOMER_SHIPPING_INFO = "set_shipping_info"
-        internal const val KEY_PAYMENT_METHOD = "payment_method"
-        internal const val KEY_PAYMENT_METHOD_TYPE = "payment_method_type"
-        internal const val KEY_SOURCE = "source"
-        internal const val KEY_SOURCE_TYPE = "source_type"
-        internal const val KEY_SHIPPING_INFO = "shipping_info"
-
         // The maximum number of active threads we support
         private const val THREAD_POOL_SIZE = 3
         // Sets the amount of time an idle thread waits before terminating

--- a/stripe/src/main/java/com/stripe/android/CustomerSessionEphemeralKeyManagerListener.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSessionEphemeralKeyManagerListener.kt
@@ -10,16 +10,14 @@ internal class CustomerSessionEphemeralKeyManagerListener(
 ) : EphemeralKeyManager.KeyManagerListener {
     override fun onKeyUpdate(
         ephemeralKey: EphemeralKey,
-        operationId: String,
-        action: String?,
-        arguments: Map<String, Any>?
+        operation: EphemeralOperation
     ) {
         val runnable =
-            runnableFactory.create(ephemeralKey, operationId, action, arguments)
+            runnableFactory.create(ephemeralKey, operation)
         runnable?.let {
             executor.execute(it)
 
-            if (action != null) {
+            if (operation !is EphemeralOperation.RetrieveKey) {
                 productUsage.reset()
             }
         }

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.kt
@@ -21,55 +21,60 @@ internal class EphemeralKeyManager(
 
     init {
         if (shouldPrefetchEphemeralKey) {
-            retrieveEphemeralKey(operationIdFactory.create(), null, null)
+            retrieveEphemeralKey(
+                EphemeralOperation.RetrieveKey(operationIdFactory.create())
+            )
         }
     }
 
-    fun retrieveEphemeralKey(
-        operationId: String,
-        actionString: String?,
-        arguments: Map<String, Any>?
+    @JvmSynthetic
+    internal fun retrieveEphemeralKey(
+        operation: EphemeralOperation
     ) {
-        val ephemeralKey = ephemeralKey
-        if (ephemeralKey == null ||
-            shouldRefreshKey(ephemeralKey, timeBufferInSeconds, overrideCalendar)) {
-            ephemeralKeyProvider.createEphemeralKey(apiVersion,
-                ClientKeyUpdateListener(this, operationId, actionString, arguments))
-        } else {
-            listener.onKeyUpdate(ephemeralKey, operationId, actionString, arguments)
-        }
+        ephemeralKey.takeUnless {
+            it == null || shouldRefreshKey(it, timeBufferInSeconds, overrideCalendar)
+        }?.let { ephemeralKey ->
+            listener.onKeyUpdate(ephemeralKey, operation)
+        } ?: ephemeralKeyProvider.createEphemeralKey(
+            apiVersion,
+            ClientKeyUpdateListener(this, operation)
+        )
     }
 
     private fun updateKey(
-        operationId: String,
-        key: String?,
-        actionString: String?,
-        arguments: Map<String, Any>?
+        operation: EphemeralOperation,
+        key: String?
     ) {
         // Key is coming from the user, so even if it's @NonNull annotated we
         // want to double check it
         if (key == null) {
-            listener.onKeyError(operationId,
+            listener.onKeyError(
+                operation.id,
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
-                "EphemeralKeyUpdateListener.onKeyUpdate was called with a null value")
+                "EphemeralKeyUpdateListener.onKeyUpdate was called with a null value"
+            )
             return
         }
         try {
             val ephemeralKey = EphemeralKeyJsonParser().parse(JSONObject(key))
             this.ephemeralKey = ephemeralKey
-            listener.onKeyUpdate(ephemeralKey, operationId, actionString, arguments)
+            listener.onKeyUpdate(ephemeralKey, operation)
         } catch (e: JSONException) {
-            listener.onKeyError(operationId,
+            listener.onKeyError(
+                operation.id,
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                 "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                     "a value that could not be JSON parsed: [${e.localizedMessage}]. " +
-                    "The raw body from Stripe's response should be passed.")
+                    "The raw body from Stripe's response should be passed."
+            )
         } catch (e: Exception) {
-            listener.onKeyError(operationId,
+            listener.onKeyError(
+                operation.id,
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                 "EphemeralKeyUpdateListener.onKeyUpdate was passed " +
                     "a JSON String that was invalid: [${e.localizedMessage}]. " +
-                    "The raw body from Stripe's response should be passed.")
+                    "The raw body from Stripe's response should be passed."
+            )
         }
     }
 
@@ -81,9 +86,7 @@ internal class EphemeralKeyManager(
     internal interface KeyManagerListener {
         fun onKeyUpdate(
             ephemeralKey: EphemeralKey,
-            operationId: String,
-            action: String?,
-            arguments: Map<String, Any>?
+            operation: EphemeralOperation
         )
 
         fun onKeyError(
@@ -95,33 +98,31 @@ internal class EphemeralKeyManager(
 
     private class ClientKeyUpdateListener internal constructor(
         private val ephemeralKeyManager: EphemeralKeyManager,
-        private val operationId: String,
-        private val actionString: String?,
-        private val arguments: Map<String, Any>?
+        private val operation: EphemeralOperation
     ) : EphemeralKeyUpdateListener {
         override fun onKeyUpdate(stripeResponseJson: String) {
-            ephemeralKeyManager.updateKey(operationId, stripeResponseJson, actionString, arguments)
+            ephemeralKeyManager.updateKey(operation, stripeResponseJson)
         }
 
         override fun onKeyUpdateFailure(responseCode: Int, message: String) {
-            ephemeralKeyManager.updateKeyError(operationId, responseCode, message)
+            ephemeralKeyManager.updateKeyError(operation.id, responseCode, message)
         }
     }
 
-    companion object {
-        fun shouldRefreshKey(
-            key: EphemeralKey?,
+    internal companion object {
+        internal fun shouldRefreshKey(
+            ephemeralKey: EphemeralKey?,
             bufferInSeconds: Long,
             proxyCalendar: Calendar?
         ): Boolean {
-            if (key == null) {
+            if (ephemeralKey == null) {
                 return true
             }
 
             val now = proxyCalendar ?: Calendar.getInstance()
             val nowInSeconds = TimeUnit.MILLISECONDS.toSeconds(now.timeInMillis)
             val nowPlusBuffer = nowInSeconds + bufferInSeconds
-            return key.expires < nowPlusBuffer
+            return ephemeralKey.expires < nowPlusBuffer
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
@@ -1,0 +1,81 @@
+package com.stripe.android
+
+import android.os.Parcelable
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
+import com.stripe.android.model.Source
+import kotlinx.android.parcel.Parcelize
+
+internal sealed class EphemeralOperation : Parcelable {
+    internal abstract val id: String
+
+    @Parcelize
+    internal data class RetrieveKey(
+        override val id: String
+    ) : EphemeralOperation()
+
+    internal sealed class Customer : EphemeralOperation() {
+        @Parcelize
+        data class AddSource(
+            val sourceId: String,
+            @Source.SourceType val sourceType: String,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class DeleteSource(
+            val sourceId: String,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class AttachPaymentMethod(
+            val paymentMethodId: String,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class DetachPaymentMethod(
+            val paymentMethodId: String,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class PaymentMethods(
+            internal val type: PaymentMethod.Type,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class UpdateShipping(
+            val shippingInformation: ShippingInformation,
+            override val id: String
+        ) : Customer()
+
+        @Parcelize
+        data class UpdateDefaultSource(
+            val sourceId: String,
+            @Source.SourceType val sourceType: String,
+            override val id: String
+        ) : Customer()
+    }
+
+    internal sealed class Issuing : EphemeralOperation() {
+        @Parcelize
+        data class RetrievePin(
+            val cardId: String,
+            val verificationId: String,
+            val userOneTimeCode: String,
+            override val id: String
+        ) : Issuing()
+
+        @Parcelize
+        data class UpdatePin(
+            val cardId: String,
+            val newPin: String,
+            val verificationId: String,
+            val userOneTimeCode: String,
+            override val id: String
+        ) : Issuing()
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -588,7 +588,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         AuthenticationException::class, CardException::class)
     override fun getPaymentMethods(
         customerId: String,
-        paymentMethodType: String,
+        paymentMethodType: PaymentMethod.Type,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
@@ -599,7 +599,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 requestOptions,
                 mapOf(
                     "customer" to customerId,
-                    "type" to paymentMethodType
+                    "type" to paymentMethodType.code
                 )
             )
         )

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -169,7 +169,7 @@ internal interface StripeRepository {
         APIConnectionException::class, APIException::class, CardException::class)
     fun getPaymentMethods(
         customerId: String,
-        paymentMethodType: String,
+        paymentMethodType: PaymentMethod.Type,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -164,7 +164,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     @Throws(APIException::class)
     override fun getPaymentMethods(
         customerId: String,
-        paymentMethodType: String,
+        paymentMethodType: PaymentMethod.Type,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.exception.APIException
@@ -33,7 +34,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.json.JSONObject
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
@@ -46,10 +46,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CustomerSessionTest {
 
-    @Mock
-    private lateinit var stripeRepository: StripeRepository
-    @Mock
-    private lateinit var threadPoolExecutor: ThreadPoolExecutor
+    private val stripeRepository: StripeRepository = mock()
+    private val threadPoolExecutor: ThreadPoolExecutor = mock()
 
     private val productUsageArgumentCaptor: KArgumentCaptor<Set<String>> by lazy {
         argumentCaptor<Set<String>>()
@@ -129,7 +127,7 @@ class CustomerSessionTest {
 
         `when`(stripeRepository.getPaymentMethods(
             any(),
-            eq("card"),
+            eq(PaymentMethod.Type.Card),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             any(),
             any()
@@ -815,7 +813,7 @@ class CustomerSessionTest {
         assertNotNull(FIRST_CUSTOMER.id)
         verify(stripeRepository).getPaymentMethods(
             eq(FIRST_CUSTOMER.id.orEmpty()),
-            eq("card"),
+            eq(PaymentMethod.Type.Card),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             productUsageArgumentCaptor.capture(),
             requestOptionsArgumentCaptor.capture()
@@ -880,7 +878,7 @@ class CustomerSessionTest {
 
         `when`(stripeRepository.getPaymentMethods(
             any(),
-            eq("card"),
+            eq(PaymentMethod.Type.Card),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             any(),
             any()))

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
@@ -3,17 +3,15 @@ package com.stripe.android
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.testharness.TestEphemeralKeyProvider
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.json.JSONObject
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 /**
@@ -22,33 +20,27 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class IssuingCardPinServiceTest {
 
-    @Mock
-    private lateinit var stripeApiRequestExecutor: ApiRequestExecutor
-    @Mock
-    private lateinit var retrievalListener: IssuingCardPinService.IssuingCardPinRetrievalListener
-    @Mock
-    private lateinit var updateListener: IssuingCardPinService.IssuingCardPinUpdateListener
-
-    private lateinit var service: IssuingCardPinService
-
-    @BeforeTest
-    fun before() {
-        MockitoAnnotations.initMocks(this)
-
-        val ephemeralKeyProvider = TestEphemeralKeyProvider()
-        ephemeralKeyProvider.setNextRawEphemeralKey(EPHEMERAL_KEY.toString())
-
-        val stripeRepository = StripeApiRepository(
+    private val stripeRepository: StripeRepository by lazy {
+        StripeApiRepository(
             ApplicationProvider.getApplicationContext<Context>(),
             null,
             FakeLogger(),
             stripeApiRequestExecutor,
             FakeFireAndForgetRequestExecutor()
         )
-
-        service = IssuingCardPinService(ephemeralKeyProvider, stripeRepository,
-            OperationIdFactory.get())
     }
+
+    private val service: IssuingCardPinService by lazy {
+        val ephemeralKeyProvider = TestEphemeralKeyProvider().also {
+            it.setNextRawEphemeralKey(EPHEMERAL_KEY.toString())
+        }
+
+        IssuingCardPinService(ephemeralKeyProvider, stripeRepository, OperationIdFactory.get())
+    }
+
+    private val stripeApiRequestExecutor: ApiRequestExecutor = mock()
+    private val retrievalListener: IssuingCardPinService.IssuingCardPinRetrievalListener = mock()
+    private val updateListener: IssuingCardPinService.IssuingCardPinUpdateListener = mock()
 
     @Test
     @Throws(InvalidRequestException::class, APIConnectionException::class)

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -581,7 +581,7 @@ class StripeApiRepositoryTest {
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
                 "cus_123",
-                PaymentMethod.Type.Card.code,
+                PaymentMethod.Type.Card,
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
@@ -631,7 +631,7 @@ class StripeApiRepositoryTest {
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
                 "cus_123",
-                PaymentMethod.Type.Card.code,
+                PaymentMethod.Type.Card,
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)


### PR DESCRIPTION
## Summary
An `EphemeralOperation` instance represents the action,
arguments, and operation id of an ephemeral key-related
operation.

## Motivation
This greatly simplifies the logic of ephemeral key-related
classes.

## Testing
Add unit tests
Manually verify
