### PR TITLE
Add error when confirming test mode PI with alipay sdk

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -351,6 +351,12 @@ internal class StripePaymentController internal constructor(
         callback: ApiResultCallback<AlipayAuthResult>
     ) : ApiOperation<AlipayAuthResult>(callback = callback) {
         override suspend fun getResult(): AlipayAuthResult {
+            if (intent.paymentMethod?.liveMode == false) {
+                throw IllegalArgumentException("Attempted to authenticate test mode " +
+                    "PaymentIntent with the Alipay SDK.\n" +
+                    "The Alipay SDK does not support test mode payments.")
+            }
+
             val nextActionData = intent.nextActionData
             if (nextActionData is StripeIntent.NextActionData.AlipayRedirect) {
                 val output =

--- a/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.PaymentIntentFixtures
+import java.lang.IllegalArgumentException
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -102,6 +103,20 @@ class AlipayAuthenticationTaskTest {
             callback
         )
         assertFailsWith<RuntimeException> {
+            runBlocking { task.getResult() }
+        }
+    }
+
+    @Test
+    fun `AlipayAuthenticationTask should throw exception in test mode`() {
+        val task = StripePaymentController.AlipayAuthenticationTask(
+            PaymentIntentFixtures.ALIPAY_TEST_MODE,
+            createAuthenticator("9000"),
+            stripeRepository,
+            requestOptions,
+            callback
+        )
+        assertFailsWith<IllegalArgumentException> {
             runBlocking { task.getResult() }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -743,4 +743,65 @@ internal object PaymentIntentFixtures {
     )
 
     val ALIPAY_REQUIRES_ACTION = PARSER.parse(ALIPAY_REQUIRES_ACTION_JSON)!!
+
+    val ALIPAY_TEST_MODE_JSON = JSONObject(
+        """
+        {
+          "id": "pi_1HDEFVKlwPmebFhpCobFP55H",
+          "object": "payment_intent",
+          "amount": 100,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_1HDEFVKlwPmebFhpCobFP55H_secret_XW8sADccCxtusewAwn5z9kAiw",
+          "confirmation_method": "automatic",
+          "created": 1596740133,
+          "currency": "usd",
+          "description": "Example PaymentIntent",
+          "last_payment_error": null,
+          "livemode": true,
+          "next_action": {
+            "alipay_handle_redirect": {
+              "native_data": null,
+              "native_url": null,
+              "return_url": "example://return_url",
+              "url": "https://hooks.stripe.com/redirect/authenticate/src_1HDEFWKlwPmebFhp6tcpln8T?client_secret=src_client_secret_S6H9mVMKK6qxk9YxsUvbH55K"
+            },
+            "type": "alipay_handle_redirect"
+          },
+          "payment_method": {
+            "id": "pm_1HDEFVKlwPmebFhpKYYkSm8H",
+            "object": "payment_method",
+            "alipay": {},
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+            },
+            "created": 1596740133,
+            "customer": null,
+            "livemode": false,
+            "type": "alipay"
+          },
+          "payment_method_types": [
+            "alipay"
+          ],
+          "receipt_email": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "status": "requires_action"
+        }
+        """.trimIndent()
+    )
+
+    val ALIPAY_TEST_MODE = PARSER.parse(ALIPAY_TEST_MODE_JSON)!!
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The Alipay SDK will fail silently when trying to authenticate a test mode PI. This can be a confusing experience. Instead, we just return an error explaining that this is the case.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Test manually. Added unit test.
