### PR TITLE
Throw detailed exception when failing to parse StripeResponse body

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -859,7 +859,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         APIException::class)
     private fun handleApiError(response: StripeResponse) {
         val requestId = response.requestId
-        val responseCode = response.responseCode
+        val responseCode = response.code
         val stripeError = StripeErrorJsonParser().parse(response.responseJson)
         when (responseCode) {
             HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND -> {
@@ -906,7 +906,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             throw APIConnectionException.create(ex, apiRequest.baseUrl)
         }
 
-        if (response.hasErrorCode()) {
+        if (response.isError) {
             handleApiError(response)
         }
 
@@ -927,7 +927,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             throw APIConnectionException.create(ex, fileUploadRequest.baseUrl)
         }
 
-        if (response.hasErrorCode()) {
+        if (response.isError) {
             handleApiError(response)
         }
 

--- a/stripe/src/test/java/com/stripe/android/StripeResponseTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeResponseTest.kt
@@ -1,16 +1,18 @@
 package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.exception.APIException
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class StripeResponseTest {
 
     @Test
     fun requestId_handlesLowerCaseKey() {
         val response = StripeResponse(
-            responseCode = 200,
-            responseBody = "{}",
-            responseHeaders = mapOf("request-id" to listOf("req_12345"))
+            code = 200,
+            body = "{}",
+            headers = mapOf("request-id" to listOf("req_12345"))
         )
 
         assertThat(response.requestId)
@@ -20,12 +22,35 @@ class StripeResponseTest {
     @Test
     fun requestId_handlesTitleCaseKey() {
         val response = StripeResponse(
-            responseCode = 200,
-            responseBody = "{}",
-            responseHeaders = mapOf("Request-Id" to listOf("req_12345"))
+            code = 200,
+            body = "{}",
+            headers = mapOf("Request-Id" to listOf("req_12345"))
         )
 
         assertThat(response.requestId)
             .isEqualTo("req_12345")
+    }
+
+    @Test
+    fun responseJson_withNonJsonBody_shouldThrowApiException() {
+        val exception = assertFailsWith<APIException> {
+            StripeResponse(
+                code = 500,
+                body = "there was an error",
+                headers = mapOf(
+                    "Request-Id" to listOf("req_12345"),
+                    "Content-Type" to listOf("text/plain")
+                )
+            ).responseJson
+        }
+        val expectedMessage = """
+                Exception while parsing response body.
+                  Status code: 500
+                  Request-Id: req_12345
+                  Content-Type: text/plain
+                  Body: "there was an error"
+        """.trimIndent()
+        assertThat(exception.message)
+            .isEqualTo(expectedMessage)
     }
 }


### PR DESCRIPTION
## Summary
When failing to parse the body in `StripeResonse`, a `JSONException`
is thrown. Wrap this exception in an `APIException` and include
relevant data, such as request id, content type, and the response
body.

## Motivation
Fixes #2187

## Testing
Add unit test
