### PR TITLE
Add canDeletePaymentMethods configurations

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CustomerSessionActivity.kt
@@ -41,7 +41,9 @@ class CustomerSessionActivity : AppCompatActivity() {
 
     private fun launchWithCustomer() {
         PaymentMethodsActivityStarter(this)
-            .startForResult(PaymentMethodsActivityStarter.Args.Builder().build())
+            .startForResult(PaymentMethodsActivityStarter.Args.Builder()
+                .setCanDeletePaymentMethods(true)
+                .build())
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -84,6 +84,7 @@ class PaymentSessionActivity : AppCompatActivity() {
                 .setWindowFlags(WindowManager.LayoutParams.FLAG_SECURE)
                 .setBillingAddressFields(BillingAddressFields.PostalCode)
                 .setShouldPrefetchCustomer(shouldPrefetchCustomer)
+                .setCanDeletePaymentMethods(true)
                 .build()
         )
         paymentSession.init(

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -237,7 +237,7 @@ class PaymentSession @VisibleForTesting internal constructor(
                 .setWindowFlags(config.windowFlags)
                 .setBillingAddressFields(config.billingAddressFields)
                 .setUseGooglePay(viewModel.paymentSessionData.useGooglePay)
-                .setCanDeletePaymentOptions(config.canDeletePaymentOptions)
+                .setCanDeletePaymentMethods(config.canDeletePaymentMethods)
                 .build()
         )
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -237,6 +237,7 @@ class PaymentSession @VisibleForTesting internal constructor(
                 .setWindowFlags(config.windowFlags)
                 .setBillingAddressFields(config.billingAddressFields)
                 .setUseGooglePay(viewModel.paymentSessionData.useGooglePay)
+                .setCanDeletePaymentOptions(config.canDeletePaymentOptions)
                 .build()
         )
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -199,7 +199,7 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
-         * @param canDeletePaymentMethods canDeletePaymentMethods controls whether the user can
+         * @param canDeletePaymentMethods controls whether the user can
          * delete a payment method by swiping on it in [PaymentMethodsActivity]. Defaults to true.
          */
         fun setCanDeletePaymentMethods(canDeletePaymentMethods: Boolean): Builder = apply {

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.ShippingMethod
 import com.stripe.android.view.AddPaymentMethodActivity
 import com.stripe.android.view.BillingAddressFields
 import com.stripe.android.view.PaymentFlowActivity
+import com.stripe.android.view.PaymentMethodsActivity
 import com.stripe.android.view.SelectShippingMethodWidget
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.android.view.ShippingInfoWidget.CustomizableShippingField
@@ -34,6 +35,7 @@ data class PaymentSessionConfig internal constructor(
     val shouldShowGooglePay: Boolean = false,
     val allowedShippingCountryCodes: Set<String> = emptySet(),
     val billingAddressFields: BillingAddressFields = DEFAULT_BILLING_ADDRESS_FIELDS,
+    val canDeletePaymentOptions: Boolean = true,
 
     internal val shouldPrefetchCustomer: Boolean = true,
     internal val shippingInformationValidator: ShippingInformationValidator = DefaultShippingInfoValidator(),
@@ -100,6 +102,7 @@ data class PaymentSessionConfig internal constructor(
         private var shippingMethodsFactory: ShippingMethodsFactory? = null
         private var windowFlags: Int? = null
         private var shouldPrefetchCustomer: Boolean = true
+        private var canDeletePaymentOptions: Boolean = true
 
         @LayoutRes
         private var addPaymentMethodFooterLayoutId: Int = 0
@@ -196,6 +199,14 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
+         * @param canDeletePaymentOptions if `false`, user could not remove payment method
+         * by swiping right on the selected payment method in [PaymentMethodsActivity]
+         */
+        fun setCanDeletePaymentOptions(canDeletePaymentOptions: Boolean): Builder = apply {
+            this.canDeletePaymentOptions = canDeletePaymentOptions
+        }
+
+        /**
          * @param allowedShippingCountryCodes A set of allowed country codes for the
          * customer's shipping address. Will be ignored if empty.
          */
@@ -264,7 +275,8 @@ data class PaymentSessionConfig internal constructor(
                 shippingMethodsFactory = shippingMethodsFactory,
                 windowFlags = windowFlags,
                 billingAddressFields = billingAddressFields,
-                shouldPrefetchCustomer = shouldPrefetchCustomer
+                shouldPrefetchCustomer = shouldPrefetchCustomer,
+                canDeletePaymentOptions = canDeletePaymentOptions
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -199,7 +199,7 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
-         * @param canDeletePaymentMethods canDeletePaymentMethods controls whether the use can
+         * @param canDeletePaymentMethods canDeletePaymentMethods controls whether the user can
          * delete a payment method by swiping on it in [PaymentMethodsActivity]. Defaults to true.
          */
         fun setCanDeletePaymentMethods(canDeletePaymentMethods: Boolean): Builder = apply {

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -35,7 +35,7 @@ data class PaymentSessionConfig internal constructor(
     val shouldShowGooglePay: Boolean = false,
     val allowedShippingCountryCodes: Set<String> = emptySet(),
     val billingAddressFields: BillingAddressFields = DEFAULT_BILLING_ADDRESS_FIELDS,
-    val canDeletePaymentOptions: Boolean = true,
+    val canDeletePaymentMethods: Boolean = true,
 
     internal val shouldPrefetchCustomer: Boolean = true,
     internal val shippingInformationValidator: ShippingInformationValidator = DefaultShippingInfoValidator(),
@@ -102,7 +102,7 @@ data class PaymentSessionConfig internal constructor(
         private var shippingMethodsFactory: ShippingMethodsFactory? = null
         private var windowFlags: Int? = null
         private var shouldPrefetchCustomer: Boolean = true
-        private var canDeletePaymentOptions: Boolean = true
+        private var canDeletePaymentMethods: Boolean = true
 
         @LayoutRes
         private var addPaymentMethodFooterLayoutId: Int = 0
@@ -199,11 +199,11 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
-         * @param canDeletePaymentOptions if `false`, user could not remove payment method
+         * @param canDeletePaymentMethods if `false`, user could not remove payment method
          * by swiping right on the selected payment method in [PaymentMethodsActivity]
          */
-        fun setCanDeletePaymentOptions(canDeletePaymentOptions: Boolean): Builder = apply {
-            this.canDeletePaymentOptions = canDeletePaymentOptions
+        fun setCanDeletePaymentMethods(canDeletePaymentMethods: Boolean): Builder = apply {
+            this.canDeletePaymentMethods = canDeletePaymentMethods
         }
 
         /**
@@ -276,7 +276,7 @@ data class PaymentSessionConfig internal constructor(
                 windowFlags = windowFlags,
                 billingAddressFields = billingAddressFields,
                 shouldPrefetchCustomer = shouldPrefetchCustomer,
-                canDeletePaymentOptions = canDeletePaymentOptions
+                canDeletePaymentMethods = canDeletePaymentMethods
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -199,8 +199,8 @@ data class PaymentSessionConfig internal constructor(
         }
 
         /**
-         * @param canDeletePaymentMethods if `false`, user could not remove payment method
-         * by swiping right on the selected payment method in [PaymentMethodsActivity]
+         * @param canDeletePaymentMethods canDeletePaymentMethods controls whether the use can
+         * delete a payment method by swiping on it in [PaymentMethodsActivity]. Defaults to true.
          */
         fun setCanDeletePaymentMethods(canDeletePaymentMethods: Boolean): Builder = apply {
             this.canDeletePaymentMethods = canDeletePaymentMethods

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -66,7 +66,8 @@ class PaymentMethodsActivity : AppCompatActivity() {
             addableTypes = args.paymentMethodTypes,
             initiallySelectedPaymentMethodId = viewModel.selectedPaymentMethodId,
             shouldShowGooglePay = args.shouldShowGooglePay,
-            useGooglePay = args.useGooglePay
+            useGooglePay = args.useGooglePay,
+            canDeletePaymentOptions = args.canDeletePaymentOptions
         )
     }
 
@@ -131,12 +132,15 @@ class PaymentMethodsActivity : AppCompatActivity() {
 
         viewBinding.recycler.adapter = adapter
         viewBinding.recycler.paymentMethodSelectedCallback = { finishWithResult(it) }
-        viewBinding.recycler.attachItemTouchHelper(
-            PaymentMethodSwipeCallback(
-                this, adapter,
-                SwipeToDeleteCallbackListener(deletePaymentMethodDialogFactory)
+
+        if (args.canDeletePaymentOptions) {
+            viewBinding.recycler.attachItemTouchHelper(
+                PaymentMethodSwipeCallback(
+                    this, adapter,
+                    SwipeToDeleteCallbackListener(deletePaymentMethodDialogFactory)
+                )
             )
-        )
+        }
     }
 
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -67,7 +67,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
             initiallySelectedPaymentMethodId = viewModel.selectedPaymentMethodId,
             shouldShowGooglePay = args.shouldShowGooglePay,
             useGooglePay = args.useGooglePay,
-            canDeletePaymentOptions = args.canDeletePaymentOptions
+            canDeletePaymentMethods = args.canDeletePaymentMethods
         )
     }
 
@@ -133,7 +133,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
         viewBinding.recycler.adapter = adapter
         viewBinding.recycler.paymentMethodSelectedCallback = { finishWithResult(it) }
 
-        if (args.canDeletePaymentOptions) {
+        if (args.canDeletePaymentMethods) {
             viewBinding.recycler.attachItemTouchHelper(
                 PaymentMethodSwipeCallback(
                     this, adapter,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -47,7 +47,9 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
         internal val windowFlags: Int? = null,
         internal val billingAddressFields: BillingAddressFields,
         internal val shouldShowGooglePay: Boolean = false,
-        internal val useGooglePay: Boolean = false
+        internal val useGooglePay: Boolean = false,
+        internal val canDeletePaymentOptions: Boolean = true
+
     ) : ActivityStarter.Args {
         class Builder : ObjectBuilder<Args> {
             private var billingAddressFields: BillingAddressFields = BillingAddressFields.PostalCode
@@ -56,6 +58,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             private var paymentMethodTypes: List<PaymentMethod.Type>? = null
             private var shouldShowGooglePay: Boolean = false
             private var useGooglePay: Boolean = false
+            private var canDeletePaymentOptions: Boolean = true
             private var paymentConfiguration: PaymentConfiguration? = null
             private var windowFlags: Int? = null
 
@@ -134,6 +137,10 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                 this.useGooglePay = useGooglePay
             }
 
+            fun setCanDeletePaymentOptions(canDeletePaymentOptions: Boolean): Builder = apply {
+                this.canDeletePaymentOptions = canDeletePaymentOptions
+            }
+
             override fun build(): Args {
                 return Args(
                     initialPaymentMethodId = initialPaymentMethodId,
@@ -144,7 +151,8 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                     paymentConfiguration = paymentConfiguration,
                     addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId,
                     windowFlags = windowFlags,
-                    billingAddressFields = billingAddressFields
+                    billingAddressFields = billingAddressFields,
+                    canDeletePaymentOptions = canDeletePaymentOptions
                 )
             }
         }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -48,7 +48,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
         internal val billingAddressFields: BillingAddressFields,
         internal val shouldShowGooglePay: Boolean = false,
         internal val useGooglePay: Boolean = false,
-        internal val canDeletePaymentOptions: Boolean = true
+        internal val canDeletePaymentMethods: Boolean = true
 
     ) : ActivityStarter.Args {
         class Builder : ObjectBuilder<Args> {
@@ -58,7 +58,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             private var paymentMethodTypes: List<PaymentMethod.Type>? = null
             private var shouldShowGooglePay: Boolean = false
             private var useGooglePay: Boolean = false
-            private var canDeletePaymentOptions: Boolean = true
+            private var canDeletePaymentMethods: Boolean = true
             private var paymentConfiguration: PaymentConfiguration? = null
             private var windowFlags: Int? = null
 
@@ -137,8 +137,8 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                 this.useGooglePay = useGooglePay
             }
 
-            fun setCanDeletePaymentOptions(canDeletePaymentOptions: Boolean): Builder = apply {
-                this.canDeletePaymentOptions = canDeletePaymentOptions
+            fun setCanDeletePaymentMethods(canDeletePaymentMethods: Boolean): Builder = apply {
+                this.canDeletePaymentMethods = canDeletePaymentMethods
             }
 
             override fun build(): Args {
@@ -152,7 +152,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                     addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId,
                     windowFlags = windowFlags,
                     billingAddressFields = billingAddressFields,
-                    canDeletePaymentOptions = canDeletePaymentOptions
+                    canDeletePaymentMethods = canDeletePaymentMethods
                 )
             }
         }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -26,7 +26,7 @@ internal class PaymentMethodsAdapter constructor(
     initiallySelectedPaymentMethodId: String? = null,
     private val shouldShowGooglePay: Boolean = false,
     private val useGooglePay: Boolean = false,
-    private val canDeletePaymentOptions: Boolean = true
+    private val canDeletePaymentMethods: Boolean = true
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     internal val paymentMethods = mutableListOf<PaymentMethod>()
@@ -178,7 +178,7 @@ internal class PaymentMethodsAdapter constructor(
     ): ViewHolder.PaymentMethodViewHolder {
         val viewHolder = ViewHolder.PaymentMethodViewHolder(parent)
 
-        if (this.canDeletePaymentOptions) {
+        if (canDeletePaymentMethods) {
             ViewCompat.addAccessibilityAction(
                 viewHolder.itemView,
                 parent.context.getString(R.string.delete_payment_method)

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -25,7 +25,8 @@ internal class PaymentMethodsAdapter constructor(
     private val addableTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card),
     initiallySelectedPaymentMethodId: String? = null,
     private val shouldShowGooglePay: Boolean = false,
-    private val useGooglePay: Boolean = false
+    private val useGooglePay: Boolean = false,
+    private val canDeletePaymentOptions: Boolean = true
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     internal val paymentMethods = mutableListOf<PaymentMethod>()
@@ -176,14 +177,17 @@ internal class PaymentMethodsAdapter constructor(
         parent: ViewGroup
     ): ViewHolder.PaymentMethodViewHolder {
         val viewHolder = ViewHolder.PaymentMethodViewHolder(parent)
-        ViewCompat.addAccessibilityAction(
-            viewHolder.itemView,
-            parent.context.getString(R.string.delete_payment_method)
-        ) { _, _ ->
-            listener?.onDeletePaymentMethodAction(
-                paymentMethod = getPaymentMethodAtPosition(viewHolder.adapterPosition)
-            )
-            true
+
+        if (this.canDeletePaymentOptions) {
+            ViewCompat.addAccessibilityAction(
+                viewHolder.itemView,
+                parent.context.getString(R.string.delete_payment_method)
+            ) { _, _ ->
+                listener?.onDeletePaymentMethodAction(
+                    paymentMethod = getPaymentMethodAtPosition(viewHolder.adapterPosition)
+                )
+                true
+            }
         }
         return viewHolder
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -53,6 +53,10 @@ internal object PaymentSessionFixtures {
         .setBillingAddressFields(BillingAddressFields.Full)
         .setShouldPrefetchCustomer(true)
 
+        // Enable PaymentMethod Deletion from PaymentMethodActivity
+        // This is default behavior
+        .setCanDeletePaymentMethods(true)
+
         .setShippingInformationValidator(FakeShippingInformationValidator())
         .setShippingMethodsFactory(FakeShippingMethodsFactory())
         .build()

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFalse
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentMethodsActivityStarterTest {
@@ -49,6 +50,16 @@ class PaymentMethodsActivityStarterTest {
             PaymentMethodsActivityStarter.Args.Builder()
                 .build()
                 .paymentMethodTypes
+        )
+    }
+
+    @Test
+    fun testDisableDeletePaymentMethods() {
+        assertFalse (
+            PaymentMethodsActivityStarter.Args.Builder()
+                .setCanDeletePaymentMethods(false)
+                .build()
+                .canDeletePaymentMethods
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityStarterTest.kt
@@ -10,9 +10,9 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.assertFalse
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentMethodsActivityStarterTest {
@@ -55,7 +55,7 @@ class PaymentMethodsActivityStarterTest {
 
     @Test
     fun testDisableDeletePaymentMethods() {
-        assertFalse (
+        assertFalse(
             PaymentMethodsActivityStarter.Args.Builder()
                 .setCanDeletePaymentMethods(false)
                 .build()


### PR DESCRIPTION
## Summary
Adding configuration `canDeletePaymentMethods` allowing enable/disable PaymentMethod detachment 

## Motivation
Feature request from
https://github.com/stripe/stripe-android/issues/2459 

## Testing
- Tested with Example App 
- Run unit tests and pass
