### PR TITLE
Make Token.Type an enum

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -50,6 +50,23 @@
             else -> {}
         }
         ```
+- Changes to `Token`
+    - `Token.TokenType` is renamed to `Token.Type` and is now an enum
+        ```kotlin
+        // before
+        when (token.type) {
+            Token.TokenType.CARD -> {}
+            Token.TokenType.BANK_ACCOUNT -> {}
+            else -> {}
+        }
+
+        // after
+        when (token.type) {
+            Token.Type.Card -> {}
+            Token.Type.BankAccount -> {}
+            else -> {}
+        }
+        ```
 - Changes to `AddPaymentMethodActivity`
     - When `CustomerSession` is instantiated with a `stripeAccountId`, it will be used in `AddPaymentMethodActivity`
       when creating a payment method

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -121,7 +121,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createTokenCreationParams(
         productUsageTokens: Set<String>?,
-        @Token.TokenType tokenType: String
+        tokenType: Token.Type
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.TokenCreate,
@@ -259,7 +259,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         event: AnalyticsEvent,
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String? = null,
-        @Token.TokenType tokenType: String? = null,
+        tokenType: Token.Type? = null,
         extraParams: Map<String, Any>? = null
     ): Map<String, Any> {
         return createStandardParams(event)
@@ -276,10 +276,10 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     private fun createTokenTypeParam(
         @Source.SourceType sourceType: String? = null,
-        @Token.TokenType tokenType: String? = null
+        tokenType: Token.Type? = null
     ): Map<String, String> {
         val value = when {
-            tokenType != null -> tokenType
+            tokenType != null -> tokenType.code
             // This is not a source event, so to match iOS we log a token without type
             // as type "unknown"
             sourceType == null -> "unknown"

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
@@ -35,26 +35,17 @@ data class AccountParams internal constructor(
      * See [BusinessTypeParams]
      */
     private val businessData: Map<String, @RawValue Any>? = null
-) : TokenParams(Token.TokenType.ACCOUNT) {
-
-    /**
-     * Create a string-keyed map representing this object that is ready to be sent over the network.
-     *
-     * @return a String-keyed map
-     */
-    override fun toParamMap(): Map<String, Any> {
-        return mapOf("account" to
-            mapOf(PARAM_TOS_SHOWN_AND_ACCEPTED to tosShownAndAccepted)
-                .plus(
-                    businessType?.code?.let { code ->
-                        mapOf(PARAM_BUSINESS_TYPE to code)
-                            .plus(
-                                businessData?.let { mapOf(code to it) }.orEmpty()
-                            )
-                    }.orEmpty()
-                )
-        )
-    }
+) : TokenParams(Token.Type.Account) {
+    override val typeDataParams: Map<String, Any>
+        get() = mapOf(PARAM_TOS_SHOWN_AND_ACCEPTED to tosShownAndAccepted)
+            .plus(
+                businessType?.code?.let { code ->
+                    mapOf(PARAM_BUSINESS_TYPE to code)
+                        .plus(
+                            businessData?.let { mapOf(code to it) }.orEmpty()
+                        )
+                }.orEmpty()
+            )
 
     /**
      * The business type.

--- a/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
@@ -53,7 +53,7 @@ data class BankAccountTokenParams @JvmOverloads constructor(
      * [bank_account.routing_number](https://stripe.com/docs/api/tokens/create_bank_account#create_bank_account_token-bank_account-routing_number)
      */
     private val routingNumber: String? = null
-) : TokenParams(Token.TokenType.BANK_ACCOUNT) {
+) : TokenParams(Token.Type.BankAccount) {
     enum class Type(internal val code: String) {
         Individual("individual"),
         Company("company");
@@ -66,8 +66,8 @@ data class BankAccountTokenParams @JvmOverloads constructor(
         }
     }
 
-    override fun toParamMap(): Map<String, Any> {
-        val bankAccountParams: Map<String, String> = listOf(
+    override val typeDataParams: Map<String, Any>
+        get() = listOf(
             PARAM_COUNTRY to country,
             PARAM_CURRENCY to currency,
             PARAM_ACCOUNT_HOLDER_NAME to accountHolderName,
@@ -79,9 +79,6 @@ data class BankAccountTokenParams @JvmOverloads constructor(
                 value?.let { mapOf(key to it) }.orEmpty()
             )
         }
-
-        return mapOf(Token.TokenType.BANK_ACCOUNT to bankAccountParams)
-    }
 
     private companion object {
         private const val PARAM_COUNTRY = "country"

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -191,7 +191,7 @@ data class Card internal constructor(
      * See [API Reference](https://stripe.com/docs/api/cards/object#card_object-metadata).
      */
     val metadata: Map<String, String>?
-) : StripeModel, StripePaymentSource, TokenParams(Token.TokenType.CARD, loggingTokens) {
+) : StripeModel, StripePaymentSource, TokenParams(Token.Type.Card, loggingTokens) {
 
     fun toPaymentMethodsParams(): PaymentMethodCreateParams {
         return PaymentMethodCreateParams.create(
@@ -332,8 +332,8 @@ data class Card internal constructor(
         }
     }
 
-    override fun toParamMap(): Map<String, Any> {
-        return CardParams(
+    override val typeDataParams: Map<String, Any>
+        get() = CardParams(
             number = number.orEmpty(),
             expMonth = expMonth ?: 0,
             expYear = expYear ?: 0,
@@ -349,7 +349,6 @@ data class Card internal constructor(
                 country = addressCountry
             )
         ).toParamMap()
-    }
 
     /**
      * Builder class for a [Card] model.

--- a/stripe/src/main/java/com/stripe/android/model/CardParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardParams.kt
@@ -144,7 +144,7 @@ internal data class CardParams internal constructor(
     )
 
     override fun toParamMap(): Map<String, Any> {
-        val params: Map<String, Any> = listOf(
+        return listOf(
             PARAM_NUMBER to number,
             PARAM_EXP_MONTH to expMonth,
             PARAM_EXP_YEAR to expYear,
@@ -162,8 +162,6 @@ internal data class CardParams internal constructor(
                 value?.let { mapOf(key to it) }.orEmpty()
             )
         }
-
-        return mapOf(Token.TokenType.CARD to params)
     }
 
     private companion object {

--- a/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
@@ -5,10 +5,7 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class CvcTokenParams(
     private val cvc: String
-) : TokenParams(Token.TokenType.CVC_UPDATE) {
-    override fun toParamMap(): Map<String, Any> {
-        return mapOf(
-            Token.TokenType.CVC_UPDATE to mapOf("cvc" to cvc)
-        )
-    }
+) : TokenParams(Token.Type.CvcUpdate) {
+    override val typeDataParams: Map<String, Any>
+        get() = mapOf("cvc" to cvc)
 }

--- a/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
@@ -150,36 +150,33 @@ data class PersonTokenParams(
      * [person.verification](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification)
      */
     val verification: Verification? = null
-) : TokenParams(Token.TokenType.BANK_ACCOUNT) {
-    override fun toParamMap(): Map<String, Any> {
-        return mapOf(PARAM_PERSON to
-            listOf(
-                PARAM_ADDRESS to address?.toParamMap(),
-                PARAM_ADDRESS_KANA to addressKana?.toParamMap(),
-                PARAM_ADDRESS_KANJI to addressKanji?.toParamMap(),
-                PARAM_DOB to dateOfBirth?.toParamMap(),
-                PARAM_EMAIL to email,
-                PARAM_FIRST_NAME to firstName,
-                PARAM_FIRST_NAME_KANA to firstNameKana,
-                PARAM_FIRST_NAME_KANJI to firstNameKanji,
-                PARAM_GENDER to gender,
-                PARAM_ID_NUMBER to idNumber,
-                PARAM_LAST_NAME to lastName,
-                PARAM_LAST_NAME_KANA to lastNameKana,
-                PARAM_LAST_NAME_KANJI to lastNameKanji,
-                PARAM_MAIDEN_NAME to maidenName,
-                PARAM_METADATA to metadata,
-                PARAM_PHONE to phone,
-                PARAM_RELATIONSHIP to relationship?.toParamMap(),
-                PARAM_SSN_LAST_4 to ssnLast4,
-                PARAM_VERIFICATION to verification?.toParamMap()
-            ).fold(emptyMap<String, Any>()) { acc, (key, value) ->
-                acc.plus(
-                    value?.let { mapOf(key to it) }.orEmpty()
-                )
-            }
-        )
-    }
+) : TokenParams(Token.Type.Person) {
+    override val typeDataParams: Map<String, Any>
+        get() = listOf(
+            PARAM_ADDRESS to address?.toParamMap(),
+            PARAM_ADDRESS_KANA to addressKana?.toParamMap(),
+            PARAM_ADDRESS_KANJI to addressKanji?.toParamMap(),
+            PARAM_DOB to dateOfBirth?.toParamMap(),
+            PARAM_EMAIL to email,
+            PARAM_FIRST_NAME to firstName,
+            PARAM_FIRST_NAME_KANA to firstNameKana,
+            PARAM_FIRST_NAME_KANJI to firstNameKanji,
+            PARAM_GENDER to gender,
+            PARAM_ID_NUMBER to idNumber,
+            PARAM_LAST_NAME to lastName,
+            PARAM_LAST_NAME_KANA to lastNameKana,
+            PARAM_LAST_NAME_KANJI to lastNameKanji,
+            PARAM_MAIDEN_NAME to maidenName,
+            PARAM_METADATA to metadata,
+            PARAM_PHONE to phone,
+            PARAM_RELATIONSHIP to relationship?.toParamMap(),
+            PARAM_SSN_LAST_4 to ssnLast4,
+            PARAM_VERIFICATION to verification?.toParamMap()
+        ).fold(emptyMap()) { acc, (key, value) ->
+            acc.plus(
+                value?.let { mapOf(key to it) }.orEmpty()
+            )
+        }
 
     /**
      * The relationship that this person has with the account’s legal entity.

--- a/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
@@ -8,10 +8,7 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 internal data class PiiTokenParams(
     private val personalId: String
-) : TokenParams(Token.TokenType.PII) {
-    override fun toParamMap(): Map<String, Any> {
-        return mapOf(
-            Token.TokenType.PII to mapOf("personal_id_number" to personalId)
-        )
-    }
+) : TokenParams(Token.Type.Pii) {
+    override val typeDataParams: Map<String, Any>
+        get() = mapOf("personal_id_number" to personalId)
 }

--- a/stripe/src/main/java/com/stripe/android/model/Token.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Token.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
-import androidx.annotation.StringDef
-import com.stripe.android.model.Token.TokenType
+import com.stripe.android.model.Token.Type
 import com.stripe.android.model.parsers.TokenJsonParser
 import java.util.Date
 import kotlinx.android.parcel.Parcelize
@@ -16,70 +15,54 @@ import org.json.JSONObject
 data class Token internal constructor(
 
     /**
-     * @return the Token id
+     * The Token id
      */
     override val id: String,
 
     /**
-     * @return Get the [TokenType] of this token.
+     * The [Type] of this token.
      */
-    @get:TokenType
-    val type: String,
+    val type: Type,
 
-    /***
-     * @return the [Date] this token was created
+    /**
+     * The [Date] this token was created
      */
     val created: Date,
 
     /**
-     * @return `true` if this token is valid for a real payment, `false` if
-     * it is only usable for testing
+     * `true` if this token is valid for a real payment, `false` if it is only usable for testing
      */
     val livemode: Boolean,
 
     /**
-     * @return `true` if this token has been used, `false` otherwise
+     * `true` if this token has been used, `false` otherwise
      */
     val used: Boolean,
 
     /**
-     * @return the [BankAccount] for this token
+     * If applicable, the [BankAccount] for this token
      */
     val bankAccount: BankAccount? = null,
 
     /**
-     * @return the [Card] for this token
+     * If applicable, the [Card] for this token
      */
     val card: Card? = null
 ) : StripeModel, StripePaymentSource {
-    @Retention(AnnotationRetention.SOURCE)
-    @StringDef(TokenType.CARD, TokenType.BANK_ACCOUNT, TokenType.PII, TokenType.ACCOUNT,
-        TokenType.CVC_UPDATE, TokenType.PERSON)
-    annotation class TokenType {
-        companion object {
-            const val CARD: String = "card"
-            const val BANK_ACCOUNT: String = "bank_account"
-            const val PII: String = "pii"
-            const val ACCOUNT: String = "account"
-            const val CVC_UPDATE: String = "cvc_update"
-            const val PERSON: String = "person"
+    enum class Type(internal val code: String) {
+        Card("card"),
+        BankAccount("bank_account"),
+        Pii("pii"),
+        Account("account"),
+        CvcUpdate("cvc_update"),
+        Person("person");
+
+        internal companion object {
+            fun fromCode(code: String?) = values().firstOrNull { it.code == code }
         }
     }
 
     companion object {
-        @JvmStatic
-        fun fromString(jsonString: String?): Token? {
-            if (jsonString == null) {
-                return null
-            }
-
-            return runCatching {
-                JSONObject(jsonString)
-            }.getOrNull()?.let {
-                fromJson(it)
-            }
-        }
-
         @JvmStatic
         fun fromJson(jsonObject: JSONObject?): Token? {
             return jsonObject?.let {

--- a/stripe/src/main/java/com/stripe/android/model/TokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/TokenParams.kt
@@ -3,9 +3,13 @@ package com.stripe.android.model
 import android.os.Parcelable
 
 abstract class TokenParams(
-    @Token.TokenType internal val tokenType: String,
+    internal val tokenType: Token.Type,
     /**
      * The SDK components that were involved in the creation of this token
      */
     internal val attribution: Set<String> = emptySet()
-) : StripeParamsModel, Parcelable
+) : StripeParamsModel, Parcelable {
+    abstract val typeDataParams: Map<String, Any>
+
+    override fun toParamMap(): Map<String, Any> = mapOf(tokenType.code to typeDataParams)
+}

--- a/stripe/src/main/java/com/stripe/android/model/parsers/TokenJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/TokenJsonParser.kt
@@ -2,92 +2,67 @@ package com.stripe.android.model.parsers
 
 import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.Token
-import com.stripe.android.model.Token.TokenType
+import com.stripe.android.model.Token.Type
 import java.util.Date
+import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 
 internal class TokenJsonParser : ModelJsonParser<Token> {
     override fun parse(json: JSONObject): Token? {
         val tokenId = StripeJsonUtils.optString(json, FIELD_ID)
         val createdTimeStamp = StripeJsonUtils.optLong(json, FIELD_CREATED)
-        @Token.TokenType val tokenType =
-            asTokenType(StripeJsonUtils.optString(json, FIELD_TYPE))
-        if (tokenId == null || createdTimeStamp == null) {
+        val tokenType = Token.Type.fromCode(StripeJsonUtils.optString(json, FIELD_TYPE))
+        if (tokenType == null || tokenId == null || createdTimeStamp == null) {
             return null
         }
 
         val used = StripeJsonUtils.optBoolean(json, FIELD_USED)
         val liveMode = StripeJsonUtils.optBoolean(json, FIELD_LIVEMODE)
-        val date = Date(createdTimeStamp * 1000)
+        val date = Date(TimeUnit.SECONDS.toMillis(createdTimeStamp))
 
-        return if (TokenType.BANK_ACCOUNT == tokenType) {
-            json.optJSONObject(FIELD_BANK_ACCOUNT)?.let {
+        return when (tokenType) {
+            Type.Card -> {
+                json.optJSONObject(Type.Card.code)?.let {
+                    Token(
+                        id = tokenId,
+                        livemode = liveMode,
+                        created = date,
+                        used = used,
+                        type = Type.Card,
+                        card = CardJsonParser().parse(it)
+                    )
+                }
+            }
+            Type.BankAccount -> {
+                json.optJSONObject(Type.BankAccount.code)?.let {
+                    Token(
+                        id = tokenId,
+                        livemode = liveMode,
+                        created = date,
+                        used = used,
+                        type = Type.BankAccount,
+                        bankAccount = BankAccountJsonParser().parse(it)
+                    )
+                }
+            }
+            else -> {
                 Token(
                     id = tokenId,
+                    type = tokenType,
                     livemode = liveMode,
                     created = date,
-                    used = used,
-                    type = TokenType.BANK_ACCOUNT,
-                    bankAccount = BankAccountJsonParser().parse(it)
+                    used = used
                 )
             }
-        } else if (TokenType.CARD == tokenType) {
-            json.optJSONObject(FIELD_CARD)?.let {
-                Token(
-                    id = tokenId,
-                    livemode = liveMode,
-                    created = date,
-                    used = used,
-                    type = TokenType.CARD,
-                    card = CardJsonParser().parse(it)
-                )
-            }
-        } else if (
-            TokenType.PII == tokenType || TokenType.ACCOUNT == tokenType ||
-            TokenType.CVC_UPDATE == tokenType || TokenType.PERSON == tokenType
-        ) {
-            Token(
-                id = tokenId,
-                type = tokenType,
-                livemode = liveMode,
-                created = date,
-                used = used
-            )
-        } else {
-            null
         }
     }
 
     private companion object {
-        // The key for these object fields is identical to their retrieved values
-        // from the Type field.
-        private const val FIELD_BANK_ACCOUNT = TokenType.BANK_ACCOUNT
-        private const val FIELD_CARD = TokenType.CARD
         private const val FIELD_CREATED = "created"
         private const val FIELD_ID = "id"
         private const val FIELD_LIVEMODE = "livemode"
 
         private const val FIELD_TYPE = "type"
         private const val FIELD_USED = "used"
-
-        /**
-         * Converts an unchecked String value to a [TokenType] or `null`.
-         *
-         * @param possibleTokenType a String that might match a [TokenType] or be empty
-         * @return `null` if the input is blank or otherwise does not match a [TokenType],
-         * else the appropriate [TokenType].
-         */
-        @TokenType
-        private fun asTokenType(possibleTokenType: String?): String? {
-            return when (possibleTokenType) {
-                TokenType.CARD -> TokenType.CARD
-                TokenType.BANK_ACCOUNT -> TokenType.BANK_ACCOUNT
-                TokenType.PII -> TokenType.PII
-                TokenType.ACCOUNT -> TokenType.ACCOUNT
-                TokenType.CVC_UPDATE -> TokenType.CVC_UPDATE
-                TokenType.PERSON -> TokenType.PERSON
-                else -> null
-            }
-        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -33,7 +33,7 @@ class AnalyticsDataFactoryTest {
 
         val params = analyticsDataFactory.createTokenCreationParams(
             ATTRIBUTION,
-            Token.TokenType.PII
+            Token.Type.Pii
         )
         // Size is SIZE-1 because tokens don't have a source_type field
         assertEquals(
@@ -41,7 +41,7 @@ class AnalyticsDataFactoryTest {
             params.size
         )
         assertEquals(expectedEvent, params[AnalyticsDataFactory.FIELD_EVENT])
-        assertEquals(Token.TokenType.PII, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
+        assertEquals(Token.Type.Pii.code, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
     }
 
     @Test
@@ -51,7 +51,7 @@ class AnalyticsDataFactoryTest {
 
         val params = analyticsDataFactory.createTokenCreationParams(
             ATTRIBUTION,
-            Token.TokenType.CVC_UPDATE
+            Token.Type.CvcUpdate
         )
         // Size is SIZE-1 because tokens don't have a source_type field
         assertEquals(
@@ -59,7 +59,7 @@ class AnalyticsDataFactoryTest {
             params.size
         )
         assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
-        assertEquals(Token.TokenType.CVC_UPDATE, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
+        assertEquals(Token.Type.CvcUpdate.code, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
     }
 
     @Test
@@ -170,12 +170,12 @@ class AnalyticsDataFactoryTest {
         val params = AnalyticsDataFactory(packageManager, packageInfo, packageName, API_KEY)
             .createTokenCreationParams(
                 ATTRIBUTION,
-                Token.TokenType.CARD
+                Token.Type.Card
             )
         assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 1, params.size)
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(ATTRIBUTION.toList(), params[AnalyticsDataFactory.FIELD_PRODUCT_USAGE])
-        assertEquals(Token.TokenType.CARD, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
+        assertEquals(Token.Type.Card.code, params[AnalyticsDataFactory.FIELD_TOKEN_TYPE])
         assertEquals(Build.VERSION.SDK_INT, params[AnalyticsDataFactory.FIELD_OS_VERSION])
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_RELEASE])
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_NAME])
@@ -197,11 +197,11 @@ class AnalyticsDataFactoryTest {
         val expectedUaName = AnalyticsDataFactory.ANALYTICS_UA
 
         val params = analyticsDataFactory.createSourceCreationParams(
-            Token.TokenType.BANK_ACCOUNT
+            Source.SourceType.SEPA_DEBIT
         )
         assertEquals(AnalyticsDataFactory.VALID_PARAM_FIELDS.size - 2, params.size)
         assertEquals(API_KEY, params[AnalyticsDataFactory.FIELD_PUBLISHABLE_KEY])
-        assertEquals(Token.TokenType.BANK_ACCOUNT, params[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
+        assertEquals(Source.SourceType.SEPA_DEBIT, params[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
 
         assertEquals(Build.VERSION.SDK_INT, params[AnalyticsDataFactory.FIELD_OS_VERSION])
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_RELEASE])

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -42,7 +42,7 @@ class StripeEndToEndTest {
                 )
             )
         )
-        assertEquals(Token.TokenType.ACCOUNT, token?.type)
+        assertEquals(Token.Type.Account, token?.type)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -150,7 +150,7 @@ public class StripeTest {
         Card returnedCard = token.getCard();
         assertNotNull(returnedCard);
         assertNull(token.getBankAccount());
-        assertEquals(Token.TokenType.CARD, token.getType());
+        assertEquals(Token.Type.Card, token.getType());
         assertEquals(CARD.getLast4(), returnedCard.getLast4());
         assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
@@ -173,7 +173,7 @@ public class StripeTest {
         Card returnedCard = token.getCard();
         assertNotNull(returnedCard);
         assertNull(token.getBankAccount());
-        assertEquals(Token.TokenType.CARD, token.getType());
+        assertEquals(Token.Type.Card, token.getType());
         assertEquals(CARD.getLast4(), returnedCard.getLast4());
         assertEquals(CardBrand.Visa, returnedCard.getBrand());
         assertEquals(CARD.getExpYear(), returnedCard.getExpYear());
@@ -278,7 +278,7 @@ public class StripeTest {
                 BankAccountTokenParamsFixtures.DEFAULT
         );
         assertNotNull(token);
-        assertEquals(Token.TokenType.BANK_ACCOUNT, token.getType());
+        assertEquals(Token.Type.BankAccount, token.getType());
         assertNull(token.getCard());
 
         final BankAccount returnedBankAccount = token.getBankAccount();
@@ -900,7 +900,7 @@ public class StripeTest {
             throws StripeException {
         final Token token = defaultStripe.createPiiTokenSynchronous("0123456789");
         assertNotNull(token);
-        assertEquals(Token.TokenType.PII, token.getType());
+        assertEquals(Token.Type.Pii, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -912,7 +912,7 @@ public class StripeTest {
 
         final Token token = defaultStripe.createCvcUpdateTokenSynchronous("1234");
         assertNotNull(token);
-        assertEquals(Token.TokenType.CVC_UPDATE, token.getType());
+        assertEquals(Token.Type.CvcUpdate, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -925,7 +925,7 @@ public class StripeTest {
         stripe.createPersonToken(PersonTokenParamsFixtures.PARAMS, tokenCallback);
         verify(tokenCallback).onSuccess(tokenArgumentCaptor.capture());
         final Token token = tokenArgumentCaptor.getValue();
-        assertEquals(Token.TokenType.PERSON, Objects.requireNonNull(token).getType());
+        assertEquals(Token.Type.Person, Objects.requireNonNull(token).getType());
         assertTrue(token.getId().startsWith("cpt_"));
     }
 
@@ -933,7 +933,7 @@ public class StripeTest {
     public void testCreatePersonTokenSynchronous() throws StripeException {
         final Token token =
                 defaultStripe.createPersonTokenSynchronous(PersonTokenParamsFixtures.PARAMS);
-        assertEquals(Token.TokenType.PERSON, Objects.requireNonNull(token).getType());
+        assertEquals(Token.Type.Person, Objects.requireNonNull(token).getType());
         assertTrue(token.getId().startsWith("cpt_"));
     }
 
@@ -952,7 +952,7 @@ public class StripeTest {
                 )
         );
         assertNotNull(token);
-        assertEquals(Token.TokenType.ACCOUNT, token.getType());
+        assertEquals(Token.Type.Account, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -972,7 +972,7 @@ public class StripeTest {
                 )
         );
         assertNotNull(token);
-        assertEquals(Token.TokenType.ACCOUNT, token.getType());
+        assertEquals(Token.Type.Account, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -992,7 +992,7 @@ public class StripeTest {
                 )
         );
         assertNotNull(token);
-        assertEquals(Token.TokenType.ACCOUNT, token.getType());
+        assertEquals(Token.Type.Account, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -1008,7 +1008,7 @@ public class StripeTest {
                 )
         );
         assertNotNull(token);
-        assertEquals(Token.TokenType.ACCOUNT, token.getType());
+        assertEquals(Token.Type.Account, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());
@@ -1019,7 +1019,7 @@ public class StripeTest {
             throws StripeException {
         final Token token = defaultStripe.createAccountTokenSynchronous(AccountParams.create(false));
         assertNotNull(token);
-        assertEquals(Token.TokenType.ACCOUNT, token.getType());
+        assertEquals(Token.Type.Account, token.getType());
         assertFalse(token.getLivemode());
         assertFalse(token.getUsed());
         assertNotNull(token.getId());

--- a/stripe/src/test/java/com/stripe/android/model/CardParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardParamsTest.kt
@@ -18,24 +18,22 @@ class CardParamsTest {
             currency = "usd"
         ).toParamMap()
 
-        val expectedParams = mapOf(
-            "card" to mapOf(
-                "number" to "4242424242424242",
-                "exp_month" to 12,
-                "exp_year" to 2025,
-                "cvc" to "123",
-                "name" to "Jenny Rosen",
-                "currency" to "usd",
-                "address_line1" to "123 Market St",
-                "address_line2" to "#345",
-                "address_city" to "San Francisco",
-                "address_state" to "CA",
-                "address_zip" to "94107",
-                "address_country" to "US"
-            )
-        )
-
         assertThat(actualParams)
-            .isEqualTo(expectedParams)
+            .isEqualTo(
+                mapOf(
+                    "number" to "4242424242424242",
+                    "exp_month" to 12,
+                    "exp_year" to 2025,
+                    "cvc" to "123",
+                    "name" to "Jenny Rosen",
+                    "currency" to "usd",
+                    "address_line1" to "123 Market St",
+                    "address_line2" to "#345",
+                    "address_city" to "San Francisco",
+                    "address_state" to "CA",
+                    "address_zip" to "94107",
+                    "address_country" to "US"
+                )
+            )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/GooglePayResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/GooglePayResultTest.kt
@@ -21,7 +21,7 @@ class GooglePayResultTest {
         )
 
         assertEquals("tok_1F4VSjBbvEcIpqUbSsbEtBap", result.token?.id)
-        assertEquals("card", result.token?.type)
+        assertEquals(Token.Type.Card, result.token?.type)
 
         assertEquals(expectedAddress, result.address)
 
@@ -37,7 +37,7 @@ class GooglePayResultTest {
         )
 
         assertEquals("tok_1F4ACMCRMbs6FrXf6fPqLnN7", result.token?.id)
-        assertEquals("card", result.token?.type)
+        assertEquals(Token.Type.Card, result.token?.type)
         assertNull(result.address)
         assertNull(result.name)
         assertNull(result.email)

--- a/stripe/src/test/java/com/stripe/android/model/TokenFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenFixtures.kt
@@ -51,7 +51,7 @@ internal object TokenFixtures {
             "id": "btok_9xJAbronBnS9bH",
             "object": "token",
             "bank_account": {
-                "id": "ba_19dOY72eZvKYlo2CVNPhmtv3",
+                "id": "ba_19d8Fh2eZvKYlo2C9qw8RwpV",
                 "object": "bank_account",
                 "account_holder_name": "Jane Austen",
                 "account_holder_type": "individual",

--- a/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenTest.kt
@@ -1,66 +1,53 @@
 package com.stripe.android.model
 
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.parsers.TokenJsonParser
 import java.util.Date
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import org.json.JSONObject
 
 class TokenTest {
 
     @Test
-    fun parseToken_whenCardToken_readsObjectCorrectly() {
-        val expectedToken = Token(
-            id = "tok_189fi32eZvKYlo2Ct0KZvU5Y",
-            livemode = false,
-            created = Date(1462905355L * 1000L),
-            used = false,
-            type = Token.TokenType.CARD,
-            card = CARD
-        )
-        assertEquals(expectedToken, TokenFixtures.CARD_TOKEN)
+    fun `Card token is parsed correctly`() {
+        assertThat(TokenFixtures.CARD_TOKEN)
+            .isEqualTo(
+                Token(
+                    id = "tok_189fi32eZvKYlo2Ct0KZvU5Y",
+                    livemode = false,
+                    created = Date(1462905355L * 1000L),
+                    used = false,
+                    type = Token.Type.Card,
+                    card = CARD
+                )
+            )
     }
 
     @Test
-    fun parseToken_whenNullString_returnsNull() {
-        assertNull(Token.fromString(null))
+    fun `BankAccount token is parsed correctly`() {
+        assertThat(TokenFixtures.BANK_TOKEN)
+            .isEqualTo(
+                Token(
+                    id = "btok_9xJAbronBnS9bH",
+                    livemode = false,
+                    created = Date(1484765567L * 1000L),
+                    used = false,
+                    type = Token.Type.BankAccount,
+                    bankAccount = BankAccountFixtures.BANK_ACCOUNT
+                )
+            )
     }
 
     @Test
-    fun parseToken_whenBankAccount_readsObject() {
-        val createdDate = Date(1484765567L * 1000L)
-        val expectedToken = Token(
-            id = "btok_9xJAbronBnS9bH",
-            livemode = false,
-            created = createdDate,
-            used = false,
-            type = Token.TokenType.BANK_ACCOUNT,
-            bankAccount = BankAccountFixtures.BANK_ACCOUNT
-        )
-        val answerToken = TokenFixtures.BANK_TOKEN
-        assertNotNull(answerToken)
-        assertEquals(expectedToken.id, answerToken.id)
-        assertEquals(expectedToken.livemode, answerToken.livemode)
-        assertEquals(expectedToken.created, answerToken.created)
-        assertEquals(expectedToken.used, answerToken.used)
-        assertEquals(Token.TokenType.BANK_ACCOUNT, answerToken.type)
-
-        assertNotNull(answerToken.bankAccount)
-        assertNull(answerToken.card)
+    fun `Token parser should require a non-null id`() {
+        assertThat(TokenJsonParser().parse(RAW_TOKEN_NO_ID))
+            .isNull()
     }
 
     @Test
-    fun parseToken_withoutId_returnsNull() {
-        val token = TokenJsonParser().parse(RAW_TOKEN_NO_ID)
-        assertNull(token)
-    }
-
-    @Test
-    fun parseToken_withoutType_returnsNull() {
-        val token = TokenJsonParser().parse(RAW_BANK_TOKEN_NO_TYPE)
-        assertNull(token)
+    fun `Token parser should require a valid type id`() {
+        assertThat(TokenJsonParser().parse(RAW_BANK_TOKEN_NO_TYPE))
+            .isNull()
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Make `Token.Type` an enum
- Fix `PersonTokenParams`'s token type
- Remove `Token.fromString()`

## Motivation
Make `Token` more ergonomic

## Testing
Update tests