### PR TITLE
Simplify normalized card number logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/CardUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.cards.Bin
+import com.stripe.android.cards.CardNumber
 import com.stripe.android.model.CardBrand
 
 /**
@@ -32,7 +33,7 @@ object CardUtils {
      */
     @JvmStatic
     fun isValidCardNumber(cardNumber: String?): Boolean {
-        val normalizedNumber = StripeTextUtils.removeSpacesAndHyphens(cardNumber)
+        val normalizedNumber = CardNumber.Unvalidated(cardNumber.orEmpty()).normalizedNumber
         return isValidLuhnNumber(normalizedNumber) && isValidCardLength(normalizedNumber)
     }
 
@@ -92,7 +93,7 @@ object CardUtils {
 
         val spacelessCardNumber =
             if (shouldNormalize) {
-                StripeTextUtils.removeSpacesAndHyphens(cardNumber)
+                CardNumber.Unvalidated(cardNumber).normalizedNumber
             } else {
                 cardNumber
             }

--- a/stripe/src/main/java/com/stripe/android/CardUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/CardUtils.kt
@@ -33,7 +33,7 @@ object CardUtils {
      */
     @JvmStatic
     fun isValidCardNumber(cardNumber: String?): Boolean {
-        val normalizedNumber = CardNumber.Unvalidated(cardNumber.orEmpty()).normalizedNumber
+        val normalizedNumber = CardNumber.Unvalidated(cardNumber.orEmpty()).normalized
         return isValidLuhnNumber(normalizedNumber) && isValidCardLength(normalizedNumber)
     }
 
@@ -93,7 +93,7 @@ object CardUtils {
 
         val spacelessCardNumber =
             if (shouldNormalize) {
-                CardNumber.Unvalidated(cardNumber).normalizedNumber
+                CardNumber.Unvalidated(cardNumber).normalized
             } else {
                 cardNumber
             }

--- a/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
@@ -16,8 +16,7 @@ object StripeTextUtils {
     @Deprecated("Will be removed in upcoming major release.")
     @JvmStatic
     fun removeSpacesAndHyphens(cardNumberWithSpaces: String?): String? {
-        return cardNumberWithSpaces.takeUnless { it.isNullOrBlank() }?.let {
-            it.filter { c -> c.isDigit() }
-        }
+        return cardNumberWithSpaces.takeUnless { it.isNullOrBlank() }
+            ?.replace("\\s|-".toRegex(), "")
     }
 }

--- a/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeTextUtils.kt
@@ -13,9 +13,11 @@ object StripeTextUtils {
      * @return the input number minus any spaces, for instance "4242424242424242".
      * Returns `null` if the input was `null` or all spaces.
      */
+    @Deprecated("Will be removed in upcoming major release.")
     @JvmStatic
     fun removeSpacesAndHyphens(cardNumberWithSpaces: String?): String? {
-        return cardNumberWithSpaces.takeUnless { it.isNullOrBlank() }
-            ?.replace("\\s|-".toRegex(), "")
+        return cardNumberWithSpaces.takeUnless { it.isNullOrBlank() }?.let {
+            it.filter { c -> c.isDigit() }
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -10,7 +10,7 @@ internal sealed class CardNumber {
     internal data class Unvalidated internal constructor(
         private val denormalizedNumber: String
     ) : CardNumber() {
-        val normalizedNumber = denormalizedNumber.filter { it.isDigit() }
+        val normalizedNumber = denormalizedNumber.filterNot { REJECT_CHARS.contains(it) }
 
         val length = normalizedNumber.length
 
@@ -74,6 +74,10 @@ internal sealed class CardNumber {
             return groups
                 .takeWhile { it != null }
                 .joinToString(" ")
+        }
+
+        private companion object {
+            private val REJECT_CHARS = setOf('-', ' ')
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.cards
 
 import com.stripe.android.CardUtils
-import com.stripe.android.StripeTextUtils
 
 internal sealed class CardNumber {
 
@@ -11,9 +10,7 @@ internal sealed class CardNumber {
     internal data class Unvalidated internal constructor(
         private val denormalizedNumber: String
     ) : CardNumber() {
-        val normalizedNumber = StripeTextUtils
-            .removeSpacesAndHyphens(denormalizedNumber)
-            .orEmpty()
+        val normalizedNumber = denormalizedNumber.filter { it.isDigit() }
 
         val length = normalizedNumber.length
 

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -8,23 +8,23 @@ internal sealed class CardNumber {
      * A representation of a partial or full card number that hasn't been validated.
      */
     internal data class Unvalidated internal constructor(
-        private val denormalizedNumber: String
+        private val denormalized: String
     ) : CardNumber() {
-        val normalizedNumber = denormalizedNumber.filterNot { REJECT_CHARS.contains(it) }
+        val normalized = denormalized.filterNot { REJECT_CHARS.contains(it) }
 
-        val length = normalizedNumber.length
+        val length = normalized.length
 
         val isMaxLength = length == MAX_PAN_LENGTH
 
-        val bin: Bin? = Bin.create(normalizedNumber)
+        val bin: Bin? = Bin.create(normalized)
 
         fun validate(panLength: Int): Validated? {
             return if (panLength >= MIN_PAN_LENGTH &&
-                normalizedNumber.length == panLength &&
-                CardUtils.isValidLuhnNumber(normalizedNumber)
+                normalized.length == panLength &&
+                CardUtils.isValidLuhnNumber(normalized)
             ) {
                 Validated(
-                    number = normalizedNumber
+                    value = normalized
                 )
             } else {
                 null
@@ -44,7 +44,7 @@ internal sealed class CardNumber {
 
         private fun formatNumber(panLength: Int): String {
             val spacePositions = getSpacePositions(panLength)
-            val spacelessCardNumber = normalizedNumber.take(panLength)
+            val spacelessCardNumber = normalized.take(panLength)
             val groups = arrayOfNulls<String?>(spacePositions.size + 1)
 
             val length = spacelessCardNumber.length
@@ -77,6 +77,7 @@ internal sealed class CardNumber {
         }
 
         private companion object {
+            // characters to remove from a denormalized number to make it normalized
             private val REJECT_CHARS = setOf('-', ' ')
         }
     }
@@ -85,7 +86,7 @@ internal sealed class CardNumber {
      * A representation of a client-side validated card number.
      */
     internal data class Validated internal constructor(
-        internal val number: String
+        internal val value: String
     ) : CardNumber()
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/model/BinRange.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BinRange.kt
@@ -13,7 +13,7 @@ internal data class BinRange(
      * bounds) to match the length of the shorter one, then do numerical compare.
      */
     internal fun matches(cardNumber: CardNumber.Unvalidated): Boolean {
-        val number = cardNumber.normalizedNumber
+        val number = cardNumber.normalized
         val numberBigDecimal = number.toBigDecimalOrNull() ?: return false
 
         val withinLowRange = if (number.length < low.length) {

--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -173,7 +173,7 @@ enum class CardBrand(
      */
     @Deprecated("Will be replaced with AccountRange#panLength, which is internal.")
     fun getMaxLengthForCardNumber(cardNumber: String): Int {
-        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalizedNumber
+        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalized
         return variantMaxLength.entries.firstOrNull { (pattern, _) ->
             pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultMaxLength
@@ -193,7 +193,7 @@ enum class CardBrand(
      */
     @Deprecated("Will be replaced with CardNumber#getSpacePositions(), which is internal.")
     fun getSpacePositionsForCardNumber(cardNumber: String): Set<Int> {
-        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalizedNumber
+        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalized
         return variantSpacePositions.entries.firstOrNull { (pattern, _) ->
             pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultSpacePositions

--- a/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardBrand.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import androidx.annotation.DrawableRes
 import com.stripe.android.R
-import com.stripe.android.StripeTextUtils
+import com.stripe.android.cards.CardNumber
 import java.util.regex.Pattern
 
 /**
@@ -173,8 +173,7 @@ enum class CardBrand(
      */
     @Deprecated("Will be replaced with AccountRange#panLength, which is internal.")
     fun getMaxLengthForCardNumber(cardNumber: String): Int {
-        val normalizedCardNumber =
-            StripeTextUtils.removeSpacesAndHyphens(cardNumber).orEmpty()
+        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalizedNumber
         return variantMaxLength.entries.firstOrNull { (pattern, _) ->
             pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultMaxLength
@@ -194,8 +193,7 @@ enum class CardBrand(
      */
     @Deprecated("Will be replaced with CardNumber#getSpacePositions(), which is internal.")
     fun getSpacePositionsForCardNumber(cardNumber: String): Set<Int> {
-        val normalizedCardNumber =
-            StripeTextUtils.removeSpacesAndHyphens(cardNumber).orEmpty()
+        val normalizedCardNumber = CardNumber.Unvalidated(cardNumber).normalizedNumber
         return variantSpacePositions.entries.firstOrNull { (pattern, _) ->
             pattern.matcher(normalizedCardNumber).matches()
         }?.value ?: defaultSpacePositions

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -258,7 +258,7 @@ class CardInputWidget @JvmOverloads constructor(
                     shouldShowErrorIcon = false
                     return CardParams(
                         setOf(LOGGING_TOKEN),
-                        number = cardNumber.number,
+                        number = cardNumber.value,
                         expMonth = cardDate.first,
                         expYear = cardDate.second,
                         cvc = cvc.value,
@@ -317,7 +317,7 @@ class CardInputWidget @JvmOverloads constructor(
                 else -> {
                     shouldShowErrorIcon = false
                     return Card.Builder(
-                        number = cardNumber.number,
+                        number = cardNumber.value,
                         expMonth = cardDate.first,
                         expYear = cardDate.second,
                         cvc = cvc.value

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -201,7 +201,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
             return CardParams(
                 setOf(CARD_MULTILINE_TOKEN),
-                number = validatedCardNumber?.number.orEmpty(),
+                number = validatedCardNumber?.value.orEmpty(),
                 expMonth = cardDate.first,
                 expYear = cardDate.second,
                 cvc = cvcValue,
@@ -231,7 +231,7 @@ class CardMultilineWidget @JvmOverloads constructor(
                 .takeIf { shouldShowPostalCode }
 
             return Card.Builder(
-                number = validatedCardNumber?.number,
+                number = validatedCardNumber?.value,
                 expMonth = cardDate.first,
                 expYear = cardDate.second,
                 cvc = cvcValue

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -118,7 +118,7 @@ class CardNumberEditText internal constructor(
     @Deprecated("Will be removed in next major release.")
     val cardNumber: String?
         get() = if (isCardNumberValid) {
-            unvalidatedCardNumber.normalizedNumber
+            unvalidatedCardNumber.normalized
         } else {
             null
         }

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -8,7 +8,6 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.R
-import com.stripe.android.StripeTextUtils
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
@@ -119,7 +118,7 @@ class CardNumberEditText internal constructor(
     @Deprecated("Will be removed in next major release.")
     val cardNumber: String?
         get() = if (isCardNumberValid) {
-            StripeTextUtils.removeSpacesAndHyphens(fieldText)
+            unvalidatedCardNumber.normalizedNumber
         } else {
             null
         }
@@ -235,11 +234,7 @@ class CardNumberEditText internal constructor(
                         return
                     }
 
-                    val spacelessNumber = StripeTextUtils.removeSpacesAndHyphens(
-                        s?.toString().orEmpty()
-                    ).orEmpty()
-
-                    val cardNumber = CardNumber.Unvalidated(spacelessNumber)
+                    val cardNumber = CardNumber.Unvalidated(s?.toString().orEmpty())
                     updateAccountRange(cardNumber)
 
                     val formattedNumber = cardNumber.getFormatted(panLength)

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -543,22 +543,22 @@ internal class CardNumberEditTextTest {
     @Test
     fun cardNumber_withSpaces_returnsCardNumberWithoutSpaces() {
         updateCardNumberAndIdle(VISA_WITH_SPACES)
-        assertThat(cardNumberEditText.validatedCardNumber?.number)
+        assertThat(cardNumberEditText.validatedCardNumber?.value)
             .isEqualTo(VISA_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
-        assertThat(cardNumberEditText.validatedCardNumber?.number)
+        assertThat(cardNumberEditText.validatedCardNumber?.value)
             .isEqualTo(AMEX_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
-        assertThat(cardNumberEditText.validatedCardNumber?.number)
+        assertThat(cardNumberEditText.validatedCardNumber?.value)
             .isEqualTo(DINERS_CLUB_14_NO_SPACES)
 
         updateCardNumberAndIdle("")
         updateCardNumberAndIdle(DINERS_CLUB_16_WITH_SPACES)
-        assertThat(cardNumberEditText.validatedCardNumber?.number)
+        assertThat(cardNumberEditText.validatedCardNumber?.value)
             .isEqualTo(DINERS_CLUB_16_NO_SPACES)
     }
 


### PR DESCRIPTION
`StripeTextUtils.removeSpacesAndHyphens()` can be simplified and is now unnecessary