### PR TITLE
Create CardNumber model

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -1,0 +1,74 @@
+package com.stripe.android.cards
+
+import com.stripe.android.StripeTextUtils
+
+/**
+ * A representation of a partial or full card number.
+ */
+internal data class CardNumber(
+    private val number: String
+) {
+    private val normalizedNumber = StripeTextUtils.removeSpacesAndHyphens(number).orEmpty()
+
+    /**
+     * Format a number based on its expected length
+     *
+     * e.g. `"4242424242424242"` with pan length `16` will return `"4242 4242 4242 4242"`;
+     * `"424242"` with pan length `16` will return `"4242 42"`;
+     * `"4242424242424242"` with pan length `14` will return `"4242 424242 4242"`;
+     */
+    fun getFormatted(
+        panLength: Int = DEFAULT_PAN_LENGTH
+    ) = formatNumber(panLength, getSpacePositions(panLength))
+
+    private fun formatNumber(
+        panLength: Int,
+        spacePositions: Set<Int>
+    ): String {
+        val spacelessCardNumber = normalizedNumber.take(panLength)
+        val groups = arrayOfNulls<String?>(spacePositions.size + 1)
+
+        val length = spacelessCardNumber.length
+        var lastUsedIndex = 0
+
+        spacePositions
+            .toList().sorted().forEachIndexed { idx, spacePosition ->
+                val adjustedSpacePosition = spacePosition - idx
+                if (length > adjustedSpacePosition) {
+                    groups[idx] = spacelessCardNumber.substring(
+                        lastUsedIndex,
+                        adjustedSpacePosition
+                    )
+                    lastUsedIndex = adjustedSpacePosition
+                }
+            }
+
+        // populate any remaining digits in the first index with a null value
+        groups
+            .indexOfFirst { it == null }
+            .takeIf {
+                it != -1
+            }?.let {
+                groups[it] = spacelessCardNumber.substring(lastUsedIndex)
+            }
+
+        return groups
+            .takeWhile { it != null }
+            .joinToString(" ")
+    }
+
+    private companion object {
+        private fun getSpacePositions(panLength: Int) = SPACE_POSITIONS[panLength]
+            ?: DEFAULT_SPACE_POSITIONS
+
+        private const val DEFAULT_PAN_LENGTH = 16
+        private val DEFAULT_SPACE_POSITIONS = setOf(4, 9, 14)
+
+        private val SPACE_POSITIONS = mapOf(
+            14 to setOf(4, 11),
+            15 to setOf(4, 11),
+            16 to setOf(4, 9, 14),
+            19 to setOf(4, 9, 14, 19)
+        )
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -19,12 +19,10 @@ internal sealed class CardNumber(number: String) {
      */
     fun getFormatted(
         panLength: Int = DEFAULT_PAN_LENGTH
-    ) = formatNumber(panLength, getSpacePositions(panLength))
+    ) = formatNumber(panLength)
 
-    private fun formatNumber(
-        panLength: Int,
-        spacePositions: Set<Int>
-    ): String {
+    private fun formatNumber(panLength: Int): String {
+        val spacePositions = getSpacePositions(panLength)
         val spacelessCardNumber = normalizedNumber.take(panLength)
         val groups = arrayOfNulls<String?>(spacePositions.size + 1)
 

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -2,20 +2,20 @@ package com.stripe.android.cards
 
 import com.stripe.android.StripeTextUtils
 
-/**
- * A representation of a partial or full card number.
- */
-internal data class CardNumber(
-    private val number: String
-) {
+internal sealed class CardNumber(number: String) {
     private val normalizedNumber = StripeTextUtils.removeSpacesAndHyphens(number).orEmpty()
+
+    /**
+     * A representation of a partial or full card number that hasn't been validated.
+     */
+    class Unvalidated(number: String) : CardNumber(number)
 
     /**
      * Format a number based on its expected length
      *
      * e.g. `"4242424242424242"` with pan length `16` will return `"4242 4242 4242 4242"`;
      * `"424242"` with pan length `16` will return `"4242 42"`;
-     * `"4242424242424242"` with pan length `14` will return `"4242 424242 4242"`;
+     * `"4242424242424242"` with pan length `14` will return `"4242 424242 4242"`
      */
     fun getFormatted(
         panLength: Int = DEFAULT_PAN_LENGTH

--- a/stripe/src/test/java/com/stripe/android/cards/AccountRangeFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/AccountRangeFixtures.kt
@@ -4,6 +4,72 @@ import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardMetadata
 
 internal object AccountRangeFixtures {
+    val VISA = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "4242424240000000",
+            high = "4242424249999999"
+        ),
+        panLength = 16,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.Visa,
+        country = "GB"
+    )
+
+    val AMERICANEXPRESS = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "378282000000000",
+            high = "378282999999999"
+        ),
+        panLength = 15,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.AmericanExpress,
+        country = "US"
+    )
+
+    val MASTERCARD = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "5100000000000000",
+            high = "5599999999999999"
+        ),
+        panLength = 16,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.Mastercard
+    )
+
+    val JCB = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "3528000000000000",
+            high = "3589999999999999"
+        ),
+        panLength = 16,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.JCB
+    )
+
+    val DINERSCLUB14 = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "36000000000000",
+            high = "36999999999999"
+        ),
+        panLength = 14,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.DinersClub
+    )
+
+    val DINERSCLUB16 = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "3000000000000000",
+            high = "3059999999999999"
+        ),
+        panLength = 16,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.DinersClub
+    )
+
+    val UNIONPAY19 = CardMetadata.AccountRange(
+        binRange = BinRange(
+            low = "6216828050000000000",
+            high = "6216828059999999999"
+        ),
+        panLength = 19,
+        brandInfo = CardMetadata.AccountRange.BrandInfo.UnionPay,
+        country = "CN"
+    )
+
     val DEFAULT = listOf(
         CardMetadata.AccountRange(
             binRange = BinRange(
@@ -14,14 +80,6 @@ internal object AccountRangeFixtures {
             brandInfo = CardMetadata.AccountRange.BrandInfo.Visa,
             country = "GB"
         ),
-        CardMetadata.AccountRange(
-            binRange = BinRange(
-                low = "4242424240000000",
-                high = "4242424249999999"
-            ),
-            panLength = 16,
-            brandInfo = CardMetadata.AccountRange.BrandInfo.Visa,
-            country = "GB"
-        )
+        VISA
     )
 }

--- a/stripe/src/test/java/com/stripe/android/cards/CardNumberTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/CardNumberTest.kt
@@ -8,56 +8,56 @@ class CardNumberTest {
     @Test
     fun `getFormatted() with panLength 16 with empty number`() {
         assertThat(
-            CardNumber("   ").getFormatted(16)
+            CardNumber.Unvalidated("   ").getFormatted(16)
         ).isEqualTo("")
     }
 
     @Test
     fun `getFormatted() with panLength 16 with 3 digit number`() {
         assertThat(
-            CardNumber("4 2 4").getFormatted(16)
+            CardNumber.Unvalidated("4 2 4").getFormatted(16)
         ).isEqualTo("424")
     }
 
     @Test
     fun `getFormatted() with panLength 16 with full number`() {
         assertThat(
-            CardNumber("42424242 42424242").getFormatted(16)
+            CardNumber.Unvalidated("42424242 42424242").getFormatted(16)
         ).isEqualTo("4242 4242 4242 4242")
     }
 
     @Test
     fun `getFormatted() with panLength 16 and extraneous digits should format and remove extraneous digits`() {
         assertThat(
-            CardNumber("42424242 42424242 42424").getFormatted(16)
+            CardNumber.Unvalidated("42424242 42424242 42424").getFormatted(16)
         ).isEqualTo("4242 4242 4242 4242")
     }
 
     @Test
     fun `getFormatted() with panLength 19 with partial number`() {
         assertThat(
-            CardNumber("6216828050").getFormatted(19)
+            CardNumber.Unvalidated("6216828050").getFormatted(19)
         ).isEqualTo("6216 8280 50")
     }
 
     @Test
     fun `getFormatted() with panLength 19 with full number`() {
         assertThat(
-            CardNumber("6216828050123456789").getFormatted(19)
+            CardNumber.Unvalidated("6216828050123456789").getFormatted(19)
         ).isEqualTo("6216 8280 5012 3456 789")
     }
 
     @Test
     fun `getFormatted() with panLength 14 with partial number`() {
         assertThat(
-            CardNumber("3622720").getFormatted(14)
+            CardNumber.Unvalidated("3622720").getFormatted(14)
         ).isEqualTo("3622 720")
     }
 
     @Test
     fun `getFormatted() with panLength 14 with full number`() {
         assertThat(
-            CardNumber("36227206271667").getFormatted(14)
+            CardNumber.Unvalidated("36227206271667").getFormatted(14)
         ).isEqualTo("3622 720627 1667")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/cards/CardNumberTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/CardNumberTest.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.cards
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class CardNumberTest {
+
+    @Test
+    fun `getFormatted() with panLength 16 with empty number`() {
+        assertThat(
+            CardNumber("   ").getFormatted(16)
+        ).isEqualTo("")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 16 with 3 digit number`() {
+        assertThat(
+            CardNumber("4 2 4").getFormatted(16)
+        ).isEqualTo("424")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 16 with full number`() {
+        assertThat(
+            CardNumber("42424242 42424242").getFormatted(16)
+        ).isEqualTo("4242 4242 4242 4242")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 16 and extraneous digits should format and remove extraneous digits`() {
+        assertThat(
+            CardNumber("42424242 42424242 42424").getFormatted(16)
+        ).isEqualTo("4242 4242 4242 4242")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 19 with partial number`() {
+        assertThat(
+            CardNumber("6216828050").getFormatted(19)
+        ).isEqualTo("6216 8280 50")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 19 with full number`() {
+        assertThat(
+            CardNumber("6216828050123456789").getFormatted(19)
+        ).isEqualTo("6216 8280 5012 3456 789")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 14 with partial number`() {
+        assertThat(
+            CardNumber("3622720").getFormatted(14)
+        ).isEqualTo("3622 720")
+    }
+
+    @Test
+    fun `getFormatted() with panLength 14 with full number`() {
+        assertThat(
+            CardNumber("36227206271667").getFormatted(14)
+        ).isEqualTo("3622 720627 1667")
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -52,14 +52,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES)
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "36000000000000",
-                    high = "36999999999999"
-                ),
-                panLength = 14,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.DinersClub
-            )
+            AccountRangeFixtures.DINERSCLUB14
         )
         assertThat(
             realStore.get(BinFixtures.DINERSCLUB14)
@@ -68,14 +61,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES)
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "3000000000000000",
-                    high = "3059999999999999"
-                ),
-                panLength = 16,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.DinersClub
-            )
+            AccountRangeFixtures.DINERSCLUB16
         )
         assertThat(
             realStore.get(BinFixtures.DINERSCLUB16)
@@ -84,15 +70,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange("378282")
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "378282000000000",
-                    high = "378282999999999"
-                ),
-                panLength = 15,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.AmericanExpress,
-                country = "US"
-            )
+            AccountRangeFixtures.AMERICANEXPRESS
         )
 
         assertThat(
@@ -102,14 +80,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange("5555552500001001")
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "5100000000000000",
-                    high = "5599999999999999"
-                ),
-                panLength = 16,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.Mastercard
-            )
+            AccountRangeFixtures.MASTERCARD
         )
         assertThat(
             realStore.get(BinFixtures.MASTERCARD)
@@ -118,14 +89,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange("356840")
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "3528000000000000",
-                    high = "3589999999999999"
-                ),
-                panLength = 16,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.JCB
-            )
+            AccountRangeFixtures.JCB
         )
         assertThat(
             realStore.get(BinFixtures.JCB)
@@ -134,15 +98,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
         assertThat(
             realRepository.getAccountRange("621682")
         ).isEqualTo(
-            CardMetadata.AccountRange(
-                binRange = BinRange(
-                    low = "6216828050000000000",
-                    high = "6216828059999999999"
-                ),
-                panLength = 19,
-                brandInfo = CardMetadata.AccountRange.BrandInfo.UnionPay,
-                country = "CN"
-            )
+            AccountRangeFixtures.UNIONPAY19
         )
 
         assertThat(


### PR DESCRIPTION
`CardNumber.Unvalidated` is a representation of a partial or full card number
that hasn't been validated.

Formatting logic is based on `CardBrand#groupNumber()`, which will
be deprecated in a future PR.

`CardNumber` will be integrated in `CardNumberEditText` in a future PR.