### PR TITLE
Remove java.version property from request headers

### DIFF
--- a/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
@@ -67,7 +67,6 @@ internal sealed class RequestHeadersFactory {
                     "bindings.version" to BuildConfig.VERSION_NAME,
                     "lang" to "Java",
                     "publisher" to "Stripe",
-                    "java.version" to systemPropertySupplier("java.version"),
                     "http.agent" to systemPropertySupplier(PROP_USER_AGENT)
                 ).plus(
                     appInfo?.createClientHeaders().orEmpty()

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
@@ -20,7 +20,6 @@ class AnalyticsRequestTest {
     @Test
     fun factoryCreate_createsExpectedObject() {
         val sdkVersion = BuildConfig.VERSION_NAME
-        val javaVersion = System.getProperty("java.version").orEmpty()
         val analyticsRequest = factory.create(
             params = AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 .createPaymentMethodCreationParams(
@@ -36,7 +35,7 @@ class AnalyticsRequestTest {
                 "Accept" to "application/json",
                 "X-Stripe-Client-User-Agent" to
                     """
-                    {"os.name":"android","os.version":"28","bindings.version":"$sdkVersion","lang":"Java","publisher":"Stripe","java.version":"$javaVersion","http.agent":"","application":{"name":"MyAwesomePlugin","version":"1.2.34","url":"https:\/\/myawesomeplugin.info","partner_id":"pp_partner_1234"}}
+                    {"os.name":"android","os.version":"28","bindings.version":"$sdkVersion","lang":"Java","publisher":"Stripe","http.agent":"","application":{"name":"MyAwesomePlugin","version":"1.2.34","url":"https:\/\/myawesomeplugin.info","partner_id":"pp_partner_1234"}}
                     """.trimIndent(),
                 "Stripe-Version" to "2020-03-02",
                 "Authorization" to "Bearer pk_test_123",

--- a/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
@@ -67,7 +67,6 @@ class ApiRequestHeadersFactoryTest {
         assertEquals("Stripe", userAgentData.getString("publisher"))
         assertEquals("android", userAgentData.getString("os.name"))
         assertEquals(Build.VERSION.SDK_INT, userAgentData.getString("os.version").toInt())
-        assertTrue(userAgentData.getString("java.version").isNotBlank())
         assertTrue(userAgentData.getString("http.agent").isNotBlank())
     }
 


### PR DESCRIPTION
This property is unavailable in Android environments because Android
does not run a JVM.