### PR TITLE
Add SavedStateHandle to PaymentSessionViewModel

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel:$androidLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidLifecycleVersion"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 
     // Api for this import because we use reflection to alter TextInputLayout

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
 import com.stripe.android.view.PaymentFlowActivity
@@ -31,6 +32,7 @@ class PaymentSession @VisibleForTesting internal constructor(
     application: Application,
     viewModelStoreOwner: ViewModelStoreOwner,
     private val lifecycleOwner: LifecycleOwner,
+    savedStateRegistryOwner: SavedStateRegistryOwner,
     private val config: PaymentSessionConfig,
     customerSession: CustomerSession,
     private val paymentMethodsActivityStarter:
@@ -44,6 +46,7 @@ class PaymentSession @VisibleForTesting internal constructor(
             viewModelStoreOwner,
             PaymentSessionViewModel.Factory(
                 application,
+                savedStateRegistryOwner,
                 paymentSessionData,
                 customerSession
             )
@@ -83,6 +86,7 @@ class PaymentSession @VisibleForTesting internal constructor(
         activity.application,
         activity,
         activity,
+        activity,
         config,
         CustomerSession.getInstance(),
         PaymentMethodsActivityStarter(activity),
@@ -100,6 +104,7 @@ class PaymentSession @VisibleForTesting internal constructor(
     constructor(fragment: Fragment, config: PaymentSessionConfig) : this(
         fragment.requireActivity().applicationContext,
         fragment.requireActivity().application,
+        fragment,
         fragment,
         fragment,
         config,

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
@@ -1,25 +1,30 @@
 package com.stripe.android
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
-import com.stripe.android.model.Customer
+import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.model.CustomerFixtures
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSessionViewModelTest {
     private val customerSession: CustomerSession = mock()
     private val paymentSessionPrefs: PaymentSessionPrefs = mock()
+    private val savedStateHandle: SavedStateHandle = mock()
 
     private val viewModel: PaymentSessionViewModel by lazy {
         PaymentSessionViewModel(
             ApplicationProvider.getApplicationContext(),
+            savedStateHandle,
             PaymentSessionFixtures.PAYMENT_SESSION_DATA,
             customerSession,
             paymentSessionPrefs
@@ -37,6 +42,30 @@ class PaymentSessionViewModelTest {
     }
 
     @Test
+    fun init_shouldGetButNotSetPaymentSessionDataFromSavedStateHandle() {
+        viewModel.paymentSessionData
+
+        verify(savedStateHandle).get<PaymentSessionData>(
+            PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA
+        )
+        verify(savedStateHandle, never()).set(
+            eq(PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA),
+            any<PaymentSessionData>()
+        )
+    }
+
+    @Test
+    fun init_whenSavedStateHasData_shouldUpdatePaymentSessionData() {
+        whenever(savedStateHandle.get<PaymentSessionData>(
+            PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA
+        )).thenReturn(UPDATED_DATA)
+
+        assertEquals(
+            UPDATED_DATA, viewModel.paymentSessionData
+        )
+    }
+
+    @Test
     fun updateCartTotal_shouldUpdatePaymentSessionData() {
         viewModel.updateCartTotal(5000)
         assertEquals(
@@ -47,7 +76,7 @@ class PaymentSessionViewModelTest {
 
     @Test
     fun getSelectedPaymentMethodId_whenPrefsNotSet_returnsNull() {
-        Mockito.`when`<Customer>(customerSession.cachedCustomer)
+        whenever(customerSession.cachedCustomer)
             .thenReturn(FIRST_CUSTOMER)
         assertNull(viewModel.getSelectedPaymentMethodId(null))
     }
@@ -55,16 +84,28 @@ class PaymentSessionViewModelTest {
     @Test
     fun getSelectedPaymentMethodId_whenHasPrefsSet_returnsExpectedId() {
         val customerId = requireNotNull(FIRST_CUSTOMER.id)
-        Mockito.`when`<String>(paymentSessionPrefs.getSelectedPaymentMethodId(customerId))
+        whenever(paymentSessionPrefs.getSelectedPaymentMethodId(customerId))
             .thenReturn("pm_12345")
 
-        Mockito.`when`<Customer>(customerSession.cachedCustomer).thenReturn(FIRST_CUSTOMER)
+        whenever(customerSession.cachedCustomer).thenReturn(FIRST_CUSTOMER)
         CustomerSession.instance = customerSession
 
         assertEquals("pm_12345", viewModel.getSelectedPaymentMethodId())
     }
 
+    @Test
+    fun settingPaymentSessionData_withSameValue_shouldUpdateSavedStateHandleOnce() {
+        repeat(3) {
+            viewModel.paymentSessionData = UPDATED_DATA
+        }
+        verify(savedStateHandle)
+            .set(PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA, UPDATED_DATA)
+    }
+
     private companion object {
         private val FIRST_CUSTOMER = CustomerFixtures.CUSTOMER
+
+        private val UPDATED_DATA = PaymentSessionFixtures.PAYMENT_SESSION_DATA
+            .copy(cartTotal = 999999)
     }
 }


### PR DESCRIPTION
## Summary
Integrate `SavedStateHandle` in `PaymentSessionViewModel`
and use it to get and set `paymentSessionData`

## Motivation
Enable `PaymentSessionViewModel` to survive process death

## Testing
Add unit tests
Enabled "Don't keep activities" and verify that `paymentSessionData`
is preserved