### PR TITLE
Cleanup StripeException subclasses

### DIFF
--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -151,7 +151,7 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
             )
             listener.onIssuingCardPinRetrieved(pin)
         } catch (e: InvalidRequestException) {
-            when (e.errorCode) {
+            when (e.stripeError?.code) {
                 "expired" -> {
                     listener.onError(
                         CardPinActionError.ONE_TIME_CODE_EXPIRED,
@@ -237,7 +237,7 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
             )
             listener.onIssuingCardPinUpdated()
         } catch (e: InvalidRequestException) {
-            when (e.errorCode) {
+            when (e.stripeError?.code) {
                 "expired" -> {
                     listener.onError(
                         CardPinActionError.ONE_TIME_CODE_EXPIRED,

--- a/stripe/src/main/java/com/stripe/android/QueryStringFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/QueryStringFactory.kt
@@ -62,7 +62,9 @@ internal class QueryStringFactory {
             "" -> throw InvalidRequestException(
                 message = "You cannot set '$keyPrefix' to an empty string. We interpret empty strings as " +
                     "null in requests. You may set '$keyPrefix' to null to delete the property.",
-                param = keyPrefix
+                stripeError = StripeError(
+                    param = keyPrefix
+                )
             )
             null -> {
                 listOf(Parameter(keyPrefix, ""))

--- a/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/InvalidRequestException.kt
@@ -3,14 +3,13 @@ package com.stripe.android.exception
 import com.stripe.android.StripeError
 
 /**
- * An [Exception] indicating that invalid parameters were used in a request.
+ * A [StripeException] indicating that invalid parameters were used in a request.
  */
-open class InvalidRequestException(
+class InvalidRequestException(
     stripeError: StripeError? = null,
     requestId: String? = null,
     statusCode: Int = 0,
     message: String? = stripeError?.message,
-    val param: String? = stripeError?.param,
     cause: Throwable? = null
 ) : StripeException(
     stripeError,
@@ -18,7 +17,4 @@ open class InvalidRequestException(
     statusCode,
     cause,
     message
-) {
-    val errorCode: String? = stripeError?.code
-    val errorDeclineCode: String? = stripeError?.declineCode
-}
+)

--- a/stripe/src/main/java/com/stripe/android/exception/RateLimitException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/RateLimitException.kt
@@ -6,10 +6,14 @@ import com.stripe.android.StripeError
  * An [Exception] indicating that too many requests have hit the API too quickly.
  */
 class RateLimitException(
-    stripeError: StripeError,
-    requestId: String? = null
-) : InvalidRequestException(
-    stripeError = stripeError,
-    requestId = requestId,
-    statusCode = 429
+    stripeError: StripeError? = null,
+    requestId: String? = null,
+    message: String? = stripeError?.message,
+    cause: Throwable? = null
+) : StripeException(
+    stripeError,
+    requestId,
+    429,
+    cause,
+    message
 )

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -270,8 +270,8 @@ class StripeApiRepositoryTest {
                 )
             }
 
-        assertEquals("source", invalidRequestException.param)
-        assertEquals("resource_missing", invalidRequestException.errorCode)
+        assertEquals("source", invalidRequestException.stripeError?.param)
+        assertEquals("resource_missing", invalidRequestException.stripeError?.code)
     }
 
     @Test
@@ -284,8 +284,8 @@ class StripeApiRepositoryTest {
                 )
             }
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND, invalidRequestException.statusCode)
-        assertEquals("source", invalidRequestException.param)
-        assertEquals("resource_missing", invalidRequestException.errorCode)
+        assertEquals("source", invalidRequestException.stripeError?.param)
+        assertEquals("resource_missing", invalidRequestException.stripeError?.code)
     }
 
     @Test
@@ -665,7 +665,7 @@ class StripeApiRepositoryTest {
             "This PaymentIntent could be not be fulfilled via this session because a different payment method was attached to it. Another session could be attempting to fulfill this PaymentIntent. Please complete that session or try again.",
             exception.message
         )
-        assertEquals("payment_intent_unexpected_state", exception.errorCode)
+        assertEquals("payment_intent_unexpected_state", exception.stripeError?.code)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -398,7 +398,7 @@ public class StripeTest {
                         stripe.createSourceSynchronous(weChatPaySourceParams);
                     }
                 });
-        assertEquals("payment_method_unactivated", ex.getErrorCode());
+        assertEquals("payment_method_unactivated", ex.getStripeError().getCode());
         assertEquals(
                 "This payment method (wechat) is not activated for your account. You can only create testmode wechat payment methods. You can learn more about this here https://support.stripe.com/questions/i-am-having-trouble-activating-a-payment-method",
                 ex.getMessage()


### PR DESCRIPTION
## Summary
- `InvalidRequestException`
    - Make `final`
    - Remove properties that can be obtained from `StripeError` object
      (i.e. `param`, `errorCode`, `errorDeclineCode`)
- `RateLimitException` now extends `StripeException`

## Motivation
Simplify classes

## Testing
Update unit tests
