### PR TITLE
Pad day and month of KlarnaSourceParams.billingDob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ This release adds support for 19-digit cards in `CardInputWidget` and `CardMulti
     * Upgrade `com.nimbusds:nimbus-jose-jwt` to `9.0.1`
     * Guard against crash when `TransactionTimer` is unavailable
 * [#2873](https://github.com/stripe/stripe-android/pull/2873) Fix `CardInputWidget` field rendering in RTL
-* [#2873](https://github.com/stripe/stripe-android/pull/2878) Remove `Stripe.createToken()`
+* [#2878](https://github.com/stripe/stripe-android/pull/2878) Remove `Stripe.createToken()`
+* [#2880](https://github.com/stripe/stripe-android/pull/2880) Fix date formatting in `KlarnaSourceParams`
 
 ## 15.1.0 - 2020-08-13
 * [#2671](https://github.com/stripe/stripe-android/pull/2671) Add `cardParams` property to `CardInputWidget` and `CardMultilineWidget`

--- a/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/KlarnaSourceActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
+import com.stripe.android.model.DateOfBirth
 import com.stripe.android.model.KlarnaSourceParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
@@ -144,7 +145,8 @@ class KlarnaSourceActivity : AppCompatActivity() {
                         .setPostalCode("N1 7BE")
                         .build(),
                     billingEmail = "test@example.com",
-                    billingPhone = "02012267709"
+                    billingPhone = "02012267709",
+                    billingDob = DateOfBirth(1, 1, 1990)
                 )
             )
         )

--- a/stripe/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
@@ -115,9 +115,9 @@ data class KlarnaSourceParams @JvmOverloads constructor(
         ).plus(
             billingDob?.let {
                 mapOf(
-                    PARAM_DOB_DAY to it.day,
-                    PARAM_DOB_MONTH to it.month,
-                    PARAM_DOB_YEAR to it.year
+                    PARAM_DOB_DAY to it.day.toString().padStart(2, '0'),
+                    PARAM_DOB_MONTH to it.month.toString().padStart(2, '0'),
+                    PARAM_DOB_YEAR to it.year.toString()
                 )
             }.orEmpty()
         )

--- a/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -23,7 +23,8 @@ internal class SourceEndToEndTest {
             currency = "eur",
             klarnaParams = KlarnaSourceParams(
                 purchaseCountry = "DE",
-                lineItems = LINE_ITEMS
+                lineItems = LINE_ITEMS,
+                billingDob = DateOfBirth(1, 1, 1990)
             )
         )
         val stripe = createStripe(ApiKeyFixtures.KLARNA_PUBLISHABLE_KEY)
@@ -88,7 +89,8 @@ internal class SourceEndToEndTest {
                 customPaymentMethods = setOf(
                     KlarnaSourceParams.CustomPaymentMethods.Installments,
                     KlarnaSourceParams.CustomPaymentMethods.PayIn4
-                )
+                ),
+                billingDob = DateOfBirth(1, 1, 1990)
             )
         )
 
@@ -143,7 +145,8 @@ internal class SourceEndToEndTest {
                 pageOptions = KlarnaSourceParams.PaymentPageOptions(
                     pageTitle = "Very cool checkout page",
                     purchaseType = KlarnaSourceParams.PaymentPageOptions.PurchaseType.Order
-                )
+                ),
+                billingDob = DateOfBirth(1, 1, 1990)
             )
         )
         val stripe = createStripe(ApiKeyFixtures.KLARNA_PUBLISHABLE_KEY)

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
 import com.stripe.android.model.CardParamsFixtures
+import com.stripe.android.model.DateOfBirth
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -28,7 +29,6 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
@@ -46,11 +46,13 @@ internal class StripeEndToEndTest {
                 individual = AccountParams.BusinessTypeParams.Individual(
                     firstName = "Jenny",
                     lastName = "Rosen",
-                    address = AddressFixtures.ADDRESS
+                    address = AddressFixtures.ADDRESS,
+                    dateOfBirth = DateOfBirth(1, 1, 1990)
                 )
             )
         )
-        assertEquals(Token.Type.Account, token?.type)
+        assertThat(requireNotNull(token).type)
+            .isEqualTo(Token.Type.Account)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/KlarnaSourceParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/KlarnaSourceParamsTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class KlarnaSourceParamsTest {
+
+    @Test
+    fun `date and month should be padded when single digit`() {
+        assertThat(
+            KlarnaSourceParams(
+                purchaseCountry = "UK",
+                lineItems = emptyList(),
+                customPaymentMethods = emptySet(),
+                billingDob = DateOfBirth(1, 1, 1990)
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "product" to "payment",
+                "purchase_country" to "UK",
+                "owner_dob_day" to "01",
+                "owner_dob_month" to "01",
+                "owner_dob_year" to "1990",
+            )
+        )
+    }
+
+    @Test
+    fun `date and month should not be padded when two digit`() {
+        assertThat(
+            KlarnaSourceParams(
+                purchaseCountry = "UK",
+                lineItems = emptyList(),
+                customPaymentMethods = emptySet(),
+                billingDob = DateOfBirth(11, 12, 1990)
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "product" to "payment",
+                "purchase_country" to "UK",
+                "owner_dob_day" to "11",
+                "owner_dob_month" to "12",
+                "owner_dob_year" to "1990",
+            )
+        )
+    }
+}


### PR DESCRIPTION
Klarna requires day and month of billing date of birth to be two digit
strings.

Fixes #2879