### PR TITLE
Pass fingerprint guid in fingerprint request

### DIFF
--- a/stripe/src/main/java/com/stripe/android/FingerprintData.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintData.kt
@@ -5,7 +5,7 @@ import org.json.JSONObject
 
 internal data class FingerprintData(
     internal val guid: String? = null,
-    internal val timestamp: Long
+    internal val timestamp: Long = 0L
 ) {
     fun toJson(): JSONObject {
         return JSONObject()

--- a/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
@@ -3,32 +3,28 @@ package com.stripe.android
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import java.util.Calendar
 import org.json.JSONException
 import org.json.JSONObject
 
 internal interface FingerprintDataStore {
-    fun get(): LiveData<FingerprintData?>
+    fun get(): LiveData<FingerprintData>
     fun save(fingerprintData: FingerprintData)
 
     class Default(context: Context) : FingerprintDataStore {
         private val prefs = context.getSharedPreferences(
             PREF_FILE, Context.MODE_PRIVATE
         )
-        private val timestampSupplier: () -> Long = {
-            Calendar.getInstance().timeInMillis
-        }
 
-        override fun get(): LiveData<FingerprintData?> {
+        override fun get(): LiveData<FingerprintData> {
             val fingerprintData = try {
                 FingerprintData.fromJson(
                     JSONObject(prefs.getString(KEY_DATA, null).orEmpty())
-                ).takeUnless { it.isExpired(timestampSupplier()) }
+                )
             } catch (e: JSONException) {
-                null
+                FingerprintData()
             }
 
-            return MutableLiveData<FingerprintData?>(fingerprintData)
+            return MutableLiveData(fingerprintData)
         }
 
         override fun save(fingerprintData: FingerprintData) {

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -71,6 +71,8 @@ data class PaymentConfiguration internal constructor(val publishableKey: String)
         fun init(context: Context, publishableKey: String) {
             instance = PaymentConfiguration(publishableKey)
             Store(context).save(publishableKey)
+
+            FingerprintDataRepository.Default(context).get()
         }
 
         @JvmSynthetic

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
@@ -16,6 +16,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PaymentConfigurationTest {
 
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
     @BeforeTest
     fun setup() {
         // Make sure we initialize before each test.
@@ -25,14 +27,14 @@ class PaymentConfigurationTest {
     @Test
     fun getInstance_beforeInit_throwsRuntimeException() {
         assertFailsWith<IllegalStateException> {
-            PaymentConfiguration.getInstance(ApplicationProvider.getApplicationContext<Context>())
+            PaymentConfiguration.getInstance(context)
         }
     }
 
     @Test
     fun getInstance_whenInstanceIsNull_loadsFromPrefs() {
         PaymentConfiguration.init(
-            ApplicationProvider.getApplicationContext<Context>(),
+            context,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
 
@@ -41,7 +43,7 @@ class PaymentConfigurationTest {
         assertEquals(
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             PaymentConfiguration
-                .getInstance(ApplicationProvider.getApplicationContext<Context>())
+                .getInstance(context)
                 .publishableKey
         )
     }


### PR DESCRIPTION
## Summary
- Update `FingerprintDataRepository#get()` to pass `guid` when making
  a fingerprint request
- Change `FingerprintDataStore#get()` to return a
  `LiveData<FingerprintData>`
- Add fetching for `FingerprintData` to `PaymentConfiguration#init()`
  to increase likelihood that fingerprint data is available
