### PR TITLE
Create EmailEditText to validate email input in BecsDebitWidget

### DIFF
--- a/stripe/res/layout/becs_debit_widget.xml
+++ b/stripe/res/layout/becs_debit_widget.xml
@@ -52,7 +52,7 @@
                 tools:ignore="UnusedAttribute"
                 style="@style/Widget.Design.TextInputLayout">
 
-                <com.stripe.android.view.StripeEditText
+                <com.stripe.android.view.EmailEditText
                     android:id="@+id/email_edit_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -165,6 +165,8 @@
     <string name="becs_widget_name_required" tools:ignore="MissingTranslation">Your name is required.</string>
     <!-- BECS Debit Widget - email address field - required error message -->
     <string name="becs_widget_email_required" tools:ignore="MissingTranslation">Your email address is required.</string>
+    <!-- BECS Debit Widget - email address field - invalid error message -->
+    <string name="becs_widget_email_invalid" tools:ignore="MissingTranslation">Your email address is invalid.</string>
     <!-- BECS Debit Widget - mandate acceptance -->
     <string name="becs_mandate_acceptance" tools:ignore="MissingTranslation">
     By providing your bank account details and confirming this payment, you agree to this

--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitWidget.kt
@@ -92,9 +92,6 @@ class BecsDebitWidget @JvmOverloads constructor(
             ErrorListener(viewBinding.nameTextInputLayout)
         )
 
-        viewBinding.emailEditText.errorMessage = resources.getString(
-            R.string.becs_widget_email_required
-        )
         viewBinding.emailEditText.setErrorMessageListener(
             ErrorListener(viewBinding.emailTextInputLayout)
         )
@@ -123,16 +120,16 @@ class BecsDebitWidget @JvmOverloads constructor(
     val params: PaymentMethodCreateParams?
         get() {
             val name = viewBinding.nameEditText.fieldText
-            val email = viewBinding.emailEditText.fieldText
+            val email = viewBinding.emailEditText.email
             val bsbNumber = viewBinding.bsbEditText.bsb
             val accountNumber = viewBinding.accountNumberEditText.accountNumber
 
             viewBinding.nameEditText.shouldShowError = name.isBlank()
-            viewBinding.emailEditText.shouldShowError = email.isBlank()
+            viewBinding.emailEditText.shouldShowError = email.isNullOrBlank()
             viewBinding.bsbEditText.shouldShowError = bsbNumber.isNullOrBlank()
             viewBinding.accountNumberEditText.shouldShowError = accountNumber.isNullOrBlank()
 
-            if (name.isBlank() || email.isBlank() || bsbNumber.isNullOrBlank() ||
+            if (name.isBlank() || email.isNullOrBlank() || bsbNumber.isNullOrBlank() ||
                 accountNumber.isNullOrBlank()) {
                 return null
             }

--- a/stripe/src/main/java/com/stripe/android/view/EmailEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/EmailEditText.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Patterns
+import com.stripe.android.R
+
+internal class EmailEditText @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle
+) : StripeEditText(context, attrs, defStyleAttr) {
+
+    val email: String?
+        get() {
+            errorMessage = when {
+                fieldText.isBlank() -> {
+                    resources.getString(R.string.becs_widget_email_required)
+                }
+                !Patterns.EMAIL_ADDRESS.matcher(fieldText).matches() -> {
+                    resources.getString(R.string.becs_widget_email_invalid)
+                }
+                else -> null
+            }
+
+            return fieldText.takeIf { errorMessage == null }
+        }
+}

--- a/stripe/src/test/java/com/stripe/android/view/EmailEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/EmailEditTextTest.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.view
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EmailEditTextTest {
+    private val emailEditText = EmailEditText(
+        ApplicationProvider.getApplicationContext()
+    )
+
+    @Test
+    fun email_withEmptyEmail_shouldSetError() {
+        assertThat(emailEditText.email)
+            .isNull()
+        assertThat(emailEditText.errorMessage)
+            .isEqualTo("Your email address is required.")
+    }
+
+    @Test
+    fun email_withIncompleteEmail_shouldSetError() {
+        emailEditText.setText("jenny@")
+        assertThat(emailEditText.email)
+            .isNull()
+        assertThat(emailEditText.errorMessage)
+            .isEqualTo("Your email address is invalid.")
+    }
+
+    @Test
+    fun email_withValidEmail_shouldNotSetError() {
+        emailEditText.setText("jrosen@example.com")
+        assertThat(emailEditText.email)
+            .isEqualTo("jrosen@example.com")
+        assertThat(emailEditText.errorMessage)
+            .isNull()
+    }
+}


### PR DESCRIPTION
## Summary
`EmailEditText` validates that input is not blank and a valid email
address.

## Testing
Add unit tests and manually verify
