### PR TITLE
Add ability to require ZIP code in CardInputWidget and CardMultilineWidget

### DIFF
--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -9,5 +9,6 @@
     <declare-styleable name="CardElement">
         <attr name="shouldShowPostalCode" format="boolean" />
         <attr name="shouldRequirePostalCode" format="boolean" />
+        <attr name="shouldRequireUsZipCode" format="boolean" />
     </declare-styleable>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
@@ -65,5 +65,6 @@ internal interface CardWidget {
     companion object {
         internal const val DEFAULT_POSTAL_CODE_ENABLED = true
         internal const val DEFAULT_POSTAL_CODE_REQUIRED = false
+        internal const val DEFAULT_US_ZIP_CODE_REQUIRED = false
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1307,6 +1307,55 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
             .isEqualTo("0000 0000 0000 ")
     }
 
+    @Test
+    fun usZipCodeRequired_whenFalse_shouldSetPostalCodeHint() {
+        cardInputWidget.usZipCodeRequired = false
+        assertThat(cardInputWidget.postalCodeEditText.hint)
+            .isEqualTo("Postal code")
+
+        cardInputWidget.setCardNumber(VISA_WITH_SPACES)
+        cardInputWidget.expiryDateEditText.append("12")
+        cardInputWidget.expiryDateEditText.append("50")
+        cardInputWidget.cvcNumberEditText.append("123")
+
+        assertThat(cardInputWidget.card)
+            .isNotNull()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() {
+        cardInputWidget.usZipCodeRequired = true
+        assertThat(cardInputWidget.postalCodeEditText.hint)
+            .isEqualTo("ZIP code")
+
+        cardInputWidget.setCardNumber(VISA_WITH_SPACES)
+        cardInputWidget.expiryDateEditText.append("12")
+        cardInputWidget.expiryDateEditText.append("50")
+        cardInputWidget.cvcNumberEditText.append("123")
+
+        // invalid zipcode
+        cardInputWidget.postalCodeEditText.setText("1234")
+        assertThat(cardInputWidget.card)
+            .isNull()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() {
+        cardInputWidget.usZipCodeRequired = true
+        assertThat(cardInputWidget.postalCodeEditText.hint)
+            .isEqualTo("ZIP code")
+
+        cardInputWidget.setCardNumber(VISA_WITH_SPACES)
+        cardInputWidget.expiryDateEditText.append("12")
+        cardInputWidget.expiryDateEditText.append("50")
+        cardInputWidget.cvcNumberEditText.append("123")
+
+        // valid zipcode
+        cardInputWidget.postalCodeEditText.setText("12345")
+        assertThat(cardInputWidget.card)
+            .isNotNull()
+    }
+
     private companion object {
         // Every Card made by the CardInputView should have the card widget token.
         private val ATTRIBUTION = setOf(LOGGING_TOKEN)

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -661,6 +661,55 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
+    fun usZipCodeRequired_whenFalse_shouldSetPostalCodeHint() {
+        cardMultilineWidget.usZipCodeRequired = false
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("Postal code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append("123")
+
+        assertThat(cardMultilineWidget.card)
+            .isNotNull()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() {
+        cardMultilineWidget.usZipCodeRequired = true
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("ZIP code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append("123")
+
+        // invalid zipcode
+        fullGroup.postalCodeEditText.setText("1234")
+        assertThat(cardMultilineWidget.card)
+            .isNull()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() {
+        cardMultilineWidget.usZipCodeRequired = true
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("ZIP code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append("123")
+
+        // valid zipcode
+        fullGroup.postalCodeEditText.setText("12345")
+        assertThat(cardMultilineWidget.card)
+            .isNotNull()
+    }
+
+    @Test
     fun setEnabled_setsEnabledPropertyOnAllChildWidgets() {
         assertTrue(cardMultilineWidget.isEnabled)
         assertTrue(fullGroup.cardInputLayout.isEnabled)

--- a/stripe/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
@@ -1,22 +1,87 @@
 package com.stripe.android.view
 
+import android.app.Activity
+import android.content.Context
 import android.text.InputType
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.CustomerSession
+import com.stripe.android.PaymentSessionFixtures
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PostalCodeEditTextTest {
-    private val postalCodeEditText = PostalCodeEditText(
-        ApplicationProvider.getApplicationContext()
-    )
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val postalCodeEditText = PostalCodeEditText(context)
+
+    @BeforeTest
+    fun setup() {
+        CustomerSession.instance = mock()
+    }
 
     @Test
     fun testConfigureForUs() {
-        postalCodeEditText.configureForUs()
+        postalCodeEditText.config = PostalCodeEditText.Config.US
         assertThat(postalCodeEditText.inputType)
             .isEqualTo(InputType.TYPE_CLASS_NUMBER)
+    }
+
+    @Test
+    fun postalCode_whenConfiguredForUs_shouldValidate() {
+        postalCodeEditText.config = PostalCodeEditText.Config.US
+        assertThat(postalCodeEditText.postalCode)
+            .isNull()
+
+        postalCodeEditText.setText("1234")
+        assertThat(postalCodeEditText.postalCode)
+            .isNull()
+
+        postalCodeEditText.setText("123 5")
+        assertThat(postalCodeEditText.postalCode)
+            .isNull()
+
+        postalCodeEditText.setText("12345")
+        assertThat(postalCodeEditText.postalCode)
+            .isEqualTo("12345")
+    }
+
+    @Test
+    fun updateHint_whenTextInputLayoutHintEnabled_shouldSetHintOnTextInputLayout() {
+        createActivity {
+            val textInputLayout = TextInputLayout(it)
+            textInputLayout.addView(postalCodeEditText)
+
+            postalCodeEditText.config = PostalCodeEditText.Config.US
+            assertThat(textInputLayout.hint)
+                .isEqualTo("ZIP code")
+        }
+    }
+
+    @Test
+    fun updateHint_whenTextInputLayoutHintDisabled_shouldSetHintOnEditText() {
+        createActivity {
+            val textInputLayout = TextInputLayout(it)
+            textInputLayout.isHintEnabled = false
+            textInputLayout.addView(postalCodeEditText)
+
+            postalCodeEditText.config = PostalCodeEditText.Config.US
+            assertThat(textInputLayout.hint)
+                .isNull()
+            assertThat(postalCodeEditText.hint)
+                .isEqualTo("ZIP code")
+        }
+    }
+
+    private fun createActivity(onActivityCallback: (Activity) -> Unit) {
+        ActivityScenarioFactory(context).create<PaymentFlowActivity>(
+            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
+        ).use { activityScenario ->
+            activityScenario.onActivity(onActivityCallback)
+        }
     }
 }


### PR DESCRIPTION
## Summary
Enable via code:
```
cardMultilineWidget.usZipCodeRequired = true
```

Enable via XML layout:
```
<com.stripe.android.view.CardMultilineWidget
    android:id="@+id/card_multiline_widget"
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    app:shouldRequireUsZipCode="true"/>
```

## Motivation
Fixes #2273

## Testing
Added tests and manually verified

