### PR TITLE
Update CardNumberEditText.completionCallback invocation logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -17,6 +17,8 @@ internal sealed class CardNumber {
 
         val length = normalizedNumber.length
 
+        val isMaxLength = length == MAX_PAN_LENGTH
+
         val bin: Bin? = Bin.create(normalizedNumber)
 
         fun validate(panLength: Int): Validated? {
@@ -76,10 +78,6 @@ internal sealed class CardNumber {
                 .takeWhile { it != null }
                 .joinToString(" ")
         }
-
-        private companion object {
-            private const val MIN_PAN_LENGTH = 14
-        }
     }
 
     /**
@@ -93,6 +91,8 @@ internal sealed class CardNumber {
         internal fun getSpacePositions(panLength: Int) = SPACE_POSITIONS[panLength]
             ?: DEFAULT_SPACE_POSITIONS
 
+        private const val MIN_PAN_LENGTH = 14
+        internal const val MAX_PAN_LENGTH = 19
         internal const val DEFAULT_PAN_LENGTH = 16
         private val DEFAULT_SPACE_POSITIONS = setOf(4, 9, 14)
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -7,7 +7,6 @@ import android.text.InputFilter
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.CardUtils
 import com.stripe.android.R
 import com.stripe.android.StripeTextUtils
 import com.stripe.android.cards.CardAccountRangeRepository
@@ -130,6 +129,9 @@ class CardNumberEditText internal constructor(
 
     private val unvalidatedCardNumber: CardNumber.Unvalidated
         get() = CardNumber.Unvalidated(fieldText)
+
+    private val isValid: Boolean
+        get() = validatedCardNumber != null
 
     @VisibleForTesting
     internal var accountRangeRepositoryJob: Job? = null
@@ -271,13 +273,14 @@ class CardNumberEditText internal constructor(
 
                     if (unvalidatedCardNumber.length == panLength) {
                         val wasCardNumberValid = isCardNumberValid
-                        isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
-                        shouldShowError = !isCardNumberValid
-                        if (!wasCardNumberValid && isCardNumberValid) {
+                        isCardNumberValid = isValid
+                        shouldShowError = !isValid
+
+                        if (isComplete(wasCardNumberValid)) {
                             completionCallback()
                         }
                     } else {
-                        isCardNumberValid = CardUtils.isValidCardNumber(fieldText)
+                        isCardNumberValid = isValid
                         // Don't show errors if we aren't full-length.
                         shouldShowError = false
                     }
@@ -291,6 +294,16 @@ class CardNumberEditText internal constructor(
                  */
                 private val digitsAdded: Boolean
                     get() = unvalidatedCardNumber.length > beforeCardNumber.length
+
+                /**
+                 * If `true`, [completionCallback] will be invoked.
+                 */
+                private fun isComplete(
+                    wasCardNumberValid: Boolean
+                ) = !wasCardNumberValid && (
+                    unvalidatedCardNumber.isMaxLength ||
+                        (isValid && accountRange != null)
+                    )
             }
         )
     }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.app.Activity
 import android.content.Context
-import android.os.Looper
 import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -28,6 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.TestFocusChangeListener
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
 import com.stripe.android.view.CardInputWidget.Companion.shouldIconShowBrand
 import kotlinx.coroutines.Dispatchers
@@ -37,7 +37,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.LooperMode
 import java.util.Calendar
 import kotlin.test.AfterTest
@@ -77,6 +76,9 @@ internal class CardInputWidgetTest {
         // The input date here will be invalid after 2050. Please update the test.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
             .isTrue()
+
+        Dispatchers.setMain(testDispatcher)
+
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
         activityScenarioFactory.create<AddPaymentMethodActivity>(
@@ -662,8 +664,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun onDeleteFromExpiryDate_whenNotEmpty_doesNotShiftFocusOrDeleteDigit() {
-        Dispatchers.setMain(testDispatcher)
-
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
         assertThat(expiryEditText.hasFocus())
@@ -819,6 +819,7 @@ internal class CardInputWidgetTest {
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
         cardInputWidget.updateSpaceSizes(false)
+        idleLooper()
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1143,8 +1144,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addValidAmExCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
-        Dispatchers.setMain(testDispatcher)
-
         cardInputWidget.postalCodeEnabled = false
 
         // Moving left with an AmEx number has a larger peek and cvc size.
@@ -1174,8 +1173,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addValidAmExCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
-        Dispatchers.setMain(testDispatcher)
-
         cardInputWidget.postalCodeEnabled = true
 
         // Moving left with an AmEx number has a larger peek and cvc size.
@@ -1207,8 +1204,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addDinersClubCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
-        Dispatchers.setMain(testDispatcher)
-
         cardInputWidget.postalCodeEnabled = false
 
         // When we move for a Diner's club card, the peek text is shorter, so we expect:
@@ -1238,8 +1233,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun addDinersClubCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
-        Dispatchers.setMain(testDispatcher)
-
         cardInputWidget.postalCodeEnabled = true
 
         // When we move for a Diner's club card, the peek text is shorter, so we expect:
@@ -1747,7 +1740,7 @@ internal class CardInputWidgetTest {
 
     private fun updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)
-        shadowOf(Looper.getMainLooper()).idle()
+        idleLooper()
     }
 
     private companion object {


### PR DESCRIPTION
When pasting a PAN that is fewer than 19 digits and `accountRange`
is null, do not call `completionCallback()`.

When pasting a PAN that is 19 digits, call `completionCallback()`
without validating the PAN.