### PR TITLE
Add better support for Request Id header

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeResponse.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeResponse.kt
@@ -29,7 +29,15 @@ internal data class StripeResponse internal constructor(
         get() = responseCode == HttpURLConnection.HTTP_OK
 
     internal val requestId: String?
-        get() = responseHeaders?.get("Request-Id")?.firstOrNull()
+        get() {
+            return REQUEST_ID_HEADER_KEYS
+                .firstOrNull { headerKey ->
+                    // figure out which header key to use
+                    responseHeaders?.containsKey(headerKey) == true
+                }?.let { headerKey ->
+                    responseHeaders?.get(headerKey)?.firstOrNull()
+                }
+        }
 
     internal fun hasErrorCode(): Boolean {
         return responseCode < 200 || responseCode >= 300
@@ -45,5 +53,9 @@ internal data class StripeResponse internal constructor(
 
     override fun toString(): String {
         return "Request-Id: $requestId, Status Code: $responseCode"
+    }
+
+    private companion object {
+        private val REQUEST_ID_HEADER_KEYS = setOf("Request-Id", "request-id")
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeResponse.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeResponse.kt
@@ -23,20 +23,14 @@ internal data class StripeResponse internal constructor(
     /**
      * @return the response headers
      */
-    internal val responseHeaders: Map<String, List<String>>? = null
+    internal val responseHeaders: Map<String, List<String>> = emptyMap()
 ) {
     internal val isOk: Boolean
         get() = responseCode == HttpURLConnection.HTTP_OK
 
     internal val requestId: String?
         get() {
-            return REQUEST_ID_HEADER_KEYS
-                .firstOrNull { headerKey ->
-                    // figure out which header key to use
-                    responseHeaders?.containsKey(headerKey) == true
-                }?.let { headerKey ->
-                    responseHeaders?.get(headerKey)?.firstOrNull()
-                }
+            return getHeaderValue(REQUEST_ID_HEADER)?.firstOrNull()
         }
 
     internal fun hasErrorCode(): Boolean {
@@ -55,7 +49,14 @@ internal data class StripeResponse internal constructor(
         return "Request-Id: $requestId, Status Code: $responseCode"
     }
 
+    internal fun getHeaderValue(key: String): List<String>? {
+        return responseHeaders.entries
+            .firstOrNull {
+                it.key.equals(key, ignoreCase = true)
+            }?.value
+    }
+
     private companion object {
-        private val REQUEST_ID_HEADER_KEYS = setOf("Request-Id", "request-id")
+        private const val REQUEST_ID_HEADER = "Request-Id"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
@@ -313,22 +314,10 @@ class StripeApiRepositoryTest {
         )
         assertNotNull(response)
 
-        val responseHeaders = response.responseHeaders.orEmpty()
-
-        // the Stripe API response will either have a 'Stripe-Account' or 'stripe-account' header,
-        // so we need to check both
-        val accounts = when {
-            responseHeaders.containsKey(STRIPE_ACCOUNT_RESPONSE_HEADER) ->
-                responseHeaders[STRIPE_ACCOUNT_RESPONSE_HEADER]
-            responseHeaders.containsKey(
-                STRIPE_ACCOUNT_RESPONSE_HEADER.toLowerCase(Locale.ROOT)) ->
-                responseHeaders[STRIPE_ACCOUNT_RESPONSE_HEADER.toLowerCase(Locale.ROOT)]
-            else -> null
-        }
-
-        requireNotNull(accounts, { "Stripe API response should contain 'Stripe-Account' header" })
-        assertEquals(1, accounts.size)
-        assertEquals(connectAccountId, accounts[0])
+        val accountsHeader = response.getHeaderValue(STRIPE_ACCOUNT_RESPONSE_HEADER)
+        requireNotNull(accountsHeader, { "Stripe API response should contain 'Stripe-Account' header" })
+        assertThat(accountsHeader)
+            .containsExactly(connectAccountId)
     }
 
     @Test
@@ -560,7 +549,7 @@ class StripeApiRepositoryTest {
                 "url": "/v1/payment_methods"
             }
             """.trimIndent()
-        val stripeResponse = StripeResponse(200, responseBody, null)
+        val stripeResponse = StripeResponse(200, responseBody)
         val queryParams = mapOf(
             "customer" to "cus_123",
             "type" to PaymentMethod.Type.Card.code
@@ -611,7 +600,7 @@ class StripeApiRepositoryTest {
                 "url": "/v1/payment_methods"
             }
             """.trimIndent()
-        val stripeResponse = StripeResponse(200, responseBody, null)
+        val stripeResponse = StripeResponse(200, responseBody)
         val queryParams = mapOf(
             "customer" to "cus_123",
             "type" to PaymentMethod.Type.Card.code

--- a/stripe/src/test/java/com/stripe/android/StripeResponseTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeResponseTest.kt
@@ -1,0 +1,31 @@
+package com.stripe.android
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class StripeResponseTest {
+
+    @Test
+    fun requestId_handlesLowerCaseKey() {
+        val response = StripeResponse(
+            responseCode = 200,
+            responseBody = "{}",
+            responseHeaders = mapOf("request-id" to listOf("req_12345"))
+        )
+
+        assertThat(response.requestId)
+            .isEqualTo("req_12345")
+    }
+
+    @Test
+    fun requestId_handlesTitleCaseKey() {
+        val response = StripeResponse(
+            responseCode = 200,
+            responseBody = "{}",
+            responseHeaders = mapOf("Request-Id" to listOf("req_12345"))
+        )
+
+        assertThat(response.requestId)
+            .isEqualTo("req_12345")
+    }
+}


### PR DESCRIPTION
The API passes the request ID header as either  `Request-Id` or
`request-id` - handle either