### PR TITLE
Refactor StripeIntentResult and subclasses

### DIFF
--- a/example/src/main/java/com/stripe/example/ExampleApplication.kt
+++ b/example/src/main/java/com/stripe/example/ExampleApplication.kt
@@ -52,6 +52,6 @@ class ExampleApplication : MultiDexApplication() {
     }
 
     private companion object {
-        private val IS_PENALTY_DEATH_ENABLED = true
+        private val IS_PENALTY_DEATH_ENABLED = false
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
@@ -1,32 +1,14 @@
 package com.stripe.android
 
-import android.os.Parcel
-import android.os.Parcelable
 import com.stripe.android.model.PaymentIntent
+import kotlinx.android.parcel.Parcelize
 
 /**
  * A model representing the result of a [PaymentIntent] confirmation via [Stripe.confirmPayment]
  * or handling of next actions via [Stripe.handleNextActionForPayment].
  */
-class PaymentIntentResult internal constructor(
-    paymentIntent: PaymentIntent,
-
-    @Outcome outcome: Int = 0
-) : StripeIntentResult<PaymentIntent>(paymentIntent, outcome) {
-    internal constructor(parcel: Parcel) : this(
-        paymentIntent = requireNotNull(
-            parcel.readParcelable<PaymentIntent>(PaymentIntent::class.java.classLoader)
-        ),
-        outcome = parcel.readInt()
-    )
-
-    companion object CREATOR : Parcelable.Creator<PaymentIntentResult> {
-        override fun createFromParcel(parcel: Parcel): PaymentIntentResult {
-            return PaymentIntentResult(parcel)
-        }
-
-        override fun newArray(size: Int): Array<PaymentIntentResult?> {
-            return arrayOfNulls<PaymentIntentResult?>(size)
-        }
-    }
-}
+@Parcelize
+data class PaymentIntentResult internal constructor(
+    override val intent: PaymentIntent,
+    @Outcome private val outcomeFromFlow: Int = 0
+) : StripeIntentResult<PaymentIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
@@ -1,31 +1,14 @@
 package com.stripe.android
 
-import android.os.Parcel
-import android.os.Parcelable
 import com.stripe.android.model.SetupIntent
+import kotlinx.android.parcel.Parcelize
 
 /**
  * A model representing the result of a [SetupIntent] confirmation via [Stripe.confirmSetupIntent]
  * or handling of next actions via [Stripe.handleNextActionForSetupIntent].
  */
-class SetupIntentResult internal constructor(
-    setupIntent: SetupIntent,
-    @Outcome outcome: Int = 0
-) : StripeIntentResult<SetupIntent>(setupIntent, outcome) {
-    internal constructor(parcel: Parcel) : this(
-        setupIntent = requireNotNull(
-            parcel.readParcelable<SetupIntent>(SetupIntent::class.java.classLoader)
-        ),
-        outcome = parcel.readInt()
-    )
-
-    companion object CREATOR : Parcelable.Creator<SetupIntentResult> {
-        override fun createFromParcel(parcel: Parcel): SetupIntentResult {
-            return SetupIntentResult(parcel)
-        }
-
-        override fun newArray(size: Int): Array<SetupIntentResult?> {
-            return arrayOfNulls<SetupIntentResult?>(size)
-        }
-    }
-}
+@Parcelize
+data class SetupIntentResult internal constructor(
+    override val intent: SetupIntent,
+    @Outcome private val outcomeFromFlow: Int = 0
+) : StripeIntentResult<SetupIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -1,11 +1,9 @@
 package com.stripe.android
 
-import android.os.Parcel
 import androidx.annotation.IntDef
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeModel
-import java.util.Objects
 
 /**
  * A model representing the result of a [StripeIntent] confirmation or authentication attempt
@@ -14,12 +12,14 @@ import java.util.Objects
  * [intent] is a [StripeIntent] retrieved after confirmation/authentication succeeded or failed.
  */
 abstract class StripeIntentResult<T : StripeIntent> internal constructor(
-    val intent: T,
-    @Outcome outcome: Int
+    @Outcome private val outcomeFromFlow: Int
 ) : StripeModel {
+    abstract val intent: T
+
     @Outcome
     @get:Outcome
-    val outcome: Int = determineOutcome(intent.status, outcome)
+    val outcome: Int
+        get() = determineOutcome(intent.status, outcomeFromFlow)
 
     @StripeIntentResult.Outcome
     private fun determineOutcome(
@@ -53,31 +53,6 @@ abstract class StripeIntentResult<T : StripeIntent> internal constructor(
                 return Outcome.UNKNOWN
             }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return when {
-            this === other -> true
-            other is StripeIntentResult<*> -> typedEquals(other)
-            else -> false
-        }
-    }
-
-    private fun typedEquals(setupIntentResult: StripeIntentResult<*>): Boolean {
-        return intent == setupIntentResult.intent && outcome == setupIntentResult.outcome
-    }
-
-    override fun hashCode(): Int {
-        return Objects.hash(intent, outcome)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeParcelable(intent, flags)
-        dest.writeInt(outcome)
     }
 
     /**

--- a/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 class PaymentIntentResultTest {
 
     @Test
-    fun testBuilder() {
+    fun `intent should return expected object`() {
         assertThat(PaymentIntentResult(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2).intent)
             .isEqualTo(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
     }
@@ -33,18 +33,18 @@ class PaymentIntentResultTest {
             status = StripeIntent.Status.Processing
         )
         val result = PaymentIntentResult(
-            paymentIntent = paymentIntent
+            intent = paymentIntent
         )
         assertThat(result.outcome)
             .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
     }
 
     @Test
-    fun shouldImplementParcelableCorrectly() {
+    fun `should parcelize correctly`() {
         ParcelUtils.verifyParcelRoundtrip(
             PaymentIntentResult(
-                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2,
-                outcome = StripeIntentResult.Outcome.CANCELED
+                intent = PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2,
+                outcomeFromFlow = StripeIntentResult.Outcome.CANCELED
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/SetupIntentResultTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android
 
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -11,19 +11,17 @@ import org.robolectric.RobolectricTestRunner
 class SetupIntentResultTest {
 
     @Test
-    fun testBuilder() {
-        assertEquals(
-            SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
-            SetupIntentResult(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT).intent
-        )
+    fun `intent should return expected object`() {
+        assertThat(SetupIntentResult(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT).intent)
+            .isEqualTo(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
     }
 
     @Test
-    fun shouldImplementParcelableCorrectly() {
+    fun `should parcelize correctly`() {
         ParcelUtils.verifyParcelRoundtrip(
             SetupIntentResult(
-                setupIntent = SetupIntentFixtures.SI_WITH_LAST_PAYMENT_ERROR,
-                outcome = StripeIntentResult.Outcome.CANCELED
+                intent = SetupIntentFixtures.SI_WITH_LAST_PAYMENT_ERROR,
+                outcomeFromFlow = StripeIntentResult.Outcome.CANCELED
             )
         )
     }


### PR DESCRIPTION
## Summary
- Make `PaymentIntentResult` and `SetupIntentResult` data classes
- Remove custom parcelizing logic

## Motivation
Simplify code

## Testing
Manually tested