### PR TITLE
Update CardInputWidget text size for ldpi screens

### DIFF
--- a/stripe/res/values-ldpi/dimens.xml
+++ b/stripe/res/values-ldpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ciw_stripe_edit_text_size">15sp</dimen>
+</resources>


### PR DESCRIPTION
This is the same value used for `mdpi` screens.

Tested on 240x400 ldpi screen. In before capture, text is cut off and fields don't have enough white space between them.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/45020849/93105933-a357b300-f67d-11ea-9363-32d420d5a056.gif) | ![ciw_after](https://user-images.githubusercontent.com/45020849/93105946-a783d080-f67d-11ea-9ccb-9908d81742db.gif) |
