### PR TITLE
Update PaymentAuthWebViewActivity back button behavior

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -101,7 +101,11 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        cancelIntentSource()
+        if (viewBinding.authWebView.canGoBack()) {
+            viewBinding.authWebView.goBack()
+        } else {
+            cancelIntentSource()
+        }
     }
 
     private fun cancelIntentSource() {


### PR DESCRIPTION
## Summary
If `PaymentAuthWebViewActivity`'s `WebView` can go back, do that instead
of finishing the Activity.

## Motivation
Improve user experience

## Testing
Manually tested