### PR TITLE
Fix bouncy castle keep rule

### DIFF
--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -4,8 +4,8 @@
 
 # Rules for BouncyCastle
 -keep class org.bouncycastle.jcajce.provider.** { *; }
--keep class org.bouncycastle.jce.provider.** { *; }
--keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi { *; }
+-keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi,org.bouncycastle.jce.provider.** { *; }
+
 
 -keep class com.stripe.android.** { *; }
 -dontwarn com.stripe.android.view.**


### PR DESCRIPTION
## Summary

Updates the bouncycastle keep rule to fix #2586 

## Motivation

This current rule will cause users of the Stripe SDK who also use ProGuard to keep too many classes.

## Testing

Rule tested on a simple HelloWorld project that uses the SDK. The previous version keeps many classes unintentionally.