### PR TITLE
Clean up PostalCodeEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -36,6 +36,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CARD
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_CVC
 import com.stripe.android.view.CardInputListener.FocusField.Companion.FOCUS_EXPIRY
+import kotlin.properties.Delegates
 
 /**
  * A card input widget that handles all animation on its own.
@@ -129,7 +130,7 @@ class CardInputWidget @JvmOverloads constructor(
     private val postalCodeValue: String?
         get() {
             return if (postalCodeEnabled) {
-                postalCodeEditText.text.toString()
+                postalCodeEditText.fieldText
             } else {
                 null
             }
@@ -270,11 +271,21 @@ class CardInputWidget @JvmOverloads constructor(
      * auth success rates, so it is discouraged to disable it unless you are collecting the postal
      * code outside of this form.
      */
-    var postalCodeEnabled: Boolean = CardWidget.DEFAULT_POSTAL_CODE_ENABLED
-        set(value) {
-            onPostalCodeEnabledChanged(value)
-            field = value
+    var postalCodeEnabled: Boolean by Delegates.observable(
+        CardWidget.DEFAULT_POSTAL_CODE_ENABLED
+    ) { _, _, isEnabled ->
+        if (isEnabled) {
+            postalCodeEditText.isEnabled = true
+            postalCodeTextInputLayout.visibility = View.VISIBLE
+
+            cvcNumberEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
+        } else {
+            postalCodeEditText.isEnabled = false
+            postalCodeTextInputLayout.visibility = View.GONE
+
+            cvcNumberEditText.imeOptions = EditorInfo.IME_ACTION_DONE
         }
+    }
 
     /**
      * If [postalCodeEnabled] is true and [postalCodeRequired] is true, then postal code is a
@@ -296,8 +307,6 @@ class CardInputWidget @JvmOverloads constructor(
 
         orientation = HORIZONTAL
         minimumWidth = resources.getDimensionPixelSize(R.dimen.stripe_card_widget_min_width)
-
-        postalCodeEditText.configureForGlobal()
 
         frameWidthSupplier = { containerLayout.width }
 
@@ -507,20 +516,6 @@ class CardInputWidget @JvmOverloads constructor(
             super.onRestoreInstanceState(state.getParcelable(STATE_SUPER_STATE))
         } else {
             super.onRestoreInstanceState(state)
-        }
-    }
-
-    private fun onPostalCodeEnabledChanged(isEnabled: Boolean) {
-        if (isEnabled) {
-            postalCodeEditText.isEnabled = true
-            postalCodeTextInputLayout.visibility = View.VISIBLE
-
-            cvcNumberEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
-        } else {
-            postalCodeEditText.isEnabled = false
-            postalCodeTextInputLayout.visibility = View.GONE
-
-            cvcNumberEditText.imeOptions = EditorInfo.IME_ACTION_DONE
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -57,7 +57,7 @@ class CardMultilineWidget @JvmOverloads constructor(
     private val cardNumberTextInputLayout = viewBinding.tlCardNumber
     private val expiryTextInputLayout = viewBinding.tlExpiry
     private val cvcTextInputLayout = viewBinding.tlCvc
-    private val postalInputLayout = viewBinding.tlPostalCode
+    internal val postalInputLayout = viewBinding.tlPostalCode
 
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
@@ -245,16 +245,12 @@ class CardMultilineWidget @JvmOverloads constructor(
         // This sets the value of shouldShowPostalCode
         attrs?.let { checkAttributeSet(it) }
 
-        // configure postal code
-        postalCodeEditText.configureForGlobal()
-        postalInputLayout.hint = postalCodeEditText.hint
-        postalCodeEditText.hint = ""
-
         initTextInputLayoutErrorHandlers(
             cardNumberTextInputLayout,
             expiryTextInputLayout,
             cvcTextInputLayout,
-            postalInputLayout)
+            postalInputLayout
+        )
 
         initFocusChangeListeners()
         initDeleteEmptyListeners()
@@ -307,6 +303,11 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
         isEnabled = true
+    }
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        postalCodeEditText.configureForUs()
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -9,6 +9,8 @@ import android.text.method.DigitsKeyListener
 import android.text.method.TextKeyListener
 import android.util.AttributeSet
 import android.view.View
+import androidx.annotation.StringRes
+import com.google.android.material.textfield.TextInputLayout
 import com.stripe.android.R
 
 class PostalCodeEditText @JvmOverloads constructor(
@@ -20,7 +22,6 @@ class PostalCodeEditText @JvmOverloads constructor(
     init {
         setErrorMessage(resources.getString(R.string.invalid_zip))
         maxLines = 1
-        configureForUs()
 
         addTextChangedListener(object : StripeTextWatcher() {
             override fun afterTextChanged(s: Editable?) {
@@ -33,12 +34,17 @@ class PostalCodeEditText @JvmOverloads constructor(
         }
     }
 
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        configureForGlobal()
+    }
+
     /**
      * Configure the field for United States users
      */
     @JvmSynthetic
     internal fun configureForUs() {
-        setHint(R.string.address_label_zip_code)
+        updateHint(R.string.address_label_zip_code)
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH_US))
         keyListener = DigitsKeyListener.getInstance(false, true)
         inputType = InputType.TYPE_CLASS_NUMBER
@@ -49,10 +55,34 @@ class PostalCodeEditText @JvmOverloads constructor(
      */
     @JvmSynthetic
     internal fun configureForGlobal() {
-        setHint(R.string.address_label_postal_code)
+        updateHint(R.string.address_label_postal_code)
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH_GLOBAL))
         keyListener = TextKeyListener.getInstance()
         inputType = InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS
+    }
+
+    /**
+     * If a `TextInputLayout` is an ancestor of this view, set the hint on it. Otherwise, set
+     * the hint on this view.
+     */
+    private fun updateHint(@StringRes hintRes: Int) {
+        getTextInputLayout()?.let {
+            it.hint = resources.getString(hintRes)
+        } ?: setHint(hintRes)
+    }
+
+    /**
+     * Copied from `TextInputEditText`
+     */
+    private fun getTextInputLayout(): TextInputLayout? {
+        var parent = parent
+        while (parent is View) {
+            if (parent is TextInputLayout) {
+                return parent
+            }
+            parent = parent.getParent()
+        }
+        return null
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -5,6 +5,8 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.textfield.TextInputLayout
+import com.google.common.truth.ExpectFailure.assertThat
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -650,6 +652,12 @@ internal class CardMultilineWidgetTest {
 
         assertFalse(isValid)
         assertTrue(shouldShowError)
+    }
+
+    @Test
+    fun onFinishInflate_shouldSetPostalCodeInputLayoutHint() {
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("ZIP code")
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.view
+
+import android.text.InputType
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PostalCodeEditTextTest {
+    private val postalCodeEditText = PostalCodeEditText(
+        ApplicationProvider.getApplicationContext()
+    )
+
+    @Test
+    fun testConfigureForUs() {
+        postalCodeEditText.configureForUs()
+        assertThat(postalCodeEditText.inputType)
+            .isEqualTo(InputType.TYPE_CLASS_NUMBER)
+    }
+}


### PR DESCRIPTION
## Summary
- Configure for global postal codes by default, but set to US
  in `CardMultilineWidget` to preserve existing behavior
- Set hint on `TextInputLayout` ancestor if one exists
- Move configuration to `onFinishInflate()` so that view hierarchy
  is available

## Testing
- Added unit test
- Manually tested
