### PR TITLE
Don't exit webview when Alipay intent fails to resolve

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -204,8 +204,12 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
             logger.debug("PaymentAuthWebViewClient#openIntent()")
             if (intent.resolveActivity(packageManager) != null) {
                 activity.startActivity(intent)
-            } else {
-                // complete auth if the deep-link can't be opened
+            } else if (intent.scheme != "alipays") {
+                // complete auth if the deep-link can't be opened unless it is Alipay.
+                // The Alipay web view tries to open the Alipay app as soon as it is opened
+                // irrespective of whether or not the app is installed.
+                // If this intent fails to resolve, we should still let the user
+                // continue on the mobile site.
                 onAuthCompleted()
             }
         }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -111,6 +111,14 @@ class PaymentAuthWebViewTest {
     }
 
     @Test
+    fun shouldOverloadUrlLoading_withAlipayDeeplink_shouldNotFinishActivity() {
+        val url = "alipays://link"
+        val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
+        verify(activity, never()).finish()
+    }
+
+    @Test
     fun shouldOverrideUrlLoading_withIntentUri_shouldParseUri() {
         val deepLink = "intent://example.com/#Intent;scheme=https;action=android.intent.action.VIEW;end"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Normally, if a web view tries to open an intent and that intent can't resolve, we consider this a failure and exit. However, this breaks the alipay use case.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Making alipay work

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested manually
