### PR TITLE
Create TimeSupplier and use in CustomerSession and EphemeralKeyManager

### DIFF
--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -72,7 +72,6 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
             }
         },
         KEY_REFRESH_BUFFER_IN_SECONDS,
-        null,
         operationIdFactory,
         true
     )

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyFixtures.kt
@@ -1,0 +1,43 @@
+package com.stripe.android
+
+import com.stripe.android.model.parsers.EphemeralKeyJsonParser
+import org.json.JSONObject
+
+internal object EphemeralKeyFixtures {
+    val FIRST_JSON = JSONObject(
+        """
+        {
+            "id": "ephkey_123",
+            "object": "ephemeral_key",
+            "secret": "ek_test_123",
+            "created": 1501179335,
+            "livemode": false,
+            "expires": 1501199335,
+            "associated_objects": [{
+                "type": "customer",
+                "id": "cus_AQsHpvKfKwJDrF"
+            }]
+        }
+        """.trimIndent()
+    )
+
+    val SECOND_JSON = JSONObject(
+        """
+        {
+            "id": "ephkey_ABC",
+            "object": "ephemeral_key",
+            "secret": "ek_test_456",
+            "created": 1601189335,
+            "livemode": false,
+            "expires": 1601199335,
+            "associated_objects": [{
+                "type": "customer",
+                "id": "cus_abc123"
+            }]
+        }
+        """.trimIndent()
+    )
+
+    val FIRST = EphemeralKeyJsonParser().parse(FIRST_JSON)
+    val SECOND = EphemeralKeyJsonParser().parse(SECOND_JSON)
+}

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyTest.kt
@@ -1,53 +1,15 @@
 package com.stripe.android
 
-import com.stripe.android.model.parsers.EphemeralKeyJsonParser
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import org.json.JSONException
-import org.json.JSONObject
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class EphemeralKeyTest {
-
     @Test
-    @Throws(JSONException::class)
-    fun fromJson_createsKeyWithExpectedValues() {
-        assertEquals("ephkey_123", EPHEMERAL_KEY.id)
-        assertEquals("ephemeral_key", EPHEMERAL_KEY.objectType)
-        assertEquals("ek_test_123", EPHEMERAL_KEY.secret)
-        assertFalse(EPHEMERAL_KEY.isLiveMode)
-        assertEquals(1483575790L, EPHEMERAL_KEY.created)
-        assertEquals(1483579790L, EPHEMERAL_KEY.expires)
-        assertEquals("customer", EPHEMERAL_KEY.type)
-        assertEquals("cus_123", EPHEMERAL_KEY.objectId)
-    }
-
-    @Test
-    @Throws(JSONException::class)
     fun toParcel_fromParcel_createsExpectedObject() {
-        assertEquals(EPHEMERAL_KEY, ParcelUtils.create(EPHEMERAL_KEY))
-    }
-
-    private companion object {
-        private val EPHEMERAL_KEY = EphemeralKeyJsonParser().parse(JSONObject(
-            """
-            {
-                "id": "ephkey_123",
-                "object": "ephemeral_key",
-                "secret": "ek_test_123",
-                "created": 1483575790,
-                "livemode": false,
-                "expires": 1483579790,
-                "associated_objects": [{
-                    "type": "customer",
-                    "id": "cus_123"
-                }]
-            }
-            """.trimIndent()
-        ))
+        assertEquals(EphemeralKeyFixtures.FIRST, ParcelUtils.create(EphemeralKeyFixtures.FIRST))
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -103,7 +103,7 @@ class PaymentSessionTest {
     @Test
     fun init_whenEphemeralKeyProviderContinues_fetchesCustomerAndNotifiesListener() {
         ephemeralKeyProvider
-            .setNextRawEphemeralKey(CustomerFixtures.EPHEMERAL_KEY_FIRST.toString())
+            .setNextRawEphemeralKey(EphemeralKeyFixtures.FIRST_JSON)
         CustomerSession.instance = createCustomerSession()
 
         val paymentSession = PaymentSession(activity, DEFAULT_CONFIG)
@@ -311,8 +311,7 @@ class PaymentSessionTest {
 
     @Test
     fun init_withSavedState_setsPaymentSessionData() {
-        ephemeralKeyProvider
-            .setNextRawEphemeralKey(CustomerFixtures.EPHEMERAL_KEY_FIRST.toString())
+        ephemeralKeyProvider.setNextRawEphemeralKey(EphemeralKeyFixtures.FIRST_JSON)
         CustomerSession.instance = createCustomerSession()
 
         val paymentSession = PaymentSession(activity, DEFAULT_CONFIG)
@@ -380,7 +379,6 @@ class PaymentSessionTest {
         return CustomerSession(
             ApplicationProvider.getApplicationContext<Context>(),
             ephemeralKeyProvider,
-            null,
             threadPoolExecutor,
             FakeStripeRepository(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,

--- a/stripe/src/test/java/com/stripe/android/model/CustomerFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CustomerFixtures.kt
@@ -73,38 +73,4 @@ internal object CustomerFixtures {
         }
         """.trimIndent()
     )))
-
-    val EPHEMERAL_KEY_FIRST = JSONObject(
-        """
-        {
-            "id": "ephkey_123",
-            "object": "ephemeral_key",
-            "secret": "ek_test_123",
-            "created": 1501179335,
-            "livemode": false,
-            "expires": 1501199335,
-            "associated_objects": [{
-                "type": "customer",
-                "id": "cus_AQsHpvKfKwJDrF"
-            }]
-        }
-        """.trimIndent()
-    )
-
-    val EPHEMERAL_KEY_SECOND = JSONObject(
-        """
-        {
-            "id": "ephkey_ABC",
-            "object": "ephemeral_key",
-            "secret": "ek_test_456",
-            "created": 1601189335,
-            "livemode": false,
-            "expires": 1601199335,
-            "associated_objects": [{
-                "type": "customer",
-                "id": "cus_abc123"
-            }]
-        }
-        """.trimIndent()
-    )
 }

--- a/stripe/src/test/java/com/stripe/android/model/parsers/EphemeralKeyJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/EphemeralKeyJsonParserTest.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.EphemeralKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.json.JSONObject
+
+class EphemeralKeyJsonParserTest {
+
+    @Test
+    fun parse() {
+        val actual = EphemeralKeyJsonParser().parse(JSONObject(
+            """
+            {
+                "id": "ephkey_123",
+                "object": "ephemeral_key",
+                "secret": "ek_test_123",
+                "created": 1483575790,
+                "livemode": false,
+                "expires": 1483579790,
+                "associated_objects": [{
+                    "type": "customer",
+                    "id": "cus_123"
+                }]
+            }
+            """.trimIndent()
+        ))
+
+        val expected = EphemeralKey(
+            objectId = "cus_123",
+            id = "ephkey_123",
+            secret = "ek_test_123",
+            isLiveMode = false,
+            created = 1483575790L,
+            expires = 1483579790L,
+            type = "customer",
+            objectType = "ephemeral_key"
+        )
+
+        assertEquals(expected, actual)
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.kt
+++ b/stripe/src/test/java/com/stripe/android/testharness/TestEphemeralKeyProvider.kt
@@ -3,6 +3,7 @@ package com.stripe.android.testharness
 import androidx.annotation.Size
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.EphemeralKeyUpdateListener
+import org.json.JSONObject
 
 /**
  * An [EphemeralKeyProvider] to be used in tests that automatically returns test values.
@@ -25,6 +26,10 @@ internal class TestEphemeralKeyProvider : EphemeralKeyProvider {
             else -> // Useful to test edge cases
                 keyUpdateListener.onKeyUpdate("")
         }
+    }
+
+    fun setNextRawEphemeralKey(ephemeralKey: JSONObject) {
+        setNextRawEphemeralKey(ephemeralKey.toString())
     }
 
     fun setNextRawEphemeralKey(rawEphemeralKey: String) {


### PR DESCRIPTION
## Motivation
Create `TimeSupplier` to simplify testing of ephemeral key expiration
logic by not relying on an actual `Calendar` instance.

## Summary
Create `TimeSupplier` and update usage in `CustomerSession` and `EphemeralKeyManager`
Create `EphemeralKeyFixtures` and consolidate fixtures

## Testing
Unit tests + manual verification
