### PR TITLE
Refactor PaymentFlowPagerAdapter state saving

### DIFF
--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
@@ -26,7 +26,10 @@ class PaymentFlowPagerAdapterTest {
     fun pageCount_updatesAfterSavingShippingInfo() {
         assertEquals(1, adapter.count)
 
-        adapter.setShippingInfoSaved(true)
+        adapter.isShippingInfoSubmitted = true
         assertEquals(2, adapter.count)
+
+        adapter.isShippingInfoSubmitted = false
+        assertEquals(1, adapter.count)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.view
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSessionConfig
@@ -11,22 +12,18 @@ import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.model.CustomerFixtures
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.MainScope
 import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentFlowViewModelTest {
-
-    @Mock
-    private lateinit var customerSession: CustomerSession
+    private val customerSession: CustomerSession = mock()
 
     private val customerRetrievalListener: KArgumentCaptor<CustomerSession.CustomerRetrievalListener> by lazy {
         argumentCaptor<CustomerSession.CustomerRetrievalListener>()
@@ -40,13 +37,10 @@ class PaymentFlowViewModelTest {
         )
     }
 
-    @BeforeTest
-    fun setup() {
-        MockitoAnnotations.initMocks(this)
-    }
-
     @Test
     fun saveCustomerShippingInformation_onSuccess_returnsExpectedData() {
+        assertFalse(viewModel.isShippingInfoSubmitted)
+
         val result =
             viewModel.saveCustomerShippingInformation(ShippingInfoFixtures.DEFAULT)
         verify(customerSession).setCustomerShippingInformation(
@@ -56,8 +50,11 @@ class PaymentFlowViewModelTest {
 
         customerRetrievalListener.firstValue.onCustomerRetrieved(CustomerFixtures.CUSTOMER)
 
-        val resultValue = requireNotNull(result.value) as PaymentFlowViewModel.SaveCustomerShippingInfoResult.Success
+        val resultValue =
+            requireNotNull(result.value) as PaymentFlowViewModel.SaveCustomerShippingInfoResult.Success
         assertNotNull(resultValue.customer)
+
+        assertTrue(viewModel.isShippingInfoSubmitted)
     }
 
     @Test
@@ -71,6 +68,7 @@ class PaymentFlowViewModelTest {
         val resultValue =
             requireNotNull(result.value) as PaymentFlowViewModel.ValidateShippingInfoResult.Success
         assertEquals(SHIPPING_METHODS, resultValue.shippingMethods)
+        assertEquals(SHIPPING_METHODS, viewModel.shippingMethods)
     }
 
     @Test
@@ -84,6 +82,7 @@ class PaymentFlowViewModelTest {
         val resultValue =
             requireNotNull(result.value) as PaymentFlowViewModel.ValidateShippingInfoResult.Success
         assertTrue(resultValue.shippingMethods.isEmpty())
+        assertTrue(viewModel.shippingMethods.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
- Move state saving logic to `PaymentFlowViewModel`
- Calculate `PaymentFlowPagerAdapter#page` on the fly
- Remove `PaymentFlowPagerAdapter.defaultShippingMethod` as it is
  unused