### PR TITLE
Add stripeAccountId to PaymentConfiguration and use in AddPaymentMethodActivity

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -68,9 +68,38 @@
             else -> {}
         }
         ```
+- Changes to `CustomerSession`
+    - `CustomerSession`'s constructor no longer takes a `stripeAccountId`;
+      instead, instantiate `PaymentConfiguration` with a `stripeAccountId`
+        ```kotlin
+        // before
+        PaymentConfiguration.init(
+            context,
+            "pk_test"
+        )
+        CustomerSession.initCustomerSession(
+            context
+            ephemeralKeyProvider,
+            "acct_1234"
+        )
+
+        // after
+        PaymentConfiguration.init(
+            context,
+            "pk_test",
+            "acct_1234"
+        )
+        CustomerSession.initCustomerSession(
+            context
+            ephemeralKeyProvider
+        )
+        ```
 - Changes to `AddPaymentMethodActivity`
-    - When `CustomerSession` is instantiated with a `stripeAccountId`, it will be used in `AddPaymentMethodActivity`
+    - When `PaymentConfiguration` is instantiated with a `stripeAccountId`, it will be used in `AddPaymentMethodActivity`
       when creating a payment method
+        ```kotlin
+        PaymentConfiguration.init(context, "pk_test", "acct_1234")
+        ```
 - Changes to `Source`
     - `Source.SourceFlow` has been renamed to `Source.Flow` and is now an enum
     - `Source.SourceStatus` has been renamed to `Source.Status` and is now an enum

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -42,7 +42,7 @@ class AddPaymentMethodActivity : StripeActivity() {
         Stripe(
             applicationContext,
             publishableKey = paymentConfiguration.publishableKey,
-            stripeAccountId = customerSession.stripeAccountId
+            stripeAccountId = paymentConfiguration.stripeAccountId
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
@@ -2,20 +2,16 @@ package com.stripe.android
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.utils.ParcelUtils
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-/**
- * Test class for [PaymentConfiguration].
- */
 @RunWith(RobolectricTestRunner::class)
 class PaymentConfigurationTest {
-
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @BeforeTest
@@ -32,6 +28,24 @@ class PaymentConfigurationTest {
     }
 
     @Test
+    fun `stripeAccountId should be persisted`() {
+        PaymentConfiguration.init(
+            context,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            "acct_12345"
+        )
+
+        assertThat(
+            PaymentConfiguration.getInstance(context)
+        ).isEqualTo(
+            PaymentConfiguration(
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                "acct_12345"
+            )
+        )
+    }
+
+    @Test
     fun getInstance_whenInstanceIsNull_loadsFromPrefs() {
         PaymentConfiguration.init(
             context,
@@ -40,19 +54,21 @@ class PaymentConfigurationTest {
 
         PaymentConfiguration.clearInstance()
 
-        assertEquals(
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            PaymentConfiguration
-                .getInstance(context)
-                .publishableKey
+        assertThat(
+            PaymentConfiguration.getInstance(context)
+        ).isEqualTo(
+            PaymentConfiguration(
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            )
         )
     }
 
     @Test
     fun testParcel() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+
         val paymentConfig = PaymentConfiguration.getInstance(context)
-        assertEquals(paymentConfig, ParcelUtils.create(paymentConfig))
+        assertThat(ParcelUtils.create(paymentConfig))
+            .isEqualTo(paymentConfig)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -62,7 +62,11 @@ class AddPaymentMethodActivityTest {
     fun setup() {
         // The input in this test class will be invalid after 2050. Please update the test.
         assertTrue(Calendar.getInstance().get(Calendar.YEAR) < 2050)
-        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        PaymentConfiguration.init(
+            context,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            "acct_12345"
+        )
         CustomerSession.instance = customerSession
     }
 


### PR DESCRIPTION
## Motivation
`AddPaymentMethodActivity` should be usable without a `CustomerSession`.
To achieve this, `stripeAccountId` should be decoupled from `CustomerSession`.

## Testing
Manually tested
