### PR TITLE
Create LegacyCardAccountRangeRepository

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/LegacyCardAccountRangeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/LegacyCardAccountRangeRepository.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.cards
+
+import com.stripe.android.model.CardMetadata
+
+/**
+ * A [CardAccountRangeRepository] that simulates existing card account range lookup logic by only
+ * using a local, static source.
+ */
+internal class LegacyCardAccountRangeRepository(
+    private val localCardAccountRangeSource: CardAccountRangeSource
+) : CardAccountRangeRepository {
+    override suspend fun getAccountRange(cardNumber: String): CardMetadata.AccountRange? {
+        return Bin.create(cardNumber)?.let {
+            localCardAccountRangeSource.getAccountRange(cardNumber)
+        }
+    }
+}


### PR DESCRIPTION
A `CardAccountRangeRepository` that simulates existing card account
range lookup logic by only using a local, static source.

Will be used in a future PR.