### PR TITLE
Refactor AddPaymentMethodActivity.Result

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -100,6 +100,35 @@
         ```kotlin
         PaymentConfiguration.init(context, "pk_test", "acct_1234")
         ```
+    - `AddPaymentMethodActivity.Result` is now a sealed class with `Success`, `Failure`, and `Canceled` subclasses
+        ```kotlin
+        // before
+        val result = AddPaymentMethodActivityStarter.Result.fromIntent(
+            intent
+        )
+        when {
+            result != null -> result.paymentMethod
+            else -> {
+                // error happened or customer canceled
+            }
+        }
+    
+        // after
+        val result = AddPaymentMethodActivityStarter.Result.fromIntent(
+            intent
+        )
+        when (result) {
+            is AddPaymentMethodActivityStarter.Result.Success -> {
+                result.paymentMethod
+            }
+            is AddPaymentMethodActivityStarter.Result.Failure -> {
+                result.exception
+            }
+            is AddPaymentMethodActivityStarter.Result.Canceled -> {
+                // customer canceled
+            }
+        }
+        ```
 - Changes to `Source`
     - `Source.SourceFlow` has been renamed to `Source.Flow` and is now an enum
     - `Source.SourceStatus` has been renamed to `Source.Status` and is now an enum

--- a/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
+++ b/example/src/main/java/com/stripe/example/activity/FpxPaymentActivity.java
@@ -55,8 +55,10 @@ public class FpxPaymentActivity extends AppCompatActivity {
 
         final AddPaymentMethodActivityStarter.Result result =
                 AddPaymentMethodActivityStarter.Result.fromIntent(data);
-        if (result != null) {
-            onPaymentMethodResult(result.getPaymentMethod());
+        if (result instanceof AddPaymentMethodActivityStarter.Result.Success) {
+            final AddPaymentMethodActivityStarter.Result.Success successResult =
+                    (AddPaymentMethodActivityStarter.Result.Success) result;
+            onPaymentMethodResult(successResult.getPaymentMethod());
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivity.kt
@@ -90,6 +90,14 @@ class AddPaymentMethodActivity : StripeActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         configureView(args)
+        setResult(
+            Activity.RESULT_OK,
+            Intent()
+                .putExtras(
+                    AddPaymentMethodActivityStarter.Result.Canceled
+                        .toBundle()
+                )
+        )
     }
 
     override fun onResume() {
@@ -207,15 +215,21 @@ class AddPaymentMethodActivity : StripeActivity() {
                 })
             },
             onFailure = {
-                finish()
+                finishWithResult(AddPaymentMethodActivityStarter.Result.Failure(it))
             }
         )
     }
 
     private fun finishWithPaymentMethod(paymentMethod: PaymentMethod) {
+        finishWithResult(AddPaymentMethodActivityStarter.Result.Success(paymentMethod))
+    }
+
+    private fun finishWithResult(result: AddPaymentMethodActivityStarter.Result) {
         isProgressBarVisible = false
-        setResult(Activity.RESULT_OK, Intent()
-            .putExtras(AddPaymentMethodActivityStarter.Result(paymentMethod).toBundle()))
+        setResult(
+            Activity.RESULT_OK,
+            Intent().putExtras(result.toBundle())
+        )
         finish()
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -145,23 +145,33 @@ class AddPaymentMethodActivityStarter : ActivityStarter<AddPaymentMethodActivity
      *
      * Retrieve in `#onActivityResult()` using [fromIntent].
      */
-    @Parcelize
-    data class Result internal constructor(
-        val paymentMethod: PaymentMethod
-    ) : ActivityStarter.Result {
+    sealed class Result : ActivityStarter.Result {
         override fun toBundle(): Bundle {
-            val bundle = Bundle()
-            bundle.putParcelable(ActivityStarter.Result.EXTRA, this)
-            return bundle
+            return Bundle().also {
+                it.putParcelable(ActivityStarter.Result.EXTRA, this)
+            }
         }
+
+        @Parcelize
+        data class Success internal constructor(
+            val paymentMethod: PaymentMethod
+        ) : Result()
+
+        @Parcelize
+        data class Failure internal constructor(
+            val exception: Throwable
+        ) : Result()
+
+        @Parcelize
+        object Canceled : Result()
 
         companion object {
             /**
-             * @return the [Result] object from the given `Intent`
+             * @return the [Result] object from the given `Intent`. [Canceled] by default.
              */
             @JvmStatic
-            fun fromIntent(intent: Intent?): Result? {
-                return intent?.getParcelableExtra(ActivityStarter.Result.EXTRA)
+            fun fromIntent(intent: Intent?): Result {
+                return intent?.getParcelableExtra(ActivityStarter.Result.EXTRA) ?: Canceled
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -160,7 +160,17 @@ class PaymentMethodsActivity : AppCompatActivity() {
         data?.let {
             val result =
                 AddPaymentMethodActivityStarter.Result.fromIntent(data)
-            result?.paymentMethod?.let { onAddedPaymentMethod(it) }
+            when (result) {
+                is AddPaymentMethodActivityStarter.Result.Success -> {
+                    onAddedPaymentMethod(result.paymentMethod)
+                }
+                is AddPaymentMethodActivityStarter.Result.Failure -> {
+                    // TODO(mshafrir-stripe): notify user that payment method can not be added at this time
+                }
+                else -> {
+                    // no-op
+                }
+            }
         } ?: fetchCustomerPaymentMethods()
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityStarterTest.kt
@@ -24,8 +24,9 @@ class AddPaymentMethodActivityStarterTest {
 
     @Test
     fun testResultParceling() {
-        val result =
-            AddPaymentMethodActivityStarter.Result(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        val result = AddPaymentMethodActivityStarter.Result.Success(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
         assertEquals(result, ParcelUtils.create(result))
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -169,7 +169,10 @@ class PaymentMethodsActivityTest {
                 assertNotNull(paymentMethod)
 
                 val resultIntent = Intent()
-                    .putExtras(AddPaymentMethodActivityStarter.Result(paymentMethod).toBundle())
+                    .putExtras(
+                        AddPaymentMethodActivityStarter.Result.Success(paymentMethod)
+                            .toBundle()
+                    )
                 activity.onActivityResult(
                     AddPaymentMethodActivityStarter.REQUEST_CODE, RESULT_OK, resultIntent
                 )


### PR DESCRIPTION
## Summary
Make `AddPaymentMethodActivity.Result` a sealed class and create
`AddPaymentMethodActivity.Result.Success` and
`AddPaymentMethodActivity.Result.Failure` and
`AddPaymentMethodActivity.Result.Canceled` subclasses.

## Motivation
Better model results of `AddPaymentMethodActivity`

## Testing
Add tests
Manually verify
