### PR TITLE
Expand payment_method when returning Payment Intent & Setup Intent confirmation result

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -90,8 +90,10 @@ internal class StripePaymentController internal constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options
     ) {
-        stripeRepository.retrieveIntent(clientSecret, requestOptions,
-            object : ApiResultCallback<StripeIntent> {
+        stripeRepository.retrieveIntent(
+            clientSecret,
+            requestOptions,
+            callback = object : ApiResultCallback<StripeIntent> {
                 override fun onSuccess(result: StripeIntent) {
                     handleNextAction(host, result, requestOptions)
                 }
@@ -207,8 +209,11 @@ internal class StripePaymentController internal constructor(
         val sourceId = result.sourceId.orEmpty()
         @StripeIntentResult.Outcome val flowOutcome = result.flowOutcome
 
-        stripeRepository.retrieveIntent(getClientSecret(data), requestOptions,
-            createPaymentIntentCallback(
+        stripeRepository.retrieveIntent(
+            getClientSecret(data),
+            requestOptions,
+            expandFields = EXPAND_PAYMENT_METHOD,
+            callback = createPaymentIntentCallback(
                 requestOptions, flowOutcome, sourceId, shouldCancelSource, callback
             )
         )
@@ -239,8 +244,11 @@ internal class StripePaymentController internal constructor(
         val sourceId = result.sourceId.orEmpty()
         @StripeIntentResult.Outcome val flowOutcome = result.flowOutcome
 
-        stripeRepository.retrieveIntent(getClientSecret(data), requestOptions,
-            createSetupIntentCallback(
+        stripeRepository.retrieveIntent(
+            getClientSecret(data),
+            requestOptions,
+            expandFields = EXPAND_PAYMENT_METHOD,
+            callback = createSetupIntentCallback(
                 requestOptions, flowOutcome, sourceId, shouldCancelSource, callback
             )
         )
@@ -529,13 +537,13 @@ internal class StripePaymentController internal constructor(
                     stripeRepository.confirmPaymentIntent(
                         params,
                         requestOptions,
-                        expandFields = listOf("payment_method")
+                        expandFields = EXPAND_PAYMENT_METHOD
                     )
                 is ConfirmSetupIntentParams ->
                     stripeRepository.confirmSetupIntent(
                         params,
                         requestOptions,
-                        expandFields = listOf("payment_method")
+                        expandFields = EXPAND_PAYMENT_METHOD
                     )
                 else -> null
             }
@@ -963,5 +971,7 @@ internal class StripePaymentController internal constructor(
         internal fun getClientSecret(data: Intent): String {
             return requireNotNull(PaymentController.Result.fromIntent(data)?.clientSecret)
         }
+
+        private val EXPAND_PAYMENT_METHOD = listOf("payment_method")
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -42,7 +42,8 @@ internal interface StripeRepository {
         APIConnectionException::class, APIException::class)
     fun retrievePaymentIntent(
         clientSecret: String,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String> = emptyList()
     ): PaymentIntent?
 
     @Throws(AuthenticationException::class, InvalidRequestException::class,
@@ -65,7 +66,8 @@ internal interface StripeRepository {
         APIConnectionException::class, APIException::class)
     fun retrieveSetupIntent(
         clientSecret: String,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String> = emptyList()
     ): SetupIntent?
 
     @Throws(AuthenticationException::class, InvalidRequestException::class,
@@ -79,6 +81,7 @@ internal interface StripeRepository {
     fun retrieveIntent(
         clientSecret: String,
         options: ApiRequest.Options,
+        expandFields: List<String> = emptyList(),
         callback: ApiResultCallback<StripeIntent>
     )
 

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -32,7 +32,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     override fun retrievePaymentIntent(
         clientSecret: String,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent? {
         return null
     }
@@ -55,7 +56,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     override fun retrieveSetupIntent(
         clientSecret: String,
-        options: ApiRequest.Options
+        options: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent? {
         return null
     }
@@ -71,6 +73,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     override fun retrieveIntent(
         clientSecret: String,
         options: ApiRequest.Options,
+        expandFields: List<String>,
         callback: ApiResultCallback<StripeIntent>
     ) {
     }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -662,6 +662,7 @@ class StripePaymentControllerTest {
         verify(stripeRepository).retrieveIntent(
             eq(clientSecret),
             eq(REQUEST_OPTIONS),
+            eq(listOf("payment_method")),
             apiResultStripeIntentArgumentCaptor.capture()
         )
         // return a PaymentIntent in `requires_action` state
@@ -777,7 +778,8 @@ class StripePaymentControllerTest {
     private class FakeStripeRepository : AbsFakeStripeRepository() {
         override fun retrieveSetupIntent(
             clientSecret: String,
-            options: ApiRequest.Options
+            options: ApiRequest.Options,
+            expandFields: List<String>
         ): SetupIntent {
             return SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT
         }
@@ -802,9 +804,10 @@ class StripePaymentControllerTest {
         override fun retrieveIntent(
             clientSecret: String,
             options: ApiRequest.Options,
+            expandFields: List<String>,
             callback: ApiResultCallback<StripeIntent>
         ) {
-            super.retrieveIntent(clientSecret, options, callback)
+            super.retrieveIntent(clientSecret, options, expandFields, callback)
             callback.onSuccess(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
         }
 


### PR DESCRIPTION
## Summary
This gives the user access to the full `PaymentMethod` object after
Payment Intent or Setup Intent confirmation is completed. This object
may have been created when confirming the Intent.

## Motivation
ANDROID-514

## Testing
Added tests and manually verified
