### PR TITLE
Enable ignored tests in CardInputWidgetTest

### DIFF
--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -42,7 +42,6 @@ import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
@@ -638,8 +637,7 @@ internal class CardInputWidgetTest {
             .isNull()
     }
 
-    // TODO(mshafrir-stripe): investigate flaky test
-    @Ignore("Flaky test")
+    @Test
     fun onCompleteCardNumber_whenValid_shiftsFocusToExpiryDate() {
         cardInputWidget.setCardInputListener(cardInputListener)
 
@@ -827,8 +825,7 @@ internal class CardInputWidgetTest {
             )
     }
 
-    // TODO(mshafrir-stripe): investigate flaky test
-    @Ignore("Flaky test")
+    @Test
     fun updateToPeekSize_withPostalCodeDisabled_withNoData_returnsExpectedValuesForCommonCardLength() {
         cardInputWidget.postalCodeEnabled = false
 


### PR DESCRIPTION
These tests seemed to become flaky after the card service integration.
They should now be passing because we now don't query the card service
by default.