### PR TITLE
Handle CustomerSession failure in PaymentMethodsActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/DeletePaymentMethodDialogFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/view/DeletePaymentMethodDialogFactory.kt
@@ -11,7 +11,7 @@ internal class DeletePaymentMethodDialogFactory internal constructor(
     private val context: Context,
     private val adapter: PaymentMethodsAdapter,
     private val cardDisplayTextFactory: CardDisplayTextFactory,
-    private val customerSession: CustomerSession,
+    private val customerSession: Result<CustomerSession>,
     private val productUsage: Set<String>,
     private val onDeletedPaymentMethodCallback: (PaymentMethod) -> Unit
 ) {
@@ -40,7 +40,7 @@ internal class DeletePaymentMethodDialogFactory internal constructor(
         adapter.deletePaymentMethod(paymentMethod)
 
         paymentMethod.id?.let { paymentMethodId ->
-            customerSession.detachPaymentMethod(
+            customerSession.getOrNull()?.detachPaymentMethod(
                 paymentMethodId = paymentMethodId,
                 productUsage = productUsage,
                 listener = PaymentMethodDeleteListener()

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -32,8 +32,8 @@ class PaymentMethodsActivity : AppCompatActivity() {
         args.isPaymentSessionActive
     }
 
-    private val customerSession: CustomerSession by lazy {
-        CustomerSession.getInstance()
+    private val customerSession: Result<CustomerSession> by lazy {
+        runCatching { CustomerSession.getInstance() }
     }
     private val cardDisplayTextFactory: CardDisplayTextFactory by lazy {
         CardDisplayTextFactory(this)
@@ -72,6 +72,13 @@ class PaymentMethodsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (customerSession.isFailure) {
+            finishWithResult(
+                null,
+                Activity.RESULT_CANCELED
+            )
+        }
+
         setContentView(viewBinding.root)
 
         args.windowFlags?.let {

--- a/stripe/src/test/java/com/stripe/android/view/DeletePaymentMethodDialogFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/DeletePaymentMethodDialogFactoryTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.Test
 class DeletePaymentMethodDialogFactoryTest {
 
     private val customerSession: CustomerSession = mock()
-    private val context: Context = ApplicationProvider.getApplicationContext<Context>()
+    private val context: Context = ApplicationProvider.getApplicationContext()
 
     @Test
     fun onDeletedPaymentMethod_shouldCallDetachPaymentMethodAndCallback() {
@@ -27,7 +27,7 @@ class DeletePaymentMethodDialogFactoryTest {
             context,
             mock(),
             CardDisplayTextFactory(context),
-            customerSession,
+            Result.success(customerSession),
             setOf(PaymentMethodsActivity.PRODUCT_TOKEN)
         ) {
             callbackPaymentMethod = it

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsViewModelTest.kt
@@ -24,7 +24,7 @@ class PaymentMethodsViewModelTest {
     private val listenerArgumentCaptor: KArgumentCaptor<CustomerSession.PaymentMethodsRetrievalListener> = argumentCaptor()
     private val viewModel = PaymentMethodsViewModel(
         application = ApplicationProvider.getApplicationContext(),
-        customerSession = customerSession,
+        customerSession = Result.success(customerSession),
         startedFromPaymentSession = true
     )
 
@@ -100,6 +100,22 @@ class PaymentMethodsViewModelTest {
             .isEqualTo("Removed Visa ending in 4242")
         assertThat(values[1])
             .isNull()
+    }
+
+    @Test
+    fun `getPaymentMethods() with CustomerSession failure should return failure result`() {
+        var result: Result<List<PaymentMethod>>? = null
+        PaymentMethodsViewModel(
+            application = ApplicationProvider.getApplicationContext(),
+            customerSession = Result.failure(RuntimeException("failure")),
+            startedFromPaymentSession = true
+        ).getPaymentMethods().observeForever {
+            result = it
+        }
+
+        requireNotNull(result)
+        assertThat(result?.isFailure)
+            .isTrue()
     }
 
     private companion object {


### PR DESCRIPTION
`CustomerSession.getInstance()` can throw an exception, so this should
be handled.

Fixes #2816