### PR TITLE
Refactor CardInputWidget.getFocusRequestOnTouch()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -547,8 +547,13 @@ class CardInputWidget @JvmOverloads constructor(
             return super.onInterceptTouchEvent(ev)
         }
 
-        return getFocusRequestOnTouch(ev.x.toInt())?.let {
-            it.requestFocus()
+        return getFocusRequestOnTouch(ev.x.toInt())?.let { field ->
+            when (field) {
+                Field.Number -> cardNumberEditText
+                Field.Expiry -> expiryDateEditText
+                Field.Cvc -> cvcEditText
+                Field.PostalCode -> postalCodeEditText
+            }.requestFocus()
             true
         } ?: super.onInterceptTouchEvent(ev)
     }
@@ -624,14 +629,14 @@ class CardInputWidget @JvmOverloads constructor(
      * Android will naturally do in response to that touch.
      *
      * @param touchX distance in pixels from the left side of this control
-     * @return a [StripeEditText] that needs to request focus, or `null`
+     * @return a [Field] that represents the [View] to request focus, or `null`
      * if no such request is necessary.
      */
     @VisibleForTesting
     internal fun getFocusRequestOnTouch(
         touchX: Int,
         frameStart: Int = containerLayout.left
-    ): View? = when {
+    ) = when {
         isShowingFullCard -> {
             // Then our view is
             // |full card||space||date|
@@ -640,9 +645,9 @@ class CardInputWidget @JvmOverloads constructor(
                 touchX < frameStart + placementParameters.cardWidth -> // Then the card edit view will already handle this touch.
                     null
                 touchX < placementParameters.cardTouchBufferLimit -> // Then we want to act like this was a touch on the card view
-                    cardNumberEditText
+                    Field.Number
                 touchX < placementParameters.dateStartPosition -> // Then we act like this was a touch on the date editor.
-                    expiryDateEditText
+                    Field.Expiry
                 else -> // Then the date editor will already handle this touch.
                     null
             }
@@ -654,21 +659,21 @@ class CardInputWidget @JvmOverloads constructor(
                 touchX < frameStart + placementParameters.peekCardWidth -> // This was a touch on the card number editor, so we don't need to handle it.
                     null
                 touchX < placementParameters.cardTouchBufferLimit -> // Then we need to act like the user touched the card editor
-                    cardNumberEditText
+                    Field.Number
                 touchX < placementParameters.dateStartPosition -> // Then we need to act like this was a touch on the date editor
-                    expiryDateEditText
+                    Field.Expiry
                 touchX < placementParameters.dateStartPosition + placementParameters.dateWidth -> // Just a regular touch on the date editor.
                     null
                 touchX < placementParameters.dateRightTouchBufferLimit -> // We need to act like this was a touch on the date editor
-                    expiryDateEditText
+                    Field.Expiry
                 touchX < placementParameters.cvcStartPosition -> // We need to act like this was a touch on the cvc editor.
-                    cvcEditText
+                    Field.Cvc
                 touchX < placementParameters.cvcStartPosition + placementParameters.cvcWidth -> // Just a regular touch on the cvc editor.
                     null
                 touchX < placementParameters.cvcRightTouchBufferLimit -> // We need to act like this was a touch on the cvc editor.
-                    cvcEditText
+                    Field.Cvc
                 touchX < placementParameters.postalCodeStartPosition -> // We need to act like this was a touch on the postal code editor.
-                    postalCodeEditText
+                    Field.PostalCode
                 else -> null
             }
         }
@@ -679,15 +684,15 @@ class CardInputWidget @JvmOverloads constructor(
                 touchX < frameStart + placementParameters.peekCardWidth -> // This was a touch on the card number editor, so we don't need to handle it.
                     null
                 touchX < placementParameters.cardTouchBufferLimit -> // Then we need to act like the user touched the card editor
-                    cardNumberEditText
+                    Field.Number
                 touchX < placementParameters.dateStartPosition -> // Then we need to act like this was a touch on the date editor
-                    expiryDateEditText
+                    Field.Expiry
                 touchX < placementParameters.dateStartPosition + placementParameters.dateWidth -> // Just a regular touch on the date editor.
                     null
                 touchX < placementParameters.dateRightTouchBufferLimit -> // We need to act like this was a touch on the date editor
-                    expiryDateEditText
+                    Field.Expiry
                 touchX < placementParameters.cvcStartPosition -> // We need to act like this was a touch on the cvc editor.
-                    cvcEditText
+                    Field.Cvc
                 else -> null
             }
         }
@@ -1447,6 +1452,13 @@ class CardInputWidget @JvmOverloads constructor(
         override fun calculate(text: String, paint: TextPaint): Int {
             return Layout.getDesiredWidth(text, paint).toInt()
         }
+    }
+
+    internal enum class Field {
+        Number,
+        Expiry,
+        Cvc,
+        PostalCode
     }
 
     internal companion object {

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -922,7 +922,7 @@ internal class CardInputWidgetTest {
                 300,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(cardNumberEditText)
+        ).isEqualTo(CardInputWidget.Field.Number)
     }
 
     @Test
@@ -936,7 +936,7 @@ internal class CardInputWidgetTest {
                 430,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(expiryEditText)
+        ).isEqualTo(CardInputWidget.Field.Expiry)
     }
 
     @Test
@@ -994,7 +994,7 @@ internal class CardInputWidgetTest {
                 150,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(cardNumberEditText)
+        ).isEqualTo(CardInputWidget.Field.Number)
     }
 
     @Test
@@ -1017,7 +1017,7 @@ internal class CardInputWidgetTest {
                 200,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(expiryEditText)
+        ).isEqualTo(CardInputWidget.Field.Expiry)
     }
 
     @Test
@@ -1040,7 +1040,7 @@ internal class CardInputWidgetTest {
                 170,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(expiryEditText)
+        ).isEqualTo(CardInputWidget.Field.Expiry)
     }
 
     @Test
@@ -1110,7 +1110,7 @@ internal class CardInputWidgetTest {
                 400,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(expiryEditText)
+        ).isEqualTo(CardInputWidget.Field.Expiry)
     }
 
     @Test
@@ -1133,7 +1133,7 @@ internal class CardInputWidgetTest {
                 185,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(expiryEditText)
+        ).isEqualTo(CardInputWidget.Field.Expiry)
     }
 
     @Test
@@ -1156,7 +1156,7 @@ internal class CardInputWidgetTest {
                 485,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(cvcEditText)
+        ).isEqualTo(CardInputWidget.Field.Cvc)
     }
 
     @Test
@@ -1179,7 +1179,7 @@ internal class CardInputWidgetTest {
                 300,
                 frameStart = BRAND_ICON_WIDTH
             )
-        ).isEqualTo(cvcEditText)
+        ).isEqualTo(CardInputWidget.Field.Cvc)
     }
 
     @Test


### PR DESCRIPTION
Change `getFocusRequestOnTouch()` to return a `Field` enum that
represents a `View` instead of the actual `View`. This is the first step
in refactoring `CardInputWidget`'s positioning logic to be more testable
and less flaky.