### PR TITLE
Update FingerprintDataRepository to fetch remotely if needed

### DIFF
--- a/stripe/src/main/java/com/stripe/android/FingerprintDataRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataRepository.kt
@@ -1,49 +1,55 @@
 package com.stripe.android
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import org.json.JSONException
-import org.json.JSONObject
+import androidx.lifecycle.Observer
 
 internal interface FingerprintDataRepository {
-
     fun get(): LiveData<FingerprintData?>
     fun save(fingerprintData: FingerprintData)
 
     class Default(
-        private val prefs: SharedPreferences
+        private val store: FingerprintDataStore,
+        private val fingerprintRequestFactory: FingerprintRequestFactory,
+        private val fingerprintRequestExecutor: FingerprintRequestExecutor =
+            FingerprintRequestExecutor.Default()
     ) : FingerprintDataRepository {
 
         constructor(context: Context) : this(
-            prefs = context.getSharedPreferences(
-                PREF_FILE, Context.MODE_PRIVATE
-            )
+            store = FingerprintDataStore.Default(context),
+            fingerprintRequestFactory = FingerprintRequestFactory(context)
         )
 
         override fun get(): LiveData<FingerprintData?> {
             val resultData = MutableLiveData<FingerprintData?>()
-            resultData.value = try {
-                FingerprintData.fromJson(
-                    JSONObject(prefs.getString(KEY, null).orEmpty())
-                )
-            } catch (e: JSONException) {
-                null
-            }
+
+            val storeData = store.get()
+            storeData.observeForever(object : Observer<FingerprintData?> {
+                override fun onChanged(localFingerprintData: FingerprintData?) {
+                    if (localFingerprintData != null) {
+                        // FingerprintData was available locally
+                        resultData.value = localFingerprintData
+                        storeData.removeObserver(this)
+                    } else {
+                        // FingerprintData needs to be fetched remotely
+                        fingerprintRequestExecutor.execute(
+                            request = fingerprintRequestFactory.create()
+                        ) { remoteFingerprintData ->
+                            resultData.value = remoteFingerprintData?.also {
+                                save(it)
+                            }
+                            storeData.removeObserver(this)
+                        }
+                    }
+                }
+            })
 
             return resultData
         }
 
         override fun save(fingerprintData: FingerprintData) {
-            prefs.edit()
-                .putString(KEY, fingerprintData.toJson().toString())
-                .apply()
-        }
-
-        private companion object {
-            private const val PREF_FILE = "FingerprintDataRepository"
-            private const val KEY = "key"
+            store.save(fingerprintData)
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
@@ -22,7 +22,7 @@ internal interface FingerprintDataStore {
         override fun get(): LiveData<FingerprintData?> {
             val fingerprintData = try {
                 FingerprintData.fromJson(
-                    JSONObject(prefs.getString(KEY, null).orEmpty())
+                    JSONObject(prefs.getString(KEY_DATA, null).orEmpty())
                 ).takeUnless { it.isExpired(timestampSupplier()) }
             } catch (e: JSONException) {
                 null
@@ -33,13 +33,13 @@ internal interface FingerprintDataStore {
 
         override fun save(fingerprintData: FingerprintData) {
             prefs.edit()
-                .putString(KEY, fingerprintData.toJson().toString())
+                .putString(KEY_DATA, fingerprintData.toJson().toString())
                 .apply()
         }
 
         private companion object {
             private const val PREF_FILE = "FingerprintDataRepository"
-            private const val KEY = "key"
+            private const val KEY_DATA = "key_fingerprint_data"
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
@@ -1,0 +1,45 @@
+package com.stripe.android
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import java.util.Calendar
+import org.json.JSONException
+import org.json.JSONObject
+
+internal interface FingerprintDataStore {
+    fun get(): LiveData<FingerprintData?>
+    fun save(fingerprintData: FingerprintData)
+
+    class Default(context: Context) : FingerprintDataStore {
+        private val prefs = context.getSharedPreferences(
+            PREF_FILE, Context.MODE_PRIVATE
+        )
+        private val timestampSupplier: () -> Long = {
+            Calendar.getInstance().timeInMillis
+        }
+
+        override fun get(): LiveData<FingerprintData?> {
+            val fingerprintData = try {
+                FingerprintData.fromJson(
+                    JSONObject(prefs.getString(KEY, null).orEmpty())
+                ).takeUnless { it.isExpired(timestampSupplier()) }
+            } catch (e: JSONException) {
+                null
+            }
+
+            return MutableLiveData<FingerprintData?>(fingerprintData)
+        }
+
+        override fun save(fingerprintData: FingerprintData) {
+            prefs.edit()
+                .putString(KEY, fingerprintData.toJson().toString())
+                .apply()
+        }
+
+        private companion object {
+            private const val PREF_FILE = "FingerprintDataRepository"
+            private const val KEY = "key"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
If `FingerprintData` is unavailable locally, or if it has expired,
fetch it remotely and save locally.

## Testing
Added unit tests
