### PR TITLE
Deflake FPX tests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
+++ b/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
@@ -2,11 +2,15 @@ package com.stripe.android.model
 
 import com.stripe.android.view.FpxBank
 import kotlinx.android.parcel.Parcelize
+import org.jetbrains.annotations.TestOnly
 
 @Parcelize
 internal data class FpxBankStatuses internal constructor(
     private val statuses: Map<String, Boolean> = emptyMap()
 ) : StripeModel {
+    @TestOnly
+    internal fun size() = statuses.size
+
     /**
      * Defaults to `true` if statuses aren't available.
      */

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -31,7 +31,7 @@ internal class AddPaymentMethodFpxView @JvmOverloads internal constructor(
     private val viewModel: FpxViewModel by lazy {
         ViewModelProvider(
             activity,
-            ViewModelProvider.AndroidViewModelFactory(activity.application)
+            FpxViewModel.Factory(activity.application)
         ).get(FpxViewModel::class.java)
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -2,25 +2,20 @@ package com.stripe.android.view
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.liveData
 import com.stripe.android.ApiRequest
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeApiRepository
+import com.stripe.android.StripeRepository
 import com.stripe.android.model.FpxBankStatuses
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 
-internal class FpxViewModel @JvmOverloads internal constructor(
+internal class FpxViewModel internal constructor(
     application: Application,
-    workDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val publishableKey: String,
+    private val stripeRepository: StripeRepository
 ) : AndroidViewModel(application) {
-    private val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
-    private val stripeRepository = StripeApiRepository(
-        application,
-        publishableKey,
-        workDispatcher = workDispatcher
-    )
-
     internal var selectedPosition: Int? = null
 
     @JvmSynthetic
@@ -30,5 +25,19 @@ internal class FpxViewModel @JvmOverloads internal constructor(
                 stripeRepository.getFpxBankStatus(ApiRequest.Options(publishableKey))
             }.getOrDefault(FpxBankStatuses())
         )
+    }
+
+    internal class Factory(
+        private val application: Application
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
+            val stripeRepository = StripeApiRepository(
+                application,
+                publishableKey
+            )
+
+            return FpxViewModel(application, publishableKey, stripeRepository) as T
+        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -32,7 +32,6 @@ import com.stripe.android.model.StripeFileFixtures
 import com.stripe.android.model.StripeFileParams
 import com.stripe.android.model.StripeFilePurpose
 import com.stripe.android.model.TokenFixtures
-import com.stripe.android.view.FpxBank
 import java.net.HttpURLConnection
 import java.net.UnknownHostException
 import java.util.Calendar
@@ -51,12 +50,9 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-/**
- * Test class for [StripeApiRepository].
- */
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-class StripeApiRepositoryTest {
+internal class StripeApiRepositoryTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -675,11 +671,8 @@ class StripeApiRepositoryTest {
         val fpxBankStatuses = stripeApiRepository.getFpxBankStatus(
             ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY)
         )
-        assertThat(
-            setOf(FpxBank.Hsbc, FpxBank.Bsn).any {
-                fpxBankStatuses.isOnline(it)
-            }
-        ).isTrue()
+        assertThat(fpxBankStatuses.size())
+            .isEqualTo(25)
     }
 
     @Test
@@ -690,11 +683,8 @@ class StripeApiRepositoryTest {
                 stripeAccount = "acct_1234"
             )
         )
-        assertThat(
-            setOf(FpxBank.Hsbc, FpxBank.Bsn).any {
-                fpxBankStatuses.isOnline(it)
-            }
-        ).isTrue()
+        assertThat(fpxBankStatuses.size())
+            .isEqualTo(25)
     }
 
     @Test


### PR DESCRIPTION
FPX banks routinely go down for maintenance, so our integration tests
shouldn't explicitly check for whether a certain bank is online.