### PR TITLE
Deprecate ActivityStarter.startForResult() with no args

### DIFF
--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
@@ -23,10 +23,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class AddFpxPaymentMethodTest {
-
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @get:Rule
     val activityScenarioRule: ActivityScenarioRule<LauncherActivity> = activityScenarioRule()

--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -40,7 +40,8 @@ class CustomerSessionActivity : AppCompatActivity() {
     }
 
     private fun launchWithCustomer() {
-        PaymentMethodsActivityStarter(this).startForResult()
+        PaymentMethodsActivityStarter(this)
+            .startForResult(PaymentMethodsActivityStarter.Args.Builder().build())
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
@@ -26,6 +26,7 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
         requestCode: Int
     ) : this(
         activity = activity,
+        fragment = null,
         targetClass = targetClass,
         defaultArgs = args,
         requestCode = requestCode
@@ -44,8 +45,12 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
         requestCode = requestCode
     )
 
-    @JvmOverloads
-    fun startForResult(args: ArgsType = defaultArgs) {
+    @Deprecated("startForResult() requires an args parameter")
+    fun startForResult() {
+        startForResult(defaultArgs)
+    }
+
+    fun startForResult(args: ArgsType) {
         val intent = Intent(activity, targetClass)
             .putExtra(Args.EXTRA, args)
 

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -359,7 +359,7 @@ class PaymentSessionTest {
         callback: (ActivityScenario<out ComponentActivity>) -> Unit
     ) {
         activityScenarioFactory.create<PaymentMethodsActivity>(
-            PaymentMethodsActivityStarter.Args.DEFAULT
+            PaymentMethodsActivityStarter.Args.Builder().build()
         ).use(callback)
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -22,10 +22,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class StripePaymentAuthTest {
-
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val activity: Activity = mock()
     private val paymentController: PaymentController = mock()

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
@@ -26,9 +26,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class AddPaymentMethodViewModelTest {
 
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val customerSession: CustomerSession = mock()
     private val paymentMethodRetrievalCaptor: KArgumentCaptor<CustomerSession.PaymentMethodRetrievalListener> = argumentCaptor()
@@ -123,7 +121,7 @@ class AddPaymentMethodViewModelTest {
         return AddPaymentMethodViewModel(
             stripe,
             customerSession,
-            AddPaymentMethodActivityStarter.Args.DEFAULT,
+            AddPaymentMethodActivityStarter.Args.Builder().build(),
             translator
         )
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowActivityTest.kt
@@ -35,12 +35,8 @@ class PaymentFlowActivityTest {
     private val shippingInformationValidator: PaymentSessionConfig.ShippingInformationValidator = mock()
     private val shippingMethodsFactory: PaymentSessionConfig.ShippingMethodsFactory = mock()
 
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
-    private val activityScenarioFactory: ActivityScenarioFactory by lazy {
-        ActivityScenarioFactory(ApplicationProvider.getApplicationContext())
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val activityScenarioFactory = ActivityScenarioFactory(context)
 
     @BeforeTest
     fun setup() {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -29,9 +29,7 @@ class PaymentMethodsAdapterTest {
 
     private val paymentMethodsAdapter: PaymentMethodsAdapter = PaymentMethodsAdapter(ARGS)
 
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @BeforeTest
     fun setup() {

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -47,13 +47,8 @@ class ShippingInfoWidgetTest {
 
     private val ephemeralKeyProvider: EphemeralKeyProvider = mock()
 
-    private val context: Context by lazy {
-        ApplicationProvider.getApplicationContext<Context>()
-    }
-
-    private val activityScenarioFactory: ActivityScenarioFactory by lazy {
-        ActivityScenarioFactory(context)
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val activityScenarioFactory = ActivityScenarioFactory(context)
 
     @BeforeTest
     fun setup() {


### PR DESCRIPTION
This is only being used by `PaymentMethodsActivityStarter`

Also clean up some related tests