### PR TITLE
Add initial support for 19 digit PANs

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -26,6 +26,7 @@ import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.stripe.android.R
+import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.Cvc
 import com.stripe.android.databinding.CardInputWidgetBinding
 import com.stripe.android.model.Address
@@ -842,7 +843,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         cardNumberEditText.brandChangeCallback = { brand ->
-            hiddenCardText = createHiddenCardText(brand)
+            hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
             updateIcon()
             cvcEditText.updateBrand(brand)
         }
@@ -870,36 +871,27 @@ class CardInputWidget @JvmOverloads constructor(
     }
 
     /**
-     * @return a [String] that is the length of a full card number for the current [brand],
-     * without the last group of digits when the card is formatted with spaces. This is used for
-     * measuring the rendered width of the hidden portion (i.e. when the card number is "peeking")
-     * and does not have to be a valid card number.
+     * @return a [String] that is the length of a full formatted PAN for the given PAN length,
+     * without the last group of digits. This is used for measuring the rendered width of the
+     * hidden portion (i.e. when the card number is "peeking") and does not have to be a valid
+     * card number.
      *
-     * e.g. if [brand] is [CardBrand.Visa], this will generate `"0000 0000 0000 "` (including the
+     * e.g. if [panLength] is `16`, this will generate `"0000 0000 0000 "` (including the
      * trailing space).
      *
      * This should only be called when [brand] changes.
      */
     @VisibleForTesting
     internal fun createHiddenCardText(
-        brand: CardBrand,
-        cardNumber: String = cardNumberEditText.fieldText
+        panLength: Int
     ): String {
-        var lastIndex = 0
-        val digits: MutableList<String> = mutableListOf()
+        val formattedNumber = CardNumber.Unvalidated(
+            List(panLength) { "0" }.joinToString(separator = "")
+        ).getFormatted(panLength)
 
-        brand.getSpacePositionsForCardNumber(cardNumber)
-            .toList()
-            .sorted()
-            .forEach {
-                repeat(it - lastIndex) {
-                    digits.add("0")
-                }
-                digits.add(" ")
-                lastIndex = it + 1
-            }
-
-        return digits.joinToString(separator = "")
+        return formattedNumber.take(
+            formattedNumber.lastIndexOf(' ') + 1
+        )
     }
 
     private fun applyAttributes(attrs: AttributeSet) {
@@ -1092,7 +1084,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
     }
 
-    private var hiddenCardText: String = createHiddenCardText(brand)
+    private var hiddenCardText: String = createHiddenCardText(cardNumberEditText.panLength)
 
     private val cvcPlaceHolder: String
         get() {

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -97,7 +97,7 @@ class CardNumberEditText internal constructor(
             updateLengthFilter()
         }
 
-    private val panLength: Int
+    internal val panLength: Int
         get() = accountRange?.panLength
             ?: staticCardAccountRanges.match(unvalidatedCardNumber)?.panLength
             ?: CardNumber.DEFAULT_PAN_LENGTH
@@ -229,8 +229,7 @@ class CardNumberEditText internal constructor(
                 }
 
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                    // skip formatting if we're past the last possible space position
-                    if (ignoreChanges || start > 16) {
+                    if (ignoreChanges) {
                         return
                     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.CardNumberFixtures.AMEX_NO_SPACES
 import com.stripe.android.CardNumberFixtures.AMEX_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_14_NO_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_14_WITH_SPACES
-import com.stripe.android.CardNumberFixtures.DINERS_CLUB_16_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
 import com.stripe.android.PaymentConfiguration
@@ -28,6 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.TestFocusChangeListener
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
 import com.stripe.android.view.CardInputWidget.Companion.shouldIconShowBrand
 import kotlinx.coroutines.Dispatchers
@@ -849,6 +849,7 @@ internal class CardInputWidgetTest {
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
         cardInputWidget.updateSpaceSizes(false)
+        idleLooper()
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1087,7 +1088,7 @@ internal class CardInputWidgetTest {
 
         // Moving left with an actual Visa number does the same as moving when empty.
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
-        cardNumberEditText.setText(VISA_WITH_SPACES)
+        updateCardNumberAndIdle(VISA_WITH_SPACES)
 
         assertThat(cardInputWidget.placementParameters)
             .isEqualTo(
@@ -1574,6 +1575,8 @@ internal class CardInputWidgetTest {
     @Test
     fun currentFields_equals_requiredFields_withPostalCodeDisabled() {
         cardInputWidget.postalCodeEnabled = false
+        idleLooper()
+
         assertThat(cardInputWidget.requiredFields)
             .isEqualTo(cardInputWidget.currentFields)
     }
@@ -1675,13 +1678,31 @@ internal class CardInputWidgetTest {
     }
 
     @Test
-    fun createHiddenCardText_shouldReturnExpectedValue() {
-        assertThat(cardInputWidget.createHiddenCardText(CardBrand.Visa, VISA_NO_SPACES))
-            .isEqualTo("0000 0000 0000 ")
-        assertThat(cardInputWidget.createHiddenCardText(CardBrand.DinersClub, DINERS_CLUB_14_NO_SPACES))
-            .isEqualTo("0000 000000 ")
-        assertThat(cardInputWidget.createHiddenCardText(CardBrand.DinersClub, DINERS_CLUB_16_NO_SPACES))
-            .isEqualTo("0000 0000 0000 ")
+    fun `createHiddenCardText with 19 digit PAN`() {
+        assertThat(
+            cardInputWidget.createHiddenCardText(19)
+        ).isEqualTo("0000 0000 0000 0000 ")
+    }
+
+    @Test
+    fun `createHiddenCardText with 16 digit PAN`() {
+        assertThat(
+            cardInputWidget.createHiddenCardText(16)
+        ).isEqualTo("0000 0000 0000 ")
+    }
+
+    @Test
+    fun `createHiddenCardText with 15 digit PAN`() {
+        assertThat(
+            cardInputWidget.createHiddenCardText(15)
+        ).isEqualTo("0000 000000 ")
+    }
+
+    @Test
+    fun `createHiddenCardText with 14 digit PAN`() {
+        assertThat(
+            cardInputWidget.createHiddenCardText(14)
+        ).isEqualTo("0000 000000 ")
     }
 
     @Test


### PR DESCRIPTION
- Simplify `CardInputWidget#createHiddenCardText()` logic
- Update `CardNumberEditText` text change logic

In a future PR, `CardInputWidget#FULL_SIZING_CARD_TEXT` will be updated
to be a 19 digit PAN, and `CardInputWidget#peekCardText` will be updated
to support 19 digit PANs.