### PR TITLE
Add optional params on CustomerSession.getPaymentMethods()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import android.app.Activity
 import android.content.Context
 import android.os.Handler
+import androidx.annotation.IntRange
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.Stripe.Companion.appInfo
@@ -250,23 +251,53 @@ class CustomerSession @VisibleForTesting internal constructor(
     }
 
     /**
-     * Retrieves all of the customer's PaymentMethod objects,
-     * filtered by a [PaymentMethod.Type].
+     * Retrieves all of the customer's PaymentMethod objects, filtered by a [PaymentMethod.Type].
+     *
+     * See [List a Customer's PaymentMethods](https://stripe.com/docs/api/payment_methods/list)
      *
      * @param paymentMethodType the [PaymentMethod.Type] to filter by
      * @param listener a [PaymentMethodRetrievalListener] called when the API call
      * completes with a list of [PaymentMethod] objects
+     *
+     * @param limit Optional. A limit on the number of objects to be returned. Limit can range
+     * between 1 and 100, and the default is 10.
+     * @param endingBefore Optional. A cursor for use in pagination. `ending_before` is an object
+     * ID that defines your place in the list. For instance, if you make a list request and receive
+     * 100 objects, starting with `obj_bar`, your subsequent call can include
+     * `ending_before=obj_bar` in order to fetch the previous page of the list.
+     * @param startingAfter Optional. A cursor for use in pagination. `starting_after` is an object
+     * ID that defines your place in the list. For instance, if you make a list request and receive
+     * 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo`
+     * in order to fetch the next page of the list.
      */
+    @JvmOverloads
+    fun getPaymentMethods(
+        paymentMethodType: PaymentMethod.Type,
+        @IntRange(from = 1, to = 100) limit: Int?,
+        endingBefore: String? = null,
+        startingAfter: String? = null,
+        listener: PaymentMethodsRetrievalListener
+    ) {
+        startOperation(
+            EphemeralOperation.Customer.GetPaymentMethods(
+                type = paymentMethodType,
+                limit = limit,
+                endingBefore = endingBefore,
+                startingAfter = startingAfter,
+                id = operationIdFactory.create()
+            ),
+            listener
+        )
+    }
+
     fun getPaymentMethods(
         paymentMethodType: PaymentMethod.Type,
         listener: PaymentMethodsRetrievalListener
     ) {
-        startOperation(
-            EphemeralOperation.Customer.PaymentMethods(
-                type = paymentMethodType,
-                id = operationIdFactory.create()
-            ),
-            listener
+        getPaymentMethods(
+            paymentMethodType,
+            limit = null,
+            listener = listener
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/CustomerSessionRunnableFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSessionRunnableFactory.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.util.Pair
 import com.stripe.android.exception.StripeException
 import com.stripe.android.model.Customer
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
 
@@ -62,7 +63,7 @@ internal class CustomerSessionRunnableFactory(
                     operation
                 )
             }
-            is EphemeralOperation.Customer.PaymentMethods -> {
+            is EphemeralOperation.Customer.GetPaymentMethods -> {
                 createGetPaymentMethodsRunnable(
                     ephemeralKey,
                     operation
@@ -174,7 +175,7 @@ internal class CustomerSessionRunnableFactory(
 
     private fun createGetPaymentMethodsRunnable(
         key: EphemeralKey,
-        operation: EphemeralOperation.Customer.PaymentMethods
+        operation: EphemeralOperation.Customer.GetPaymentMethods
     ): Runnable {
         return object : CustomerSessionRunnable<List<PaymentMethod>>(
             handler,
@@ -184,8 +185,13 @@ internal class CustomerSessionRunnableFactory(
             @Throws(StripeException::class)
             public override fun createMessageObject(): List<PaymentMethod> {
                 return stripeRepository.getPaymentMethods(
-                    key.objectId,
-                    operation.type,
+                    ListPaymentMethodsParams(
+                        customerId = key.objectId,
+                        paymentMethodType = operation.type,
+                        limit = operation.limit,
+                        endingBefore = operation.endingBefore,
+                        startingAfter = operation.startingAfter
+                    ),
                     publishableKey,
                     productUsage.get(),
                     ApiRequest.Options(key.secret, stripeAccountId)

--- a/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
@@ -41,8 +41,11 @@ internal sealed class EphemeralOperation : Parcelable {
         ) : Customer()
 
         @Parcelize
-        data class PaymentMethods(
+        data class GetPaymentMethods(
             internal val type: PaymentMethod.Type,
+            internal val limit: Int? = null,
+            internal val endingBefore: String? = null,
+            internal val startingAfter: String? = null,
             override val id: String
         ) : Customer()
 

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
 import com.stripe.android.model.FpxBankStatuses
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -441,7 +442,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
      * is being created
      * @param options a [ApiRequest.Options] object that contains connection data like the api
      * key, api version, etc
-     * @param tokenType the [Token.TokenType] being created
+     *
      * @return a [Token] that can be used to perform other operations with this card
      */
     @Throws(AuthenticationException::class, InvalidRequestException::class,
@@ -588,8 +589,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     @Throws(InvalidRequestException::class, APIConnectionException::class, APIException::class,
         AuthenticationException::class, CardException::class)
     override fun getPaymentMethods(
-        customerId: String,
-        paymentMethodType: PaymentMethod.Type,
+        listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
@@ -598,10 +598,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             apiRequestFactory.createGet(
                 paymentMethodsUrl,
                 requestOptions,
-                mapOf(
-                    "customer" to customerId,
-                    "type" to paymentMethodType.code
-                )
+                listPaymentMethodsParams.toParamMap()
             )
         )
 

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
 import com.stripe.android.model.FpxBankStatuses
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -168,8 +169,7 @@ internal interface StripeRepository {
     @Throws(AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class, APIException::class, CardException::class)
     fun getPaymentMethods(
-        customerId: String,
-        paymentMethodType: PaymentMethod.Type,
+        listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options

--- a/stripe/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+internal data class ListPaymentMethodsParams(
+    private val customerId: String,
+    private val paymentMethodType: PaymentMethod.Type,
+    private val limit: Int? = null,
+    private val endingBefore: String? = null,
+    private val startingAfter: String? = null
+) : StripeParamsModel, Parcelable {
+    override fun toParamMap(): Map<String, Any> {
+        return listOf(
+            PARAM_CUSTOMER to customerId,
+            PARAM_TYPE to paymentMethodType.code,
+            PARAM_LIMIT to limit,
+            PARAM_ENDING_BEFORE to endingBefore,
+            PARAM_STARTING_AFTER to startingAfter
+        ).fold(emptyMap()) { acc, (key, value) ->
+            acc.plus(
+                value?.let { mapOf(key to it) }.orEmpty()
+            )
+        }
+    }
+
+    private companion object {
+        private const val PARAM_CUSTOMER = "customer"
+        private const val PARAM_TYPE = "type"
+        private const val PARAM_LIMIT = "limit"
+        private const val PARAM_ENDING_BEFORE = "ending_before"
+        private const val PARAM_STARTING_AFTER = "starting_after"
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -5,6 +5,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
 import com.stripe.android.model.FpxBankStatuses
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -163,8 +164,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     @Throws(APIException::class)
     override fun getPaymentMethods(
-        customerId: String,
-        paymentMethodType: PaymentMethod.Type,
+        listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.exception.APIException
 import com.stripe.android.model.Customer
 import com.stripe.android.model.CustomerFixtures
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.Source
@@ -122,7 +123,6 @@ class CustomerSessionTest {
 
         `when`(stripeRepository.getPaymentMethods(
             any(),
-            eq(PaymentMethod.Type.Card),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             any(),
             any()
@@ -695,8 +695,10 @@ class CustomerSessionTest {
         assertTrue(customerSession.productUsageTokens.isEmpty())
         assertNotNull(FIRST_CUSTOMER.id)
         verify(stripeRepository).getPaymentMethods(
-            eq(FIRST_CUSTOMER.id.orEmpty()),
-            eq(PaymentMethod.Type.Card),
+            eq(ListPaymentMethodsParams(
+                customerId = FIRST_CUSTOMER.id.orEmpty(),
+                paymentMethodType = PaymentMethod.Type.Card
+            )),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             productUsageArgumentCaptor.capture(),
             requestOptionsArgumentCaptor.capture()
@@ -763,7 +765,6 @@ class CustomerSessionTest {
 
         `when`(stripeRepository.getPaymentMethods(
             any(),
-            eq(PaymentMethod.Type.Card),
             eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
             any(),
             any()))

--- a/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/EphemeralKeyManagerTest.kt
@@ -119,7 +119,7 @@ class EphemeralKeyManagerTest {
 
         val keyManager = createEphemeralKeyManager(operationIdFactory)
 
-        val operation = EphemeralOperation.Customer.PaymentMethods(
+        val operation = EphemeralOperation.Customer.GetPaymentMethods(
             type = PaymentMethod.Type.Card,
             id = operationIdFactory.create()
         )

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.BankAccountTokenParamsFixtures
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardFixtures
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -580,8 +581,10 @@ class StripeApiRepositoryTest {
         val stripeApiRepository = create()
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
-                "cus_123",
-                PaymentMethod.Type.Card,
+                ListPaymentMethodsParams(
+                    "cus_123",
+                    PaymentMethod.Type.Card
+                ),
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
@@ -630,8 +633,10 @@ class StripeApiRepositoryTest {
         val stripeApiRepository = create()
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
-                "cus_123",
-                PaymentMethod.Type.Card,
+                ListPaymentMethodsParams(
+                    "cus_123",
+                    PaymentMethod.Type.Card
+                ),
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)


### PR DESCRIPTION
## Summary
Add optional params for retrieving a Customer's
Payment Methods [0]:
- `ending_before`
- `limit`
- `starting_after`

[0] https://stripe.com/docs/api/payment_methods/list

## Motivation
Improve API bindings

## Testing
Update unit tests
Manually verify
