### PR TITLE
Remove PaymentSession and CustomerSession's "Activity" Listeners

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -68,6 +68,8 @@
             else -> {}
         }
         ```
+- Changes to `PaymentSession`
+    - Remove `PaymentSession#ActivityPaymentSessionListener`
 - Changes to `CustomerSession`
     - `CustomerSession`'s constructor no longer takes a `stripeAccountId`;
       instead, instantiate `PaymentConfiguration` with a `stripeAccountId`
@@ -94,6 +96,8 @@
             ephemeralKeyProvider
         )
         ```
+    - Remove `CustomerSession#ActivityCustomerRetrievalListener`, `CustomerSession#ActivityPaymentMethodRetrievalListener`,
+      `CustomerSession#ActivityPaymentMethodsRetrievalListener`, and `CustomerSession#ActivitySourceRetrievalListener`
 - Changes to `AddPaymentMethodActivity`
     - When `PaymentConfiguration` is instantiated with a `stripeAccountId`, it will be used in `AddPaymentMethodActivity`
       when creating a payment method

--- a/stripe/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/stripe/src/main/java/com/stripe/android/CustomerSession.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import android.app.Activity
 import android.content.Context
 import android.os.Handler
 import androidx.annotation.IntRange
@@ -12,7 +11,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.Source
 import com.stripe.android.model.Source.SourceType
-import java.lang.ref.WeakReference
 import java.util.Calendar
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -465,12 +463,6 @@ class CustomerSession @VisibleForTesting internal constructor(
         return listeners.remove(operationId) as L?
     }
 
-    abstract class ActivityCustomerRetrievalListener<A : Activity?>(activity: A) : CustomerRetrievalListener {
-        private val activityRef: WeakReference<A> = WeakReference(activity)
-        protected val activity: A?
-            get() = activityRef.get()
-    }
-
     interface CustomerRetrievalListener : RetrievalListener {
         fun onCustomerRetrieved(customer: Customer)
     }
@@ -489,36 +481,6 @@ class CustomerSession @VisibleForTesting internal constructor(
 
     interface RetrievalListener {
         fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?)
-    }
-
-    /**
-     * Abstract implementation of [PaymentMethodsRetrievalListener] that holds a
-     * [WeakReference] to an `Activity` object.
-     */
-    abstract class ActivityPaymentMethodsRetrievalListener<A : Activity?>(activity: A) : PaymentMethodsRetrievalListener {
-        private val activityRef: WeakReference<A> = WeakReference(activity)
-        protected val activity: A?
-            get() = activityRef.get()
-    }
-
-    /**
-     * Abstract implementation of [SourceRetrievalListener] that holds a
-     * [WeakReference] to an `Activity` object.
-     */
-    abstract class ActivitySourceRetrievalListener<A : Activity?>(activity: A) : SourceRetrievalListener {
-        private val activityRef: WeakReference<A> = WeakReference(activity)
-        protected val activity: A?
-            get() = activityRef.get()
-    }
-
-    /**
-     * Abstract implementation of [PaymentMethodRetrievalListener] that holds a
-     * [WeakReference] to an `Activity` object.
-     */
-    abstract class ActivityPaymentMethodRetrievalListener<A : Activity?>(activity: A) : PaymentMethodRetrievalListener {
-        private val activityRef: WeakReference<A> = WeakReference(activity)
-        protected val activity: A?
-            get() = activityRef.get()
     }
 
     companion object {

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -22,7 +22,6 @@ import com.stripe.android.view.PaymentFlowActivity
 import com.stripe.android.view.PaymentFlowActivityStarter
 import com.stripe.android.view.PaymentMethodsActivity
 import com.stripe.android.view.PaymentMethodsActivityStarter
-import java.lang.ref.WeakReference
 
 /**
  * Represents a single start-to-finish payment operation.
@@ -309,19 +308,6 @@ class PaymentSession @VisibleForTesting internal constructor(
          * @param data the updated [PaymentSessionData]
          */
         fun onPaymentSessionDataChanged(data: PaymentSessionData)
-    }
-
-    /**
-     * Abstract implementation of [PaymentSessionListener] that holds a
-     * [WeakReference] to an `Activity` object.
-     */
-    abstract class ActivityPaymentSessionListener<A : Activity>(
-        activity: A
-    ) : PaymentSessionListener {
-        private val activityRef: WeakReference<A> = WeakReference(activity)
-
-        protected val listenerActivity: A?
-            get() = activityRef.get()
     }
 
     internal companion object {


### PR DESCRIPTION
Remove the following classes:
- `PaymentSession#ActivityPaymentSessionListener`
- `CustomerSession#ActivityCustomerRetrievalListener`
- `CustomerSession#ActivityPaymentMethodRetrievalListener`
- `CustomerSession#ActivityPaymentMethodsRetrievalListener`
- `CustomerSession#ActivitySourceRetrievalListener`

Motivation
- Simplify API
- Users should handle Activity lifecycle
