### PR TITLE
Fire missing analytics event for StripeApiRepository.retrieveSource

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -156,6 +156,13 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     }
 
     @JvmSynthetic
+    internal fun createSourceRetrieveParams(sourceId: String): Map<String, Any> {
+        return createParams(AnalyticsEvent.SourceRetrieve,
+                extraParams = mapOf(FIELD_SOURCE_ID to sourceId)
+        )
+    }
+
+    @JvmSynthetic
     internal fun createAddSourceParams(
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -158,8 +158,8 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createSourceRetrieveParams(sourceId: String): Map<String, Any> {
         return createParams(
-                AnalyticsEvent.SourceRetrieve,
-                extraParams = mapOf(FIELD_SOURCE_ID to sourceId)
+            AnalyticsEvent.SourceRetrieve,
+            extraParams = mapOf(FIELD_SOURCE_ID to sourceId)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -157,7 +157,8 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createSourceRetrieveParams(sourceId: String): Map<String, Any> {
-        return createParams(AnalyticsEvent.SourceRetrieve,
+        return createParams(
+                AnalyticsEvent.SourceRetrieve,
                 extraParams = mapOf(FIELD_SOURCE_ID to sourceId)
         )
     }

--- a/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
@@ -23,6 +23,7 @@ internal enum class AnalyticsEvent(internal val code: String) {
 
     // Source
     SourceCreate("source_creation"),
+    SourceRetrieve("source_retrieve"),
 
     // Payment Intents
     PaymentIntentConfirm("payment_intent_confirmation"),

--- a/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
@@ -23,7 +23,7 @@ internal enum class AnalyticsEvent(internal val code: String) {
 
     // Source
     SourceCreate("source_creation"),
-    SourceRetrieve("source_retrieve"),
+    SourceRetrieve("retrieve_source"),
 
     // Payment Intents
     PaymentIntentConfirm("payment_intent_confirmation"),

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -385,6 +385,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     ): Source? {
         val apiUrl = getRetrieveSourceApiUrl(sourceId)
 
+        fireAnalyticsRequest(
+                analyticsDataFactory.createSourceRetrieveParams(sourceId),
+                options.apiKey
+        )
+
         try {
             return fetchStripeModel(
                 apiRequestFactory.createGet(

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -386,8 +386,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val apiUrl = getRetrieveSourceApiUrl(sourceId)
 
         fireAnalyticsRequest(
-                analyticsDataFactory.createSourceRetrieveParams(sourceId),
-                options.apiKey
+            analyticsDataFactory.createSourceRetrieveParams(sourceId),
+            options.apiKey
         )
 
         try {

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -245,18 +245,18 @@ class StripeApiRepositoryTest {
     @Test
     fun retrieveSource_shouldFireAnalytics_andReturnSource() {
         val stripeResponse = StripeResponse(
-                200,
-                SourceFixtures.SOURCE_CARD_JSON.toString(),
-                emptyMap()
+            200,
+            SourceFixtures.SOURCE_CARD_JSON.toString(),
+            emptyMap()
         )
         whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-                .thenReturn(stripeResponse)
+            .thenReturn(stripeResponse)
 
         val sourceId = "src_19t3xKBZqEXluyI4uz2dxAfQ"
         val source = create().retrieveSource(
-                sourceId,
-                "mocked",
-                DEFAULT_OPTIONS
+            sourceId,
+            "mocked",
+            DEFAULT_OPTIONS
         )
 
         assertNotNull(source)

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -849,36 +849,23 @@ public class StripeTest {
         );
     }
 
-  @Test
-  public void retrieveSourceSynchronous_withValidData_passesIntegrationTest()
-      throws StripeException {
-    final Source source = createSource();
+    @Test
+    public void retrieveSourceSynchronous_withValidData_passesIntegrationTest()
+            throws StripeException {
+        final Source source = createSource();
 
-    final String sourceId = source.getId();
-    final String clientSecret = source.getClientSecret();
-    assertNotNull(sourceId);
-    assertNotNull(clientSecret);
+        final String sourceId = source.getId();
+        final String clientSecret = source.getClientSecret();
+        assertNotNull(sourceId);
+        assertNotNull(clientSecret);
 
-    final Source retrievedSource =
-        createStripe(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, fireAndForgetRequestExecutor)
-            .retrieveSourceSynchronous(sourceId, clientSecret);
+        final Source retrievedSource = createStripe()
+                .retrieveSourceSynchronous(sourceId, clientSecret);
 
-    // We aren't actually updating the source on the server, so the two sources should
-    // be identical.
-    assertEquals(source, retrievedSource);
-
-    verify(fireAndForgetRequestExecutor).executeAsync(stripeRequestArgumentCaptor.capture());
-    final StripeRequest analyticsRequest = stripeRequestArgumentCaptor.getValue();
-    assertEquals(AnalyticsRequestFactory.HOST, analyticsRequest.getBaseUrl());
-
-    assertEquals(
-        AnalyticsEvent.SourceRetrieve.toString(),
-        Objects.requireNonNull(analyticsRequest.getParams()).get(AnalyticsDataFactory.FIELD_EVENT));
-    assertEquals(
-        sourceId,
-        Objects.requireNonNull(analyticsRequest.getParams())
-            .get(AnalyticsDataFactory.FIELD_SOURCE_ID));
-  }
+        // We aren't actually updating the source on the server, so the two sources should
+        // be identical.
+        assertEquals(source, retrievedSource);
+    }
 
     @Test
     public void createSourceFromTokenParams_withExtraParams_succeeds()

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -849,23 +849,36 @@ public class StripeTest {
         );
     }
 
-    @Test
-    public void retrieveSourceSynchronous_withValidData_passesIntegrationTest()
-            throws StripeException {
-        final Source source = createSource();
+  @Test
+  public void retrieveSourceSynchronous_withValidData_passesIntegrationTest()
+      throws StripeException {
+    final Source source = createSource();
 
-        final String sourceId = source.getId();
-        final String clientSecret = source.getClientSecret();
-        assertNotNull(sourceId);
-        assertNotNull(clientSecret);
+    final String sourceId = source.getId();
+    final String clientSecret = source.getClientSecret();
+    assertNotNull(sourceId);
+    assertNotNull(clientSecret);
 
-        final Source retrievedSource = createStripe()
-                .retrieveSourceSynchronous(sourceId, clientSecret);
+    final Source retrievedSource =
+        createStripe(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY, fireAndForgetRequestExecutor)
+            .retrieveSourceSynchronous(sourceId, clientSecret);
 
-        // We aren't actually updating the source on the server, so the two sources should
-        // be identical.
-        assertEquals(source, retrievedSource);
-    }
+    // We aren't actually updating the source on the server, so the two sources should
+    // be identical.
+    assertEquals(source, retrievedSource);
+
+    verify(fireAndForgetRequestExecutor).executeAsync(stripeRequestArgumentCaptor.capture());
+    final StripeRequest analyticsRequest = stripeRequestArgumentCaptor.getValue();
+    assertEquals(AnalyticsRequestFactory.HOST, analyticsRequest.getBaseUrl());
+
+    assertEquals(
+        AnalyticsEvent.SourceRetrieve.toString(),
+        Objects.requireNonNull(analyticsRequest.getParams()).get(AnalyticsDataFactory.FIELD_EVENT));
+    assertEquals(
+        sourceId,
+        Objects.requireNonNull(analyticsRequest.getParams())
+            .get(AnalyticsDataFactory.FIELD_SOURCE_ID));
+  }
 
     @Test
     public void createSourceFromTokenParams_withExtraParams_succeeds()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add an analytics event when retrieving a source

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
All the other api methods fire events but this one didn't. We should be consistent

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Wrote a unit test