### PR TITLE
Fix vector icon references in layout files

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -121,6 +121,8 @@ android {
         targetSdkVersion rootProject.ext.compileSdkVersion
         multiDexEnabled true
 
+        vectorDrawables.useSupportLibrary = true
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 

--- a/example/res/layout/google_pay_button.xml
+++ b/example/res/layout/google_pay_button.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="48sp"
     android:background="@drawable/pay_with_google_button_background"
@@ -18,7 +19,7 @@
             android:layout_height="0dp"
             android:scaleType="fitCenter"
             android:duplicateParentState="true"
-            android:src="@drawable/pay_with_google_button_content"
+            app:srcCompat="@drawable/pay_with_google_button_content"
             android:contentDescription="@string/pay_with_google" />
     </LinearLayout>
 
@@ -28,5 +29,5 @@
         android:scaleType="fitXY"
         android:duplicateParentState="true"
         android:contentDescription="@null"
-        android:src="@drawable/pay_with_google_button_overlay"/>
+        app:srcCompat="@drawable/pay_with_google_button_overlay"/>
 </RelativeLayout>

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -70,6 +70,8 @@ android {
         targetSdkVersion rootProject.ext.compileSdkVersion
         consumerProguardFiles 'proguard-rules.txt'
 
+        vectorDrawables.useSupportLibrary = true
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
     }

--- a/stripe/res/drawable/stripe_google_pay_mark.xml
+++ b/stripe/res/drawable/stripe_google_pay_mark.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="32dp"
-    android:height="21dp"
+    android:height="20.48dp"
     android:viewportWidth="425"
     android:viewportHeight="272">
   <path

--- a/stripe/res/layout/add_payment_method_row.xml
+++ b/stripe/res/layout/add_payment_method_row.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/stripe_activity_total_margin"
@@ -13,9 +14,9 @@
     android:orientation="horizontal">
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/stripe_masked_card_icon_width"
-        android:src="@drawable/stripe_ic_add_black_32dp"
+        android:layout_width="@dimen/stripe_masked_card_icon_width"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/stripe_ic_add_black_32dp"
         android:tint="?attr/colorAccent"
         android:layout_gravity="center_vertical|start"
         />

--- a/stripe/res/layout/card_brand_view.xml
+++ b/stripe/res/layout/card_brand_view.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <ImageView
         android:id="@+id/icon"
         android:layout_width="@dimen/card_brand_view_width"
         android:layout_height="@dimen/card_brand_view_height"
-        android:src="@drawable/stripe_ic_unknown"
+        app:srcCompat="@drawable/stripe_ic_unknown"
         android:contentDescription="@null" />
 </merge>

--- a/stripe/res/layout/fpx_bank_item.xml
+++ b/stripe/res/layout/fpx_bank_item.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="@dimen/stripe_list_row_height"
@@ -12,7 +14,7 @@
         android:layout_width="@dimen/stripe_masked_card_icon_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|start"
-        android:src="@drawable/stripe_ic_bank_generic" />
+        app:srcCompat="@drawable/stripe_ic_bank_generic" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/name"
@@ -28,6 +30,6 @@
         android:layout_width="@dimen/stripe_masked_card_icon_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:src="@drawable/stripe_ic_checkmark" />
+        app:srcCompat="@drawable/stripe_ic_checkmark" />
 
 </LinearLayout>

--- a/stripe/res/layout/google_pay_row.xml
+++ b/stripe/res/layout/google_pay_row.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="@dimen/stripe_list_row_height"
     android:layout_marginTop="@dimen/stripe_activity_total_margin"
@@ -13,9 +14,10 @@
     android:orientation="horizontal">
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/stripe_masked_card_icon_width"
-        android:src="@drawable/stripe_google_pay_mark"
+        android:layout_height="wrap_content"
+        android:layout_width="@dimen/stripe_masked_card_icon_width"
+        app:srcCompat="@drawable/stripe_google_pay_mark"
+        android:scaleType="centerInside"
         android:focusableInTouchMode="false"
         android:clickable="false"
         android:layout_gravity="center_vertical|start"
@@ -39,7 +41,7 @@
         android:layout_width="@dimen/stripe_masked_card_icon_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:src="@drawable/stripe_ic_checkmark"
+        app:srcCompat="@drawable/stripe_ic_checkmark"
         android:visibility="invisible"
         />
 

--- a/stripe/res/layout/masked_card_view.xml
+++ b/stripe/res/layout/masked_card_view.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/brand_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/stripe_masked_card_icon_width"
-        android:src="@drawable/stripe_ic_unknown"
+        android:layout_height="@dimen/stripe_masked_card_icon_height"
+        android:layout_width="@dimen/stripe_masked_card_icon_width"
+        app:srcCompat="@drawable/stripe_ic_unknown"
         android:layout_gravity="center_vertical|start"
         />
 
@@ -24,7 +25,7 @@
         android:layout_width="@dimen/stripe_masked_card_icon_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:src="@drawable/stripe_ic_checkmark"
+        app:srcCompat="@drawable/stripe_ic_checkmark"
         android:visibility="invisible"
         />
 

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="stripe_card_icon_multiline_padding">8dp</dimen>
     <dimen name="stripe_card_icon_multiline_padding_bottom">1.52380955dp</dimen>
     <dimen name="stripe_masked_card_icon_width">32dp</dimen>
+    <dimen name="stripe_masked_card_icon_height">21dp</dimen>
     <dimen name="stripe_list_top_margin">8dp</dimen>
     <dimen name="stripe_shipping_check_icon_width">24dp</dimen>
     <dimen name="stripe_masked_card_vertical_padding">4dp</dimen>


### PR DESCRIPTION
## Summary
Add `vectorDrawables.useSupportLibrary = true` to `build.gradle` [0].
Without this, when targeting API <= 19, PNG versions of vector
drawables will be generated at build time. This reduces the SDK's
filesize from 219kb to 189kb.

Use `app:srcCompat` instead of `android:src` when referencing vector
drawables.

Fix some drawable dimensions and layouts.

[0] https://developer.android.com/guide/topics/graphics/vector-drawable-resources#vector-drawables-backward-solution

## Motivation
Fixes #2578

## Testing
Manually tested