### PR TITLE
Add SOFORT to PROCESSING_IS_SUCCESS set

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -104,7 +104,8 @@ abstract class StripeIntentResult<T : StripeIntent> internal constructor(
         private val PROCESSING_IS_SUCCESS = setOf(
             PaymentMethod.Type.SepaDebit,
             PaymentMethod.Type.BacsDebit,
-            PaymentMethod.Type.AuBecsDebit
+            PaymentMethod.Type.AuBecsDebit,
+            PaymentMethod.Type.Sofort
         )
     }
 }


### PR DESCRIPTION
SOFORT is a delayed notification payment method so `PaymentIntent.status` of `processing` should be considered as a successful confirmation