### PR TITLE
Covert CardBrand prefixes to regex

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import androidx.annotation.DrawableRes
 import com.stripe.android.R
+import com.stripe.android.StripeTextUtils
 import java.util.regex.Pattern
 
 /**
@@ -159,8 +160,10 @@ enum class CardBrand(
      * Note: currently only [CardBrand.DinersClub] has variants
      */
     fun getMaxLengthForCardNumber(cardNumber: String): Int {
+        val normalizedCardNumber =
+            StripeTextUtils.removeSpacesAndHyphens(cardNumber).orEmpty()
         return variantMaxLength.entries.firstOrNull { (pattern, _) ->
-            pattern.matcher(cardNumber).matches()
+            pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultMaxLength
     }
 
@@ -176,8 +179,10 @@ enum class CardBrand(
      * Note: currently only [CardBrand.DinersClub] has variants
      */
     fun getSpacePositionsForCardNumber(cardNumber: String): Set<Int> {
+        val normalizedCardNumber =
+            StripeTextUtils.removeSpacesAndHyphens(cardNumber).orEmpty()
         return variantSpacePositions.entries.firstOrNull { (pattern, _) ->
-            pattern.matcher(cardNumber).matches()
+            pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultSpacePositions
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
@@ -35,42 +35,32 @@ class CardBrandTest {
 
     @Test
     fun fromCardNumber_withDinersClub14() {
-        assertEquals(
-            CardBrand.DinersClub,
-            CardBrand.fromCardNumber(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES)
-        )
+        assertThat(CardBrand.fromCardNumber(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES))
+            .isEqualTo(CardBrand.DinersClub)
     }
 
     @Test
     fun fromCardNumber_withDinersClub16() {
-        assertEquals(
-            CardBrand.DinersClub,
-            CardBrand.fromCardNumber(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES)
-        )
+        assertThat(CardBrand.fromCardNumber(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES))
+            .isEqualTo(CardBrand.DinersClub)
     }
 
     @Test
     fun fromCardNumber_withJcb() {
-        assertEquals(
-            CardBrand.JCB,
-            CardBrand.fromCardNumber(CardNumberFixtures.JCB_NO_SPACES)
-        )
+        assertThat(CardBrand.fromCardNumber(CardNumberFixtures.JCB_NO_SPACES))
+            .isEqualTo(CardBrand.JCB)
     }
 
     @Test
     fun fromCardNumber_withVisa() {
-        assertEquals(
-            CardBrand.Visa,
-            CardBrand.fromCardNumber(CardNumberFixtures.VISA_NO_SPACES)
-        )
+        assertThat(CardBrand.fromCardNumber(CardNumberFixtures.VISA_NO_SPACES))
+            .isEqualTo(CardBrand.Visa)
     }
 
     @Test
     fun fromCardNumber_withInvalidVisa() {
-        assertEquals(
-            CardBrand.Unknown,
-            CardBrand.fromCardNumber("1" + CardNumberFixtures.VISA_NO_SPACES)
-        )
+        assertThat(CardBrand.fromCardNumber("1" + CardNumberFixtures.VISA_NO_SPACES))
+            .isEqualTo(CardBrand.Unknown)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -620,13 +620,13 @@ internal class CardInputWidgetTest : BaseViewTest<CardInputTestActivity>(
     fun onUpdateIcon_forCommonLengthBrand_setsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.
-        cardNumberEditText.append(CardBrand.Visa.prefixes.first())
+        cardNumberEditText.append("4")
         assertTrue(ViewTestUtils.hasMaxLength(cvcEditText, 3))
     }
 
     @Test
     fun onUpdateText_forAmExPrefix_setsLengthOnCvc() {
-        cardNumberEditText.append(CardBrand.AmericanExpress.prefixes.first())
+        cardNumberEditText.append("34")
         assertTrue(ViewTestUtils.hasMaxLength(cvcEditText, 4))
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -249,35 +249,34 @@ class CardNumberEditTextTest {
         // We reset because just attaching the listener calls the method once.
         lastBrandChangeCallbackInvocation = null
         // There is only one Visa Prefix.
-        cardNumberEditText.setText(cardNumberEditText.text?.toString() + CardBrand.Visa.prefixes[0])
+        cardNumberEditText.setText(cardNumberEditText.text?.toString() + "4")
         assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun addAmExPrefix_callsBrandListener() {
-        CardBrand.AmericanExpress.prefixes.forEach(
-            verifyCardBrandPrefix(CardBrand.AmericanExpress)
-        )
+        verifyCardBrandPrefix(CardBrand.AmericanExpress, "34")
     }
 
     @Test
     fun addDinersClubPrefix_callsBrandListener() {
-        CardBrand.DinersClub.prefixes.forEach(verifyCardBrandPrefix(CardBrand.DinersClub))
+        verifyCardBrandPrefix(CardBrand.DinersClub, "36")
+        verifyCardBrandPrefix(CardBrand.DinersClub, "30")
     }
 
     @Test
     fun addDiscoverPrefix_callsBrandListener() {
-        CardBrand.Discover.prefixes.forEach(verifyCardBrandPrefix(CardBrand.Discover))
+        verifyCardBrandPrefix(CardBrand.Discover, "60")
     }
 
     @Test
     fun addMasterCardPrefix_callsBrandListener() {
-        CardBrand.MasterCard.prefixes.forEach(verifyCardBrandPrefix(CardBrand.MasterCard))
+        verifyCardBrandPrefix(CardBrand.MasterCard, "2222")
     }
 
     @Test
     fun addJCBPrefix_callsBrandListener() {
-        CardBrand.JCB.prefixes.forEach(verifyCardBrandPrefix(CardBrand.JCB))
+        verifyCardBrandPrefix(CardBrand.JCB, "35")
     }
 
     @Test
@@ -293,7 +292,7 @@ class CardNumberEditTextTest {
     @Test
     fun enterBrandPrefix_thenDelete_callsUpdateWithUnknown() {
         lastBrandChangeCallbackInvocation = null
-        val dinersPrefix = CardBrand.DinersClub.prefixes[0]
+        val dinersPrefix = "36"
         // All the Diners Club prefixes are longer than one character, but I specifically want
         // to test that a nonempty string still triggers this action, so this test will fail if
         // the Diners Club prefixes are ever changed.
@@ -309,7 +308,7 @@ class CardNumberEditTextTest {
     @Test
     fun enterBrandPrefix_thenClearAllText_callsUpdateWithUnknown() {
         lastBrandChangeCallbackInvocation = null
-        val prefixVisa = CardBrand.Visa.prefixes[0]
+        val prefixVisa = "4"
         cardNumberEditText.setText(cardNumberEditText.text?.toString() + prefixVisa)
         assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
 
@@ -374,13 +373,14 @@ class CardNumberEditTextTest {
         assertEquals(CardBrand.AmericanExpress, lastBrandChangeCallbackInvocation)
     }
 
-    private fun verifyCardBrandPrefix(cardBrand: CardBrand): (String) -> Unit {
-        return { prefix ->
-            // Reset inside the loop so we don't count each prefix
-            lastBrandChangeCallbackInvocation = null
-            cardNumberEditText.setText(cardNumberEditText.text?.toString() + prefix)
-            assertEquals(cardBrand, lastBrandChangeCallbackInvocation)
-            cardNumberEditText.setText("")
-        }
+    private fun verifyCardBrandPrefix(
+        cardBrand: CardBrand,
+        prefix: String
+    ) {
+        // Reset inside the loop so we don't count each prefix
+        lastBrandChangeCallbackInvocation = null
+        cardNumberEditText.setText(cardNumberEditText.text?.toString() + prefix)
+        assertEquals(cardBrand, lastBrandChangeCallbackInvocation)
+        cardNumberEditText.setText("")
     }
 }


### PR DESCRIPTION
## Summary
- Convert prefixes to regex
- Add `^81` as a pattern for `CardBrand.UnionPay`

## Motivation
Regex allows for more power and flexibility for describing how to match
a card brand.

## Testing
Update tests
