### PR TITLE
Fix Mastercard display name

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -85,7 +85,7 @@ enum class CardBrand(
 
     MasterCard(
         "mastercard",
-        "MasterCard",
+        "Mastercard",
         R.drawable.stripe_ic_mastercard,
         prefixes = listOf(
             "2221", "2222", "2223", "2224", "2225", "2226", "2227", "2228", "2229", "223", "224",


### PR DESCRIPTION
See https://brand.mastercard.com/brandcenter/mastercard-brand-mark.html

Fixes #2167