### PR TITLE
Deprecate CardNumberEditText.cardNumber

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -86,7 +86,7 @@ internal sealed class CardNumber {
      * A representation of a client-side validated card number.
      */
     internal data class Validated internal constructor(
-        private val number: String
+        internal val number: String
     ) : CardNumber()
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -92,7 +92,7 @@ class CardInputWidget @JvmOverloads constructor(
         get() {
             return listOfNotNull(
                 CardValidCallback.Fields.Number.takeIf {
-                    cardNumberEditText.cardNumber == null
+                    cardNumberEditText.validatedCardNumber == null
                 },
                 CardValidCallback.Fields.Expiry.takeIf {
                     expiryDateEditText.validDateFields == null
@@ -219,7 +219,7 @@ class CardInputWidget @JvmOverloads constructor(
      */
     override val cardParams: CardParams?
         get() {
-            val cardNumber = cardNumberEditText.cardNumber
+            val cardNumber = cardNumberEditText.validatedCardNumber
             val cardDate = expiryDateEditText.validDateFields
             val cvcValue = this.cvcValue
 
@@ -256,7 +256,7 @@ class CardInputWidget @JvmOverloads constructor(
                     shouldShowErrorIcon = false
                     return CardParams(
                         setOf(LOGGING_TOKEN),
-                        number = cardNumber,
+                        number = cardNumber.number,
                         expMonth = cardDate.first,
                         expYear = cardDate.second,
                         cvc = cvcValue,
@@ -279,7 +279,7 @@ class CardInputWidget @JvmOverloads constructor(
     @Deprecated("Use cardParams", ReplaceWith("cardParams"))
     override val cardBuilder: Card.Builder?
         get() {
-            val cardNumber = cardNumberEditText.cardNumber
+            val cardNumber = cardNumberEditText.validatedCardNumber
             val cardDate = expiryDateEditText.validDateFields
             val cvcValue = this.cvcValue
 
@@ -314,7 +314,12 @@ class CardInputWidget @JvmOverloads constructor(
                 }
                 else -> {
                     shouldShowErrorIcon = false
-                    return Card.Builder(cardNumber, cardDate.first, cardDate.second, cvcValue)
+                    return Card.Builder(
+                        number = cardNumber.number,
+                        expMonth = cardDate.first,
+                        expYear = cardDate.second,
+                        cvc = cvcValue
+                    )
                         .addressZip(postalCodeValue)
                         .loggingTokens(setOf(LOGGING_TOKEN))
                 }

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -111,12 +111,16 @@ class CardNumberEditText internal constructor(
      * A normalized form of the card number. If the entered card number is "4242 4242 4242 4242",
      * this will be "4242424242424242". If the entered card number is invalid, this is `null`.
      */
+    @Deprecated("Will be removed in next major release.")
     val cardNumber: String?
         get() = if (isCardNumberValid) {
             StripeTextUtils.removeSpacesAndHyphens(fieldText)
         } else {
             null
         }
+
+    internal val validatedCardNumber: CardNumber.Validated?
+        get() = unvalidatedCardNumber.validate(panLength)
 
     private val unvalidatedCardNumber: CardNumber.Unvalidated
         get() = CardNumber.Unvalidated(fieldText)
@@ -219,7 +223,7 @@ class CardNumberEditText internal constructor(
                 }
 
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-// skip formatting if we're past the last possible space position
+                    // skip formatting if we're past the last possible space position
                     if (ignoreChanges || start > 16) {
                         return
                     }
@@ -276,9 +280,9 @@ class CardNumberEditText internal constructor(
                 private val shouldUpdateAfterChange: Boolean
                     get() = (digitsAdded || !isLastKeyDelete) && formattedNumber != null
 
-/**
-* Have digits been added in this text change.
-*/
+                /**
+                 * Have digits been added in this text change.
+                 */
                 private val digitsAdded: Boolean
                     get() = unvalidatedCardNumber.length > beforeCardNumber.length
             }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -499,22 +499,22 @@ internal class CardNumberEditTextTest {
     @Test
     fun cardNumber_withSpaces_returnsCardNumberWithoutSpaces() {
         updateCardNumberAndIdle(VISA_WITH_SPACES)
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber?.number)
             .isEqualTo(VISA_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber?.number)
             .isEqualTo(AMEX_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber?.number)
             .isEqualTo(DINERS_CLUB_14_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(DINERS_CLUB_16_WITH_SPACES)
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber?.number)
             .isEqualTo(DINERS_CLUB_16_NO_SPACES)
     }
 
@@ -523,7 +523,7 @@ internal class CardNumberEditTextTest {
         updateCardNumberAndIdle(
             DINERS_CLUB_14_WITH_SPACES.take(DINERS_CLUB_14_WITH_SPACES.length - 2)
         )
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber)
             .isNull()
     }
 
@@ -532,7 +532,7 @@ internal class CardNumberEditTextTest {
         updateCardNumberAndIdle(
             withoutLastCharacter(VISA_WITH_SPACES) + "3" // creates the 4242 4242 4242 4243 bad number
         )
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber)
             .isNull()
     }
 
@@ -541,7 +541,7 @@ internal class CardNumberEditTextTest {
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
 
-        assertThat(cardNumberEditText.cardNumber)
+        assertThat(cardNumberEditText.validatedCardNumber)
             .isNull()
     }
 


### PR DESCRIPTION
Replace raw card number string with `CardNumber` instance