### PR TITLE
Update CardBrand.JCB regex

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -79,12 +79,10 @@ enum class CardBrand(
         "jcb",
         "JCB",
         R.drawable.stripe_ic_jcb,
-        pattern = Pattern.compile("^(35)[0-9]*$"),
+        pattern = Pattern.compile("^(352[89]|35[3-8][0-9])[0-9]*$"),
         partialPatterns = mapOf(
             2 to Pattern.compile("^(35)$"),
-            3 to Pattern.compile("^(35[2-8])$"),
-            4 to Pattern.compile("^(352[89]|35[3-8][0-9])$"),
-            5 to Pattern.compile("^(3528[0-9]|3529[0-9]|35[3-8][0-9]{2})$")
+            3 to Pattern.compile("^(35[2-8])$")
         )
     ),
 

--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -34,6 +34,11 @@ enum class CardBrand(
     val pattern: Pattern? = null,
 
     /**
+     * Patterns for discrete lengths
+     */
+    private val partialPatterns: Map<Int, Pattern> = emptyMap(),
+
+    /**
      * The position of spaces in a formatted card number. For example, "4242424242424242" is
      * formatted to "4242 4242 4242 4242".
      */
@@ -74,7 +79,13 @@ enum class CardBrand(
         "jcb",
         "JCB",
         R.drawable.stripe_ic_jcb,
-        pattern = Pattern.compile("^(35)[0-9]*$")
+        pattern = Pattern.compile("^(35)[0-9]*$"),
+        partialPatterns = mapOf(
+            2 to Pattern.compile("^(35)$"),
+            3 to Pattern.compile("^(35[2-8])$"),
+            4 to Pattern.compile("^(352[89]|35[3-8][0-9])$"),
+            5 to Pattern.compile("^(3528[0-9]|3529[0-9]|35[3-8][0-9]{2})$")
+        )
     ),
 
     /**
@@ -241,6 +252,10 @@ enum class CardBrand(
         return groups
     }
 
+    private fun getPatternForLength(cardNumber: String): Pattern? {
+        return partialPatterns[cardNumber.length] ?: pattern
+    }
+
     companion object {
         /**
          * @param cardNumber a card number
@@ -254,7 +269,7 @@ enum class CardBrand(
 
             return values()
                 .firstOrNull { cardBrand ->
-                    cardBrand.pattern?.matcher(cardNumber)?.matches() == true
+                    cardBrand.getPatternForLength(cardNumber)?.matcher(cardNumber)?.matches() == true
                 } ?: Unknown
         }
 

--- a/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardBrandTest.kt
@@ -295,4 +295,20 @@ class CardBrandTest {
             )
         )
     }
+
+    @Test
+    fun fromCardNumber_shouldUsePartialPatternsIfAvailable() {
+        assertThat(CardBrand.fromCardNumber("3"))
+            .isEqualTo(CardBrand.Unknown)
+        assertThat(CardBrand.fromCardNumber("35"))
+            .isEqualTo(CardBrand.JCB)
+        assertThat(CardBrand.fromCardNumber("352"))
+            .isEqualTo(CardBrand.JCB)
+        assertThat(CardBrand.fromCardNumber("3527"))
+            .isEqualTo(CardBrand.Unknown)
+        assertThat(CardBrand.fromCardNumber("3528"))
+            .isEqualTo(CardBrand.JCB)
+        assertThat(CardBrand.fromCardNumber("352800"))
+            .isEqualTo(CardBrand.JCB)
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/CardTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardTest.kt
@@ -47,7 +47,7 @@ class CardTest {
 
     @Test
     fun testTypeReturnsCorrectlyForJCBCard() {
-        val card = Card.create(number = "3512123412341234")
+        val card = Card.create(number = CardNumberFixtures.JCB_NO_SPACES)
         assertEquals(CardBrand.JCB, card.brand)
     }
 


### PR DESCRIPTION
Add `CardBrand.partialPatterns` to have finer-grained control of brand
matching.

![jcb](https://user-images.githubusercontent.com/45020849/78292229-b6722e80-74f4-11ea-9f69-026aab28916a.gif)
