### PR TITLE
Set constraint on ApiResultCallback's generic type

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiOperation.kt
@@ -4,6 +4,7 @@ import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.APIException
 import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.exception.StripeException
+import com.stripe.android.model.StripeModel
 import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
@@ -12,7 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONException
 
-internal abstract class ApiOperation<ResultType>(
+internal abstract class ApiOperation<out ResultType : StripeModel>(
     private val workScope: CoroutineScope = CoroutineScope(IO),
     private val callback: ApiResultCallback<ResultType>
 ) {

--- a/stripe/src/main/java/com/stripe/android/ApiResultCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiResultCallback.kt
@@ -1,10 +1,12 @@
 package com.stripe.android
 
+import com.stripe.android.model.StripeModel
+
 /**
  * Generic interface for an API operation callback that either returns a
  * result, [ResultType], or an [Exception]
  */
-interface ApiResultCallback<ResultType> {
+interface ApiResultCallback<in ResultType : StripeModel> {
     fun onSuccess(result: ResultType)
 
     fun onError(e: Exception)

--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -12,6 +12,7 @@ import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.exception.PermissionException
 import com.stripe.android.exception.RateLimitException
 import com.stripe.android.exception.StripeException
+import com.stripe.android.model.Complete3ds2Result
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
@@ -858,7 +859,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     @VisibleForTesting
     @Throws(InvalidRequestException::class, APIConnectionException::class, APIException::class,
         CardException::class, AuthenticationException::class)
-    internal fun complete3ds2Auth(sourceId: String, requestOptions: ApiRequest.Options): Boolean {
+    internal fun complete3ds2Auth(
+        sourceId: String,
+        requestOptions: ApiRequest.Options
+    ): Complete3ds2Result {
         val response = makeApiRequest(
             apiRequestFactory.createPost(
                 getApiUrl("3ds2/challenge_complete"),
@@ -866,13 +870,13 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("source" to sourceId)
             )
         )
-        return response.isOk
+        return Complete3ds2Result(response.isOk)
     }
 
     override fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<Boolean>
+        callback: ApiResultCallback<Complete3ds2Result>
     ) {
         Complete3ds2AuthTask(this, sourceId, requestOptions, callback)
             .execute()
@@ -1062,10 +1066,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         private val stripeApiRepository: StripeApiRepository,
         private val sourceId: String,
         private val requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<Boolean>
-    ) : ApiOperation<Boolean>(callback = callback) {
+        callback: ApiResultCallback<Complete3ds2Result>
+    ) : ApiOperation<Complete3ds2Result>(callback = callback) {
         @Throws(StripeException::class)
-        override suspend fun getResult(): Boolean {
+        override suspend fun getResult(): Complete3ds2Result {
             return stripeApiRepository.complete3ds2Auth(sourceId, requestOptions)
         }
     }

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -6,6 +6,7 @@ import com.stripe.android.exception.APIException
 import com.stripe.android.exception.AuthenticationException
 import com.stripe.android.exception.CardException
 import com.stripe.android.exception.InvalidRequestException
+import com.stripe.android.model.Complete3ds2Result
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
@@ -242,7 +243,7 @@ internal interface StripeRepository {
     fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<Boolean>
+        callback: ApiResultCallback<Complete3ds2Result>
     )
 
     fun createFile(

--- a/stripe/src/main/java/com/stripe/android/model/AlipayAuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AlipayAuthResult.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.model
+
+import com.stripe.android.StripeIntentResult
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+internal data class AlipayAuthResult(
+    @StripeIntentResult.Outcome val outcome: Int
+) : StripeModel

--- a/stripe/src/main/java/com/stripe/android/model/Complete3ds2Result.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Complete3ds2Result.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.model
+
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+internal data class Complete3ds2Result(val result: Boolean) : StripeModel

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import androidx.lifecycle.MutableLiveData
 import com.stripe.android.exception.APIException
+import com.stripe.android.model.Complete3ds2Result
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.Customer
@@ -241,7 +242,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     override fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<Boolean>
+        callback: ApiResultCallback<Complete3ds2Result>
     ) {
     }
 

--- a/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.PaymentIntentFixtures
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
@@ -12,7 +13,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class AlipayAuthenticationTaskTest {
     private val intent = PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION
-    private val callback: ApiResultCallback<Int> = mock()
+    private val callback: ApiResultCallback<AlipayAuthResult> = mock()
 
     @Test
     fun `AlipayAuthenticationTask should handle success`() {
@@ -22,7 +23,8 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         val result = runBlocking { task.getResult() }
-        assertThat(result).isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
+        assertThat(result?.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
     }
 
     @Test
@@ -33,7 +35,8 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         val result = runBlocking { task.getResult() }
-        assertThat(result).isEqualTo(StripeIntentResult.Outcome.CANCELED)
+        assertThat(result?.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.CANCELED)
     }
 
     @Test
@@ -44,7 +47,8 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         val result = runBlocking { task.getResult() }
-        assertThat(result).isEqualTo(StripeIntentResult.Outcome.FAILED)
+        assertThat(result?.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.FAILED)
     }
 
     @Test
@@ -55,7 +59,8 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         val result = runBlocking { task.getResult() }
-        assertThat(result).isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
+        assertThat(result?.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
     }
 
     @Test
@@ -66,7 +71,8 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         val result = runBlocking { task.getResult() }
-        assertThat(result).isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
+        assertThat(result?.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -19,6 +19,7 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.exception.APIException
 import com.stripe.android.exception.InvalidRequestException
+import com.stripe.android.model.Complete3ds2Result
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntent
@@ -804,9 +805,9 @@ class StripePaymentControllerTest {
         override fun complete3ds2Auth(
             sourceId: String,
             requestOptions: ApiRequest.Options,
-            callback: ApiResultCallback<Boolean>
+            callback: ApiResultCallback<Complete3ds2Result>
         ) {
-            callback.onSuccess(true)
+            callback.onSuccess(Complete3ds2Result(true))
         }
 
         override fun retrieveIntent(


### PR DESCRIPTION
`ResultType` is now `out StripeModel`