### PR TITLE
Don't cancel source when non-3DSecure webview cancelled

### DIFF
--- a/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
@@ -82,7 +82,7 @@ internal class StripeIntentViewModel(
                     $errorMessage
                     """.trimIndent()
                 )
-                inProgress.value = false
+                inProgress.postValue(false)
             }
         )
 

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -30,7 +30,8 @@ internal class PaymentAuthWebViewStarter internal constructor(
         val returnUrl: String? = null,
         val enableLogging: Boolean = false,
         val toolbarCustomization: StripeToolbarCustomization? = null,
-        val stripeAccountId: String? = null
+        val stripeAccountId: String? = null,
+        val shouldCancelSource: Boolean = false
     ) : Parcelable
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -499,10 +499,12 @@ internal class StripePaymentController internal constructor(
                         stripeIntent.clientSecret.orEmpty(),
                         nextActionData.url,
                         requestOptions.stripeAccount,
-                        enableLogging = enableLogging
+                        enableLogging = enableLogging,
+                        // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
+                        shouldCancelSource = true
                     )
                 }
-                is StripeIntent.NextActionData.RedirectToUrl -> {
+                is RedirectToUrl -> {
                     analyticsRequestExecutor.executeAsync(
                         analyticsRequestFactory.create(
                             analyticsDataFactory.createAuthParams(
@@ -702,7 +704,9 @@ internal class StripePaymentController internal constructor(
                     stripeIntent.clientSecret.orEmpty(),
                     result.fallbackRedirectUrl,
                     requestOptions.stripeAccount,
-                    enableLogging = enableLogging
+                    enableLogging = enableLogging,
+                    // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
+                    shouldCancelSource = true
                 )
             } else {
                 val error = result.error
@@ -1028,12 +1032,14 @@ internal class StripePaymentController internal constructor(
             authUrl: String,
             stripeAccount: String?,
             returnUrl: String? = null,
-            enableLogging: Boolean = false
+            enableLogging: Boolean = false,
+            shouldCancelSource: Boolean = false
         ) {
             Logger.getInstance(enableLogging).debug("PaymentAuthWebViewStarter#start()")
             val starter = PaymentAuthWebViewStarter(host, requestCode)
             starter.start(
-                PaymentAuthWebViewStarter.Args(clientSecret, authUrl, returnUrl, enableLogging, stripeAccountId = stripeAccount)
+                PaymentAuthWebViewStarter.Args(clientSecret, authUrl, returnUrl, enableLogging,
+                    stripeAccountId = stripeAccount, shouldCancelSource = shouldCancelSource)
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -8,7 +8,6 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.Logger
@@ -105,10 +104,8 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
     }
 
     private fun cancelIntentSource() {
-        viewModel.cancelIntentSource().observe(this, Observer { intent ->
-            setResult(Activity.RESULT_OK, intent)
-            finish()
-        })
+        setResult(Activity.RESULT_OK, viewModel.cancellationResult)
+        finish()
     }
 
     private fun customizeToolbar() {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -2,8 +2,6 @@ package com.stripe.android.view
 
 import android.content.Intent
 import android.net.Uri
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.PaymentAuthWebViewStarter
@@ -39,17 +37,16 @@ internal class PaymentAuthWebViewActivityViewModel(
             )
         }
 
-    @JvmSynthetic
-    internal fun cancelIntentSource(): LiveData<Intent> {
-        val resultData = MutableLiveData<Intent>()
-        resultData.value = Intent().putExtras(
-            paymentResult.copy(
-                flowOutcome = StripeIntentResult.Outcome.CANCELED,
-                shouldCancelSource = args.shouldCancelSource
-            ).toBundle()
-        )
-        return resultData
-    }
+    internal val cancellationResult: Intent
+        @JvmSynthetic
+        get() {
+            return Intent().putExtras(
+                paymentResult.copy(
+                    flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                    shouldCancelSource = args.shouldCancelSource
+                ).toBundle()
+            )
+        }
 
     internal data class ToolbarTitleData(
         internal val text: String,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -45,7 +45,7 @@ internal class PaymentAuthWebViewActivityViewModel(
         resultData.value = Intent().putExtras(
             paymentResult.copy(
                 flowOutcome = StripeIntentResult.Outcome.CANCELED,
-                shouldCancelSource = true
+                shouldCancelSource = args.shouldCancelSource
             ).toBundle()
         )
         return resultData

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -18,7 +18,8 @@ class PaymentAuthWebViewActivityViewModelTest {
         val viewModel = PaymentAuthWebViewActivityViewModel(
             PaymentAuthWebViewStarter.Args(
                 clientSecret = "client_secret",
-                url = "https://example.com"
+                url = "https://example.com",
+                shouldCancelSource = true
             )
         )
 
@@ -27,9 +28,11 @@ class PaymentAuthWebViewActivityViewModelTest {
             intent = it
         }
 
+        val resultIntent = PaymentController.Result.fromIntent(requireNotNull(intent))
         assertThat(
-            PaymentController.Result.fromIntent(requireNotNull(intent))?.flowOutcome
+            resultIntent?.flowOutcome
         ).isEqualTo(StripeIntentResult.Outcome.CANCELED)
+        assertThat(resultIntent?.shouldCancelSource).isTrue()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.view
 
-import android.content.Intent
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentAuthWebViewStarter
 import com.stripe.android.PaymentController
@@ -14,7 +13,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PaymentAuthWebViewActivityViewModelTest {
     @Test
-    fun cancelIntentSource() {
+    fun cancellationResult() {
         val viewModel = PaymentAuthWebViewActivityViewModel(
             PaymentAuthWebViewStarter.Args(
                 clientSecret = "client_secret",
@@ -23,11 +22,7 @@ class PaymentAuthWebViewActivityViewModelTest {
             )
         )
 
-        var intent: Intent? = null
-        viewModel.cancelIntentSource().observeForever {
-            intent = it
-        }
-
+        val intent = viewModel.cancellationResult
         val resultIntent = PaymentController.Result.fromIntent(requireNotNull(intent))
         assertThat(
             resultIntent?.flowOutcome


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add a param to PaymentAuthWebView to indicate whether we should cancel the source if the user cancels the web view. This is only set to true for 3D-Secure based flows.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Per discussion in AUTHN-631, this endpoint is only intended to be used for 3DS1/2 and throws an error when used for other flows.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Modified tests. Tested manually.