### PR TITLE
Remove multidex support library from example app

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -42,7 +42,6 @@ private def readProperty(name) {
 
 dependencies {
     implementation project(':stripe')
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
@@ -116,7 +115,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion rootProject.ext.compileSdkVersion
-        multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true
 

--- a/example/src/main/java/com/stripe/example/ExampleApplication.kt
+++ b/example/src/main/java/com/stripe/example/ExampleApplication.kt
@@ -1,7 +1,7 @@
 package com.stripe.example
 
+import android.app.Application
 import android.os.StrictMode
-import androidx.multidex.MultiDexApplication
 import com.facebook.stetho.Stetho
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentConfiguration
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class ExampleApplication : MultiDexApplication() {
+class ExampleApplication : Application() {
 
     override fun onCreate() {
         PaymentConfiguration.init(this, Settings(this).publishableKey)


### PR DESCRIPTION
## Motivation
Multidex is enabled by default on API 21 and above
https://developer.android.com/studio/build/multidex#mdex-on-l

## Testing
Manually verified