### PR TITLE
Fix broken FPX tests

### DIFF
--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -682,8 +682,11 @@ class StripeApiRepositoryTest {
             ).observeForever {
                 fpxBankStatuses = it
             }
-            assertThat(fpxBankStatuses?.isOnline(FpxBank.Hsbc))
-                .isTrue()
+            assertThat(
+                setOf(FpxBank.Hsbc, FpxBank.Bsn).any {
+                    fpxBankStatuses?.isOnline(it) == true
+                }
+            ).isTrue()
         }
     }
 
@@ -699,8 +702,11 @@ class StripeApiRepositoryTest {
             ).observeForever {
                 fpxBankStatuses = it
             }
-            assertThat(fpxBankStatuses?.isOnline(FpxBank.Hsbc))
-                .isTrue()
+            assertThat(
+                setOf(FpxBank.Hsbc, FpxBank.Bsn).any {
+                    fpxBankStatuses?.isOnline(it) == true
+                }
+            ).isTrue()
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
@@ -38,8 +38,11 @@ class FpxViewModelTest {
                 bankStatuses = it
             }
 
-            assertThat(requireNotNull(bankStatuses).isOnline(FpxBank.Hsbc))
-                .isTrue()
+            assertThat(
+                setOf(FpxBank.Hsbc, FpxBank.Bsn).any {
+                    bankStatuses?.isOnline(it) == true
+                }
+            ).isTrue()
         }
     }
 }


### PR DESCRIPTION
## Summary
Make tests more resilient by checking for more than one bank being online.

## Motivation
FPX banks can go offline for maintenance. This shouldn't break out tests.

## Testing
Updated tests