### PR TITLE
Fix MUID fingerprinting logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ClientFingerprintDataStore.kt
+++ b/stripe/src/main/java/com/stripe/android/ClientFingerprintDataStore.kt
@@ -1,0 +1,33 @@
+package com.stripe.android
+
+import android.content.Context
+import java.util.UUID
+
+internal interface ClientFingerprintDataStore {
+    fun getMuid(): String
+
+    class Default(context: Context) : ClientFingerprintDataStore {
+        private val prefs = context.getSharedPreferences(
+            PREF_NAME, Context.MODE_PRIVATE
+        )
+
+        override fun getMuid(): String {
+            val currentMuid = prefs.getString(KEY_MUID, null)
+            return currentMuid ?: createMuid()
+        }
+
+        private fun createMuid(): String {
+            return UUID.randomUUID().toString().also {
+                prefs
+                    .edit()
+                    .putString(KEY_MUID, it)
+                    .apply()
+            }
+        }
+
+        private companion object {
+            private const val PREF_NAME = "client_fingerprint_data"
+            private const val KEY_MUID = "muid"
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/FingerprintRequestFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintRequestFactory.kt
@@ -4,15 +4,25 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 
 internal class FingerprintRequestFactory @VisibleForTesting internal constructor(
-    private val telemetryClientUtil: TelemetryClientUtil
+    private val telemetryClientUtil: TelemetryClientUtil,
+    private val uidSupplier: Supplier<StripeUid>
 ) : Factory0<FingerprintRequest> {
 
-    internal constructor(context: Context) : this(TelemetryClientUtil(context))
+    internal constructor(context: Context) : this(
+        telemetryClientUtil = TelemetryClientUtil(context),
+        uidSupplier = UidSupplier(context)
+    )
 
     override fun create(): FingerprintRequest {
+        val guid = uidSupplier.get().value.takeUnless {
+            it.isBlank()
+        }?.let {
+            StripeTextUtils.shaHashInput(it).orEmpty()
+        }.orEmpty()
+
         return FingerprintRequest(
-            telemetryClientUtil.createTelemetryMap(),
-            telemetryClientUtil.hashedUid
+            params = telemetryClientUtil.createTelemetryMap(),
+            guid = guid
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardFixtures
 import java.io.ByteArrayOutputStream
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -14,10 +15,17 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class ApiRequestTest {
 
+    private val networkUtils = StripeNetworkUtils(
+        UidParamsFactory(
+            store = FakeClientFingerprintDataStore(MUID),
+            uidSupplier = FakeUidSupplier("abc123")
+        )
+    )
+
     @Test
     fun url_withCardData_createsProperQueryString() {
         val cardMap = CardFixtures.MINIMUM_CARD.toParamMap()
-            .plus(NETWORK_UTILS.createUidParams())
+            .plus(networkUtils.createUidParams())
         val url = FACTORY.createGet(
             StripeApiRepository.sourcesUrl,
             OPTIONS,
@@ -25,7 +33,7 @@ internal class ApiRequestTest {
         ).url
 
         assertThat(Uri.parse(url))
-            .isEqualTo(Uri.parse("https://api.stripe.com/v1/sources?muid=BF3BF4D775100923AAAFA82884FB759001162E28&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bnumber%5D=4242424242424242&card%5Bexp_month%5D=1&card%5Bcvc%5D=123&card%5Bexp_year%5D=2050"))
+            .isEqualTo(Uri.parse("https://api.stripe.com/v1/sources?muid=$MUID&guid=6367C48DD193D56EA7B0BAAD25B19455E529F5EE&card%5Bnumber%5D=4242424242424242&card%5Bexp_month%5D=1&card%5Bcvc%5D=123&card%5Bexp_year%5D=2050"))
     }
 
     @Test
@@ -92,15 +100,10 @@ internal class ApiRequestTest {
     }
 
     private companion object {
-        private val NETWORK_UTILS = StripeNetworkUtils(
-            UidParamsFactory(
-                "com.example.app",
-                FakeUidSupplier("abc123")
-            )
-        )
-
         private val OPTIONS = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
 
         private val FACTORY = ApiRequest.Factory()
+
+        private val MUID = UUID.randomUUID()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/ClientFingerprintDataStoreTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ClientFingerprintDataStoreTest.kt
@@ -1,0 +1,21 @@
+package com.stripe.android
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClientFingerprintDataStoreTest {
+
+    private val store = ClientFingerprintDataStore.Default(
+        ApplicationProvider.getApplicationContext()
+    )
+
+    @Test
+    fun getMuid_shouldReturnSameValue() {
+        assertThat(store.getMuid())
+            .isEqualTo(store.getMuid())
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/FakeClientFingerprintDataStore.kt
+++ b/stripe/src/test/java/com/stripe/android/FakeClientFingerprintDataStore.kt
@@ -1,0 +1,9 @@
+package com.stripe.android
+
+import java.util.UUID
+
+internal class FakeClientFingerprintDataStore(
+    private val muid: UUID = UUID.randomUUID()
+) : ClientFingerprintDataStore {
+    override fun getMuid(): String = muid.toString()
+}

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -853,7 +853,10 @@ class StripeApiRepositoryTest {
             fireAndForgetRequestExecutor = fireAndForgetRequestExecutor,
             fingerprintRequestExecutor = fingerprintRequestExecutor,
             networkUtils = StripeNetworkUtils(
-                UidParamsFactory("com.stripe.example", FakeUidSupplier())
+                UidParamsFactory(
+                    store = FakeClientFingerprintDataStore(),
+                    uidSupplier = FakeUidSupplier()
+                )
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeNetworkUtilsTest.kt
@@ -18,7 +18,10 @@ import org.robolectric.RobolectricTestRunner
 class StripeNetworkUtilsTest {
 
     private val networkUtils = StripeNetworkUtils(
-        UidParamsFactory("com.example.app", FakeUidSupplier())
+        UidParamsFactory(
+            store = FakeClientFingerprintDataStore(),
+            uidSupplier = FakeUidSupplier()
+        )
     )
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -1422,6 +1422,7 @@ public class StripeTest {
             @NonNull final String publishableKey,
             @NonNull FireAndForgetRequestExecutor fireAndForgetRequestExecutor
     ) {
+        final Supplier<StripeUid> uidSupplier = new FakeUidSupplier();
         return new StripeApiRepository(
                 context,
                 publishableKey,
@@ -1431,7 +1432,8 @@ public class StripeTest {
                 fireAndForgetRequestExecutor,
                 fingerprintRequestExecutor,
                 new FingerprintRequestFactory(
-                        new TelemetryClientUtil(context, new FakeUidSupplier())
+                        new TelemetryClientUtil(context, uidSupplier),
+                        uidSupplier
                 )
         );
     }

--- a/stripe/src/test/java/com/stripe/android/UidParamsFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/UidParamsFactoryTest.kt
@@ -1,14 +1,24 @@
 package com.stripe.android
 
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class UidParamsFactoryTest {
+
+    private val factory = UidParamsFactory(
+        store = ClientFingerprintDataStore.Default(
+            ApplicationProvider.getApplicationContext()
+        ),
+        uidSupplier = FakeUidSupplier()
+    )
 
     @Test
     fun testCreate() {
-        val uidParams = UidParamsFactory("com.app", FakeUidSupplier())
-            .createParams()
+        val uidParams = factory.createParams()
         assertThat(uidParams.keys)
             .containsExactly("muid", "guid")
     }


### PR DESCRIPTION
## Summary
The MUID fingerprinting value should be generated on the client and
reused when available.

Create `ClientFingerprintDataStore` to handle persistence of the MUID
value.

Use the MUID value in `TelemetryClientUtil` and `UidParamsFactory`.

## Testing
Add unit tests
