### PR TITLE
Refactor PaymentFlowActivity state logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
@@ -16,7 +16,8 @@ internal class PaymentFlowPagerAdapter(
     private val context: Context,
     private val paymentSessionConfig: PaymentSessionConfig,
     private val customerSession: CustomerSession,
-    private val allowedShippingCountryCodes: Set<String> = emptySet()
+    private val allowedShippingCountryCodes: Set<String> = emptySet(),
+    private val onShippingMethodSelectedCallback: (ShippingMethod) -> Unit = {}
 ) : PagerAdapter() {
     private val pages: List<PaymentFlowPage>
         get() {
@@ -77,7 +78,7 @@ internal class PaymentFlowPagerAdapter(
             is PaymentFlowViewHolder.ShippingMethodViewHolder -> {
                 customerSession
                     .addProductUsageTokenIfValid(PaymentFlowActivity.TOKEN_SHIPPING_METHOD_SCREEN)
-                viewHolder.bind(shippingMethods, selectedShippingMethod)
+                viewHolder.bind(shippingMethods, selectedShippingMethod, onShippingMethodSelectedCallback)
             }
         }
         collection.addView(layout)
@@ -139,9 +140,13 @@ internal class PaymentFlowPagerAdapter(
 
             fun bind(
                 shippingMethods: List<ShippingMethod>,
-                selectedShippingMethod: ShippingMethod?
+                selectedShippingMethod: ShippingMethod?,
+                onShippingMethodSelectedCallback: (ShippingMethod) -> Unit
             ) {
                 shippingMethodWidget.setShippingMethods(shippingMethods)
+                shippingMethodWidget.setShippingMethodSelectedCallback(
+                    onShippingMethodSelectedCallback
+                )
                 selectedShippingMethod?.let {
                     shippingMethodWidget.setSelectedShippingMethod(it)
                 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
@@ -23,10 +23,16 @@ internal class PaymentFlowViewModel(
     internal var shippingMethods: List<ShippingMethod> = emptyList()
     internal var isShippingInfoSubmitted: Boolean = false
 
+    internal var selectedShippingMethod: ShippingMethod? = null
+    internal var submittedShippingInfo: ShippingInformation? = null
+
+    internal var currentPage: Int = 0
+
     @JvmSynthetic
     internal fun saveCustomerShippingInformation(
         shippingInformation: ShippingInformation
     ): LiveData<SaveCustomerShippingInfoResult> {
+        submittedShippingInfo = shippingInformation
         val resultData = MutableLiveData<SaveCustomerShippingInfoResult>()
         customerSession.setCustomerShippingInformation(
             shippingInformation,

--- a/stripe/src/main/java/com/stripe/android/view/SelectShippingMethodWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/SelectShippingMethodWidget.kt
@@ -34,14 +34,15 @@ internal class SelectShippingMethodWidget @JvmOverloads constructor(
         shipping_methods.layoutManager = LinearLayoutManager(context)
     }
 
+    fun setShippingMethodSelectedCallback(callback: (ShippingMethod) -> Unit) {
+        shippingMethodAdapter.onShippingMethodSelectedCallback = callback
+    }
+
     /**
      * Specify the shipping methods to show.
      */
-    fun setShippingMethods(
-        shippingMethods: List<ShippingMethod>,
-        defaultShippingMethod: ShippingMethod? = null
-    ) {
-        shippingMethodAdapter.setShippingMethods(shippingMethods, defaultShippingMethod)
+    fun setShippingMethods(shippingMethods: List<ShippingMethod>) {
+        shippingMethodAdapter.shippingMethods = shippingMethods
     }
 
     fun setSelectedShippingMethod(shippingMethod: ShippingMethod) {

--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.kt
@@ -9,16 +9,35 @@ import com.stripe.android.model.ShippingMethod
  */
 internal class ShippingMethodAdapter :
     RecyclerView.Adapter<ShippingMethodAdapter.ShippingMethodViewHolder>() {
+    internal var onShippingMethodSelectedCallback: (ShippingMethod) -> Unit = {}
 
-    private var shippingMethods: List<ShippingMethod> = emptyList()
-    private var selectedIndex = 0
+    internal var shippingMethods: List<ShippingMethod> = emptyList()
+        set(value) {
+            // reset selected
+            selectedIndex = 0
+            field = value
+            notifyDataSetChanged()
+        }
+
+    @JvmSynthetic
+    internal var selectedIndex = 0
+        set(value) {
+            if (field != value) {
+                // only notify change if the field's value is changing
+                notifyItemChanged(field)
+                notifyItemChanged(value)
+                field = value
+
+                onShippingMethodSelectedCallback(shippingMethods[value])
+            }
+        }
 
     init {
         setHasStableIds(true)
     }
 
     val selectedShippingMethod: ShippingMethod?
-        get() = shippingMethods[selectedIndex]
+        get() = shippingMethods.getOrNull(selectedIndex)
 
     override fun getItemCount(): Int {
         return shippingMethods.size
@@ -36,34 +55,12 @@ internal class ShippingMethodAdapter :
         holder.setShippingMethod(shippingMethods[i])
         holder.setSelected(i == selectedIndex)
         holder.shippingMethodView.setOnClickListener {
-            onShippingMethodSelected(holder.adapterPosition)
+            selectedIndex = holder.adapterPosition
         }
-    }
-
-    fun setShippingMethods(
-        shippingMethods: List<ShippingMethod>,
-        defaultShippingMethod: ShippingMethod? = null
-    ) {
-        this.shippingMethods = shippingMethods
-        selectedIndex = defaultShippingMethod?.let { shippingMethods.indexOf(it) } ?: 0
-        notifyDataSetChanged()
-    }
-
-    private fun onShippingMethodSelected(selectedIndex: Int) {
-        val previousSelectedIndex = this.selectedIndex
-        this.selectedIndex = selectedIndex
-
-        notifyItemChanged(previousSelectedIndex)
-        notifyItemChanged(selectedIndex)
     }
 
     internal fun setSelected(shippingMethod: ShippingMethod) {
-        val previouslySelectedIndex = selectedIndex
         selectedIndex = shippingMethods.indexOf(shippingMethod)
-        if (previouslySelectedIndex != selectedIndex) {
-            notifyItemChanged(previouslySelectedIndex)
-            notifyItemChanged(selectedIndex)
-        }
     }
 
     internal class ShippingMethodViewHolder constructor(

--- a/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/SelectShippingMethodWidgetTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.stripe.android.model.ShippingMethod
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
@@ -17,31 +16,23 @@ class SelectShippingMethodWidgetTest {
     private val selectShippingMethodWidget: SelectShippingMethodWidget by lazy {
         SelectShippingMethodWidget(ApplicationProvider.getApplicationContext<Context>())
             .also {
-                it.setShippingMethods(listOf(UPS, FEDEX), UPS)
+                it.setShippingMethods(listOf(
+                    ShippingMethodFixtures.UPS,
+                    ShippingMethodFixtures.FEDEX
+                ))
             }
     }
 
     @Test
     fun selectedShippingMethodWidget_whenSelected_selectionChanges() {
-        assertEquals(UPS, selectShippingMethodWidget.selectedShippingMethod)
-        selectShippingMethodWidget.setSelectedShippingMethod(FEDEX)
-        assertEquals(FEDEX, selectShippingMethodWidget.selectedShippingMethod)
-    }
-
-    private companion object {
-        private val UPS = ShippingMethod(
-            "UPS Ground",
-            "ups-ground",
-            0,
-            "USD",
-            "Arrives in 3-5 days"
+        assertEquals(
+            ShippingMethodFixtures.UPS,
+            selectShippingMethodWidget.selectedShippingMethod
         )
-        private val FEDEX = ShippingMethod(
-            "FedEx",
-            "fedex",
-            599,
-            "USD",
-            "Arrives tomorrow"
+        selectShippingMethodWidget.setSelectedShippingMethod(ShippingMethodFixtures.FEDEX)
+        assertEquals(
+            ShippingMethodFixtures.FEDEX,
+            selectShippingMethodWidget.selectedShippingMethod
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/ShippingMethodAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingMethodAdapterTest.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.view
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ShippingMethodAdapterTest {
+    private val adapter: ShippingMethodAdapter = ShippingMethodAdapter()
+
+    @Test
+    fun selectedShippingMethod_withNoItems_returnsNull() {
+        assertNull(adapter.selectedShippingMethod)
+    }
+
+    @Test
+    fun selectedIndex_whenValueChanges_shouldInvokeCallback() {
+        adapter.shippingMethods = listOf(
+            ShippingMethodFixtures.UPS,
+            ShippingMethodFixtures.FEDEX
+        )
+        var callbackCount = 0
+        adapter.onShippingMethodSelectedCallback = {
+            callbackCount += 1
+        }
+
+        adapter.selectedIndex = 0
+        assertEquals(0, callbackCount)
+
+        adapter.selectedIndex = 1
+        assertEquals(1, callbackCount)
+
+        adapter.selectedIndex = 1
+        adapter.selectedIndex = 1
+        adapter.selectedIndex = 1
+        assertEquals(1, callbackCount)
+
+        adapter.selectedIndex = 0
+        assertEquals(2, callbackCount)
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/ShippingMethodFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingMethodFixtures.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.view
+
+import com.stripe.android.model.ShippingMethod
+
+internal object ShippingMethodFixtures {
+    val UPS = ShippingMethod(
+        "UPS Ground",
+        "ups-ground",
+        0,
+        "USD",
+        "Arrives in 3-5 days"
+    )
+    val FEDEX = ShippingMethod(
+        "FedEx",
+        "fedex",
+        599,
+        "USD",
+        "Arrives tomorrow"
+    )
+}


### PR DESCRIPTION
## Summary
Remove `PaymentFlowActivity`'s explicit state saving
logic. Instead, handle it in `PaymentFlowViewModel`.

## Motivation
Simplify state logic

## Testing
Added unit tests
