### PR TITLE
Add RTL support to card widgets

### DIFF
--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -50,10 +50,10 @@
 
     <dimen name="stripe_card_widget_progress_size">12dp</dimen>
 
-    <!--    Checkout -->
+    <!-- Checkout -->
     <dimen name="stripe_checkout_payment_method_icon_size">76dp</dimen>
     <dimen name="stripe_checkout_outer_spacing">10dp</dimen>
 
-    <dimen name="stripe_card_number_text_input_layout_progress_left_margin">25dp</dimen>
+    <dimen name="stripe_card_number_text_input_layout_progress_start_margin">25dp</dimen>
     <dimen name="stripe_card_number_text_input_layout_progress_top_margin">10dp</dimen>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidgetPlacement.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidgetPlacement.kt
@@ -21,53 +21,53 @@ internal data class CardInputWidgetPlacement(
 
     internal var cardTouchBufferLimit: Int = 0,
     internal var dateStartPosition: Int = 0,
-    internal var dateRightTouchBufferLimit: Int = 0,
+    internal var dateEndTouchBufferLimit: Int = 0,
     internal var cvcStartPosition: Int = 0,
-    internal var cvcRightTouchBufferLimit: Int = 0,
+    internal var cvcEndTouchBufferLimit: Int = 0,
     internal var postalCodeStartPosition: Int = 0
 ) {
-    private val cardPeekDateLeftMargin: Int
+    private val cardPeekDateStartMargin: Int
         @JvmSynthetic
         get() {
             return peekCardWidth + cardDateSeparation
         }
 
-    private val cardPeekCvcLeftMargin: Int
+    private val cardPeekCvcStartMargin: Int
         @JvmSynthetic
         get() {
-            return cardPeekDateLeftMargin + dateWidth + dateCvcSeparation
+            return cardPeekDateStartMargin + dateWidth + dateCvcSeparation
         }
 
-    private val cardPeekPostalCodeLeftMargin: Int
+    private val cardPeekPostalCodeStartMargin: Int
         @JvmSynthetic
         get() {
-            return cardPeekCvcLeftMargin + postalCodeWidth + cvcPostalCodeSeparation
+            return cardPeekCvcStartMargin + postalCodeWidth + cvcPostalCodeSeparation
         }
 
     @JvmSynthetic
-    internal fun getDateLeftMargin(isFullCard: Boolean): Int {
+    internal fun getDateStartMargin(isFullCard: Boolean): Int {
         return if (isFullCard) {
             cardWidth + cardDateSeparation
         } else {
-            cardPeekDateLeftMargin
+            cardPeekDateStartMargin
         }
     }
 
     @JvmSynthetic
-    internal fun getCvcLeftMargin(isFullCard: Boolean): Int {
+    internal fun getCvcStartMargin(isFullCard: Boolean): Int {
         return if (isFullCard) {
             totalLengthInPixels
         } else {
-            cardPeekCvcLeftMargin
+            cardPeekCvcStartMargin
         }
     }
 
     @JvmSynthetic
-    internal fun getPostalCodeLeftMargin(isFullCard: Boolean): Int {
+    internal fun getPostalCodeStartMargin(isFullCard: Boolean): Int {
         return if (isFullCard) {
             totalLengthInPixels
         } else {
-            cardPeekPostalCodeLeftMargin
+            cardPeekPostalCodeStartMargin
         }
     }
 
@@ -96,11 +96,11 @@ internal data class CardInputWidgetPlacement(
                 this.dateStartPosition = dateStartPosition
 
                 val cvcStartPosition = dateStartPosition + dateWidth + dateCvcSeparation
-                this.dateRightTouchBufferLimit = cvcStartPosition / 3
+                this.dateEndTouchBufferLimit = cvcStartPosition / 3
                 this.cvcStartPosition = cvcStartPosition
 
                 val postalCodeStartPosition = cvcStartPosition + cvcWidth + cvcPostalCodeSeparation
-                this.cvcRightTouchBufferLimit = postalCodeStartPosition / 3
+                this.cvcEndTouchBufferLimit = postalCodeStartPosition / 3
                 this.postalCodeStartPosition = postalCodeStartPosition
             }
             else -> {
@@ -111,7 +111,7 @@ internal data class CardInputWidgetPlacement(
                 this.cardTouchBufferLimit = frameStart + peekCardWidth + cardDateSeparation / 2
                 this.dateStartPosition = frameStart + peekCardWidth + cardDateSeparation
 
-                this.dateRightTouchBufferLimit = dateStartPosition + dateWidth + dateCvcSeparation / 2
+                this.dateEndTouchBufferLimit = dateStartPosition + dateWidth + dateCvcSeparation / 2
                 this.cvcStartPosition = dateStartPosition + dateWidth + dateCvcSeparation
             }
         }
@@ -126,7 +126,7 @@ internal data class CardInputWidgetPlacement(
      * naturally give focus to that control, and we don't want to interfere with what
      * Android will naturally do in response to that touch.
      *
-     * @param touchX distance in pixels from the left side of this control
+     * @param touchX distance in pixels from the start of this control
      * @return a [Field] that represents the [View] to request focus, or `null`
      * if no such request is necessary.
      */
@@ -163,13 +163,13 @@ internal data class CardInputWidgetPlacement(
                     Field.Expiry
                 touchX < dateStartPosition + dateWidth -> // Just a regular touch on the date editor.
                     null
-                touchX < dateRightTouchBufferLimit -> // We need to act like this was a touch on the date editor
+                touchX < dateEndTouchBufferLimit -> // We need to act like this was a touch on the date editor
                     Field.Expiry
                 touchX < cvcStartPosition -> // We need to act like this was a touch on the cvc editor.
                     Field.Cvc
                 touchX < cvcStartPosition + cvcWidth -> // Just a regular touch on the cvc editor.
                     null
-                touchX < cvcRightTouchBufferLimit -> // We need to act like this was a touch on the cvc editor.
+                touchX < cvcEndTouchBufferLimit -> // We need to act like this was a touch on the cvc editor.
                     Field.Cvc
                 touchX < postalCodeStartPosition -> // We need to act like this was a touch on the postal code editor.
                     Field.PostalCode
@@ -188,7 +188,7 @@ internal data class CardInputWidgetPlacement(
                     Field.Expiry
                 touchX < dateStartPosition + dateWidth -> // Just a regular touch on the date editor.
                     null
-                touchX < dateRightTouchBufferLimit -> // We need to act like this was a touch on the date editor
+                touchX < dateEndTouchBufferLimit -> // We need to act like this was a touch on the date editor
                     Field.Expiry
                 touchX < cvcStartPosition -> // We need to act like this was a touch on the cvc editor.
                     Field.Cvc
@@ -203,9 +203,9 @@ internal data class CardInputWidgetPlacement(
             Touch Buffer Data:
             CardTouchBufferLimit = $cardTouchBufferLimit
             DateStartPosition = $dateStartPosition
-            DateRightTouchBufferLimit = $dateRightTouchBufferLimit
+            DateEndTouchBufferLimit = $dateEndTouchBufferLimit
             CvcStartPosition = $cvcStartPosition
-            CvcRightTouchBufferLimit = $cvcRightTouchBufferLimit
+            CvcEndTouchBufferLimit = $cvcEndTouchBufferLimit
             PostalCodeStartPosition = $postalCodeStartPosition
             """
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
@@ -38,8 +38,8 @@ internal class CardNumberTextInputLayout @JvmOverloads constructor(
 
         // absolutely position the progress view over the brand icon
         progressView.updateLayoutParams<FrameLayout.LayoutParams> {
-            leftMargin = resources.getDimensionPixelSize(
-                R.dimen.stripe_card_number_text_input_layout_progress_left_margin
+            marginStart = resources.getDimensionPixelSize(
+                R.dimen.stripe_card_number_text_input_layout_progress_start_margin
             )
             topMargin = resources.getDimensionPixelSize(
                 R.dimen.stripe_card_number_text_input_layout_progress_top_margin

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetPlacementTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetPlacementTest.kt
@@ -17,9 +17,9 @@ class CardInputWidgetPlacementTest {
         postalCodeWidth = 100,
         cardTouchBufferLimit = 400,
         dateStartPosition = 510,
-        dateRightTouchBufferLimit = 0,
+        dateEndTouchBufferLimit = 0,
         cvcStartPosition = 0,
-        cvcRightTouchBufferLimit = 0,
+        cvcEndTouchBufferLimit = 0,
         postalCodeStartPosition = 0,
     )
 
@@ -36,9 +36,9 @@ class CardInputWidgetPlacementTest {
         postalCodeWidth = 100,
         cardTouchBufferLimit = 66,
         dateStartPosition = 198,
-        dateRightTouchBufferLimit = 110,
+        dateEndTouchBufferLimit = 110,
         cvcStartPosition = 330,
-        cvcRightTouchBufferLimit = 120,
+        cvcEndTouchBufferLimit = 120,
         postalCodeStartPosition = 360
     )
 
@@ -55,9 +55,9 @@ class CardInputWidgetPlacementTest {
         postalCodeWidth = 100,
         cardTouchBufferLimit = 192,
         dateStartPosition = 285,
-        dateRightTouchBufferLimit = 432,
+        dateEndTouchBufferLimit = 432,
         cvcStartPosition = 530,
-        cvcRightTouchBufferLimit = 0,
+        cvcEndTouchBufferLimit = 0,
         postalCodeStartPosition = 0
     )
 
@@ -158,7 +158,7 @@ class CardInputWidgetPlacementTest {
     }
 
     @Test
-    fun getFocusField_whenInDateLeftSlopAfterShift_withPostalCodeEnabled_returnsDateEditor() {
+    fun getFocusField_whenInDateStartSlopAfterShift_withPostalCodeEnabled_returnsDateEditor() {
         // |img==60||---total == 500--------|
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
@@ -191,7 +191,7 @@ class CardInputWidgetPlacementTest {
     }
 
     @Test
-    fun getFocusField_whenInDateLeftSlopAfterShift_withPostalCodeDisabled_returnsDateEditor() {
+    fun getFocusField_whenInDateStartSlopAfterShift_withPostalCodeDisabled_returnsDateEditor() {
         // |img==60||---total == 500--------|
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
@@ -241,7 +241,7 @@ class CardInputWidgetPlacementTest {
     }
 
     @Test
-    fun getFocusField_withPostalCodeDisabled_whenInDateRightSlopAfterShift_returnsDateEditor() {
+    fun getFocusField_withPostalCodeDisabled_whenInDateEndSlopAfterShift_returnsDateEditor() {
         // |img==60||---total == 500--------|
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
@@ -257,7 +257,7 @@ class CardInputWidgetPlacementTest {
     }
 
     @Test
-    fun getFocusField_withPostalCodeEnabled_whenInDateRightSlopAfterShift_returnsDateEditor() {
+    fun getFocusField_withPostalCodeEnabled_whenInDateEndSlopAfterShift_returnsDateEditor() {
         // |img==60||---total == 500--------|
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -136,7 +136,7 @@ internal class CardInputWidgetTest {
                 (it.cardBrandView.layoutParams as ViewGroup.MarginLayoutParams)
                     .also { params ->
                         params.width = 48
-                        params.rightMargin = 12
+                        params.marginEnd = 12
                     }
 
             it.viewTreeObserver
@@ -820,7 +820,7 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 0,
-                    dateRightTouchBufferLimit = 0,
+                    dateEndTouchBufferLimit = 0,
                     cardTouchBufferLimit = 400,
                     dateStartPosition = 510
                 )
@@ -832,7 +832,7 @@ internal class CardInputWidgetTest {
     fun updateToPeekSize_withPostalCodeDisabled_withNoData_returnsExpectedValuesForCommonCardLength() {
         cardInputWidget.postalCodeEnabled = false
 
-        // Moving left uses Visa-style ("common") defaults
+        // Moving to the end uses Visa-style ("common") defaults
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
         cardInputWidget.updateSpaceSizes(
@@ -856,7 +856,7 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 530,
-                    dateRightTouchBufferLimit = 432,
+                    dateEndTouchBufferLimit = 432,
                     cardTouchBufferLimit = 192,
                     dateStartPosition = 285
                 )
@@ -867,7 +867,7 @@ internal class CardInputWidgetTest {
     fun updateToPeekSize_withPostalCodeEnabled_withNoData_returnsExpectedValuesForCommonCardLength() {
         cardInputWidget.postalCodeEnabled = true
 
-        // Moving left uses Visa-style ("common") defaults
+        // Moving to the end uses Visa-style ("common") defaults
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         // |img=60|cardTouchLimit==192|dateStart==285|dateTouchLim==432|cvcStart==530|
         cardInputWidget.updateSpaceSizes(
@@ -891,10 +891,10 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
-                    dateRightTouchBufferLimit = 110,
+                    dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    cvcRightTouchBufferLimit = 120,
+                    cvcEndTouchBufferLimit = 120,
                     postalCodeStartPosition = 360
                 )
             )
@@ -904,7 +904,7 @@ internal class CardInputWidgetTest {
     fun addValidVisaCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
         cardInputWidget.postalCodeEnabled = false
 
-        // Moving left with an actual Visa number does the same as moving when empty.
+        // Moving to the end with an actual Visa number does the same as moving when empty.
         // |(peek==40)--(space==185)--(date==50)--(space==195)--(cvc==30)|
         updateCardNumberAndIdle(VISA_WITH_SPACES)
 
@@ -922,7 +922,7 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 530,
-                    dateRightTouchBufferLimit = 432,
+                    dateEndTouchBufferLimit = 432,
                     cardTouchBufferLimit = 192,
                     dateStartPosition = 285
                 )
@@ -933,7 +933,7 @@ internal class CardInputWidgetTest {
     fun addValidVisaCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
         cardInputWidget.postalCodeEnabled = true
 
-        // Moving left with an actual Visa number does the same as moving when empty.
+        // Moving to the end with an actual Visa number does the same as moving when empty.
         // |(peek==40)--(space==98)--(date==50)--(space==82)--(cvc==30)--(space==0)--(postal==100)|
         updateCardNumberAndIdle(VISA_WITH_SPACES)
 
@@ -951,8 +951,8 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
-                    cvcRightTouchBufferLimit = 120,
-                    dateRightTouchBufferLimit = 110,
+                    cvcEndTouchBufferLimit = 120,
+                    dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
                     postalCodeStartPosition = 360
@@ -964,7 +964,7 @@ internal class CardInputWidgetTest {
     fun addValidAmExCard_withPostalCodeDisabled_scrollsOver_andSetsExpectedDisplayValues() {
         cardInputWidget.postalCodeEnabled = false
 
-        // Moving left with an AmEx number has a larger peek and cvc size.
+        // Moving to the end with an AmEx number has a larger peek and cvc size.
         // |(peek==50)--(space==175)--(date==50)--(space==185)--(cvc==40)|
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
@@ -982,7 +982,7 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 520,
-                    dateRightTouchBufferLimit = 427,
+                    dateEndTouchBufferLimit = 427,
                     cardTouchBufferLimit = 197,
                     dateStartPosition = 285
                 )
@@ -993,7 +993,7 @@ internal class CardInputWidgetTest {
     fun addValidAmExCard_withPostalCodeEnabled_scrollsOver_andSetsExpectedDisplayValues() {
         cardInputWidget.postalCodeEnabled = true
 
-        // Moving left with an AmEx number has a larger peek and cvc size.
+        // Moving to the end with an AmEx number has a larger peek and cvc size.
         // |(peek==50)--(space==88)--(date==50)--(space==72)--(cvc==40)--(space==0)--(postal==100)|
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
@@ -1011,8 +1011,8 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 320,
-                    cvcRightTouchBufferLimit = 120,
-                    dateRightTouchBufferLimit = 106,
+                    cvcEndTouchBufferLimit = 120,
+                    dateEndTouchBufferLimit = 106,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
                     postalCodeStartPosition = 360
@@ -1042,7 +1042,7 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 530,
-                    dateRightTouchBufferLimit = 432,
+                    dateEndTouchBufferLimit = 432,
                     cardTouchBufferLimit = 182,
                     dateStartPosition = 285
                 )
@@ -1071,10 +1071,10 @@ internal class CardInputWidgetTest {
                     cvcPostalCodeSeparation = 0,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
-                    dateRightTouchBufferLimit = 110,
+                    dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    cvcRightTouchBufferLimit = 120,
+                    cvcEndTouchBufferLimit = 120,
                     postalCodeStartPosition = 360
                 )
             )

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -547,7 +547,7 @@ internal class CardMultilineWidgetTest {
             .isEqualTo(View.GONE)
 
         val params = fullGroup.cvcInputLayout.layoutParams as LinearLayout.LayoutParams
-        assertThat(params.rightMargin)
+        assertThat(params.marginEnd)
             .isEqualTo(0)
         assertThat(params.marginEnd)
             .isEqualTo(0)
@@ -575,7 +575,7 @@ internal class CardMultilineWidgetTest {
             .getDimensionPixelSize(R.dimen.stripe_add_card_expiry_middle_margin)
 
         val params = noZipGroup.cvcInputLayout.layoutParams as LinearLayout.LayoutParams
-        assertThat(params.rightMargin)
+        assertThat(params.marginEnd)
             .isEqualTo(expectedMargin)
         assertThat(params.marginEnd)
             .isEqualTo(expectedMargin)


### PR DESCRIPTION
Use `start` instead of `left` and `end` instead of `right`.

Fixes #2852

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/45020849/93790410-ff33b600-fc00-11ea-8460-df47c76452c8.gif) | ![after](https://user-images.githubusercontent.com/45020849/93790423-03f86a00-fc01-11ea-8c82-e8e28cca13f7.gif) |
