### PR TITLE
Make CardParams public

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -13,6 +13,7 @@ import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.SourceTypeModel
@@ -55,7 +56,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
         setContentView(viewBinding.root)
 
         viewBinding.createButton.setOnClickListener {
-            viewBinding.cardWidget.card?.let {
+            viewBinding.cardWidget.cardParams?.let {
                 createCardSource(it)
             } ?: showSnackbar("Enter a valid card.")
         }
@@ -91,17 +92,17 @@ class CreateCardSourceActivity : AppCompatActivity() {
     }
 
     /**
-     * To start the 3DS cycle, create a [Source] out of the user-entered [Card].
+     * To start the 3DS cycle, create a [Source] out of the user-entered [CardParams].
      *
-     * @param card the [Card] used to create a source
+     * @param cardParams the [CardParams] used to create a source
      */
-    private fun createCardSource(card: Card) {
+    private fun createCardSource(cardParams: CardParams) {
         keyboardController.hide()
 
         viewBinding.createButton.isEnabled = false
         viewBinding.progressBar.visibility = View.VISIBLE
 
-        val params = SourceParams.createCardParams(card)
+        val params = SourceParams.createCardParams(cardParams)
         viewModel.createSource(params).observe(
             this,
             Observer { result ->
@@ -138,7 +139,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
      * to verify the third-party approval. The only information from the Card source
      * that is used is the ID field.
      *
-     * @param source the [Card]-created [Source].
+     * @param source the [CardParams]-created [Source].
      */
     private fun createThreeDSecureSource(source: Source) {
         // This represents a request for a 3DS purchase of 10.00 euro.

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.model.Card
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.Token
 import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
@@ -51,20 +51,16 @@ class CreateCardTokenActivity : AppCompatActivity() {
         viewBinding.createTokenButton.setOnClickListener {
             BackgroundTaskTracker.onStart()
 
-            val card = viewBinding.cardInputWidget.card
-
-            if (card != null) {
+            viewBinding.cardInputWidget.cardParams?.let { cardParams ->
                 onRequestStart()
-                viewModel.createCardToken(card).observe(
+                viewModel.createCardToken(cardParams).observe(
                     this,
                     Observer {
                         onRequestEnd()
                         adapter.addToken(it)
                     }
                 )
-            } else {
-                snackbarController.show(getString(R.string.invalid_card_details))
-            }
+            } ?: snackbarController.show(getString(R.string.invalid_card_details))
         }
 
         viewBinding.cardInputWidget.setCardValidCallback(object : CardValidCallback {
@@ -132,11 +128,11 @@ class CreateCardTokenActivity : AppCompatActivity() {
     ) : AndroidViewModel(application) {
         private val stripe = StripeFactory(application).create()
 
-        fun createCardToken(card: Card): LiveData<Token> {
+        fun createCardToken(cardParams: CardParams): LiveData<Token> {
             val data = MutableLiveData<Token>()
 
             stripe.createCardToken(
-                card,
+                cardParams,
                 callback = object : ApiResultCallback<Token> {
                     override fun onSuccess(result: Token) {
                         BackgroundTaskTracker.onStop()

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -1257,7 +1257,7 @@ class Stripe internal constructor(
      */
     @UiThread
     @JvmOverloads
-    internal fun createCardToken(
+    fun createCardToken(
         cardParams: CardParams,
         idempotencyKey: String? = null,
         stripeAccountId: String? = this.stripeAccountId,
@@ -1334,7 +1334,7 @@ class Stripe internal constructor(
         APIConnectionException::class, CardException::class, APIException::class)
     @WorkerThread
     @JvmOverloads
-    internal fun createCardTokenSynchronous(
+    fun createCardTokenSynchronous(
         cardParams: CardParams,
         idempotencyKey: String? = null,
         stripeAccountId: String? = this.stripeAccountId

--- a/stripe/src/main/java/com/stripe/android/model/CardParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardParams.kt
@@ -6,7 +6,7 @@ import kotlinx.android.parcel.Parcelize
  * [Create a card token](https://stripe.com/docs/api/tokens/create_card)
  */
 @Parcelize
-internal data class CardParams internal constructor(
+data class CardParams internal constructor(
     private val loggingTokens: Set<String> = emptySet(),
 
     /**
@@ -81,7 +81,7 @@ internal data class CardParams internal constructor(
 ) : TokenParams(Token.Type.Card, loggingTokens) {
 
     @JvmOverloads
-    constructor(
+    internal constructor(
         /**
          * [card.number](https://stripe.com/docs/api/tokens/create_card#create_card_token-card-number)
          *

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
@@ -685,7 +685,7 @@ class SourceParams private constructor(
          * @see [Card Payments with Sources](https://stripe.com/docs/sources/cards)
          */
         @JvmStatic
-        internal fun createCardParams(cardParams: CardParams): SourceParams {
+        fun createCardParams(cardParams: CardParams): SourceParams {
             return SourceParams(SourceType.CARD, cardParams.attribution)
                 .setApiParameterMap(
                     mapOf(

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -63,10 +63,13 @@ class CardInputWidget @JvmOverloads constructor(
 
     @JvmSynthetic
     internal val cardNumberEditText = viewBinding.cardNumberEditText
+
     @JvmSynthetic
     internal val expiryDateEditText = viewBinding.expiryDateEditText
+
     @JvmSynthetic
     internal val cvcNumberEditText = viewBinding.cvcEditText
+
     @JvmSynthetic
     internal val postalCodeEditText = viewBinding.postalCodeEditText
 
@@ -209,7 +212,11 @@ class CardInputWidget @JvmOverloads constructor(
             return cardBuilder?.build()
         }
 
-    internal val cardParams: CardParams?
+    /**
+     * A [CardParams] representing the card details and postal code if all fields are valid;
+     * otherwise `null`
+     */
+    override val cardParams: CardParams?
         get() {
             val cardNumber = cardNumberEditText.cardNumber
             val cardDate = expiryDateEditText.validDateFields

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -177,7 +177,11 @@ class CardMultilineWidget @JvmOverloads constructor(
             return cardBuilder?.build()
         }
 
-    internal val cardParams: CardParams?
+    /**
+     * A [CardParams] representing the card details and postal code if all fields are valid;
+     * otherwise `null`
+     */
+    override val cardParams: CardParams?
         get() {
             if (!validateAllFields()) {
                 shouldShowErrorIcon = true

--- a/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardWidget.kt
@@ -3,6 +3,7 @@ package com.stripe.android.view
 import android.text.TextWatcher
 import androidx.annotation.IntRange
 import com.stripe.android.model.Card
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethodCreateParams
 
 internal interface CardWidget {
@@ -11,6 +12,12 @@ internal interface CardWidget {
      * otherwise `null`
      */
     val card: Card?
+
+    /**
+     * A [CardParams] representing the card details and postal code if all fields are valid;
+     * otherwise `null`
+     */
+    val cardParams: CardParams?
 
     /**
      * A [Card.Builder] representing the card details and postal code if all fields are valid;


### PR DESCRIPTION
## Summary
`CardParams`'s constructors are `internal` for now - this object will
likely only be created through `CardInputWidget` and
`CardMultilineWidget`.

## Motivation
Continue migration from `Card` to `CardParams` for creating card tokens

## Testing
Manual testing