### PR TITLE
Add PaymentSession.clearPaymentMethod()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -265,6 +265,15 @@ class PaymentSession @VisibleForTesting internal constructor(
         )
     }
 
+    /**
+     * Clear the payment method associated with this [PaymentSession] in [PaymentSessionData].
+     *
+     * Will trigger a call to [PaymentSessionListener.onPaymentSessionDataChanged].
+     */
+    fun clearPaymentMethod() {
+        viewModel.clearPaymentMethod()
+    }
+
     private fun fetchCustomer(isInitialFetch: Boolean = false) {
         viewModel.fetchCustomer(isInitialFetch).observe(lifecycleOwner, Observer {
             if (it is PaymentSessionViewModel.FetchCustomerResult.Error) {

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -52,6 +52,10 @@ internal class PaymentSessionViewModel(
         paymentSessionData = paymentSessionData.copy(cartTotal = cartTotal)
     }
 
+    fun clearPaymentMethod() {
+        paymentSessionData = paymentSessionData.copy(paymentMethod = null)
+    }
+
     @JvmSynthetic
     fun onCompleted() {
         customerSession.resetUsageTokens()


### PR DESCRIPTION
## Summary
Add `PaymentSession.clearPaymentMethod()` to enable clearing the payment
method associated with the `PaymentSession`.

## Motivation
Fixes #2240

## Testing
Manually verified