### PR TITLE
Mark some interfaces as fun

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -42,16 +42,9 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
         viewBinding.paymentMethods.layoutManager = LinearLayoutManager(this)
         viewBinding.paymentMethods.adapter = adapter
 
-        viewBinding.cardMultilineWidget.setCardValidCallback(
-            object : CardValidCallback {
-                override fun onInputChanged(
-                    isValid: Boolean,
-                    invalidFields: Set<CardValidCallback.Fields>
-                ) {
-                    // added as an example - no-op
-                }
-            }
-        )
+        viewBinding.cardMultilineWidget.setCardValidCallback { isValid, invalidFields ->
+            // added as an example - no-op
+        }
 
         viewBinding.createButton.setOnClickListener {
             keyboardController.hide()

--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.view.CardValidCallback
 import com.stripe.example.databinding.CreateCardPaymentMethodActivityBinding
 import com.stripe.example.databinding.PaymentMethodItemBinding
 

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -62,16 +62,9 @@ class CreateCardTokenActivity : AppCompatActivity() {
             } ?: snackbarController.show(getString(R.string.invalid_card_details))
         }
 
-        viewBinding.cardInputWidget.setCardValidCallback(
-            object : CardValidCallback {
-                override fun onInputChanged(
-                    isValid: Boolean,
-                    invalidFields: Set<CardValidCallback.Fields>
-                ) {
-                    // added as an example - no-op
-                }
-            }
-        )
+        viewBinding.cardInputWidget.setCardValidCallback { isValid, invalidFields ->
+            // added as an example - no-op
+        }
 
         viewBinding.cardInputWidget.requestFocus()
     }

--- a/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardTokenActivity.kt
@@ -16,7 +16,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.Token
-import com.stripe.android.view.CardValidCallback
 import com.stripe.example.R
 import com.stripe.example.StripeFactory
 import com.stripe.example.databinding.CreateCardTokenActivityBinding

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -832,16 +832,12 @@ class CardInputWidget @JvmOverloads constructor(
             updateIconCvc(hasFocus, cvc?.value)
         }
 
-        cvcEditText.setAfterTextChangedListener(
-            object : StripeEditText.AfterTextChangedListener {
-                override fun onTextChanged(text: String) {
-                    if (brand.isMaxCvc(text)) {
-                        cardInputListener?.onCvcComplete()
-                    }
-                    updateIconCvc(cvcEditText.hasFocus(), text)
-                }
+        cvcEditText.setAfterTextChangedListener { text ->
+            if (brand.isMaxCvc(text)) {
+                cardInputListener?.onCvcComplete()
             }
-        )
+            updateIconCvc(cvcEditText.hasFocus(), text)
+        }
 
         cardNumberEditText.completionCallback = {
             scrollRight()

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -323,22 +323,18 @@ class CardMultilineWidget @JvmOverloads constructor(
             cardInputListener?.onExpirationComplete()
         }
 
-        cvcEditText.setAfterTextChangedListener(
-            object : StripeEditText.AfterTextChangedListener {
-                override fun onTextChanged(text: String) {
-                    if (cardBrand.isMaxCvc(text)) {
-                        updateBrandUi()
-                        if (shouldShowPostalCode) {
-                            postalCodeEditText.requestFocus()
-                        }
-                        cardInputListener?.onCvcComplete()
-                    } else {
-                        flipToCvcIconIfNotFinished()
-                    }
-                    cvcEditText.shouldShowError = false
+        cvcEditText.setAfterTextChangedListener { text ->
+            if (cardBrand.isMaxCvc(text)) {
+                updateBrandUi()
+                if (shouldShowPostalCode) {
+                    postalCodeEditText.requestFocus()
                 }
+                cardInputListener?.onCvcComplete()
+            } else {
+                flipToCvcIconIfNotFinished()
             }
-        )
+            cvcEditText.shouldShowError = false
+        }
 
         adjustViewForPostalCodeAttribute(shouldShowPostalCode)
 

--- a/stripe/src/main/java/com/stripe/android/view/CardValidCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardValidCallback.kt
@@ -3,7 +3,7 @@ package com.stripe.android.view
 /**
  * An interface for a callback object that will be called when the user's input changes.
  */
-interface CardValidCallback {
+fun interface CardValidCallback {
     /**
      * @param isValid if the current input is valid
      * @param invalidFields if the current input is invalid, this [Set] will be populated with the

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -238,15 +238,15 @@ open class StripeEditText @JvmOverloads constructor(
         return keyCode == KeyEvent.KEYCODE_DEL && event.action == KeyEvent.ACTION_DOWN
     }
 
-    interface DeleteEmptyListener {
+    fun interface DeleteEmptyListener {
         fun onDeleteEmpty()
     }
 
-    interface AfterTextChangedListener {
+    fun interface AfterTextChangedListener {
         fun onTextChanged(text: String)
     }
 
-    interface ErrorMessageListener {
+    fun interface ErrorMessageListener {
         fun displayErrorMessage(message: String?)
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1704,17 +1704,10 @@ internal class CardInputWidgetTest {
     fun testCardValidCallback() {
         var currentIsValid = false
         var currentInvalidFields = emptySet<CardValidCallback.Fields>()
-        cardInputWidget.setCardValidCallback(
-            object : CardValidCallback {
-                override fun onInputChanged(
-                    isValid: Boolean,
-                    invalidFields: Set<CardValidCallback.Fields>
-                ) {
-                    currentIsValid = isValid
-                    currentInvalidFields = invalidFields
-                }
-            }
-        )
+        cardInputWidget.setCardValidCallback { isValid, invalidFields ->
+            currentIsValid = isValid
+            currentInvalidFields = invalidFields
+        }
 
         assertThat(currentIsValid)
             .isFalse()

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -955,17 +955,10 @@ internal class CardMultilineWidgetTest {
     fun testCardValidCallback() {
         var currentIsValid = false
         var currentInvalidFields = emptySet<CardValidCallback.Fields>()
-        cardMultilineWidget.setCardValidCallback(
-            object : CardValidCallback {
-                override fun onInputChanged(
-                    isValid: Boolean,
-                    invalidFields: Set<CardValidCallback.Fields>
-                ) {
-                    currentIsValid = isValid
-                    currentInvalidFields = invalidFields
-                }
-            }
-        )
+        cardMultilineWidget.setCardValidCallback { isValid, invalidFields ->
+            currentIsValid = isValid
+            currentInvalidFields = invalidFields
+        }
 
         assertThat(currentIsValid)
             .isFalse()


### PR DESCRIPTION
## Summary
Some simple interfaces can benefit from getting marked as `fun`, so Kotlin allows a callback to be passed instead.

## Motivation
This is a nice-to-have for the edit text and card validation!

## Testing
Tests and samples were updated to use the new style.
