### PR TITLE
Refactor PaymentSessionData

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
@@ -11,7 +11,9 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 data class PaymentSessionData internal constructor(
-    private val config: PaymentSessionConfig,
+    private val isShippingInfoRequired: Boolean,
+
+    private val isShippingMethodRequired: Boolean,
 
     /**
      * The cart total value, excluding shipping and tax items.
@@ -45,6 +47,10 @@ data class PaymentSessionData internal constructor(
      */
     val useGooglePay: Boolean = false
 ) : Parcelable {
+    internal constructor(config: PaymentSessionConfig) : this(
+        isShippingInfoRequired = config.isShippingInfoRequired,
+        isShippingMethodRequired = config.isShippingMethodRequired
+    )
 
     /**
      * Whether the payment data is ready for making a charge. This can be used to
@@ -53,6 +59,6 @@ data class PaymentSessionData internal constructor(
     val isPaymentReadyToCharge: Boolean
         get() =
             (paymentMethod != null || useGooglePay) &&
-                (!config.isShippingInfoRequired || shippingInformation != null) &&
-                (!config.isShippingMethodRequired || shippingMethod != null)
+                (!isShippingInfoRequired || shippingInformation != null) &&
+                (!isShippingMethodRequired || shippingMethod != null)
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionDataTest.kt
@@ -35,20 +35,23 @@ class PaymentSessionDataTest {
         assertFalse(PaymentSessionData(config).isPaymentReadyToCharge)
 
         assertFalse(PaymentSessionData(
-            config,
+            isShippingInfoRequired = config.isShippingInfoRequired,
+            isShippingMethodRequired = config.isShippingMethodRequired,
             paymentMethod = PAYMENT_METHOD
         ).isPaymentReadyToCharge)
 
         assertFalse(PaymentSessionData(
-            config,
+            isShippingInfoRequired = config.isShippingInfoRequired,
+            isShippingMethodRequired = config.isShippingMethodRequired,
             paymentMethod = PAYMENT_METHOD,
-            shippingInformation = ShippingInformation(null, null, null)
+            shippingInformation = ShippingInformation()
         ).isPaymentReadyToCharge)
 
         assertTrue(PaymentSessionData(
-            config,
+            isShippingInfoRequired = config.isShippingInfoRequired,
+            isShippingMethodRequired = config.isShippingMethodRequired,
             paymentMethod = PAYMENT_METHOD,
-            shippingInformation = ShippingInformation(null, null, null),
+            shippingInformation = ShippingInformation(),
             shippingMethod = ShippingMethod("label", "id", 0, "USD")
         ).isPaymentReadyToCharge)
     }
@@ -56,7 +59,8 @@ class PaymentSessionDataTest {
     @Test
     fun writeToParcel_withNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData(
-            config = PaymentSessionFixtures.CONFIG,
+            isShippingInfoRequired = true,
+            isShippingMethodRequired = true,
             cartTotal = 100L,
             shippingTotal = 150L
         )
@@ -67,11 +71,12 @@ class PaymentSessionDataTest {
     @Test
     fun writeToParcel_withoutNulls_readsFromParcelCorrectly() {
         val data = PaymentSessionData(
-            config = PaymentSessionFixtures.CONFIG,
+            isShippingInfoRequired = true,
+            isShippingMethodRequired = true,
             cartTotal = 100L,
             shippingTotal = 150L,
             paymentMethod = PAYMENT_METHOD,
-            shippingInformation = ShippingInformation(null, null, null),
+            shippingInformation = ShippingInformation(),
             shippingMethod = ShippingMethod("UPS", "SuperFast", 10000L, "USD")
         )
 


### PR DESCRIPTION
## Summary
Make `PaymentSessionData` not depend on `PaymentSessionConfig`
directly. Instead, create `isShippingInfoRequired` and
`isShippingMethodRequired` properties and populate those
from a `PaymentSessionConfig` instance.

## Motivation
`PaymentSessionConfig` is a complex object and equality checks
often fail unexpectedly. To make equality checks on
`PaymentSessionData` succeed, remove dependency on
`PaymentSessionConfig`.

## Testing
Add unit tests