### PR TITLE
Revert "Update pinned API version to 2020-08-27"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This release adds support for 19-digit cards in `CardInputWidget` and `CardMulti
 * [#2837](https://github.com/stripe/stripe-android/pull/2837) Upgrade Kotlin to `1.4.10`
 * [#2841](https://github.com/stripe/stripe-android/pull/2841) Add new string translations
     * Adds support for several new languages
-* [#2843](https://github.com/stripe/stripe-android/pull/2843) Update pinned API version to [2020-08-27](https://stripe.com/docs/upgrades#2020-08-27)
 * [#2847](https://github.com/stripe/stripe-android/pull/2847) Update `CardInputWidget` text size for `ldpi` screens
 * [#2854](https://github.com/stripe/stripe-android/pull/2854) Upgrade `com.google.android.material:material` to `1.2.1`
 * [#2867](https://github.com/stripe/stripe-android/pull/2867) Upgrade 3DS2 SDK to `4.1.0`

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -16,7 +16,7 @@ internal data class ApiVersion internal constructor(internal val code: String) {
     }
 
     internal companion object {
-        private const val API_VERSION_CODE: String = "2020-08-27"
+        private const val API_VERSION_CODE: String = "2020-03-02"
 
         private val INSTANCE = ApiVersion(API_VERSION_CODE)
 

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
@@ -38,7 +38,7 @@ class AnalyticsRequestTest {
                         """
                     {"os.name":"android","os.version":"28","bindings.version":"$sdkVersion","lang":"Java","publisher":"Stripe","http.agent":"","application":{"name":"MyAwesomePlugin","version":"1.2.34","url":"https:\/\/myawesomeplugin.info","partner_id":"pp_partner_1234"}}
                         """.trimIndent(),
-                    "Stripe-Version" to Stripe.API_VERSION,
+                    "Stripe-Version" to "2020-03-02",
                     "Authorization" to "Bearer pk_test_123",
                     "Accept-Language" to "en-US",
                     "User-Agent" to "Stripe/v1 AndroidBindings/$sdkVersion MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",

--- a/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -142,7 +142,7 @@ class PaymentMethodEndToEndTest {
         val repository = StripeApiRepository(
             context,
             ApiKeyFixtures.OXXO_PUBLISHABLE_KEY,
-            apiVersion = "${Stripe.API_VERSION};oxxo_beta=v1"
+            apiVersion = "2020-03-02;oxxo_beta=v1"
         )
         val paymentMethod = repository.createPaymentMethod(
             PaymentMethodCreateParams.createOxxo(
@@ -161,7 +161,7 @@ class PaymentMethodEndToEndTest {
         val repository = StripeApiRepository(
             context,
             ApiKeyFixtures.OXXO_PUBLISHABLE_KEY,
-            apiVersion = "${Stripe.API_VERSION};oxxo_beta=v1"
+            apiVersion = "2020-03-02;oxxo_beta=v1"
         )
 
         val missingNameException = assertFailsWith<InvalidRequestException>(

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -114,8 +114,7 @@ public class StripeTest {
 
     @Test
     public void testApiVersion() {
-        assertThat(Stripe.API_VERSION)
-                .isEqualTo("2020-08-27");
+        assertEquals("2020-03-02", Stripe.API_VERSION);
     }
 
     @Test


### PR DESCRIPTION
`2020-08-27` introduces some breaking changes to the `Customer` object that will require further planning