### PR TITLE
Refactor card account range retrieval loading logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardAccountRangeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardAccountRangeRepository.kt
@@ -1,11 +1,17 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
 
 internal interface CardAccountRangeRepository {
     suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange?
+
+    /**
+     * Flow that represents whether any of the [CardAccountRangeSource] instances are loading.
+     */
+    val loading: Flow<Boolean>
 
     interface Factory {
         fun create(): CardAccountRangeRepository

--- a/stripe/src/main/java/com/stripe/android/cards/CardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardAccountRangeSource.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
 
 internal interface CardAccountRangeSource {
     suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange?
+
+    val loading: Flow<Boolean>
 }

--- a/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepository.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 
 internal class DefaultCardAccountRangeRepository(
     private val inMemoryCardAccountRangeSource: CardAccountRangeSource,
@@ -15,5 +17,16 @@ internal class DefaultCardAccountRangeRepository(
                 ?: remoteCardAccountRangeSource.getAccountRange(cardNumber)
                 ?: staticCardAccountRangeSource.getAccountRange(cardNumber)
         }
+    }
+
+    override val loading: Flow<Boolean> = combine(
+        listOf(
+            inMemoryCardAccountRangeSource.loading,
+            remoteCardAccountRangeSource.loading,
+            staticCardAccountRangeSource.loading
+        )
+    ) { loading ->
+        // emit true if any of the sources are loading data
+        loading.any { it }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/cards/InMemoryCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/InMemoryCardAccountRangeSource.kt
@@ -1,10 +1,14 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 internal class InMemoryCardAccountRangeSource(
     private val store: CardAccountRangeStore
 ) : CardAccountRangeSource {
+    override val loading: Flow<Boolean> = flowOf(false)
+
     override suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange? {

--- a/stripe/src/main/java/com/stripe/android/cards/LegacyCardAccountRangeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/LegacyCardAccountRangeRepository.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * A [CardAccountRangeRepository] that simulates existing card account range lookup logic by only
@@ -16,4 +18,6 @@ internal class LegacyCardAccountRangeRepository(
             staticCardAccountRangeSource.getAccountRange(cardNumber)
         }
     }
+
+    override val loading: Flow<Boolean> = flowOf(false)
 }

--- a/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
@@ -3,21 +3,33 @@ package com.stripe.android.cards
 import com.stripe.android.ApiRequest
 import com.stripe.android.StripeRepository
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
+@ExperimentalCoroutinesApi
 internal class RemoteCardAccountRangeSource(
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
     private val cardAccountRangeStore: CardAccountRangeStore
 ) : CardAccountRangeSource {
 
+    private val mutableLoading = MutableStateFlow(false)
+
+    override val loading: Flow<Boolean>
+        get() = mutableLoading
+
     override suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange? {
         return cardNumber.bin?.let { bin ->
+            mutableLoading.value = true
+
             val accountRanges =
                 stripeRepository.getCardMetadata(bin, requestOptions).accountRanges
-
             cardAccountRangeStore.save(bin, accountRanges)
+
+            mutableLoading.value = false
 
             accountRanges
                 .firstOrNull { (binRange) ->

--- a/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRangeSource.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * A [CardAccountRangeSource] that uses a local, static source of BIN ranges.
@@ -8,6 +10,8 @@ import com.stripe.android.model.CardMetadata
 internal class StaticCardAccountRangeSource(
     private val accountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges()
 ) : CardAccountRangeSource {
+    override val loading: Flow<Boolean> = flowOf(false)
+
     override suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange? {

--- a/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -25,11 +25,11 @@ internal class CardBrandView @JvmOverloads constructor(
     @ColorInt
     internal var tintColorInt: Int = 0
 
-    var isProcessing: Boolean by Delegates.observable(
+    var isLoading: Boolean by Delegates.observable(
         false
-    ) { _, wasProcessing, isProcessing ->
-        if (SHOULD_SHOW_PROGRESS && wasProcessing != isProcessing) {
-            if (isProcessing) {
+    ) { _, wasLoading, isLoading ->
+        if (SHOULD_SHOW_PROGRESS && wasLoading != isLoading) {
+            if (isLoading) {
                 progressView.show()
             } else {
                 progressView.hide()

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -865,8 +865,8 @@ class CardInputWidget @JvmOverloads constructor(
             cardNumberEditText.requestFocus()
         }
 
-        cardNumberEditText.isProcessingCallback = {
-            cardBrandView.isProcessing = it
+        cardNumberEditText.isLoadingCallback = {
+            cardBrandView.isLoading = it
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/cards/CardWidgetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/CardWidgetViewModelTest.kt
@@ -6,6 +6,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardNumberFixtures
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -34,6 +36,8 @@ class CardWidgetViewModelTest {
         override suspend fun getAccountRange(
             cardNumber: CardNumber.Unvalidated
         ) = ACCOUNT_RANGE
+
+        override val loading: Flow<Boolean> = flowOf(false)
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -11,6 +11,9 @@ import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardMetadata
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
@@ -125,6 +128,36 @@ internal class DefaultCardAccountRangeRepositoryTest {
         ).isNull()
     }
 
+    @Test
+    fun `loading when no sources are loading should emit false`() = testDispatcher.runBlockingTest {
+        val collected = mutableListOf<Boolean>()
+        DefaultCardAccountRangeRepository(
+            inMemoryCardAccountRangeSource = FakeCardAccountRangeSource(),
+            remoteCardAccountRangeSource = FakeCardAccountRangeSource(),
+            staticCardAccountRangeSource = FakeCardAccountRangeSource()
+        ).loading.collect {
+            collected.add(it)
+        }
+
+        assertThat(collected)
+            .containsExactly(false)
+    }
+
+    @Test
+    fun `loading when one source is loading should emit true`() = testDispatcher.runBlockingTest {
+        val collected = mutableListOf<Boolean>()
+        DefaultCardAccountRangeRepository(
+            inMemoryCardAccountRangeSource = FakeCardAccountRangeSource(),
+            remoteCardAccountRangeSource = FakeCardAccountRangeSource(isLoading = true),
+            staticCardAccountRangeSource = FakeCardAccountRangeSource()
+        ).loading.collect {
+            collected.add(it)
+        }
+
+        assertThat(collected)
+            .containsExactly(true)
+    }
+
     private fun createRealRepository(
         store: CardAccountRangeStore
     ): CardAccountRangeRepository {
@@ -145,11 +178,15 @@ internal class DefaultCardAccountRangeRepositoryTest {
         )
     }
 
-    private class FakeCardAccountRangeSource : CardAccountRangeSource {
+    private class FakeCardAccountRangeSource(
+        isLoading: Boolean = false
+    ) : CardAccountRangeSource {
         override suspend fun getAccountRange(
             cardNumber: CardNumber.Unvalidated
         ): CardMetadata.AccountRange? {
             return null
         }
+
+        override val loading: Flow<Boolean> = flowOf(isLoading)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/cards/NullCardAccountRangeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/NullCardAccountRangeRepository.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.CardMetadata
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 internal class NullCardAccountRangeRepository : CardAccountRangeRepository {
     override suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): CardMetadata.AccountRange? = null
+
+    override val loading: Flow<Boolean> = flowOf(false)
 }

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -989,6 +989,8 @@ internal class CardInputWidgetTest {
         // So any touch between 285 and 335 does nothing
         cardInputWidget.isShowingFullCard = false
         cardInputWidget.updateSpaceSizes(false)
+        idleLooper()
+
         assertThat(cardInputWidget.getFocusRequestOnTouch(300))
             .isNull()
     }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.cards.LegacyCardAccountRangeRepository
 import com.stripe.android.cards.NullCardAccountRangeRepository
 import com.stripe.android.cards.StaticCardAccountRangeSource
 import com.stripe.android.cards.StaticCardAccountRanges
-import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardMetadata
 import com.stripe.android.testharness.ViewTestUtils
@@ -35,6 +34,8 @@ import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
@@ -655,28 +656,6 @@ internal class CardNumberEditTextTest {
     }
 
     @Test
-    fun `isProcessingCallback should be invoked with 'true' when fetching account range and 'false' when fetch is completed`() {
-        var isProcessing = false
-        cardNumberEditText.isProcessingCallback = {
-            isProcessing = it
-        }
-
-        // not processing at rest
-        assertThat(isProcessing)
-            .isFalse()
-
-        // start processing once a BIN is typed in
-        cardNumberEditText.setText(BinFixtures.VISA.value)
-        assertThat(isProcessing)
-            .isTrue()
-        idleLooper()
-
-        // account range data has been retrieved
-        assertThat(isProcessing)
-            .isFalse()
-    }
-
-    @Test
     fun `getAccountRange() should only be called when necessary`() {
         Dispatchers.setMain(testDispatcher)
 
@@ -691,6 +670,8 @@ internal class CardNumberEditTextTest {
                     repositoryCalls++
                     return cardAccountRangeRepository.getAccountRange(cardNumber)
                 }
+
+                override val loading: Flow<Boolean> = flowOf(false)
             }
         )
 
@@ -754,6 +735,8 @@ internal class CardNumberEditTextTest {
             delay(TimeUnit.SECONDS.toMillis(10))
             return null
         }
+
+        override val loading: Flow<Boolean> = flowOf(false)
     }
 
     private companion object {


### PR DESCRIPTION
Expose a `Flow` that represents whether any of the sources are currently
loading account range data.

This allows the `CardAccountRangeSource` instances to specify whether
they are currently loading a source. Only remote sources should
ever be in a loading state.