### PR TITLE
Fix lint warnings related to context leak

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/BaseViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/BaseViewModel.kt
@@ -1,7 +1,7 @@
 package com.stripe.example.activity
 
 import android.app.Application
-import android.content.Context
+import android.content.res.Resources
 import androidx.lifecycle.AndroidViewModel
 import com.stripe.example.module.BackendApiFactory
 import com.stripe.example.service.BackendApi
@@ -13,9 +13,9 @@ import kotlin.coroutines.CoroutineContext
 abstract class BaseViewModel(
     application: Application
 ) : AndroidViewModel(application) {
-    protected val context: Context = application.applicationContext
+    protected val resources: Resources = application.resources
     protected val workContext: CoroutineContext = Dispatchers.IO + SupervisorJob()
-    protected val backendApi: BackendApi = BackendApiFactory(application.applicationContext).create()
+    protected val backendApi: BackendApi = BackendApiFactory(application).create()
 
     override fun onCleared() {
         super.onCleared()

--- a/example/src/main/java/com/stripe/example/activity/PaymentMethodViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentMethodViewModel.kt
@@ -12,7 +12,7 @@ import com.stripe.example.StripeFactory
 internal class PaymentMethodViewModel(
     application: Application
 ) : AndroidViewModel(application) {
-    private val stripe = StripeFactory(application.applicationContext).create()
+    private val stripe = StripeFactory(application).create()
 
     internal fun createPaymentMethod(
         params: PaymentMethodCreateParams

--- a/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
@@ -12,7 +12,7 @@ import com.stripe.example.StripeFactory
 internal class SourceViewModel(
     application: Application
 ) : AndroidViewModel(application) {
-    private val stripe = StripeFactory(application.applicationContext).create()
+    private val stripe = StripeFactory(application).create()
 
     internal var source: Source? = null
 

--- a/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
@@ -49,7 +49,7 @@ internal class StripeIntentViewModel(
         apiMethod: suspend () -> ResponseBody
     ) = liveData<Result<JSONObject>>(workContext) {
         inProgress.postValue(true)
-        status.postValue(context.getString(creatingStringRes))
+        status.postValue(resources.getString(creatingStringRes))
 
         val result = runCatching {
             JSONObject(apiMethod().string())
@@ -57,7 +57,7 @@ internal class StripeIntentViewModel(
 
         result.fold(
             onSuccess = {
-                val intentStatus = context.getString(
+                val intentStatus = resources.getString(
                     resultStringRes,
                     it.getString("status")
                 )

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -18,8 +18,7 @@ internal class PaymentSessionViewModel(
     private val savedStateHandle: SavedStateHandle,
     paymentSessionData: PaymentSessionData,
     private val customerSession: CustomerSession,
-    private val paymentSessionPrefs: PaymentSessionPrefs =
-        PaymentSessionPrefs.create(application.applicationContext)
+    private val paymentSessionPrefs: PaymentSessionPrefs = PaymentSessionPrefs.create(application)
 ) : AndroidViewModel(application) {
 
     var paymentSessionData: PaymentSessionData = paymentSessionData

--- a/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -16,11 +16,9 @@ internal class FpxViewModel @JvmOverloads internal constructor(
     application: Application,
     private val workContext: CoroutineContext = Dispatchers.IO
 ) : AndroidViewModel(application) {
-
-    private val context = application.applicationContext
-    private val publishableKey = PaymentConfiguration.getInstance(context).publishableKey
+    private val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
     private val stripeRepository = StripeApiRepository(
-        context,
+        application,
         publishableKey,
         workContext = workContext
     )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -20,8 +20,8 @@ internal class PaymentMethodsViewModel(
     internal var selectedPaymentMethodId: String? = null,
     private val startedFromPaymentSession: Boolean
 ) : AndroidViewModel(application) {
-    private val context = application.applicationContext
-    private val cardDisplayTextFactory = CardDisplayTextFactory(context)
+    private val resources = application.resources
+    private val cardDisplayTextFactory = CardDisplayTextFactory(application)
 
     internal val productUsage: Set<String> = listOfNotNull(
         PaymentSession.PRODUCT_TOKEN.takeIf { startedFromPaymentSession },
@@ -50,7 +50,7 @@ internal class PaymentMethodsViewModel(
         @StringRes stringRes: Int
     ): String? {
         return paymentMethod.card?.let { paymentMethodId ->
-            context.getString(
+            resources.getString(
                 stringRes,
                 cardDisplayTextFactory.createUnstyled(paymentMethodId)
             )


### PR DESCRIPTION
Lint complains about ViewModels that have `Context` instance properties.