### PR TITLE
Create PaymentMethodCreateParams.createCard()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -198,6 +198,7 @@ data class Card internal constructor(
     val metadata: Map<String, String>? = null
 ) : StripeModel, StripePaymentSource, TokenParams(Token.Type.Card, loggingTokens) {
 
+    @Deprecated("Use PaymentMethodCreateParams#createCard()")
     fun toPaymentMethodsParams(): PaymentMethodCreateParams {
         return PaymentMethodCreateParams.create(
             card = toPaymentMethodParamsCard(),
@@ -218,6 +219,7 @@ data class Card internal constructor(
     /**
      * Use [toPaymentMethodsParams] to include Billing Details
      */
+    @Deprecated("Use PaymentMethodCreateParams#createCard()")
     fun toPaymentMethodParamsCard(): PaymentMethodCreateParams.Card {
         return PaymentMethodCreateParams.Card(
             number = number,

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -400,10 +400,8 @@ data class PaymentMethodCreateParams internal constructor(
          * @return params for creating a [PaymentMethod.Type.Card] payment method
          */
         @JvmStatic
-        @JvmOverloads
         fun createCard(
-            cardParams: CardParams,
-            metadata: Map<String, String>? = null
+            cardParams: CardParams
         ): PaymentMethodCreateParams {
             return create(
                 card = Card(
@@ -417,7 +415,7 @@ data class PaymentMethodCreateParams internal constructor(
                     name = cardParams.name,
                     address = cardParams.address
                 ),
-                metadata = metadata
+                metadata = cardParams.metadata
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -401,6 +401,31 @@ data class PaymentMethodCreateParams internal constructor(
          */
         @JvmStatic
         @JvmOverloads
+        fun createCard(
+            cardParams: CardParams,
+            metadata: Map<String, String>? = null
+        ): PaymentMethodCreateParams {
+            return create(
+                card = Card(
+                    number = cardParams.number,
+                    expiryMonth = cardParams.expMonth,
+                    expiryYear = cardParams.expYear,
+                    cvc = cardParams.cvc,
+                    attribution = cardParams.attribution
+                ),
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = cardParams.name,
+                    address = cardParams.address
+                ),
+                metadata = metadata
+            )
+        }
+
+        /**
+         * @return params for creating a [PaymentMethod.Type.Card] payment method
+         */
+        @JvmStatic
+        @JvmOverloads
         fun create(
             card: Card,
             billingDetails: PaymentMethod.BillingDetails? = null,

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.CardNumberFixtures
 import com.stripe.android.view.AddPaymentMethodActivity
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -180,6 +181,32 @@ class PaymentMethodCreateParamsTest {
                 "CardMultilineWidget",
                 AddPaymentMethodActivity.PRODUCT_TOKEN
             )
+    }
+
+    @Test
+    fun `createCard() with CardParams returns expected PaymentMethodCreateParams`() {
+        val cardParams = CardParamsFixtures.DEFAULT
+            .copy(loggingTokens = setOf("CardInputView"))
+
+        assertThat(
+            PaymentMethodCreateParams.createCard(cardParams)
+        ).isEqualTo(
+            PaymentMethodCreateParams(
+                type = PaymentMethodCreateParams.Type.Card,
+                card = PaymentMethodCreateParams.Card(
+                    number = CardNumberFixtures.VISA_NO_SPACES,
+                    expiryMonth = 12,
+                    expiryYear = 2025,
+                    cvc = "123",
+                    attribution = setOf("CardInputView")
+                ),
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = cardParams.name,
+                    address = cardParams.address
+                ),
+                metadata = mapOf("fruit" to "orange")
+            )
+        )
     }
 
     private fun createFpx(): PaymentMethodCreateParams {


### PR DESCRIPTION
## Summary
Add `PaymentMethodCreateParams.createCard()` to create a card payment
method from a `CardParams`.

Deprecate `Card#toPaymentMethodsParams()` and
`Card#toPaymentMethodParamsCard()`.

## Motivation
Continue migration to `CardParams` for card creation.

## Testing
Unit test
