### PR TITLE
Cache payment methods list in MC

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
     testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test:rules:$androidTestVersion"

--- a/stripe/src/main/java/com/stripe/android/checkout/CheckoutPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/checkout/CheckoutPaymentMethodsListFragment.kt
@@ -16,13 +16,22 @@ internal class CheckoutPaymentMethodsListFragment : Fragment(R.layout.fragment_c
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        if (activity == null) {
+            return
+        }
+
         val binding = FragmentCheckoutPaymentMethodsListBinding.bind(view)
         binding.recycler.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
 
-        viewModel.getPaymentMethods(requireActivity()).observe(viewLifecycleOwner) {
+        viewModel.paymentMethods.observe(viewLifecycleOwner) {
             binding.recycler.adapter = CheckoutPaymentMethodsAdapter(it) {
                 viewModel.transitionTo(CheckoutViewModel.TransitionTarget.AddCard)
             }
+        }
+
+        // Only fetch the payment methods list if we haven't already
+        if (viewModel.paymentMethods.value == null) {
+            viewModel.updatePaymentMethods(requireActivity().intent)
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/checkout/CheckoutPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/checkout/CheckoutPaymentMethodsListFragment.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentCheckoutPaymentMethodsListBinding
-import java.lang.IllegalStateException
 
 internal class CheckoutPaymentMethodsListFragment : Fragment(R.layout.fragment_checkout_payment_methods_list) {
     private val viewModel by activityViewModels<CheckoutViewModel> {
@@ -20,26 +19,10 @@ internal class CheckoutPaymentMethodsListFragment : Fragment(R.layout.fragment_c
         val binding = FragmentCheckoutPaymentMethodsListBinding.bind(view)
         binding.recycler.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
 
-        val args: CheckoutActivityStarter.Args? = CheckoutActivityStarter.Args.fromIntent(requireActivity().intent)
-        if (args == null) {
-            viewModel.onError(IllegalStateException("Missing activity args"))
-            return
-        }
-
-        viewModel.getPaymentMethods(
-            args.customerId,
-            args.ephemeralKey
-        ).observe(viewLifecycleOwner) { result ->
-            result.fold(
-                onSuccess = {
-                    binding.recycler.adapter = CheckoutPaymentMethodsAdapter(it) {
-                        viewModel.transitionTo(CheckoutViewModel.TransitionTarget.AddCard)
-                    }
-                },
-                onFailure = {
-                    viewModel.onError(it)
-                }
-            )
+        viewModel.getPaymentMethods(requireActivity()).observe(viewLifecycleOwner) {
+            binding.recycler.adapter = CheckoutPaymentMethodsAdapter(it) {
+                viewModel.transitionTo(CheckoutViewModel.TransitionTarget.AddCard)
+            }
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/checkout/CheckoutViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/checkout/CheckoutViewModel.kt
@@ -1,19 +1,22 @@
 package com.stripe.android.checkout
 
+import android.app.Activity
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.liveData
 import com.stripe.android.ApiRequest
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeApiRepository
 import com.stripe.android.StripeRepository
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.lang.IllegalStateException
 import kotlin.coroutines.CoroutineContext
 
 internal class CheckoutViewModel internal constructor(
@@ -25,6 +28,7 @@ internal class CheckoutViewModel internal constructor(
 ) : AndroidViewModel(application) {
     private val mutableError = MutableLiveData<Throwable>()
     private val mutableTransition = MutableLiveData<TransitionTarget>()
+    private val paymentMethods = MutableLiveData<List<PaymentMethod>>()
     internal val error: LiveData<Throwable> = mutableError
     internal val transition: LiveData<TransitionTarget> = mutableTransition
 
@@ -36,13 +40,35 @@ internal class CheckoutViewModel internal constructor(
         mutableTransition.postValue(target)
     }
 
-    fun getPaymentMethods(
-        customerId: String,
+    /**
+     * Fetch the customer's saved payment methods.
+     * The activity args are assumed to be static across the lifetime of the view model
+     * so calling this method multiple times will not result in re-fetching the payment methods.
+     *
+     * If you wish to force an update, call [updatePaymentMethods] directly.
+     */
+    fun getPaymentMethods(activity: Activity): LiveData<List<PaymentMethod>> {
+        if (paymentMethods.value == null) {
+            val args: CheckoutActivityStarter.Args? = CheckoutActivityStarter.Args.fromIntent(activity.intent)
+            if (args == null) {
+                onError(IllegalStateException("Missing activity args"))
+            } else {
+                updatePaymentMethods(
+                    args.ephemeralKey,
+                    args.customerId
+                )
+            }
+        }
+        return paymentMethods
+    }
+
+    fun updatePaymentMethods(
         ephemeralKey: String,
+        customerId: String,
         stripeAccountId: String? = this.stripeAccountId
-    ) = liveData(workContext) {
-        val result =
-            kotlin.runCatching {
+    ) {
+        CoroutineScope(workContext).launch {
+            val result = kotlin.runCatching {
                 stripeRepository.getPaymentMethods(
                     ListPaymentMethodsParams(
                         customerId = customerId,
@@ -53,7 +79,15 @@ internal class CheckoutViewModel internal constructor(
                     ApiRequest.Options(ephemeralKey, stripeAccountId)
                 )
             }
-        emit(result)
+            result.fold(
+                onSuccess = {
+                    paymentMethods.postValue(it)
+                },
+                onFailure = {
+                    onError(it)
+                }
+            )
+        }
     }
 
     internal enum class TransitionTarget {

--- a/stripe/src/main/java/com/stripe/android/checkout/CheckoutViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/checkout/CheckoutViewModel.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.checkout
 
-import android.app.Activity
 import android.app.Application
+import android.content.Intent
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -28,7 +28,7 @@ internal class CheckoutViewModel internal constructor(
 ) : AndroidViewModel(application) {
     private val mutableError = MutableLiveData<Throwable>()
     private val mutableTransition = MutableLiveData<TransitionTarget>()
-    private val paymentMethods = MutableLiveData<List<PaymentMethod>>()
+    internal val paymentMethods = MutableLiveData<List<PaymentMethod>>()
     internal val error: LiveData<Throwable> = mutableError
     internal val transition: LiveData<TransitionTarget> = mutableTransition
 
@@ -40,29 +40,19 @@ internal class CheckoutViewModel internal constructor(
         mutableTransition.postValue(target)
     }
 
-    /**
-     * Fetch the customer's saved payment methods.
-     * The activity args are assumed to be static across the lifetime of the view model
-     * so calling this method multiple times will not result in re-fetching the payment methods.
-     *
-     * If you wish to force an update, call [updatePaymentMethods] directly.
-     */
-    fun getPaymentMethods(activity: Activity): LiveData<List<PaymentMethod>> {
-        if (paymentMethods.value == null) {
-            val args: CheckoutActivityStarter.Args? = CheckoutActivityStarter.Args.fromIntent(activity.intent)
-            if (args == null) {
-                onError(IllegalStateException("Missing activity args"))
-            } else {
-                updatePaymentMethods(
-                    args.ephemeralKey,
-                    args.customerId
-                )
-            }
+    fun updatePaymentMethods(intent: Intent) {
+        val args: CheckoutActivityStarter.Args? = CheckoutActivityStarter.Args.fromIntent(intent)
+        if (args == null) {
+            onError(IllegalStateException("Missing activity args"))
+        } else {
+            updatePaymentMethods(
+                args.ephemeralKey,
+                args.customerId
+            )
         }
-        return paymentMethods
     }
 
-    fun updatePaymentMethods(
+    private fun updatePaymentMethods(
         ephemeralKey: String,
         customerId: String,
         stripeAccountId: String? = this.stripeAccountId

--- a/stripe/src/test/java/com/stripe/android/checkout/CheckoutViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/checkout/CheckoutViewModelTest.kt
@@ -53,7 +53,7 @@ class CheckoutViewModelTest {
     }
 
     @Test
-    fun `getPaymentMethods should call onError when no args supplied`() {
+    fun `updatePaymentMethods should call onError when no args supplied`() {
         var error: Throwable? = null
         viewModel.error.observeForever {
             error = it

--- a/stripe/src/test/java/com/stripe/android/checkout/CheckoutViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/checkout/CheckoutViewModelTest.kt
@@ -1,0 +1,88 @@
+package com.stripe.android.checkout
+
+import android.app.Activity
+import android.content.Intent
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.AbsFakeStripeRepository
+import com.stripe.android.ApiRequest
+import com.stripe.android.StripeRepository
+import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.view.ActivityStarter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.lang.IllegalStateException
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class CheckoutViewModelTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private val activity =
+        Activity().apply {
+            intent = Intent().putExtra(
+                ActivityStarter.Args.EXTRA,
+                CheckoutActivityStarter.Args(
+                    "client_secret",
+                    "ephemeral_key",
+                    "customer_id"
+                )
+            )
+        }
+    private val stripeRepository: StripeRepository = FakeStripeRepository()
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val viewModel = CheckoutViewModel(
+        ApplicationProvider.getApplicationContext(),
+        "publishable_key",
+        "stripe_account_id",
+        stripeRepository,
+        testDispatcher
+    )
+
+    @Test
+    fun `getPaymentMethods should fetch from api repository`() = testDispatcher.runBlockingTest {
+        var paymentMethods: List<PaymentMethod>? = null
+        viewModel.getPaymentMethods(activity).observeForever {
+            paymentMethods = it
+        }
+        assertThat(paymentMethods).containsExactly(FAKE_CARD)
+    }
+
+    @Test
+    fun `getPaymentMethods should call onError when no args supplied`() {
+        var error: Throwable? = null
+        viewModel.error.observeForever {
+            error = it
+        }
+        viewModel.getPaymentMethods(Activity().apply { intent = Intent() })
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `getPaymentMethods should not update multipe times`() = testDispatcher.runBlockingTest {
+        var updates = 0
+        viewModel.getPaymentMethods(activity).observeForever {
+            updates += 1
+        }
+        viewModel.getPaymentMethods(activity).observeForever {}
+        assertThat(updates).isEqualTo(1)
+    }
+
+    private class FakeStripeRepository : AbsFakeStripeRepository() {
+        override fun getPaymentMethods(listPaymentMethodsParams: ListPaymentMethodsParams, publishableKey: String, productUsageTokens: Set<String>, requestOptions: ApiRequest.Options): List<PaymentMethod> {
+            return listOf(FAKE_CARD)
+        }
+    }
+
+    private companion object {
+        val FAKE_CARD = PaymentMethod("fake_pm", created = 0, liveMode = false, type = PaymentMethod.Type.Card)
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Also refactor logic so view model calls `onError` directly instead of relying on the caller to communicate errors

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We don't want to refetch the list after a screen rotation or if the users navigates back to the list.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested manually. Write unit tests.
