### PR TITLE
Update FingerprintDataRepository

### DIFF
--- a/stripe/src/main/java/com/stripe/android/FingerprintDataRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataRepository.kt
@@ -25,12 +25,10 @@ internal interface FingerprintDataRepository {
         }
 
         constructor(
-            context: Context,
-            handler: Handler = Handler(Looper.getMainLooper())
+            context: Context
         ) : this(
             store = FingerprintDataStore.Default(context),
-            fingerprintRequestFactory = FingerprintRequestFactory(context),
-            handler = handler
+            fingerprintRequestFactory = FingerprintRequestFactory(context)
         )
 
         override fun refresh() {
@@ -46,7 +44,6 @@ internal interface FingerprintDataRepository {
                                 )
                             ) { remoteFingerprintData ->
                                 remoteFingerprintData?.let {
-                                    cachedFingerprintData = it
                                     save(it)
                                 }
                                 liveData.removeObserver(this)
@@ -65,6 +62,7 @@ internal interface FingerprintDataRepository {
         }
 
         override fun save(fingerprintData: FingerprintData) {
+            cachedFingerprintData = fingerprintData
             store.save(fingerprintData)
         }
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -72,7 +72,7 @@ data class PaymentConfiguration internal constructor(val publishableKey: String)
             instance = PaymentConfiguration(publishableKey)
             Store(context).save(publishableKey)
 
-            FingerprintDataRepository.Default(context).get()
+            FingerprintDataRepository.Default(context).refresh()
         }
 
         @JvmSynthetic

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -1,8 +1,6 @@
 package com.stripe.android
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.util.Pair
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.exception.APIConnectionException
@@ -60,12 +58,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     private val stripeApiRequestExecutor: ApiRequestExecutor = ApiRequestExecutor.Default(logger),
     private val fireAndForgetRequestExecutor: FireAndForgetRequestExecutor =
         StripeFireAndForgetRequestExecutor(logger),
-    private val handler: Handler = Handler(Looper.getMainLooper()),
     private val fingerprintDataRepository: FingerprintDataRepository =
-        FingerprintDataRepository.Default(
-            context = context,
-            handler = handler
-        ),
+        FingerprintDataRepository.Default(context),
     private val apiFingerprintParamsFactory: ApiFingerprintParamsFactory =
         ApiFingerprintParamsFactory(context),
     private val analyticsDataFactory: AnalyticsDataFactory =

--- a/stripe/src/test/java/com/stripe/android/FakeFingerprintDataRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/FakeFingerprintDataRepository.kt
@@ -1,0 +1,19 @@
+package com.stripe.android
+
+import java.util.UUID
+
+internal class FakeFingerprintDataRepository(
+    private val guid: UUID = UUID.randomUUID()
+) : FingerprintDataRepository {
+    override fun refresh() {
+    }
+
+    override fun get(): FingerprintData? {
+        return FingerprintData(
+            guid = guid.toString()
+        )
+    }
+
+    override fun save(fingerprintData: FingerprintData) {
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import android.content.Context
-import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
@@ -69,11 +68,9 @@ class StripeApiRepositoryTest {
     @BeforeTest
     fun before() {
         whenever(fingerprintDataRepository.get()).thenReturn(
-            MutableLiveData(
-                FingerprintData(
-                    guid = UUID.randomUUID().toString(),
-                    timestamp = Calendar.getInstance().timeInMillis
-                )
+            FingerprintData(
+                guid = UUID.randomUUID().toString(),
+                timestamp = Calendar.getInstance().timeInMillis
             )
         )
 
@@ -829,7 +826,7 @@ class StripeApiRepositoryTest {
         productUsage: List<String>? = null
     ) {
         verify(fingerprintDataRepository, times(2))
-            .get()
+            .refresh()
 
         verifyAnalyticsRequest(event, productUsage)
     }


### PR DESCRIPTION
## Summary
- Change existing `get()` to `refresh()` without a return type
- Add new `get()` method that returns cached `FingerprintData` in
  default implementation

## Motivation
Increase the likelihood that `FingerprintData` is available

## Testing
Updated unit tests
