### PR TITLE
Convert CustomerSession's ThreadPoolExecutor to CoroutineDispatcher

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CustomerSessionEphemeralKeyManagerListener.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSessionEphemeralKeyManagerListener.kt
@@ -1,10 +1,12 @@
 package com.stripe.android
 
-import java.util.concurrent.ThreadPoolExecutor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 internal class CustomerSessionEphemeralKeyManagerListener(
     private val runnableFactory: CustomerSessionRunnableFactory,
-    private val executor: ThreadPoolExecutor,
+    private val workDispatcher: CoroutineDispatcher,
     private val listeners: MutableMap<String, CustomerSession.RetrievalListener?>
 ) : EphemeralKeyManager.KeyManagerListener {
     override fun onKeyUpdate(
@@ -12,7 +14,9 @@ internal class CustomerSessionEphemeralKeyManagerListener(
         operation: EphemeralOperation
     ) {
         runnableFactory.create(ephemeralKey, operation)?.let {
-            executor.execute(it)
+            CoroutineScope(workDispatcher).launch {
+                it.run()
+            }
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -20,16 +20,15 @@ import com.stripe.android.testharness.TestEphemeralKeyProvider
 import com.stripe.android.view.AddPaymentMethodActivity
 import com.stripe.android.view.PaymentMethodsActivity
 import java.util.Calendar
-import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlinx.coroutines.Dispatchers
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.doAnswer
 import org.robolectric.RobolectricTestRunner
 
 /**
@@ -37,9 +36,7 @@ import org.robolectric.RobolectricTestRunner
  */
 @RunWith(RobolectricTestRunner::class)
 class CustomerSessionTest {
-
     private val stripeRepository: StripeRepository = mock()
-    private val threadPoolExecutor: ThreadPoolExecutor = mock()
 
     private val paymentMethodRetrievalListener: CustomerSession.PaymentMethodRetrievalListener = mock()
     private val paymentMethodsRetrievalListener: CustomerSession.PaymentMethodsRetrievalListener = mock()
@@ -111,11 +108,6 @@ class CustomerSessionTest {
             any()
         ))
             .thenReturn(listOf(PAYMENT_METHOD))
-
-        doAnswer { invocation ->
-            invocation.getArgument<Runnable>(0).run()
-            null
-        }.`when`<ThreadPoolExecutor>(threadPoolExecutor).execute(any())
     }
 
     @Test
@@ -736,7 +728,7 @@ class CustomerSessionTest {
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             "acct_abc123",
             timeSupplier = timeSupplier,
-            threadPoolExecutor = threadPoolExecutor,
+            workDispatcher = Dispatchers.Main,
             ephemeralKeyManagerFactory = ephemeralKeyManagerFactory
         )
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -15,7 +15,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.model.Customer
 import com.stripe.android.model.CustomerFixtures
 import com.stripe.android.model.PaymentMethod
@@ -29,13 +28,13 @@ import com.stripe.android.view.PaymentFlowActivity
 import com.stripe.android.view.PaymentFlowActivityStarter
 import com.stripe.android.view.PaymentMethodsActivity
 import com.stripe.android.view.PaymentMethodsActivityStarter
-import java.util.concurrent.ThreadPoolExecutor
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
@@ -50,7 +49,6 @@ class PaymentSessionTest {
 
     private val ephemeralKeyProvider = TestEphemeralKeyProvider()
 
-    private val threadPoolExecutor: ThreadPoolExecutor = mock()
     private val paymentSessionListener: PaymentSession.PaymentSessionListener = mock()
     private val customerSession: CustomerSession = mock()
     private val paymentMethodsActivityStarter:
@@ -68,9 +66,6 @@ class PaymentSessionTest {
     @BeforeTest
     fun setup() {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
-        whenever(threadPoolExecutor.execute(any())).thenAnswer {
-            it.getArgument<Runnable>(0).run()
-        }
         CustomerSession.instance = createCustomerSession()
     }
 
@@ -342,7 +337,7 @@ class PaymentSessionTest {
             stripeRepository,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             "acct_abc123",
-            threadPoolExecutor = threadPoolExecutor,
+            workDispatcher = Dispatchers.Main,
             ephemeralKeyManagerFactory = EphemeralKeyManager.Factory.Default(
                 keyProvider = ephemeralKeyProvider,
                 shouldPrefetchEphemeralKey = true


### PR DESCRIPTION
## Motivation
Simplify API for starting async work

## Testing
Update unit tests
Manually verify
