### PR TITLE
Remove Stripe.createToken()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ This release adds support for 19-digit cards in `CardInputWidget` and `CardMulti
     * Upgrade `com.nimbusds:nimbus-jose-jwt` to `9.0.1`
     * Guard against crash when `TransactionTimer` is unavailable
 * [#2873](https://github.com/stripe/stripe-android/pull/2873) Fix `CardInputWidget` field rendering in RTL
+* [#2873](https://github.com/stripe/stripe-android/pull/2878) Remove `Stripe.createToken()`
 
-## 15.1.0 - 2020-08-13 
+## 15.1.0 - 2020-08-13
 * [#2671](https://github.com/stripe/stripe-android/pull/2671) Add `cardParams` property to `CardInputWidget` and `CardMultilineWidget`
 * [#2675](https://github.com/stripe/stripe-android/pull/2675) Add `CardParams` methods to `Stripe`
 * [#2677](https://github.com/stripe/stripe-android/pull/2677) Deprecate `Card.create()`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -53,6 +53,7 @@
 - Changes to `Stripe`
     - `createCardParams()` that accepts a `Card` parameter is deprecated.
       Use `createCardParams()` that accepts a `CardParams` parameter instead.
+    - `createToken()` has been removed; use `createCardToken()` instead.
 
 ## Migrating from versions < 15.0.0
 - The SDK now targets JVM 1.8

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -1256,34 +1256,6 @@ class Stripe internal constructor(
      *
      * @param card the [Card] used to create this payment token
      * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
-     * @param callback a [ApiResultCallback] to receive the result or error
-     */
-    @Deprecated(
-        "Deprecated, replace with Stripe#createCardToken()",
-        ReplaceWith("createCardToken(card, idempotencyKey, callback)")
-    )
-    @UiThread
-    @JvmOverloads
-    fun createToken(
-        card: Card,
-        idempotencyKey: String? = null,
-        callback: ApiResultCallback<Token>
-    ) {
-        createCardToken(
-            card,
-            idempotencyKey = idempotencyKey,
-            callback = callback
-        )
-    }
-
-    /**
-     * Create a Card token asynchronously.
-     *
-     * See [Create a card token](https://stripe.com/docs/api/tokens/create_card).
-     * `POST /v1/tokens`
-     *
-     * @param card the [Card] used to create this payment token
-     * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      * @param callback a [ApiResultCallback] to receive the result or error


### PR DESCRIPTION
This method has been deprecated since v12.3.0 (see #1781).