### PR TITLE
Conditionally fire CardMetadataLoadedTooSlow

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -20,13 +20,24 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     private val packageManager: PackageManager?,
     private val packageInfo: PackageInfo?,
     private val packageName: String,
-    private val publishableKey: String
+    private val publishableKeySupplier: () -> String
 ) {
-    internal constructor(context: Context, publishableKey: String) : this(
+    internal constructor(
+        context: Context,
+        publishableKey: String
+    ) : this(
+        context,
+        { publishableKey }
+    )
+
+    internal constructor(
+        context: Context,
+        publishableKeySupplier: () -> String
+    ) : this(
         context.applicationContext.packageManager,
         context.applicationContext.packageInfo,
         context.applicationContext.packageName.orEmpty(),
-        publishableKey
+        publishableKeySupplier
     )
 
     @JvmSynthetic
@@ -286,7 +297,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         return mapOf(
             FIELD_ANALYTICS_UA to ANALYTICS_UA,
             FIELD_EVENT to event.toString(),
-            FIELD_PUBLISHABLE_KEY to publishableKey,
+            FIELD_PUBLISHABLE_KEY to publishableKeySupplier(),
             FIELD_OS_NAME to Build.VERSION.CODENAME,
             FIELD_OS_RELEASE to Build.VERSION.RELEASE,
             FIELD_OS_VERSION to Build.VERSION.SDK_INT,

--- a/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/CardNumber.kt
@@ -18,10 +18,12 @@ internal sealed class CardNumber {
 
         val bin: Bin? = Bin.create(normalized)
 
+        val isValidLuhn = CardUtils.isValidLuhnNumber(normalized)
+
         fun validate(panLength: Int): Validated? {
             return if (panLength >= MIN_PAN_LENGTH &&
                 normalized.length == panLength &&
-                CardUtils.isValidLuhnNumber(normalized)
+                isValidLuhn
             ) {
                 Validated(
                     value = normalized

--- a/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
@@ -5,7 +5,6 @@ import com.stripe.android.AnalyticsEvent
 import com.stripe.android.AnalyticsRequest
 import com.stripe.android.AnalyticsRequestExecutor
 import com.stripe.android.ApiRequest
-import com.stripe.android.CardUtils
 import com.stripe.android.StripeRepository
 import com.stripe.android.model.AccountRange
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,10 +45,8 @@ internal class RemoteCardAccountRangeSource(
                             binRange.matches(cardNumber)
                         }
 
-                    if (matchedAccountRange == null &&
-                        CardUtils.isValidLuhnNumber(cardNumber.normalized)
-                    ) {
-                        fireMissingRangeRequest()
+                    if (matchedAccountRange == null && cardNumber.isValidLuhn) {
+                        onCardMetadataMissingRange()
                     }
 
                     matchedAccountRange
@@ -59,7 +56,7 @@ internal class RemoteCardAccountRangeSource(
         }
     }
 
-    private fun fireMissingRangeRequest() {
+    private fun onCardMetadataMissingRange() {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create(
                 analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataMissingRange),

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -177,7 +177,7 @@ class AnalyticsDataFactoryTest {
         }
 
         val params =
-            AnalyticsDataFactory(packageManager, packageInfo, packageName, API_KEY)
+            AnalyticsDataFactory(packageManager, packageInfo, packageName) { API_KEY }
                 .createTokenCreationParams(
                     ATTRIBUTION,
                     Token.Type.Card
@@ -231,7 +231,7 @@ class AnalyticsDataFactoryTest {
     @Test
     fun createAppDataParams_whenPackageNameIsEmpty_returnsEmptyMap() {
         assertThat(
-            AnalyticsDataFactory(null, null, "", API_KEY)
+            AnalyticsDataFactory(null, null, "") { API_KEY }
                 .createAppDataParams()
         ).isEmpty()
     }
@@ -240,7 +240,7 @@ class AnalyticsDataFactoryTest {
     fun createAppDataParams_whenPackageInfoNotFound_returnsEmptyMap() {
         val packageName = "fake_package"
         assertThat(
-            AnalyticsDataFactory(packageManager, null, packageName, API_KEY)
+            AnalyticsDataFactory(packageManager, null, packageName) { API_KEY }
                 .createAppDataParams()
         ).isEmpty()
     }


### PR DESCRIPTION
- Update `AnalyticsDataFactory` to take a `publishableKeySupplier`.
  This is useful for when obtaining the publishable key should be
  deferred until after object construction. See `CardNumberEditText`.
- Add `CardNumber.Unvalidated#isValidLuhn`.