### PR TITLE
Make PaymentAuthActivity extend PaymentIntentActivity

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/ConnectExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConnectExampleActivity.kt
@@ -22,9 +22,9 @@ class ConnectExampleActivity : PaymentIntentActivity() {
 
         viewBinding.payNow.setOnClickListener {
             viewBinding.cardWidget.paymentMethodCreateParams?.let {
-                createAndConfirmPaymentIntent("us", it,
+                val connectAccount =
                     viewBinding.connectAccount.text.toString().takeIf(String::isNotBlank)
-                )
+                createAndConfirmPaymentIntent("us", it, stripeAccountId = connectAccount)
             } ?: showSnackbar("Missing card details")
         }
     }

--- a/example/src/main/java/com/stripe/example/activity/ConnectExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConnectExampleActivity.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.lifecycle.Observer
 import com.stripe.example.databinding.ConnectExampleActivityBinding
 
-class ConnectExampleActivity : PaymentIntentActivity() {
+class ConnectExampleActivity : StripeIntentActivity() {
     private val viewBinding: ConnectExampleActivityBinding by lazy {
         ConnectExampleActivityBinding.inflate(layoutInflater)
     }

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -14,7 +14,7 @@ import com.stripe.example.databinding.PaymentAuthActivityBinding
 /**
  * An example of creating a PaymentIntent, then confirming it with [Stripe.confirmPayment]
  */
-class PaymentAuthActivity : PaymentIntentActivity() {
+class PaymentAuthActivity : StripeIntentActivity() {
 
     private val viewBinding: PaymentAuthActivityBinding by lazy {
         PaymentAuthActivityBinding.inflate(layoutInflater)

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -1,59 +1,31 @@
 package com.stripe.example.activity
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
-import com.stripe.android.ApiResultCallback
+import androidx.lifecycle.Observer
 import com.stripe.android.PaymentAuthConfig
-import com.stripe.android.PaymentIntentResult
-import com.stripe.android.SetupIntentResult
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.example.R
 import com.stripe.example.Settings
-import com.stripe.example.StripeFactory
 import com.stripe.example.databinding.PaymentAuthActivityBinding
-import com.stripe.example.module.BackendApiFactory
-import com.stripe.example.service.BackendApi
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
-import okhttp3.ResponseBody
-import org.json.JSONException
-import org.json.JSONObject
-import java.io.IOException
-import java.lang.ref.WeakReference
 
 /**
  * An example of creating a PaymentIntent, then confirming it with [Stripe.confirmPayment]
  */
-class PaymentAuthActivity : AppCompatActivity() {
+class PaymentAuthActivity : PaymentIntentActivity() {
 
     private val viewBinding: PaymentAuthActivityBinding by lazy {
         PaymentAuthActivityBinding.inflate(layoutInflater)
     }
 
-    private val compositeSubscription = CompositeDisposable()
-    private val backendApi: BackendApi by lazy {
-        BackendApiFactory(this).create()
-    }
-    private val stripeAccountId: String? by lazy {
-        Settings(this).stripeAccountId
-    }
-    private val stripe: Stripe by lazy {
-        StripeFactory(this, stripeAccountId).create()
-    }
-    private val keyboardController: KeyboardController by lazy {
-        KeyboardController(this)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
+
+        viewModel.inProgress.observe(this, Observer { enableUi(!it) })
+        viewModel.status.observe(this, Observer(viewBinding.status::setText))
 
         val stripeAccountId = Settings(this).stripeAccountId
 
@@ -66,232 +38,45 @@ class PaymentAuthActivity : AppCompatActivity() {
                 .build())
             .build())
 
-        if (savedInstanceState != null) {
-            viewBinding.status.text = savedInstanceState.getString(STATE_STATUS)
-        }
-
         viewBinding.confirmWith3ds1Button.setOnClickListener {
-            createPaymentIntent(stripeAccountId, ConfirmationType.ThreeDS1)
+            createAndConfirmPaymentIntent("us",
+                confirmParams3ds1,
+                stripeAccountId = stripeAccountId,
+                returnUrl = RETURN_URL)
         }
         viewBinding.confirmWith3ds2Button.setOnClickListener {
-            createPaymentIntent(stripeAccountId, ConfirmationType.ThreeDS2)
+            createAndConfirmPaymentIntent("us",
+                confirmParams3ds2,
+                stripeAccountId = stripeAccountId,
+                shippingDetails = SHIPPING,
+                returnUrl = RETURN_URL)
         }
 
         viewBinding.confirmWithNewCardButton.setOnClickListener {
             viewBinding.cardInputWidget.paymentMethodCreateParams?.let {
-                keyboardController.hide()
-
-                createPaymentIntent(
-                    stripeAccountId,
-                    ConfirmationType.NewCard
-                )
+                createAndConfirmPaymentIntent("us",
+                    requireNotNull(
+                        viewBinding.cardInputWidget.paymentMethodCreateParams
+                    ),
+                    stripeAccountId = stripeAccountId,
+                    shippingDetails = SHIPPING)
             }
         }
 
-        viewBinding.setupButton.setOnClickListener { createSetupIntent() }
-    }
-
-    private fun confirmPaymentIntent(
-        paymentIntentClientSecret: String,
-        confirmationType: ConfirmationType
-    ) {
-        viewBinding.status.append("\n\nStarting payment authentication")
-        stripe.confirmPayment(
-            this,
-            when (confirmationType) {
-                ConfirmationType.ThreeDS1 -> create3ds1ConfirmParams(paymentIntentClientSecret)
-                ConfirmationType.ThreeDS2 -> create3ds2ConfirmParams(paymentIntentClientSecret)
-                ConfirmationType.NewCard ->
-                    ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                        paymentMethodCreateParams = requireNotNull(
-                            viewBinding.cardInputWidget.paymentMethodCreateParams
-                        ),
-                        clientSecret = paymentIntentClientSecret,
-                        shipping = SHIPPING
-                    )
-            }
-        )
-    }
-
-    private fun confirmSetupIntent(setupIntentClientSecret: String) {
-        viewBinding.status.append("\n\nStarting setup intent authentication")
-        stripe.confirmSetupIntent(this, create3ds2SetupIntentParams(setupIntentClientSecret))
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        viewBinding.progressBar.visibility = View.VISIBLE
-        viewBinding.status.append("\n\nPayment authentication completed, getting result")
-
-        val isPaymentResult =
-            stripe.onPaymentResult(requestCode, data, PaymentIntentResultCallback(this))
-        if (!isPaymentResult) {
-            stripe.onSetupResult(requestCode, data, SetupIntentResultCallback(this))
+        viewBinding.setupButton.setOnClickListener {
+            createAndConfirmSetupIntent("us",
+                confirmParams3ds2,
+                stripeAccountId = stripeAccountId,
+                returnUrl = RETURN_URL)
         }
     }
 
-    override fun onPause() {
-        viewBinding.progressBar.visibility = View.INVISIBLE
-        super.onPause()
-    }
-
-    override fun onDestroy() {
-        compositeSubscription.dispose()
-        super.onDestroy()
-    }
-
-    override fun onSaveInstanceState(bundle: Bundle) {
-        super.onSaveInstanceState(bundle)
-        bundle.putString(STATE_STATUS, viewBinding.status.text.toString())
-    }
-
-    private fun createPaymentIntent(
-        stripeAccountId: String?,
-        confirmationType: ConfirmationType
-    ) {
-        compositeSubscription.add(
-            backendApi
-                .createPaymentIntent(
-                    createPaymentIntentParams(stripeAccountId).toMutableMap()
-                )
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .doOnSubscribe {
-                    disableUi()
-                    viewBinding.status.setText(R.string.creating_payment_intent)
-                }
-                .subscribe(
-                    { handleCreatePaymentIntentResponse(it, confirmationType) },
-                    { handleError(it) }
-                )
-        )
-    }
-
-    private fun createSetupIntent() {
-        compositeSubscription.add(
-            backendApi.createSetupIntent(mutableMapOf("country" to "us"))
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .doOnSubscribe {
-                    disableUi()
-                    viewBinding.status.setText(R.string.creating_setup_intent)
-                }
-                .subscribe(
-                    { handleCreateSetupIntentResponse(it) },
-                    { handleError(it) }
-                )
-        )
-    }
-
-    private fun disableUi() {
-        viewBinding.progressBar.visibility = View.VISIBLE
-        viewBinding.confirmWith3ds2Button.isEnabled = false
-        viewBinding.confirmWith3ds1Button.isEnabled = false
-        viewBinding.confirmWithNewCardButton.isEnabled = false
-        viewBinding.setupButton.isEnabled = false
-    }
-
-    private fun handleError(err: Throwable) {
-        viewBinding.progressBar.visibility = View.INVISIBLE
-        err.printStackTrace()
-        viewBinding.status.append("\n\n" + err.message)
-    }
-
-    private fun handleCreatePaymentIntentResponse(
-        responseBody: ResponseBody,
-        confirmationType: ConfirmationType
-    ) {
-        try {
-            val responseData = JSONObject(responseBody.string())
-            viewBinding.status.append("\n\n" + getString(R.string.payment_intent_status,
-                responseData.getString("status")))
-            val secret = responseData.getString("secret")
-            confirmPaymentIntent(secret, confirmationType)
-        } catch (e: IOException) {
-            e.printStackTrace()
-        } catch (e: JSONException) {
-            e.printStackTrace()
-        }
-    }
-
-    private fun handleCreateSetupIntentResponse(responseBody: ResponseBody) {
-        try {
-            val responseData = JSONObject(responseBody.string())
-            viewBinding.status.append("\n\n" + getString(R.string.setup_intent_status,
-                responseData.getString("status")))
-            val secret = responseData.getString("secret")
-            confirmSetupIntent(secret)
-        } catch (e: IOException) {
-            e.printStackTrace()
-        } catch (e: JSONException) {
-            e.printStackTrace()
-        }
-    }
-
-    private fun onConfirmComplete() {
-        viewBinding.confirmWith3ds2Button.isEnabled = true
-        viewBinding.confirmWith3ds1Button.isEnabled = true
-        viewBinding.confirmWithNewCardButton.isEnabled = true
-        viewBinding.setupButton.isEnabled = true
-        viewBinding.progressBar.visibility = View.INVISIBLE
-    }
-
-    private fun createPaymentIntentParams(stripeAccountId: String?): Map<String, Any> {
-        return mapOf(
-            "amount" to 1000,
-            "country" to "us"
-        )
-            .plus(
-                stripeAccountId?.let {
-                    mapOf("stripe_account" to it)
-                }.orEmpty()
-            )
-    }
-
-    private class PaymentIntentResultCallback constructor(
-        activity: PaymentAuthActivity
-    ) : ApiResultCallback<PaymentIntentResult> {
-        private val activityRef: WeakReference<PaymentAuthActivity> = WeakReference(activity)
-
-        override fun onSuccess(result: PaymentIntentResult) {
-            val activity = activityRef.get() ?: return
-
-            val paymentIntent = result.intent
-            activity.viewBinding.status.append("\n\n" +
-                "Auth outcome: ${result.outcome}\n\n" +
-                activity.getString(R.string.payment_intent_status, paymentIntent.status)
-            )
-            activity.onConfirmComplete()
-        }
-
-        override fun onError(e: Exception) {
-            val activity = activityRef.get() ?: return
-
-            activity.viewBinding.status.append("\n\nException: " + e.message)
-            activity.onConfirmComplete()
-        }
-    }
-
-    private class SetupIntentResultCallback constructor(
-        activity: PaymentAuthActivity
-    ) : ApiResultCallback<SetupIntentResult> {
-        private val activityRef: WeakReference<PaymentAuthActivity> = WeakReference(activity)
-
-        override fun onSuccess(result: SetupIntentResult) {
-            val activity = activityRef.get() ?: return
-
-            val setupIntent = result.intent
-            activity.viewBinding.status.append("\n\n" + activity.getString(R.string.setup_intent_status, setupIntent.status))
-            activity.onConfirmComplete()
-        }
-
-        override fun onError(e: Exception) {
-            val activity = activityRef.get() ?: return
-
-            activity.viewBinding.status.append("\n\nException: " + e.message)
-            activity.onConfirmComplete()
-        }
+    private fun enableUi(enable: Boolean) {
+        viewBinding.progressBar.visibility = if (enable) View.INVISIBLE else View.VISIBLE
+        viewBinding.confirmWith3ds2Button.isEnabled = enable
+        viewBinding.confirmWith3ds1Button.isEnabled = enable
+        viewBinding.confirmWithNewCardButton.isEnabled = enable
+        viewBinding.setupButton.isEnabled = enable
     }
 
     private companion object {
@@ -299,67 +84,27 @@ class PaymentAuthActivity : AppCompatActivity() {
         /**
          * See https://stripe.com/docs/payments/3d-secure#three-ds-cards for more options.
          */
-        private fun create3ds2ConfirmParams(
-            paymentIntentClientSecret: String
-        ): ConfirmPaymentIntentParams {
-            return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParams.create(
-                    PaymentMethodCreateParams.Card.Builder()
-                        .setNumber("4000000000003238")
-                        .setExpiryMonth(1)
-                        .setExpiryYear(2025)
-                        .setCvc("123")
-                        .build()
-                ),
-                clientSecret = paymentIntentClientSecret,
-                returnUrl = RETURN_URL,
-                shipping = SHIPPING
+        private val confirmParams3ds2 =
+            PaymentMethodCreateParams.create(
+                PaymentMethodCreateParams.Card.Builder()
+                    .setNumber("4000000000003238")
+                    .setExpiryMonth(1)
+                    .setExpiryYear(2025)
+                    .setCvc("123")
+                    .build()
             )
-        }
 
-        private fun create3ds1ConfirmParams(
-            paymentIntentClientSecret: String
-        ): ConfirmPaymentIntentParams {
-            return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParams.create(
-                    PaymentMethodCreateParams.Card.Builder()
-                        .setNumber("4000000000003063")
-                        .setExpiryMonth(1)
-                        .setExpiryYear(2025)
-                        .setCvc("123")
-                        .build()
-                ),
-                paymentIntentClientSecret,
-                RETURN_URL
+        private val confirmParams3ds1 =
+            PaymentMethodCreateParams.create(
+                PaymentMethodCreateParams.Card.Builder()
+                    .setNumber("4000000000003063")
+                    .setExpiryMonth(1)
+                    .setExpiryYear(2025)
+                    .setCvc("123")
+                    .build()
             )
-        }
-
-        private fun create3ds2SetupIntentParams(
-            setupIntentClientSecret: String
-        ): ConfirmSetupIntentParams {
-            return ConfirmSetupIntentParams.create(
-                PaymentMethodCreateParams.create(
-                    PaymentMethodCreateParams.Card.Builder()
-                        .setNumber("4000000000003238")
-                        .setExpiryMonth(1)
-                        .setExpiryYear(2025)
-                        .setCvc("123")
-                        .build()
-                ),
-                setupIntentClientSecret,
-                RETURN_URL
-            )
-        }
 
         private const val RETURN_URL = "stripe://payment_auth"
-
-        private const val STATE_STATUS = "status"
-
-        enum class ConfirmationType {
-            ThreeDS1,
-            ThreeDS2,
-            NewCard
-        }
 
         private val SHIPPING = ConfirmPaymentIntentParams.Shipping(
             address = Address.Builder()

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -55,9 +55,7 @@ class PaymentAuthActivity : PaymentIntentActivity() {
         viewBinding.confirmWithNewCardButton.setOnClickListener {
             viewBinding.cardInputWidget.paymentMethodCreateParams?.let {
                 createAndConfirmPaymentIntent("us",
-                    requireNotNull(
-                        viewBinding.cardInputWidget.paymentMethodCreateParams
-                    ),
+                    it,
                     stripeAccountId = stripeAccountId,
                     shippingDetails = SHIPPING)
             }

--- a/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentIntentActivity.kt
@@ -4,20 +4,23 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
+import com.stripe.android.SetupIntentResult
 import com.stripe.android.Stripe
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
+import com.stripe.example.Settings
+import com.stripe.example.StripeFactory
 import com.stripe.example.module.PaymentIntentViewModel
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 
 /**
  * Base class for Activity's that wish to create and confirm payment methods.
- * Subclasses should observer on the [PaymentIntentViewModel]'s LiveData properties
- * in order to display state on the interaction.
+ * Subclasses should observe on the [PaymentIntentViewModel]'s LiveData properties
+ * in order to display state of the interaction.
  */
 abstract class PaymentIntentActivity : AppCompatActivity() {
     internal val viewModel: PaymentIntentViewModel by lazy {
@@ -25,8 +28,11 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
             ViewModelProvider.AndroidViewModelFactory(application)
         )[PaymentIntentViewModel::class.java]
     }
+    protected val stripeAccountId: String? by lazy {
+        Settings(this).stripeAccountId
+    }
     protected val stripe: Stripe by lazy {
-        Stripe(this, PaymentConfiguration.getInstance(this).publishableKey)
+        StripeFactory(this, stripeAccountId).create()
     }
     private val keyboardController: KeyboardController by lazy {
         KeyboardController(this)
@@ -35,32 +41,73 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
     protected fun createAndConfirmPaymentIntent(
         country: String,
         paymentMethodCreateParams: PaymentMethodCreateParams,
-        stripeAccountId: String? = null
+        shippingDetails: ConfirmPaymentIntentParams.Shipping? = null,
+        stripeAccountId: String? = null,
+        returnUrl: String = "example://return_url"
     ) {
         keyboardController.hide()
 
         viewModel.createPaymentIntent(country) {
-            handleCreatePaymentIntentResponse(it, paymentMethodCreateParams, stripeAccountId)
+            handleCreatePaymentIntentResponse(it, paymentMethodCreateParams, shippingDetails, stripeAccountId, returnUrl)
+        }
+    }
+
+    protected fun createAndConfirmSetupIntent(
+        country: String,
+        params: PaymentMethodCreateParams,
+        stripeAccountId: String? = null,
+        returnUrl: String = "example://return_url"
+    ) {
+        keyboardController.hide()
+
+        viewModel.createSetupIntent(country) {
+            handleCreateSetupIntentResponse(it, params, stripeAccountId, returnUrl)
         }
     }
 
     private fun handleCreatePaymentIntentResponse(
         responseData: JSONObject,
         params: PaymentMethodCreateParams,
-        stripeAccountId: String?
+        shippingDetails: ConfirmPaymentIntentParams.Shipping?,
+        stripeAccountId: String?,
+        returnUrl: String
     ) {
         val secret = responseData.getString("secret")
         viewModel.status.postValue(
             viewModel.status.value +
-            "\n\nStarting PaymentIntent confirmation" + (stripeAccountId?.let {
-            " for $it"
-        } ?: ""))
+                "\n\nStarting PaymentIntent confirmation" + (stripeAccountId?.let {
+                " for $it"
+            } ?: ""))
         stripe.confirmPayment(
             this,
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                 paymentMethodCreateParams = params,
                 clientSecret = secret,
-                returnUrl = "example://return_url"
+                shipping = shippingDetails,
+                returnUrl = returnUrl
+            ),
+            stripeAccountId
+        )
+    }
+
+    fun handleCreateSetupIntentResponse(
+        responseData: JSONObject,
+        params: PaymentMethodCreateParams,
+        stripeAccountId: String?,
+        returnUrl: String
+    ) {
+        val secret = responseData.getString("secret")
+        viewModel.status.postValue(
+            viewModel.status.value +
+                "\n\nStarting SetupIntent confirmation" + (stripeAccountId?.let {
+                " for $it"
+            } ?: ""))
+        stripe.confirmSetupIntent(
+            this,
+            ConfirmSetupIntentParams.create(
+                paymentMethodCreateParams = params,
+                clientSecret = secret,
+                returnUrl = returnUrl
             ),
             stripeAccountId
         )
@@ -68,7 +115,15 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        stripe.onPaymentResult(requestCode, data, PaymentIntentResultCallback(this))
+
+        keyboardController.hide()
+
+        viewModel.status.value += "\n\nPayment authentication completed, getting result"
+        val isPaymentResult =
+            stripe.onPaymentResult(requestCode, data, PaymentIntentResultCallback(this))
+        if (!isPaymentResult) {
+            stripe.onSetupResult(requestCode, data, SetupIntentResultCallback(this))
+        }
     }
 
     protected fun onConfirmSuccess(result: PaymentIntentResult) {
@@ -76,6 +131,14 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
         viewModel.status.value += "\n\n" +
             "PaymentIntent confirmation outcome: ${result.outcome}\n\n" +
             getString(R.string.payment_intent_status, paymentIntent.status)
+        viewModel.inProgress.value = false
+    }
+
+    protected fun onConfirmSuccess(result: SetupIntentResult) {
+        val setupIntentResult = result.intent
+        viewModel.status.value += "\n\n" +
+            "SetupIntent confirmation outcome: ${result.outcome}\n\n" +
+            getString(R.string.setup_intent_status, setupIntentResult.status)
         viewModel.inProgress.value = false
     }
 
@@ -91,6 +154,21 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
         private val activityRef = WeakReference(activity)
 
         override fun onSuccess(result: PaymentIntentResult) {
+            activityRef.get()?.onConfirmSuccess(result)
+        }
+
+        override fun onError(e: Exception) {
+            activityRef.get()?.onConfirmError(e)
+        }
+    }
+
+    internal class SetupIntentResultCallback(
+        activity: PaymentIntentActivity
+    ) : ApiResultCallback<SetupIntentResult> {
+
+        private val activityRef = WeakReference(activity)
+
+        override fun onSuccess(result: SetupIntentResult) {
             activityRef.get()?.onConfirmSuccess(result)
         }
 

--- a/example/src/main/java/com/stripe/example/activity/SimplePaymentMethodConfirmationActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SimplePaymentMethodConfirmationActivity.kt
@@ -15,7 +15,7 @@ import com.stripe.example.R
 import com.stripe.example.databinding.DropdownMenuPopupItemBinding
 import com.stripe.example.databinding.SimplePaymentMethodActivityBinding
 
-class SimplePaymentMethodConfirmationActivity : PaymentIntentActivity() {
+class SimplePaymentMethodConfirmationActivity : StripeIntentActivity() {
 
     private val viewBinding: SimplePaymentMethodActivityBinding by lazy {
         SimplePaymentMethodActivityBinding.inflate(layoutInflater)

--- a/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.databinding.SofortActivityBinding
 
-class SofortPaymentMethodActivity : PaymentIntentActivity() {
+class SofortPaymentMethodActivity : StripeIntentActivity() {
     private val viewBinding: SofortActivityBinding by lazy {
         SofortActivityBinding.inflate(layoutInflater)
     }

--- a/example/src/main/java/com/stripe/example/activity/StripeIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/StripeIntentActivity.kt
@@ -13,25 +13,25 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.R
 import com.stripe.example.Settings
 import com.stripe.example.StripeFactory
-import com.stripe.example.module.PaymentIntentViewModel
+import com.stripe.example.module.StripeIntentViewModel
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 
 /**
  * Base class for Activity's that wish to create and confirm payment methods.
- * Subclasses should observe on the [PaymentIntentViewModel]'s LiveData properties
+ * Subclasses should observe on the [StripeIntentViewModel]'s LiveData properties
  * in order to display state of the interaction.
  */
-abstract class PaymentIntentActivity : AppCompatActivity() {
-    internal val viewModel: PaymentIntentViewModel by lazy {
+abstract class StripeIntentActivity : AppCompatActivity() {
+    internal val viewModel: StripeIntentViewModel by lazy {
         ViewModelProvider(this,
             ViewModelProvider.AndroidViewModelFactory(application)
-        )[PaymentIntentViewModel::class.java]
+        )[StripeIntentViewModel::class.java]
     }
-    protected val stripeAccountId: String? by lazy {
+    private val stripeAccountId: String? by lazy {
         Settings(this).stripeAccountId
     }
-    protected val stripe: Stripe by lazy {
+    private val stripe: Stripe by lazy {
         StripeFactory(this, stripeAccountId).create()
     }
     private val keyboardController: KeyboardController by lazy {
@@ -148,7 +148,7 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
     }
 
     internal class PaymentIntentResultCallback(
-        activity: PaymentIntentActivity
+        activity: StripeIntentActivity
     ) : ApiResultCallback<PaymentIntentResult> {
 
         private val activityRef = WeakReference(activity)
@@ -163,7 +163,7 @@ abstract class PaymentIntentActivity : AppCompatActivity() {
     }
 
     internal class SetupIntentResultCallback(
-        activity: PaymentIntentActivity
+        activity: StripeIntentActivity
     ) : ApiResultCallback<SetupIntentResult> {
 
         private val activityRef = WeakReference(activity)

--- a/example/src/main/java/com/stripe/example/module/PaymentIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/PaymentIntentViewModel.kt
@@ -1,12 +1,15 @@
 package com.stripe.example.module
 
 import android.app.Application
+import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import com.stripe.example.R
+import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import okhttp3.ResponseBody
 import org.json.JSONObject
 import retrofit2.HttpException
 
@@ -24,15 +27,44 @@ internal class PaymentIntentViewModel(
         country: String,
         callback: (JSONObject) -> Unit
     ) {
+        callApi(
+            backendApi::createPaymentIntent,
+            R.string.creating_payment_intent,
+            R.string.payment_intent_status,
+            country,
+            callback
+        )
+    }
+
+    fun createSetupIntent(
+        country: String,
+        callback: (JSONObject) -> Unit
+    ) {
+        callApi(
+            backendApi::createSetupIntent,
+            R.string.creating_setup_intent,
+            R.string.setup_intent_status,
+            country,
+            callback
+        )
+    }
+
+    private fun callApi(
+        apiMethod: (MutableMap<String, Any>) -> Observable<ResponseBody>,
+        @StringRes creating: Int,
+        @StringRes result: Int,
+        country: String,
+        callback: (JSONObject) -> Unit
+    ) {
         compositeSubscription.add(
-            backendApi.createPaymentIntent(
+            apiMethod(
                 mutableMapOf(
                     "country" to country
                 )
             )
                 .doOnSubscribe {
                     inProgress.postValue(true)
-                    status.postValue(context.getString(R.string.creating_payment_intent))
+                    status.postValue(context.getString(creating))
                 }
                 .map {
                     JSONObject(it.string())
@@ -42,7 +74,7 @@ internal class PaymentIntentViewModel(
                 .subscribe(
                     {
                         status.postValue(status.value + "\n\n" +
-                            context.getString(R.string.payment_intent_status,
+                            context.getString(result,
                                 it.getString("status")))
                         callback(it)
                     },

--- a/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
@@ -13,7 +13,7 @@ import okhttp3.ResponseBody
 import org.json.JSONObject
 import retrofit2.HttpException
 
-internal class PaymentIntentViewModel(
+internal class StripeIntentViewModel(
     application: Application
 ) : AndroidViewModel(application) {
     val inProgress = MutableLiveData<Boolean>()

--- a/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
@@ -27,7 +27,7 @@ internal class StripeIntentViewModel(
         country: String,
         callback: (JSONObject) -> Unit
     ) {
-        callApi(
+        makeBackendRequest(
             backendApi::createPaymentIntent,
             R.string.creating_payment_intent,
             R.string.payment_intent_status,
@@ -40,7 +40,7 @@ internal class StripeIntentViewModel(
         country: String,
         callback: (JSONObject) -> Unit
     ) {
-        callApi(
+        makeBackendRequest(
             backendApi::createSetupIntent,
             R.string.creating_setup_intent,
             R.string.setup_intent_status,
@@ -49,7 +49,7 @@ internal class StripeIntentViewModel(
         )
     }
 
-    private fun callApi(
+    private fun makeBackendRequest(
         apiMethod: (MutableMap<String, Any>) -> Observable<ResponseBody>,
         @StringRes creating: Int,
         @StringRes result: Int,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds support for SetupIntent's in PaymentIntentViewModel
Uses PaymentIntentViewModel (via PaymentIntentActivity) in PaymentAuthActivity

![ezgif com-optimize (2)](https://user-images.githubusercontent.com/47332718/80164107-f7f27880-858c-11ea-8c3d-eecfea7ae63e.gif)




## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Remove duplicate code

## Testing
<!-- How was the code tested? Be as specific as possible. -->
