### PR TITLE
Fix off by 1 error in PaymentMethodSwipeCallback

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
@@ -42,7 +42,7 @@ internal class PaymentMethodSwipeCallback(
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        val paymentMethod = adapter.paymentMethods[viewHolder.adapterPosition]
+        val paymentMethod = adapter.getPaymentMethodAtPosition(viewHolder.adapterPosition)
         listener.onSwiped(paymentMethod)
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -192,6 +192,7 @@ internal class PaymentMethodsAdapter constructor(
         return ViewHolder.GooglePayViewHolder(itemView)
     }
 
+    @JvmSynthetic
     internal fun deletePaymentMethod(paymentMethod: PaymentMethod) {
         val indexToDelete = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
         if (indexToDelete >= 0) {
@@ -200,19 +201,36 @@ internal class PaymentMethodsAdapter constructor(
         }
     }
 
+    @JvmSynthetic
     internal fun resetPaymentMethod(paymentMethod: PaymentMethod) {
-        val indexToReset = paymentMethods.indexOfFirst { it.id == paymentMethod.id }
-        if (indexToReset >= 0) {
-            notifyItemChanged(indexToReset)
+        getPosition(paymentMethod)?.let {
+            notifyItemChanged(it)
         }
     }
 
-    private fun getPaymentMethodAtPosition(position: Int): PaymentMethod {
-        return paymentMethods[getPaymentMethodPosition(position)]
+    /**
+     * Given an adapter position, translate to a `paymentMethods` element
+     */
+    @JvmSynthetic
+    internal fun getPaymentMethodAtPosition(position: Int): PaymentMethod {
+        return paymentMethods[getPaymentMethodIndex(position)]
     }
 
-    private fun getPaymentMethodPosition(position: Int): Int {
+    /**
+     * Given an adapter position, translate to a `paymentMethods` index
+     */
+    private fun getPaymentMethodIndex(position: Int): Int {
         return position - googlePayCount
+    }
+
+    /**
+     * Given a Payment Method, get its adapter position. For example, if the Google Pay button is
+     * being shown, the 2nd element in [paymentMethods] is actually the 3rd item in the adapter.
+     */
+    internal fun getPosition(paymentMethod: PaymentMethod): Int? {
+        return paymentMethods.indexOf(paymentMethod).takeIf { it >= 0 }?.let {
+            it + googlePayCount
+        }
     }
 
     private fun getAddableTypesPosition(position: Int): Int {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -13,9 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.times
-import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 /**
@@ -23,11 +22,8 @@ import org.robolectric.RobolectricTestRunner
  */
 @RunWith(RobolectricTestRunner::class)
 class PaymentMethodsAdapterTest {
-    @Mock
-    private lateinit var adapterDataObserver: RecyclerView.AdapterDataObserver
-
-    @Mock
-    private lateinit var listener: PaymentMethodsAdapter.Listener
+    private val adapterDataObserver: RecyclerView.AdapterDataObserver = mock()
+    private val listener: PaymentMethodsAdapter.Listener = mock()
 
     private val paymentMethodsAdapter: PaymentMethodsAdapter = PaymentMethodsAdapter(ARGS)
 
@@ -37,7 +33,6 @@ class PaymentMethodsAdapterTest {
 
     @BeforeTest
     fun setup() {
-        MockitoAnnotations.initMocks(this)
         paymentMethodsAdapter.registerAdapterDataObserver(adapterDataObserver)
     }
 
@@ -233,6 +228,25 @@ class PaymentMethodsAdapterTest {
 
         itemView.performClick()
         verify(listener).onGooglePayClick()
+    }
+
+    @Test
+    fun getPosition_withValidPaymentMethod_returnsPosition() {
+        val adapter = PaymentMethodsAdapter(ARGS, shouldShowGooglePay = true)
+        adapter.setPaymentMethods(PaymentMethodFixtures.CARD_PAYMENT_METHODS)
+
+        assertEquals(
+            3,
+            adapter.getPosition(PaymentMethodFixtures.CARD_PAYMENT_METHODS.last())
+        )
+    }
+
+    @Test
+    fun getPosition_withInvalidPaymentMethod_returnsNull() {
+        val adapter = PaymentMethodsAdapter(ARGS, shouldShowGooglePay = true)
+        adapter.setPaymentMethods(PaymentMethodFixtures.CARD_PAYMENT_METHODS)
+
+        assertNull(adapter.getPosition(PaymentMethodFixtures.FPX_PAYMENT_METHOD))
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
When the Google Pay button is enabled in `PaymentMethodsActivity`,
`PaymentMethodSwipeCallback#onSwiped()` would get the wrong
element from the `paymentMethods` list.

## Testing
Unit tests + manual verification