### PR TITLE
Conditionally fire CardMetadataMissingRange

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -22,7 +22,6 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     private val packageName: String,
     private val publishableKey: String
 ) {
-
     internal constructor(context: Context, publishableKey: String) : this(
         context.applicationContext.packageManager,
         context.applicationContext.packageInfo,

--- a/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.cards
 
 import android.content.Context
+import com.stripe.android.AnalyticsDataFactory
+import com.stripe.android.AnalyticsRequest
+import com.stripe.android.AnalyticsRequestExecutor
 import com.stripe.android.ApiRequest
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeApiRepository
@@ -20,18 +23,23 @@ internal class DefaultCardAccountRangeRepositoryFactory(
         val paymentConfiguration = PaymentConfiguration.getInstance(
             appContext
         )
+        val publishableKey = paymentConfiguration.publishableKey
         val store = DefaultCardAccountRangeStore(appContext)
         return DefaultCardAccountRangeRepository(
             inMemorySource = InMemoryCardAccountRangeSource(store),
             remoteSource = RemoteCardAccountRangeSource(
                 StripeApiRepository(
                     appContext,
-                    paymentConfiguration.publishableKey
+                    publishableKey
                 ),
                 ApiRequest.Options(
-                    paymentConfiguration.publishableKey
+                    publishableKey
                 ),
-                DefaultCardAccountRangeStore(appContext)
+                DefaultCardAccountRangeStore(appContext),
+                AnalyticsRequestExecutor.Default(),
+                AnalyticsRequest.Factory(),
+                AnalyticsDataFactory(appContext, publishableKey),
+                publishableKey
             ),
             staticSource = StaticCardAccountRangeSource(),
             store = store

--- a/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
@@ -5,6 +5,7 @@ import com.stripe.android.AnalyticsEvent
 import com.stripe.android.AnalyticsRequest
 import com.stripe.android.AnalyticsRequestExecutor
 import com.stripe.android.ApiRequest
+import com.stripe.android.CardUtils
 import com.stripe.android.StripeRepository
 import com.stripe.android.model.AccountRange
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -45,7 +46,9 @@ internal class RemoteCardAccountRangeSource(
                             binRange.matches(cardNumber)
                         }
 
-                    if (matchedAccountRange == null) {
+                    if (matchedAccountRange == null &&
+                        CardUtils.isValidLuhnNumber(cardNumber.normalized)
+                    ) {
                         fireMissingRangeRequest()
                     }
 

--- a/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.cards
 
+import com.stripe.android.AnalyticsDataFactory
+import com.stripe.android.AnalyticsEvent
+import com.stripe.android.AnalyticsRequest
+import com.stripe.android.AnalyticsRequestExecutor
 import com.stripe.android.ApiRequest
 import com.stripe.android.StripeRepository
 import com.stripe.android.model.AccountRange
@@ -11,7 +15,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 internal class RemoteCardAccountRangeSource(
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
-    private val cardAccountRangeStore: CardAccountRangeStore
+    private val cardAccountRangeStore: CardAccountRangeStore,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequest.Factory,
+    private val analyticsDataFactory: AnalyticsDataFactory,
+    private val publishableKey: String
 ) : CardAccountRangeSource {
 
     private val mutableLoading = MutableStateFlow(false)
@@ -25,16 +33,35 @@ internal class RemoteCardAccountRangeSource(
         return cardNumber.bin?.let { bin ->
             mutableLoading.value = true
 
-            val accountRanges =
-                stripeRepository.getCardMetadata(bin, requestOptions)?.accountRanges.orEmpty()
+            val accountRanges = stripeRepository.getCardMetadata(bin, requestOptions)?.accountRanges.orEmpty()
             cardAccountRangeStore.save(bin, accountRanges)
 
             mutableLoading.value = false
 
-            accountRanges
-                .firstOrNull { (binRange) ->
-                    binRange.matches(cardNumber)
+            when {
+                accountRanges.isNotEmpty() -> {
+                    val matchedAccountRange = accountRanges
+                        .firstOrNull { (binRange) ->
+                            binRange.matches(cardNumber)
+                        }
+
+                    if (matchedAccountRange == null) {
+                        fireMissingRangeRequest()
+                    }
+
+                    matchedAccountRange
                 }
+                else -> null
+            }
         }
+    }
+
+    private fun fireMissingRangeRequest() {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.create(
+                analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataMissingRange),
+                ApiRequest.Options(publishableKey)
+            )
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -6,6 +6,8 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.AnalyticsDataFactory
+import com.stripe.android.AnalyticsRequest
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.ApiRequest
 import com.stripe.android.CardNumberFixtures
@@ -194,18 +196,21 @@ internal class DefaultCardAccountRangeRepositoryTest {
     }
 
     private fun createRemoteCardAccountRangeSource(
-        store: CardAccountRangeStore
+        store: CardAccountRangeStore,
+        publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     ): CardAccountRangeSource {
         val stripeRepository = StripeApiRepository(
             application,
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            publishableKey
         )
         return RemoteCardAccountRangeSource(
             stripeRepository,
-            ApiRequest.Options(
-                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
-            ),
-            store
+            ApiRequest.Options(publishableKey),
+            store,
+            { },
+            AnalyticsRequest.Factory(),
+            AnalyticsDataFactory(application, publishableKey),
+            publishableKey
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.cards
 
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.AbsFakeStripeRepository
+import com.stripe.android.AnalyticsDataFactory
+import com.stripe.android.AnalyticsRequest
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.ApiRequest
 import com.stripe.android.CardNumberFixtures
@@ -17,8 +20,11 @@ import com.stripe.android.model.CardMetadata
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
+@RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 internal class RemoteCardAccountRangeSourceTest {
     private val testDispatcher = TestCoroutineDispatcher()
@@ -30,7 +36,14 @@ internal class RemoteCardAccountRangeSourceTest {
         val remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
             FakeStripeRepository(VISA_METADATA),
             REQUEST_OPTIONS,
-            cardAccountRangeStore
+            cardAccountRangeStore,
+            { },
+            AnalyticsRequest.Factory(),
+            AnalyticsDataFactory(
+                ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
 
         assertThat(
@@ -59,7 +72,14 @@ internal class RemoteCardAccountRangeSourceTest {
         val remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
             FakeStripeRepository(EMPTY_METADATA),
             REQUEST_OPTIONS,
-            cardAccountRangeStore
+            cardAccountRangeStore,
+            { },
+            AnalyticsRequest.Factory(),
+            AnalyticsDataFactory(
+                ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
 
         assertThat(
@@ -80,7 +100,14 @@ internal class RemoteCardAccountRangeSourceTest {
         val remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
             repository,
             REQUEST_OPTIONS,
-            cardAccountRangeStore
+            cardAccountRangeStore,
+            { },
+            AnalyticsRequest.Factory(),
+            AnalyticsDataFactory(
+                ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
 
         assertThat(
@@ -91,6 +118,35 @@ internal class RemoteCardAccountRangeSourceTest {
 
         verify(repository, never()).getCardMetadata(any(), any())
         verify(cardAccountRangeStore, never()).save(any(), any())
+    }
+
+    @Test
+    fun `getAccountRange() should fire missing range analytics request when response is not empty but card number does not match`() = testDispatcher.runBlockingTest {
+        val analyticsRequests = mutableListOf<AnalyticsRequest>()
+
+        val remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
+            FakeStripeRepository(VISA_METADATA),
+            REQUEST_OPTIONS,
+            cardAccountRangeStore,
+            {
+                analyticsRequests.add(it)
+            },
+            AnalyticsRequest.Factory(),
+            AnalyticsDataFactory(
+                ApplicationProvider.getApplicationContext(),
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+
+        remoteCardAccountRangeSource.getAccountRange(
+            CardNumber.Unvalidated("4242424259999999")
+        )
+
+        assertThat(analyticsRequests)
+            .hasSize(1)
+        assertThat(analyticsRequests.first().params["event"])
+            .isEqualTo("stripe_android.card_metadata_missing_range")
     }
 
     private class FakeStripeRepository(

--- a/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -125,7 +125,22 @@ internal class RemoteCardAccountRangeSourceTest {
         val analyticsRequests = mutableListOf<AnalyticsRequest>()
 
         val remoteCardAccountRangeSource = RemoteCardAccountRangeSource(
-            FakeStripeRepository(VISA_METADATA),
+            FakeStripeRepository(
+                CardMetadata(
+                    bin = BinFixtures.VISA,
+                    accountRanges = listOf(
+                        AccountRange(
+                            binRange = BinRange(
+                                low = "4242420000000000",
+                                high = "4242424200000000"
+                            ),
+                            panLength = 16,
+                            brandInfo = AccountRange.BrandInfo.Visa,
+                            country = "GB"
+                        )
+                    )
+                )
+            ),
             REQUEST_OPTIONS,
             cardAccountRangeStore,
             {
@@ -140,7 +155,7 @@ internal class RemoteCardAccountRangeSourceTest {
         )
 
         remoteCardAccountRangeSource.getAccountRange(
-            CardNumber.Unvalidated("4242424259999999")
+            CardNumber.Unvalidated("4242424242424242")
         )
 
         assertThat(analyticsRequests)


### PR DESCRIPTION
If the card service response had account ranges but none of them matched
the input, fire `CardMetadataMissingRange`.