### PR TITLE
Add context string to payment/setup intent result

### DIFF
--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -182,4 +182,8 @@
     <!-- Checkout -->
     <string name="stripe_checkout_pay_with_your"  tools:ignore="MissingTranslation">Pay with your</string>
     <string name="stripe_checkout_add_payment_method" tools:ignore="MissingTranslation">Add payment method</string>
+
+    <!-- Failure Reason -->
+    <string name="stripe_failure_reason_authentication" tools:ignore="MissingTranslation">We are unable to authenticate your payment method. Please choose a different payment method and try again.</string>
+    <string name="stripe_failure_reason_timed_out" tools:ignore="MissingTranslation">Timed out authenticating your payment method -- try again</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
@@ -11,5 +11,5 @@ import kotlinx.android.parcel.Parcelize
 data class PaymentIntentResult internal constructor(
     override val intent: PaymentIntent,
     @Outcome private val outcomeFromFlow: Int = 0,
-    val context: String? = null
+    val failureMessage: String? = null
 ) : StripeIntentResult<PaymentIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
@@ -10,5 +10,6 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class PaymentIntentResult internal constructor(
     override val intent: PaymentIntent,
-    @Outcome private val outcomeFromFlow: Int = 0
+    @Outcome private val outcomeFromFlow: Int = 0,
+    val context: String? = null
 ) : StripeIntentResult<PaymentIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
@@ -11,5 +11,5 @@ import kotlinx.android.parcel.Parcelize
 data class SetupIntentResult internal constructor(
     override val intent: SetupIntent,
     @Outcome private val outcomeFromFlow: Int = 0,
-    val context: String? = null
+    val failureMessage: String? = null
 ) : StripeIntentResult<SetupIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
@@ -10,5 +10,6 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class SetupIntentResult internal constructor(
     override val intent: SetupIntent,
-    @Outcome private val outcomeFromFlow: Int = 0
+    @Outcome private val outcomeFromFlow: Int = 0,
+    val context: String? = null
 ) : StripeIntentResult<SetupIntent>(outcomeFromFlow)

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -439,7 +439,7 @@ internal class StripePaymentController internal constructor(
                     } else {
                         logger.debug("Dispatching PaymentIntentResult for ${result.id}")
                         callback.onSuccess(
-                            PaymentIntentResult(result, flowOutcome, getIntentResultContext(result, flowOutcome))
+                            PaymentIntentResult(result, flowOutcome, getFailureMessage(result, flowOutcome))
                         )
                     }
                 } else {
@@ -457,7 +457,7 @@ internal class StripePaymentController internal constructor(
         }
     }
 
-    private fun getIntentResultContext(intent: StripeIntent, @StripeIntentResult.Outcome outcome: Int): String? {
+    private fun getFailureMessage(intent: StripeIntent, @StripeIntentResult.Outcome outcome: Int): String? {
         return when {
             intent.status == StripeIntent.Status.RequiresPaymentMethod -> {
                 when (intent) {
@@ -526,7 +526,7 @@ internal class StripePaymentController internal constructor(
                     } else {
                         logger.debug("Dispatching SetupIntentResult for ${result.id}")
                         resultCallback.onSuccess(
-                            SetupIntentResult(result, flowOutcome, getIntentResultContext(result, flowOutcome))
+                            SetupIntentResult(result, flowOutcome, getFailureMessage(result, flowOutcome))
                         )
                     }
                 } else {

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -218,6 +218,10 @@ data class PaymentIntent internal constructor(
                 fun fromCode(typeCode: String?) = values().firstOrNull { it.code == typeCode }
             }
         }
+
+        internal companion object {
+            internal const val CODE_AUTHENTICATION_ERROR = "payment_intent_authentication_failure"
+        }
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -168,6 +168,10 @@ data class SetupIntent internal constructor(
                 }
             }
         }
+
+        internal companion object {
+            internal const val CODE_AUTHENTICATION_ERROR = "payment_intent_authentication_failure"
+        }
     }
 
     internal data class ClientSecret(internal val value: String) {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This attempts to mimic the logic in the iOS sdk [here](https://github.com/stripe/stripe-ios/blob/ffa5dc704c5426d61d0c43a86d94bd87a100aaff/Stripe/Payments/STPPaymentHandler.m#L932-L988)

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The iOS SDK includes client-side error messages with translations that we do not have on Android and users have asked for parity here. Moreover, the iOS SDK provides an NSError object with additional detail for many cases that we consider to be a success, but are really more ambiguous - e.g. when the user manually cancels authentication, this is neither clearly a success nor a failure. The payment didn't fail but it also certainly didn't succeed. Having additional context can help the user understand what happened.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
