### PR TITLE
Capitalize currency code in GooglePayJsonFactory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -129,7 +129,7 @@ class GooglePayJsonFactory constructor(
         transactionInfo: TransactionInfo
     ): JSONObject {
         return JSONObject()
-            .put("currencyCode", transactionInfo.currencyCode)
+            .put("currencyCode", transactionInfo.currencyCode.toUpperCase(Locale.ROOT))
             .put("totalPriceStatus", transactionInfo.totalPriceStatus.code)
             .apply {
                 transactionInfo.countryCode?.let {
@@ -381,7 +381,7 @@ class GooglePayJsonFactory constructor(
         internal val merchantName: String? = null
     ) : Parcelable
 
-    companion object {
+    private companion object {
         private const val API_VERSION = 2
         private const val API_VERSION_MINOR = 0
 

--- a/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -176,6 +176,21 @@ class GooglePayJsonFactoryTest {
     }
 
     @Test
+    fun currencyCode_shouldBeCapitalized() {
+        val createPaymentDataRequestJson = factory.createPaymentDataRequest(
+            transactionInfo = GooglePayJsonFactory.TransactionInfo(
+                currencyCode = "usd",
+                totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final
+            )
+        )
+        val currencyCode = createPaymentDataRequestJson
+            .getJSONObject("transactionInfo")
+            .getString("currencyCode")
+        assertThat(currencyCode)
+            .isEqualTo("USD")
+    }
+
+    @Test
     fun shippingAddressAllowedCountryCodes_shouldBeCapitalized() {
         val createPaymentDataRequestJson = factory.createPaymentDataRequest(
             transactionInfo = GooglePayJsonFactory.TransactionInfo(


### PR DESCRIPTION
## Summary
Capitalize currency code in `GooglePayJsonFactory`

## Motivation
Google Pay API requires this value to be uppercase

## Testing
Added tests