### PR TITLE
Create CardFunding enum

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -2,7 +2,6 @@ package com.stripe.android.model
 
 import androidx.annotation.IntRange
 import androidx.annotation.Size
-import androidx.annotation.StringDef
 import com.stripe.android.CardUtils
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.parsers.CardJsonParser
@@ -128,9 +127,7 @@ data class Card internal constructor(
      *
      * [API Reference](https://stripe.com/docs/api/cards/object#card_object-funding)
      */
-    @FundingType
-    @get:FundingType
-    val funding: String?,
+    val funding: CardFunding?,
 
     /**
      * @return Uniquely identifies this particular card number. You can use this attribute to
@@ -198,17 +195,6 @@ data class Card internal constructor(
      */
     val metadata: Map<String, String>?
 ) : StripeModel, StripePaymentSource, TokenParams(Token.TokenType.CARD, loggingTokens) {
-
-    @Retention(AnnotationRetention.SOURCE)
-    @StringDef(FundingType.CREDIT, FundingType.DEBIT, FundingType.PREPAID, FundingType.UNKNOWN)
-    annotation class FundingType {
-        companion object {
-            const val CREDIT: String = "credit"
-            const val DEBIT: String = "debit"
-            const val PREPAID: String = "prepaid"
-            const val UNKNOWN: String = "unknown"
-        }
-    }
 
     fun toPaymentMethodsParams(): PaymentMethodCreateParams {
         return PaymentMethodCreateParams.create(
@@ -396,8 +382,7 @@ data class Card internal constructor(
         private var addressZipCheck: String? = null
         private var addressCountry: String? = null
         private var brand: CardBrand? = null
-        @FundingType
-        private var funding: String? = null
+        private var funding: CardFunding? = null
         @Size(4)
         private var last4: String? = null
         private var fingerprint: String? = null
@@ -455,7 +440,7 @@ data class Card internal constructor(
             return this
         }
 
-        fun funding(@FundingType funding: String?): Builder = apply {
+        fun funding(funding: CardFunding?): Builder = apply {
             this.funding = funding
         }
 
@@ -520,7 +505,7 @@ data class Card internal constructor(
                 last4 = last4,
                 brand = brand ?: CardUtils.getPossibleCardType(number),
                 fingerprint = fingerprint.takeUnless { it.isNullOrBlank() },
-                funding = asFundingType(funding).takeUnless { it.isNullOrBlank() },
+                funding = funding,
                 country = country.takeUnless { it.isNullOrBlank() },
                 currency = currency.takeUnless { it.isNullOrBlank() },
                 customerId = customerId.takeUnless { it.isNullOrBlank() },
@@ -547,30 +532,6 @@ data class Card internal constructor(
 
     companion object {
         internal const val OBJECT_TYPE = "card"
-
-        /**
-         * Converts an unchecked String value to a [FundingType] or `null`.
-         *
-         * @param possibleFundingType a String that might match a [FundingType] or be empty
-         * @return `null` if the input is blank, else the appropriate [FundingType]
-         */
-        @JvmStatic
-        @FundingType
-        fun asFundingType(possibleFundingType: String?): String? {
-            if (possibleFundingType.isNullOrBlank()) {
-                return null
-            }
-
-            return when {
-                FundingType.CREDIT.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.CREDIT
-                FundingType.DEBIT.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.DEBIT
-                FundingType.PREPAID.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.PREPAID
-                else -> FundingType.UNKNOWN
-            }
-        }
 
         /**
          * Create a Card object from a raw JSON string.

--- a/stripe/src/main/java/com/stripe/android/model/CardFunding.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardFunding.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.model
+
+enum class CardFunding(internal val code: String) {
+    Credit("credit"),
+    Debit("debit"),
+    Prepaid("prepaid"),
+    Unknown("unknown");
+
+    internal companion object {
+        internal fun fromCode(code: String?): CardFunding? {
+            return values().firstOrNull { it.code == code }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/model/SourceCardData.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceCardData.kt
@@ -10,19 +10,13 @@ import kotlinx.android.parcel.Parcelize
 data class SourceCardData internal constructor(
     val addressLine1Check: String?,
     val addressZipCheck: String?,
-
     val brand: CardBrand,
-
     val country: String?,
     val cvcCheck: String?,
     val dynamicLast4: String?,
     val expiryMonth: Int?,
     val expiryYear: Int?,
-
-    @Card.FundingType
-    @get:Card.FundingType
-    val funding: String?,
-
+    val funding: CardFunding?,
     val last4: String?,
     @ThreeDSecureStatus
     @get:ThreeDSecureStatus

--- a/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.model.Card
-import com.stripe.android.model.Card.FundingType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.TokenizationMethod
 import org.json.JSONObject
@@ -36,7 +36,7 @@ internal class CardJsonParser : ModelJsonParser<Card> {
             .customer(StripeJsonUtils.optString(json, FIELD_CUSTOMER))
             .currency(StripeJsonUtils.optCurrency(json, FIELD_CURRENCY))
             .cvcCheck(StripeJsonUtils.optString(json, FIELD_CVC_CHECK))
-            .funding(asFundingType(StripeJsonUtils.optString(json, FIELD_FUNDING)))
+            .funding(CardFunding.fromCode(StripeJsonUtils.optString(json, FIELD_FUNDING)))
             .fingerprint(StripeJsonUtils.optString(json, FIELD_FINGERPRINT))
             .id(StripeJsonUtils.optString(json, FIELD_ID))
             .last4(StripeJsonUtils.optString(json, FIELD_LAST4))
@@ -77,29 +77,5 @@ internal class CardJsonParser : ModelJsonParser<Card> {
         private const val FIELD_LAST4 = "last4"
         private const val FIELD_ID = "id"
         private const val FIELD_TOKENIZATION_METHOD = "tokenization_method"
-
-        /**
-         * Converts an unchecked String value to a [FundingType] or `null`.
-         *
-         * @param possibleFundingType a String that might match a [FundingType] or be empty
-         * @return `null` if the input is blank, else the appropriate [FundingType]
-         */
-        @JvmStatic
-        @FundingType
-        fun asFundingType(possibleFundingType: String?): String? {
-            if (possibleFundingType.isNullOrBlank()) {
-                return null
-            }
-
-            return when {
-                FundingType.CREDIT.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.CREDIT
-                FundingType.DEBIT.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.DEBIT
-                FundingType.PREPAID.equals(possibleFundingType, ignoreCase = true) ->
-                    FundingType.PREPAID
-                else -> FundingType.UNKNOWN
-            }
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.TokenizationMethod
@@ -20,7 +20,7 @@ internal class SourceCardDataJsonParser : ModelJsonParser<SourceCardData> {
             dynamicLast4 = StripeJsonUtils.optString(json, FIELD_DYNAMIC_LAST4),
             expiryMonth = StripeJsonUtils.optInteger(json, FIELD_EXP_MONTH),
             expiryYear = StripeJsonUtils.optInteger(json, FIELD_EXP_YEAR),
-            funding = Card.asFundingType(StripeJsonUtils.optString(json, FIELD_FUNDING)),
+            funding = CardFunding.fromCode(StripeJsonUtils.optString(json, FIELD_FUNDING)),
             last4 = StripeJsonUtils.optString(json, FIELD_LAST4),
             threeDSecureStatus = asThreeDSecureStatus(
                 StripeJsonUtils.optString(json, FIELD_THREE_D_SECURE)

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -17,6 +17,7 @@ import com.stripe.android.model.BankAccountTokenParamsFixtures;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.CardBrand;
 import com.stripe.android.model.CardFixtures;
+import com.stripe.android.model.CardFunding;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.PaymentMethodCreateParams;
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures;
@@ -169,7 +170,7 @@ public class StripeTest {
         assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
         assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
-        assertEquals(Card.FundingType.CREDIT, returnedCard.getFunding());
+        assertEquals(CardFunding.Credit, returnedCard.getFunding());
     }
 
     @Test
@@ -192,7 +193,7 @@ public class StripeTest {
         assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
         assertEquals(CARD.getExpMonth(), returnedCard.getExpMonth());
-        assertEquals(Card.FundingType.CREDIT, returnedCard.getFunding());
+        assertEquals(CardFunding.Credit, returnedCard.getFunding());
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CardFundingTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardFundingTest.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CardFundingTest {
+    @Test
+    fun fromCode_shouldReturnExpectedValue() {
+        CardFunding.values().forEach {
+            assertEquals(it, CardFunding.fromCode(it.code))
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
 import com.stripe.android.CardNumberFixtures
-import com.stripe.android.model.Card.Companion.asFundingType
 import com.stripe.android.model.parsers.CardJsonParser
 import java.util.Calendar
 import kotlin.test.BeforeTest
@@ -25,41 +24,6 @@ class CardTest {
         calendar.set(Calendar.YEAR, 1997)
         calendar.set(Calendar.MONTH, Calendar.AUGUST)
         calendar.set(Calendar.DAY_OF_MONTH, 29)
-    }
-
-    @Test
-    fun asFundingType_whenDebit_returnsDebit() {
-        assertEquals(Card.FundingType.DEBIT, asFundingType("debit"))
-    }
-
-    @Test
-    fun asFundingType_whenCredit_returnsCredit() {
-        assertEquals(Card.FundingType.CREDIT, asFundingType("credit"))
-    }
-
-    @Test
-    fun asFundingType_whenCreditAndCapitalized_returnsCredit() {
-        assertEquals(Card.FundingType.CREDIT, asFundingType("Credit"))
-    }
-
-    @Test
-    fun asFundingType_whenNull_returnsNull() {
-        assertNull(asFundingType(null))
-    }
-
-    @Test
-    fun asFundingType_whenBlank_returnsNull() {
-        assertNull(asFundingType("   \t"))
-    }
-
-    @Test
-    fun asFundingType_whenUnknown_returnsUnknown() {
-        assertEquals(Card.FundingType.UNKNOWN, asFundingType("unknown"))
-    }
-
-    @Test
-    fun asFundingType_whenGobbledegook_returnsUnkown() {
-        assertEquals(Card.FundingType.UNKNOWN, asFundingType("personal iou"))
     }
 
     @Test
@@ -652,7 +616,7 @@ class CardTest {
 
         internal val CARD_USD = Card.Builder(expMonth = 8, expYear = 2017)
             .brand(CardBrand.Visa)
-            .funding(Card.FundingType.CREDIT)
+            .funding(CardFunding.Credit)
             .last4("4242")
             .id("card_189fi32eZvKYlo2CHK8NPRME")
             .country("US")

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
@@ -69,7 +69,7 @@ class TokenTest {
             .brand(CardBrand.Visa)
             .country("US")
             .last4("4242")
-            .funding(Card.FundingType.CREDIT)
+            .funding(CardFunding.Credit)
             .metadata(emptyMap())
             .build()
 

--- a/stripe/src/test/java/com/stripe/android/model/parsers/SourceCardDataJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/SourceCardDataJsonParserTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.model.SourceCardData
 import com.stripe.android.model.SourceFixtures
 import com.stripe.android.model.TokenizationMethod
@@ -29,7 +29,7 @@ class SourceCardDataJsonParserTest {
     @Test
     fun fromExampleJsonCard_createsExpectedObject() {
         assertEquals(CardBrand.Visa, CARD_DATA.brand)
-        assertEquals(Card.FundingType.CREDIT, CARD_DATA.funding)
+        assertEquals(CardFunding.Credit, CARD_DATA.funding)
         assertEquals("4242", CARD_DATA.last4)
         assertNotNull(CARD_DATA.expiryMonth)
         assertNotNull(CARD_DATA.expiryYear)


### PR DESCRIPTION
## Summary
Convert `Card.FundingType` `@StringDef` to an enum

## Motivation
Simplify logic and reuse in a future PR
