### PR TITLE
Create CardWidgetViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardWidgetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardWidgetViewModel.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.cards
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.liveData
+import com.stripe.android.ApiRequest
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.StripeApiRepository
+import com.stripe.android.view.CardWidget
+
+/**
+ * A [ViewModel] for [CardWidget] instances.
+ */
+internal class CardWidgetViewModel(
+    private val cardAccountRangeRepository: CardAccountRangeRepository
+) : ViewModel() {
+
+    fun getAccountRange(cardNumber: String) = liveData {
+        emit(cardAccountRangeRepository.getAccountRange(cardNumber))
+    }
+
+    internal class Factory(
+        private val application: Application
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            val paymentConfiguration = PaymentConfiguration.getInstance(
+                application.applicationContext
+            )
+            return CardWidgetViewModel(
+                DefaultCardAccountRangeRepository(
+                    localCardAccountRangeSource = LocalCardAccountRangeSource(),
+                    remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
+                        StripeApiRepository(
+                            application.applicationContext,
+                            paymentConfiguration.publishableKey
+                        ),
+                        ApiRequest.Options(
+                            paymentConfiguration.publishableKey
+                        )
+                    )
+                )
+            ) as T
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/cards/CardWidgetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/CardWidgetViewModelTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.cards
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.CardNumberFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.BinRange
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardMetadata
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CardWidgetViewModelTest {
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+    private val viewModel = CardWidgetViewModel(FakeCardAccountRangeRepository())
+
+    @Test
+    fun `getAccountRange() should return expected value`() {
+        var accountRange: CardMetadata.AccountRange? = null
+        viewModel.getAccountRange(CardNumberFixtures.VISA_NO_SPACES).observeForever {
+            accountRange = it
+        }
+        assertThat(accountRange)
+            .isEqualTo(ACCOUNT_RANGE)
+    }
+
+    @Test
+    fun `Factory#create() should succeed`() {
+        PaymentConfiguration.init(application, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        assertThat(
+            CardWidgetViewModel.Factory(application)
+                .create(CardWidgetViewModel::class.java)
+        ).isNotNull()
+    }
+
+    private class FakeCardAccountRangeRepository : CardAccountRangeRepository {
+        override suspend fun getAccountRange(cardNumber: String) = ACCOUNT_RANGE
+    }
+
+    private companion object {
+        private val ACCOUNT_RANGE = CardMetadata.AccountRange(
+            binRange = BinRange(
+                low = "4242420000000000",
+                high = "4242424239999999"
+            ),
+            panLength = 16,
+            brandName = "VISA",
+            brand = CardBrand.Visa,
+            country = "GB"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
A `ViewModel` for `CardInputWidget` and `CardMultilineWidget` that
allows for getting `AccountRange` data for a given card number.

## Motivation
Will be integrated in a future PR.

## Testing
Unit tests
