### PR TITLE
Move AddPaymentMethodFpxView state logic to FpxViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -33,6 +33,8 @@ internal class FpxViewModel internal constructor(
             return internalFpxBankStatuses
         }
 
+    internal var selectedPosition: Int? = null
+
     @JvmSynthetic
     internal fun loadFpxBankStatues() {
         val stripeRepository: StripeRepository = StripeApiRepository(context, publishableKey)
@@ -46,9 +48,7 @@ internal class FpxViewModel internal constructor(
             }
 
             withContext(Main) {
-                fpxBankStatuses.let {
-                    this@FpxViewModel.internalFpxBankStatuses.value = it
-                }
+                this@FpxViewModel.internalFpxBankStatuses.value = fpxBankStatuses
             }
         }
     }


### PR DESCRIPTION
## Summary
Previously, `selectedPosition` save/restore state was managed with
relatively complex logic. Simplify this by using `FpxViewModel`.

## Testing
Manually verified


![fpx](https://user-images.githubusercontent.com/45020849/74954861-c533d480-53d1-11ea-8e55-2a5a2c29e344.gif)

