### PR TITLE
Capitalize GooglePayJsonFactory's allowedCountryCodes

### DIFF
--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -162,10 +162,14 @@ class GooglePayJsonFactory constructor(
         shippingAddressParameters: ShippingAddressParameters
     ): JSONObject {
         return JSONObject()
-            .put("allowedCountryCodes",
-                JSONArray(shippingAddressParameters.allowedCountryCodes))
-            .put("phoneNumberRequired",
-                shippingAddressParameters.phoneNumberRequired)
+            .put(
+                "allowedCountryCodes",
+                JSONArray(shippingAddressParameters.normalizedAllowedCountryCodes)
+            )
+            .put(
+                "phoneNumberRequired",
+                shippingAddressParameters.phoneNumberRequired
+            )
     }
 
     private fun createCardPaymentMethod(
@@ -335,16 +339,26 @@ class GooglePayJsonFactory constructor(
          * ISO 3166-1 alpha-2 country code values of the countries where shipping is allowed.
          * If this object isn't specified, all shipping address countries are allowed.
          */
-        internal val allowedCountryCodes: Set<String> = emptySet(),
+        private val allowedCountryCodes: Set<String> = emptySet(),
 
         /**
          * Set to true if a phone number is required for the provided shipping address.
          */
         internal val phoneNumberRequired: Boolean = false
     ) : Parcelable {
+        /**
+         * Normalized form of [allowedCountryCodes] (i.e. capitalized country codes)
+         */
+        internal val normalizedAllowedCountryCodes: Set<String>
+            get() {
+                return allowedCountryCodes.map {
+                    it.toUpperCase(Locale.ROOT)
+                }.toSet()
+            }
+
         init {
             val countryCodes = Locale.getISOCountries()
-            allowedCountryCodes.forEach { allowedShippingCountryCode ->
+            normalizedAllowedCountryCodes.forEach { allowedShippingCountryCode ->
                 require(
                     countryCodes.any { allowedShippingCountryCode == it }
                 ) {

--- a/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -176,6 +176,33 @@ class GooglePayJsonFactoryTest {
     }
 
     @Test
+    fun shippingAddressAllowedCountryCodes_shouldBeCapitalized() {
+        val createPaymentDataRequestJson = factory.createPaymentDataRequest(
+            transactionInfo = GooglePayJsonFactory.TransactionInfo(
+                currencyCode = "USD",
+                totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+                totalPrice = 500,
+                countryCode = "US",
+                totalPriceLabel = "Your total price"
+            ),
+            shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
+                isRequired = true,
+                allowedCountryCodes = setOf("us", "de")
+            )
+        )
+
+        val allowedCountryCodes = createPaymentDataRequestJson
+            .getJSONObject("shippingAddressParameters")
+            .getJSONArray("allowedCountryCodes")
+            .let {
+                StripeJsonUtils.jsonArrayToList(it)
+            }
+
+        assertThat(allowedCountryCodes)
+            .containsExactly("US", "DE")
+    }
+
+    @Test
     fun allowedCardNetworks_whenJcbDisabled_shouldNotIncludeJcb() {
         val allowedCardNetworks = factory.createIsReadyToPayRequest()
             .getJSONArray("allowedPaymentMethods")


### PR DESCRIPTION
## Motivation
Google Pay requires `allowedCountryCodes` to be capitalized

## Testing
Add test