### PR TITLE
Update CardNumberEditText pan length logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -57,11 +57,11 @@ internal sealed class CardNumber(number: String) {
             .joinToString(" ")
     }
 
-    private companion object {
-        private fun getSpacePositions(panLength: Int) = SPACE_POSITIONS[panLength]
+    internal companion object {
+        internal fun getSpacePositions(panLength: Int) = SPACE_POSITIONS[panLength]
             ?: DEFAULT_SPACE_POSITIONS
 
-        private const val DEFAULT_PAN_LENGTH = 16
+        internal const val DEFAULT_PAN_LENGTH = 16
         private val DEFAULT_SPACE_POSITIONS = setOf(4, 9, 14)
 
         private val SPACE_POSITIONS = mapOf(

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -76,10 +76,16 @@ class CardNumberEditText internal constructor(
     @JvmSynthetic
     internal var completionCallback: () -> Unit = {}
 
+    @Deprecated("Will be removed in upcoming major release.")
     val lengthMax: Int
         get() {
             return cardBrand.getMaxLengthWithSpacesForCardNumber(fieldText)
         }
+
+    private var panLength = CardNumber.DEFAULT_PAN_LENGTH
+
+    private val formattedPanLength: Int
+        get() = panLength + CardNumber.getSpacePositions(panLength).size
 
     private var ignoreChanges = false
 
@@ -125,7 +131,7 @@ class CardNumberEditText internal constructor(
 
     @JvmSynthetic
     internal fun updateLengthFilter() {
-        filters = arrayOf<InputFilter>(InputFilter.LengthFilter(lengthMax))
+        filters = arrayOf<InputFilter>(InputFilter.LengthFilter(formattedPanLength))
     }
 
     /**
@@ -200,7 +206,7 @@ class CardNumberEditText internal constructor(
                 val cardNumber = CardNumber.Unvalidated(spacelessNumber)
                 updateCardBrand(cardNumber.bin)
 
-                val formattedNumber = cardBrand.formatNumber(spacelessNumber)
+                val formattedNumber = cardNumber.getFormatted(panLength)
                 this.newCursorPosition = updateSelectionIndex(
                     formattedNumber.length,
                     latestChangeStart,
@@ -226,7 +232,7 @@ class CardNumberEditText internal constructor(
 
                 ignoreChanges = false
 
-                if (fieldText.length == lengthMax) {
+                if (fieldText.length == formattedPanLength) {
                     val wasCardNumberValid = isCardNumberValid
                     isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
                     shouldShowError = !isCardNumberValid
@@ -266,6 +272,7 @@ class CardNumberEditText internal constructor(
     private suspend fun onAccountRangeResult(
         accountRange: CardMetadata.AccountRange?
     ) = withContext(Dispatchers.Main) {
+        panLength = accountRange?.panLength ?: CardNumber.DEFAULT_PAN_LENGTH
         cardBrand = accountRange?.brand ?: CardBrand.Unknown
     }
 }


### PR DESCRIPTION
Previously, `lengthMax` was used to determine the expected formatted PAN
length. This relied on `CardBrand`, which we are deprecating for calculating
PAN length.

Use `CardNumber` to calculate formatted PAN length instead.

Existing tests verify the change in logic.