### PR TITLE
Make EphemeralKeyManager.Factory an interface

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -438,7 +438,7 @@ class CustomerSession @VisibleForTesting internal constructor(
         ) {
             val operationIdFactory = StripeOperationIdFactory()
             val timeSupplier = { Calendar.getInstance().timeInMillis }
-            val ephemeralKeyManagerFactory = EphemeralKeyManager.Factory(
+            val ephemeralKeyManagerFactory = EphemeralKeyManager.Factory.Default(
                 keyProvider = ephemeralKeyProvider,
                 shouldPrefetchEphemeralKey = shouldPrefetchEphemeralKey,
                 operationIdFactory = operationIdFactory,

--- a/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKeyManager.kt
@@ -119,21 +119,23 @@ internal class EphemeralKeyManager(
         return ephemeralKey.expires < nowPlusBuffer
     }
 
-    internal class Factory(
-        private val keyProvider: EphemeralKeyProvider,
-        private val shouldPrefetchEphemeralKey: Boolean,
-        private val operationIdFactory: OperationIdFactory = StripeOperationIdFactory(),
-        private val timeSupplier: TimeSupplier = { Calendar.getInstance().timeInMillis }
-    ) {
-        @JvmSynthetic
-        fun create(listener: KeyManagerListener): EphemeralKeyManager {
-            return EphemeralKeyManager(
-                keyProvider,
-                listener,
-                operationIdFactory,
-                shouldPrefetchEphemeralKey,
-                timeSupplier
-            )
+    internal interface Factory : Factory1<KeyManagerListener, EphemeralKeyManager> {
+        class Default(
+            private val keyProvider: EphemeralKeyProvider,
+            private val shouldPrefetchEphemeralKey: Boolean,
+            private val operationIdFactory: OperationIdFactory = StripeOperationIdFactory(),
+            private val timeSupplier: TimeSupplier = { Calendar.getInstance().timeInMillis }
+        ) : Factory {
+            @JvmSynthetic
+            override fun create(arg: KeyManagerListener): EphemeralKeyManager {
+                return EphemeralKeyManager(
+                    keyProvider,
+                    arg,
+                    operationIdFactory,
+                    shouldPrefetchEphemeralKey,
+                    timeSupplier
+                )
+            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/Factory1.kt
+++ b/stripe/src/main/java/com/stripe/android/Factory1.kt
@@ -1,5 +1,5 @@
 package com.stripe.android
 
-internal interface Factory<ArgType, ReturnType> {
+internal interface Factory1<ArgType, ReturnType> {
     fun create(arg: ArgType): ReturnType
 }

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -757,7 +757,7 @@ internal class StripePaymentController internal constructor(
         }
 
         internal interface Complete3ds2AuthCallbackFactory :
-            Factory<Stripe3ds2CompletionStarter.Args, ApiResultCallback<Boolean>>
+            Factory1<Stripe3ds2CompletionStarter.Args, ApiResultCallback<Boolean>>
 
         internal companion object {
             private const val VALUE_YES = "Y"

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -780,7 +780,7 @@ class CustomerSessionTest {
             "acct_abc123",
             timeSupplier = timeSupplier,
             threadPoolExecutor = threadPoolExecutor,
-            ephemeralKeyManagerFactory = EphemeralKeyManager.Factory(
+            ephemeralKeyManagerFactory = EphemeralKeyManager.Factory.Default(
                 keyProvider = ephemeralKeyProvider,
                 shouldPrefetchEphemeralKey = true,
                 timeSupplier = timeSupplier

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -370,7 +370,7 @@ class PaymentSessionTest {
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             "acct_abc123",
             threadPoolExecutor = threadPoolExecutor,
-            ephemeralKeyManagerFactory = EphemeralKeyManager.Factory(
+            ephemeralKeyManagerFactory = EphemeralKeyManager.Factory.Default(
                 keyProvider = ephemeralKeyProvider,
                 shouldPrefetchEphemeralKey = true
             )


### PR DESCRIPTION
## Summary
Create a default implementation, `EphemeralKeyManager.Factory.Default`

## Motivation
Simplify mocking