### PR TITLE
Add shipping property to PaymentIntent

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -132,7 +132,12 @@ data class PaymentIntent internal constructor(
     /**
      * @return The payment error encountered in the previous PaymentIntent confirmation.
      */
-    val lastPaymentError: Error? = null
+    val lastPaymentError: Error? = null,
+
+    /**
+     * @return Shipping information for this PaymentIntent.
+     */
+    val shipping: Shipping? = null
 ) : StripeIntent {
     @IgnoredOnParcel
     override val nextActionType: StripeIntent.NextActionType? = nextAction?.let {
@@ -258,6 +263,51 @@ data class PaymentIntent internal constructor(
             }
         }
     }
+
+    /**
+     * Shipping information for this PaymentIntent.
+     *
+     * See [shipping](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping)
+     */
+    @Parcelize
+    data class Shipping(
+        /**
+         * Shipping address.
+         *
+         * See [shipping.address](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping-address)
+         */
+        val address: Address,
+
+        /**
+         * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
+         *
+         * See [shipping.carrier](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping-carrier)
+         */
+        val carrier: String? = null,
+
+        /**
+         * Recipient name.
+         *
+         * See [shipping.name](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping-name)
+         */
+        val name: String? = null,
+
+        /**
+         * Recipient phone (including extension).
+         *
+         * See [shipping.phone](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping-phone)
+         */
+        val phone: String? = null,
+
+        /**
+         * The tracking number for a physical product, obtained from the delivery service.
+         * If multiple tracking numbers were generated for this purchase, please separate them
+         * with commas.
+         *
+         * See [shipping.tracking_number](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping-tracking_number)
+         */
+        val trackingNumber: String? = null
+    ) : StripeModel
 
     internal data class ClientSecret(internal val value: String) {
         internal val paymentIntentId: String =

--- a/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeJsonUtils
@@ -48,6 +49,10 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
                 ErrorJsonParser().parse(it)
             }
 
+        val shipping = json.optJSONObject(FIELD_SHIPPING)?.let {
+            ShippingJsonParser().parse(it)
+        }
+
         return PaymentIntent(
             id = id,
             objectType = objectType,
@@ -68,7 +73,8 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
             receiptEmail = receiptEmail,
             status = status,
             setupFutureUsage = setupFutureUsage,
-            lastPaymentError = lastPaymentError
+            lastPaymentError = lastPaymentError,
+            shipping = shipping
         )
     }
 
@@ -102,6 +108,28 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         }
     }
 
+    internal class ShippingJsonParser : ModelJsonParser<PaymentIntent.Shipping> {
+        override fun parse(json: JSONObject): PaymentIntent.Shipping? {
+            return PaymentIntent.Shipping(
+                address = json.optJSONObject(FIELD_ADDRESS)?.let {
+                    AddressJsonParser().parse(it)
+                } ?: Address(),
+                carrier = StripeJsonUtils.optString(json, FIELD_CARRIER),
+                name = StripeJsonUtils.optString(json, FIELD_NAME),
+                phone = StripeJsonUtils.optString(json, FIELD_PHONE),
+                trackingNumber = StripeJsonUtils.optString(json, FIELD_TRACKING_NUMBER)
+            )
+        }
+
+        private companion object {
+            private const val FIELD_ADDRESS = "address"
+            private const val FIELD_CARRIER = "carrier"
+            private const val FIELD_NAME = "name"
+            private const val FIELD_PHONE = "phone"
+            private const val FIELD_TRACKING_NUMBER = "tracking_number"
+        }
+    }
+
     private companion object {
         private const val OBJECT_TYPE = "payment_intent"
 
@@ -122,6 +150,7 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_PAYMENT_METHOD = "payment_method"
         private const val FIELD_PAYMENT_METHOD_TYPES = "payment_method_types"
         private const val FIELD_RECEIPT_EMAIL = "receipt_email"
+        private const val FIELD_SHIPPING = "shipping"
         private const val FIELD_STATUS = "status"
         private const val FIELD_SETUP_FUTURE_USAGE = "setup_future_usage"
     }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -482,7 +482,7 @@ internal object PaymentIntentFixtures {
         """.trimIndent()
     ))
 
-    val EXPANDED_PAYMENT_METHOD = JSONObject(
+    val EXPANDED_PAYMENT_METHOD_JSON = JSONObject(
         """
         {
             "id": "pi_1GSTxJCRMbs",
@@ -557,6 +557,90 @@ internal object PaymentIntentFixtures {
             },
             "source": null,
             "status": "requires_action"
+        }
+        """.trimIndent()
+    )
+
+    val PI_WITH_SHIPPING_JSON = JSONObject(
+        """
+        {
+            "id": "pi_1GYda2CRMbs",
+            "object": "payment_intent",
+            "amount": 1099,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "client_secret": "pi_1GYda2CRMbs_secret_Z2zduomY0",
+            "confirmation_method": "automatic",
+            "created": 1587066058,
+            "currency": "usd",
+            "description": "Example PaymentIntent",
+            "last_payment_error": null,
+            "livemode": false,
+            "next_action": null,
+            "payment_method": {
+                "id": "pm_1GYda7CRMbs6FrX",
+                "object": "payment_method",
+                "billing_details": {
+                    "address": {
+                        "city": "San Francisco",
+                        "country": "US",
+                        "line1": "123 Market St",
+                        "line2": "#345",
+                        "postal_code": "94107",
+                        "state": "CA"
+                    },
+                    "email": null,
+                    "name": "Jenny Rosen",
+                    "phone": null
+                },
+                "card": {
+                    "brand": "visa",
+                    "checks": {
+                        "address_line1_check": null,
+                        "address_postal_code_check": null,
+                        "cvc_check": null
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2025,
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "4242",
+                    "three_d_secure_usage": {
+                        "supported": true
+                    },
+                    "wallet": {
+                        "dynamic_last4": "4242",
+                        "google_pay": {},
+                        "type": "google_pay"
+                    }
+                },
+                "created": 1587066063,
+                "customer": null,
+                "livemode": false,
+                "metadata": {},
+                "type": "card"
+            },
+            "payment_method_types": ["card"],
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": {
+                "address": {
+                    "city": "San Francisco",
+                    "country": "US",
+                    "line1": "123 Market St",
+                    "line2": "#345",
+                    "postal_code": "94107",
+                    "state": "CA"
+                },
+                "carrier": "UPS",
+                "name": "Jenny Rosen",
+                "phone": "1-800-555-1234",
+                "tracking_number": "12345"
+            },
+            "source": null,
+            "status": "succeeded"
         }
         """.trimIndent()
     )

--- a/stripe/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import kotlin.test.Test
 import org.junit.runner.RunWith
@@ -11,11 +13,36 @@ class PaymentIntentJsonParserTest {
     @Test
     fun parse_withExpandedPaymentMethod_shouldCreateExpectedObject() {
         val paymentIntent = PaymentIntentJsonParser().parse(
-            PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD
+            PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD_JSON
         )
         assertThat(paymentIntent?.paymentMethodId)
             .isEqualTo("pm_1GSTxOCRMbs6FrXfYCosDqyr")
         assertThat(paymentIntent?.paymentMethod?.id)
             .isEqualTo("pm_1GSTxOCRMbs6FrXfYCosDqyr")
+    }
+
+    @Test
+    fun parse_withShipping_shouldCreateExpectedObject() {
+        val paymentIntent = PaymentIntentJsonParser().parse(
+            PaymentIntentFixtures.PI_WITH_SHIPPING_JSON
+        )
+
+        assertThat(paymentIntent?.shipping)
+            .isEqualTo(
+                PaymentIntent.Shipping(
+                    address = Address(
+                        line1 = "123 Market St",
+                        line2 = "#345",
+                        city = "San Francisco",
+                        state = "CA",
+                        postalCode = "94107",
+                        country = "US"
+                    ),
+                    carrier = "UPS",
+                    name = "Jenny Rosen",
+                    phone = "1-800-555-1234",
+                    trackingNumber = "12345"
+                )
+            )
     }
 }


### PR DESCRIPTION
## Summary
Add support for
https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping

## Testing
Added test
