### PR TITLE
Remove payment_method_types[] from mobile backend requests in examples

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/BacsDebitPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/BacsDebitPaymentMethodActivity.kt
@@ -86,7 +86,6 @@ class BacsDebitPaymentMethodActivity : AppCompatActivity() {
             backendApi
                 .createPaymentIntent(
                     mapOf(
-                        "payment_method_types[]" to "bacs_debit",
                         "amount" to 1000,
                         "country" to "gb"
                     ).toMutableMap()

--- a/example/src/main/java/com/stripe/example/activity/ConfirmSepaDebitActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConfirmSepaDebitActivity.kt
@@ -180,7 +180,6 @@ class ConfirmSepaDebitActivity : AppCompatActivity() {
         private const val TEST_ACCOUNT_NUMBER = "DE89370400440532013000"
 
         private val PAYMENT_INTENT_PARAMAS = mapOf(
-            "payment_method_types[]" to "sepa_debit",
             "amount" to 1000,
             "country" to "nl"
         )

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesViewModel.kt
@@ -9,7 +9,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import org.json.JSONObject
-import java.util.HashMap
 
 class FragmentExamplesViewModel(
     application: Application
@@ -20,7 +19,13 @@ class FragmentExamplesViewModel(
     fun createPaymentIntent(): LiveData<JSONObject> {
         val result = MutableLiveData<JSONObject>()
         compositeDisposable.add(
-            backendApi.createPaymentIntent(createPaymentIntentParams())
+            backendApi
+                .createPaymentIntent(
+                    mutableMapOf(
+                        "amount" to 1000,
+                        "country" to "us"
+                    )
+                )
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
@@ -33,7 +38,10 @@ class FragmentExamplesViewModel(
     fun createSetupIntent(): LiveData<JSONObject> {
         val result = MutableLiveData<JSONObject>()
         compositeDisposable.add(
-            backendApi.createSetupIntent(hashMapOf("country" to "us"))
+            backendApi
+                .createSetupIntent(
+                    mutableMapOf("country" to "us")
+                )
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
@@ -45,13 +53,5 @@ class FragmentExamplesViewModel(
 
     fun dispose() {
         compositeDisposable.dispose()
-    }
-
-    private fun createPaymentIntentParams(): HashMap<String, Any> {
-        return hashMapOf(
-            "payment_method_types[]" to "card",
-            "amount" to 1000,
-            "country" to "us"
-        )
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -170,7 +170,7 @@ class PaymentAuthActivity : AppCompatActivity() {
 
     private fun createSetupIntent() {
         compositeSubscription.add(
-            backendApi.createSetupIntent(hashMapOf("country" to "us"))
+            backendApi.createSetupIntent(mutableMapOf("country" to "us"))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnSubscribe {
@@ -239,7 +239,6 @@ class PaymentAuthActivity : AppCompatActivity() {
 
     private fun createPaymentIntentParams(stripeAccountId: String?): Map<String, Any> {
         return mapOf(
-            "payment_method_types[]" to "card",
             "amount" to 1000,
             "country" to "us"
         )

--- a/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
@@ -85,7 +85,6 @@ class SofortPaymentMethodActivity : AppCompatActivity() {
             backendApi
                 .createPaymentIntent(
                     mapOf(
-                        "payment_method_types[]" to "sofort",
                         "amount" to 1000,
                         "country" to "de"
                     ).toMutableMap()


### PR DESCRIPTION
The `payment_method_types[]` is generated on the mobile backend based
on the specified country.
