### PR TITLE
Drop instance state handling in fragment examples

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesActivity.kt
@@ -10,40 +10,19 @@ class FragmentExamplesActivity : AppCompatActivity() {
         FragmentsExampleActivityBinding.inflate(layoutInflater)
     }
 
-    private var fragment: FragmentExamplesFragment? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
         setTitle(R.string.launch_payment_session_from_fragment)
 
         if (savedInstanceState == null) {
-            this.fragment = FragmentExamplesFragment().also {
-                supportFragmentManager
-                    .beginTransaction()
-                    .replace(
-                        viewBinding.fragmentContainer.id,
-                        it,
-                        FragmentExamplesFragment::class.java.simpleName
-                    )
-                    .commit()
-            }
-        } else {
-            this.fragment = supportFragmentManager.getFragment(
-                savedInstanceState,
-                STATE_FRAGMENT
-            ) as? FragmentExamplesFragment?
+            supportFragmentManager
+                .beginTransaction()
+                .replace(
+                    viewBinding.fragmentContainer.id,
+                    FragmentExamplesFragment()
+                )
+                .commit()
         }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        fragment?.let {
-            supportFragmentManager.putFragment(outState, STATE_FRAGMENT, it)
-        }
-    }
-
-    private companion object {
-        private const val STATE_FRAGMENT = "state_fragment"
     }
 }


### PR DESCRIPTION

## Summary
<!-- Simple summary of what was changed. -->
This is not needed, fragment manager handles the state handling by
itself. See FragmentActivity onSaveInstanceState
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To add even more to how much the part with var fragment saving doesn't make much sense  - the fragment displayed and fragment shown will be actually 2 different instances after fragment recreation on instance state save. 

I will also open a new PR for FragmentExamplesFragment as there are some issues with lifecycle handling and an issue about state being lost on fragment recreation - which is observable before and after changes.
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested the samples they work like before