### PR TITLE
Upgrade Dokka to 1.4.0-rc and change to HTML format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlinVersion = '1.3.72'
-    ext.dokkaVersion = '0.10.1'
+    ext.dokkaVersion = '1.4.0-rc'
 
     repositories {
         jcenter()

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     androidTestUtil 'androidx.test:orchestrator:1.2.0'
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
+
+    dokkaHtmlPlugin("org.jetbrains.dokka:dokka-base:$dokkaVersion")
 }
 
 android {
@@ -102,8 +104,7 @@ android {
         lintConfig file("../settings/lint.xml")
     }
 
-    dokka {
-        outputFormat = 'javadoc'
+    dokkaHtml {
         outputDirectory = "${project.rootDir}/docs/"
     }
 


### PR DESCRIPTION
## Motivation
Migrating our docs to use Dokka's default HTML format


