### PR TITLE
For #2642: Add callback to coroutine bridge

### DIFF
--- a/stripe/src/main/java/com/stripe/android/ApiResultCoroutineBridge.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiResultCoroutineBridge.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import com.stripe.android.model.StripeModel
-import kotlinx.coroutines.Deferred
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException

--- a/stripe/src/main/java/com/stripe/android/ApiResultCoroutineBridge.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiResultCoroutineBridge.kt
@@ -1,0 +1,37 @@
+package com.stripe.android
+
+import com.stripe.android.model.StripeModel
+import kotlinx.coroutines.Deferred
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Generic class to bridge an API operation callback with coroutines.
+ *
+ * @param continuation [Continuation] obtained from [suspendCoroutine]
+ */
+class ApiResultCoroutineBridge<in ResultType : StripeModel>(
+    private val continuation: Continuation<ResultType>
+) : ApiResultCallback<ResultType> {
+
+    override fun onSuccess(result: ResultType) {
+        continuation.resume(result)
+    }
+
+    override fun onError(e: Exception) {
+        continuation.resumeWithException(e)
+    }
+}
+
+/**
+ * Suspend the currently running coroutine until one of the [ApiResultCallback] methods are invoked.
+ */
+suspend inline fun <ResultType : StripeModel> suspendApiResultCoroutine(
+    crossinline block: (callback: ApiResultCallback<ResultType>) -> Unit
+): ResultType {
+    return suspendCoroutine { cont ->
+        block(ApiResultCoroutineBridge(cont))
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -1059,6 +1059,31 @@ class Stripe internal constructor(
     }
 
     /**
+     * Create a [Token] asynchronously.
+     *
+     * See [Create an account token](https://stripe.com/docs/api/tokens/create_account).
+     * `POST /v1/tokens`
+     *
+     * @param accountParams the [AccountParams] used to create this token
+     * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+     * @param stripeAccountId Optional, the Connect account to associate with this request.
+     * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+     */
+    @UiThread
+    suspend fun createAccountToken(
+        accountParams: AccountParams,
+        idempotencyKey: String? = null,
+        stripeAccountId: String? = this.stripeAccountId
+    ): Token = suspendApiResultCoroutine { callback ->
+        createAccountToken(
+            accountParams = accountParams,
+            idempotencyKey = idempotencyKey,
+            stripeAccountId = stripeAccountId,
+            callback = callback
+        )
+    }
+
+    /**
      * Blocking method to create a [Token] for a Connect Account. Do not call this on the UI
      * thread or your app will crash.
      *

--- a/stripe/src/test/java/com/stripe/android/ApiResultCoroutineBridgeTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiResultCoroutineBridgeTest.kt
@@ -1,0 +1,64 @@
+package com.stripe.android
+
+import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.model.StripeModel
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class ApiResultCoroutineBridgeTest {
+
+    private val scope = TestCoroutineScope()
+
+    @Test
+    fun onSuccess_shouldResumeCoroutine() {
+        var callback: ApiResultCallback<StripeModel>? = null
+        val deferred = scope.async<StripeModel> {
+            suspendApiResultCoroutine { callback = it }
+        }
+
+        assertFalse(deferred.isCompleted)
+
+        val result = mock<StripeModel>()
+        callback!!.onSuccess(result)
+
+        assertTrue(deferred.isCompleted)
+
+        runBlocking {
+            assertEquals(result, deferred.await())
+        }
+    }
+
+    @Test
+    fun onError_shouldResumeCoroutineWithException() {
+        var callback: ApiResultCallback<StripeModel>? = null
+        val deferred = scope.async<StripeModel> {
+            suspendApiResultCoroutine { callback = it }
+        }
+
+        assertFalse(deferred.isCompleted)
+
+        callback!!.onError(IllegalStateException("hello world"))
+
+        assertTrue(deferred.isCompleted)
+
+        runBlocking {
+            val result = runCatching { deferred.await() }
+            val error = result.exceptionOrNull()
+            assertTrue(error is IllegalStateException)
+            assertEquals("hello world", error?.message)
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/ApiResultCoroutineBridgeTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiResultCoroutineBridgeTest.kt
@@ -2,19 +2,16 @@ package com.stripe.android
 
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.model.StripeModel
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertSame
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
## Summary
Adding a simple helper to bridge callbacks and Kotlin coroutines. 

`ApiResultCoroutineBridge` implements `ApiResultCallback` and makes calls to a Kotlin `Continuation` helper. This helper is used with `suspendCoroutine` to make callback based APIs suspend a coroutine. This reduces boilerplate for both the internal SDK developers and external SDK users.

`suspendApiResultCoroutine` is a wrapper around `suspendCoroutine` that gives an `ApiResultCallback` instead of a `Continuation`.

## Motivation
More and more apps are using Kotlin as a main language for android apps and it would be nice to have support for suspendable functions instead of wrapping callback api into a suspendCoroutine.

## Testing
Tests have been added for the new class. As a proof-of-concept, I added a suspending version of `Stripe.createAccountToken`.
