### PR TITLE
Support pasting a 19 digit PAN in CardNumberEditText

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -93,7 +93,7 @@ internal sealed class CardNumber {
         internal fun getSpacePositions(panLength: Int) = SPACE_POSITIONS[panLength]
             ?: DEFAULT_SPACE_POSITIONS
 
-        private const val MIN_PAN_LENGTH = 14
+        internal const val MIN_PAN_LENGTH = 14
         internal const val MAX_PAN_LENGTH = 19
         internal const val DEFAULT_PAN_LENGTH = 16
         private val DEFAULT_SPACE_POSITIONS = setOf(4, 9, 14)

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -892,7 +892,7 @@ class CardInputWidget @JvmOverloads constructor(
         panLength: Int
     ): String {
         val formattedNumber = CardNumber.Unvalidated(
-            List(panLength) { "0" }.joinToString(separator = "")
+            "0".repeat(panLength)
         ).getFormatted(panLength)
 
         return formattedNumber.take(
@@ -1109,7 +1109,7 @@ class CardInputWidget @JvmOverloads constructor(
                 14 -> 2
                 else -> 4
             }.let { peekSize ->
-                List(peekSize) { "0" }.joinToString(separator = "")
+                "0".repeat(peekSize)
             }
         }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -275,6 +275,26 @@ internal class CardNumberEditTextTest {
     }
 
     @Test
+    fun `when 19 digit PAN is pasted, full PAN is accepted and formatted`() {
+        val cardNumberEditText = CardNumberEditText(
+            context,
+            workDispatcher = testDispatcher,
+            cardAccountRangeRepository = NullCardAccountRangeRepository(),
+            staticCardAccountRanges = object : StaticCardAccountRanges {
+                override fun match(
+                    cardNumber: CardNumber.Unvalidated
+                ): AccountRange? = null
+            }
+        )
+
+        cardNumberEditText.setText("6216828050000000000")
+        idleLooper()
+
+        assertThat(cardNumberEditText.fieldText)
+            .isEqualTo("6216 8280 5000 0000 000")
+    }
+
+    @Test
     fun `updating text with null account range should format text correctly but not set card brand`() {
         val cardNumberEditText = CardNumberEditText(
             context,


### PR DESCRIPTION
Follow-up PR: fix selection position after pasting a 19 digit number

![paste19](https://user-images.githubusercontent.com/45020849/92519471-ff3abb80-f1e7-11ea-8200-71ecf6f92890.gif)
