### PR TITLE
Use onViewCreated and viewLifecycleOwner for methods calling views

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
@@ -58,8 +58,8 @@ class FragmentExamplesFragment : Fragment() {
         )
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         initPaymentSession(createCustomerSession())
         viewBinding.launchPaymentSession.setOnClickListener {
@@ -69,7 +69,7 @@ class FragmentExamplesFragment : Fragment() {
         viewBinding.launchSetupAuth.setOnClickListener { createSetupIntent() }
 
         viewModel.paymentIntentResultLiveData.observe(
-            this,
+            viewLifecycleOwner,
             Observer { result ->
                 result.fold(
                     onSuccess = {
@@ -86,7 +86,7 @@ class FragmentExamplesFragment : Fragment() {
         )
 
         viewModel.setupIntentResultLiveData.observe(
-            this,
+            viewLifecycleOwner,
             Observer { result ->
                 result.fold(
                     onSuccess = {


### PR DESCRIPTION


## Summary
<!-- Simple summary of what was changed. -->
Old setup methods depended on onActivityCreated which is discouraged and
actually deprecated in new androidx.fragment and could be not called in
some conditions.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Minor improvements as mentioned in #2568 up to consideration.
## Testing
<!-- How was the code tested? Be as specific as possible. -->
