### PR TITLE
Convert CustomizableShippingField to enum

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -133,6 +133,10 @@
             }
         }
         ```
+- Changes to `ShippingInfoWidget`
+    - `setOptionalFields()` is now `optionalFields`
+    - `setHiddenFields()` is now `hiddenFields`
+    - `CustomizableShippingField` is now an enum
 - Changes to `Source`
     - `Source.SourceFlow` has been renamed to `Source.Flow` and is now an enum
     - `Source.SourceStatus` has been renamed to `Source.Status` and is now an enum

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
@@ -51,8 +51,8 @@ class FragmentExamplesFragment : Fragment() {
             config = PaymentSessionConfig.Builder()
                 .setShippingMethodsRequired(false)
                 .setHiddenShippingInfoFields(
-                    ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD,
-                    ShippingInfoWidget.CustomizableShippingField.CITY_FIELD
+                    ShippingInfoWidget.CustomizableShippingField.Phone,
+                    ShippingInfoWidget.CustomizableShippingField.City
                 )
                 .build()
         )

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.LayoutRes
 import androidx.annotation.WorkerThread
@@ -24,8 +23,8 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 data class PaymentSessionConfig internal constructor(
-    val hiddenShippingInfoFields: List<String> = emptyList(),
-    val optionalShippingInfoFields: List<String> = emptyList(),
+    val hiddenShippingInfoFields: List<CustomizableShippingField> = emptyList(),
+    val optionalShippingInfoFields: List<CustomizableShippingField> = emptyList(),
     val prepopulatedShippingInfo: ShippingInformation? = null,
     val isShippingInfoRequired: Boolean = false,
     val isShippingMethodRequired: Boolean = false,
@@ -93,8 +92,8 @@ data class PaymentSessionConfig internal constructor(
         private var billingAddressFields: BillingAddressFields = DEFAULT_BILLING_ADDRESS_FIELDS
         private var shippingInfoRequired = true
         private var shippingMethodsRequired = true
-        private var hiddenShippingInfoFields: List<String>? = null
-        private var optionalShippingInfoFields: List<String>? = null
+        private var hiddenShippingInfoFields: List<CustomizableShippingField>? = null
+        private var optionalShippingInfoFields: List<CustomizableShippingField>? = null
         private var shippingInformation: ShippingInformation? = null
         private var paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card)
         private var shouldShowGooglePay: Boolean = false
@@ -122,9 +121,8 @@ data class PaymentSessionConfig internal constructor(
          * hidden in the shipping information screen. All fields will be shown if this list is
          * empty. Note that not all fields can be hidden, such as country or name.
          */
-        @SuppressLint("WrongConstant")
         fun setHiddenShippingInfoFields(
-            @CustomizableShippingField vararg hiddenShippingInfoFields: String
+            vararg hiddenShippingInfoFields: CustomizableShippingField
         ): Builder = apply {
             this.hiddenShippingInfoFields = listOf(*hiddenShippingInfoFields)
         }
@@ -133,9 +131,8 @@ data class PaymentSessionConfig internal constructor(
          * @param optionalShippingInfoFields [CustomizableShippingField] fields that should be
          * optional in the [ShippingInfoWidget]
          */
-        @SuppressLint("WrongConstant")
         fun setOptionalShippingInfoFields(
-            @CustomizableShippingField vararg optionalShippingInfoFields: String
+            vararg optionalShippingInfoFields: CustomizableShippingField
         ): Builder = apply {
             this.optionalShippingInfoFields = listOf(*optionalShippingInfoFields)
         }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowPagerAdapter.kt
@@ -123,10 +123,8 @@ internal class PaymentFlowPagerAdapter(
                 shippingInformation: ShippingInformation?,
                 allowedShippingCountryCodes: Set<String>
             ) {
-                shippingInfoWidget
-                    .setHiddenFields(paymentSessionConfig.hiddenShippingInfoFields)
-                shippingInfoWidget
-                    .setOptionalFields(paymentSessionConfig.optionalShippingInfoFields)
+                shippingInfoWidget.hiddenFields = paymentSessionConfig.hiddenShippingInfoFields
+                shippingInfoWidget.optionalFields = paymentSessionConfig.optionalShippingInfoFields
                 shippingInfoWidget
                     .setAllowedCountryCodes(allowedShippingCountryCodes)
                 shippingInfoWidget

--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
@@ -11,8 +11,8 @@ internal class PostalCodeValidator {
     fun isValid(
         postalCode: String,
         countryCode: String?,
-        optionalShippingInfoFields: List<String>,
-        hiddenShippingInfoFields: List<String>
+        optionalShippingInfoFields: List<ShippingInfoWidget.CustomizableShippingField>,
+        hiddenShippingInfoFields: List<ShippingInfoWidget.CustomizableShippingField>
     ): Boolean {
         if (countryCode == null) {
             return false
@@ -42,13 +42,13 @@ internal class PostalCodeValidator {
         )
 
         private fun isPostalCodeNotRequired(
-            optionalShippingInfoFields: List<String>,
-            hiddenShippingInfoFields: List<String>
+            optionalShippingInfoFields: List<ShippingInfoWidget.CustomizableShippingField>,
+            hiddenShippingInfoFields: List<ShippingInfoWidget.CustomizableShippingField>
         ): Boolean {
             return optionalShippingInfoFields.contains(
-                ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD
+                ShippingInfoWidget.CustomizableShippingField.PostalCode
             ) || hiddenShippingInfoFields.contains(
-                ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD
+                ShippingInfoWidget.CustomizableShippingField.PostalCode
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -9,7 +9,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
-import androidx.annotation.StringDef
 import com.stripe.android.R
 import com.stripe.android.databinding.AddressWidgetBinding
 import com.stripe.android.model.Address
@@ -32,8 +31,28 @@ class ShippingInfoWidget @JvmOverloads constructor(
         )
     }
     private val postalCodeValidator: PostalCodeValidator = PostalCodeValidator()
-    private var optionalShippingInfoFields: List<String> = emptyList()
-    private var hiddenShippingInfoFields: List<String> = emptyList()
+
+    /**
+     * Address fields that should be optional.
+     */
+    var optionalFields: List<CustomizableShippingField> = emptyList()
+        set(value) {
+            field = value
+
+            renderLabels()
+            countryAutoCompleteTextView.selectedCountry?.let(::updateConfigForCountry)
+        }
+
+    /**
+     * Address fields that should be hidden. Hidden fields are automatically optional.
+     */
+    var hiddenFields: List<CustomizableShippingField> = emptyList()
+        set(value) {
+            field = value
+
+            renderLabels()
+            countryAutoCompleteTextView.selectedCountry?.let(::updateConfigForCountry)
+        }
 
     private val countryAutoCompleteTextView = viewBinding.countryAutocompleteAaw
     private val addressLine1TextInputLayout = viewBinding.tlAddressLine1Aaw
@@ -86,23 +105,13 @@ class ShippingInfoWidget @JvmOverloads constructor(
      * Constants that can be used to mark fields in this widget as optional or hidden.
      * Some fields cannot be hidden.
      */
-    @Retention(AnnotationRetention.SOURCE)
-    @StringDef(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD,
-        CustomizableShippingField.ADDRESS_LINE_TWO_FIELD,
-        CustomizableShippingField.CITY_FIELD,
-        CustomizableShippingField.POSTAL_CODE_FIELD,
-        CustomizableShippingField.STATE_FIELD,
-        CustomizableShippingField.PHONE_FIELD)
-    annotation class CustomizableShippingField {
-        companion object {
-            const val ADDRESS_LINE_ONE_FIELD: String = "address_line_one"
-            // address line two is optional by default
-            const val ADDRESS_LINE_TWO_FIELD: String = "address_line_two"
-            const val CITY_FIELD: String = "city"
-            const val POSTAL_CODE_FIELD: String = "postal_code"
-            const val STATE_FIELD: String = "state"
-            const val PHONE_FIELD: String = "phone"
-        }
+    enum class CustomizableShippingField {
+        Line1,
+        Line2, // optional by default
+        City,
+        PostalCode,
+        State,
+        Phone
     }
 
     init {
@@ -116,27 +125,6 @@ class ShippingInfoWidget @JvmOverloads constructor(
         }
 
         initView()
-    }
-
-    /**
-     * @param optionalAddressFields address fields that should be optional.
-     */
-    fun setOptionalFields(optionalAddressFields: List<String>?) {
-        optionalShippingInfoFields = optionalAddressFields.orEmpty()
-        renderLabels()
-
-        countryAutoCompleteTextView.selectedCountry?.let(::updateConfigForCountry)
-    }
-
-    /**
-     * @param hiddenAddressFields address fields that should be hidden. Hidden fields are
-     * automatically optional.
-     */
-    fun setHiddenFields(hiddenAddressFields: List<String>?) {
-        hiddenShippingInfoFields = hiddenAddressFields.orEmpty()
-        renderLabels()
-
-        countryAutoCompleteTextView.selectedCountry?.let(::updateConfigForCountry)
     }
 
     /**
@@ -188,28 +176,28 @@ class ShippingInfoWidget @JvmOverloads constructor(
         val isPostalCodeValid = postalCodeValidator.isValid(
             postalCode,
             selectedCountry?.code,
-            optionalShippingInfoFields,
-            hiddenShippingInfoFields
+            optionalFields,
+            hiddenFields
         )
         postalCodeEditText.shouldShowError = !isPostalCodeValid
 
         val requiredAddressLine1Empty = address.isEmpty() &&
-            isFieldRequired(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)
+            isFieldRequired(CustomizableShippingField.Line1)
         addressEditText.shouldShowError = requiredAddressLine1Empty
 
         val requiredCityEmpty = city.isEmpty() &&
-            isFieldRequired(CustomizableShippingField.CITY_FIELD)
+            isFieldRequired(CustomizableShippingField.City)
         cityEditText.shouldShowError = requiredCityEmpty
 
         val requiredNameEmpty = name.isEmpty()
         nameEditText.shouldShowError = requiredNameEmpty
 
         val requiredStateEmpty = state.isEmpty() &&
-            isFieldRequired(CustomizableShippingField.STATE_FIELD)
+            isFieldRequired(CustomizableShippingField.State)
         stateEditText.shouldShowError = requiredStateEmpty
 
         val requiredPhoneNumberEmpty = phoneNumber.isEmpty() &&
-            isFieldRequired(CustomizableShippingField.PHONE_FIELD)
+            isFieldRequired(CustomizableShippingField.Phone)
         phoneNumberEditText.shouldShowError = requiredPhoneNumberEmpty
 
         return isPostalCodeValid && !requiredAddressLine1Empty && !requiredCityEmpty &&
@@ -217,16 +205,16 @@ class ShippingInfoWidget @JvmOverloads constructor(
             selectedCountry != null
     }
 
-    private fun isFieldRequired(@CustomizableShippingField field: String): Boolean {
+    private fun isFieldRequired(field: CustomizableShippingField): Boolean {
         return !isFieldOptional(field) && !isFieldHidden(field)
     }
 
-    private fun isFieldOptional(@CustomizableShippingField field: String): Boolean {
-        return optionalShippingInfoFields.contains(field)
+    private fun isFieldOptional(field: CustomizableShippingField): Boolean {
+        return optionalFields.contains(field)
     }
 
-    private fun isFieldHidden(@CustomizableShippingField field: String): Boolean {
-        return hiddenShippingInfoFields.contains(field)
+    private fun isFieldHidden(field: CustomizableShippingField): Boolean {
+        return hiddenFields.contains(field)
     }
 
     private fun initView() {
@@ -256,13 +244,13 @@ class ShippingInfoWidget @JvmOverloads constructor(
     private fun renderLabels() {
         nameTextInputLayout.hint = resources.getString(R.string.address_label_name)
         cityTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.CITY_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.City)) {
                 resources.getString(R.string.address_label_city_optional)
             } else {
                 resources.getString(R.string.address_label_city)
             }
         phoneNumberTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.PHONE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.Phone)) {
                 resources.getString(R.string.address_label_phone_number_optional)
             } else {
                 resources.getString(R.string.address_label_phone_number)
@@ -271,22 +259,22 @@ class ShippingInfoWidget @JvmOverloads constructor(
     }
 
     private fun hideHiddenFields() {
-        if (isFieldHidden(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.Line1)) {
             addressLine1TextInputLayout.visibility = View.GONE
         }
-        if (isFieldHidden(CustomizableShippingField.ADDRESS_LINE_TWO_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.Line2)) {
             addressLine2TextInputLayout.visibility = View.GONE
         }
-        if (isFieldHidden(CustomizableShippingField.STATE_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.State)) {
             stateTextInputLayout.visibility = View.GONE
         }
-        if (isFieldHidden(CustomizableShippingField.CITY_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.City)) {
             cityTextInputLayout.visibility = View.GONE
         }
-        if (isFieldHidden(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.PostalCode)) {
             postalCodeTextInputLayout.visibility = View.GONE
         }
-        if (isFieldHidden(CustomizableShippingField.PHONE_FIELD)) {
+        if (isFieldHidden(CustomizableShippingField.Phone)) {
             phoneNumberTextInputLayout.visibility = View.GONE
         }
     }
@@ -303,7 +291,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
         postalCodeTextInputLayout.visibility =
             if (CountryUtils.doesCountryUsePostalCode(country.code) &&
-                !isFieldHidden(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+                !isFieldHidden(CustomizableShippingField.PostalCode)) {
                 View.VISIBLE
             } else {
                 View.GONE
@@ -319,7 +307,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
     private fun renderUSForm() {
         addressLine1TextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.Line1)) {
                 resources.getString(R.string.address_label_address_optional)
             } else {
                 resources.getString(R.string.address_label_address)
@@ -327,13 +315,13 @@ class ShippingInfoWidget @JvmOverloads constructor(
         addressLine2TextInputLayout.hint = resources.getString(R.string
             .address_label_apt_optional)
         postalCodeTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.PostalCode)) {
                 resources.getString(R.string.address_label_zip_code_optional)
             } else {
                 resources.getString(R.string.address_label_zip_code)
             }
         stateTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.STATE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.State)) {
                 resources.getString(R.string.address_label_state_optional)
             } else {
                 resources.getString(R.string.address_label_state)
@@ -344,7 +332,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
     private fun renderGreatBritainForm() {
         addressLine1TextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.Line1)) {
                 resources.getString(R.string.address_label_address_line1_optional)
             } else {
                 resources.getString(R.string.address_label_address_line1)
@@ -353,13 +341,13 @@ class ShippingInfoWidget @JvmOverloads constructor(
             R.string.address_label_address_line2_optional
         )
         postalCodeTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.PostalCode)) {
                 resources.getString(R.string.address_label_postcode_optional)
             } else {
                 resources.getString(R.string.address_label_postcode)
             }
         stateTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.STATE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.State)) {
                 resources.getString(R.string.address_label_county_optional)
             } else {
                 resources.getString(R.string.address_label_county)
@@ -370,20 +358,20 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
     private fun renderCanadianForm() {
         addressLine1TextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.Line1)) {
                 resources.getString(R.string.address_label_address_optional)
             } else {
                 resources.getString(R.string.address_label_address)
             }
         addressLine2TextInputLayout.hint = resources.getString(R.string.address_label_apt_optional)
         postalCodeTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.PostalCode)) {
                 resources.getString(R.string.address_label_postal_code_optional)
             } else {
                 resources.getString(R.string.address_label_postal_code)
             }
         stateTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.STATE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.State)) {
                 resources.getString(R.string.address_label_province_optional)
             } else {
                 resources.getString(R.string.address_label_province)
@@ -397,7 +385,7 @@ class ShippingInfoWidget @JvmOverloads constructor(
 
     private fun renderInternationalForm() {
         addressLine1TextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.ADDRESS_LINE_ONE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.Line1)) {
                 resources.getString(R.string.address_label_address_line1_optional)
             } else {
                 resources.getString(R.string.address_label_address_line1)
@@ -406,14 +394,14 @@ class ShippingInfoWidget @JvmOverloads constructor(
             resources.getString(R.string.address_label_address_line2_optional)
 
         postalCodeTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.POSTAL_CODE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.PostalCode)) {
                 resources.getString(R.string.address_label_zip_postal_code_optional)
             } else {
                 resources.getString(R.string.address_label_zip_postal_code)
             }
 
         stateTextInputLayout.hint =
-            if (isFieldOptional(CustomizableShippingField.STATE_FIELD)) {
+            if (isFieldOptional(CustomizableShippingField.State)) {
                 resources.getString(R.string.address_label_region_generic_optional)
             } else {
                 resources.getString(R.string.address_label_region_generic)

--- a/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentSessionFixtures.kt
@@ -13,12 +13,12 @@ internal object PaymentSessionFixtures {
 
         // hide the phone field on the shipping information form
         .setHiddenShippingInfoFields(
-            ShippingInfoWidget.CustomizableShippingField.ADDRESS_LINE_TWO_FIELD
+            ShippingInfoWidget.CustomizableShippingField.Line2
         )
 
         // make the address line 2 field optional
         .setOptionalShippingInfoFields(
-            ShippingInfoWidget.CustomizableShippingField.PHONE_FIELD
+            ShippingInfoWidget.CustomizableShippingField.Phone
         )
 
         // specify an address to pre-populate the shipping information form

--- a/stripe/src/test/java/com/stripe/android/view/PostalCodeValidatorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PostalCodeValidatorTest.kt
@@ -12,7 +12,7 @@ class PostalCodeValidatorTest {
             postalCode = "",
             countryCode = "US",
             optionalShippingInfoFields = listOf(
-                ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD
+                ShippingInfoWidget.CustomizableShippingField.PostalCode
             ),
             hiddenShippingInfoFields = emptyList()
         ))
@@ -24,7 +24,7 @@ class PostalCodeValidatorTest {
             postalCode = "94107",
             countryCode = "",
             optionalShippingInfoFields = listOf(
-                ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD
+                ShippingInfoWidget.CustomizableShippingField.PostalCode
             ),
             hiddenShippingInfoFields = emptyList()
         ))

--- a/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -248,8 +248,8 @@ class ShippingInfoWidgetTest {
             .isEqualTo(res.getString(R.string.address_label_zip_code))
         assertThat(nameTextInputLayout.hint.toString())
             .isEqualTo(res.getString(R.string.address_label_name))
-        shippingInfoWidget.setOptionalFields(
-            listOf(ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD)
+        shippingInfoWidget.optionalFields = listOf(
+            ShippingInfoWidget.CustomizableShippingField.PostalCode
         )
         assertThat(postalCodeTextInputLayout.hint.toString())
             .isEqualTo(res.getString(R.string.address_label_zip_code_optional))
@@ -258,10 +258,10 @@ class ShippingInfoWidgetTest {
         countryAutoCompleteTextView.updateUiForCountryEntered(Locale.CANADA.displayCountry)
         assertThat(stateTextInputLayout.hint.toString())
             .isEqualTo(res.getString(R.string.address_label_province))
-        shippingInfoWidget.setOptionalFields(listOf(
-            ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD,
-            ShippingInfoWidget.CustomizableShippingField.STATE_FIELD
-        ))
+        shippingInfoWidget.optionalFields = listOf(
+            ShippingInfoWidget.CustomizableShippingField.PostalCode,
+            ShippingInfoWidget.CustomizableShippingField.State
+        )
         assertThat(stateTextInputLayout.hint.toString())
             .isEqualTo(res.getString(R.string.address_label_province_optional))
     }
@@ -272,8 +272,8 @@ class ShippingInfoWidgetTest {
             .isEqualTo(View.VISIBLE)
         assertThat(postalCodeTextInputLayout.visibility)
             .isEqualTo(View.VISIBLE)
-        shippingInfoWidget.setHiddenFields(
-            listOf(ShippingInfoWidget.CustomizableShippingField.POSTAL_CODE_FIELD)
+        shippingInfoWidget.hiddenFields = listOf(
+            ShippingInfoWidget.CustomizableShippingField.PostalCode
         )
         assertThat(postalCodeTextInputLayout.visibility)
             .isEqualTo(View.GONE)


### PR DESCRIPTION
## Summary
- `setOptionalFields()` is now `optionalFields`
- `setHiddenFields()` is now `hiddenFields`
- `CustomizableShippingField` is now an enum

## Motivation
Consistency

## Testing
<!-- How was the code tested? Be as specific as possible. -->
