### PR TITLE
Refactor FingerprintDataRepository

### DIFF
--- a/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintDataStore.kt
@@ -1,15 +1,15 @@
 package com.stripe.android
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.liveData
 import com.stripe.android.model.parsers.FingerprintDataJsonParser
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.json.JSONObject
 
 internal interface FingerprintDataStore {
-    fun get(): LiveData<FingerprintData?>
+    fun get(): Flow<FingerprintData?>
     fun save(fingerprintData: FingerprintData)
 
     class Default(
@@ -22,7 +22,7 @@ internal interface FingerprintDataStore {
             )
         }
 
-        override fun get() = liveData<FingerprintData?>(coroutineDispatcher) {
+        override fun get() = flow<FingerprintData?> {
             emit(
                 runCatching {
                     val json = JSONObject(prefs.getString(KEY_DATA, null).orEmpty())

--- a/stripe/src/main/java/com/stripe/android/FingerprintRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintRequestExecutor.kt
@@ -1,19 +1,16 @@
 package com.stripe.android
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.liveData
 import com.stripe.android.model.parsers.FingerprintDataJsonParser
 import java.util.Calendar
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 internal interface FingerprintRequestExecutor {
     fun execute(
         request: FingerprintRequest
-    ): LiveData<FingerprintData?>
+    ): Flow<FingerprintData?>
 
     class Default(
-        private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
         private val connectionFactory: ConnectionFactory = ConnectionFactory.Default()
     ) : FingerprintRequestExecutor {
         private val timestampSupplier = {
@@ -22,7 +19,7 @@ internal interface FingerprintRequestExecutor {
 
         override fun execute(
             request: FingerprintRequest
-        ) = liveData<FingerprintData?>(dispatcher) {
+        ) = flow<FingerprintData?> {
             emit(
                 // fingerprint request failures should be non-fatal
                 runCatching {

--- a/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
@@ -43,7 +43,7 @@ class FingerprintDataRepositoryTest {
     fun `get() when FingerprintData is expired should request new remote FingerprintData`() {
         val expectedFingerprintData = createFingerprintData()
         val repository = FingerprintDataRepository.Default(
-            store = FingerprintDataStore.Default(
+            localStore = FingerprintDataStore.Default(
                 context,
                 testDispatcher
             ),
@@ -68,7 +68,7 @@ class FingerprintDataRepositoryTest {
         val store: FingerprintDataStore = mock()
         val fingerprintRequestFactory: FingerprintRequestFactory = mock()
         val repository = FingerprintDataRepository.Default(
-            store = store,
+            localStore = store,
             fingerprintRequestFactory = fingerprintRequestFactory,
             fingerprintRequestExecutor = fingerprintRequestExecutor,
             dispatcher = testDispatcher

--- a/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
@@ -11,8 +11,8 @@ import java.util.Calendar
 import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -49,7 +49,7 @@ class FingerprintDataRepositoryTest {
             ),
             fingerprintRequestFactory = FingerprintRequestFactory(context),
             fingerprintRequestExecutor = object : FingerprintRequestExecutor {
-                override fun execute(request: FingerprintRequest) = flowOf(expectedFingerprintData)
+                override suspend fun execute(request: FingerprintRequest) = expectedFingerprintData
             },
             dispatcher = testDispatcher
         )
@@ -62,7 +62,7 @@ class FingerprintDataRepositoryTest {
     }
 
     @Test
-    fun `refresh() when advancedFraudSignals is disabled should not fetch FingerprintData`() {
+    fun `refresh() when advancedFraudSignals is disabled should not fetch FingerprintData`() = testDispatcher.runBlockingTest {
         Stripe.advancedFraudSignalsEnabled = false
 
         val store: FingerprintDataStore = mock()


### PR DESCRIPTION
## Summary
Update `FingerprintDataRepository` related classes to return a
single object instead of a stream.

## Motivation
This moves fingerprint-related operations off the main
thread.

## Testing
Unit tests
Manual testing
