### PR TITLE
Downgrade Robolectric to 4.3.1

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13'
     testImplementation "org.mockito:mockito-core:3.5.7"
-    testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation 'org.json:json:20200518'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"


### PR DESCRIPTION
We have observed flaky tests since upgrading to Robolectric 4.4.
Downgrade as a potential fix.