### PR TITLE
Update ConfirmSetupIntentParams

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -16,22 +16,36 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class ConfirmSetupIntentParams internal constructor(
     @get:JvmSynthetic override val clientSecret: String,
+
+    /**
+     * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+     * SetupIntent.
+     */
     @get:JvmSynthetic internal val paymentMethodId: String? = null,
+
     @get:JvmSynthetic internal val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
-    private val returnUrl: String? = null,
+
+    /**
+     * The URL to redirect your customer back to after they authenticate on the payment method’s
+     * app or site. If you’d prefer to redirect to a mobile application, you can alternatively
+     * supply an application URI scheme. This parameter is only used for cards and other
+     * redirect-based payment methods.
+     */
+    var returnUrl: String? = null,
+
     private val useStripeSdk: Boolean = false,
 
     /**
      * ID of the mandate to be used for this payment.
      */
-    private val mandateId: String? = null,
+    var mandateId: String? = null,
 
     /**
      * This hash contains details about the Mandate to create.
      *
-     * [mandate_data](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data)
+     * See [mandate_data](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data).
      */
-    private val mandateData: MandateDataParams? = null
+    var mandateData: MandateDataParams? = null
 ) : ConfirmStripeIntentParams, Parcelable {
 
     override fun shouldUseStripeSdk(): Boolean {
@@ -42,22 +56,22 @@ data class ConfirmSetupIntentParams internal constructor(
         return copy(useStripeSdk = shouldUseStripeSdk)
     }
 
-    /**
-     * Create a string-keyed map representing this object that is
-     * ready to be sent over the network.
-     *
-     * @return a String-keyed map
-     */
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
             PARAM_CLIENT_SECRET to clientSecret,
             PARAM_USE_STRIPE_SDK to useStripeSdk
         ).plus(
-            returnUrl?.let { mapOf(PARAM_RETURN_URL to it) }.orEmpty()
+            returnUrl?.let {
+                mapOf(PARAM_RETURN_URL to it)
+            }.orEmpty()
         ).plus(
-            mandateId?.let { mapOf(PARAM_MANDATE_ID to it) }.orEmpty()
+            mandateId?.let {
+                mapOf(PARAM_MANDATE_ID to it)
+            }.orEmpty()
         ).plus(
-            mandateDataParams?.let { mapOf(PARAM_MANDATE_DATA to it) }.orEmpty()
+            mandateDataParams?.let {
+                mapOf(PARAM_MANDATE_DATA to it)
+            }.orEmpty()
         ).plus(paymentMethodParamMap)
     }
 

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -1,176 +1,179 @@
 package com.stripe.android.model
 
+import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class ConfirmSetupIntentParamsTest {
 
     @Test
-    fun shouldUseStripeSdk_withPaymentMethodId() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            "pm_123", "client_secret", "return_url")
-        assertFalse(confirmSetupIntentParams.shouldUseStripeSdk())
-
-        assertTrue(confirmSetupIntentParams
-            .withShouldUseStripeSdk(true)
-            .shouldUseStripeSdk())
-    }
-
-    @Test
-    fun shouldUseStripeSdk_withPaymentMethodCreateParams() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            "client_secret",
-            "return_url"
+    fun shouldUseStripeSdk_shouldReturnExpectedValues() {
+        val params = ConfirmSetupIntentParams.create(
+            "pm_123",
+            CLIENT_SECRET
         )
-        assertFalse(confirmSetupIntentParams.shouldUseStripeSdk())
 
-        assertTrue(confirmSetupIntentParams
-            .withShouldUseStripeSdk(true)
-            .shouldUseStripeSdk())
+        assertThat(params.shouldUseStripeSdk())
+            .isFalse()
+
+        assertThat(
+            params
+                .withShouldUseStripeSdk(true)
+                .shouldUseStripeSdk()
+        ).isTrue()
     }
 
     @Test
-    fun create_withPaymentMethodId_shouldPopulateParamMapCorrectly() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            "pm_12345",
-            "client_secret",
-            null
+    fun toParamMap_withPaymentMethodId_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmSetupIntentParams.create(
+                "pm_12345",
+                CLIENT_SECRET
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "payment_method" to "pm_12345"
+            )
         )
-        val params = confirmSetupIntentParams.toParamMap()
-        assertNull(params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_DATA])
-        assertEquals("pm_12345",
-            params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_ID])
     }
 
     @Test
-    fun create_withPaymentMethodCreateParams_shouldPopulateParamMapCorrectly() {
-        val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
-            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            "client_secret", null
+    fun toParamMap_withPaymentMethodCreateParams_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmSetupIntentParams.create(
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                CLIENT_SECRET
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "payment_method_data" to PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap()
+            )
         )
-        val params = confirmSetupIntentParams.toParamMap()
-        assertNull(params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_ID])
-        val paymentMethodData =
-            params[ConfirmStripeIntentParams.PARAM_PAYMENT_METHOD_DATA] as Map<String, Any>
-        assertEquals("card", paymentMethodData["type"])
-        assertNotNull(paymentMethodData["card"])
     }
 
     @Test
-    fun create_withoutPaymentMethod() {
-        val params = ConfirmSetupIntentParams.createWithoutPaymentMethod("client_secret")
-        assertNull(params.paymentMethodCreateParams)
-        assertNull(params.paymentMethodId)
+    fun toParamMap_withoutPaymentMethod_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmSetupIntentParams.createWithoutPaymentMethod(CLIENT_SECRET)
+                .toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false
+            )
+        )
     }
 
     @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "infer_from_client" to true
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
+        assertThat(
+            ConfirmSetupIntentParams.create(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "infer_from_client" to true
+                        )
                     )
-                )
-            ),
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
+                ),
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
                 )
             )
         )
-
-        val actualParams = ConfirmSetupIntentParams.create(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT
-        ).toParamMap()
-        assertEquals(expectedParams, actualParams)
     }
 
     @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "ip_address" to "127.0.0.1",
-                        "user_agent" to "my_user_agent"
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseMandateDataIfSpecified() {
+        assertThat(
+            ConfirmSetupIntentParams.create(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+                mandateData = MandateDataParamsFixtures.DEFAULT
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "ip_address" to "127.0.0.1",
+                            "user_agent" to "my_user_agent"
+                        )
                     )
-                )
-            ),
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
+                ),
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
                 )
             )
         )
-
-        val actualParams = ConfirmSetupIntentParams.create(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
-            mandateData = MandateDataParamsFixtures.DEFAULT
-        ).toParamMap()
-        assertEquals(expectedParams, actualParams)
     }
 
     @Test
-    fun create_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "use_stripe_sdk" to false,
-            "mandate_data" to mapOf(
-                "customer_acceptance" to mapOf(
-                    "type" to "online",
-                    "online" to mapOf(
-                        "ip_address" to "127.0.0.1",
-                        "user_agent" to "my_user_agent"
+    fun toParamMap_withSepaDebitPaymentMethodId_shouldUseMandateDataIfSpecified() {
+        assertThat(
+            ConfirmSetupIntentParams.create(
+                clientSecret = CLIENT_SECRET,
+                paymentMethodId = "pm_12345",
+                mandateData = MandateDataParamsFixtures.DEFAULT
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "mandate_data" to mapOf(
+                    "customer_acceptance" to mapOf(
+                        "type" to "online",
+                        "online" to mapOf(
+                            "ip_address" to "127.0.0.1",
+                            "user_agent" to "my_user_agent"
+                        )
                     )
-                )
-            ),
-            "payment_method" to "pm_12345"
-        )
-
-        val actualParams = ConfirmSetupIntentParams.create(
-            clientSecret = CLIENT_SECRET,
-            paymentMethodId = "pm_12345",
-            mandateData = MandateDataParamsFixtures.DEFAULT
-        ).toParamMap()
-        assertEquals(expectedParams, actualParams)
-    }
-
-    @Test
-    fun create_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
-        val expectedParams = mapOf(
-            "client_secret" to CLIENT_SECRET,
-            "use_stripe_sdk" to false,
-            "mandate" to "mandate_123456789",
-            "payment_method_data" to mapOf(
-                "type" to "sepa_debit",
-                "sepa_debit" to mapOf(
-                    "iban" to "my_iban"
-                )
+                ),
+                "payment_method" to "pm_12345"
             )
         )
-        val actualParams =
+    }
+
+    @Test
+    fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseMandateIdIfSpecified() {
+        assertThat(
             ConfirmSetupIntentParams.create(
                 clientSecret = CLIENT_SECRET,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
                 mandateId = "mandate_123456789"
             ).toParamMap()
-        assertEquals(expectedParams, actualParams)
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "mandate" to "mandate_123456789",
+                "payment_method_data" to mapOf(
+                    "type" to "sepa_debit",
+                    "sepa_debit" to mapOf(
+                        "iban" to "my_iban"
+                    )
+                )
+            )
+        )
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Make optional parameters `var` to make them easier to update
- Update docstrings

## Motivation
Make `ConfirmSetupIntentParams` more ergonomic

## Testing
Convert tests to use `assertThat`
