### PR TITLE
Add GooglePayJsonFactory.isJcbEnabled

### DIFF
--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -13,12 +13,31 @@ import org.json.JSONObject
  * for Google Pay API version 2.0.
  */
 class GooglePayJsonFactory constructor(
-    private val googlePayConfig: GooglePayConfig
+    private val googlePayConfig: GooglePayConfig,
+
+    /**
+     * Enable JCB as a payment method. By default, JCB is disabled.
+     *
+     * JCB currently can only be accepted in Japan.
+     */
+    private val isJcbEnabled: Boolean = false
 ) {
     /**
      * [PaymentConfiguration] must be instantiated before calling this.
      */
-    constructor(context: Context) : this(GooglePayConfig(context))
+    constructor(
+        context: Context,
+
+        /**
+         * Enable JCB as a payment method. By default, JCB is disabled.
+         *
+         * JCB currently can only be accepted in Japan.
+         */
+        isJcbEnabled: Boolean = false
+    ) : this(
+        googlePayConfig = GooglePayConfig(context),
+        isJcbEnabled = isJcbEnabled
+    )
 
     /**
      * [IsReadyToPayRequest](https://developers.google.com/pay/api/android/reference/request-objects#IsReadyToPayRequest)
@@ -174,7 +193,11 @@ class GooglePayJsonFactory constructor(
     private fun createBaseCardPaymentMethodParams(): JSONObject {
         return JSONObject()
             .put("allowedAuthMethods", JSONArray(ALLOWED_AUTH_METHODS))
-            .put("allowedCardNetworks", JSONArray(ALLOWED_CARD_NETWORKS))
+            .put("allowedCardNetworks", JSONArray(
+                DEFAULT_CARD_NETWORKS.plus(
+                    listOf(JCB_CARD_NETWORK).takeIf { isJcbEnabled } ?: emptyList()
+                )
+            ))
     }
 
     /**
@@ -351,7 +374,8 @@ class GooglePayJsonFactory constructor(
         private const val CARD_PAYMENT_METHOD = "CARD"
 
         private val ALLOWED_AUTH_METHODS = listOf("PAN_ONLY", "CRYPTOGRAM_3DS")
-        private val ALLOWED_CARD_NETWORKS =
-            listOf("AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA")
+        private val DEFAULT_CARD_NETWORKS =
+            listOf("AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA")
+        private const val JCB_CARD_NETWORK = "JCB"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -16,7 +16,7 @@ class GooglePayJsonFactory constructor(
     private val googlePayConfig: GooglePayConfig,
 
     /**
-     * Enable JCB as a payment method. By default, JCB is disabled.
+     * Enable JCB as an allowed card network. By default, JCB is disabled.
      *
      * JCB currently can only be accepted in Japan.
      */
@@ -29,7 +29,7 @@ class GooglePayJsonFactory constructor(
         context: Context,
 
         /**
-         * Enable JCB as a payment method. By default, JCB is disabled.
+         * Enable JCB as an allowed card network. By default, JCB is disabled.
          *
          * JCB currently can only be accepted in Japan.
          */

--- a/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.StripeJsonUtils
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"]
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA"]
                     },
                     "tokenizationSpecification": {
                         "type": "PAYMENT_GATEWAY",
@@ -59,7 +60,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA"],
                         "billingAddressRequired": true,
                         "billingAddressParameters": {
                             "phoneNumberRequired": true,
@@ -93,7 +94,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA"],
                         "billingAddressRequired": true,
                         "billingAddressParameters": {
                             "phoneNumberRequired": true,
@@ -172,5 +173,37 @@ class GooglePayJsonFactoryTest {
             .getString("countryCode")
         assertThat(countryCode)
             .isEqualTo("US")
+    }
+
+    @Test
+    fun allowedCardNetworks_whenJcbDisabled_shouldNotIncludeJcb() {
+        val allowedCardNetworks = factory.createIsReadyToPayRequest()
+            .getJSONArray("allowedPaymentMethods")
+            .getJSONObject(0)
+            .getJSONObject("parameters")
+            .getJSONArray("allowedCardNetworks")
+            .let {
+                StripeJsonUtils.jsonArrayToList(it)
+            }
+
+        assertThat(allowedCardNetworks)
+            .isEqualTo(listOf("AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA"))
+    }
+
+    @Test
+    fun allowedCardNetworks_whenJcbEnabled_shouldIncludeJcb() {
+        val allowedCardNetworks =
+            GooglePayJsonFactory(googlePayConfig, isJcbEnabled = true)
+                .createIsReadyToPayRequest()
+                .getJSONArray("allowedPaymentMethods")
+                .getJSONObject(0)
+                .getJSONObject("parameters")
+                .getJSONArray("allowedCardNetworks")
+                .let {
+                    StripeJsonUtils.jsonArrayToList(it)
+                }
+
+        assertThat(allowedCardNetworks)
+            .isEqualTo(listOf("AMEX", "DISCOVER", "INTERAC", "MASTERCARD", "VISA", "JCB"))
     }
 }


### PR DESCRIPTION
## Summary
Enable JCB as an allowed card network. By default, JCB is disabled.

## Motivation
JCB currently can only be accepted in Japan.

## Testing
Unit tests
