### PR TITLE
Fix `brand` property mapping for `Card` and `SourceTypeModel.Card`

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -584,5 +584,22 @@ data class Card internal constructor(
             return Builder(number, expMonth, expYear, cvc)
                 .build()
         }
+
+        /**
+         * See https://stripe.com/docs/api/cards/object#card_object-brand for valid values.
+         */
+        @JvmSynthetic
+        internal fun getCardBrand(brandName: String?): CardBrand {
+            return when (brandName) {
+                "American Express" -> CardBrand.AmericanExpress
+                "Diners Club" -> CardBrand.DinersClub
+                "Discover" -> CardBrand.Discover
+                "JCB" -> CardBrand.JCB
+                "MasterCard" -> CardBrand.MasterCard
+                "UnionPay" -> CardBrand.UnionPay
+                "Visa" -> CardBrand.Visa
+                else -> CardBrand.Unknown
+            }
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.model.Card
-import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
 import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.TokenizationMethod
@@ -33,7 +32,7 @@ internal class CardJsonParser : ModelJsonParser<Card> {
             addressState = StripeJsonUtils.optString(json, FIELD_ADDRESS_STATE),
             addressZip = StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP),
             addressZipCheck = StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP_CHECK),
-            brand = CardBrand.fromCode(StripeJsonUtils.optString(json, FIELD_BRAND)),
+            brand = Card.getCardBrand(StripeJsonUtils.optString(json, FIELD_BRAND)),
             country = StripeJsonUtils.optCountryCode(json, FIELD_COUNTRY),
             customerId = StripeJsonUtils.optString(json, FIELD_CUSTOMER),
             currency = StripeJsonUtils.optCurrency(json, FIELD_CURRENCY),

--- a/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.CardBrand
+import com.stripe.android.model.Card
 import com.stripe.android.model.CardFunding
 import com.stripe.android.model.SourceTypeModel
 import com.stripe.android.model.StripeJsonUtils
@@ -12,7 +12,7 @@ internal class SourceCardDataJsonParser : ModelJsonParser<SourceTypeModel.Card> 
         return SourceTypeModel.Card(
             addressLine1Check = StripeJsonUtils.optString(json, FIELD_ADDRESS_LINE1_CHECK),
             addressZipCheck = StripeJsonUtils.optString(json, FIELD_ADDRESS_ZIP_CHECK),
-            brand = CardBrand.fromCode(StripeJsonUtils.optString(json, FIELD_BRAND)),
+            brand = Card.getCardBrand(StripeJsonUtils.optString(json, FIELD_BRAND)),
             country = StripeJsonUtils.optString(json, FIELD_COUNTRY),
             cvcCheck = StripeJsonUtils.optString(json, FIELD_CVC_CHECK),
             dynamicLast4 = StripeJsonUtils.optString(json, FIELD_DYNAMIC_LAST4),

--- a/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AlipayAuthenticationTaskTest.kt
@@ -6,9 +6,9 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.PaymentIntentFixtures
 import java.lang.IllegalArgumentException
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 

--- a/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintDataRepositoryTest.kt
@@ -10,10 +10,10 @@ import com.nhaarman.mockitokotlin2.verify
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
+import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 

--- a/stripe/src/test/java/com/stripe/android/FingerprintDataTest.kt
+++ b/stripe/src/test/java/com/stripe/android/FingerprintDataTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android
 import com.google.common.truth.Truth.assertThat
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
-import org.junit.Test
+import kotlin.test.Test
 
 class FingerprintDataTest {
 

--- a/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -108,7 +108,7 @@ internal class SourceEndToEndTest {
                 CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
                 CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
                 CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
-                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub,
+                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub
             ).all { (cardNumber, cardBrand) ->
                 val source = requireNotNull(stripe.createSourceSynchronous(
                     SourceParams.createCardParams(

--- a/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -3,16 +3,19 @@ package com.stripe.android
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.DateOfBirth
 import com.stripe.android.model.KlarnaSourceParams
 import com.stripe.android.model.SourceOrder
 import com.stripe.android.model.SourceParams
+import com.stripe.android.model.SourceTypeModel
 import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class SourceEndToEndTest {
+internal class SourceEndToEndTest {
     @Test
     fun createKlarnaParams_createsExpectedSourceOrderItems() {
         val sourceParams = SourceParams.createKlarna(
@@ -91,6 +94,38 @@ class SourceEndToEndTest {
         val source = requireNotNull(stripe.createSourceSynchronous(sourceParams))
         assertThat(source.redirect?.returnUrl)
             .isEqualTo(RETURN_URL)
+    }
+
+    @Test
+    fun `Source objects should be populated with the expected CardBrand value`() {
+        val stripe = createStripe(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+
+        assertThat(
+            listOf(
+                CardNumberFixtures.AMEX_NO_SPACES to CardBrand.AmericanExpress,
+                CardNumberFixtures.VISA_NO_SPACES to CardBrand.Visa,
+                CardNumberFixtures.MASTERCARD_NO_SPACES to CardBrand.MasterCard,
+                CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
+                CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
+                CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
+                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub,
+            ).all { (cardNumber, cardBrand) ->
+                val source = requireNotNull(stripe.createSourceSynchronous(
+                    SourceParams.createCardParams(
+                        CardParams(
+                            number = cardNumber,
+                            expMonth = 10,
+                            expYear = 2030,
+                            cvc = "123"
+                        )
+                    )
+                ))
+                val cardModel = requireNotNull(
+                    source.sourceTypeModel as? SourceTypeModel.Card
+                )
+                cardModel.brand == cardBrand
+            }
+        ).isTrue()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -195,7 +195,7 @@ internal class StripeEndToEndTest {
                 CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
                 CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
                 CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
-                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub,
+                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub
             ).all { (cardNumber, cardBrand) ->
                 val token = defaultStripe.createCardTokenSynchronous(
                     CardParamsFixtures.DEFAULT.copy(

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -31,7 +31,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-class StripeEndToEndTest {
+internal class StripeEndToEndTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val defaultStripe = Stripe(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
 
@@ -183,6 +183,28 @@ class StripeEndToEndTest {
                     metadata = emptyMap()
                 )
             )
+    }
+
+    @Test
+    fun `Card objects should be populated with the expected CardBrand value`() {
+        assertThat(
+            listOf(
+                CardNumberFixtures.AMEX_NO_SPACES to CardBrand.AmericanExpress,
+                CardNumberFixtures.VISA_NO_SPACES to CardBrand.Visa,
+                CardNumberFixtures.MASTERCARD_NO_SPACES to CardBrand.MasterCard,
+                CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
+                CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
+                CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
+                CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub,
+            ).all { (cardNumber, cardBrand) ->
+                val token = defaultStripe.createCardTokenSynchronous(
+                    CardParamsFixtures.DEFAULT.copy(
+                        number = cardNumber
+                    )
+                )
+                token?.card?.brand == cardBrand
+            }
+        ).isTrue()
     }
 
     private fun createStripeWithTestScope(

--- a/stripe/src/test/java/com/stripe/android/model/AlipayRedirectTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/AlipayRedirectTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 

--- a/stripe/src/test/java/com/stripe/android/model/BinRangeTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/BinRangeTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import kotlin.test.Test
 
 class BinRangeTest {
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/ContextUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ContextUtilsTest.kt
@@ -7,7 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.utils.ContextUtils.packageInfo
-import org.junit.Test
+import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 

--- a/stripe/src/test/java/com/stripe/android/model/parsers/CardMetadataJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/CardMetadataJsonParserTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardMetadata
+import kotlin.test.Test
 import org.json.JSONObject
-import org.junit.Test
 
 class CardMetadataJsonParserTest {
 

--- a/stripe/src/test/java/com/stripe/android/model/parsers/SourceJsonParserTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/parsers/SourceJsonParserTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceFixtures
+import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.junit.Test
 
 class SourceJsonParserTest {
 

--- a/stripe/src/test/java/com/stripe/android/utils/StripeUrlUtilsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/utils/StripeUrlUtilsTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
@@ -4,8 +4,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSessionFixtures
+import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 


### PR DESCRIPTION
Card/Source and PaymentMethod all have `brand` properties,
but the enumerated values for these properties differ.

Create `Card.getCardBrand()` for mapping a brand name to a
`CardBrand`.