### PR TITLE
Update CardBrandView logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -29,6 +29,8 @@ internal class CardBrandView @JvmOverloads constructor(
         false
     ) { _, wasLoading, isLoading ->
         if (wasLoading != isLoading) {
+            updateIcon()
+
             if (isLoading) {
                 progressView.show()
             } else {
@@ -37,32 +39,69 @@ internal class CardBrandView @JvmOverloads constructor(
         }
     }
 
+    var brand: CardBrand by Delegates.observable(
+        CardBrand.Unknown
+    ) { _, prevValue, newValue ->
+        if (prevValue != newValue) {
+            updateIcon()
+        }
+    }
+
+    var shouldShowCvc: Boolean by Delegates.observable(
+        false
+    ) { _, prevValue, newValue ->
+        if (prevValue != newValue) {
+            updateIcon()
+        }
+    }
+
+    var shouldShowErrorIcon: Boolean by Delegates.observable(
+        false
+    ) { _, prevValue, newValue ->
+        if (prevValue != newValue) {
+            updateIcon()
+        }
+    }
+
     init {
         isClickable = false
         isFocusable = false
     }
 
-    internal fun showBrandIcon(brand: CardBrand, shouldShowErrorIcon: Boolean) {
-        if (shouldShowErrorIcon) {
-            iconView.setImageResource(brand.errorIcon)
-        } else {
-            iconView.setImageResource(brand.icon)
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        super.onWindowFocusChanged(hasWindowFocus)
+        // needed to tint CardBrand.Unknown icon
+        updateIcon()
+    }
 
-            if (brand == CardBrand.Unknown) {
-                applyTint()
-            }
+    private fun updateIcon() {
+        if (isLoading) {
+            renderBrandIcon()
+        } else if (shouldShowErrorIcon) {
+            iconView.setImageResource(brand.errorIcon)
+        } else if (shouldShowCvc && !isLoading) {
+            iconView.setImageResource(brand.cvcIcon)
+            applyTint()
+        } else {
+            renderBrandIcon()
         }
     }
 
-    internal fun showCvcIcon(brand: CardBrand) {
-        iconView.setImageResource(brand.cvcIcon)
-        applyTint()
+    private fun renderBrandIcon() {
+        iconView.setImageResource(brand.icon)
+
+        if (brand == CardBrand.Unknown) {
+            applyTint()
+        }
     }
 
-    internal fun applyTint() {
-        val icon = iconView.drawable
-        val compatIcon = DrawableCompat.wrap(icon)
-        DrawableCompat.setTint(compatIcon.mutate(), tintColorInt)
-        iconView.setImageDrawable(DrawableCompat.unwrap(compatIcon))
+    private fun applyTint() {
+        iconView.setImageDrawable(
+            DrawableCompat.unwrap(
+                DrawableCompat.wrap(iconView.drawable).also { compatIcon ->
+                    DrawableCompat.setTint(compatIcon.mutate(), tintColorInt)
+                }
+            )
+        )
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -75,15 +75,20 @@ internal class CardBrandView @JvmOverloads constructor(
     }
 
     private fun updateIcon() {
-        if (isLoading) {
-            renderBrandIcon()
-        } else if (shouldShowErrorIcon) {
-            iconView.setImageResource(brand.errorIcon)
-        } else if (shouldShowCvc && !isLoading) {
-            iconView.setImageResource(brand.cvcIcon)
-            applyTint()
-        } else {
-            renderBrandIcon()
+        when {
+            isLoading -> {
+                renderBrandIcon()
+            }
+            shouldShowErrorIcon -> {
+                iconView.setImageResource(brand.errorIcon)
+            }
+            shouldShowCvc -> {
+                iconView.setImageResource(brand.cvcIcon)
+                applyTint()
+            }
+            else -> {
+                renderBrandIcon()
+            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -112,12 +112,8 @@ class CardInputWidget @JvmOverloads constructor(
     @VisibleForTesting
     internal var shouldShowErrorIcon = false
         private set(value) {
-            val isValueChange = field != value
+            cardBrandView.shouldShowErrorIcon = value
             field = value
-
-            if (isValueChange) {
-                updateIcon()
-            }
         }
 
     /**
@@ -760,18 +756,18 @@ class CardInputWidget @JvmOverloads constructor(
         postalCodeEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(cvcEditText))
 
         cvcEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            cardBrandView.shouldShowCvc = hasFocus
+
             if (hasFocus) {
                 scrollRight()
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.Cvc)
             }
-            updateIconCvc(hasFocus, cvc?.value)
         }
 
         cvcEditText.setAfterTextChangedListener { text ->
             if (brand.isMaxCvc(text)) {
                 cardInputListener?.onCvcComplete()
             }
-            updateIconCvc(cvcEditText.hasFocus(), text)
         }
 
         cardNumberEditText.completionCallback = {
@@ -780,8 +776,8 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         cardNumberEditText.brandChangeCallback = { brand ->
+            cardBrandView.brand = brand
             hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
-            updateIcon()
             cvcEditText.updateBrand(brand)
         }
 
@@ -976,13 +972,6 @@ class CardInputWidget @JvmOverloads constructor(
         containerLayout.startAnimation(animationSet)
     }
 
-    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
-        super.onWindowFocusChanged(hasWindowFocus)
-        if (hasWindowFocus && CardBrand.Unknown == brand) {
-            cardBrandView.applyTint()
-        }
-    }
-
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         super.onLayout(changed, l, t, r, b)
         if (!isViewInitialized && width != 0) {
@@ -1043,31 +1032,6 @@ class CardInputWidget @JvmOverloads constructor(
                 "0".repeat(peekSize)
             }
         }
-
-    private fun updateIcon() {
-        cardBrandView.showBrandIcon(brand, shouldShowErrorIcon)
-    }
-
-    private fun updateIconCvc(
-        hasFocus: Boolean,
-        cvcText: String?
-    ) {
-        when {
-            shouldShowErrorIcon -> {
-                updateIcon()
-            }
-            shouldIconShowBrand(brand, hasFocus, cvcText) -> {
-                updateIcon()
-            }
-            else -> {
-                updateIconForCvcEntry()
-            }
-        }
-    }
-
-    private fun updateIconForCvcEntry() {
-        cardBrandView.showCvcIcon(brand)
-    }
 
     private abstract class CardFieldAnimation : Animation() {
         init {


### PR DESCRIPTION
The logic for what icon to render in `CardBrandView` was split between
`CardBrandView` and `CardInputWidget`. Refactor `CardBrandView` to
handle what drawable to show based on the current state of the view.
Update state from `CardInputWidget`.

Update icon rendering rules to make loading state have precedent
over all other states. For example, previously loading indicator
would be shown over the CVC icon if the CVC field was focused. Now,
if the CVC field is focused while loading, the loading indicator will
show until loading is complete. After that, the CVC icon will be shown.