### PR TITLE
Update ConfirmPaymentIntentParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -2,7 +2,8 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage
-import com.stripe.android.model.ConfirmPaymentIntentParams.Shipping
+import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
@@ -21,7 +22,7 @@ data class ConfirmPaymentIntentParams internal constructor(
      * ID of the payment method (a PaymentMethod, Card, or compatible Source object) to attach to
      * this PaymentIntent.
      *
-     * [payment_method](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-payment_method)
+     * See [payment_method](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-payment_method).
      */
     val paymentMethodId: String? = null,
     val sourceParams: SourceParams? = null,
@@ -40,7 +41,7 @@ data class ConfirmPaymentIntentParams internal constructor(
      * Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment)
      * and learn about how `client_secret` should be handled.
      *
-     * [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
+     * See [client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
      */
     override val clientSecret: String,
 
@@ -50,9 +51,9 @@ data class ConfirmPaymentIntentParams internal constructor(
      * can alternatively supply an application URI scheme. This parameter is only used for cards
      * and other redirect-based payment methods.
      *
-     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * See [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url).
      */
-    val returnUrl: String? = null,
+    var returnUrl: String? = null,
 
     /**
      * If the PaymentIntent has a `payment_method` and a `customer` or if you’re attaching a payment
@@ -62,52 +63,61 @@ data class ConfirmPaymentIntentParams internal constructor(
      * If the payment method is already saved to a customer, this does nothing. If this type of
      * payment method cannot be saved to a customer, the request will error.
      *
-     * [save_payment_method](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-save_payment_method)
+     * See [save_payment_method](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-save_payment_method).
      */
-    private val savePaymentMethod: Boolean? = null,
+    var savePaymentMethod: Boolean? = null,
 
     /**
      * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle
      * additional authentication steps.
      *
-     * [use_stripe_sdk](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-use_stripe_sdk)
+     * See [use_stripe_sdk](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-use_stripe_sdk).
      */
     private val useStripeSdk: Boolean = false,
 
     /**
      * Payment-method-specific configuration for this PaymentIntent.
      *
-     * [payment_method_options](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-payment_method_options)
+     * See [payment_method_options](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-payment_method_options).
      */
-    private val paymentMethodOptions: PaymentMethodOptionsParams? = null,
+    var paymentMethodOptions: PaymentMethodOptionsParams? = null,
 
     /**
      * ID of the mandate to be used for this payment.
      *
-     * [mandate](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate)
+     * See [mandate](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate).
      */
-    private val mandateId: String? = null,
+    var mandateId: String? = null,
 
     /**
      * This hash contains details about the Mandate to create.
      *
-     * [mandate_data](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate_data)
+     * See [mandate_data](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate_data).
      */
-    private val mandateData: MandateDataParams? = null,
+    var mandateData: MandateDataParams? = null,
 
     /**
-     * See [SetupFutureUsage]
+     * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
      *
-     * [setup_future_usage](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-setup_future_usage)
+     * See [SetupFutureUsage] for more information.
+     *
+     * See [setup_future_usage](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-setup_future_usage).
      */
-    private val setupFutureUsage: SetupFutureUsage? = null,
+    var setupFutureUsage: SetupFutureUsage? = null,
 
     /**
-     * See [Shipping]
+     * Shipping information for this PaymentIntent.
      *
-     * [shipping](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping)
+     * See [shipping](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping).
      */
-    private val shipping: Shipping? = null
+    var shipping: Shipping? = null,
+
+    /**
+     * Email address that the receipt for the resulting payment will be sent to.
+     *
+     * See [receipt_email](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-receipt_email).
+     */
+    var receiptEmail: String? = null
 ) : ConfirmStripeIntentParams {
 
     fun shouldSavePaymentMethod(): Boolean {
@@ -151,10 +161,14 @@ data class ConfirmPaymentIntentParams internal constructor(
             }.orEmpty()
         ).plus(
             shipping?.let {
-                mapOf(PARAM_SHIPPING to shipping.toParamMap())
+                mapOf(PARAM_SHIPPING to it.toParamMap())
             }.orEmpty()
         ).plus(
             paymentMethodParamMap
+        ).plus(
+            receiptEmail?.let {
+                mapOf(PARAM_RECEIPT_EMAIL to it)
+            }.orEmpty()
         ).plus(
             extraParams.orEmpty()
         )
@@ -195,21 +209,23 @@ data class ConfirmPaymentIntentParams internal constructor(
         }
 
     /**
-     * [setup_future_usage](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-setup_future_usage)
+     * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
      *
-     * Use `on_session` if you intend to only reuse the payment method when your customer is
-     * present in your checkout flow. Use `off_session` if your customer may or may not be in
-     * your checkout flow.
+     * Providing this parameter will
+     * [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the
+     * PaymentIntent’s Customer, if present, after the PaymentIntent is confirmed and any required
+     * actions from the user are complete. If no Customer was provided, the payment method can still
+     * be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the
+     * transaction completes.
      *
-     * Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
-     * regional legislation and network rules. For example, if your customer is impacted by
-     * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will
-     * ensure that they are authenticated while processing this PaymentIntent. You will then be
-     * able to collect [off-session payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
-     * for this customer.
+     * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize
+     * your payment flow and comply with regional legislation and network rules, such as
+     * [SCA](https://stripe.com/docs/strong-customer-authentication).
      *
      * If `setup_future_usage` is already set, you may only update the value
-     * from `on_session` to `off_session`.
+     * from [OnSession] to [OffSession].
+     *
+     * See [setup_future_usage](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-setup_future_usage).
      */
     enum class SetupFutureUsage(
         internal val code: String
@@ -294,13 +310,13 @@ data class ConfirmPaymentIntentParams internal constructor(
     }
 
     companion object {
-        const val PARAM_SOURCE_DATA: String = "source_data"
-
-        internal const val PARAM_SOURCE_ID = "source"
-        internal const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
-        internal const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
-        private const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
+        private const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
+        private const val PARAM_RECEIPT_EMAIL = "receipt_email"
+        private const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
         private const val PARAM_SHIPPING = "shipping"
+        private const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
+        internal const val PARAM_SOURCE_DATA: String = "source_data"
+        private const val PARAM_SOURCE_ID = "source"
 
         /**
          * Create a [ConfirmPaymentIntentParams] without a payment method.

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -1,320 +1,344 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.CardNumberFixtures.VISA_NO_SPACES
-import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
-import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SAVE_PAYMENT_METHOD
-import com.stripe.android.model.ConfirmPaymentIntentParams.Companion.PARAM_SOURCE_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class ConfirmPaymentIntentParamsTest {
 
     @Test
-    fun createConfirmPaymentIntentWithSourceDataParams_withAllFields_hasExpectedFields() {
-        val sourceParams = SourceParams.createCardParams(FULL_FIELDS_VISA_CARD)
+    fun toParamMap_withSourceParams_shouldCreateExpectedMap() {
+        val sourceParams = SourceParams.createCardParams(CardFixtures.CARD)
         val params = ConfirmPaymentIntentParams
             .createWithSourceParams(sourceParams, CLIENT_SECRET, RETURN_URL)
+            .toParamMap()
 
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(sourceParams, params.sourceParams)
-        assertFalse(params.shouldSavePaymentMethod())
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "source_data" to sourceParams.toParamMap()
+                )
+            )
     }
 
     @Test
-    fun createConfirmPaymentIntentWithSourceIdParams_withAllFields_hasExpectedFields() {
+    fun toParamMap_withSourceId_shouldCreateExpectedMap() {
         val params = ConfirmPaymentIntentParams
             .createWithSourceId(SOURCE_ID, CLIENT_SECRET, RETURN_URL)
+            .toParamMap()
 
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(SOURCE_ID, params.sourceId)
-        assertFalse(params.shouldSavePaymentMethod())
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "source" to SOURCE_ID
+                )
+            )
     }
 
     @Test
-    fun createConfirmPaymentIntentWithSourceIdParams_withSavePaymentMethod_hasExpectedFields() {
+    fun toParamMap_withSavePaymentMethod_shouldCreateExpectedMap() {
         val params = ConfirmPaymentIntentParams
             .createWithSourceId(SOURCE_ID, CLIENT_SECRET, RETURN_URL, true)
+            .toParamMap()
 
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(SOURCE_ID, params.sourceId)
-        assertTrue(params.shouldSavePaymentMethod())
-
-        assertTrue(params.toParamMap()[PARAM_SAVE_PAYMENT_METHOD] == true)
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "source" to SOURCE_ID,
+                    "save_payment_method" to true
+                )
+            )
     }
 
     @Test
-    fun createWithPaymentMethodCreateParams_hasExpectedFields() {
-        val paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+    fun toParamMap_withPaymentMethodCreateParams_shouldCreateExpectedMap() {
         val params = ConfirmPaymentIntentParams
-            .createWithPaymentMethodCreateParams(paymentMethodCreateParams, CLIENT_SECRET, RETURN_URL)
+            .createWithPaymentMethodCreateParams(
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                CLIENT_SECRET,
+                RETURN_URL
+            )
+            .toParamMap()
 
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(paymentMethodCreateParams, params.paymentMethodCreateParams)
-        assertFalse(params.shouldSavePaymentMethod())
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "payment_method_data" to PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap()
+                )
+            )
     }
 
     @Test
-    fun createConfirmPaymentIntentWithPaymentMethodId_hasExpectedFields() {
+    fun toParamMap_withPaymentMethodId_shouldCreateExpectedMap() {
         val params = ConfirmPaymentIntentParams
             .createWithPaymentMethodId(PM_ID, CLIENT_SECRET, RETURN_URL)
+            .toParamMap()
 
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(PM_ID, params.paymentMethodId)
-        assertFalse(params.shouldSavePaymentMethod())
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "payment_method" to PM_ID
+                )
+            )
     }
 
     @Test
-    fun createConfirmPaymentIntentWithPaymentMethodCreateParams_withSavePaymentMethod_hasExpectedFields() {
+    fun toParamMap_withPaymentMethodCreateParamsAndSavePaymentMethod_shouldCreateExpectedMap() {
         val paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
         val params = ConfirmPaymentIntentParams
-            .createWithPaymentMethodCreateParams(paymentMethodCreateParams,
-                CLIENT_SECRET, RETURN_URL, true)
-
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(paymentMethodCreateParams, params.paymentMethodCreateParams)
-        assertTrue(params.shouldSavePaymentMethod())
-    }
-
-    @Test
-    fun createConfirmPaymentIntentWithPaymentMethodId_withSavePaymentMethod_hasExpectedFields() {
-        val params = ConfirmPaymentIntentParams
-            .createWithPaymentMethodId(PM_ID, CLIENT_SECRET, RETURN_URL, true)
-
-        assertEquals(CLIENT_SECRET, params.clientSecret)
-        assertEquals(RETURN_URL, params.returnUrl)
-        assertEquals(PM_ID, params.paymentMethodId)
-        assertTrue(params.shouldSavePaymentMethod())
-
-        assertTrue(params.toParamMap()[PARAM_SAVE_PAYMENT_METHOD] == true)
-    }
-
-    @Test
-    fun createWithSourceId_toParamMap_createsExpectedMap() {
-        val confirmPaymentIntentParams = ConfirmPaymentIntentParams
-            .createWithSourceId(
-                SOURCE_ID,
+            .createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams,
                 CLIENT_SECRET,
                 RETURN_URL,
-                savePaymentMethod = false
+                savePaymentMethod = true
             )
+            .toParamMap()
 
-        val paramMap = confirmPaymentIntentParams.toParamMap()
-        assertEquals(paramMap[PARAM_SOURCE_ID], SOURCE_ID)
-        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertEquals(paramMap[PARAM_RETURN_URL], RETURN_URL)
-        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "payment_method_data" to PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap(),
+                    "save_payment_method" to true
+                )
+            )
     }
 
     @Test
-    fun createWithPaymentMethodId_withoutReturnUrl_toParamMap_createsExpectedMap() {
-        val confirmPaymentIntentParams = ConfirmPaymentIntentParams
-            .createWithPaymentMethodId(PM_ID, CLIENT_SECRET)
+    fun toParamMap_withPaymentMethodIdAndSavePaymentMethod_shouldCreateExpectedMap() {
+        val params = ConfirmPaymentIntentParams
+            .createWithPaymentMethodId(PM_ID, CLIENT_SECRET, RETURN_URL, true)
+            .toParamMap()
 
-        val paramMap = confirmPaymentIntentParams.toParamMap()
-
-        assertEquals(paramMap[PARAM_PAYMENT_METHOD_ID], PM_ID)
-        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertFalse(paramMap.containsKey(PARAM_RETURN_URL))
-        assertNull(paramMap[PARAM_SAVE_PAYMENT_METHOD])
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "return_url" to RETURN_URL,
+                    "use_stripe_sdk" to false,
+                    "payment_method" to PM_ID,
+                    "save_payment_method" to true
+                )
+            )
     }
 
     @Test
-    fun createWithPaymentMethodId_withReturnUrl_toParamMap_createsExpectedMap() {
-        val confirmPaymentIntentParams = ConfirmPaymentIntentParams
-            .createWithPaymentMethodId(PM_ID, CLIENT_SECRET, RETURN_URL)
+    fun toParamMap_withExtraParams_shouldCreateExpectedMap() {
+        val params = ConfirmPaymentIntentParams
+            .createWithPaymentMethodId(
+                "pm_123",
+                CLIENT_SECRET,
+                extraParams = mapOf(
+                    "animal" to "dog",
+                    "color" to "brown"
+                )
+            )
+            .toParamMap()
 
-        val paramMap = confirmPaymentIntentParams.toParamMap()
-
-        assertEquals(paramMap[PARAM_PAYMENT_METHOD_ID], PM_ID)
-        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertEquals(paramMap[PARAM_RETURN_URL], RETURN_URL)
-        assertNull(paramMap[PARAM_SAVE_PAYMENT_METHOD])
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                    "payment_method" to "pm_123",
+                    "animal" to "dog",
+                    "color" to "brown"
+                )
+            )
     }
 
     @Test
-    fun toParamMap_whenExtraParamsProvided_createsExpectedMap() {
-        val extraParamKey1 = "extra_param_key_1"
-        val extraParamKey2 = "extra_param_key_2"
-        val extraParamValue1 = "extra_param_value_1"
-        val extraParamValue2 = "extra_param_value_2"
-        val extraParams = mapOf(
-            extraParamKey1 to extraParamValue1,
-            extraParamKey2 to extraParamValue2
+    fun toParamMap_withClientSecret_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmPaymentIntentParams.create(CLIENT_SECRET).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false
+            )
         )
-
-        val confirmPaymentIntentParams = ConfirmPaymentIntentParams
-            .createWithPaymentMethodId("pm_123", CLIENT_SECRET,
-                RETURN_URL, false, extraParams)
-
-        val paramMap = confirmPaymentIntentParams.toParamMap()
-
-        assertEquals(paramMap[PARAM_CLIENT_SECRET], CLIENT_SECRET)
-        assertEquals(paramMap[extraParamKey1], extraParamValue1)
-        assertEquals(paramMap[extraParamKey2], extraParamValue2)
-        assertEquals(false, paramMap[PARAM_SAVE_PAYMENT_METHOD])
-    }
-
-    @Test
-    fun create_withClientSecret() {
-        assertEquals(CLIENT_SECRET,
-            ConfirmPaymentIntentParams.create(CLIENT_SECRET, "")
-                .clientSecret)
     }
 
     @Test
     fun shouldUseStripeSdk() {
-        val confirmPaymentIntentParams =
-            ConfirmPaymentIntentParams.create(CLIENT_SECRET, "return_url")
-        assertFalse(confirmPaymentIntentParams.shouldUseStripeSdk())
+        val params = ConfirmPaymentIntentParams.create(CLIENT_SECRET)
 
-        assertTrue(confirmPaymentIntentParams
-            .withShouldUseStripeSdk(true)
-            .shouldUseStripeSdk())
+        assertThat(params.shouldUseStripeSdk())
+            .isFalse()
+
+        assertThat(
+            params
+                .withShouldUseStripeSdk(true)
+                .shouldUseStripeSdk()
+        ).isTrue()
     }
 
     @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "save_payment_method" to false,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "infer_from_client" to true
-                    )
-                )
-            ),
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
-                )
-            )
-        )
-        val actualParams =
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
+        assertThat(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                 clientSecret = CLIENT_SECRET,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
                 savePaymentMethod = false
             ).toParamMap()
-        assertEquals(expectedParams, actualParams)
-    }
-
-    @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "save_payment_method" to false,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "ip_address" to "127.0.0.1",
-                        "user_agent" to "my_user_agent"
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "save_payment_method" to false,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "infer_from_client" to true
+                        )
                     )
-                )
-            ),
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
+                ),
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
                 )
             )
         )
-        val actualParams =
+    }
+
+    @Test
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
+        assertThat(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                 clientSecret = CLIENT_SECRET,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
                 mandateData = MandateDataParamsFixtures.DEFAULT,
                 savePaymentMethod = false
             ).toParamMap()
-        assertEquals(expectedParams, actualParams)
-    }
-
-    @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "save_payment_method" to false,
-            "use_stripe_sdk" to false,
-            "mandate" to "mandate_123456789",
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "save_payment_method" to false,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "ip_address" to "127.0.0.1",
+                            "user_agent" to "my_user_agent"
+                        )
+                    )
+                ),
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
                 )
             )
         )
-        val actualParams =
+    }
+
+    @Test
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
+        assertThat(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                 clientSecret = CLIENT_SECRET,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
                 mandateId = "mandate_123456789",
                 savePaymentMethod = false
             ).toParamMap()
-        assertEquals(expectedParams, actualParams)
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "save_payment_method" to false,
+                "use_stripe_sdk" to false,
+                "mandate" to "mandate_123456789",
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
+                )
+            )
+        )
     }
 
     @Test
-    fun create_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "ip_address" to "127.0.0.1",
-                        "user_agent" to "my_user_agent"
-                    )
-                )
-            ),
-            "payment_method" to "pm_12345"
-        )
-        val actualParams =
+    fun toParamMap_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
+        assertThat(
             ConfirmPaymentIntentParams.createWithPaymentMethodId(
                 clientSecret = CLIENT_SECRET,
                 paymentMethodId = "pm_12345",
                 mandateData = MandateDataParamsFixtures.DEFAULT
             ).toParamMap()
-        assertEquals(expectedParams, actualParams)
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "ip_address" to "127.0.0.1",
+                            "user_agent" to "my_user_agent"
+                        )
+                    )
+                ),
+                "payment_method" to "pm_12345"
+            )
+        )
     }
 
     @Test
-    fun create_withPaymentMethodOptions() {
-        val params = ConfirmPaymentIntentParams(
-            paymentMethodId = "pm_123",
-            paymentMethodOptions = PaymentMethodOptionsParams.Card(
-                cvc = "123"
-            ),
-            clientSecret = CLIENT_SECRET
-        ).toParamMap()
-
-        assertEquals(
+    fun toParamMap_withPaymentMethodOptions_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmPaymentIntentParams(
+                paymentMethodId = "pm_123",
+                paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                    cvc = "123"
+                ),
+                clientSecret = CLIENT_SECRET
+            ).toParamMap()
+        ).isEqualTo(
             mapOf(
-                PARAM_PAYMENT_METHOD_ID to "pm_123",
-                PARAM_PAYMENT_METHOD_OPTIONS to mapOf("card" to mapOf("cvc" to "123")),
-                PARAM_CLIENT_SECRET to CLIENT_SECRET,
-                PARAM_USE_STRIPE_SDK to false
-            ),
-            params
+                "payment_method" to "pm_123",
+                "payment_method_options" to mapOf("card" to mapOf("cvc" to "123")),
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false
+            )
+        )
+    }
+
+    @Test
+    fun toParamMap_withReceiptEmail_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmPaymentIntentParams(
+                paymentMethodId = "pm_123",
+                clientSecret = CLIENT_SECRET,
+                receiptEmail = "jenny.rosen@example.com"
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "payment_method" to "pm_123",
+                "receipt_email" to "jenny.rosen@example.com"
+            )
         )
     }
 
@@ -352,18 +376,6 @@ class ConfirmPaymentIntentParamsTest {
     }
 
     private companion object {
-        private val FULL_FIELDS_VISA_CARD =
-            Card.Builder(VISA_NO_SPACES, 12, 2050, "123")
-                .name("Captain Cardholder")
-                .addressLine1("1 ABC Street")
-                .addressLine2("Apt. 123")
-                .addressCity("San Francisco")
-                .addressState("CA")
-                .addressZip("94107")
-                .addressState("US")
-                .currency("usd")
-                .build()
-
         private const val CLIENT_SECRET = "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA"
 
         private const val RETURN_URL = "stripe://return_url"


### PR DESCRIPTION
## Summary
- Add `receiptEmail` param
- Make optional parameters `var` to make them easier to update
- Update docstrings

## Motivation
Make `ConfirmPaymentIntentParams` more ergonomic

## Testing
Added tests
Removed redundant tests
Converted tests to use `assertThat`
