### PR TITLE
Remove return type from PaymentSession.init()

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -246,7 +246,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
         }
 
         private fun initPaymentSession(customerSession: CustomerSession) {
-            val paymentSessionInitialized = paymentSession.init(
+            paymentSession.init(
                 object : PaymentSession.PaymentSessionListener {
                     override fun onCommunicatingStateChanged(isCommunicating: Boolean) {
                     }
@@ -271,9 +271,7 @@ class FragmentExamplesActivity : AppCompatActivity() {
                     }
                 }
             )
-            if (paymentSessionInitialized) {
-                paymentSession.setCartTotal(2000L)
-            }
+            paymentSession.setCartTotal(2000L)
         }
 
         private fun createCustomerSession(): CustomerSession {

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -95,13 +95,11 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setShouldPrefetchCustomer(shouldPrefetchCustomer)
                 .build()
         )
-        val paymentSessionInitialized = paymentSession.init(
+        paymentSession.init(
             listener = PaymentSessionListenerImpl(this, customerSession),
             savedInstanceState = savedInstanceState
         )
-        if (paymentSessionInitialized) {
-            paymentSession.setCartTotal(2000L)
-        }
+        paymentSession.setCartTotal(2000L)
 
         return paymentSession
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -162,26 +162,16 @@ class PaymentSession @VisibleForTesting internal constructor(
      * in payment session status, including networking status
      * @param savedInstanceState a `Bundle` containing the saved state of a
      * PaymentSession that was stored in [savePaymentSessionInstanceState]
-     *
-     * @return `true` if the PaymentSession is initialized, `false` if a state error
-     * occurs. Failure can only occur if there is no initialized [CustomerSession].
      */
     @JvmOverloads
     fun init(
         listener: PaymentSessionListener,
         savedInstanceState: Bundle? = null
-    ): Boolean {
-        // Checking to make sure that there is a valid CustomerSession -- the getInstance() call
-        // will throw a runtime exception if none is ready.
-        try {
-            if (savedInstanceState == null) {
-                customerSession.resetUsageTokens()
-            }
-            customerSession.addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION)
-        } catch (illegalState: IllegalStateException) {
-            paymentSessionListener = null
-            return false
+    ) {
+        if (savedInstanceState == null) {
+            customerSession.resetUsageTokens()
         }
+        customerSession.addProductUsageTokenIfValid(TOKEN_PAYMENT_SESSION)
 
         paymentSessionListener = listener
 
@@ -191,8 +181,6 @@ class PaymentSession @VisibleForTesting internal constructor(
         if (config.shouldPrefetchCustomer) {
             fetchCustomer()
         }
-
-        return true
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -206,7 +206,7 @@ class PaymentSessionTest {
     @Test
     fun getSelectedPaymentMethodId_whenHasPaymentSessionData_returnsExpectedId() {
         val paymentSession = createPaymentSession(
-            PaymentSessionFixtures.PAYMENT_SESSION_DATA.copy(
+            paymentSessionData = PaymentSessionFixtures.PAYMENT_SESSION_DATA.copy(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         )
@@ -232,7 +232,7 @@ class PaymentSessionTest {
     @Test
     fun getSelectedPaymentMethodId_whenHasUserSpecifiedPaymentMethod_returnsExpectedId() {
         val paymentSession = createPaymentSession(
-            PaymentSessionFixtures.PAYMENT_SESSION_DATA.copy(
+            paymentSessionData = PaymentSessionFixtures.PAYMENT_SESSION_DATA.copy(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         )
@@ -350,11 +350,12 @@ class PaymentSessionTest {
     }
 
     private fun createPaymentSession(
-        paymentSessionData: PaymentSessionData = PaymentSessionFixtures.PAYMENT_SESSION_DATA
+        config: PaymentSessionConfig = DEFAULT_CONFIG,
+        paymentSessionData: PaymentSessionData = PaymentSessionData(config)
     ): PaymentSession {
         return PaymentSession(
             context,
-            DEFAULT_CONFIG,
+            config,
             customerSession,
             paymentMethodsActivityStarter,
             paymentFlowActivityStarter,


### PR DESCRIPTION
## Summary
Previously, `PaymentSession.init()` would return `false`
if an `IllegalStateException` was thrown. This logic
existed because `CustomerSession.getInstance()`, which
can throw an exception, was called within `init()`.

The `CustomerSession` instance is now injected via
the constructor, and will throw an exception at
construction time
