### PR TITLE
Add Alipay authCompleteUrl

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -164,7 +164,21 @@ interface StripeIntent : StripeModel {
                 @Parcelize
                 data class Alipay(
                     val data: String
-                ) : MobileData()
+                ) : MobileData() {
+                    /**
+                     * The alipay data string is formatted as query parameters.
+                     * When authenticate is complete, we make a request to the
+                     * return_url, as a hint to the backend to ping Alipay for
+                     * the updated state
+                     */
+                    val authCompleteUrl: String?
+                    get() = runCatching {
+                        Uri.parse("alipay://url?$data")
+                            .getQueryParameter("return_url")?.takeIf {
+                                Uri.parse(it).host == "hooks.stripe.com"
+                            }
+                    }.getOrNull()
+                }
             }
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -171,8 +171,13 @@ interface StripeIntent : StripeModel {
                      * return_url, as a hint to the backend to ping Alipay for
                      * the updated state
                      */
-                    val authCompleteUrl: String?
-                    get() = runCatching {
+                    /**
+                     * The alipay data string is formatted as query parameters.
+                     * When authenticate is complete, we make a request to the
+                     * return_url, as a hint to the backend to ping Alipay for
+                     * the updated state
+                     */
+                    val authCompleteUrl: String? = runCatching {
                         Uri.parse("alipay://url?$data")
                             .getQueryParameter("return_url")?.takeIf {
                                 Uri.parse(it).host == "hooks.stripe.com"

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -168,13 +168,7 @@ interface StripeIntent : StripeModel {
                     /**
                      * The alipay data string is formatted as query parameters.
                      * When authenticate is complete, we make a request to the
-                     * return_url, as a hint to the backend to ping Alipay for
-                     * the updated state
-                     */
-                    /**
-                     * The alipay data string is formatted as query parameters.
-                     * When authenticate is complete, we make a request to the
-                     * return_url, as a hint to the backend to ping Alipay for
+                     * return_url param, as a hint to the backend to ping Alipay for
                      * the updated state
                      */
                     val authCompleteUrl: String? = runCatching {

--- a/stripe/src/test/java/com/stripe/android/model/MobileDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/MobileDataTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.StripeIntent.NextActionData.RedirectToUrl.MobileData
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MobileDataTest {
+    @Test
+    fun `Alipay data should parse return_url correctly`() {
+        val data = MobileData.Alipay("_input_charset=utf-8&app_pay=Y" +
+            "&currency=USD&forex_biz=FP" +
+            "&notify_url=https%3A%2F%2Fhooks.stripe.com%2Falipay%2Falipay%2Fhook%2F6255d30b067c8f7a162c79c654483646%2Fsrc_1Gt188KlwPmebFhp4SWhZwn1" +
+            "&out_trade_no=src_1Gt188KlwPmebFhp4SWhZwn1" +
+            "&partner=2088621828244481&payment_type=1" +
+            "&product_code=NEW_WAP_OVERSEAS_SELLER" +
+            "&return_url=https%3A%2F%2Fhooks.stripe.com%2Fadapter%2Falipay%2Fredirect%2Fcomplete%2Fsrc_1Gt188KlwPmebFhp4SWhZwn1%2Fsrc_client_secret_RMaQKPfAmHOdUwcNhXEjolR4" +
+            "&secondary_merchant_id=acct_1EqOyCKlwPmebFhp" +
+            "&secondary_merchant_industry=5734" +
+            "&secondary_merchant_name=Yuki-Test" +
+            "&sendFormat=normal" +
+            "&service=create_forex_trade_wap" +
+            "&sign=44e797e6d5ba1c784d3cceb176c359db" +
+            "&sign_type=MD5" +
+            "&subject=Yuki-Test" +
+            "&supplier=Yuki-Test" +
+            "&timeout_rule=20m" +
+            "&total_fee=1.00")
+        assertThat(data.authCompleteUrl).isEqualTo(
+            "https://hooks.stripe.com/adapter/alipay/redirect/complete/src_1Gt188KlwPmebFhp4SWhZwn1/src_client_secret_RMaQKPfAmHOdUwcNhXEjolR4"
+        )
+    }
+
+    @Test
+    fun `Alipay data should handle missing data`() {
+        val data = MobileData.Alipay("")
+        assertThat(data.authCompleteUrl).isNull()
+    }
+
+    @Test
+    fun `Alipay data should ignore non-stripe urls`() {
+        val data = MobileData.Alipay("return_url=https://google.com")
+        assertThat(data.authCompleteUrl).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add authCompleteUrl to the Alipay data object. This is used when authentication is complete as a hint to the backend to ping Alipay for the updated state.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Avoid PI still being in "requires_action" state due to race conditions

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Added unit tests
