### PR TITLE
Support focusedByDefault in CardInputWidget

### DIFF
--- a/example/res/layout/payment_auth_activity.xml
+++ b/example/res/layout/payment_auth_activity.xml
@@ -47,6 +47,7 @@
 
         <com.stripe.android.view.CardInputWidget
             android:id="@+id/card_input_widget"
+            android:focusedByDefault="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
         <Button

--- a/stripe/res/values/attrs.xml
+++ b/stripe/res/values/attrs.xml
@@ -4,6 +4,7 @@
         <attr name="cardHintText" format="string" />
         <attr name="cardTint" format="color"/>
         <attr name="cardTextErrorColor" format="color"/>
+        <attr name="android:focusedByDefault" />
     </declare-styleable>
 
     <declare-styleable name="CardElement">

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -688,6 +688,7 @@ class CardInputWidget @JvmOverloads constructor(
         @ColorInt var errorColorInt = cardNumberEditText.defaultErrorColorInt
         cardBrandView.tintColorInt = cardNumberEditText.hintTextColors.defaultColor
         var cardHintText: String? = null
+        val shouldRequestFocus: Boolean
         if (attrs != null) {
             val a = context.theme.obtainStyledAttributes(
                 attrs,
@@ -701,9 +702,12 @@ class CardInputWidget @JvmOverloads constructor(
                 )
                 errorColorInt = a.getColor(R.styleable.CardInputView_cardTextErrorColor, errorColorInt)
                 cardHintText = a.getString(R.styleable.CardInputView_cardHintText)
+                shouldRequestFocus = a.getBoolean(R.styleable.CardInputView_android_focusedByDefault, true)
             } finally {
                 a.recycle()
             }
+        } else {
+            shouldRequestFocus = false
         }
 
         cardHintText?.let {
@@ -773,7 +777,9 @@ class CardInputWidget @JvmOverloads constructor(
 
         allFields.forEach { it.addTextChangedListener(inputChangeTextWatcher) }
 
-        cardNumberEditText.requestFocus()
+        if (shouldRequestFocus) {
+            cardNumberEditText.requestFocus()
+        }
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -707,7 +707,7 @@ class CardInputWidget @JvmOverloads constructor(
                 a.recycle()
             }
         } else {
-            shouldRequestFocus = false
+            shouldRequestFocus = true
         }
 
         cardHintText?.let {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
See title. Note: This only works on Android API level 26 and above.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ANDROID-536
fixes #2463

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested manually on API 25 and 28.