### PR TITLE
Always use publishable key in AnalyticsDataFactory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -18,12 +18,14 @@ import java.util.HashMap
  */
 internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     private val packageManager: PackageManager?,
-    private val packageName: String?
+    private val packageName: String?,
+    private val publishableKey: String
 ) {
 
-    internal constructor(context: Context) : this(
+    internal constructor(context: Context, publishableKey: String) : this(
         context.applicationContext.packageManager,
-        context.applicationContext.packageName
+        context.applicationContext.packageName,
+        publishableKey
     )
 
     @Retention(AnnotationRetention.SOURCE)
@@ -43,12 +45,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createAuthParams(
         event: AnalyticsEvent,
-        intentId: String,
-        publishableKey: String
+        intentId: String
     ): Map<String, Any> {
         return createParams(
             event,
-            publishableKey,
             extraParams = createIntentParam(intentId)
         )
     }
@@ -56,12 +56,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createAuthSourceParams(
         event: AnalyticsEvent,
-        publishableKey: String,
         sourceId: String?
     ): Map<String, Any> {
         return createParams(
             event,
-            publishableKey,
             extraParams = sourceId?.let { mapOf(FIELD_SOURCE_ID to it) }
         )
     }
@@ -70,12 +68,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     internal fun create3ds2ChallengeParams(
         event: AnalyticsEvent,
         intentId: String,
-        uiTypeCode: String,
-        publishableKey: String
+        uiTypeCode: String
     ): Map<String, Any> {
         return createParams(
             event,
-            publishableKey,
             extraParams = createIntentParam(intentId)
                 .plus(FIELD_3DS2_UI_TYPE to get3ds2UiType(uiTypeCode))
         )
@@ -84,12 +80,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun create3ds2ChallengeErrorParams(
         intentId: String,
-        runtimeErrorEvent: RuntimeErrorEvent,
-        publishableKey: String
+        runtimeErrorEvent: RuntimeErrorEvent
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.Auth3ds2ChallengeErrored,
-            publishableKey,
             extraParams = createIntentParam(intentId)
                 .plus(FIELD_ERROR_DATA to mapOf(
                     "type" to "runtime_error_event",
@@ -102,8 +96,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun create3ds2ChallengeErrorParams(
         intentId: String,
-        protocolErrorEvent: ProtocolErrorEvent,
-        publishableKey: String
+        protocolErrorEvent: ProtocolErrorEvent
     ): Map<String, Any> {
         val errorMessage = protocolErrorEvent.errorMessage
         val errorData = mapOf(
@@ -117,7 +110,6 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
         return createParams(
             AnalyticsEvent.Auth3ds2ChallengeErrored,
-            publishableKey,
             extraParams = createIntentParam(intentId)
                 .plus(FIELD_ERROR_DATA to errorData)
         )
@@ -126,12 +118,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createTokenCreationParams(
         productUsageTokens: Set<String>?,
-        publishableKey: String,
         @Token.TokenType tokenType: String
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.TokenCreate,
-            publishableKey,
             productUsageTokens = productUsageTokens,
             tokenType = tokenType
         )
@@ -139,14 +129,12 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createPaymentMethodCreationParams(
-        publishableKey: String,
         paymentMethodId: String?,
         paymentMethodType: PaymentMethod.Type?,
         productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.PaymentMethodCreate,
-            publishableKey,
             sourceType = paymentMethodType?.code,
             productUsageTokens = productUsageTokens,
             extraParams = paymentMethodId?.let {
@@ -157,13 +145,11 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createSourceCreationParams(
-        publishableKey: String,
         @Source.SourceType sourceType: String,
         productUsageTokens: Set<String>? = null
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.SourceCreate,
-            publishableKey,
             productUsageTokens = productUsageTokens,
             sourceType = sourceType
         )
@@ -172,12 +158,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createAddSourceParams(
         productUsageTokens: Set<String>? = null,
-        publishableKey: String,
         @Source.SourceType sourceType: String
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.CustomerAddSource,
-            publishableKey,
             productUsageTokens = productUsageTokens,
             sourceType = sourceType
         )
@@ -185,73 +169,61 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createDeleteSourceParams(
-        productUsageTokens: Set<String>?,
-        publishableKey: String
+        productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.CustomerDeleteSource,
-            publishableKey,
             productUsageTokens = productUsageTokens
         )
     }
 
     @JvmSynthetic
     internal fun createAttachPaymentMethodParams(
-        productUsageTokens: Set<String>?,
-        publishableKey: String
+        productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.CustomerAttachPaymentMethod,
-            publishableKey,
             productUsageTokens = productUsageTokens
         )
     }
 
     @JvmSynthetic
     internal fun createDetachPaymentMethodParams(
-        productUsageTokens: Set<String>?,
-        publishableKey: String
+        productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.CustomerDetachPaymentMethod,
-            publishableKey,
             productUsageTokens = productUsageTokens
         )
     }
 
     @JvmSynthetic
     internal fun createPaymentIntentConfirmationParams(
-        publishableKey: String,
         paymentMethodType: String? = null
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.PaymentIntentConfirm,
-            publishableKey,
             sourceType = paymentMethodType
         )
     }
 
     @JvmSynthetic
     internal fun createPaymentIntentRetrieveParams(
-        publishableKey: String,
         intentId: String
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.PaymentIntentRetrieve,
-            publishableKey,
             extraParams = createIntentParam(intentId)
         )
     }
 
     @JvmSynthetic
     internal fun createSetupIntentConfirmationParams(
-        publishableKey: String,
         paymentMethodType: String?,
         intentId: String
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.SetupIntentConfirm,
-            publishableKey,
             extraParams = createIntentParam(intentId)
                 .plus(
                     paymentMethodType?.let {
@@ -263,12 +235,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createSetupIntentRetrieveParams(
-        publishableKey: String,
         intentId: String
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.SetupIntentRetrieve,
-            publishableKey,
             extraParams = createIntentParam(intentId)
         )
     }
@@ -276,13 +246,12 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createParams(
         event: AnalyticsEvent,
-        publishableKey: String,
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String? = null,
         @Token.TokenType tokenType: String? = null,
         extraParams: Map<String, Any>? = null
     ): Map<String, Any> {
-        return createStandardParams(event, publishableKey)
+        return createStandardParams(event)
             .plus(createNameAndVersionParams())
             .plus(
                 productUsageTokens.takeUnless { it.isNullOrEmpty() }?.let {
@@ -312,8 +281,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     }
 
     private fun createStandardParams(
-        event: AnalyticsEvent,
-        publishableKey: String
+        event: AnalyticsEvent
     ): Map<String, Any> {
         return mapOf(
             FIELD_ANALYTICS_UA to ANALYTICS_UA,

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -476,10 +476,11 @@ class CustomerSession @VisibleForTesting internal constructor(
                 timeSupplier = timeSupplier
             )
 
+            val publishableKey = PaymentConfiguration.getInstance(context).publishableKey
             instance = CustomerSession(
                 context,
-                StripeApiRepository(context, appInfo),
-                PaymentConfiguration.getInstance(context).publishableKey,
+                StripeApiRepository(context, publishableKey, appInfo),
+                publishableKey,
                 stripeAccountId,
                 createThreadPoolExecutor(),
                 operationIdFactory,

--- a/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/stripe/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -333,9 +333,28 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
             context: Context,
             keyProvider: EphemeralKeyProvider
         ): IssuingCardPinService {
+            return create(
+                context,
+                PaymentConfiguration.getInstance(context).publishableKey,
+                keyProvider
+            )
+        }
+
+        /**
+         * Create a [IssuingCardPinService] with the provided [EphemeralKeyProvider].
+         *
+         * @param publishableKey an API publishable key
+         * @param keyProvider an [EphemeralKeyProvider] used to obtain an [EphemeralKey]
+         */
+        @JvmStatic
+        fun create(
+            context: Context,
+            publishableKey: String,
+            keyProvider: EphemeralKeyProvider
+        ): IssuingCardPinService {
             return IssuingCardPinService(
                 keyProvider,
-                StripeApiRepository(context, appInfo),
+                StripeApiRepository(context, publishableKey, appInfo),
                 StripeOperationIdFactory()
             )
         }

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -77,6 +77,7 @@ class Stripe internal constructor(
         context.applicationContext,
         StripeApiRepository(
             context.applicationContext,
+            publishableKey,
             appInfo,
             Logger.getInstance(enableLogging)
         ),
@@ -93,8 +94,9 @@ class Stripe internal constructor(
         enableLogging: Boolean
     ) : this(
         stripeRepository,
-        StripePaymentController.create(
+        StripePaymentController(
             context.applicationContext,
+            publishableKey,
             stripeRepository,
             enableLogging
         ),

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.Dispatchers
  */
 internal class StripePaymentController internal constructor(
     context: Context,
+    publishableKey: String,
     private val stripeRepository: StripeRepository,
     private val enableLogging: Boolean = false,
     private val messageVersionRegistry: MessageVersionRegistry =
@@ -51,7 +52,7 @@ internal class StripePaymentController internal constructor(
     private val analyticsRequestExecutor: FireAndForgetRequestExecutor =
         StripeFireAndForgetRequestExecutor(Logger.getInstance(enableLogging)),
     private val analyticsDataFactory: AnalyticsDataFactory =
-        AnalyticsDataFactory(context.applicationContext),
+        AnalyticsDataFactory(context.applicationContext, publishableKey),
     private val challengeFlowStarter: ChallengeFlowStarter =
         ChallengeFlowStarterImpl(),
     private val workScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
@@ -108,7 +109,6 @@ internal class StripePaymentController internal constructor(
             analyticsRequestFactory.create(
                 analyticsDataFactory.createAuthSourceParams(
                     AnalyticsEvent.AuthSourceStart,
-                    requestOptions.apiKey,
                     source.id
                 ),
                 requestOptions
@@ -141,7 +141,6 @@ internal class StripePaymentController internal constructor(
                 analyticsRequestFactory.create(
                     analyticsDataFactory.createAuthSourceParams(
                         AnalyticsEvent.AuthSourceRedirect,
-                        requestOptions.apiKey,
                         source.id
                     ),
                     requestOptions
@@ -257,7 +256,6 @@ internal class StripePaymentController internal constructor(
             analyticsRequestFactory.create(
                 analyticsDataFactory.createAuthSourceParams(
                     AnalyticsEvent.AuthSourceResult,
-                    requestOptions.apiKey,
                     sourceId
                 ),
                 requestOptions
@@ -373,8 +371,7 @@ internal class StripePaymentController internal constructor(
                                 analyticsRequestFactory.create(
                                     analyticsDataFactory.createAuthParams(
                                         AnalyticsEvent.Auth3ds2Fingerprint,
-                                        stripeIntent.id.orEmpty(),
-                                        requestOptions.apiKey
+                                        stripeIntent.id.orEmpty()
                                     ),
                                     requestOptions
                                 )
@@ -392,8 +389,7 @@ internal class StripePaymentController internal constructor(
                                 analyticsRequestFactory.create(
                                     analyticsDataFactory.createAuthParams(
                                         AnalyticsEvent.Auth3ds1Sdk,
-                                        stripeIntent.id.orEmpty(),
-                                        requestOptions.apiKey
+                                        stripeIntent.id.orEmpty()
                                     ),
                                     requestOptions
                                 )
@@ -415,8 +411,7 @@ internal class StripePaymentController internal constructor(
                         analyticsRequestFactory.create(
                             analyticsDataFactory.createAuthParams(
                                 AnalyticsEvent.AuthRedirect,
-                                stripeIntent.id.orEmpty(),
-                                requestOptions.apiKey
+                                stripeIntent.id.orEmpty()
                             ),
                             requestOptions
                         )
@@ -575,8 +570,7 @@ internal class StripePaymentController internal constructor(
                     analyticsRequestFactory.create(
                         analyticsDataFactory.createAuthParams(
                             AnalyticsEvent.Auth3ds2Fallback,
-                            stripeIntent.id.orEmpty(),
-                            requestOptions.apiKey
+                            stripeIntent.id.orEmpty()
                         ),
                         requestOptions
                     )
@@ -619,8 +613,7 @@ internal class StripePaymentController internal constructor(
                 analyticsRequestFactory.create(
                     analyticsDataFactory.createAuthParams(
                         AnalyticsEvent.Auth3ds2Frictionless,
-                        stripeIntent.id.orEmpty(),
-                        requestOptions.apiKey
+                        stripeIntent.id.orEmpty()
                     ),
                     requestOptions
                 )
@@ -674,8 +667,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeParams(
                         AnalyticsEvent.Auth3ds2ChallengeCompleted,
                         stripeIntent.id.orEmpty(),
-                        uiTypeCode,
-                        requestOptions.apiKey
+                        uiTypeCode
                     ),
                     requestOptions
                 )
@@ -695,8 +687,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeParams(
                         AnalyticsEvent.Auth3ds2ChallengeCanceled,
                         stripeIntent.id.orEmpty(),
-                        uiTypeCode,
-                        requestOptions.apiKey
+                        uiTypeCode
                     ),
                     requestOptions
                 )
@@ -712,8 +703,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeParams(
                         AnalyticsEvent.Auth3ds2ChallengeTimedOut,
                         stripeIntent.id.orEmpty(),
-                        uiTypeCode,
-                        requestOptions.apiKey
+                        uiTypeCode
                     ),
                     requestOptions
                 )
@@ -728,8 +718,7 @@ internal class StripePaymentController internal constructor(
                 analyticsRequestFactory.create(
                     analyticsDataFactory.create3ds2ChallengeErrorParams(
                         stripeIntent.id.orEmpty(),
-                        protocolErrorEvent,
-                        requestOptions.apiKey
+                        protocolErrorEvent
                     ),
                     requestOptions
                 )
@@ -744,8 +733,7 @@ internal class StripePaymentController internal constructor(
                 analyticsRequestFactory.create(
                     analyticsDataFactory.create3ds2ChallengeErrorParams(
                         stripeIntent.id.orEmpty(),
-                        runtimeErrorEvent,
-                        requestOptions.apiKey
+                        runtimeErrorEvent
                     ),
                     requestOptions
                 )
@@ -760,8 +748,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeParams(
                         AnalyticsEvent.Auth3ds2ChallengePresented,
                         stripeIntent.id.orEmpty(),
-                        transaction.initialChallengeUiType.orEmpty(),
-                        requestOptions.apiKey
+                        transaction.initialChallengeUiType.orEmpty()
                     ),
                     requestOptions
                 )
@@ -927,11 +914,13 @@ internal class StripePaymentController internal constructor(
         @JvmOverloads
         fun create(
             context: Context,
+            publishableKey: String,
             stripeRepository: StripeRepository,
             enableLogging: Boolean = false
         ): PaymentController {
             return StripePaymentController(
                 context.applicationContext,
+                publishableKey,
                 stripeRepository,
                 enableLogging
             )

--- a/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -23,6 +23,7 @@ internal class FpxViewModel internal constructor(
 ) : AndroidViewModel(application) {
 
     private val context = application.applicationContext
+    private val publishableKey = PaymentConfiguration.getInstance(context).publishableKey
 
     private val internalFpxBankStatuses: MutableLiveData<FpxBankStatuses> = MutableLiveData()
 
@@ -34,7 +35,7 @@ internal class FpxViewModel internal constructor(
 
     @JvmSynthetic
     internal fun loadFpxBankStatues() {
-        val stripeRepository: StripeRepository = StripeApiRepository(context)
+        val stripeRepository: StripeRepository = StripeApiRepository(context, publishableKey)
         val paymentConfiguration = PaymentConfiguration.getInstance(context)
         workScope.launch {
             val fpxBankStatuses = try {
@@ -52,7 +53,9 @@ internal class FpxViewModel internal constructor(
         }
     }
 
-    internal class Factory(private val application: Application) : ViewModelProvider.Factory {
+    internal class Factory(
+        private val application: Application
+    ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return FpxViewModel(application) as T
         }

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -24,7 +24,8 @@ import org.robolectric.RobolectricTestRunner
 class AnalyticsDataFactoryTest {
 
     private val analyticsDataFactory = AnalyticsDataFactory(
-        ApplicationProvider.getApplicationContext<Context>()
+        ApplicationProvider.getApplicationContext<Context>(),
+        API_KEY
     )
 
     @Test
@@ -34,7 +35,6 @@ class AnalyticsDataFactoryTest {
 
         val params = analyticsDataFactory.createTokenCreationParams(
             ATTRIBUTION,
-            API_KEY,
             Token.TokenType.PII
         )
         // Size is SIZE-1 because tokens don't have a source_type field
@@ -53,7 +53,6 @@ class AnalyticsDataFactoryTest {
 
         val params = analyticsDataFactory.createTokenCreationParams(
             ATTRIBUTION,
-            API_KEY,
             Token.TokenType.CVC_UPDATE
         )
         // Size is SIZE-1 because tokens don't have a source_type field
@@ -70,7 +69,6 @@ class AnalyticsDataFactoryTest {
         // Size is SIZE-1 because tokens don't have a token_type field
         val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1
         val loggingParams = analyticsDataFactory.createSourceCreationParams(
-            API_KEY,
             Source.SourceType.SEPA_DEBIT,
             ATTRIBUTION
         )
@@ -106,7 +104,6 @@ class AnalyticsDataFactoryTest {
 
         val actualParams = analyticsDataFactory
             .createPaymentMethodCreationParams(
-                API_KEY,
                 "pm_12345",
                 PaymentMethod.Type.Card,
                 ATTRIBUTION
@@ -121,7 +118,6 @@ class AnalyticsDataFactoryTest {
         val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2
         val loggingParams =
             analyticsDataFactory.createPaymentIntentConfirmationParams(
-                API_KEY,
                 PaymentMethod.Type.Card.code
             )
         assertEquals(expectedSize, loggingParams.size)
@@ -138,8 +134,7 @@ class AnalyticsDataFactoryTest {
     fun getPaymentIntentRetrieveParams_withValidInput_createsCorrectMap() {
         val expectedSize = AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2
         val loggingParams = analyticsDataFactory.createParams(
-            AnalyticsEvent.PaymentIntentRetrieve,
-            API_KEY
+            AnalyticsEvent.PaymentIntentRetrieve
         )
         assertEquals(expectedSize, loggingParams.size)
         assertEquals(API_KEY, loggingParams[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
@@ -154,7 +149,6 @@ class AnalyticsDataFactoryTest {
     @Test
     fun getSetupIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val params = analyticsDataFactory.createSetupIntentConfirmationParams(
-            API_KEY,
             PaymentMethod.Type.Card.code,
             "seti_12345"
         )
@@ -178,10 +172,9 @@ class AnalyticsDataFactoryTest {
         `when`(packageManager.getPackageInfo(packageName, 0))
             .thenReturn(packageInfo)
 
-        val params = AnalyticsDataFactory(packageManager, packageName)
+        val params = AnalyticsDataFactory(packageManager, packageName, API_KEY)
             .createTokenCreationParams(
                 ATTRIBUTION,
-                API_KEY,
                 Token.TokenType.CARD
             )
         assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1, params.size)
@@ -210,7 +203,7 @@ class AnalyticsDataFactoryTest {
         val expectedUaName = AnalyticsDataFactory.ANALYTICS_UA
 
         val params = analyticsDataFactory.createSourceCreationParams(
-            API_KEY, Token.TokenType.BANK_ACCOUNT
+            Token.TokenType.BANK_ACCOUNT
         )
         assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2, params.size)
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
@@ -230,8 +223,9 @@ class AnalyticsDataFactoryTest {
 
     @Test
     fun addNameAndVersion_whenApplicationContextIsNull_addsNoContextValues() {
-        val paramsMap = AnalyticsDataFactory(null, null)
-            .createNameAndVersionParams()
+        val paramsMap =
+            AnalyticsDataFactory(null, null, API_KEY)
+                .createNameAndVersionParams()
         assertEquals(AnalyticsDataFactory.NO_CONTEXT, paramsMap[AnalyticsDataFactory.FIELD_APP_NAME])
         assertEquals(AnalyticsDataFactory.NO_CONTEXT, paramsMap[AnalyticsDataFactory.FIELD_APP_VERSION])
     }
@@ -245,7 +239,7 @@ class AnalyticsDataFactoryTest {
         `when`(manager.getPackageInfo(packageName, 0))
             .thenThrow(PackageManager.NameNotFoundException())
 
-        val paramsMap = AnalyticsDataFactory(manager, packageName)
+        val paramsMap = AnalyticsDataFactory(manager, packageName, API_KEY)
             .createNameAndVersionParams()
         assertEquals(AnalyticsDataFactory.UNKNOWN, paramsMap[AnalyticsDataFactory.FIELD_APP_NAME])
         assertEquals(AnalyticsDataFactory.UNKNOWN, paramsMap[AnalyticsDataFactory.FIELD_APP_VERSION])

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -12,13 +13,13 @@ import org.robolectric.RobolectricTestRunner
 class AnalyticsRequestFactoryTest {
 
     private val logger: Logger = mock()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun create_shouldLogRequest() {
         AnalyticsRequestFactory(logger).create(
-            AnalyticsDataFactory(ApplicationProvider.getApplicationContext())
+            AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 .createPaymentMethodCreationParams(
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     "pm_12345",
                     PaymentMethod.Type.Card,
                     emptySet()

--- a/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
@@ -23,10 +23,9 @@ class IssuingCardPinServiceTest {
     private val stripeRepository: StripeRepository by lazy {
         StripeApiRepository(
             ApplicationProvider.getApplicationContext<Context>(),
-            null,
-            FakeLogger(),
-            stripeApiRequestExecutor,
-            FakeFireAndForgetRequestExecutor()
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            stripeApiRequestExecutor = stripeApiRequestExecutor,
+            fireAndForgetRequestExecutor = FakeFireAndForgetRequestExecutor()
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -55,7 +55,7 @@ class StripeApiRepositoryTest {
         ApplicationProvider.getApplicationContext<Context>()
     }
     private val stripeApiRepository: StripeApiRepository by lazy {
-        StripeApiRepository(context)
+        StripeApiRepository(context, DEFAULT_OPTIONS.apiKey)
     }
     private val fileFactory: FileFactory by lazy {
         FileFactory(context)
@@ -404,6 +404,7 @@ class StripeApiRepositoryTest {
     fun createSource_createsObjectAndLogs() {
         val stripeApiRepository = StripeApiRepository(
             context,
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             stripeApiRequestExecutor = ApiRequestExecutor.Default(),
             fireAndForgetRequestExecutor = fireAndForgetRequestExecutor
         )
@@ -707,6 +708,7 @@ class StripeApiRepositoryTest {
 
         val stripeRepository = StripeApiRepository(
             context,
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             sdkVersion = "AndroidBindings/13.0.0"
         )
 
@@ -728,6 +730,7 @@ class StripeApiRepositoryTest {
 
         val stripeRepository = StripeApiRepository(
             context,
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             sdkVersion = "AndroidBindings/14.0.0"
         )
 
@@ -852,6 +855,7 @@ class StripeApiRepositoryTest {
     private fun create(): StripeApiRepository {
         return StripeApiRepository(
             context,
+            DEFAULT_OPTIONS.apiKey,
             stripeApiRequestExecutor = stripeApiRequestExecutor,
             fireAndForgetRequestExecutor = fireAndForgetRequestExecutor,
             networkUtils = StripeNetworkUtils(

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -125,7 +125,7 @@ class StripePaymentAuthTest {
         return Stripe(
             StripeApiRepository(
                 context,
-                null,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                 stripeApiRequestExecutor = ApiRequestExecutor.Default(),
                 fireAndForgetRequestExecutor = FakeFireAndForgetRequestExecutor()
             ),

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -77,7 +77,7 @@ class StripePaymentControllerTest {
         createController()
     }
     private val analyticsDataFactory: AnalyticsDataFactory by lazy {
-        AnalyticsDataFactory(context)
+        AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
     }
     private val host: AuthActivityStarter.Host by lazy {
         AuthActivityStarter.Host.create(activity)
@@ -700,6 +700,7 @@ class StripePaymentControllerTest {
     ): PaymentController {
         return StripePaymentController(
             context,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeRepository,
             false,
             MessageVersionRegistry(),

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1397,10 +1397,13 @@ public class StripeTest {
     private Stripe createStripe(
             @NonNull String publishableKey,
             @NonNull FireAndForgetRequestExecutor fireAndForgetRequestExecutor) {
-        final StripeRepository stripeRepository = createStripeRepository(fireAndForgetRequestExecutor);
+        final StripeRepository stripeRepository = createStripeRepository(
+                publishableKey,
+                fireAndForgetRequestExecutor
+        );
         return new Stripe(
                 stripeRepository,
-                StripePaymentController.create(context, stripeRepository),
+                StripePaymentController.create(context, publishableKey, stripeRepository),
                 publishableKey,
                 null
         );
@@ -1409,10 +1412,12 @@ public class StripeTest {
     @NonNull
     private Stripe createStripe(@NonNull CoroutineScope workScope) {
         final StripeRepository stripeRepository = createStripeRepository(
-                new FakeFireAndForgetRequestExecutor());
+                NON_LOGGING_PK,
+                new FakeFireAndForgetRequestExecutor()
+        );
         return new Stripe(
                 stripeRepository,
-                StripePaymentController.create(context, stripeRepository),
+                StripePaymentController.create(context, NON_LOGGING_PK, stripeRepository),
                 NON_LOGGING_PK,
                 null,
                 workScope
@@ -1421,9 +1426,12 @@ public class StripeTest {
 
     @NonNull
     private StripeRepository createStripeRepository(
-            @NonNull FireAndForgetRequestExecutor fireAndForgetRequestExecutor) {
+            @NonNull final String publishableKey,
+            @NonNull FireAndForgetRequestExecutor fireAndForgetRequestExecutor
+    ) {
         return new StripeApiRepository(
                 context,
+                publishableKey,
                 null,
                 new FakeLogger(),
                 new ApiRequestExecutor.Default(),


### PR DESCRIPTION
## Summary
Inject `publishableKey` into `StripeApiRepository` and create
`AnalyticsDataFactory` with it.

## Motivation
In some cases, the `publishableKey` passed into
`AnalyticsDataFactory`'s methods was an ephemeral
key. Always use the publishable key for consistency.

## Testing
Update unit tests
