### PR TITLE
Fix SDK source paths and source publishing

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -77,6 +77,9 @@ android {
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
         }
+        main.kotlin.srcDirs += 'src/main/java'
+        main.java.srcDirs += 'src/main/java'
+
         test {
 
         }

--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -28,6 +28,23 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
+task androidJavadocs(type: Javadoc) {
+    excludes = ['**/*.kt']
+    source = android.sourceSets.main.java.srcDirs
+    classpath = configurations.compile
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    archiveClassifier.set('javadoc')
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
 afterEvaluate { project ->
     // See https://developer.android.com/studio/build/maven-publish-plugin
     publishing {
@@ -36,6 +53,10 @@ afterEvaluate { project ->
             release(MavenPublication) {
                 // Applies the component for the release build variant.
                 from components.release
+
+                // Adds Javadocs and Sources as separate jars.
+                artifact androidJavadocsJar
+                artifact androidSourcesJar
 
                 // You can then customize attributes of the publication as shown below.
                 groupId = GROUP
@@ -111,23 +132,6 @@ afterEvaluate { project ->
 
     tasks.withType(Sign) {
         onlyIf { isReleaseBuild() && project.hasProperty('signing.gnupg.keyName') }
-    }
-
-    task androidJavadocs(type: Javadoc) {
-        excludes = ['**/*.kt']
-        source = android.sourceSets.main.java.srcDirs
-        classpath = configurations.compile
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    }
-
-    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-        classifier = 'javadoc'
-        from androidJavadocs.destinationDir
-    }
-
-    task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.sourceFiles
     }
 
     artifacts {


### PR DESCRIPTION
## Summary
See [Kotlin's Using Gradle doc](https://kotlinlang.org/docs/reference/using-gradle.html) for more details.

## Motivation
Fixes #2426

## Testing
1. Published to local Maven repository
2. Verified that `sources.jar` and `javadocs.jar` were correctly
   populated
3. Verified that Android Studio correctly shows source code when opening
   a `stripe-android` class

