### PR TITLE
Revert "Use CustomerSession.stripeAccountId in AddPaymentMethodActivity (#2504)"

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -27,7 +27,7 @@ class CustomerSession @VisibleForTesting internal constructor(
     context: Context,
     stripeRepository: StripeRepository,
     publishableKey: String,
-    internal val stripeAccountId: String?,
+    stripeAccountId: String?,
     private val threadPoolExecutor: ThreadPoolExecutor = createThreadPoolExecutor(),
     private val operationIdFactory: OperationIdFactory = StripeOperationIdFactory(),
     private val timeSupplier: TimeSupplier = { Calendar.getInstance().timeInMillis },

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -39,11 +39,7 @@ class AddPaymentMethodActivity : StripeActivity() {
     private val stripe: Stripe by lazy {
         val paymentConfiguration = args.paymentConfiguration
             ?: PaymentConfiguration.getInstance(this)
-        Stripe(
-            applicationContext,
-            publishableKey = paymentConfiguration.publishableKey,
-            stripeAccountId = customerSession.stripeAccountId
-        )
+        Stripe(applicationContext, paymentConfiguration.publishableKey)
     }
 
     private val paymentMethodType: PaymentMethod.Type by lazy {


### PR DESCRIPTION
## Summary
This reverts commit 58f29a73a4628bce1cd1a81e28d582d46f825780.

## Motivation
This is a breaking change, so we'll add it back in for an upcoming major version bump.