### PR TITLE
Change CardInputWidget icon to represent validity of input

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -11,6 +11,7 @@ enum class CardBrand(
     val displayName: String,
     @DrawableRes val icon: Int,
     @DrawableRes val cvcIcon: Int = R.drawable.stripe_ic_cvc,
+    @DrawableRes val errorIcon: Int = R.drawable.stripe_ic_error,
 
     /**
      * Accepted CVC lengths
@@ -47,6 +48,7 @@ enum class CardBrand(
         "American Express",
         R.drawable.stripe_ic_amex,
         cvcIcon = R.drawable.stripe_ic_cvc_amex,
+        errorIcon = R.drawable.stripe_ic_error_amex,
         cvcLength = setOf(3, 4),
         defaultMaxLength = 15,
         prefixes = listOf("34", "37"),

--- a/stripe/src/test/java/com/stripe/android/view/CardInputTestActivity.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputTestActivity.kt
@@ -11,28 +11,34 @@ import com.stripe.android.R
  */
 internal class CardInputTestActivity : AppCompatActivity() {
 
-    lateinit var cardInputWidget: CardInputWidget
-    lateinit var cardMultilineWidget: CardMultilineWidget
-    lateinit var noZipCardMulitlineWidget: CardMultilineWidget
-    lateinit var maskedCardView: MaskedCardView
+    val cardInputWidget: CardInputWidget by lazy {
+        CardInputWidget(this)
+    }
+    val cardMultilineWidget: CardMultilineWidget by lazy {
+        CardMultilineWidget(this, shouldShowPostalCode = true)
+    }
+    val noZipCardMulitlineWidget: CardMultilineWidget by lazy {
+        CardMultilineWidget(this, shouldShowPostalCode = false)
+    }
+    val maskedCardView: MaskedCardView by lazy {
+        MaskedCardView(this)
+    }
+    val cardNumberEditText: CardNumberEditText by lazy {
+        cardInputWidget.findViewById<CardNumberEditText>(R.id.et_card_number)
+    }
 
-    val cardNumberEditText: CardNumberEditText
-        get() = cardInputWidget.findViewById(R.id.et_card_number)
+    val expiryDateEditText: ExpiryDateEditText by lazy {
+        cardInputWidget.findViewById<ExpiryDateEditText>(R.id.et_expiry_date)
+    }
 
-    val expiryDateEditText: ExpiryDateEditText
-        get() = cardInputWidget.findViewById(R.id.et_expiry_date)
-
-    val cvcEditText: StripeEditText
-        get() = cardInputWidget.findViewById(R.id.et_cvc)
+    val cvcEditText: StripeEditText by lazy {
+        cardInputWidget.findViewById<StripeEditText>(R.id.et_cvc)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setTheme(R.style.StripeDefaultTheme)
-        cardInputWidget = CardInputWidget(this)
-        cardMultilineWidget = CardMultilineWidget(this, shouldShowPostalCode = true)
-        noZipCardMulitlineWidget = CardMultilineWidget(this, shouldShowPostalCode = false)
-        maskedCardView = MaskedCardView(this)
 
         val linearLayout = LinearLayout(this)
         linearLayout.addView(cardInputWidget)

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -65,6 +65,9 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
         cardInputWidget.findViewById<PostalCodeEditText>(R.id.et_postal_code)
     }
     private val cardInputListener: CardInputListener = mock()
+    private val cardIcon: ImageView by lazy {
+        cardInputWidget.findViewById<ImageView>(R.id.iv_card_icon)
+    }
 
     @BeforeTest
     fun setup() {
@@ -1204,13 +1207,13 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     @Test
     fun allFields_equals_standardFields_withPostalCodeDisabled() {
         cardInputWidget.postalCodeEnabled = false
-        assertEquals(cardInputWidget.standardFields, cardInputWidget.allFields)
+        assertEquals(cardInputWidget.requiredFields, cardInputWidget.currentFields)
     }
 
     @Test
     fun allFields_notEquals_standardFields_withPostalCodeEnabled() {
         cardInputWidget.postalCodeEnabled = true
-        assertNotEquals(cardInputWidget.standardFields, cardInputWidget.allFields)
+        assertNotEquals(cardInputWidget.requiredFields, cardInputWidget.currentFields)
     }
 
     @Test
@@ -1275,6 +1278,27 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
             setOf(CardValidCallback.Fields.Cvc),
             currentInvalidFields
         )
+    }
+
+    @Test
+    fun shouldShowErrorIcon_shouldBeUpdatedCorrectly() {
+        cardInputWidget.setExpiryDate(12, 2030)
+        cardInputWidget.setCvcCode(CVC_VALUE_COMMON)
+
+        // show error icon when validating fields with invalid card number
+        cardInputWidget.setCardNumber(VISA_NO_SPACES.take(6))
+        assertNull(cardInputWidget.paymentMethodCreateParams)
+        assertTrue(cardInputWidget.shouldShowErrorIcon)
+
+        // don't show error icon after changing input
+        cardInputWidget.setCardNumber(VISA_NO_SPACES.take(7))
+        assertFalse(cardInputWidget.shouldShowErrorIcon)
+
+        // don't show error icon when validating fields with invalid card number
+        assertNull(cardInputWidget.paymentMethodCreateParams)
+        cardInputWidget.setCardNumber(VISA_NO_SPACES)
+        assertNotNull(cardInputWidget.paymentMethodCreateParams)
+        assertFalse(cardInputWidget.shouldShowErrorIcon)
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
After validating `CardInputWidget` input (i.e. when a params object is
attempted to be created), if validation fails, show an error icon for
the brand icon.

## Motivation
Previously, error state was only visually indicated by changing the text color of the fields. For some users, it is difficult or impossible to distinguish solely on color.

Fixes #2200 

## Testing
Unit test
Manual validation

![ciw](https://user-images.githubusercontent.com/45020849/75272393-cd25b700-57cb-11ea-8f1d-4a89462ec57a.gif)
