### PR TITLE
Simplify PaymentSession state and lifecycle management

### DIFF
--- a/example/src/main/java/com/stripe/example/ExampleApplication.kt
+++ b/example/src/main/java/com/stripe/example/ExampleApplication.kt
@@ -4,9 +4,8 @@ import android.os.StrictMode
 import androidx.multidex.MultiDexApplication
 import com.facebook.stetho.Stetho
 import com.stripe.android.CustomerSession
-import com.stripe.android.EphemeralKeyProvider
-import com.stripe.android.EphemeralKeyUpdateListener
 import com.stripe.android.PaymentConfiguration
+import com.stripe.example.service.ExampleEphemeralKeyProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -38,12 +37,10 @@ class ExampleApplication : MultiDexApplication() {
             Stetho.initializeWithDefaults(this@ExampleApplication)
         }
 
-        // initialize empty CustomerSession
-        CustomerSession.initCustomerSession(this,
-            object : EphemeralKeyProvider {
-                override fun createEphemeralKey(apiVersion: String, keyUpdateListener: EphemeralKeyUpdateListener) {
-                }
-            }
+        CustomerSession.initCustomerSession(
+            this,
+            ExampleEphemeralKeyProvider(this),
+            false
         )
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -11,7 +11,6 @@ import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.PaymentMethodsActivityStarter
 import com.stripe.example.R
-import com.stripe.example.service.ExampleEphemeralKeyProvider
 import kotlinx.android.synthetic.main.activity_customer_session.*
 
 /**
@@ -28,11 +27,6 @@ class CustomerSessionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_customer_session)
         setTitle(R.string.customer_payment_data_example)
-        CustomerSession.initCustomerSession(
-            this,
-            ExampleEphemeralKeyProvider(this),
-            false
-        )
 
         progress_bar.visibility = View.VISIBLE
         CustomerSession.getInstance().retrieveCurrentCustomer(

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -28,7 +28,6 @@ import com.stripe.example.R
 import com.stripe.example.StripeFactory
 import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
-import com.stripe.example.service.ExampleEphemeralKeyProvider
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -50,8 +49,8 @@ class FragmentExamplesActivity : AppCompatActivity() {
 
         val newFragment = LauncherFragment()
 
-        val ft = supportFragmentManager.beginTransaction()
-        ft.add(R.id.root, newFragment, LauncherFragment::class.java.simpleName)
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.root, newFragment, LauncherFragment::class.java.simpleName)
             .commit()
     }
 
@@ -275,10 +274,6 @@ class FragmentExamplesActivity : AppCompatActivity() {
         }
 
         private fun createCustomerSession(): CustomerSession {
-            CustomerSession.initCustomerSession(
-                requireContext(),
-                ExampleEphemeralKeyProvider(requireContext())
-            )
             val customerSession = CustomerSession.getInstance()
             customerSession.retrieveCurrentCustomer(
                 object : CustomerSession.CustomerRetrievalListener {

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -72,7 +72,7 @@ class PaymentSession @VisibleForTesting internal constructor(
     /**
      * Create a PaymentSession attached to the given host Activity.
      *
-     * @param activity an `AppCompatActivity` from which to launch other Stripe Activities. This
+     * @param activity a `ComponentActivity` from which to launch other Stripe Activities. This
      * Activity will receive results in
      * `Activity#onActivityResult(int, int, Intent)` that should be
      * passed back to this session.

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
@@ -52,7 +52,7 @@ data class PaymentSessionData internal constructor(
      */
     val isPaymentReadyToCharge: Boolean
         get() =
-            (paymentMethod != null || useGooglePay) && config != null &&
+            (paymentMethod != null || useGooglePay) &&
                 (!config.isShippingInfoRequired || shippingInformation != null) &&
                 (!config.isShippingMethodRequired || shippingMethod != null)
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -1,0 +1,106 @@
+package com.stripe.android
+
+import android.app.Application
+import androidx.annotation.IntRange
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.model.Customer
+import com.stripe.android.model.PaymentMethod
+
+internal class PaymentSessionViewModel(
+    application: Application,
+    var paymentSessionData: PaymentSessionData,
+    private val customerSession: CustomerSession,
+    private val paymentSessionPrefs: PaymentSessionPrefs =
+        PaymentSessionPrefs.create(application.applicationContext)
+) : AndroidViewModel(application) {
+    init {
+        customerSession.resetUsageTokens()
+        customerSession.addProductUsageTokenIfValid(PaymentSession.TOKEN_PAYMENT_SESSION)
+    }
+
+    @JvmSynthetic
+    fun updateCartTotal(@IntRange(from = 0) cartTotal: Long) {
+        paymentSessionData = paymentSessionData.copy(cartTotal = cartTotal)
+    }
+
+    @JvmSynthetic
+    fun persistPaymentMethodResult(
+        paymentMethod: PaymentMethod?,
+        useGooglePay: Boolean
+    ) {
+        customerSession.cachedCustomer?.id?.let { customerId ->
+            paymentSessionPrefs.saveSelectedPaymentMethodId(customerId, paymentMethod?.id)
+        }
+        paymentSessionData = paymentSessionData.copy(
+            paymentMethod = paymentMethod,
+            useGooglePay = useGooglePay
+        )
+    }
+
+    @JvmSynthetic
+    fun onCompleted() {
+        customerSession.resetUsageTokens()
+    }
+
+    @JvmSynthetic
+    fun fetchCustomer(): LiveData<FetchCustomerResult> {
+        val resultData: MutableLiveData<FetchCustomerResult> = MutableLiveData()
+        customerSession.retrieveCurrentCustomer(
+            object : CustomerSession.CustomerRetrievalListener {
+                override fun onCustomerRetrieved(customer: Customer) {
+                    resultData.value = FetchCustomerResult.Success
+                }
+
+                override fun onError(
+                    errorCode: Int,
+                    errorMessage: String,
+                    stripeError: StripeError?
+                ) {
+                    resultData.value = FetchCustomerResult.Error(
+                        errorCode, errorMessage, stripeError
+                    )
+                }
+            }
+        )
+        return resultData
+    }
+
+    @JvmSynthetic
+    fun getSelectedPaymentMethodId(userSelectedPaymentMethodId: String? = null): String? {
+        return userSelectedPaymentMethodId
+            ?: if (paymentSessionData.paymentMethod != null) {
+                paymentSessionData.paymentMethod?.id
+            } else {
+                customerSession.cachedCustomer?.id?.let { customerId ->
+                    paymentSessionPrefs.getSelectedPaymentMethodId(customerId)
+                }
+            }
+    }
+
+    sealed class FetchCustomerResult {
+        object Success : FetchCustomerResult()
+        class Error(
+            val errorCode: Int,
+            val errorMessage: String,
+            val stripeError: StripeError?
+        ) : FetchCustomerResult()
+    }
+
+    internal class Factory(
+        private val application: Application,
+        private val paymentSessionData: PaymentSessionData,
+        private val customerSession: CustomerSession
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return PaymentSessionViewModel(
+                application,
+                paymentSessionData,
+                customerSession
+            ) as T
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.stripe.android
+
+import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.model.Customer
+import com.stripe.android.model.CustomerFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentSessionViewModelTest {
+    private val customerSession: CustomerSession = mock()
+    private val paymentSessionPrefs: PaymentSessionPrefs = mock()
+
+    private val viewModel: PaymentSessionViewModel by lazy {
+        PaymentSessionViewModel(
+            ApplicationProvider.getApplicationContext(),
+            PaymentSessionFixtures.PAYMENT_SESSION_DATA,
+            customerSession,
+            paymentSessionPrefs
+        )
+    }
+
+    @Test
+    fun init_shouldUpdateProductUsage() {
+        viewModel.paymentSessionData
+
+        verify(customerSession).resetUsageTokens()
+        verify(customerSession).addProductUsageTokenIfValid(
+            PaymentSession.TOKEN_PAYMENT_SESSION
+        )
+    }
+
+    @Test
+    fun updateCartTotal_shouldUpdatePaymentSessionData() {
+        viewModel.updateCartTotal(5000)
+        assertEquals(
+            5000,
+            viewModel.paymentSessionData.cartTotal
+        )
+    }
+
+    @Test
+    fun getSelectedPaymentMethodId_whenPrefsNotSet_returnsNull() {
+        Mockito.`when`<Customer>(customerSession.cachedCustomer)
+            .thenReturn(FIRST_CUSTOMER)
+        assertNull(viewModel.getSelectedPaymentMethodId(null))
+    }
+
+    @Test
+    fun getSelectedPaymentMethodId_whenHasPrefsSet_returnsExpectedId() {
+        val customerId = requireNotNull(FIRST_CUSTOMER.id)
+        Mockito.`when`<String>(paymentSessionPrefs.getSelectedPaymentMethodId(customerId))
+            .thenReturn("pm_12345")
+
+        Mockito.`when`<Customer>(customerSession.cachedCustomer).thenReturn(FIRST_CUSTOMER)
+        CustomerSession.instance = customerSession
+
+        assertEquals("pm_12345", viewModel.getSelectedPaymentMethodId())
+    }
+
+    private companion object {
+        private val FIRST_CUSTOMER = CustomerFixtures.CUSTOMER
+    }
+}


### PR DESCRIPTION
## Summary
- Create `PaymentSessionViewModel` and integrate in `PaymentSession`
- Remove `savedInstanceState` argument from `PaymentSession#init()`
- Remove `PaymentSession#savePaymentSessionInstanceState()`
- Remove `PaymentSession#onDestroy()` - the `listener` instance
  is now released automatically
- In `PaymentSession#init()`, immediately call the `listener` when
  `shouldPrefetchCustomer` is false
- Move `CustomerSession` initialization in example app to
  `Application` subclass

## Motivation
Simplify `PaymentSession` state management and API. It is
no longer necessary to pass a state `Bundle` and manage
lifecycle events.

## Testing
Add unit tests
Manually verify with both `Activity` and `Fragment`
