### PR TITLE
Fix HTML select option rendering in WebView

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -23,7 +23,7 @@ configurations {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-rc02'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -6,7 +6,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.util.AttributeSet
@@ -31,7 +30,7 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : WebView(createContext(context), attrs, defStyleAttr) {
+) : WebView(context, attrs, defStyleAttr) {
     private var webViewClient: PaymentAuthWebViewClient? = null
 
     init {
@@ -107,18 +106,6 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
             it.hasLoadedBlank = true
         }
         loadUrl(BLANK_PAGE)
-    }
-
-    private companion object {
-        /**
-         * Fix for crash in API 21 and 22
-         *
-         * See <a href="https://stackoverflow.com/q/41025200/">https://stackoverflow.com/q/41025200/</a>
-         * for more context.
-         */
-        private fun createContext(context: Context): Context {
-            return context.createConfigurationContext(Configuration())
-        }
     }
 
     internal class PaymentAuthWebViewClient(


### PR DESCRIPTION
## Summary
`appcompat:1.1.0` introduced an issue that caused WebViews on API 21
and 22 to crash on creation. There was a known fix for this issue,
but that fix broke rendering of HTML select options. This was because
the fix made the `WebView` use an `Application` context instead of
`Activity` context; `Activity` context is required to correctly render
HTML select options.

Upgrade to `appcompat:1.2.0-rc02` and remove the fix.

See https://issuetracker.google.com/issues/141132133 for more details.

## Motivation
Fixes #2656

## Testing
Manually verified that WebViews render correctly after upgrading to
`appcompat:1.2.0-rc02` and removing the crash workaround.

Manually verified that HTML select options now render correctly when
clicked.

![select](https://user-images.githubusercontent.com/45020849/88548192-bf7b9400-cfec-11ea-9cd4-c0bec8422c23.gif)
