### PR TITLE
Fix TokenizationMethod.GooglePay mapping

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/TokenizationMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/TokenizationMethod.kt
@@ -5,16 +5,26 @@ package com.stripe.android.model
  *
  * See [tokenization_method](https://stripe.com/docs/api/cards/object#card_object-tokenization_method)
  */
-enum class TokenizationMethod(val code: String) {
-    ApplePay("apple_pay"),
-    GooglePay("google_pay"),
-    Masterpass("masterpass"),
-    VisaCheckout("visa_checkout");
+enum class TokenizationMethod(
+    private val code: Set<String>
+) {
+    ApplePay(
+        setOf("apple_pay")
+    ),
+    GooglePay(
+        setOf("android_pay", "google")
+    ),
+    Masterpass(
+        setOf("masterpass")
+    ),
+    VisaCheckout(
+        setOf("visa_checkout")
+    );
 
     internal companion object {
         internal fun fromCode(code: String?): TokenizationMethod? {
             return values().firstOrNull {
-                it.code == code
+                it.code.contains(code)
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/model/CardFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/CardFixtures.kt
@@ -81,7 +81,7 @@ object CardFixtures {
             "fingerprint": "abc123",
             "last4": "4242",
             "name": "John Cardholder",
-            "tokenization_method": "google_pay",
+            "tokenization_method": "android_pay",
             "metadata": {
                 "color": "blue",
                 "animal": "dog"

--- a/stripe/src/test/java/com/stripe/android/model/TokenizationMethodTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/TokenizationMethodTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class TokenizationMethodTest {
+
+    @Test
+    fun `android_pay should map to GooglePay`() {
+        assertThat(
+            TokenizationMethod.fromCode("android_pay")
+        ).isEqualTo(TokenizationMethod.GooglePay)
+    }
+
+    @Test
+    fun `google should map to GooglePay`() {
+        assertThat(
+            TokenizationMethod.fromCode("google")
+        ).isEqualTo(TokenizationMethod.GooglePay)
+    }
+
+    @Test
+    fun `apple_pay should map to ApplePay`() {
+        assertThat(
+            TokenizationMethod.fromCode("apple_pay")
+        ).isEqualTo(TokenizationMethod.ApplePay)
+    }
+}


### PR DESCRIPTION
Google Pay tokenization method is either represented by `"android_pay"`
or `"google"`, but not `"google_pay"`.