### PR TITLE
Remove maxLength attr from CardNumberEditText in CardInputWidget layout

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -45,7 +45,6 @@
                 android:background="@android:color/transparent"
                 android:imeOptions="actionNext"
                 android:inputType="number"
-                android:maxLength="19"
                 android:hint="@string/card_number_hint"
                 style="@style/Stripe.CardInputWidget.EditText"
                 />

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -78,6 +78,8 @@ class CardNumberEditText @JvmOverloads constructor(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_NUMBER)
         }
+
+        updateLengthFilter()
     }
 
     override val accessibilityText: String?


### PR DESCRIPTION
`CardNumberEditText` manages its max length programmatically

Manually verified