### PR TITLE
Remove unused defaultArgs property in ActivityStarter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
@@ -16,32 +16,27 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
     private val activity: Activity,
     private val fragment: Fragment? = null,
     private val targetClass: Class<TargetActivityType>,
-    private val defaultArgs: ArgsType,
     private val requestCode: Int
 ) {
     internal constructor(
         activity: Activity,
         targetClass: Class<TargetActivityType>,
-        args: ArgsType,
         requestCode: Int
     ) : this(
         activity = activity,
         fragment = null,
         targetClass = targetClass,
-        defaultArgs = args,
         requestCode = requestCode
     )
 
     internal constructor(
         fragment: Fragment,
         targetClass: Class<TargetActivityType>,
-        args: ArgsType,
         requestCode: Int
     ) : this(
         activity = fragment.requireActivity(),
         fragment = fragment,
         targetClass = targetClass,
-        defaultArgs = args,
         requestCode = requestCode
     )
 

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -24,14 +24,12 @@ class AddPaymentMethodActivityStarter : ActivityStarter<AddPaymentMethodActivity
     constructor(activity: Activity) : super(
         activity,
         AddPaymentMethodActivity::class.java,
-        Args.DEFAULT,
         REQUEST_CODE
     )
 
     constructor(fragment: Fragment) : super(
         fragment,
         AddPaymentMethodActivity::class.java,
-        Args.DEFAULT,
         REQUEST_CODE
     )
 
@@ -131,8 +129,6 @@ class AddPaymentMethodActivityStarter : ActivityStarter<AddPaymentMethodActivity
         }
 
         internal companion object {
-            internal val DEFAULT = Builder().build()
-
             @JvmSynthetic
             internal fun create(intent: Intent): Args {
                 return requireNotNull(intent.getParcelableExtra(ActivityStarter.Args.EXTRA))

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
@@ -14,20 +14,12 @@ class PaymentFlowActivityStarter :
     constructor(activity: Activity, config: PaymentSessionConfig) : super(
         activity,
         PaymentFlowActivity::class.java,
-        Args(
-            paymentSessionConfig = config,
-            paymentSessionData = PaymentSessionData(config)
-        ),
         REQUEST_CODE
     )
 
     constructor(fragment: Fragment, config: PaymentSessionConfig) : super(
         fragment,
         PaymentFlowActivity::class.java,
-        Args(
-            paymentSessionConfig = config,
-            paymentSessionData = PaymentSessionData(config)
-        ),
         REQUEST_CODE
     )
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -26,14 +26,12 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
     constructor(activity: Activity) : super(
         activity,
         PaymentMethodsActivity::class.java,
-        Args.DEFAULT,
         REQUEST_CODE
     )
 
     constructor(fragment: Fragment) : super(
         fragment,
         PaymentMethodsActivity::class.java,
-        Args.DEFAULT,
         REQUEST_CODE
     )
 
@@ -158,8 +156,6 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
         }
 
         internal companion object {
-            internal val DEFAULT = Builder().build()
-
             @JvmSynthetic
             internal fun create(intent: Intent): Args {
                 return requireNotNull(intent.getParcelableExtra(ActivityStarter.Args.EXTRA))


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I'm adding a new activity starter that doesn't have a reasonable default, and we don't use this property anyway so may as well delete it.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
