### PR TITLE
Fix CardNumberEditText text formatting issue

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -15,6 +15,8 @@ internal sealed class CardNumber {
             .removeSpacesAndHyphens(denormalizedNumber)
             .orEmpty()
 
+        val length = normalizedNumber.length
+
         val bin: Bin? = Bin.create(normalizedNumber)
 
         fun validate(panLength: Int): Validated? {

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -191,8 +191,12 @@ class CardNumberEditText internal constructor(
             private var newCursorPosition: Int? = null
             private var formattedNumber: String? = null
 
+            private var beforeCardNumber = CardNumber.Unvalidated("")
+
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
                 if (!ignoreChanges) {
+                    beforeCardNumber = CardNumber.Unvalidated(s?.toString().orEmpty())
+
                     latestChangeStart = start
                     latestInsertionSize = after
                 }
@@ -226,12 +230,14 @@ class CardNumberEditText internal constructor(
                 }
 
                 ignoreChanges = true
-                if (!isLastKeyDelete && formattedNumber != null) {
+
+                if (shouldUpdateAfterChange) {
                     setText(formattedNumber)
                     newCursorPosition?.let {
                         setSelection(it.coerceIn(0, fieldText.length))
                     }
                 }
+
                 formattedNumber = null
                 newCursorPosition = null
 
@@ -250,6 +256,15 @@ class CardNumberEditText internal constructor(
                     shouldShowError = false
                 }
             }
+
+            private val shouldUpdateAfterChange: Boolean
+                get() = (digitsAdded || !isLastKeyDelete) && formattedNumber != null
+
+            /**
+             * Have digits been added in this text change.
+             */
+            private val digitsAdded: Boolean
+                get() = CardNumber.Unvalidated(fieldText).length > beforeCardNumber.length
         })
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -13,6 +13,8 @@ import com.stripe.android.CardNumberFixtures.DINERS_CLUB_14_NO_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_14_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_16_NO_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_16_WITH_SPACES
+import com.stripe.android.CardNumberFixtures.JCB_NO_SPACES
+import com.stripe.android.CardNumberFixtures.JCB_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
 import com.stripe.android.PaymentConfiguration
@@ -510,6 +512,25 @@ internal class CardNumberEditTextTest {
 
         assertThat(cardNumberEditText.cardNumber)
             .isNull()
+    }
+
+    @Test
+    fun `pasting a full number, fully deleting it via delete key, then pasting a new full number should format the new number`() {
+        // paste a full number
+        updateCardNumberAndIdle(VISA_NO_SPACES)
+
+        // fully delete it with delete key
+        repeat(cardNumberEditText.fieldText.length) {
+            ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
+        }
+        assertThat(cardNumberEditText.fieldText)
+            .isEmpty()
+
+        // paste a new number
+        updateCardNumberAndIdle(JCB_NO_SPACES)
+
+        assertThat(cardNumberEditText.fieldText)
+            .isEqualTo(JCB_WITH_SPACES)
     }
 
     @Test


### PR DESCRIPTION
`CardNumberEditText` will only apply formatting to its text if the last
key pressed was not delete. This was tracked
via `StripeEditText#isLastKeyDelete`.

A bug was discovered where pressing delete and then pasting a full
card number would result in the text not being formatted.

Update the logic in `CardNumberEditText`'s `TextWatcher` to handle
pastes by also tracking whether the text change resulted in added
digits (e.g. `""` to `"42"` is considered as added digits;
`"4242"` to `"424"` is not). If digits have been added, ignore the
`isLastKeyDelete` flag.

| Before | After |
|-|-|
| ![before_delete](https://user-images.githubusercontent.com/45020849/90905997-fac87300-e39e-11ea-8442-36cfcbfb6ddf.gif) | ![after_delete](https://user-images.githubusercontent.com/45020849/90906012-02881780-e39f-11ea-8091-ccbb88d45fd9.gif) |

