### PR TITLE
Change CI timeout for unit tests to 35 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     unit-tests:
         name: Unit tests
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     unit-tests:
         name: Unit tests
         runs-on: ubuntu-latest
-        timeout-minutes: 25
+        timeout-minutes: 35
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -42,4 +42,4 @@ jobs:
                 path: ~/.gradle/caches
                 key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
             - name: Unit tests
-              run: ./gradlew testDebugUnitTest --info
+              run: ./gradlew testDebugUnitTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     unit-tests:
         name: Unit tests
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
                 path: ~/.gradle/caches
                 key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
             - name: Unit tests
-              run: ./gradlew testDebugUnitTest
+              run: ./gradlew testDebugUnitTest --info


### PR DESCRIPTION
Some CI runs take slightly more than 15 minutes. Set to 35 minutes and add `--info` to avoid timeouts in these cases.