### PR TITLE
Use real publishable keys in card widget tests

### DIFF
--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -77,7 +77,7 @@ internal class CardInputWidgetTest {
 
         Dispatchers.setMain(testDispatcher)
 
-        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        PaymentConfiguration.init(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
 
         activityScenarioFactory.create<AddPaymentMethodActivity>(
             AddPaymentMethodActivityStarter.Args.Builder()

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -66,7 +66,7 @@ internal class CardMultilineWidgetTest {
 
         CustomerSession.instance = mock()
 
-        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        PaymentConfiguration.init(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
 
         activityScenarioFactory
             .createAddPaymentMethodActivity()


### PR DESCRIPTION
A real key is required for card service integration