### PR TITLE
Refactor Stripe3ds2Fingerprint

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -598,9 +598,9 @@ internal class StripePaymentController internal constructor(
         val activity = host.activity ?: return
 
         val transaction = threeDs2Service.createTransaction(
-            stripe3ds2Fingerprint.directoryServer.id,
+            stripe3ds2Fingerprint.directoryServerEncryption.directoryServerId,
             messageVersionRegistry.current, stripeIntent.isLiveMode,
-            stripe3ds2Fingerprint.directoryServer.networkName,
+            stripe3ds2Fingerprint.directoryServerName,
             stripe3ds2Fingerprint.directoryServerEncryption.rootCerts,
             stripe3ds2Fingerprint.directoryServerEncryption.directoryServerPublicKey,
             stripe3ds2Fingerprint.directoryServerEncryption.keyId,
@@ -619,7 +619,7 @@ internal class StripePaymentController internal constructor(
 
         challengeProgressActivityStarter.start(
             activity,
-            stripe3ds2Fingerprint.directoryServer.networkName,
+            stripe3ds2Fingerprint.directoryServerName,
             false,
             config.stripe3ds2Config.uiCustomization.uiCustomization
         )

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -97,10 +97,10 @@ class StripePaymentControllerTest {
             .directoryServerPublicKey
         whenever(
             threeDs2Service.createTransaction(
-                eq(Stripe3ds2Fingerprint.DirectoryServer.Mastercard.id),
+                eq(MASTERCARD_DS_ID),
                 eq(MESSAGE_VERSION),
                 eq(paymentIntent.isLiveMode),
-                eq(Stripe3ds2Fingerprint.DirectoryServer.Mastercard.networkName),
+                eq("mastercard"),
                 any(),
                 eq(dsPublicKey),
                 eq("7c4debe3f4af7f9d1569a2ffea4343c2566826ee"),
@@ -111,10 +111,10 @@ class StripePaymentControllerTest {
             .thenReturn(transaction)
         controller.handleNextAction(host, paymentIntent, REQUEST_OPTIONS)
         verify(threeDs2Service).createTransaction(
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Mastercard.id),
+            eq(MASTERCARD_DS_ID),
             eq(MESSAGE_VERSION),
             eq(paymentIntent.isLiveMode),
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Mastercard.networkName),
+            eq("mastercard"),
             any(),
             eq(dsPublicKey),
             eq("7c4debe3f4af7f9d1569a2ffea4343c2566826ee"),
@@ -143,10 +143,10 @@ class StripePaymentControllerTest {
     @Test
     fun handleNextAction_withAmexAnd3ds2_shouldStart3ds2ChallengeFlow() {
         whenever(threeDs2Service.createTransaction(
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Amex.id),
+            eq(AMEX_DS_ID),
             eq(MESSAGE_VERSION),
             eq(PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2.isLiveMode),
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Amex.networkName),
+            eq("american_express"),
             any(),
             eq(Stripe3ds2FingerprintTest.DS_RSA_PUBLIC_KEY),
             eq(PaymentIntentFixtures.KEY_ID),
@@ -160,10 +160,10 @@ class StripePaymentControllerTest {
             REQUEST_OPTIONS
         )
         verify(threeDs2Service).createTransaction(
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Amex.id),
+            eq(AMEX_DS_ID),
             eq(MESSAGE_VERSION),
             eq(PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2.isLiveMode),
-            eq(Stripe3ds2Fingerprint.DirectoryServer.Amex.networkName),
+            eq("american_express"),
             any(),
             eq(Stripe3ds2FingerprintTest.DS_RSA_PUBLIC_KEY),
             eq(PaymentIntentFixtures.KEY_ID),
@@ -821,5 +821,8 @@ class StripePaymentControllerTest {
                 .setTimeout(5)
                 .build())
             .build()
+
+        private const val MASTERCARD_DS_ID = "A000000004"
+        private const val AMEX_DS_ID = "A000000025"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/Stripe3ds2FingerprintTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.model
 
 import java.io.ByteArrayInputStream
 import java.security.PublicKey
-import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import kotlin.test.Test
@@ -15,23 +14,19 @@ import org.robolectric.RobolectricTestRunner
 class Stripe3ds2FingerprintTest {
 
     @Test
-    @Throws(CertificateException::class)
     fun create_with3ds2SdkData_shouldCreateObject() {
         val sdkData = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
             .nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
         assertNotNull(sdkData)
         val stripe3ds2Fingerprint = Stripe3ds2Fingerprint(sdkData)
         assertEquals("src_1ExkUeAWhjPjYwPiLWUvXrSA", stripe3ds2Fingerprint.source)
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Mastercard,
-            stripe3ds2Fingerprint.directoryServer)
+        assertEquals("mastercard", stripe3ds2Fingerprint.directoryServerName)
         assertEquals("34b16ea1-1206-4ee8-84d2-d292bc73c2ae",
             stripe3ds2Fingerprint.serverTransactionId)
 
         val directoryServerEncryption =
             stripe3ds2Fingerprint.directoryServerEncryption
-        assertNotNull(stripe3ds2Fingerprint.directoryServerEncryption)
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Mastercard.id,
-            directoryServerEncryption.directoryServerId)
+        assertEquals("A000000004", directoryServerEncryption.directoryServerId)
         assertNotNull(directoryServerEncryption.directoryServerPublicKey)
         assertEquals("7c4debe3f4af7f9d1569a2ffea4343c2566826ee",
             directoryServerEncryption.keyId)
@@ -39,25 +34,22 @@ class Stripe3ds2FingerprintTest {
     }
 
     @Test
-    @Throws(CertificateException::class)
     fun create_with3ds2AmexSdkData_shouldCreateObject() {
         val sdkData = PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2
             .nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
         assertNotNull(sdkData)
         val stripe3ds2Fingerprint = Stripe3ds2Fingerprint(sdkData)
         assertEquals("src_1EceOlCRMbs6FrXf2hqrI1g5", stripe3ds2Fingerprint.source)
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Amex,
-            stripe3ds2Fingerprint.directoryServer)
+        assertEquals("american_express", stripe3ds2Fingerprint.directoryServerName)
         assertEquals("e64bb72f-60ac-4845-b8b6-47cfdb0f73aa",
             stripe3ds2Fingerprint.serverTransactionId)
 
-        assertNotNull(stripe3ds2Fingerprint.directoryServerEncryption)
-        assertEquals(Stripe3ds2Fingerprint.DirectoryServer.Amex.id,
-            stripe3ds2Fingerprint.directoryServerEncryption.directoryServerId)
-        assertEquals(DS_RSA_PUBLIC_KEY,
-            stripe3ds2Fingerprint.directoryServerEncryption.directoryServerPublicKey)
+        val directoryServerEncryption =
+            stripe3ds2Fingerprint.directoryServerEncryption
+        assertEquals("A000000025", directoryServerEncryption.directoryServerId)
+        assertEquals(DS_RSA_PUBLIC_KEY, directoryServerEncryption.directoryServerPublicKey)
         assertEquals("7c4debe3f4af7f9d1569a2ffea4343c2566826ee",
-            stripe3ds2Fingerprint.directoryServerEncryption.keyId)
+            directoryServerEncryption.keyId)
     }
 
     internal companion object {


### PR DESCRIPTION
## Summary
Remove `DirectoryServer` enum because the 3DS2 SDK already has
knowledge of supported directory servers. Instead, pass the directory
server id and name directly to the 3DS2 SDK so that it is the source
of truth.

Remove unused code in `Stripe3ds2Fingerprint`.

## Testing
Updated unit tests
Manually verified
