### PR TITLE
Simplify PaymentSession onPaymentSessionDataChanged callback logic

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -274,15 +274,15 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setPostalCode("94107")
                 .setState("CA")
                 .build(),
-            "Fake Name",
+            "Jenny Rosen",
             "(555) 555-5555"
         )
 
         private val SHIPPING_METHODS = listOf(
             ShippingMethod("UPS Ground", "ups-ground",
-                0, "USD", "Arrives in 3-5 days"),
-            ShippingMethod("FedEx", "fedex",
-                599, "USD", "Arrives tomorrow")
+                599, "USD", "Arrives in 3-5 days"),
+            ShippingMethod("FedEx Overnight", "fedex",
+                1499, "USD", "Arrives tomorrow")
         )
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.view.PaymentMethodsActivityStarter
 
 internal class PaymentSessionViewModel(
     application: Application,
@@ -26,8 +27,12 @@ internal class PaymentSessionViewModel(
             if (value != field) {
                 field = value
                 savedStateHandle.set(KEY_PAYMENT_SESSION_DATA, value)
+                mutablePaymentSessionDataLiveData.value = value
             }
         }
+
+    private val mutablePaymentSessionDataLiveData: MutableLiveData<PaymentSessionData> = MutableLiveData()
+    val paymentSessionDataLiveData: LiveData<PaymentSessionData> = mutablePaymentSessionDataLiveData
 
     init {
         customerSession.resetUsageTokens()
@@ -103,6 +108,21 @@ internal class PaymentSessionViewModel(
                     paymentSessionPrefs.getSelectedPaymentMethodId(customerId)
                 }
             }
+    }
+
+    fun onPaymentMethodResult(result: PaymentMethodsActivityStarter.Result?) {
+        persistPaymentMethodResult(
+            paymentMethod = result?.paymentMethod,
+            useGooglePay = result?.useGooglePay ?: false
+        )
+    }
+
+    fun onPaymentFlowResult(paymentSessionData: PaymentSessionData) {
+        this.paymentSessionData = paymentSessionData
+    }
+
+    fun onListenerAttached() {
+        mutablePaymentSessionDataLiveData.value = paymentSessionData
     }
 
     sealed class FetchCustomerResult {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
@@ -9,9 +9,11 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.model.CustomerFixtures
+import com.stripe.android.view.PaymentMethodsActivityStarter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -100,6 +102,24 @@ class PaymentSessionViewModelTest {
         }
         verify(savedStateHandle)
             .set(PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA, UPDATED_DATA)
+    }
+
+    @Test
+    fun settingPaymentSessionData_shouldUpdateLiveData() {
+        var liveData: PaymentSessionData? = null
+        viewModel.paymentSessionDataLiveData.observeForever { liveData = it }
+        viewModel.paymentSessionData = UPDATED_DATA
+        assertEquals(UPDATED_DATA, liveData)
+    }
+
+    @Test
+    fun onPaymentMethodResult_withGooglePay_shouldUpdateLiveData() {
+        var liveData: PaymentSessionData? = null
+        viewModel.paymentSessionDataLiveData.observeForever { liveData = it }
+        viewModel.onPaymentMethodResult(PaymentMethodsActivityStarter.Result(
+            useGooglePay = true
+        ))
+        assertTrue(liveData?.useGooglePay == true)
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
Call `onPaymentSessionDataChanged()` whenever
`PaymentSessionData` has changed.

Additionally, call `onPaymentSessionDataChanged()`
when the listener is first attached, so that the
callback always happens.

Move some logic from `PaymentSession` to
`PaymentSessionViewModel`.

## Motivation
Simplify logic for calling `onPaymentSessionDataChanged()`

## Testing
Add tests
Manually verify
