### PR TITLE
Remove Kotlin stdlib dependency

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -35,7 +35,6 @@ dependencies {
 
     implementation "com.stripe:stripe-3ds2-android:4.0.5"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 


### PR DESCRIPTION
From https://kotlinlang.org/docs/reference/whatsnew14.html#dependency-on-the-standard-library-added-by-default

> You no longer need to declare a dependency on the `stdlib` library in
> any Kotlin Gradle project, including a multiplatform one.
> The dependency is added by default.