### PR TITLE
Add support for BECS Debit in PaymentMethodCreateParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -117,7 +117,8 @@ data class PaymentMethod internal constructor(
         CardPresent("card_present"),
         Fpx("fpx", false),
         Ideal("ideal"),
-        SepaDebit("sepa_debit");
+        SepaDebit("sepa_debit"),
+        AuBecsDebit("au_becs_debit");
 
         override fun toString(): String {
             return code

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -23,6 +23,7 @@ data class PaymentMethodCreateParams internal constructor(
     private val ideal: Ideal? = null,
     private val fpx: Fpx? = null,
     private val sepaDebit: SepaDebit? = null,
+    private val auBecsDebit: AuBecsDebit? = null,
     private val billingDetails: PaymentMethod.BillingDetails? = null,
     private val metadata: Map<String, String>? = null
 ) : StripeParamsModel, Parcelable {
@@ -83,6 +84,17 @@ data class PaymentMethodCreateParams internal constructor(
         metadata = metadata
     )
 
+    private constructor(
+        auBecsDebit: AuBecsDebit,
+        billingDetails: PaymentMethod.BillingDetails,
+        metadata: Map<String, String>?
+    ) : this(
+        type = Type.AuBecsDebit,
+        auBecsDebit = auBecsDebit,
+        billingDetails = billingDetails,
+        metadata = metadata
+    )
+
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
             PARAM_TYPE to type.code
@@ -104,6 +116,9 @@ data class PaymentMethodCreateParams internal constructor(
                 Type.SepaDebit -> {
                     mapOf(PARAM_SEPA_DEBIT to sepaDebit?.toParamMap().orEmpty())
                 }
+                Type.AuBecsDebit -> {
+                    mapOf(PARAM_AU_BECS_DEBIT to auBecsDebit?.toParamMap().orEmpty())
+                }
             }
         ).plus(
             metadata?.let {
@@ -116,7 +131,8 @@ data class PaymentMethodCreateParams internal constructor(
         Card("card"),
         Ideal("ideal"),
         Fpx("fpx"),
-        SepaDebit("sepa_debit", true)
+        SepaDebit("sepa_debit", true),
+        AuBecsDebit("au_becs_debit", true)
     }
 
     @Parcelize
@@ -186,6 +202,9 @@ data class PaymentMethodCreateParams internal constructor(
             private const val PARAM_CVC: String = "cvc"
             private const val PARAM_TOKEN: String = "token"
 
+            /**
+             * Create a [Card] from a Card token.
+             */
             @JvmStatic
             fun create(token: String): Card {
                 return Card(token = token, number = null)
@@ -194,7 +213,7 @@ data class PaymentMethodCreateParams internal constructor(
     }
 
     @Parcelize
-    data class Ideal constructor(
+    data class Ideal(
         private val bank: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -213,13 +232,13 @@ data class PaymentMethodCreateParams internal constructor(
             }
         }
 
-        companion object {
+        private companion object {
             private const val PARAM_BANK: String = "bank"
         }
     }
 
     @Parcelize
-    data class Fpx constructor(
+    data class Fpx(
         private val bank: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -240,13 +259,13 @@ data class PaymentMethodCreateParams internal constructor(
             }
         }
 
-        companion object {
+        private companion object {
             private const val PARAM_BANK: String = "bank"
         }
     }
 
     @Parcelize
-    data class SepaDebit constructor(
+    data class SepaDebit(
         private val iban: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -267,8 +286,27 @@ data class PaymentMethodCreateParams internal constructor(
             }
         }
 
-        companion object {
+        private companion object {
             private const val PARAM_IBAN: String = "iban"
+        }
+    }
+
+    @Parcelize
+    data class AuBecsDebit(
+        private val bsbNumber: String,
+        private val accountNumber: String
+    ) : StripeParamsModel, Parcelable {
+
+        override fun toParamMap(): Map<String, Any> {
+            return mapOf(
+                PARAM_BSB_NUMBER to bsbNumber,
+                PARAM_ACCOUNT_NUMBER to accountNumber
+            )
+        }
+
+        private companion object {
+            private const val PARAM_BSB_NUMBER: String = "bsb_number"
+            private const val PARAM_ACCOUNT_NUMBER: String = "account_number"
         }
     }
 
@@ -278,10 +316,14 @@ data class PaymentMethodCreateParams internal constructor(
         private const val PARAM_FPX = "fpx"
         private const val PARAM_IDEAL = "ideal"
         private const val PARAM_SEPA_DEBIT = "sepa_debit"
+        private const val PARAM_AU_BECS_DEBIT = "au_becs_debit"
 
         private const val PARAM_BILLING_DETAILS = "billing_details"
         private const val PARAM_METADATA = "metadata"
 
+        /**
+         * @return params for creating a [PaymentMethod.Type.Card] payment method
+         */
         @JvmStatic
         @JvmOverloads
         fun create(
@@ -292,6 +334,9 @@ data class PaymentMethodCreateParams internal constructor(
             return PaymentMethodCreateParams(card, billingDetails, metadata)
         }
 
+        /**
+         * @return params for creating a [PaymentMethod.Type.Ideal] payment method
+         */
         @JvmStatic
         @JvmOverloads
         fun create(
@@ -302,6 +347,9 @@ data class PaymentMethodCreateParams internal constructor(
             return PaymentMethodCreateParams(ideal, billingDetails, metadata)
         }
 
+        /**
+         * @return params for creating a [PaymentMethod.Type.Fpx] payment method
+         */
         @JvmStatic
         @JvmOverloads
         fun create(
@@ -312,6 +360,9 @@ data class PaymentMethodCreateParams internal constructor(
             return PaymentMethodCreateParams(fpx, billingDetails, metadata)
         }
 
+        /**
+         * @return params for creating a [PaymentMethod.Type.SepaDebit] payment method
+         */
         @JvmStatic
         @JvmOverloads
         fun create(
@@ -320,6 +371,19 @@ data class PaymentMethodCreateParams internal constructor(
             metadata: Map<String, String>? = null
         ): PaymentMethodCreateParams {
             return PaymentMethodCreateParams(sepaDebit, billingDetails, metadata)
+        }
+
+        /**
+         * @return params for creating a [PaymentMethod.Type.AuBecsDebit] payment method
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun create(
+            auBecsDebit: AuBecsDebit,
+            billingDetails: PaymentMethod.BillingDetails,
+            metadata: Map<String, String>? = null
+        ): PaymentMethodCreateParams {
+            return PaymentMethodCreateParams(auBecsDebit, billingDetails, metadata)
         }
 
         /**

--- a/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -7,5 +7,6 @@ internal object ApiKeyFixtures {
     const val FAKE_EPHEMERAL_KEY = "ek_test_123"
     const val FAKE_SECRET_KEY = "sk_test_123"
     const val FPX_PUBLISHABLE_KEY = "pk_test_gQDRnExb8Jjs2Dk6RiQ09RSg007c7pKhDT"
+    const val AU_BECS_DEBIT_PUBLISHABLE_KEY = "pk_test_Bfx5IwoTeK7kUbfS15dcgTrs00beFpWwto"
     const val KLARNA_PUBLISHABLE_KEY = "pk_test_8JUGw3jTOFqWQOt5nr2pjzF9"
 }

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -1,8 +1,12 @@
 package com.stripe.android
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.AccountParams
 import com.stripe.android.model.AddressFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.Token
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,8 +16,9 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StripeEndToEndTest {
 
+    private val context: Context = ApplicationProvider.getApplicationContext()
     private val stripe: Stripe by lazy {
-        Stripe(ApplicationProvider.getApplicationContext(), ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+        Stripe(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
     }
 
     @Test
@@ -29,5 +34,17 @@ class StripeEndToEndTest {
             )
         )
         assertEquals(Token.TokenType.ACCOUNT, token?.type)
+    }
+
+    @Test
+    fun createPaymentMethodSynchronous_withAuBecsDebit() {
+        val paymentMethod =
+            Stripe(context, ApiKeyFixtures.AU_BECS_DEBIT_PUBLISHABLE_KEY)
+                .createPaymentMethodSynchronous(
+                    PaymentMethodCreateParamsFixtures.AU_BECS_DEBIT
+                )
+        requireNotNull(paymentMethod)
+        assertThat(paymentMethod.type)
+            .isEqualTo(PaymentMethod.Type.AuBecsDebit)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -37,6 +37,14 @@ internal object PaymentMethodCreateParamsFixtures {
         PaymentMethodCreateParams.SepaDebit(iban = "my_iban")
     )
 
+    internal val AU_BECS_DEBIT = PaymentMethodCreateParams.create(
+        PaymentMethodCreateParams.AuBecsDebit(
+            bsbNumber = "000000",
+            accountNumber = "000123456"
+        ),
+        BILLING_DETAILS
+    )
+
     @JvmStatic
     fun createWith(metadata: Map<String, String>): PaymentMethodCreateParams {
         return PaymentMethodCreateParams.create(

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model
 
+import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -76,6 +77,20 @@ class PaymentMethodCreateParamsTest {
             expectedParams,
             PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT.toParamMap()
         )
+    }
+
+    @Test
+    fun auBecsDebit_toParamMap_shouldCreateExpectedMap() {
+        assertThat(PaymentMethodCreateParamsFixtures.AU_BECS_DEBIT.toParamMap())
+            .isEqualTo(
+                mapOf(
+                    "type" to "au_becs_debit",
+                    "au_becs_debit" to mapOf(
+                        "bsb_number" to "000000",
+                        "account_number" to "000123456"
+                    )
+                )
+            )
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -88,6 +88,17 @@ class PaymentMethodCreateParamsTest {
                     "au_becs_debit" to mapOf(
                         "bsb_number" to "000000",
                         "account_number" to "000123456"
+                    ),
+                    "billing_details" to mapOf(
+                        "address" to mapOf(
+                            "city" to "Los Angeles",
+                            "country" to "US",
+                            "line1" to "123 Main St",
+                            "state" to "CA"
+                        ),
+                        "email" to "me@example.com",
+                        "name" to "Home",
+                        "phone" to "1-800-555-1234"
                     )
                 )
             )


### PR DESCRIPTION
## Summary
Create `PaymentMethodCreateParams.AuBecsDebit` and related methods

## Motivation
Add BECS Debit support

## Testing
Add unit and end to end tests
