### PR TITLE
Use CustomerSession.stripeAccountId in AddPaymentMethodActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -27,7 +27,7 @@ class CustomerSession @VisibleForTesting internal constructor(
     context: Context,
     stripeRepository: StripeRepository,
     publishableKey: String,
-    stripeAccountId: String?,
+    internal val stripeAccountId: String?,
     private val threadPoolExecutor: ThreadPoolExecutor = createThreadPoolExecutor(),
     private val operationIdFactory: OperationIdFactory = StripeOperationIdFactory(),
     private val timeSupplier: TimeSupplier = { Calendar.getInstance().timeInMillis },

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -39,7 +39,11 @@ class AddPaymentMethodActivity : StripeActivity() {
     private val stripe: Stripe by lazy {
         val paymentConfiguration = args.paymentConfiguration
             ?: PaymentConfiguration.getInstance(this)
-        Stripe(applicationContext, paymentConfiguration.publishableKey)
+        Stripe(
+            applicationContext,
+            publishableKey = paymentConfiguration.publishableKey,
+            stripeAccountId = customerSession.stripeAccountId
+        )
     }
 
     private val paymentMethodType: PaymentMethod.Type by lazy {


### PR DESCRIPTION
## Summary
This property must be used to correctly create a PaymentMethod as the
connected again, when specified.

## Motivation
MOBILE-266

