### PR TITLE
Fix CardNumberEditText pasting logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -288,7 +288,7 @@ class CardNumberEditText internal constructor(
             val cardNumber = CardNumber.Unvalidated(s?.toString().orEmpty())
             updateAccountRange(cardNumber)
 
-            isPastedPan = isPastedPan(start, cardNumber)
+            isPastedPan = isPastedPan(start, before, count, cardNumber)
 
             if (isPastedPan) {
                 updateLengthFilter(cardNumber.getFormatted(cardNumber.length).length)
@@ -363,8 +363,14 @@ class CardNumberEditText internal constructor(
                 (isValid && accountRange != null)
             )
 
-        private fun isPastedPan(start: Int, cardNumber: CardNumber.Unvalidated): Boolean {
-            return start == 0 && cardNumber.normalized.length >= CardNumber.MIN_PAN_LENGTH
+        private fun isPastedPan(
+            start: Int,
+            before: Int,
+            count: Int,
+            cardNumber: CardNumber.Unvalidated
+        ): Boolean {
+            return count > before && start == 0 &&
+                cardNumber.normalized.length >= CardNumber.MIN_PAN_LENGTH
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -644,18 +644,16 @@ internal class CardInputWidgetTest {
         assertThat(expiryEditText.hasFocus())
             .isTrue()
 
-        // The above functionality is tested elsewhere, so we reset this listener.
-        reset(cardInputListener)
-
         ViewTestUtils.sendDeleteKeyEvent(expiryEditText)
-        verify(cardInputListener).onFocusChange(CardInputListener.FocusField.CardNumber)
+        verify(cardInputListener)
+            .onFocusChange(CardInputListener.FocusField.CardNumber)
         assertThat(onGlobalFocusChangeListener.oldFocusId)
             .isEqualTo(expiryEditText.id)
         assertThat(onGlobalFocusChangeListener.newFocusId)
             .isEqualTo(cardNumberEditText.id)
 
         val subString = VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1)
-        assertThat(cardNumberEditText.text.toString())
+        assertThat(cardNumberEditText.fieldText)
             .isEqualTo(subString)
         assertThat(cardNumberEditText.selectionStart)
             .isEqualTo(subString.length)
@@ -673,7 +671,7 @@ internal class CardInputWidgetTest {
 
         assertThat(expiryEditText.hasFocus())
             .isTrue()
-        assertThat(cardNumberEditText.text.toString())
+        assertThat(cardNumberEditText.fieldText)
             .isEqualTo(AMEX_WITH_SPACES)
     }
 
@@ -704,7 +702,7 @@ internal class CardInputWidgetTest {
             .isEqualTo(expiryEditText.id)
 
         val expectedResult = "12/7"
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEqualTo(expectedResult)
         assertThat(expiryEditText.selectionStart)
             .isEqualTo(expectedResult.length)
@@ -726,7 +724,7 @@ internal class CardInputWidgetTest {
 
         assertThat(cvcEditText.hasFocus())
             .isTrue()
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEqualTo("12/79")
     }
 
@@ -746,7 +744,7 @@ internal class CardInputWidgetTest {
 
         assertThat(cvcEditText.hasFocus())
             .isTrue()
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEqualTo("12/79")
     }
 
@@ -1395,14 +1393,14 @@ internal class CardInputWidgetTest {
     @Test
     fun setExpirationDate_withValidData_setsCorrectValues() {
         cardInputWidget.setExpiryDate(12, 79)
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEqualTo("12/79")
     }
 
     @Test
     fun setCvcCode_withValidData_setsValue() {
         cardInputWidget.setCvcCode(CVC_VALUE_COMMON)
-        assertThat(cvcEditText.text.toString())
+        assertThat(cvcEditText.fieldText)
             .isEqualTo(CVC_VALUE_COMMON)
     }
 
@@ -1411,7 +1409,7 @@ internal class CardInputWidgetTest {
         cvcEditText.updateBrand(CardBrand.Visa)
         cardInputWidget.setCvcCode(CVC_VALUE_AMEX)
 
-        assertThat(cvcEditText.text.toString())
+        assertThat(cvcEditText.fieldText)
             .isEqualTo(CVC_VALUE_COMMON)
     }
 
@@ -1420,7 +1418,7 @@ internal class CardInputWidgetTest {
         cardInputWidget.setCardNumber(AMEX_NO_SPACES)
         cardInputWidget.setCvcCode(CVC_VALUE_AMEX)
 
-        assertThat(cvcEditText.text.toString())
+        assertThat(cvcEditText.fieldText)
             .isEqualTo(CVC_VALUE_AMEX)
     }
 
@@ -1579,11 +1577,11 @@ internal class CardInputWidgetTest {
         cardInputWidget.setCvcCode(CVC_VALUE_AMEX)
         cardInputWidget.clear()
 
-        assertThat(cardNumberEditText.text.toString())
+        assertThat(cardNumberEditText.fieldText)
             .isEmpty()
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEmpty()
-        assertThat(cvcEditText.text.toString())
+        assertThat(cvcEditText.fieldText)
             .isEmpty()
 
         assertThat(onGlobalFocusChangeListener.oldFocusId)
@@ -1601,13 +1599,13 @@ internal class CardInputWidgetTest {
         cardInputWidget.setPostalCode(POSTAL_CODE_VALUE)
         cardInputWidget.clear()
 
-        assertThat(cardNumberEditText.text.toString())
+        assertThat(cardNumberEditText.fieldText)
             .isEmpty()
-        assertThat(expiryEditText.text.toString())
+        assertThat(expiryEditText.fieldText)
             .isEmpty()
-        assertThat(cvcEditText.text.toString())
+        assertThat(cvcEditText.fieldText)
             .isEmpty()
-        assertThat(postalCodeEditText.text.toString())
+        assertThat(postalCodeEditText.fieldText)
             .isEmpty()
 
         assertThat(onGlobalFocusChangeListener.oldFocusId)

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -8,6 +8,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardNumberFixtures.AMEX_NO_SPACES
@@ -30,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
-import org.mockito.Mockito.reset
 import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import kotlin.coroutines.CoroutineContext
@@ -629,15 +629,10 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
-    fun deleteWhenEmpty_fromExpiry_shiftsToCardNumber() {
+    fun deleteWhenEmpty_fromExpiry_withPostalCode_shiftsToCardNumber() {
         cardMultilineWidget.setCardInputListener(fullCardListener)
-        noZipCardMultilineWidget.setCardInputListener(noZipCardListener)
-
-        val deleteOneCharacterString =
-            VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1)
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
 
-        reset(fullCardListener)
         assertThat(fullGroup.expiryDateEditText.hasFocus())
             .isTrue()
         ViewTestUtils.sendDeleteKeyEvent(fullGroup.expiryDateEditText)
@@ -646,11 +641,14 @@ internal class CardMultilineWidgetTest {
         assertThat(fullGroup.cardNumberEditText.hasFocus())
             .isTrue()
         assertThat(fullGroup.cardNumberEditText.text?.toString())
-            .isEqualTo(deleteOneCharacterString)
+            .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
+    }
 
+    @Test
+    fun deleteWhenEmpty_fromExpiry_withoutPostalCode_shiftsToCardNumber() {
+        noZipCardMultilineWidget.setCardInputListener(noZipCardListener)
         noZipGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
 
-        reset(noZipCardListener)
         assertThat(noZipGroup.expiryDateEditText.hasFocus())
             .isTrue()
         ViewTestUtils.sendDeleteKeyEvent(noZipGroup.expiryDateEditText)
@@ -659,7 +657,7 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.cardNumberEditText.hasFocus())
             .isTrue()
         assertThat(noZipGroup.cardNumberEditText.text?.toString())
-            .isEqualTo(deleteOneCharacterString)
+            .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
     }
 
     @Test
@@ -670,7 +668,6 @@ internal class CardMultilineWidgetTest {
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
 
-        reset(fullCardListener)
         assertThat(fullGroup.cvcEditText.hasFocus())
             .isTrue()
         ViewTestUtils.sendDeleteKeyEvent(fullGroup.cvcEditText)
@@ -684,7 +681,6 @@ internal class CardMultilineWidgetTest {
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
 
-        reset(noZipCardListener)
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()
         ViewTestUtils.sendDeleteKeyEvent(noZipGroup.cvcEditText)
@@ -692,7 +688,7 @@ internal class CardMultilineWidgetTest {
         verify(noZipCardListener).onFocusChange(CardInputListener.FocusField.ExpiryDate)
         assertThat(noZipGroup.expiryDateEditText.hasFocus())
             .isTrue()
-        assertThat(noZipGroup.expiryDateEditText.text.toString())
+        assertThat(noZipGroup.expiryDateEditText.fieldText)
             .isEqualTo("12/5")
     }
 


### PR DESCRIPTION
In certain cases, deleting a character was treated as a PAN paste.
Fix this logic in `isPastedPan()`.