### PR TITLE
Extendable StripeEditText subclasses

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitAccountNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitAccountNumberEditText.kt
@@ -7,7 +7,7 @@ import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import com.stripe.android.R
 
-internal class BecsDebitAccountNumberEditText @JvmOverloads constructor(
+open class BecsDebitAccountNumberEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
@@ -7,7 +7,7 @@ import java.util.Scanner
 import kotlinx.android.parcel.Parcelize
 import org.json.JSONObject
 
-internal class BecsDebitBanks(
+class BecsDebitBanks(
     internal val banks: List<Bank>,
     private val shouldIncludeTestBank: Boolean = true
 ) {

--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
@@ -7,7 +7,7 @@ import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import com.stripe.android.R
 
-internal class BecsDebitBsbEditText @JvmOverloads constructor(
+open class BecsDebitBsbEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -15,7 +15,7 @@ import com.stripe.android.model.CardBrand
 /**
  * A [StripeEditText] that handles spacing out the digits of a credit card.
  */
-class CardNumberEditText @JvmOverloads constructor(
+open class CardNumberEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -15,7 +15,7 @@ import com.stripe.android.model.CardBrand
 /**
  * A [StripeEditText] for CVC input.
  */
-class CvcEditText @JvmOverloads constructor(
+open class CvcEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/EmailEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/EmailEditText.kt
@@ -5,7 +5,7 @@ import android.util.AttributeSet
 import android.util.Patterns
 import com.stripe.android.R
 
-internal class EmailEditText @JvmOverloads constructor(
+open class EmailEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -13,7 +13,7 @@ import kotlin.math.min
 /**
  * An [EditText] that handles putting numbers around a central divider character.
  */
-class ExpiryDateEditText @JvmOverloads constructor(
+open class ExpiryDateEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle

--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -15,7 +15,7 @@ import com.stripe.android.R
 import java.util.regex.Pattern
 import kotlin.properties.Delegates
 
-class PostalCodeEditText @JvmOverloads constructor(
+open class PostalCodeEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle


### PR DESCRIPTION
## Summary
All StripeEditText subclasses made open instead of final.

## Motivation
Allows extending all StripeEditTexts in order to customize them in places where styling won't help, and fix bugs in Material Components TextInputEditText/TextInputLayout.
Specific use case for me: Override `setBackground` to apply rounded corners to collapsed label cutout.

## Testing
Not required, no code changes, only class visibility.