### PR TITLE
Fetch previously used PaymentMethod in PaymentSession

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionPrefs.kt
@@ -3,13 +3,13 @@ package com.stripe.android
 import android.content.Context
 
 internal interface PaymentSessionPrefs {
-    fun getSelectedPaymentMethodId(customerId: String): String?
-    fun saveSelectedPaymentMethodId(customerId: String, paymentMethodId: String?)
+    fun getPaymentMethodId(customerId: String?): String?
+    fun savePaymentMethodId(customerId: String, paymentMethodId: String?)
 
     companion object {
         private const val PREF_FILE = "PaymentSessionPrefs"
 
-        private fun getPaymentMethodKey(customerId: String): String {
+        private fun getPaymentMethodKey(customerId: String?): String {
             return "customer[$customerId].payment_method"
         }
 
@@ -19,11 +19,15 @@ internal interface PaymentSessionPrefs {
                 PREF_FILE, Context.MODE_PRIVATE
             )
             return object : PaymentSessionPrefs {
-                override fun getSelectedPaymentMethodId(customerId: String): String? {
-                    return prefs?.getString(getPaymentMethodKey(customerId), null)
+                override fun getPaymentMethodId(customerId: String?): String? {
+                    return if (customerId != null) {
+                        prefs?.getString(getPaymentMethodKey(customerId), null)
+                    } else {
+                        null
+                    }
                 }
 
-                override fun saveSelectedPaymentMethodId(
+                override fun savePaymentMethodId(
                     customerId: String,
                     paymentMethodId: String?
                 ) {

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionViewModelTest.kt
@@ -2,18 +2,23 @@ package com.stripe.android
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.model.CustomerFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.view.PaymentMethodsActivityStarter
+import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -23,14 +28,23 @@ class PaymentSessionViewModelTest {
     private val paymentSessionPrefs: PaymentSessionPrefs = mock()
     private val savedStateHandle: SavedStateHandle = mock()
 
-    private val viewModel: PaymentSessionViewModel by lazy {
-        PaymentSessionViewModel(
-            ApplicationProvider.getApplicationContext(),
-            savedStateHandle,
-            PaymentSessionFixtures.PAYMENT_SESSION_DATA,
-            customerSession,
-            paymentSessionPrefs
-        )
+    private val paymentMethodsListenerCaptor: KArgumentCaptor<CustomerSession.PaymentMethodsRetrievalListener> = argumentCaptor()
+    private val customerRetrievalListenerCaptor: KArgumentCaptor<CustomerSession.CustomerRetrievalListener> = argumentCaptor()
+
+    private val viewModel: PaymentSessionViewModel by lazy { createViewModel() }
+
+    private val paymentSessionDatas: MutableList<PaymentSessionData> = mutableListOf()
+    private val networkStates: MutableList<PaymentSessionViewModel.NetworkState> = mutableListOf()
+
+    @BeforeTest
+    fun before() {
+        viewModel.networkState.observeForever {
+            networkStates.add(it)
+        }
+
+        viewModel.paymentSessionDataLiveData.observeForever {
+            paymentSessionDatas.add(it)
+        }
     }
 
     @Test
@@ -62,37 +76,41 @@ class PaymentSessionViewModelTest {
             PaymentSessionViewModel.KEY_PAYMENT_SESSION_DATA
         )).thenReturn(UPDATED_DATA)
 
-        assertEquals(
-            UPDATED_DATA, viewModel.paymentSessionData
-        )
+        val viewModel = createViewModel()
+        viewModel.paymentSessionDataLiveData.observeForever {
+            paymentSessionDatas.add(it)
+        }
+
+        assertThat(paymentSessionDatas)
+            .containsExactly(UPDATED_DATA)
     }
 
     @Test
     fun updateCartTotal_shouldUpdatePaymentSessionData() {
         viewModel.updateCartTotal(5000)
-        assertEquals(
-            5000,
-            viewModel.paymentSessionData.cartTotal
-        )
+        assertThat(viewModel.paymentSessionData.cartTotal)
+            .isEqualTo(5000)
     }
 
     @Test
     fun getSelectedPaymentMethodId_whenPrefsNotSet_returnsNull() {
         whenever(customerSession.cachedCustomer)
             .thenReturn(FIRST_CUSTOMER)
-        assertNull(viewModel.getSelectedPaymentMethodId(null))
+        assertThat(viewModel.getSelectedPaymentMethodId(null))
+            .isNull()
     }
 
     @Test
     fun getSelectedPaymentMethodId_whenHasPrefsSet_returnsExpectedId() {
         val customerId = requireNotNull(FIRST_CUSTOMER.id)
-        whenever(paymentSessionPrefs.getSelectedPaymentMethodId(customerId))
+        whenever(paymentSessionPrefs.getPaymentMethodId(customerId))
             .thenReturn("pm_12345")
 
         whenever(customerSession.cachedCustomer).thenReturn(FIRST_CUSTOMER)
         CustomerSession.instance = customerSession
 
-        assertEquals("pm_12345", viewModel.getSelectedPaymentMethodId())
+        assertThat(viewModel.getSelectedPaymentMethodId())
+            .isEqualTo("pm_12345")
     }
 
     @Test
@@ -106,26 +124,197 @@ class PaymentSessionViewModelTest {
 
     @Test
     fun settingPaymentSessionData_shouldUpdateLiveData() {
-        var liveData: PaymentSessionData? = null
-        viewModel.paymentSessionDataLiveData.observeForever { liveData = it }
         viewModel.paymentSessionData = UPDATED_DATA
-        assertEquals(UPDATED_DATA, liveData)
+        assertThat(paymentSessionDatas)
+            .containsExactly(UPDATED_DATA)
     }
 
     @Test
     fun onPaymentMethodResult_withGooglePay_shouldUpdateLiveData() {
-        var liveData: PaymentSessionData? = null
-        viewModel.paymentSessionDataLiveData.observeForever { liveData = it }
         viewModel.onPaymentMethodResult(PaymentMethodsActivityStarter.Result(
             useGooglePay = true
         ))
-        assertTrue(liveData?.useGooglePay == true)
+        assertThat(paymentSessionDatas.last().useGooglePay)
+            .isTrue()
     }
+
+    @Test
+    fun onCustomerRetrieved_whenIsInitialFetchAndPreviouslyUsedPaymentMethodExists_shouldUpdatePaymentSessionData() {
+        val customerPaymentMethods = PaymentMethodFixtures.createCards(20)
+        doNothing().whenever(customerSession).getPaymentMethods(
+            paymentMethodType = eq(PaymentMethod.Type.Card),
+            limit = eq(100),
+            endingBefore = anyOrNull(),
+            startingAfter = anyOrNull(),
+            listener = any()
+        )
+        whenever(paymentSessionPrefs.getPaymentMethodId("cus_123"))
+            .thenReturn(customerPaymentMethods.last().id)
+
+        var onCompleteCallbackCount = 0
+        viewModel.onCustomerRetrieved(
+            customerId = "cus_123",
+            isInitialFetch = true
+        ) {
+            onCompleteCallbackCount++
+        }
+
+        verify(customerSession).getPaymentMethods(
+            paymentMethodType = eq(PaymentMethod.Type.Card),
+            limit = eq(100),
+            endingBefore = anyOrNull(),
+            startingAfter = anyOrNull(),
+            listener = paymentMethodsListenerCaptor.capture()
+        )
+        paymentMethodsListenerCaptor.firstValue.onPaymentMethodsRetrieved(
+            customerPaymentMethods
+        )
+
+        assertThat(paymentSessionDatas.last().paymentMethod)
+            .isEqualTo(customerPaymentMethods.last())
+
+        assertThat(onCompleteCallbackCount)
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun onCustomerRetrieved_whenIsInitialFetchAndPreviouslyUsedPaymentMethodIsNotFoundInList_shouldNotUpdatePaymentSessionData() {
+        val customerPaymentMethods = PaymentMethodFixtures.createCards(20)
+        doNothing().whenever(customerSession).getPaymentMethods(
+            paymentMethodType = eq(PaymentMethod.Type.Card),
+            limit = eq(100),
+            endingBefore = anyOrNull(),
+            startingAfter = anyOrNull(),
+            listener = any()
+        )
+        whenever(paymentSessionPrefs.getPaymentMethodId("cus_123"))
+            .thenReturn("pm_not_in_list")
+
+        var onCompleteCallbackCount = 0
+        viewModel.onCustomerRetrieved(
+            customerId = "cus_123",
+            isInitialFetch = true
+        ) {
+            onCompleteCallbackCount++
+        }
+
+        verify(customerSession).getPaymentMethods(
+            paymentMethodType = eq(PaymentMethod.Type.Card),
+            limit = eq(100),
+            endingBefore = anyOrNull(),
+            startingAfter = anyOrNull(),
+            listener = paymentMethodsListenerCaptor.capture()
+        )
+        paymentMethodsListenerCaptor.firstValue.onPaymentMethodsRetrieved(
+            customerPaymentMethods
+        )
+
+        assertThat(paymentSessionDatas)
+            .isEmpty()
+
+        assertThat(onCompleteCallbackCount)
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun onCustomerRetrieved_whenIsInitialFetchAndPreviouslyUsedPaymentMethodDoesNotExist_shouldNotFetchPaymentMethods() {
+        whenever(paymentSessionPrefs.getPaymentMethodId("cus_123"))
+            .thenReturn(null)
+
+        var onCompleteCallbackCount = 0
+        viewModel.onCustomerRetrieved(
+            customerId = "cus_123",
+            isInitialFetch = true
+        ) {
+            onCompleteCallbackCount++
+        }
+
+        verify(customerSession, never()).getPaymentMethods(
+            paymentMethodType = eq(PaymentMethod.Type.Card),
+            limit = eq(100),
+            endingBefore = anyOrNull(),
+            startingAfter = anyOrNull(),
+            listener = any()
+        )
+
+        assertThat(paymentSessionDatas)
+            .isEmpty()
+
+        assertThat(onCompleteCallbackCount)
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun fetchCustomer_onSuccess_returnsSuccessResult() {
+        doNothing().whenever(customerSession).retrieveCurrentCustomer(
+            listener = any()
+        )
+
+        val results: MutableList<PaymentSessionViewModel.FetchCustomerResult> = mutableListOf()
+        viewModel.fetchCustomer().observeForever {
+            results.add(it)
+        }
+
+        verify(customerSession).retrieveCurrentCustomer(
+            customerRetrievalListenerCaptor.capture()
+        )
+        customerRetrievalListenerCaptor.firstValue
+            .onCustomerRetrieved(CustomerFixtures.CUSTOMER)
+
+        assertThat(results)
+            .containsExactly(PaymentSessionViewModel.FetchCustomerResult.Success)
+
+        assertThat(networkStates)
+            .isEqualTo(EXPECTED_NETWORK_STATES)
+    }
+
+    @Test
+    fun fetchCustomer_onError_returnsErrorResult() {
+        doNothing().whenever(customerSession).retrieveCurrentCustomer(
+            listener = any()
+        )
+
+        val results: MutableList<PaymentSessionViewModel.FetchCustomerResult> = mutableListOf()
+        viewModel.fetchCustomer().observeForever {
+            results.add(it)
+        }
+
+        verify(customerSession).retrieveCurrentCustomer(
+            customerRetrievalListenerCaptor.capture()
+        )
+        customerRetrievalListenerCaptor.firstValue
+            .onError(500, "error", StripeErrorFixtures.INVALID_REQUEST_ERROR)
+
+        assertThat(results)
+            .containsExactly(
+                PaymentSessionViewModel.FetchCustomerResult.Error(
+                    500,
+                    "error",
+                    StripeErrorFixtures.INVALID_REQUEST_ERROR
+                )
+            )
+
+        assertThat(networkStates)
+            .isEqualTo(EXPECTED_NETWORK_STATES)
+    }
+
+    private fun createViewModel() = PaymentSessionViewModel(
+        ApplicationProvider.getApplicationContext(),
+        savedStateHandle,
+        PaymentSessionFixtures.PAYMENT_SESSION_DATA,
+        customerSession,
+        paymentSessionPrefs
+    )
 
     private companion object {
         private val FIRST_CUSTOMER = CustomerFixtures.CUSTOMER
 
         private val UPDATED_DATA = PaymentSessionFixtures.PAYMENT_SESSION_DATA
             .copy(cartTotal = 999999)
+
+        private val EXPECTED_NETWORK_STATES = listOf(
+            PaymentSessionViewModel.NetworkState.Active,
+            PaymentSessionViewModel.NetworkState.Inactive
+        )
     }
 }


### PR DESCRIPTION
## Summary
When a customer starts a new `PaymentSession`, if they
have previously selected a payment method (determined
via `PaymentSessionPrefs`), fetch the full `PaymentMethod`
object from the API and update the `PaymentSessionData`.

This behavior will only be triggered when
`PaymentSessionConfig.shouldPrefetchCustomer == true`.

## Motivation
Fixes #1977

## Testing
- Add unit tests
- Manually verify

Customer selects a payment method, leaves the `PaymentSession`, then starts a new `PaymentSession`. The UI is updated with the previously selected payment method.

![persisted](https://user-images.githubusercontent.com/45020849/74481406-a937ac80-4e80-11ea-8d56-b35298c8f07a.gif)
