### PR TITLE
Create CardParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -336,24 +336,22 @@ data class Card internal constructor(
     }
 
     override fun toParamMap(): Map<String, Any> {
-        return mapOf(Token.TokenType.CARD to createCardParams())
-    }
-
-    private fun createCardParams(): Map<String, Any?> {
-        return mapOf(
-            "number" to number.takeUnless { it.isNullOrBlank() },
-            "cvc" to cvc.takeUnless { it.isNullOrBlank() },
-            "exp_month" to expMonth,
-            "exp_year" to expYear,
-            "name" to name.takeUnless { it.isNullOrBlank() },
-            "currency" to currency.takeUnless { it.isNullOrBlank() },
-            "address_line1" to addressLine1.takeUnless { it.isNullOrBlank() },
-            "address_line2" to addressLine2.takeUnless { it.isNullOrBlank() },
-            "address_city" to addressCity.takeUnless { it.isNullOrBlank() },
-            "address_zip" to addressZip.takeUnless { it.isNullOrBlank() },
-            "address_state" to addressState.takeUnless { it.isNullOrBlank() },
-            "address_country" to addressCountry.takeUnless { it.isNullOrBlank() }
-        )
+        return CardParams(
+            number = number.orEmpty(),
+            expMonth = expMonth ?: 0,
+            expYear = expYear ?: 0,
+            cvc = cvc,
+            name = name,
+            currency = currency,
+            address = Address(
+                line1 = addressLine1,
+                line2 = addressLine2,
+                city = addressCity,
+                state = addressState,
+                postalCode = addressZip,
+                country = addressCountry
+            )
+        ).toParamMap()
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/CardParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardParams.kt
@@ -1,0 +1,108 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * [Create a card token](https://stripe.com/docs/api/tokens/create_card)
+ */
+@Parcelize
+internal data class CardParams @JvmOverloads constructor(
+    /**
+     * [card.number](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-number)
+     *
+     * Required
+     *
+     * The card number, as a string without any separators.
+     */
+    private val number: String,
+
+    /**
+     * [card.exp_month](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-exp_month)
+     *
+     * Required
+     *
+     * Two-digit number representing the card's expiration month.
+     */
+    private val expMonth: Int,
+
+    /**
+     * [card.exp_year](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-exp_year)
+     *
+     * Required
+     *
+     * Two- or four-digit number representing the card's expiration year.
+     */
+    private val expYear: Int,
+
+    /**
+     * [card.cvc](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-cvc)
+     *
+     * Usually required
+     *
+     * Card security code. Highly recommended to always include this value, but it's required only
+     * for accounts based in European countries.
+     */
+    private val cvc: String? = null,
+
+    /**
+     * [card.name](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-name)
+     *
+     * Optional
+     *
+     * Cardholder's full name.
+     */
+    private val name: String? = null,
+
+    private val address: Address? = null,
+
+    /**
+     * [card.currency](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-currency)
+     *
+     * Optional - Custom Connect Only
+     *
+     * Required in order to add the card to an account; in all other cases, this parameter is
+     * not used. When added to an account, the card (which must be a debit card) can be used
+     * as a transfer destination for funds in this currency. Currently, the only supported
+     * currency for debit card payouts is `usd`.
+     */
+    private val currency: String? = null
+) : StripeParamsModel, Parcelable {
+    override fun toParamMap(): Map<String, Any> {
+        val params: Map<String, Any> = listOf(
+            PARAM_NUMBER to number,
+            PARAM_EXP_MONTH to expMonth,
+            PARAM_EXP_YEAR to expYear,
+            PARAM_CVC to cvc,
+            PARAM_NAME to name,
+            PARAM_CURRENCY to currency,
+            PARAM_ADDRESS_LINE1 to address?.line1,
+            PARAM_ADDRESS_LINE2 to address?.line2,
+            PARAM_ADDRESS_CITY to address?.city,
+            PARAM_ADDRESS_STATE to address?.state,
+            PARAM_ADDRESS_ZIP to address?.postalCode,
+            PARAM_ADDRESS_COUNTRY to address?.country
+        ).fold(emptyMap()) { acc, (key, value) ->
+            acc.plus(
+                value?.let { mapOf(key to it) }.orEmpty()
+            )
+        }
+
+        return mapOf(Token.TokenType.CARD to params)
+    }
+
+    private companion object {
+        private const val PARAM_NUMBER = "number"
+        private const val PARAM_EXP_MONTH = "exp_month"
+        private const val PARAM_EXP_YEAR = "exp_year"
+        private const val PARAM_CVC = "cvc"
+        private const val PARAM_NAME = "name"
+        private const val PARAM_ADDRESS_LINE1 = "address_line1"
+        private const val PARAM_ADDRESS_LINE2 = "address_line2"
+        private const val PARAM_ADDRESS_CITY = "address_city"
+        private const val PARAM_ADDRESS_STATE = "address_state"
+        private const val PARAM_ADDRESS_ZIP = "address_zip"
+        private const val PARAM_ADDRESS_COUNTRY = "address_country"
+        private const val PARAM_CURRENCY = "currency"
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android
 
+import android.net.Uri
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardFixtures
 import java.io.ByteArrayOutputStream
 import kotlin.test.Test
@@ -22,8 +24,8 @@ internal class ApiRequestTest {
             cardMap
         ).url
 
-        val expectedValue = "https://api.stripe.com/v1/sources?muid=BF3BF4D775100923AAAFA82884FB759001162E28&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bexp_month%5D=1&card%5Bexp_year%5D=2050&card%5Bnumber%5D=4242424242424242&card%5Bcvc%5D=123"
-        assertEquals(expectedValue, url)
+        assertThat(Uri.parse(url))
+            .isEqualTo(Uri.parse("https://api.stripe.com/v1/sources?muid=BF3BF4D775100923AAAFA82884FB759001162E28&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bnumber%5D=4242424242424242&card%5Bexp_month%5D=1&card%5Bcvc%5D=123&card%5Bexp_year%5D=2050"))
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/CardParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardParamsTest.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.CardNumberFixtures
+import kotlin.test.Test
+
+class CardParamsTest {
+
+    @Test
+    fun toParamMap_shouldCreateExpectedMap() {
+        val actualParams = CardParams(
+            number = CardNumberFixtures.VALID_VISA_NO_SPACES,
+            expMonth = 12,
+            expYear = 2025,
+            cvc = "123",
+            name = "Jenny Rosen",
+            address = AddressFixtures.ADDRESS,
+            currency = "usd"
+        ).toParamMap()
+
+        val expectedParams = mapOf(
+            "card" to mapOf(
+                "number" to "4242424242424242",
+                "exp_month" to 12,
+                "exp_year" to 2025,
+                "cvc" to "123",
+                "name" to "Jenny Rosen",
+                "currency" to "usd",
+                "address_line1" to "123 Market St",
+                "address_line2" to "#345",
+                "address_city" to "San Francisco",
+                "address_state" to "CA",
+                "address_zip" to "94107",
+                "address_country" to "US"
+            )
+        )
+
+        assertThat(actualParams)
+            .isEqualTo(expectedParams)
+    }
+}


### PR DESCRIPTION
## Motivation
Create a new class, `CardParams`, to represent the parameters for [creating a card](https://stripe.com/docs/api/cards/create). This was previously done with `Card`, which was used for both creating a card and representing a card object.

`CardParams` is currently internal only, but will be made available in a future PR.

## Testing
Create a unit test

