### PR TITLE
Remove comments from non-english string resource files

### DIFF
--- a/stripe/res/values-de/strings.xml
+++ b/stripe/res/values-de/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">Neue Karte hinzufügen…</string>
     <string name="title_add_a_card">Karte hinzufügen</string>
     <string name="title_payment_method">Zahlungsmethode</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">Bitte geben Sie Ihren Ort ein</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">Bitte geben Sie Ihr Land ein</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">Adresse</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">Adresszeile 1</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">Adresszeile 1 (optional)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Adresszeile 2</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">Adresszeile 2 (optional)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">Adresse (optional) </string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">Wohnung/Gebäude</string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">Wohnung/Gebäude (optional)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">Ort</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">Ort (optional)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">Land</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">Kreis/Bezirk</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">Kreis/Bezirk (optional)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">Name</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Name (optional)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">Telefonnummer</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">Telefonnummer (optional)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">Postleitzahl</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">Postleitzahl (optional)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">Postleitzahl</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">Postleitzahl (optional)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">Kanton</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">Kanton (optional)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic"> Bundesland / Kanton / Region</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">Bundesland / Kanton / Region (optional)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">Bundesland</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">Bundesland (optional)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">Postleitzahl</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">Postleitzahl (optional)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">Postleitzahl</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">Postleitzahl (optional)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">Bitte geben Sie Ihren Namen ein</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">Bitte gehen Sie Ihre Telefonnummer ein</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">Ihre Postleitzahl ist ungültig</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">Ihre Postleitzahl ist ungültig</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">Bitte geben Sie Ihren Kanton ein</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">Bitte gehen Sie Ihr(e/n) Bundesland / Kanton / Region ein</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">Bitte geben Sie Ihre Adresse ein</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Versandadresse</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">Bitte geben Sie Ihren Bundesland ein</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">Ihre Postleitzahl ist ungültig.</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">Ihre Postleitzahl ist ungültig</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">Fügen Sie eine neue Debit- oder Kreditkarte hinzu, um in dieser App Käufe zu tätigen.</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">Keine Zahlungsmethoden.</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">Gratis</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">Adresse hinzufügen</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">Versandmethode auswählen</string>
     <string name="invalid_shipping_information">Ungültige Versandadresse</string>
     <string name="secure_checkout">Sicherer Bezahlvorgang</string>

--- a/stripe/res/values-es/strings.xml
+++ b/stripe/res/values-es/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">Añadir tarjeta nueva…</string>
     <string name="title_add_a_card">Añadir una tarjeta</string>
     <string name="title_payment_method">Método de pago</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">Introduce el nombre de tu localidad</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">Introduce el nombre de tu condado</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">Dirección</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">Dirección línea 1 </string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">Dirección línea 1 (opcional)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Dirección línea 2</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">Dirección línea 2 (opcional)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">Dirección (opcional) </string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">Apto.  </string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">Apto. (opcional)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">Localidad</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">Localidad (opcional)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">País</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">Condado</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">Condado (opcional)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">Nombre</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Nombre (opcional)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">Número de teléfono</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">Número de teléfono (opcional)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">Código postal</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">Código postal</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">Provincia</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">Provincia (opcional)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic"> Estado/ Provincia / Región</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">Estado/ Provincia / Región (opcional)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">Estado</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">Estado (opcional)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">Código postal</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">Código postal</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">Introduce tu nombre</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">Introduce tu número de teléfono</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">El código postal no es válido</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">El código postal no es válido</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">Introduce el nombre de tu provincia</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">Introduce el nombre de tu estado / provincia / región</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">Introduce tu dirección</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Dirección de envío</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">Introduce el nombre de tu estado</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">El código postal no es válido.</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">El código postal no es válido</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">Añade una tarjeta de crédito o de débito nueva para realizar compras en esta aplicación.</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">Ningún método de pago.</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">Gratuito</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">Añade una dirección</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">Selecciona el método de envío</string>
     <string name="invalid_shipping_information">Dirección de envío no válida</string>
     <string name="secure_checkout">Proceso de compra seguro</string>

--- a/stripe/res/values-fr/strings.xml
+++ b/stripe/res/values-fr/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">Ajouter une nouvelle carte…</string>
     <string name="title_add_a_card">Ajouter une carte</string>
     <string name="title_payment_method">Moyen de paiement</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">Indiquez votre ville</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">Indiquez votre département</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">Adresse</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">Adresse - Ligne 1</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">Adresse - Ligne 1 (facultatif)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Adresse - Ligne 2</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">Adresse - Ligne 2 (facultatif)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">Adresse (facultatif) </string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">Appart. </string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">Appart. (facultatif)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">Ville</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">Ville (facultatif)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">Pays</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">Département</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">Département (facultatif)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">Nom</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Nom (facultatif)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">Numéro de téléphone</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">Numéro de téléphone (facultatif)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">Code postal</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">Code postal (facultatif)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">Code postal</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">Code postal (facultatif)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">Province</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">Province (facultatif)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic">Département / État / Province / Région</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">Département / État / Province / Région (facultatif)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">État</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">État (facultatif)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">Code postal</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">Code postal (facultatif)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">Code ZIP/ postal</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">Code ZIP/ postal (facultatif)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">Indiquez votre nom</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">Indiquez votre numéro de téléphone</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">Votre code postal n’est pas valide</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">Votre code postal n’est pas valide</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">Indiquez votre province</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">Indiquez votre département/État/province/région</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">Indiquez votre adresse</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Adresse d\'expédition</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">Indiquez votre département</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">Votre code postal n’est pas valide.</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">Votre code ZIP/postal n’est pas valide</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">Ajoutez une nouvelle carte de débit ou de crédit pour faire des achats à partir de cette application.</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">Aucun moyen de paiement.</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">Gratuit</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">Ajoutez une adresse</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">Sélectionnez un mode d’expédition</string>
     <string name="invalid_shipping_information">Adresse d’expédition incorrecte</string>
     <string name="secure_checkout">Paiement sécurisé</string>

--- a/stripe/res/values-it/strings.xml
+++ b/stripe/res/values-it/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">Aggiungi una nuova carta…</string>
     <string name="title_add_a_card">Aggiungi una carta</string>
     <string name="title_payment_method">Metodo di pagamento</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">Inserisci la città</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">Inserisci la contea</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">Indirizzo</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">Indirizzo riga 1</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">Indirizzo riga 1 (facoltativo)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Indirizzo riga 2</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">Indirizzo riga 2 (facoltativo)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">Indirizzo (facoltativo) </string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">Appart.</string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">Appart. (facoltativo)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">Città</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">Città (facoltativo)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">Paese</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">Regione</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">Regione (facoltativo)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">Nome</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Nome (facoltativo)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">Numero di telefono</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">Numero di telefono (facoltativo)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">Codice postale</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">Codice postale (facoltativo)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">Codice postale</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">Codice postale (facoltativo)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">Provincia</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">Provincia (facoltativo)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic"> Stato / Provincia / Regione</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">Stato / Provincia / Regione (facoltativo)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">Stato</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">Stato (facoltativo)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">Codice postale</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">Codice postale (facoltativo)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">CAP/Codice postale</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">CAP/Codice postale (facoltativo)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">Inserisci il tuo nome</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">Inserisci il tuo numero di telefono</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">Il codice postale non è valido</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">Il codice postale non è valido</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">Inserisci la provincia</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">Inserisci lo Stato/Provincia/Regione</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">Inserisci il tuo indirizzo</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Indirizzo di spedizione</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">Inserisci lo stato</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">Il codice postale non è valido.</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">Il CAP/codice postale non è valido</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">Aggiungi una nuova carta di credito o di debito per fare acquisti in questa app.</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">Nessuna modalità di pagamento.</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">Gratuito</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">Aggiungi un indirizzo</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">Seleziona metodo di spedizione</string>
     <string name="invalid_shipping_information">Indirizzo di spedizione non valido</string>
     <string name="secure_checkout">Completamento del pagamento sicuro</string>

--- a/stripe/res/values-ja/strings.xml
+++ b/stripe/res/values-ja/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">新しいカードを追加…</string>
     <string name="title_add_a_card">カードを追加</string>
     <string name="title_payment_method">お支払い方法</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">市区町村を入力してください</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">国を入力してください</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">住所</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">住所 (1 行目)</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">住所 (1 行目、省略可)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">住所 (2 行目)</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">住所 (2 行目、省略可)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">住所 (省略可)</string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">アパート / マンション名など</string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">アパート / マンション名など (省略可)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">市区町村</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">市区町村 (省略可)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">国</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">群</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">群 (省略可)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">名称</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">名称 (省略可)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">電話番号</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">電話番号 (省略可)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">郵便番号</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">郵便番号 (省略可)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">郵便番号</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">郵便番号 (省略可)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">都道府県</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">都道府県 (省略可)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic">都道府県</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">都道府県 (省略可)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">都道府県</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">都道府県 (省略可)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">郵便番号</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">郵便番号 (省略可)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">郵便番号</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">郵便番号 (省略可)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">名前を入力してください</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">電話番号を入力してください</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">郵便番号が無効です</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">郵便番号が無効です</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">都道府県を入力してください</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">都道府県を入力してください</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">住所を入力してください</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">配送先住所</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">都道府県を入力してください</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">郵便番号が無効です。</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">郵便番号が無効です</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">このアプリで購入するには、別のデビットカードまたはクレジットカードの登録が必要です。</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">支払い方法が指定されていません。</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">無料</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">住所を設定してください</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">配送方法を選択してください</string>
     <string name="invalid_shipping_information">配送先住所エラー</string>
     <string name="secure_checkout">セキュアな Checkout</string>

--- a/stripe/res/values-nl/strings.xml
+++ b/stripe/res/values-nl/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">Nieuwe kaart toevoegen…</string>
     <string name="title_add_a_card">Een kaart toevoegen</string>
     <string name="title_payment_method">Betalingsmethode</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">Geef je plaats op</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">Geef je graafschap op</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">Adres</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">Adresregel 1</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">Adresregel 1 (optioneel)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Adresregel 2</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">Adresregel 2 (optioneel)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">Adres (optioneel) </string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">App.</string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">App. (optioneel)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">Plaats</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">Plaats (optioneel)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">Land</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">Graafschap</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">Graafschap (optioneel)</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">Naam</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Naam (optioneel)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">Telefoonnummer</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">Telefoonnummer (optioneel)</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">Postcode</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">Postcode (optioneel)</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">Postcode</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">Postcode (optioneel)</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">Provincie</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">Provincie (optioneel)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic">Staat/provincie/regio</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">Staat/provincie/regio (optioneel)</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">Staat</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">Staat (optioneel)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">Postcode</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">Postcode (optioneel)</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">Postcode</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">Postcode (optioneel)</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">Geef je naam op</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">Geef je telefoonnummer op</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">Je postcode is ongeldig</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">Je postcode is ongeldig</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">Geef je provincie op</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">Geef je staat/provincie/regio op</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">Geef je adres op</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Verzendadres</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">Geef je staat op</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">Je postcode is ongeldig.</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">Je postcode is ongeldig</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">Voeg een nieuwe betaalkaart toe om aankopen te doen in deze app.</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">Geen betalingsmethoden.</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">Gratis</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">Voeg een adres toe</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">Selecteer een verzendmethode</string>
     <string name="invalid_shipping_information">Ongeldig verzendadres</string>
     <string name="secure_checkout">Beveiligde Checkout</string>

--- a/stripe/res/values-pt/strings.xml
+++ b/stripe/res/values-pt/strings.xml
@@ -7,95 +7,50 @@
     <string name="acc_label_card_number_node">%s, Número do cartão</string>
     <string name="acc_label_expiry_date_node">%s, Data de validade</string>
     <string name="acc_label_cvc_node">%s, CVC</string>
-    <!--Label for input requesting the name of a customer-->
     <string name="address_label_name">Nome</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">Nome (opcional)</string>
-    <!--Label for input requesting the first line of an address, used for US and Canadian addresses-->
     <string name="address_label_address">Endereço</string>
-    <!--Label for input requesting the first line of an address where input is optional, used for US and Canadian addresses-->
     <string name="address_label_address_optional">Endereço (opcional) </string>
-    <!--Label for input requesting the first line of an address, used for international addresses-->
     <string name="address_label_address_line1">Linha de endereço 1</string>
-    <!--Label for input requesting the first line of an address where , used for international addresses-->
     <string name="address_label_address_line1_optional">Linha de endereço 1 (opcional)</string>
-    <!--Label for input requesting apartment number (address line 2) where input is optional, used for US addresses-->
     <string name="address_label_apt_optional">Ap. (opcional)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">Linha de endereço 2</string>
-    <!--Label for input requesting address line 2 where input in optional used for international addresses-->
     <string name="address_label_address_line2_optional">Linha de endereço 2 (opcional)</string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">Ap.</string>
-    <!--Label for input requesting city, used for all locations-->
     <string name="address_label_city">Cidade</string>
-    <!--Label for input requesting city where input is optional, used for all locations-->
     <string name="address_label_city_optional">Cidade (opcional)</string>
-    <!--Label for input requesting county, used for UK based addresses-->
     <string name="address_label_county">Município</string>
-    <!--Label for input requesting county where input is optional , used for UK based addresses-->
     <string name="address_label_county_optional">Município (opcional)</string>
-    <!--Label for input requesting country, used for all locations-->
     <string name="address_label_country">País</string>
-    <!--Label for input requesting phone number, used for all locations-->
     <string name="address_label_phone_number">Número de telefone</string>
-    <!--Label for input requesting phone number where input is optional, used for all locations-->
     <string name="address_label_phone_number_optional">Número de telefone (opcional)</string>
-    <!--Label for input requesting state, used for US addreses-->
     <string name="address_label_state">Estado</string>
-    <!--Label for input requesting state where input is optional, used for US addresses-->
     <string name="address_label_state_optional">Estado (opcional)</string>
-    <!--Label for input requesting zip code, used for US addreses-->
     <string name="address_label_zip_code">Código postal</string>
-    <!--Label for input requesting zip code where input is optional, used for US addresses-->
     <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <!--Label for input requesting postal code, used for Canadian addresses-->
     <string name="address_label_postal_code">Código postal</string>
-    <!--Label for input requesting postal code where input is optional, used for Canadian addresses-->
     <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <!--Label for input requesting postcode, used for UK based addresses-->
     <string name="address_label_postcode">Código postal</string>
-    <!--Label for input requesting postcode where input is optional, used for UK based addresses-->
     <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <!--Label for input requesting postal code, used for international addresses-->
     <string name="address_label_zip_postal_code">CEP / Código postal</string>
-    <!--Label for input requesting postal code where input is optional, used for international addresses-->
     <string name="address_label_zip_postal_code_optional">CEP / Código postal (opcional)</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">Endereço de entrega</string>
-    <!--Error text indicating zip code is invalid, used for US addresses-->
     <string name="address_zip_invalid">Seu CEP é inválido.</string>
-    <!--Error text indicating postcode is invalid, used for UK addresses-->
     <string name="address_postcode_invalid">Seu código postal é inválido</string>
-    <!--Error text indicating postal code is invalid, used for Canadian addresses-->
     <string name="address_postal_code_invalid">Seu código postal é inválido</string>
-    <!--Error text indicating zip/ postal code is invalid, used for international addresses-->
     <string name="address_zip_postal_invalid">Seu CEP/Código postal é inválido</string>
-    <!--Label for input requesting province, used for canadian addresses-->
     <string name="address_label_province">Província</string>
-    <!--Label for input requesting province where province is optional, used for canadian addresses-->
     <string name="address_label_province_optional">Província (opcional)</string>
-    <!--Label for input requesting the region, used for international addresses-->
     <string name="address_label_region_generic">Estado / Província / Região</string>
-    <!--Label for input requesting the region where input is optional, used for international addresses-->
     <string name="address_label_region_generic_optional">Estado / Província / Região (opcional)</string>
-    <!--Error text indicating name is required-->
     <string name="address_name_required">Digite seu nome</string>
-    <!--Error text indicating that address is required, used for all locations-->
     <string name="address_required">Digite seu endereço</string>
-    <!--Error text indicating that city is required, used for all locations-->
     <string name="address_city_required">Digite o nome da sua cidade</string>
-    <!--Error text indicating that county is required, used for UK addresses-->
     <string name="address_county_required">Digite o nome do seu município</string>
-    <!--Error text indicating that state is required, used for US addresses-->
     <string name="address_state_required">Digite o nome do seu estado</string>
-    <!--Error text indicating that province is required, used for Canadian addresses-->
     <string name="address_province_required">Digite o nome da sua província</string>
-    <!--Error text indicating that region is required, used for international addresses-->
     <string name="address_region_generic_required">Digite o nome do seu Estado / Província / Região</string>
-    <!--Error text indicating that phone number is required, used for all addresses-->
     <string name="address_phone_number_required">Digite seu número de telefone</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s terminado em %2$s</string>
     <string name="expiry_date_hint">MM/AA</string>
     <string name="expiry_label_short">Validade</string>
@@ -105,17 +60,12 @@
     <string name="invalid_cvc">O código de segurança do seu cartão é inválido.</string>
     <string name="invalid_zip">Seu código postal está incompleto.</string>
     <string name="payment_method_add_new_card">Adicionar novo cartão…</string>
-    <!--Human-friendly label for something with $0 price-->
     <string name="price_free">Grátis</string>
     <string name="title_add_a_card">Adicionar um cartão</string>
     <string name="title_payment_method">Forma de pagamento</string>
-    <!--Screen title telling users they should add an address-->
     <string name="title_add_an_address">Adicionar um endereço</string>
-    <!--Screen title telling users they should select a shipping address-->
     <string name="title_select_shipping_method">Selecione forma de envio</string>
-    <!--Text informing user there are no existing payment methods in the application-->
     <string name="no_payment_methods">Nenhuma forma de pagamento.</string>
-    <!--Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application-->
     <string name="add_card">Adicione um novo cartão de débito ou cartão de crédito para fazer compras neste app.</string>
     <string name="invalid_shipping_information">Endereço de entrega inválido</string>
     <string name="secure_checkout">Finalização de compra segura</string>

--- a/stripe/res/values-zh/strings.xml
+++ b/stripe/res/values-zh/strings.xml
@@ -17,105 +17,55 @@
     <string name="payment_method_add_new_card">添加新卡……</string>
     <string name="title_add_a_card">添加一张卡</string>
     <string name="title_payment_method">支付方式</string>
-    <!-- Error text indicating that city is required, used for all locations -->
     <string name="address_city_required">请输入您所在的城市</string>
-    <!-- Error text indicating that county is required, used for UK addresses -->
     <string name="address_county_required">请输入您所在的县</string>
-    <!-- Label for input requesting the first line of an address, used for US and Canada addresses -->
     <string name="address_label_address">地址</string>
-    <!-- Label for input requesting the first line of an address, used for international addresses -->
     <string name="address_label_address_line1">第 1 行地址</string>
-    <!-- Label for input requesting the first line of an address where , used for international addresses -->
     <string name="address_label_address_line1_optional">第 1 行地址 (可选)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
     <string name="address_label_address_line2">第 2 行地址</string>
-    <!-- Label for input requesting address line 2 where input in optional used for international addresses -->
     <string name="address_label_address_line2_optional">第 2 行地址 (可选)</string>
-    <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
     <string name="address_label_address_optional">地址 (可选)</string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
     <string name="address_label_apt">公寓号码 </string>
-    <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
     <string name="address_label_apt_optional">公寓号码 (可选)</string>
-    <!-- Label for input requesting city, used for all locations -->
     <string name="address_label_city">城市</string>
-    <!-- Label for input requesting city where input is optional, used for all locations -->
     <string name="address_label_city_optional">城市 (可选)</string>
-    <!-- Label for input requesting country, used for all locations -->
     <string name="address_label_country">国家</string>
-    <!-- Label for input requesting county, used for UK based addresses -->
     <string name="address_label_county">县</string>
-    <!-- Label for input requesting county where input is optional , used for UK based addresses -->
     <string name="address_label_county_optional">县（可选）</string>
-    <!-- Label for input requesting the name of a customer -->
     <string name="address_label_name">姓名</string>
-    <!-- Label for input requesting the name of a customer where input is optional -->
     <string name="address_label_name_optional">姓名 (可选)</string>
-    <!-- Label for input requesting phone number, used for all locations -->
     <string name="address_label_phone_number">电话号码</string>
-    <!-- Label for input requesting phone number where input is optional, used for all locations -->
     <string name="address_label_phone_number_optional">电话号码（可选）</string>
-    <!-- Label for input requesting postal code, used for Canada based addresses -->
     <string name="address_label_postal_code">邮政编码</string>
-    <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
     <string name="address_label_postal_code_optional">邮政编码（可选）</string>
-    <!-- Label for input requesting postcode, used for UK based addresses -->
     <string name="address_label_postcode">邮政编码</string>
-    <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
     <string name="address_label_postcode_optional">邮政编码（可选）</string>
-    <!-- Label for input requesting province, used for canadian addresses -->
     <string name="address_label_province">省</string>
-    <!-- Label for input requesting province where province is optional, used for canadian addresses -->
     <string name="address_label_province_optional">省 (可选)</string>
-    <!-- Label for input requesting the region, used for international addresses -->
     <string name="address_label_region_generic"> 州/省/地区</string>
-    <!-- Label for input requesting the region where input is optional, used for international addresses -->
     <string name="address_label_region_generic_optional">州/省/地区（可选）</string>
-    <!-- Label for input requesting state, used for US based addreses -->
     <string name="address_label_state">州</string>
-    <!-- Label for input requesting state where input is optional, used for US based addresses -->
     <string name="address_label_state_optional">州 (可选)</string>
-    <!-- Label for input requesting zip code, used for US based addreses -->
     <string name="address_label_zip_code">邮政编码</string>
-    <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
     <string name="address_label_zip_code_optional">邮政编码（可选）</string>
-    <!-- Label for input requesting postal code, used for international addresses -->
     <string name="address_label_zip_postal_code">邮政编码</string>
-    <!-- Label for input requesting postal code where input is optional, used for international addresses -->
     <string name="address_label_zip_postal_code_optional">邮政编码（可选）</string>
-    <!-- Error text indicating name is required -->
     <string name="address_name_required">请输入您的姓名</string>
-    <!-- Error text indicating that phone number is required, used for all addresses -->
     <string name="address_phone_number_required">请输入您的电话号码</string>
-    <!-- Error text indicating postal code is invalid, used for Canada addresses -->
     <string name="address_postal_code_invalid">您的邮政编码无效</string>
-    <!-- Error text indicating postcode is invalid, used for UK addresses -->
     <string name="address_postcode_invalid">您的邮政编码无效</string>
-    <!-- Error text indicating that province is required, used for Canada addresses -->
     <string name="address_province_required">请输入您所在的省</string>
-    <!-- Error text indicating that region is required, used for international addresses -->
     <string name="address_region_generic_required">请输入您所在的州/省/地区</string>
-    <!-- Error text indicating that address is required, used for all locations -->
     <string name="address_required">请输入您的地址</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
     <string name="address_shipping_address">配送地址</string>
-    <!-- Error text indicating that state is required, used for US addresses -->
     <string name="address_state_required">请输入您所在的州</string>
-    <!-- Error text indicating zip code is invalid, used for US addresses -->
     <string name="address_zip_invalid">您的邮政编码无效。</string>
-    <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
     <string name="address_zip_postal_invalid">您的邮政编码无效</string>
-    <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
     <string name="add_card">添加一张新的借记卡或信用卡以便在此应用中进行购买。</string>
-    <!--Used to display masked card numbers-->
     <string name="ending_in">%1$s - %2$s</string>
-    <!-- Text informing user there are no existing payment methods in the application -->
     <string name="no_payment_methods">没有付款方式。</string>
-    <!-- Human friendly label for something with $0 price -->
     <string name="price_free">免费</string>
-    <!-- Screen title telling users they should add an address -->
     <string name="title_add_an_address">添加一个地址</string>
-    <!-- Screen title telling users they should select a shipping address -->
     <string name="title_select_shipping_method">选择送货方式</string>
     <string name="invalid_shipping_information">无效配送地址</string>
     <string name="secure_checkout">安全的支付流程</string>


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Comments still remain on the english strings

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Make it easier to import strings from Lokalize.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
