### PR TITLE
Create AnalyticsRequestFactory

### DIFF
--- a/example/src/main/java/com/stripe/example/StripeFactory.kt
+++ b/example/src/main/java/com/stripe/example/StripeFactory.kt
@@ -1,0 +1,20 @@
+package com.stripe.example
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.Stripe
+
+internal class StripeFactory(
+    private val context: Context,
+    private val stripeAccountId: String? = null,
+    private val enableLogging: Boolean = true
+) {
+    fun create(): Stripe {
+        return Stripe(
+            context,
+            PaymentConfiguration.getInstance(context).publishableKey,
+            stripeAccountId,
+            enableLogging
+        )
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/ConfirmSepaDebitActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConfirmSepaDebitActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
@@ -14,6 +13,7 @@ import com.stripe.android.model.MandateDataParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -40,7 +40,7 @@ class ConfirmSepaDebitActivity : AppCompatActivity() {
     }
 
     private val stripe: Stripe by lazy {
-        Stripe(this, PaymentConfiguration.getInstance(this).publishableKey)
+        StripeFactory(this).create()
     }
 
     private var clientSecret: String? = null

--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -8,11 +8,11 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -24,10 +24,7 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
 
     private val adapter: PaymentMethodsAdapter = PaymentMethodsAdapter()
     private val stripe: Stripe by lazy {
-        Stripe(
-            applicationContext,
-            PaymentConfiguration.getInstance(this).publishableKey
-        )
+        StripeFactory(this).create()
     }
     private val snackbarController: SnackbarController by lazy {
         SnackbarController(findViewById(android.R.id.content))

--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
@@ -17,6 +16,7 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.SourceParams
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import com.stripe.example.adapter.SourcesAdapter
 import kotlinx.android.synthetic.main.activity_card_sources.*
 
@@ -34,8 +34,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
         SourcesAdapter()
     }
     private val stripe: Stripe by lazy {
-        Stripe(applicationContext,
-            PaymentConfiguration.getInstance(this).publishableKey)
+        StripeFactory(this).create()
     }
     private val keyboardController: KeyboardController by lazy {
         KeyboardController(this)

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -16,12 +16,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.Stripe
 import com.stripe.android.model.Card
 import com.stripe.android.model.Token
 import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import kotlinx.android.synthetic.main.card_token_activity.*
 
 class CreateCardTokenActivity : AppCompatActivity() {
@@ -123,10 +122,7 @@ class CreateCardTokenActivity : AppCompatActivity() {
         application: Application
     ) : AndroidViewModel(application) {
         private val context = application.applicationContext
-        private val stripe = Stripe(
-            context,
-            PaymentConfiguration.getInstance(context).publishableKey
-        )
+        private val stripe = StripeFactory(context).create()
 
         fun createCardToken(card: Card): LiveData<Token> {
             val data = MutableLiveData<Token>()

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.CustomerSession
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.PaymentSession
 import com.stripe.android.PaymentSessionConfig
@@ -26,6 +25,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
 import com.stripe.example.service.ExampleEphemeralKeyProvider
@@ -59,10 +59,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
         private val compositeDisposable = CompositeDisposable()
 
         private val stripe: Stripe by lazy {
-            Stripe(
-                requireContext(),
-                PaymentConfiguration.getInstance(requireContext()).publishableKey
-            )
+            StripeFactory(requireContext()).create()
         }
         private val backendApi: BackendApi by lazy {
             BackendApiFactory(requireContext()).create()

--- a/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
@@ -14,7 +14,7 @@ import com.stripe.android.model.KlarnaSourceParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.example.R
-import com.stripe.example.Settings
+import com.stripe.example.StripeFactory
 import kotlinx.android.synthetic.main.activity_klarna_source.*
 
 class KlarnaSourceActivity : AppCompatActivity() {
@@ -26,11 +26,7 @@ class KlarnaSourceActivity : AppCompatActivity() {
     }
 
     private val stripe: Stripe by lazy {
-        Stripe(
-            applicationContext,
-            Settings(applicationContext).publishableKey,
-            enableLogging = true
-        )
+        StripeFactory(this).create()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
@@ -17,19 +17,20 @@ import com.google.android.gms.wallet.Wallet
 import com.google.android.gms.wallet.WalletConstants
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
+import com.stripe.example.StripeFactory
 import kotlinx.android.synthetic.main.activity_pay_with_google.*
 import org.json.JSONObject
 
 class PayWithGoogleActivity : AppCompatActivity() {
 
     private val stripe: Stripe by lazy {
-        Stripe(this, PaymentConfiguration.getInstance(this).publishableKey)
+        StripeFactory(this).create()
     }
+
     private val paymentsClient: PaymentsClient by lazy {
         Wallet.getPaymentsClient(this,
             Wallet.WalletOptions.Builder()

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentAuthConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.SetupIntentResult
 import com.stripe.android.Stripe
@@ -15,6 +14,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
 import com.stripe.example.Settings
+import com.stripe.example.StripeFactory
 import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -40,12 +40,7 @@ class PaymentAuthActivity : AppCompatActivity() {
         Settings(this).stripeAccountId
     }
     private val stripe: Stripe by lazy {
-        Stripe(
-            this,
-            PaymentConfiguration.getInstance(this).publishableKey,
-            stripeAccountId = stripeAccountId,
-            enableLogging = true
-        )
+        StripeFactory(this, stripeAccountId).create()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
@@ -5,18 +5,14 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.Stripe
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
-import com.stripe.example.Settings
+import com.stripe.example.StripeFactory
 
 internal class SourceViewModel(
     application: Application
 ) : AndroidViewModel(application) {
-    private val stripe = Stripe(
-        application.applicationContext,
-        Settings(application.applicationContext).publishableKey
-    )
+    private val stripe = StripeFactory(application.applicationContext).create()
 
     internal var source: Source? = null
 

--- a/stripe/src/main/java/com/stripe/android/AnalyticsRequestFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsRequestFactory.kt
@@ -1,15 +1,20 @@
 package com.stripe.android
 
-internal object AnalyticsRequest {
-    const val HOST = "https://q.stripe.com"
-
+internal class AnalyticsRequestFactory(
+    private val logger: Logger = Logger.noop()
+) {
     @JvmSynthetic
     internal fun create(
         params: Map<String, *>,
         requestOptions: ApiRequest.Options,
         appInfo: AppInfo? = null
     ): ApiRequest {
+        logger.info("Event: ${params[AnalyticsDataFactory.FIELD_EVENT]}")
         return ApiRequest.Factory(appInfo = appInfo)
             .createGet(HOST, requestOptions, params)
+    }
+
+    internal companion object {
+        internal const val HOST = "https://q.stripe.com"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -63,6 +63,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     apiVersion: String = ApiVersion.get().code,
     sdkVersion: String = Stripe.VERSION
 ) : StripeRepository {
+    private val analyticsRequestFactory = AnalyticsRequestFactory(logger)
     private val apiRequestFactory = ApiRequest.Factory(
         appInfo = appInfo,
         apiVersion = apiVersion,
@@ -999,7 +1000,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         publishableKey: String
     ) {
         makeFireAndForgetRequest(
-            AnalyticsRequest.create(
+            analyticsRequestFactory.create(
                 loggingMap,
                 ApiRequest.Options(publishableKey),
                 appInfo

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
@@ -1,0 +1,33 @@
+package com.stripe.android
+
+import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.model.PaymentMethod
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsRequestFactoryTest {
+
+    private val logger: Logger = mock()
+
+    @Test
+    fun create_shouldLogRequest() {
+        AnalyticsRequestFactory(logger).create(
+            AnalyticsDataFactory(ApplicationProvider.getApplicationContext())
+                .createPaymentMethodCreationParams(
+                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    "pm_12345",
+                    PaymentMethod.Type.Card,
+                    emptySet()
+                ),
+            ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        )
+
+        verify(logger).info(
+            "Event: stripe_android.payment_method_creation"
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1204,7 +1204,7 @@ public class StripeTest {
         final List<StripeRequest> fireAndForgetRequests =
                 stripeRequestArgumentCaptor.getAllValues();
         final StripeRequest analyticsRequest = fireAndForgetRequests.get(1);
-        assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
+        assertEquals(AnalyticsRequestFactory.HOST, analyticsRequest.getBaseUrl());
         assertEquals(createdPaymentMethod.id,
                 analyticsRequest.getParams().get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID));
     }
@@ -1243,7 +1243,7 @@ public class StripeTest {
         final List<StripeRequest> fireAndForgetRequests =
                 stripeRequestArgumentCaptor.getAllValues();
         final StripeRequest analyticsRequest = fireAndForgetRequests.get(1);
-        assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
+        assertEquals(AnalyticsRequestFactory.HOST, analyticsRequest.getBaseUrl());
         assertEquals(createdPaymentMethod.id,
                 analyticsRequest.getParams().get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID));
     }
@@ -1288,7 +1288,7 @@ public class StripeTest {
         final List<StripeRequest> fireAndForgetRequests =
                 stripeRequestArgumentCaptor.getAllValues();
         final StripeRequest analyticsRequest = fireAndForgetRequests.get(1);
-        assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
+        assertEquals(AnalyticsRequestFactory.HOST, analyticsRequest.getBaseUrl());
         assertEquals(createdPaymentMethod.id,
                 analyticsRequest.getParams().get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID));
     }


### PR DESCRIPTION
## Summary
- Create `AnalyticsRequestFactory`
- Create `StripeFactory` in example app and use to
  enable logging by default

## Motivation
This allows injecting of a `Logger` instance to inspect
what is being logged.

## Testing
Add tests