### PR TITLE
Default CardMultilineWidget to global postal code configuration

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -324,7 +324,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     override fun onFinishInflate() {
         super.onFinishInflate()
-        postalCodeEditText.config = PostalCodeEditText.Config.US
+        postalCodeEditText.config = PostalCodeEditText.Config.Global
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -657,7 +657,7 @@ internal class CardMultilineWidgetTest {
     @Test
     fun onFinishInflate_shouldSetPostalCodeInputLayoutHint() {
         assertThat(cardMultilineWidget.postalInputLayout.hint)
-            .isEqualTo("ZIP code")
+            .isEqualTo("Postal code")
     }
 
     @Test


### PR DESCRIPTION
## Summary
To require a US zip code via code:
```
cardMultilineWidget.usZipCodeRequired = true
```

To require a US zip code via XML layout:
```
<com.stripe.android.view.CardMultilineWidget
    android:id="@+id/card_multiline_widget"
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    app:shouldRequireUsZipCode="true"/>
```

## Motivation
Fixes #2129
