### PR TITLE
Allow stripe account to be configured on a per-request basis

### DIFF
--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -1198,7 +1198,11 @@ class Stripe internal constructor(
         idempotencyKey: String? = null,
         callback: ApiResultCallback<Token>
     ) {
-        createCardToken(card, idempotencyKey, callback)
+        createCardToken(
+            card,
+            idempotencyKey = idempotencyKey,
+            callback = callback
+        )
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -367,7 +367,6 @@ class Stripe internal constructor(
      *
      * @param activity the `Activity` that is launching the payment authentication flow
      */
-    @JvmOverloads
     fun confirmSetupIntent(
         activity: Activity,
         confirmSetupIntentParams: ConfirmSetupIntentParams

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -128,7 +128,8 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
      * [PaymentIntent]
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     fun confirmPayment(
@@ -152,7 +153,8 @@ class Stripe internal constructor(
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the [PaymentIntent]
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     fun confirmPayment(
@@ -201,7 +203,8 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
      * property of a confirmed [PaymentIntent] object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     fun handleNextActionForPayment(
@@ -250,7 +253,8 @@ class Stripe internal constructor(
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
      * property of a confirmed [PaymentIntent] object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     fun handleNextActionForPayment(
@@ -306,7 +310,8 @@ class Stripe internal constructor(
      * `GET /v1/payment_intents/:id`
      *
      * @param clientSecret the client_secret with which to retrieve the PaymentIntent
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @return a [PaymentIntent] or `null` if a problem occurred
      */
     @Throws(APIException::class, AuthenticationException::class,
@@ -365,7 +370,8 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
      * @param activity the `Activity` that is launching the payment authentication flow
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     @JvmOverloads
@@ -388,7 +394,8 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     @JvmOverloads
@@ -435,7 +442,8 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * property of a confirmed [SetupIntent] object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     @JvmOverloads
@@ -482,7 +490,8 @@ class Stripe internal constructor(
      * @param fragment the `Fragment` launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * property of a confirmed [SetupIntent] object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @UiThread
     @JvmOverloads
@@ -538,7 +547,8 @@ class Stripe internal constructor(
      * `GET /v1/setup_intents/:id`
      *
      * @param clientSecret client_secret of the SetupIntent to retrieve
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @return a [SetupIntent] or `null` if a problem occurred
      */
     @Throws(APIException::class, AuthenticationException::class, InvalidRequestException::class,
@@ -601,7 +611,8 @@ class Stripe internal constructor(
      *
      * @param paymentMethodCreateParams the [PaymentMethodCreateParams] to be used
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -634,7 +645,8 @@ class Stripe internal constructor(
      *
      * @param paymentMethodCreateParams params with which to create the PaymentMethod
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [PaymentMethod] or `null` if a problem occurred
      */
@@ -669,7 +681,8 @@ class Stripe internal constructor(
      *
      * @param activity the `Activity` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @JvmOverloads
     fun authenticateSource(
@@ -692,7 +705,8 @@ class Stripe internal constructor(
      *
      * @param fragment the `Fragment` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @JvmOverloads
     fun authenticateSource(
@@ -745,7 +759,8 @@ class Stripe internal constructor(
      *
      * @param sourceParams the [SourceParams] to be used
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -778,7 +793,8 @@ class Stripe internal constructor(
      *
      * @param params a set of [SourceParams] with which to create the source
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Source], or `null` if a problem occurred
      *
@@ -815,7 +831,8 @@ class Stripe internal constructor(
      *
      * @param sourceId the [Source.id] field of the desired Source object
      * @param clientSecret the [Source.clientSecret] field of the desired Source object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      *
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
@@ -851,7 +868,8 @@ class Stripe internal constructor(
      *
      * @param sourceId the [Source.id] field of the desired Source object
      * @param clientSecret the [Source.clientSecret] field of the desired Source object
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Source] if one could be found based on the input params, or `null` if
      * no such Source could be found.
@@ -891,7 +909,8 @@ class Stripe internal constructor(
      *
      * @param accountParams the [AccountParams] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -919,7 +938,8 @@ class Stripe internal constructor(
      *
      * @param accountParams params to use for this token.
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] that can be used for this account.
      *
@@ -961,7 +981,8 @@ class Stripe internal constructor(
      *
      * @param bankAccountTokenParams the [BankAccountTokenParams] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -989,7 +1010,8 @@ class Stripe internal constructor(
      *
      * @param bankAccountTokenParams the [BankAccountTokenParams] to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] that can be used for this [BankAccount]
      *
@@ -1028,7 +1050,8 @@ class Stripe internal constructor(
      *
      * @param bankAccount the [BankAccount] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @Deprecated("Use BankAccountTokenParams")
@@ -1122,7 +1145,8 @@ class Stripe internal constructor(
      *
      * @param personalId the personal ID to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] that can be used for this card
      *
@@ -1181,7 +1205,8 @@ class Stripe internal constructor(
      *
      * @param card the [Card] used to create this payment token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1209,7 +1234,8 @@ class Stripe internal constructor(
      *
      * @param card the [Card] to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] that can be used for this card
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
@@ -1245,7 +1271,8 @@ class Stripe internal constructor(
      *
      * @param cvc the CVC used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1272,7 +1299,8 @@ class Stripe internal constructor(
      *
      * @param cvc the CVC to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] that can be used for this card
      *
@@ -1310,7 +1338,8 @@ class Stripe internal constructor(
      *
      * @param params the person token creation params
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1338,7 +1367,8 @@ class Stripe internal constructor(
      *
      * @param params the person token creation params
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      *
      * @return a [Token] representing the person
      */
@@ -1385,7 +1415,8 @@ class Stripe internal constructor(
      *
      * @param fileParams the [StripeFileParams] used to create the [StripeFile]
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @JvmOverloads
@@ -1413,7 +1444,8 @@ class Stripe internal constructor(
      *
      * @param fileParams the [StripeFileParams] used to create the [StripeFile]
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param stripeAccountId the Connect account to execute this request as
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
     @JvmOverloads
     fun createFileSynchronous(

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -128,11 +128,13 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
      * [PaymentIntent]
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
     fun confirmPayment(
         activity: Activity,
-        confirmPaymentIntentParams: ConfirmPaymentIntentParams
+        confirmPaymentIntentParams: ConfirmPaymentIntentParams,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(activity),
@@ -150,11 +152,13 @@ class Stripe internal constructor(
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the [PaymentIntent]
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
     fun confirmPayment(
         fragment: Fragment,
-        confirmPaymentIntentParams: ConfirmPaymentIntentParams
+        confirmPaymentIntentParams: ConfirmPaymentIntentParams,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(fragment),
@@ -197,9 +201,14 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
      * property of a confirmed [PaymentIntent] object
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
-    fun handleNextActionForPayment(activity: Activity, clientSecret: String) {
+    fun handleNextActionForPayment(
+        activity: Activity,
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ) {
         paymentController.startAuth(
             AuthActivityStarter.Host.create(activity),
             PaymentIntent.ClientSecret(clientSecret).value,
@@ -241,9 +250,14 @@ class Stripe internal constructor(
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
      * property of a confirmed [PaymentIntent] object
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
-    fun handleNextActionForPayment(fragment: Fragment, clientSecret: String) {
+    fun handleNextActionForPayment(
+        fragment: Fragment,
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ) {
         paymentController.startAuth(
             AuthActivityStarter.Host.create(fragment),
             PaymentIntent.ClientSecret(clientSecret).value,
@@ -258,11 +272,15 @@ class Stripe internal constructor(
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a PaymentIntent automatic confirmation (see [confirmPayment]) or
      * manual confirmation (see [handleNextActionForPayment]})
+     *
+     * TODO(smaskell): figure out if we can get account id from the intent
      */
+    @JvmOverloads
     @UiThread
     fun onPaymentResult(
         requestCode: Int,
         data: Intent?,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
         return if (data != null && paymentController.shouldHandlePaymentResult(requestCode, data)) {
@@ -288,12 +306,17 @@ class Stripe internal constructor(
      * `GET /v1/payment_intents/:id`
      *
      * @param clientSecret the client_secret with which to retrieve the PaymentIntent
+     * @param stripeAccountId the Connect account to execute this request as
      * @return a [PaymentIntent] or `null` if a problem occurred
      */
     @Throws(APIException::class, AuthenticationException::class,
         InvalidRequestException::class, APIConnectionException::class)
     @WorkerThread
-    fun retrievePaymentIntentSynchronous(clientSecret: String): PaymentIntent? {
+    @JvmOverloads
+    fun retrievePaymentIntentSynchronous(
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ): PaymentIntent? {
         return stripeRepository.retrievePaymentIntent(
             PaymentIntent.ClientSecret(clientSecret).value,
             ApiRequest.Options(
@@ -342,11 +365,14 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
      * @param activity the `Activity` that is launching the payment authentication flow
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
+    @JvmOverloads
     fun confirmSetupIntent(
         activity: Activity,
-        confirmSetupIntentParams: ConfirmSetupIntentParams
+        confirmSetupIntentParams: ConfirmSetupIntentParams,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(activity),
@@ -362,11 +388,14 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
+    @JvmOverloads
     fun confirmSetupIntent(
         fragment: Fragment,
-        confirmSetupIntentParams: ConfirmSetupIntentParams
+        confirmSetupIntentParams: ConfirmSetupIntentParams,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(fragment),
@@ -406,9 +435,15 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * property of a confirmed [SetupIntent] object
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
-    fun handleNextActionForSetupIntent(activity: Activity, clientSecret: String) {
+    @JvmOverloads
+    fun handleNextActionForSetupIntent(
+        activity: Activity,
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ) {
         paymentController.startAuth(
             AuthActivityStarter.Host.create(activity),
             SetupIntent.ClientSecret(clientSecret).value,
@@ -447,9 +482,15 @@ class Stripe internal constructor(
      * @param fragment the `Fragment` launching the payment authentication flow
      * @param clientSecret the [client_secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * property of a confirmed [SetupIntent] object
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @UiThread
-    fun handleNextActionForSetupIntent(fragment: Fragment, clientSecret: String) {
+    @JvmOverloads
+    fun handleNextActionForSetupIntent(
+        fragment: Fragment,
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ) {
         paymentController.startAuth(
             AuthActivityStarter.Host.create(fragment),
             SetupIntent.ClientSecret(clientSecret).value,
@@ -463,11 +504,15 @@ class Stripe internal constructor(
     /**
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a SetupIntent confirmation (see [confirmSetupIntent]).
+     *
+     * TODO(smaskell): figure out if we can get account id from the intent
      */
+    @JvmOverloads
     @UiThread
     fun onSetupResult(
         requestCode: Int,
         data: Intent?,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
         return if (data != null && paymentController.shouldHandleSetupResult(requestCode, data)) {
@@ -493,12 +538,17 @@ class Stripe internal constructor(
      * `GET /v1/setup_intents/:id`
      *
      * @param clientSecret client_secret of the SetupIntent to retrieve
+     * @param stripeAccountId the Connect account to execute this request as
      * @return a [SetupIntent] or `null` if a problem occurred
      */
     @Throws(APIException::class, AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class)
     @WorkerThread
-    fun retrieveSetupIntentSynchronous(clientSecret: String): SetupIntent? {
+    @JvmOverloads
+    fun retrieveSetupIntentSynchronous(
+        clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
+    ): SetupIntent? {
         return stripeRepository.retrieveSetupIntent(
             SetupIntent.ClientSecret(clientSecret).value,
             ApiRequest.Options(
@@ -551,6 +601,7 @@ class Stripe internal constructor(
      *
      * @param paymentMethodCreateParams the [PaymentMethodCreateParams] to be used
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -558,6 +609,7 @@ class Stripe internal constructor(
     fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<PaymentMethod>
     ) {
         CreatePaymentMethodTask(
@@ -582,6 +634,7 @@ class Stripe internal constructor(
      *
      * @param paymentMethodCreateParams params with which to create the PaymentMethod
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [PaymentMethod] or `null` if a problem occurred
      */
@@ -591,7 +644,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createPaymentMethodSynchronous(
         paymentMethodCreateParams: PaymentMethodCreateParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): PaymentMethod? {
         return stripeRepository.createPaymentMethod(
             paymentMethodCreateParams,
@@ -615,10 +669,13 @@ class Stripe internal constructor(
      *
      * @param activity the `Activity` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
+     * @param stripeAccountId the Connect account to execute this request as
      */
+    @JvmOverloads
     fun authenticateSource(
         activity: Activity,
-        source: Source
+        source: Source,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startAuthenticateSource(
             AuthActivityStarter.Host.create(activity),
@@ -635,10 +692,13 @@ class Stripe internal constructor(
      *
      * @param fragment the `Fragment` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
+     * @param stripeAccountId the Connect account to execute this request as
      */
+    @JvmOverloads
     fun authenticateSource(
         fragment: Fragment,
-        source: Source
+        source: Source,
+        stripeAccountId: String? = this.stripeAccountId
     ) {
         paymentController.startAuthenticateSource(
             AuthActivityStarter.Host.create(fragment),
@@ -661,9 +721,13 @@ class Stripe internal constructor(
      * The result of a call to [authenticateSource].
      *
      * Use [isAuthenticateSourceResult] before calling this method.
+     *
+     * TODO(smaskell): Figure out if we can get account id from the intent
      */
+    @JvmOverloads
     fun onAuthenticateSourceResult(
         data: Intent,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Source>
     ) {
         paymentController.handleSourceResult(
@@ -681,6 +745,7 @@ class Stripe internal constructor(
      *
      * @param sourceParams the [SourceParams] to be used
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -688,6 +753,7 @@ class Stripe internal constructor(
     fun createSource(
         sourceParams: SourceParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Source>
     ) {
         CreateSourceTask(
@@ -712,6 +778,7 @@ class Stripe internal constructor(
      *
      * @param params a set of [SourceParams] with which to create the source
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Source], or `null` if a problem occurred
      *
@@ -727,7 +794,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createSourceSynchronous(
         params: SourceParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Source? {
         return stripeRepository.createSource(
             params,
@@ -747,6 +815,7 @@ class Stripe internal constructor(
      *
      * @param sourceId the [Source.id] field of the desired Source object
      * @param clientSecret the [Source.clientSecret] field of the desired Source object
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      *
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
@@ -754,10 +823,12 @@ class Stripe internal constructor(
      * @throws APIConnectionException failure to connect to Stripe's API
      * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
      */
+    @JvmOverloads
     @UiThread
     fun retrieveSource(
         @Size(min = 1) sourceId: String,
         @Size(min = 1) clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Source>
     ) {
         RetrieveSourceTask(
@@ -780,6 +851,8 @@ class Stripe internal constructor(
      *
      * @param sourceId the [Source.id] field of the desired Source object
      * @param clientSecret the [Source.clientSecret] field of the desired Source object
+     * @param stripeAccountId the Connect account to execute this request as
+     *
      * @return a [Source] if one could be found based on the input params, or `null` if
      * no such Source could be found.
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
@@ -790,9 +863,11 @@ class Stripe internal constructor(
     @Throws(AuthenticationException::class, InvalidRequestException::class,
         APIConnectionException::class, APIException::class)
     @WorkerThread
+    @JvmOverloads
     fun retrieveSourceSynchronous(
         @Size(min = 1) sourceId: String,
-        @Size(min = 1) clientSecret: String
+        @Size(min = 1) clientSecret: String,
+        stripeAccountId: String? = this.stripeAccountId
     ): Source? {
         return stripeRepository.retrieveSource(
             sourceId,
@@ -816,6 +891,7 @@ class Stripe internal constructor(
      *
      * @param accountParams the [AccountParams] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -823,10 +899,12 @@ class Stripe internal constructor(
     fun createAccountToken(
         accountParams: AccountParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             tokenParams = accountParams,
+            stripeAccountId = stripeAccountId,
             idempotencyKey = idempotencyKey,
             callback = callback
         )
@@ -841,6 +919,7 @@ class Stripe internal constructor(
      *
      * @param accountParams params to use for this token.
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] that can be used for this account.
      *
@@ -856,7 +935,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createAccountTokenSynchronous(
         accountParams: AccountParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return try {
             stripeRepository.createToken(
@@ -881,6 +961,7 @@ class Stripe internal constructor(
      *
      * @param bankAccountTokenParams the [BankAccountTokenParams] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -888,10 +969,12 @@ class Stripe internal constructor(
     fun createBankAccountToken(
         bankAccountTokenParams: BankAccountTokenParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             bankAccountTokenParams,
+            stripeAccountId,
             idempotencyKey,
             callback
         )
@@ -906,6 +989,7 @@ class Stripe internal constructor(
      *
      * @param bankAccountTokenParams the [BankAccountTokenParams] to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] that can be used for this [BankAccount]
      *
@@ -923,7 +1007,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createBankAccountTokenSynchronous(
         bankAccountTokenParams: BankAccountTokenParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return stripeRepository.createToken(
             bankAccountTokenParams,
@@ -943,6 +1028,7 @@ class Stripe internal constructor(
      *
      * @param bankAccount the [BankAccount] used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @Deprecated("Use BankAccountTokenParams")
@@ -951,10 +1037,12 @@ class Stripe internal constructor(
     fun createBankAccountToken(
         bankAccount: BankAccount,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             bankAccount,
+            stripeAccountId,
             idempotencyKey,
             callback
         )
@@ -1014,10 +1102,12 @@ class Stripe internal constructor(
     fun createPiiToken(
         personalId: String,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             PiiTokenParams(personalId),
+            stripeAccountId,
             idempotencyKey,
             callback
         )
@@ -1032,6 +1122,7 @@ class Stripe internal constructor(
      *
      * @param personalId the personal ID to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] that can be used for this card
      *
@@ -1047,7 +1138,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createPiiTokenSynchronous(
         personalId: String,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return stripeRepository.createToken(
             PiiTokenParams(personalId),
@@ -1089,6 +1181,7 @@ class Stripe internal constructor(
      *
      * @param card the [Card] used to create this payment token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1096,10 +1189,12 @@ class Stripe internal constructor(
     fun createCardToken(
         card: Card,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             tokenParams = card,
+            stripeAccountId = stripeAccountId,
             idempotencyKey = idempotencyKey,
             callback = callback
         )
@@ -1114,6 +1209,7 @@ class Stripe internal constructor(
      *
      * @param card the [Card] to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] that can be used for this card
      * @throws AuthenticationException failure to properly authenticate yourself (check your key)
@@ -1129,7 +1225,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createCardTokenSynchronous(
         card: Card,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return stripeRepository.createToken(
             card,
@@ -1148,6 +1245,7 @@ class Stripe internal constructor(
      *
      * @param cvc the CVC used to create this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1155,10 +1253,12 @@ class Stripe internal constructor(
     fun createCvcUpdateToken(
         @Size(min = 3, max = 4) cvc: String,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             CvcTokenParams(cvc),
+            stripeAccountId,
             idempotencyKey,
             callback
         )
@@ -1172,6 +1272,7 @@ class Stripe internal constructor(
      *
      * @param cvc the CVC to use for this token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] that can be used for this card
      *
@@ -1187,7 +1288,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createCvcUpdateTokenSynchronous(
         cvc: String,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return stripeRepository.createToken(
             CvcTokenParams(cvc),
@@ -1208,6 +1310,7 @@ class Stripe internal constructor(
      *
      * @param params the person token creation params
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -1215,10 +1318,12 @@ class Stripe internal constructor(
     fun createPersonToken(
         params: PersonTokenParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Token>
     ) {
         createToken(
             params,
+            stripeAccountId,
             idempotencyKey,
             callback
         )
@@ -1233,6 +1338,7 @@ class Stripe internal constructor(
      *
      * @param params the person token creation params
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      *
      * @return a [Token] representing the person
      */
@@ -1242,7 +1348,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun createPersonTokenSynchronous(
         params: PersonTokenParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): Token? {
         return stripeRepository.createToken(
             params,
@@ -1256,6 +1363,7 @@ class Stripe internal constructor(
 
     private fun createToken(
         tokenParams: TokenParams,
+        stripeAccountId: String?,
         idempotencyKey: String? = null,
         callback: ApiResultCallback<Token>
     ) {
@@ -1277,12 +1385,14 @@ class Stripe internal constructor(
      *
      * @param fileParams the [StripeFileParams] used to create the [StripeFile]
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @JvmOverloads
     fun createFile(
         fileParams: StripeFileParams,
         idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<StripeFile>
     ) {
         CreateFileTask(
@@ -1303,11 +1413,13 @@ class Stripe internal constructor(
      *
      * @param fileParams the [StripeFileParams] used to create the [StripeFile]
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId the Connect account to execute this request as
      */
     @JvmOverloads
     fun createFileSynchronous(
         fileParams: StripeFileParams,
-        idempotencyKey: String? = null
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
     ): StripeFile {
         return stripeRepository.createFile(
             fileParams,

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -131,6 +131,7 @@ class Stripe internal constructor(
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
+    @JvmOverloads
     @UiThread
     fun confirmPayment(
         activity: Activity,
@@ -156,6 +157,7 @@ class Stripe internal constructor(
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
+    @JvmOverloads
     @UiThread
     fun confirmPayment(
         fragment: Fragment,
@@ -206,6 +208,7 @@ class Stripe internal constructor(
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
+    @JvmOverloads
     @UiThread
     fun handleNextActionForPayment(
         activity: Activity,
@@ -256,6 +259,7 @@ class Stripe internal constructor(
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
+    @JvmOverloads
     @UiThread
     fun handleNextActionForPayment(
         fragment: Fragment,

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -128,15 +128,11 @@ class Stripe internal constructor(
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
      * [PaymentIntent]
-     * @param stripeAccountId Optional, the Connect account to associate with this request.
-     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
-    @JvmOverloads
     @UiThread
     fun confirmPayment(
         activity: Activity,
-        confirmPaymentIntentParams: ConfirmPaymentIntentParams,
-        stripeAccountId: String? = this.stripeAccountId
+        confirmPaymentIntentParams: ConfirmPaymentIntentParams
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(activity),
@@ -280,15 +276,11 @@ class Stripe internal constructor(
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a PaymentIntent automatic confirmation (see [confirmPayment]) or
      * manual confirmation (see [handleNextActionForPayment]})
-     *
-     * TODO(smaskell): figure out if we can get account id from the intent
      */
-    @JvmOverloads
     @UiThread
     fun onPaymentResult(
         requestCode: Int,
         data: Intent?,
-        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
         return if (data != null && paymentController.shouldHandlePaymentResult(requestCode, data)) {
@@ -374,15 +366,11 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
      * @param activity the `Activity` that is launching the payment authentication flow
-     * @param stripeAccountId Optional, the Connect account to associate with this request.
-     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
-    @UiThread
     @JvmOverloads
     fun confirmSetupIntent(
         activity: Activity,
-        confirmSetupIntentParams: ConfirmSetupIntentParams,
-        stripeAccountId: String? = this.stripeAccountId
+        confirmSetupIntentParams: ConfirmSetupIntentParams
     ) {
         paymentController.startConfirmAndAuth(
             AuthActivityStarter.Host.create(activity),
@@ -517,15 +505,11 @@ class Stripe internal constructor(
     /**
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a SetupIntent confirmation (see [confirmSetupIntent]).
-     *
-     * TODO(smaskell): figure out if we can get account id from the intent
      */
-    @JvmOverloads
     @UiThread
     fun onSetupResult(
         requestCode: Int,
         data: Intent?,
-        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
         return if (data != null && paymentController.shouldHandleSetupResult(requestCode, data)) {
@@ -685,14 +669,10 @@ class Stripe internal constructor(
      *
      * @param activity the `Activity` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
-     * @param stripeAccountId Optional, the Connect account to associate with this request.
-     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
-    @JvmOverloads
     fun authenticateSource(
         activity: Activity,
-        source: Source,
-        stripeAccountId: String? = this.stripeAccountId
+        source: Source
     ) {
         paymentController.startAuthenticateSource(
             AuthActivityStarter.Host.create(activity),
@@ -709,14 +689,10 @@ class Stripe internal constructor(
      *
      * @param fragment the `Fragment` that is launching the [Source] authentication flow
      * @param source the [Source] to confirm
-     * @param stripeAccountId Optional, the Connect account to associate with this request.
-     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
-    @JvmOverloads
     fun authenticateSource(
         fragment: Fragment,
-        source: Source,
-        stripeAccountId: String? = this.stripeAccountId
+        source: Source
     ) {
         paymentController.startAuthenticateSource(
             AuthActivityStarter.Host.create(fragment),
@@ -739,13 +715,9 @@ class Stripe internal constructor(
      * The result of a call to [authenticateSource].
      *
      * Use [isAuthenticateSourceResult] before calling this method.
-     *
-     * TODO(smaskell): Figure out if we can get account id from the intent
      */
-    @JvmOverloads
     fun onAuthenticateSourceResult(
         data: Intent,
-        stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Source>
     ) {
         paymentController.handleSourceResult(

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -100,7 +100,8 @@ class StripePaymentAuthTest {
             StripePaymentController.PAYMENT_REQUEST_CODE, data))
             .thenReturn(true)
         val stripe = createStripe()
-        stripe.onPaymentResult(StripePaymentController.PAYMENT_REQUEST_CODE, data, paymentCallback)
+        stripe.onPaymentResult(StripePaymentController.PAYMENT_REQUEST_CODE, data,
+            callback = paymentCallback)
 
         verify(paymentController).handlePaymentResult(data,
             ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
@@ -114,7 +115,8 @@ class StripePaymentAuthTest {
             StripePaymentController.SETUP_REQUEST_CODE, data))
             .thenReturn(true)
         val stripe = createStripe()
-        stripe.onSetupResult(StripePaymentController.SETUP_REQUEST_CODE, data, setupCallback)
+        stripe.onSetupResult(StripePaymentController.SETUP_REQUEST_CODE, data,
+            callback = setupCallback)
 
         verify(paymentController).handleSetupResult(data,
             ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
@@ -50,7 +50,8 @@ class AddPaymentMethodViewModelTest {
         verify(stripe).createPaymentMethod(
             paymentMethodCreateParamsCaptor.capture(),
             anyOrNull(),
-            callback = any()
+            anyOrNull(),
+            any()
         )
 
         assertEquals(

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
@@ -50,7 +50,7 @@ class AddPaymentMethodViewModelTest {
         verify(stripe).createPaymentMethod(
             paymentMethodCreateParamsCaptor.capture(),
             anyOrNull(),
-            any()
+            callback = any()
         )
 
         assertEquals(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds a stripeAccountId parameter to most methods in Stripe.kt
Note: This does not update
- confirmPayment/onPaymentResult
- confirmSetupIntent/onSetupResult
- authenticateSource/onAuthenticateSourceResult

These will be updated later as they require passing the stripe account id through the intent

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ANDROID-247

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Unit tests still pass
