### PR TITLE
Upgrade Mockito to 3.4.6

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     javadocDeps 'com.google.android.material:material:1.1.0'
 
     testImplementation 'junit:junit:4.13'
-    testImplementation "org.mockito:mockito-core:3.3.3"
+    testImplementation "org.mockito:mockito-core:3.4.6"
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.json:json:20200518'

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -32,7 +33,7 @@ internal class AddPaymentMethodViewModel(
     ): LiveData<Result<PaymentMethod>> {
         val resultData = MutableLiveData<Result<PaymentMethod>>()
         stripe.createPaymentMethod(
-            paymentMethodCreateParams = params.copy(productUsage = productUsage),
+            paymentMethodCreateParams = updatedPaymentMethodCreateParams(params),
             callback = object : ApiResultCallback<PaymentMethod> {
                 override fun onSuccess(result: PaymentMethod) {
                     resultData.value = Result.success(result)
@@ -44,6 +45,11 @@ internal class AddPaymentMethodViewModel(
             })
         return resultData
     }
+
+    @VisibleForTesting
+    internal fun updatedPaymentMethodCreateParams(
+        params: PaymentMethodCreateParams
+    ) = params.copy(productUsage = productUsage)
 
     @JvmSynthetic
     internal fun attachPaymentMethod(

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodViewModelTest.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -20,41 +18,29 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.view.i18n.ErrorMessageTranslator
 import com.stripe.android.view.i18n.TranslatorManager
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class AddPaymentMethodViewModelTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val stripe = Stripe(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
     private val customerSession: CustomerSession = mock()
     private val paymentMethodRetrievalCaptor: KArgumentCaptor<CustomerSession.PaymentMethodRetrievalListener> = argumentCaptor()
-    private val paymentMethodCreateParamsCaptor: KArgumentCaptor<PaymentMethodCreateParams> = argumentCaptor()
 
     @Test
-    fun createPaymentMethod_shouldIncludeProductUsageTokens() {
-        val stripe: Stripe = mock()
-        createViewModel(
-            stripe = stripe
-        ).createPaymentMethod(
-            PaymentMethodCreateParams.create(
-                PaymentMethodCreateParamsFixtures.CARD.copy(
-                    attribution = setOf("CardMultilineWidget")
-                )
+    fun `updatedPaymentMethodCreateParams should include expected attribution`() {
+        val params = PaymentMethodCreateParams.create(
+            PaymentMethodCreateParamsFixtures.CARD.copy(
+                attribution = setOf("CardMultilineWidget")
             )
         )
-
-        verify(stripe).createPaymentMethod(
-            paymentMethodCreateParamsCaptor.capture(),
-            anyOrNull(),
-            anyOrNull(),
-            any()
-        )
-
-        assertEquals(
-            setOf("CardMultilineWidget", AddPaymentMethodActivity.PRODUCT_TOKEN),
-            paymentMethodCreateParamsCaptor.firstValue.attribution
+        assertThat(
+            createViewModel().updatedPaymentMethodCreateParams(params).attribution
+        ).containsExactly(
+            "CardMultilineWidget",
+            AddPaymentMethodActivity.PRODUCT_TOKEN
         )
     }
 
@@ -125,7 +111,6 @@ class AddPaymentMethodViewModelTest {
     }
 
     private fun createViewModel(
-        stripe: Stripe = Stripe(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
         translator: ErrorMessageTranslator = TranslatorManager.getErrorMessageTranslator()
     ): AddPaymentMethodViewModel {
         return AddPaymentMethodViewModel(


### PR DESCRIPTION
## Summary
`AddPaymentMethodViewModelTest` previously mocked `Stripe`, but this
is no longer possible in `3.4.6`.


## Testing
Updated unit test
