### PR TITLE
Use TestCoroutineScope instead of MainScope in tests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
@@ -12,7 +12,6 @@ import com.stripe.android.StripeError
 import com.stripe.android.model.Customer
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
-import java.lang.RuntimeException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/stripe/src/test/java/com/stripe/android/ApiOperationTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiOperationTest.kt
@@ -9,16 +9,17 @@ import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.exception.RateLimitException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
-import java.lang.RuntimeException
 import kotlin.test.Test
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.json.JSONException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class ApiOperationTest {
-
     private val callback: ApiResultCallback<PaymentIntent> = mock()
 
     @Test
@@ -89,7 +90,7 @@ class ApiOperationTest {
         private val resultSupplier: () -> PaymentIntent?,
         callback: ApiResultCallback<PaymentIntent>
     ) : ApiOperation<PaymentIntent>(
-        workScope = MainScope(),
+        workScope = TestCoroutineScope(TestCoroutineDispatcher()),
         callback = callback
     ) {
         override suspend fun getResult(): PaymentIntent? = resultSupplier()

--- a/stripe/src/test/java/com/stripe/android/FingerprintRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintRequestExecutorTest.kt
@@ -7,12 +7,17 @@ import com.nhaarman.mockitokotlin2.whenever
 import java.io.IOException
 import java.util.UUID
 import kotlin.test.Test
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class FingerprintRequestExecutorTest {
+    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
+
     private val fingerprintRequestFactory = FingerprintRequestFactory(
         context = ApplicationProvider.getApplicationContext()
     )
@@ -76,7 +81,7 @@ class FingerprintRequestExecutorTest {
     private fun createFingerprintRequestExecutor(
         connectionFactory: ConnectionFactory = ConnectionFactory.Default()
     ) = FingerprintRequestExecutor.Default(
-        workScope = MainScope(),
+        workScope = testScope,
         connectionFactory = connectionFactory
     )
 

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -16,15 +16,19 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.Token
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class StripeEndToEndTest {
-
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val defaultStripe = Stripe(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+
+    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
 
     @Test
     fun testCreateAccountToken() {
@@ -56,7 +60,7 @@ class StripeEndToEndTest {
     @Test
     fun retrievePaymentIntentAsync_withInvalidClientSecret_shouldReturnInvalidRequestException() {
         val paymentIntentCallback: ApiResultCallback<PaymentIntent> = mock()
-        createStripeWithMainScope().retrievePaymentIntent(
+        createStripeWithTestScope().retrievePaymentIntent(
             clientSecret = "pi_abc_secret_invalid",
             callback = paymentIntentCallback
         )
@@ -72,7 +76,7 @@ class StripeEndToEndTest {
     fun retrieveSetupIntentAsync_withInvalidClientSecret_shouldReturnInvalidRequestException() {
         val setupIntentCallback: ApiResultCallback<SetupIntent> = mock()
 
-        createStripeWithMainScope().retrieveSetupIntent(
+        createStripeWithTestScope().retrieveSetupIntent(
             clientSecret = "seti_abc_secret_invalid",
             callback = setupIntentCallback
         )
@@ -84,7 +88,7 @@ class StripeEndToEndTest {
         )
     }
 
-    private fun createStripeWithMainScope(
+    private fun createStripeWithTestScope(
         publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     ): Stripe {
         val stripeRepository = StripeApiRepository(context, publishableKey)
@@ -96,7 +100,7 @@ class StripeEndToEndTest {
                 stripeRepository
             ),
             publishableKey = publishableKey,
-            workScope = MainScope()
+            workScope = testScope
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
@@ -27,7 +27,7 @@ class FpxViewModelTest {
     }
 
     @Test
-    fun loadFpxBankStatues_workingOnMainThread_shouldUpdateLiveData() {
+    fun `getFpxBankStatues should update LiveData`() {
         val viewModel = FpxViewModel(application, workContext = testDispatcher)
         testDispatcher.runBlockingTest {
             var bankStatuses: FpxBankStatuses? = null

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
@@ -18,21 +18,26 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class PaymentFlowViewModelTest {
     private val customerSession: CustomerSession = mock()
 
     private val customerRetrievalListener: KArgumentCaptor<CustomerSession.CustomerRetrievalListener> = argumentCaptor()
 
+    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
+
     private val viewModel: PaymentFlowViewModel by lazy {
         PaymentFlowViewModel(
             customerSession = customerSession,
             paymentSessionData = PaymentSessionData(PaymentSessionFixtures.CONFIG),
-            workScope = MainScope()
+            workScope = testScope
         )
     }
 


### PR DESCRIPTION
`TestCoroutineScope` provides better control of coroutines in tests and
reports uncaught exceptions in test failures.

See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
for more details.