### PR TITLE
Create PaymentSessionViewModel.networkState

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -70,6 +70,16 @@ class PaymentSession @VisibleForTesting internal constructor(
 
     init {
         lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        viewModel.networkState.observe(lifecycleOwner, Observer {
+            it?.let { networkState ->
+                listener?.onCommunicatingStateChanged(
+                    when (networkState) {
+                        PaymentSessionViewModel.NetworkState.Active -> true
+                        PaymentSessionViewModel.NetworkState.Inactive -> false
+                    }
+                )
+            }
+        })
     }
 
     /**
@@ -179,7 +189,6 @@ class PaymentSession @VisibleForTesting internal constructor(
 
     private fun dispatchUpdates() {
         listener?.onPaymentSessionDataChanged(paymentSessionData)
-        listener?.onCommunicatingStateChanged(false)
     }
 
     private fun persistPaymentMethodResult(
@@ -274,8 +283,6 @@ class PaymentSession @VisibleForTesting internal constructor(
     }
 
     private fun fetchCustomer() {
-        listener?.onCommunicatingStateChanged(true)
-
         viewModel.fetchCustomer().observe(lifecycleOwner, Observer {
             when (it) {
                 PaymentSessionViewModel.FetchCustomerResult.Success -> {
@@ -283,7 +290,6 @@ class PaymentSession @VisibleForTesting internal constructor(
                 }
                 is PaymentSessionViewModel.FetchCustomerResult.Error -> {
                     listener?.onError(it.errorCode, it.errorMessage)
-                    listener?.onCommunicatingStateChanged(false)
                 }
             }
         })

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -39,6 +39,9 @@ internal class PaymentSessionViewModel(
         }
     }
 
+    private val mutableNetworkState: MutableLiveData<NetworkState> = MutableLiveData()
+    internal val networkState: LiveData<NetworkState> = mutableNetworkState
+
     @JvmSynthetic
     fun updateCartTotal(@IntRange(from = 0) cartTotal: Long) {
         paymentSessionData = paymentSessionData.copy(cartTotal = cartTotal)
@@ -65,10 +68,13 @@ internal class PaymentSessionViewModel(
 
     @JvmSynthetic
     fun fetchCustomer(): LiveData<FetchCustomerResult> {
+        mutableNetworkState.value = NetworkState.Active
+
         val resultData: MutableLiveData<FetchCustomerResult> = MutableLiveData()
         customerSession.retrieveCurrentCustomer(
             object : CustomerSession.CustomerRetrievalListener {
                 override fun onCustomerRetrieved(customer: Customer) {
+                    mutableNetworkState.value = NetworkState.Inactive
                     resultData.value = FetchCustomerResult.Success
                 }
 
@@ -77,6 +83,7 @@ internal class PaymentSessionViewModel(
                     errorMessage: String,
                     stripeError: StripeError?
                 ) {
+                    mutableNetworkState.value = NetworkState.Inactive
                     resultData.value = FetchCustomerResult.Error(
                         errorCode, errorMessage, stripeError
                     )
@@ -105,6 +112,11 @@ internal class PaymentSessionViewModel(
             val errorMessage: String,
             val stripeError: StripeError?
         ) : FetchCustomerResult()
+    }
+
+    enum class NetworkState {
+        Active,
+        Inactive
     }
 
     internal class Factory(


### PR DESCRIPTION
A `LiveData` that represents the network state
(e.g. whether a network request is in progress)