### PR TITLE
StripeApiRepository.getFpxBankStatus should ignore account id

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -8,25 +8,25 @@ import com.stripe.android.ApiRequest
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeApiRepository
 import com.stripe.android.model.FpxBankStatuses
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelChildren
 
 internal class FpxViewModel @JvmOverloads internal constructor(
     application: Application,
-    private val workContext: CoroutineContext = Dispatchers.IO
+    private val workDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : AndroidViewModel(application) {
     private val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
     private val stripeRepository = StripeApiRepository(
         application,
         publishableKey,
-        workContext = workContext
+        workDispatcher = workDispatcher
     )
 
     internal var selectedPosition: Int? = null
 
     @JvmSynthetic
-    internal fun getFpxBankStatues() = liveData<FpxBankStatuses>(workContext) {
+    internal fun getFpxBankStatues() = liveData<FpxBankStatuses>(workDispatcher) {
         emitSource(
             runCatching {
                 stripeRepository.getFpxBankStatus(ApiRequest.Options(publishableKey))
@@ -36,6 +36,6 @@ internal class FpxViewModel @JvmOverloads internal constructor(
 
     override fun onCleared() {
         super.onCleared()
-        workContext.cancelChildren()
+        workDispatcher.cancelChildren()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -66,7 +66,7 @@ class StripeApiRepositoryTest {
     private val stripeApiRepository = StripeApiRepository(
         context,
         DEFAULT_OPTIONS.apiKey,
-        workContext = testDispatcher
+        workDispatcher = testDispatcher
     )
     private val fileFactory = FileFactory(context)
 

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -688,6 +688,23 @@ class StripeApiRepositoryTest {
     }
 
     @Test
+    fun getFpxBankStatus_withFpxKey_ignoresStripeAccountId() {
+        testScope.runBlockingTest {
+            var fpxBankStatuses: FpxBankStatuses? = null
+            stripeApiRepository.getFpxBankStatus(
+                ApiRequest.Options(
+                    apiKey = ApiKeyFixtures.FPX_PUBLISHABLE_KEY,
+                    stripeAccount = "acct_1234"
+                )
+            ).observeForever {
+                fpxBankStatuses = it
+            }
+            assertThat(fpxBankStatuses?.isOnline(FpxBank.Hsbc))
+                .isTrue()
+        }
+    }
+
+    @Test
     fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() {
         val exception = assertFailsWith<InvalidRequestException> {
             stripeApiRepository.cancelPaymentIntentSource(

--- a/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
@@ -28,7 +28,10 @@ class FpxViewModelTest {
 
     @Test
     fun `getFpxBankStatues should update LiveData`() {
-        val viewModel = FpxViewModel(application, workContext = testDispatcher)
+        val viewModel = FpxViewModel(
+            application,
+            workDispatcher = testDispatcher
+        )
         testDispatcher.runBlockingTest {
             var bankStatuses: FpxBankStatuses? = null
             viewModel.getFpxBankStatues().observeForever {


### PR DESCRIPTION
This request will fail if an account header is set