### PR TITLE
Support starting 3DS2 challenge flow from a Fragmnent

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -1,6 +1,5 @@
 package com.stripe.example.activity
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.example.R
@@ -42,11 +41,6 @@ class FragmentExamplesActivity : AppCompatActivity() {
         fragment?.let {
             supportFragmentManager.putFragment(outState, STATE_FRAGMENT, it)
         }
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        fragment?.onActivityResult(requestCode, resultCode, data)
     }
 
     private companion object {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // Api for this import because we use reflection to alter TextInputLayout
     api 'com.google.android.material:material:1.1.0'
 
-    implementation "com.stripe:stripe-3ds2-android:2.7.8"
+    implementation "com.stripe:stripe-3ds2-android:2.8.1"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -24,6 +24,7 @@ import com.stripe.android.stripe3ds2.transaction.CompletionEvent
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent
 import com.stripe.android.stripe3ds2.transaction.RuntimeErrorEvent
+import com.stripe.android.stripe3ds2.transaction.Stripe3ds2ActivityStarterHost
 import com.stripe.android.stripe3ds2.transaction.StripeChallengeParameters
 import com.stripe.android.stripe3ds2.transaction.StripeChallengeStatusReceiver
 import com.stripe.android.stripe3ds2.transaction.Transaction
@@ -685,10 +686,16 @@ internal class StripePaymentController internal constructor(
                 it.acsTransactionId = ares.acsTransId
             }
 
-            host.activity?.let { activity ->
+            val host = host.fragment?.let { fragment ->
+                Stripe3ds2ActivityStarterHost(fragment)
+            } ?: host.activity?.let { activity ->
+                Stripe3ds2ActivityStarterHost(activity)
+            }
+
+            host?.let {
                 challengeFlowStarter.start(Runnable {
                     transaction.doChallenge(
-                        activity,
+                        it,
                         challengeParameters,
                         PaymentAuth3ds2ChallengeStatusReceiver.create(
                             stripeRepository,

--- a/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
@@ -19,6 +19,9 @@ internal interface AuthActivityStarter<ArgsType> {
         internal val activity: Activity?
             get() = activityRef.get()
 
+        internal val fragment: Fragment?
+            get() = fragmentRef?.get()
+
         internal fun startActivityForResult(target: Class<*>, extras: Bundle, requestCode: Int) {
             val activity = activityRef.get() ?: return
 


### PR DESCRIPTION
## Summary
Previously, the 3DS2 challenge flow could only be started from an
`Activity`. Add support for starting from a `Fragment`.

## Motivation
Fixes #2482

## Testing
Manually verified
