### PR TITLE
Support paymentMethod field in PaymentIntent and SetupIntent JSON

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -109,6 +109,8 @@ data class PaymentIntent internal constructor(
      */
     val nextAction: Map<String, @RawValue Any?>? = null,
 
+    override val paymentMethod: PaymentMethod? = null,
+
     /**
      * @return ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object)
      * to attach to this PaymentIntent.

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -56,6 +56,8 @@ data class SetupIntent internal constructor(
 
     override val nextActionType: StripeIntent.NextActionType? = null,
 
+    override val paymentMethod: PaymentMethod? = null,
+
     /**
      * @return ID of the payment method used with this SetupIntent.
      */

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -29,6 +29,8 @@ interface StripeIntent : StripeModel {
      */
     val isLiveMode: Boolean
 
+    val paymentMethod: PaymentMethod?
+
     /**
      * ID of the payment method used in this PaymentIntent.
      */

--- a/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -31,8 +31,9 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         val paymentMethod = json.optJSONObject(FIELD_PAYMENT_METHOD)?.let {
             PaymentMethodJsonParser().parse(it)
         }
-        val paymentMethodId = StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD_ID)
-            ?: paymentMethod?.id
+        val paymentMethodId =
+            StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD).takeIf { paymentMethod == null }
+                ?: paymentMethod?.id
 
         val receiptEmail = StripeJsonUtils.optString(json, FIELD_RECEIPT_EMAIL)
         val status = StripeIntent.Status.fromCode(
@@ -119,7 +120,6 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_LIVEMODE = "livemode"
         private const val FIELD_NEXT_ACTION = "next_action"
         private const val FIELD_PAYMENT_METHOD = "payment_method"
-        private const val FIELD_PAYMENT_METHOD_ID = "payment_method_id"
         private const val FIELD_PAYMENT_METHOD_TYPES = "payment_method_types"
         private const val FIELD_RECEIPT_EMAIL = "receipt_email"
         private const val FIELD_STATUS = "status"

--- a/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -27,7 +27,13 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         val currency = StripeJsonUtils.optCurrency(json, FIELD_CURRENCY)
         val description = StripeJsonUtils.optString(json, FIELD_DESCRIPTION)
         val livemode = StripeJsonUtils.optBoolean(json, FIELD_LIVEMODE)
+
+        val paymentMethod = json.optJSONObject(FIELD_PAYMENT_METHOD)?.let {
+            PaymentMethodJsonParser().parse(it)
+        }
         val paymentMethodId = StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD_ID)
+            ?: paymentMethod?.id
+
         val receiptEmail = StripeJsonUtils.optString(json, FIELD_RECEIPT_EMAIL)
         val status = StripeIntent.Status.fromCode(
             StripeJsonUtils.optString(json, FIELD_STATUS)
@@ -56,6 +62,7 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
             description = description,
             isLiveMode = livemode,
             nextAction = nextAction,
+            paymentMethod = paymentMethod,
             paymentMethodId = paymentMethodId,
             receiptEmail = receiptEmail,
             status = status,
@@ -111,6 +118,7 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_LAST_PAYMENT_ERROR = "last_payment_error"
         private const val FIELD_LIVEMODE = "livemode"
         private const val FIELD_NEXT_ACTION = "next_action"
+        private const val FIELD_PAYMENT_METHOD = "payment_method"
         private const val FIELD_PAYMENT_METHOD_ID = "payment_method_id"
         private const val FIELD_PAYMENT_METHOD_TYPES = "payment_method_types"
         private const val FIELD_RECEIPT_EMAIL = "receipt_email"

--- a/stripe/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -16,6 +16,13 @@ internal class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         val nextActionType = nextAction?.let {
             StripeIntent.NextActionType.fromCode(it[FIELD_NEXT_ACTION_TYPE] as String?)
         }
+
+        val paymentMethod = json.optJSONObject(FIELD_PAYMENT_METHOD)?.let {
+            PaymentMethodJsonParser().parse(it)
+        }
+        val paymentMethodId = StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD_ID)
+            ?: paymentMethod?.id
+
         return SetupIntent(
             id = StripeJsonUtils.optString(json, FIELD_ID),
             objectType = objectType,
@@ -26,7 +33,8 @@ internal class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
             ),
             description = StripeJsonUtils.optString(json, FIELD_DESCRIPTION),
             isLiveMode = json.optBoolean(FIELD_LIVEMODE),
-            paymentMethodId = StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD),
+            paymentMethod = paymentMethod,
+            paymentMethodId = paymentMethodId,
             paymentMethodTypes = ModelJsonParser.jsonArrayToList(
                 json.optJSONArray(FIELD_PAYMENT_METHOD_TYPES)
             ),
@@ -82,6 +90,7 @@ internal class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         private const val FIELD_STATUS = "status"
         private const val FIELD_USAGE = "usage"
         private const val FIELD_PAYMENT_METHOD = "payment_method"
+        private const val FIELD_PAYMENT_METHOD_ID = "payment_method_id"
 
         private const val FIELD_NEXT_ACTION_TYPE = "type"
     }

--- a/stripe/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -20,8 +20,9 @@ internal class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         val paymentMethod = json.optJSONObject(FIELD_PAYMENT_METHOD)?.let {
             PaymentMethodJsonParser().parse(it)
         }
-        val paymentMethodId = StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD_ID)
-            ?: paymentMethod?.id
+        val paymentMethodId =
+            StripeJsonUtils.optString(json, FIELD_PAYMENT_METHOD).takeIf { paymentMethod == null }
+                ?: paymentMethod?.id
 
         return SetupIntent(
             id = StripeJsonUtils.optString(json, FIELD_ID),
@@ -90,7 +91,6 @@ internal class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         private const val FIELD_STATUS = "status"
         private const val FIELD_USAGE = "usage"
         private const val FIELD_PAYMENT_METHOD = "payment_method"
-        private const val FIELD_PAYMENT_METHOD_ID = "payment_method_id"
 
         private const val FIELD_NEXT_ACTION_TYPE = "type"
     }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -481,4 +481,83 @@ internal object PaymentIntentFixtures {
         }
         """.trimIndent()
     ))
+
+    val EXPANDED_PAYMENT_METHOD = JSONObject(
+        """
+        {
+            "id": "pi_1GSTxJCRMbs",
+            "object": "payment_intent",
+            "amount": 1099,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "client_secret": "pi_1GSTxJCRMbs_secret_NqmhRfE9f",
+            "confirmation_method": "automatic",
+            "created": 1585599093,
+            "currency": "usd",
+            "description": "Example PaymentIntent",
+            "last_payment_error": null,
+            "livemode": false,
+            "payment_method": {
+                "id": "pm_1GSTxOCRMbs6FrXfYCosDqyr",
+                "object": "payment_method",
+                "billing_details": {
+                    "address": {
+                        "city": null,
+                        "country": null,
+                        "line1": null,
+                        "line2": null,
+                        "postal_code": null,
+                        "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                },
+                "card": {
+                    "brand": "visa",
+                    "checks": {
+                        "address_line1_check": null,
+                        "address_postal_code_check": null,
+                        "cvc_check": null
+                    },
+                    "country": "IE",
+                    "exp_month": 1,
+                    "exp_year": 2025,
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "3238",
+                    "three_d_secure_usage": {
+                        "supported": true
+                    },
+                    "wallet": null
+                },
+                "created": 1585599098,
+                "customer": null,
+                "livemode": false,
+                "metadata": {},
+                "type": "card"
+            },
+            "payment_method_types": ["card"],
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": {
+                "address": {
+                    "city": "San Francisco",
+                    "country": "US",
+                    "line1": "123 Market St",
+                    "line2": "#345",
+                    "postal_code": "94107",
+                    "state": "CA"
+                },
+                "carrier": "Fedex",
+                "name": "Jenny Rosen",
+                "phone": null,
+                "tracking_number": "12345"
+            },
+            "source": null,
+            "status": "requires_action"
+        }
+        """.trimIndent()
+    )
 }

--- a/stripe/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -6,7 +6,7 @@ import org.json.JSONObject
 internal object SetupIntentFixtures {
     private val PARSER = SetupIntentJsonParser()
 
-    private val SI_NEXT_ACTION_REDIRECT_JSON = JSONObject(
+    internal val SI_NEXT_ACTION_REDIRECT_JSON = JSONObject(
         """
         {
             "id": "seti_1EqTSZGMT9dGPIDGVzCUs6dV",
@@ -137,6 +137,64 @@ internal object SetupIntentFixtures {
         }
         """.trimIndent()
     )))
+
+    internal val EXPANDED_PAYMENT_METHOD = JSONObject(
+        """
+        {
+            "id": "seti_1GSmaFCRMbs",
+            "object": "setup_intent",
+            "cancellation_reason": null,
+            "client_secret": "seti_1GSmaFCRMbs6FrXfmjThcHan_secret_H0oC2iSB4FtW4d",
+            "created": 1585670699,
+            "description": null,
+            "last_setup_error": null,
+            "livemode": false,
+            "payment_method": {
+                "id": "pm_1GSmaGCRMbs6F",
+                "object": "payment_method",
+                "billing_details": {
+                    "address": {
+                        "city": null,
+                        "country": null,
+                        "line1": null,
+                        "line2": null,
+                        "postal_code": null,
+                        "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                },
+                "card": {
+                    "brand": "visa",
+                    "checks": {
+                        "address_line1_check": null,
+                        "address_postal_code_check": null,
+                        "cvc_check": null
+                    },
+                    "country": "IE",
+                    "exp_month": 1,
+                    "exp_year": 2025,
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "3238",
+                    "three_d_secure_usage": {
+                        "supported": true
+                    },
+                    "wallet": null
+                },
+                "created": 1585670700,
+                "customer": null,
+                "livemode": false,
+                "metadata": {},
+                "type": "card"
+            },
+            "payment_method_types": ["card"],
+            "status": "requires_action",
+            "usage": "off_session"
+        }
+        """.trimIndent()
+    )
 
     val SI_NEXT_ACTION_REDIRECT = requireNotNull(
         PARSER.parse(SI_NEXT_ACTION_REDIRECT_JSON)

--- a/stripe/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.model.parsers
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentIntentFixtures
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentIntentJsonParserTest {
+    @Test
+    fun parse_withExpandedPaymentMethod_shouldCreateExpectedObject() {
+        val paymentIntent = PaymentIntentJsonParser().parse(
+            PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD
+        )
+        assertThat(paymentIntent?.paymentMethodId)
+            .isEqualTo("pm_1GSTxOCRMbs6FrXfYCosDqyr")
+        assertThat(paymentIntent?.paymentMethod?.id)
+            .isEqualTo("pm_1GSTxOCRMbs6FrXfYCosDqyr")
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/parsers/SetupIntentJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/SetupIntentJsonParserTest.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.model.parsers
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.SetupIntentFixtures
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SetupIntentJsonParserTest {
+    @Test
+    fun parse_withNotExpandedPaymentMethod_shouldCreateExpectedObject() {
+        val setupIntent = requireNotNull(
+            SetupIntentJsonParser().parse(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT_JSON)
+        )
+        assertThat(setupIntent.paymentMethodId)
+            .isEqualTo("pm_1EqTSoGMT9dGPIDG7dgafX1H")
+        assertThat(setupIntent.paymentMethod)
+            .isNull()
+    }
+
+    @Test
+    fun parse_withExpandedPaymentMethod_shouldCreateExpectedObject() {
+        val setupIntent = requireNotNull(
+            SetupIntentJsonParser().parse(SetupIntentFixtures.EXPANDED_PAYMENT_METHOD)
+        )
+        assertThat(setupIntent.paymentMethodId)
+            .isEqualTo("pm_1GSmaGCRMbs6F")
+        assertThat(setupIntent.paymentMethod?.id)
+            .isEqualTo("pm_1GSmaGCRMbs6F")
+    }
+}


### PR DESCRIPTION
## Summary
The `paymentMethod` field of `PaymentIntent` and `SetupIntent`
can be expanded [0].

[0] https://stripe.com/docs/api/expanding_objects

## Testing
Added unit test
