### PR TITLE
Expand payment_method field for StripeIntents in StripePaymentController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -101,10 +101,12 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         APIConnectionException::class, APIException::class)
     override fun confirmPaymentIntent(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent? {
         val params = fingerprintParamsUtils.addFingerprintData(
-            confirmPaymentIntentParams.toParamMap(),
+            confirmPaymentIntentParams.toParamMap()
+                .plus(createExpandParam(expandFields)),
             fingerprintGuid
         )
         val apiUrl = getConfirmPaymentIntentUrl(
@@ -212,7 +214,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         APIConnectionException::class, APIException::class)
     override fun confirmSetupIntent(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent? {
         val setupIntentId =
             SetupIntent.ClientSecret(confirmSetupIntentParams.clientSecret).setupIntentId
@@ -232,7 +235,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     getConfirmSetupIntentUrl(setupIntentId),
                     options,
                     fingerprintParamsUtils.addFingerprintData(
-                        confirmSetupIntentParams.toParamMap(),
+                        confirmSetupIntentParams.toParamMap()
+                            .plus(createExpandParam(expandFields)),
                         fingerprintGuid
                     )
                 ),
@@ -1272,6 +1276,12 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
 
         private fun getApiUrl(path: String): String {
             return "${ApiRequest.API_HOST}/v1/$path"
+        }
+
+        private fun createExpandParam(expandFields: List<String>): Map<String, List<String>> {
+            return expandFields.takeIf { it.isNotEmpty() }?.let {
+                mapOf("expand" to it)
+            }.orEmpty()
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -103,7 +103,8 @@ abstract class StripeIntentResult<T : StripeIntent> internal constructor(
     private companion object {
         private val PROCESSING_IS_SUCCESS = setOf(
             PaymentMethod.Type.SepaDebit,
-            PaymentMethod.Type.BacsDebit
+            PaymentMethod.Type.BacsDebit,
+            PaymentMethod.Type.AuBecsDebit
         )
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import androidx.annotation.IntDef
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import java.util.Objects
 
@@ -40,7 +41,11 @@ abstract class StripeIntentResult<T : StripeIntent> internal constructor(
                 return Outcome.SUCCEEDED
             }
             StripeIntent.Status.Processing -> {
-                return Outcome.UNKNOWN
+                return if (PROCESSING_IS_SUCCESS.contains(intent.paymentMethod?.type)) {
+                    Outcome.SUCCEEDED
+                } else {
+                    Outcome.UNKNOWN
+                }
             }
             else -> {
                 return Outcome.UNKNOWN
@@ -93,5 +98,12 @@ abstract class StripeIntentResult<T : StripeIntent> internal constructor(
              */
             const val TIMEDOUT: Int = 4
         }
+    }
+
+    private companion object {
+        private val PROCESSING_IS_SUCCESS = setOf(
+            PaymentMethod.Type.SepaDebit,
+            PaymentMethod.Type.BacsDebit
+        )
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -526,9 +526,17 @@ internal class StripePaymentController internal constructor(
         override suspend fun getResult(): StripeIntent? {
             return when (params) {
                 is ConfirmPaymentIntentParams ->
-                    stripeRepository.confirmPaymentIntent(params, requestOptions)
+                    stripeRepository.confirmPaymentIntent(
+                        params,
+                        requestOptions,
+                        expandFields = listOf("payment_method")
+                    )
                 is ConfirmSetupIntentParams ->
-                    stripeRepository.confirmSetupIntent(params, requestOptions)
+                    stripeRepository.confirmSetupIntent(
+                        params,
+                        requestOptions,
+                        expandFields = listOf("payment_method")
+                    )
                 else -> null
             }
         }

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -34,7 +34,8 @@ internal interface StripeRepository {
         APIConnectionException::class, APIException::class)
     fun confirmPaymentIntent(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String> = emptyList()
     ): PaymentIntent?
 
     @Throws(AuthenticationException::class, InvalidRequestException::class,
@@ -56,7 +57,8 @@ internal interface StripeRepository {
         APIConnectionException::class, APIException::class)
     fun confirmSetupIntent(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String> = emptyList()
     ): SetupIntent?
 
     @Throws(AuthenticationException::class, InvalidRequestException::class,

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -42,7 +42,7 @@ data class PaymentIntent internal constructor(
      * @return Populated when `status` is `canceled`, this is the time at which the PaymentIntent
      * was canceled. Measured in seconds since the Unix epoch. If unavailable, will return 0.
      */
-    val canceledAt: Long,
+    val canceledAt: Long = 0L,
 
     /**
      * @return Reason for cancellation of this PaymentIntent
@@ -80,7 +80,7 @@ data class PaymentIntent internal constructor(
      * state after handling `next_action`s, and requires your server to initiate each
      * payment attempt with an explicit confirmation.
      */
-    val confirmationMethod: String?,
+    val confirmationMethod: String? = null,
 
     /**
      * @return Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -125,14 +125,14 @@ data class PaymentIntent internal constructor(
     /**
      * @return Status of this PaymentIntent.
      */
-    override val status: StripeIntent.Status?,
+    override val status: StripeIntent.Status? = null,
 
-    private val setupFutureUsage: StripeIntent.Usage?,
+    private val setupFutureUsage: StripeIntent.Usage? = null,
 
     /**
      * @return The payment error encountered in the previous PaymentIntent confirmation.
      */
-    val lastPaymentError: Error?
+    val lastPaymentError: Error? = null
 ) : StripeIntent {
     @IgnoredOnParcel
     override val nextActionType: StripeIntent.NextActionType? = nextAction?.let {

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -24,7 +24,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     override fun confirmPaymentIntent(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent? {
         return null
     }
@@ -46,7 +47,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     override fun confirmSetupIntent(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent? {
         return null
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android
 
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.StripeIntent
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -11,9 +14,29 @@ class PaymentIntentResultTest {
 
     @Test
     fun testBuilder() {
-        assertEquals(
-            PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
-            PaymentIntentResult(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2).intent
+        assertThat(PaymentIntentResult(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2).intent)
+            .isEqualTo(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
+    }
+
+    @Test
+    fun outcome_whenBacsAndProcessing_shouldReturnSucceeded() {
+        val paymentIntent = PaymentIntent(
+            created = 500L,
+            amount = 1000L,
+            captureMethod = "automatic",
+            clientSecret = "secret",
+            paymentMethod = PaymentMethodFixtures.BACS_DEBIT_PAYMENT_METHOD,
+            isLiveMode = false,
+            id = "pi_12345",
+            currency = "usd",
+            objectType = "payment_intent",
+            paymentMethodTypes = listOf("card"),
+            status = StripeIntent.Status.Processing
         )
+        val result = PaymentIntentResult(
+            paymentIntent = paymentIntent
+        )
+        assertThat(result.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
     }
 }


### PR DESCRIPTION
## Summary
Modify `StripeRepository` to expand the `payment_method` field when
confirming a `PaymentIntent` or `SetupIntent`

## Motivation
For BACS and SEPA Debit, the StripeIntent state of `processing`
should be considered successful, because they require multiple business
days to resolve.

## Testing
Add unit tests
Manually verify
