### PR TITLE
Update CardNumberEditText's brand updating logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -5,6 +5,8 @@ import com.stripe.android.StripeTextUtils
 internal sealed class CardNumber(number: String) {
     private val normalizedNumber = StripeTextUtils.removeSpacesAndHyphens(number).orEmpty()
 
+    val bin: Bin? = Bin.create(normalizedNumber)
+
     /**
      * A representation of a partial or full card number that hasn't been validated.
      */

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -12,6 +12,7 @@ import com.stripe.android.R
 import com.stripe.android.StripeTextUtils
 import com.stripe.android.cards.Bin
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.LegacyCardAccountRangeRepository
 import com.stripe.android.cards.LocalCardAccountRangeSource
 import com.stripe.android.model.CardBrand
@@ -189,7 +190,8 @@ class CardNumberEditText internal constructor(
                     s?.toString().orEmpty()
                 ).orEmpty()
 
-                updateCardBrand(Bin.create(spacelessNumber))
+                val cardNumber = CardNumber.Unvalidated(spacelessNumber)
+                updateCardBrand(cardNumber.bin)
 
                 val formattedNumber = cardBrand.formatNumber(spacelessNumber)
                 this.newCursorPosition = updateSelectionIndex(

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -100,7 +100,8 @@ class CardNumberEditText internal constructor(
             null
         }
 
-    private var accountRangeRepositoryjob: Job? = null
+    @VisibleForTesting
+    internal var accountRangeRepositoryJob: Job? = null
 
     init {
         setErrorMessage(resources.getString(R.string.invalid_card_number))
@@ -115,6 +116,12 @@ class CardNumberEditText internal constructor(
         get() {
             return resources.getString(R.string.acc_label_card_number_node, text)
         }
+
+    override fun onDetachedFromWindow() {
+        cancelAccountRangeRepositoryJob()
+
+        super.onDetachedFromWindow()
+    }
 
     @JvmSynthetic
     internal fun updateLengthFilter() {
@@ -238,10 +245,9 @@ class CardNumberEditText internal constructor(
     @JvmSynthetic
     internal fun updateCardBrand(inputBin: Bin?) {
         // cancel in-flight job
-        accountRangeRepositoryjob?.cancel()
-        accountRangeRepositoryjob = null
+        cancelAccountRangeRepositoryJob()
 
-        accountRangeRepositoryjob = CoroutineScope(workDispatcher).launch {
+        accountRangeRepositoryJob = CoroutineScope(workDispatcher).launch {
             if (inputBin != null) {
                 onAccountRangeResult(
                     cardAccountRangeRepository.getAccountRange(inputBin.value)
@@ -250,6 +256,11 @@ class CardNumberEditText internal constructor(
                 onAccountRangeResult(null)
             }
         }
+    }
+
+    private fun cancelAccountRangeRepositoryJob() {
+        accountRangeRepositoryJob?.cancel()
+        accountRangeRepositoryJob = null
     }
 
     private suspend fun onAccountRangeResult(

--- a/stripe/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
 
 internal class ActivityScenarioFactory(
     private val context: Context
@@ -16,4 +18,12 @@ internal class ActivityScenarioFactory(
                 .putExtra(ActivityStarter.Args.EXTRA, args)
         )
     }
+
+    fun createAddPaymentMethodActivity() = create<AddPaymentMethodActivity>(
+        AddPaymentMethodActivityStarter.Args.Builder()
+            .setPaymentMethodType(PaymentMethod.Type.Card)
+            .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
+            .setBillingAddressFields(BillingAddressFields.PostalCode)
+            .build()
+    )
 }

--- a/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/AddPaymentMethodActivityTest.kt
@@ -36,6 +36,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.robolectric.RobolectricTestRunner
@@ -45,8 +47,10 @@ import org.robolectric.shadows.ShadowAlertDialog
 /**
  * Test class for [AddPaymentMethodActivity].
  */
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddPaymentMethodActivityTest {
+    private val testDispatcher = TestCoroutineDispatcher()
 
     private val customerSession: CustomerSession = mock()
     private val viewModel: AddPaymentMethodViewModel = mock()
@@ -79,7 +83,7 @@ class AddPaymentMethodActivityTest {
                 val cardMultilineWidget: CardMultilineWidget =
                     it.findViewById(R.id.card_multiline_widget)
                 val widgetControlGroup =
-                    CardMultilineWidgetTest.WidgetControlGroup(cardMultilineWidget)
+                    CardMultilineWidgetTest.WidgetControlGroup(cardMultilineWidget, testDispatcher)
                 assertEquals(View.VISIBLE, widgetControlGroup.postalCodeInputLayout.visibility)
             }
         }
@@ -94,7 +98,7 @@ class AddPaymentMethodActivityTest {
                 val cardMultilineWidget: CardMultilineWidget =
                     activity.findViewById(R.id.card_multiline_widget)
                 val widgetControlGroup =
-                    CardMultilineWidgetTest.WidgetControlGroup(cardMultilineWidget)
+                    CardMultilineWidgetTest.WidgetControlGroup(cardMultilineWidget, testDispatcher)
                 assertEquals(View.VISIBLE, widgetControlGroup.postalCodeInputLayout.visibility)
             }
         }

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
@@ -37,24 +37,20 @@ internal class BecsDebitWidgetTest {
     @BeforeTest
     fun setup() {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .setBillingAddressFields(BillingAddressFields.PostalCode)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity { activity ->
-                activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
-                    root.removeAllViews()
-                    becsDebitWidget = BecsDebitWidget(
-                        activity,
-                        companyName = COMPANY_NAME
-                    )
-                    root.addView(becsDebitWidget)
+        activityScenarioFactory
+            .createAddPaymentMethodActivity()
+            .use { activityScenario ->
+                activityScenario.onActivity { activity ->
+                    activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
+                        root.removeAllViews()
+                        becsDebitWidget = BecsDebitWidget(
+                            activity,
+                            companyName = COMPANY_NAME
+                        )
+                        root.addView(becsDebitWidget)
+                    }
                 }
             }
-        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -75,8 +75,6 @@ internal class CardInputWidgetTest {
 
     @BeforeTest
     fun setup() {
-//        Dispatchers.setMain(testDispatcher)
-
         // The input date here will be invalid after 2050. Please update the test.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
             .isTrue()

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.app.Activity
 import android.content.Context
+import android.os.Looper
 import android.text.TextPaint
 import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider
@@ -31,19 +32,33 @@ import com.stripe.android.testharness.ViewTestUtils
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
 import com.stripe.android.view.CardInputWidget.Companion.shouldIconShowBrand
 import java.util.Calendar
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.LooperMode
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
 internal class CardInputWidgetTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val activityScenarioFactory = ActivityScenarioFactory(context)
 
     private lateinit var cardInputWidget: CardInputWidget
     private val cardNumberEditText: CardNumberEditText by lazy {
-        cardInputWidget.cardNumberEditText
+        cardInputWidget.cardNumberEditText.also {
+            it.workDispatcher = testDispatcher
+        }
     }
     private val expiryEditText: StripeEditText by lazy {
         cardInputWidget.expiryDateEditText
@@ -60,6 +75,8 @@ internal class CardInputWidgetTest {
 
     @BeforeTest
     fun setup() {
+//        Dispatchers.setMain(testDispatcher)
+
         // The input date here will be invalid after 2050. Please update the test.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
             .isTrue()
@@ -80,6 +97,11 @@ internal class CardInputWidgetTest {
                 }
             }
         }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        Dispatchers.resetMain()
     }
 
     private fun createCardInputWidget(activity: Activity): CardInputWidget {
@@ -604,7 +626,7 @@ internal class CardInputWidgetTest {
     fun onCompleteCardNumber_whenValid_shiftsFocusToExpiryDate() {
         cardInputWidget.setCardInputListener(cardInputListener)
 
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
 
         verify(cardInputListener).onCardComplete()
         verify(cardInputListener).onFocusChange(CardInputListener.FocusField.ExpiryDate)
@@ -618,7 +640,9 @@ internal class CardInputWidgetTest {
     @Test
     fun onDeleteFromExpiryDate_whenEmpty_shiftsFocusToCardNumberAndDeletesDigit() {
         cardInputWidget.setCardInputListener(cardInputListener)
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
+
         assertThat(expiryEditText.hasFocus())
             .isTrue()
 
@@ -641,7 +665,10 @@ internal class CardInputWidgetTest {
 
     @Test
     fun onDeleteFromExpiryDate_whenNotEmpty_doesNotShiftFocusOrDeleteDigit() {
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+        Dispatchers.setMain(testDispatcher)
+
+        updateCardNumberAndIdle(AMEX_WITH_SPACES)
+
         assertThat(expiryEditText.hasFocus())
             .isTrue()
 
@@ -657,7 +684,7 @@ internal class CardInputWidgetTest {
     @Test
     fun onDeleteFromCvcDate_whenEmpty_shiftsFocusToExpiryAndDeletesDigit() {
         cardInputWidget.setCardInputListener(cardInputListener)
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
 
         verify(cardInputListener).onCardComplete()
         verify(cardInputListener).onFocusChange(CardInputListener.FocusField.ExpiryDate)
@@ -745,14 +772,16 @@ internal class CardInputWidgetTest {
     fun onUpdateIcon_forCommonLengthBrand_setsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.
-        cardNumberEditText.append(CardNumberFixtures.VISA_BIN)
+        updateCardNumberAndIdle(CardNumberFixtures.VISA_BIN)
+
         assertThat(ViewTestUtils.hasMaxLength(cvcEditText, 3))
             .isTrue()
     }
 
     @Test
     fun onUpdateText_forAmexBin_setsLengthOnCvc() {
-        cardNumberEditText.append(CardNumberFixtures.AMEX_BIN)
+        updateCardNumberAndIdle(CardNumberFixtures.AMEX_BIN)
+
         assertThat(ViewTestUtils.hasMaxLength(cvcEditText, 4))
             .isTrue()
     }
@@ -1117,11 +1146,13 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addValidAmExCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
+        Dispatchers.setMain(testDispatcher)
+
         cardInputWidget.postalCodeEnabled = false
 
         // Moving left with an AmEx number has a larger peek and cvc size.
         // |(peek==50)--(space==175)--(date==50)--(space==185)--(cvc==40)|
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+        updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1146,11 +1177,13 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addValidAmExCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
+        Dispatchers.setMain(testDispatcher)
+
         cardInputWidget.postalCodeEnabled = true
 
         // Moving left with an AmEx number has a larger peek and cvc size.
         // |(peek==50)--(space==88)--(date==50)--(space==72)--(cvc==40)--(space==0)--(postal==100)|
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+        updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1177,11 +1210,13 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addDinersClubCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
+        Dispatchers.setMain(testDispatcher)
+
         cardInputWidget.postalCodeEnabled = false
 
         // When we move for a Diner's club card, the peek text is shorter, so we expect:
         // |(peek==20)--(space==205)--(date==50)--(space==195)--(cvc==30)|
-        cardNumberEditText.setText(DINERS_CLUB_14_WITH_SPACES)
+        updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1206,11 +1241,13 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addDinersClubCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
+        Dispatchers.setMain(testDispatcher)
+
         cardInputWidget.postalCodeEnabled = true
 
         // When we move for a Diner's club card, the peek text is shorter, so we expect:
         // |(peek==20)--(space==205)--(date==50)--(space==195)--(cvc==30)--(space==0)--(postal==100)|
-        cardNumberEditText.setText(DINERS_CLUB_14_WITH_SPACES)
+        updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1707,6 +1744,11 @@ internal class CardInputWidgetTest {
                         .build()
                 )
             )
+    }
+
+    private fun updateCardNumberAndIdle(cardNumber: String) {
+        cardNumberEditText.setText(cardNumber)
+        shadowOf(Looper.getMainLooper()).idle()
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -27,6 +27,9 @@ import com.stripe.android.testharness.ViewTestUtils
 import java.util.Calendar
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.mockito.Mockito.reset
 import org.robolectric.RobolectricTestRunner
@@ -34,8 +37,10 @@ import org.robolectric.RobolectricTestRunner
 /**
  * Test class for [CardMultilineWidget].
  */
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 internal class CardMultilineWidgetTest {
+    private val testDispatcher = TestCoroutineDispatcher()
 
     private lateinit var cardMultilineWidget: CardMultilineWidget
     private lateinit var noZipCardMultilineWidget: CardMultilineWidget
@@ -67,7 +72,7 @@ internal class CardMultilineWidgetTest {
         ).use { activityScenario ->
             activityScenario.onActivity { activity ->
                 cardMultilineWidget = activity.findViewById(R.id.card_multiline_widget)
-                fullGroup = WidgetControlGroup(cardMultilineWidget)
+                fullGroup = WidgetControlGroup(cardMultilineWidget, testDispatcher)
 
                 fullGroup.cardNumberEditText.setText("")
 
@@ -89,7 +94,7 @@ internal class CardMultilineWidgetTest {
             activityScenario.onActivity {
                 noZipCardMultilineWidget = it.findViewById(R.id.card_multiline_widget)
                 noZipCardMultilineWidget.setShouldShowPostalCode(false)
-                noZipGroup = WidgetControlGroup(noZipCardMultilineWidget)
+                noZipGroup = WidgetControlGroup(noZipCardMultilineWidget, testDispatcher)
             }
         }
     }
@@ -1043,8 +1048,13 @@ internal class CardMultilineWidgetTest {
             .isFalse()
     }
 
-    internal class WidgetControlGroup(widget: CardMultilineWidget) {
-        val cardNumberEditText: CardNumberEditText = widget.findViewById(R.id.et_card_number)
+    internal class WidgetControlGroup(
+        widget: CardMultilineWidget,
+        workDispatcher: CoroutineDispatcher
+    ) {
+        val cardNumberEditText: CardNumberEditText = widget.findViewById<CardNumberEditText>(R.id.et_card_number).also {
+            it.workDispatcher = workDispatcher
+        }
         val cardInputLayout: TextInputLayout = widget.findViewById(R.id.tl_card_number)
         val expiryDateEditText: ExpiryDateEditText = widget.findViewById(R.id.et_expiry)
         val expiryInputLayout: TextInputLayout = widget.findViewById(R.id.tl_expiry)

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -63,40 +63,32 @@ internal class CardMultilineWidgetTest {
 
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .setBillingAddressFields(BillingAddressFields.PostalCode)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity { activity ->
-                cardMultilineWidget = activity.findViewById(R.id.card_multiline_widget)
-                fullGroup = WidgetControlGroup(cardMultilineWidget, testDispatcher)
+        activityScenarioFactory
+            .createAddPaymentMethodActivity()
+            .use { activityScenario ->
+                activityScenario.onActivity { activity ->
+                    cardMultilineWidget = activity.findViewById(R.id.card_multiline_widget)
+                    fullGroup = WidgetControlGroup(cardMultilineWidget, testDispatcher)
 
-                fullGroup.cardNumberEditText.setText("")
+                    fullGroup.cardNumberEditText.setText("")
 
-                cardMultilineWidget.setCardNumberTextWatcher(EMPTY_WATCHER)
-                cardMultilineWidget.setExpiryDateTextWatcher(EMPTY_WATCHER)
-                cardMultilineWidget.setCvcNumberTextWatcher(EMPTY_WATCHER)
-                cardMultilineWidget.setPostalCodeTextWatcher(EMPTY_WATCHER)
-                cardMultilineWidget.paymentMethodBillingDetailsBuilder
+                    cardMultilineWidget.setCardNumberTextWatcher(EMPTY_WATCHER)
+                    cardMultilineWidget.setExpiryDateTextWatcher(EMPTY_WATCHER)
+                    cardMultilineWidget.setCvcNumberTextWatcher(EMPTY_WATCHER)
+                    cardMultilineWidget.setPostalCodeTextWatcher(EMPTY_WATCHER)
+                    cardMultilineWidget.paymentMethodBillingDetailsBuilder
+                }
             }
-        }
 
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .setBillingAddressFields(BillingAddressFields.None)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity {
-                noZipCardMultilineWidget = it.findViewById(R.id.card_multiline_widget)
-                noZipCardMultilineWidget.setShouldShowPostalCode(false)
-                noZipGroup = WidgetControlGroup(noZipCardMultilineWidget, testDispatcher)
+        activityScenarioFactory
+            .createAddPaymentMethodActivity()
+            .use { activityScenario ->
+                activityScenario.onActivity {
+                    noZipCardMultilineWidget = it.findViewById(R.id.card_multiline_widget)
+                    noZipCardMultilineWidget.setShouldShowPostalCode(false)
+                    noZipGroup = WidgetControlGroup(noZipCardMultilineWidget, testDispatcher)
+                }
             }
-        }
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import android.content.Context
+import android.os.Looper
 import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -33,6 +34,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.LooperMode
 
 /**
@@ -194,8 +196,12 @@ class CardNumberEditTextTest {
     }
 
     @Test
-    fun setText_whenTextIsValidAmExDinersClubLengthNumber_changesCardValidState() {
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+    fun `valid Amex should change isCardNumberValid to true and invoke completion callback`() {
+        // type Amex BIN
+        updateCardNumberAndIdle(CardNumberFixtures.AMEX_BIN)
+        // type rest of card number
+        cardNumberEditText.append(AMEX_NO_SPACES.drop(6))
+        idle()
 
         assertThat(cardNumberEditText.isCardNumberValid)
             .isTrue()
@@ -205,7 +211,7 @@ class CardNumberEditTextTest {
 
     @Test
     fun setText_whenTextChangesFromValidToInvalid_changesCardValidState() {
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
         // Simply setting the value interacts with this mock once -- that is tested elsewhere
         completionCallbackInvocations = 0
 
@@ -223,7 +229,7 @@ class CardNumberEditTextTest {
     @Test
     fun setText_whenTextIsInvalidCommonLengthNumber_doesNotNotifyListener() {
         // This creates a full-length but not valid number: 4242 4242 4242 4243
-        cardNumberEditText.setText(
+        updateCardNumberAndIdle(
             withoutLastCharacter(VISA_WITH_SPACES) + "3"
         )
 
@@ -239,36 +245,40 @@ class CardNumberEditTextTest {
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
 
-        cardNumberEditText.setText("123")
+        updateCardNumberAndIdle("123")
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
     }
 
     @Test
     fun finishTypingCommonLengthCardNumber_whenValidCard_doesNotSetErrorValue() {
-        cardNumberEditText.setText(withoutLastCharacter(VISA_WITH_SPACES))
+        updateCardNumberAndIdle(withoutLastCharacter(VISA_WITH_SPACES))
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
 
         // We now have the valid 4242 Visa
         cardNumberEditText.append("2")
+        idle()
+
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
     }
 
     @Test
     fun finishTypingCommonLengthCardNumber_whenInvalidCard_setsErrorValue() {
-        cardNumberEditText.setText(withoutLastCharacter(VISA_WITH_SPACES))
+        updateCardNumberAndIdle(withoutLastCharacter(VISA_WITH_SPACES))
 
         // This makes the number officially invalid
         cardNumberEditText.append("3")
+        idle()
+
         assertThat(cardNumberEditText.shouldShowError)
             .isTrue()
     }
 
     @Test
     fun finishTypingInvalidCardNumber_whenFollowedByDelete_setsErrorBackToFalse() {
-        cardNumberEditText.setText(
+        updateCardNumberAndIdle(
             withoutLastCharacter(VISA_WITH_SPACES) + "3"
         )
         assertThat(cardNumberEditText.shouldShowError)
@@ -282,25 +292,31 @@ class CardNumberEditTextTest {
 
     @Test
     fun finishTypingDinersClub14_whenInvalid_setsErrorValueAndRemovesItAppropriately() {
-        cardNumberEditText.setText(
-            withoutLastCharacter(DINERS_CLUB_14_WITH_SPACES) + "3"
+        // type DinersClub BIN
+        updateCardNumberAndIdle(CardNumberFixtures.DINERS_CLUB_14_BIN)
+        // type rest of card number
+        cardNumberEditText.append(
+            withoutLastCharacter(DINERS_CLUB_14_WITH_SPACES.drop(6)) + "3"
         )
         assertThat(cardNumberEditText.shouldShowError)
             .isTrue()
 
         // Now that we're in an error state, back up by one
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
+        idle()
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
 
         cardNumberEditText.append(DINERS_CLUB_14_WITH_SPACES.last().toString())
+        idle()
+
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
     }
 
     @Test
     fun finishTypingDinersClub16_whenInvalid_setsErrorValueAndRemovesItAppropriately() {
-        cardNumberEditText.setText(
+        updateCardNumberAndIdle(
             withoutLastCharacter(DINERS_CLUB_16_WITH_SPACES) + "3"
         )
         assertThat(cardNumberEditText.shouldShowError)
@@ -312,24 +328,33 @@ class CardNumberEditTextTest {
             .isFalse()
 
         cardNumberEditText.append(DINERS_CLUB_16_WITH_SPACES.last().toString())
+        idle()
+
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
     }
 
     @Test
     fun finishTypingAmEx_whenInvalid_setsErrorValueAndRemovesItAppropriately() {
-        cardNumberEditText.setText(
-            withoutLastCharacter(AMEX_WITH_SPACES) + "3"
+        // type Amex BIN
+        updateCardNumberAndIdle(CardNumberFixtures.AMEX_BIN)
+        // type rest of card number
+        cardNumberEditText.append(
+            withoutLastCharacter(AMEX_NO_SPACES.drop(6)) + "3"
         )
+        idle()
         assertThat(cardNumberEditText.shouldShowError)
             .isTrue()
 
         // Now that we're in an error state, back up by one
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
+        idle()
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
 
         cardNumberEditText.append("5")
+        idle()
+
         assertThat(cardNumberEditText.shouldShowError)
             .isFalse()
     }
@@ -341,7 +366,7 @@ class CardNumberEditTextTest {
 
     @Test
     fun enterVisaBin_callsBrandListener() {
-        cardNumberEditText.setText(CardNumberFixtures.VISA_BIN)
+        updateCardNumberAndIdle(CardNumberFixtures.VISA_BIN)
         assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
     }
 
@@ -374,60 +399,65 @@ class CardNumberEditTextTest {
     @Test
     fun enterCompleteNumberInParts_onlyCallsBrandListenerOnce() {
         cardNumberEditText.append(AMEX_WITH_SPACES.take(2))
+        idle()
         cardNumberEditText.append(AMEX_WITH_SPACES.drop(2))
+        idle()
         assertEquals(CardBrand.AmericanExpress, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun enterBrandBin_thenDelete_callsUpdateWithUnknown() {
-        cardNumberEditText.setText(CardNumberFixtures.DINERS_CLUB_14_BIN)
+        updateCardNumberAndIdle(CardNumberFixtures.DINERS_CLUB_14_BIN)
         assertEquals(CardBrand.DinersClub, lastBrandChangeCallbackInvocation)
 
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
+        idle()
         assertEquals(CardBrand.Unknown, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun enterBrandBin_thenClearAllText_callsUpdateWithUnknown() {
-        cardNumberEditText.setText(CardNumberFixtures.VISA_BIN)
+        updateCardNumberAndIdle(CardNumberFixtures.VISA_BIN)
         assertEquals(CardBrand.Visa, lastBrandChangeCallbackInvocation)
 
         // Just adding some other text. Not enough to invalidate the card or complete it.
         lastBrandChangeCallbackInvocation = null
         cardNumberEditText.append("123")
+        idle()
+
         assertNull(lastBrandChangeCallbackInvocation)
 
         // This simulates the user selecting all text and deleting it.
-        cardNumberEditText.setText("")
+        updateCardNumberAndIdle("")
 
         assertEquals(CardBrand.Unknown, lastBrandChangeCallbackInvocation)
     }
 
     @Test
     fun cardNumber_withSpaces_returnsCardNumberWithoutSpaces() {
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
         assertThat(cardNumberEditText.cardNumber)
             .isEqualTo(VISA_NO_SPACES)
 
-        cardNumberEditText.setText("")
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+        updateCardNumberAndIdle("")
+        updateCardNumberAndIdle(AMEX_WITH_SPACES)
         assertThat(cardNumberEditText.cardNumber)
             .isEqualTo(AMEX_NO_SPACES)
 
-        cardNumberEditText.setText("")
-        cardNumberEditText.setText(DINERS_CLUB_14_WITH_SPACES)
+        updateCardNumberAndIdle("")
+        updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
         assertThat(cardNumberEditText.cardNumber)
             .isEqualTo(DINERS_CLUB_14_NO_SPACES)
 
-        cardNumberEditText.setText("")
-        cardNumberEditText.setText(DINERS_CLUB_16_WITH_SPACES)
+        updateCardNumberAndIdle("")
+        updateCardNumberAndIdle(DINERS_CLUB_16_WITH_SPACES)
         assertThat(cardNumberEditText.cardNumber)
             .isEqualTo(DINERS_CLUB_16_NO_SPACES)
     }
 
     @Test
     fun getCardNumber_whenIncompleteCard_returnsNull() {
-        cardNumberEditText.setText(
+        updateCardNumberAndIdle(
             DINERS_CLUB_14_WITH_SPACES.take(DINERS_CLUB_14_WITH_SPACES.length - 2)
         )
         assertThat(cardNumberEditText.cardNumber)
@@ -436,7 +466,7 @@ class CardNumberEditTextTest {
 
     @Test
     fun getCardNumber_whenInvalidCardNumber_returnsNull() {
-        cardNumberEditText.setText(
+        updateCardNumberAndIdle(
             withoutLastCharacter(VISA_WITH_SPACES) + "3" // creates the 4242 4242 4242 4243 bad number
         )
         assertThat(cardNumberEditText.cardNumber)
@@ -445,7 +475,7 @@ class CardNumberEditTextTest {
 
     @Test
     fun getCardNumber_whenValidNumberIsChangedToInvalid_returnsNull() {
-        cardNumberEditText.setText(AMEX_WITH_SPACES)
+        updateCardNumberAndIdle(AMEX_WITH_SPACES)
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
 
         assertThat(cardNumberEditText.cardNumber)
@@ -455,9 +485,11 @@ class CardNumberEditTextTest {
     @Test
     fun `updateCardBrand() should update cardBrand value`() {
         cardNumberEditText.updateCardBrand(BinFixtures.DINERSCLUB14)
+        idle()
         assertEquals(CardBrand.DinersClub, lastBrandChangeCallbackInvocation)
 
         cardNumberEditText.updateCardBrand(BinFixtures.AMEX)
+        idle()
         assertEquals(CardBrand.AmericanExpress, lastBrandChangeCallbackInvocation)
     }
 
@@ -502,10 +534,17 @@ class CardNumberEditTextTest {
     ) {
         // Reset inside the loop so we don't count each prefix
         lastBrandChangeCallbackInvocation = null
-        cardNumberEditText.setText(bin)
+        updateCardNumberAndIdle(bin)
         assertEquals(cardBrand, lastBrandChangeCallbackInvocation)
-        cardNumberEditText.setText("")
+        updateCardNumberAndIdle("")
     }
+
+    private fun updateCardNumberAndIdle(cardNumber: String) {
+        cardNumberEditText.setText(cardNumber)
+        idle()
+    }
+
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
 
     private class DelayedCardAccountRangeRepository : CardAccountRangeRepository {
         override suspend fun getAccountRange(cardNumber: String): CardMetadata.AccountRange? {

--- a/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/IconTextInputLayoutTest.kt
@@ -6,7 +6,6 @@ import com.google.android.material.textfield.TextInputLayout
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
-import com.stripe.android.model.PaymentMethod
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
@@ -29,18 +28,15 @@ internal class IconTextInputLayoutTest {
         val context: Context = ApplicationProvider.getApplicationContext()
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity {
-                val iconTextInputLayout = it
-                    .findViewById<CardMultilineWidget>(R.id.card_multiline_widget)
-                    .findViewById<IconTextInputLayout>(R.id.tl_card_number)
-                assertTrue(iconTextInputLayout.hasObtainedCollapsingTextHelper())
+        activityScenarioFactory
+            .createAddPaymentMethodActivity()
+            .use { activityScenario ->
+                activityScenario.onActivity {
+                    val iconTextInputLayout = it
+                        .findViewById<CardMultilineWidget>(R.id.card_multiline_widget)
+                        .findViewById<IconTextInputLayout>(R.id.tl_card_number)
+                    assertTrue(iconTextInputLayout.hasObtainedCollapsingTextHelper())
+                }
             }
-        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/ViewWidthAnimatorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ViewWidthAnimatorTest.kt
@@ -10,7 +10,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
-import com.stripe.android.model.PaymentMethod
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.junit.runner.RunWith
@@ -30,23 +29,19 @@ class ViewWidthAnimatorTest {
     fun setup() {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .setBillingAddressFields(BillingAddressFields.PostalCode)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity { activity ->
-                activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
-                    root.removeAllViews()
-                    view = Button(activity).also {
-                        it.layoutParams = ViewGroup.LayoutParams(START_WIDTH, 100)
+        activityScenarioFactory
+            .createAddPaymentMethodActivity()
+            .use { activityScenario ->
+                activityScenario.onActivity { activity ->
+                    activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
+                        root.removeAllViews()
+                        view = Button(activity).also {
+                            it.layoutParams = ViewGroup.LayoutParams(START_WIDTH, 100)
+                        }
+                        root.addView(view)
                     }
-                    root.addView(view)
                 }
             }
-        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
Use `LegacyCardAccountRangeRepository` to update brand.

Update tests to use `ShadowLooper.idle()` to ensure that repository
calls off of the main thread complete before processing.

This is a no-op for user experience.

## Motivation
Begin migrating views to new card brand updating logic.

## Testing
Added tests
Manually verified
