### PR TITLE
Make publishable key a soft requirement for card widgets

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -297,7 +297,9 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         return mapOf(
             FIELD_ANALYTICS_UA to ANALYTICS_UA,
             FIELD_EVENT to event.toString(),
-            FIELD_PUBLISHABLE_KEY to publishableKeySupplier(),
+            FIELD_PUBLISHABLE_KEY to runCatching {
+                publishableKeySupplier()
+            }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY),
             FIELD_OS_NAME to Build.VERSION.CODENAME,
             FIELD_OS_RELEASE to Build.VERSION.RELEASE,
             FIELD_OS_VERSION to Build.VERSION.SDK_INT,

--- a/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
@@ -60,6 +60,9 @@ internal enum class AnalyticsEvent(internal val code: String) {
     AuthSourceRedirect("auth_source_redirect"),
     AuthSourceResult("auth_source_result"),
 
+    CardMetadataPublishableKeyAvailable("card_metadata_pk_available"),
+    CardMetadataPublishableKeyUnavailable("card_metadata_pk_unavailable"),
+
     CardMetadataLoadedTooSlow("card_metadata_loaded_too_slow"),
     CardMetadataLoadFailure("card_metadata_load_failure"),
     CardMetadataMissingRange("card_metadata_missing_range");

--- a/stripe/src/main/java/com/stripe/android/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiRequest.kt
@@ -50,6 +50,10 @@ internal data class ApiRequest internal constructor(
         init {
             ApiKeyValidator().requireValid(apiKey)
         }
+
+        companion object {
+            const val UNDEFINED_PUBLISHABLE_KEY = "pk_undefined"
+        }
     }
 
     class Factory(

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -292,11 +292,16 @@ class CardNumberEditText internal constructor(
             accountRange?.binRange?.matches(cardNumber) == false
     }
 
-    private fun onCardMetadataLoadedTooSlow() {
+    @JvmSynthetic
+    internal fun onCardMetadataLoadedTooSlow() {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create(
                 analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataLoadedTooSlow),
-                ApiRequest.Options(publishableKeySupplier())
+                ApiRequest.Options(
+                    runCatching {
+                        publishableKeySupplier()
+                    }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
+                )
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android
 
+import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
@@ -21,9 +22,10 @@ import kotlin.test.assertNotNull
 @RunWith(RobolectricTestRunner::class)
 class AnalyticsDataFactoryTest {
     private val packageManager = mock<PackageManager>()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val analyticsDataFactory = AnalyticsDataFactory(
-        ApplicationProvider.getApplicationContext(),
+        context,
         API_KEY
     )
 
@@ -280,6 +282,18 @@ class AnalyticsDataFactoryTest {
                 "99"
             )
         ).containsEntry("3ds2_ui_type", "none")
+    }
+
+    @Test
+    fun `when publishable key is unavailable, create params with undefined key`() {
+        val params = AnalyticsDataFactory(
+            context
+        ) {
+            throw RuntimeException()
+        }.createSourceRetrieveParams("src_123")
+
+        assertThat(params["publishable_key"])
+            .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.cards
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.AnalyticsRequest
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import org.junit.runner.RunWith
@@ -12,8 +13,13 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultCardAccountRangeRepositoryFactoryTest {
+    private val analyticsRequests = mutableListOf<AnalyticsRequest>()
     private val context: Context = ApplicationProvider.getApplicationContext()
-    private val factory = DefaultCardAccountRangeRepositoryFactory(context)
+    private val factory = DefaultCardAccountRangeRepositoryFactory(
+        context,
+        { analyticsRequests.add(it) },
+        AnalyticsRequest.Factory()
+    )
 
     @BeforeTest
     fun setup() {
@@ -24,6 +30,10 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
     fun `create() without config should succeed`() {
         assertThat(factory.create())
             .isNotNull()
+        assertThat(analyticsRequests)
+            .hasSize(1)
+        assertThat(analyticsRequests.first().params["event"])
+            .isEqualTo("stripe_android.card_metadata_pk_unavailable")
     }
 
     @Test
@@ -31,5 +41,9 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         assertThat(factory.create())
             .isNotNull()
+        assertThat(analyticsRequests)
+            .hasSize(1)
+        assertThat(analyticsRequests.first().params["event"])
+            .isEqualTo("stripe_android.card_metadata_pk_available")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultCardAccountRangeRepositoryFactoryTest {
@@ -22,10 +21,9 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
     }
 
     @Test
-    fun `create() without config should throw exception`() {
-        assertFailsWith<IllegalStateException> {
-            factory.create()
-        }
+    fun `create() without config should succeed`() {
+        assertThat(factory.create())
+            .isNotNull()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.AnalyticsDataFactory
 import com.stripe.android.AnalyticsRequest
 import com.stripe.android.AnalyticsRequestExecutor
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.ApiRequest
 import com.stripe.android.CardNumberFixtures
 import com.stripe.android.CardNumberFixtures.AMEX_BIN
 import com.stripe.android.CardNumberFixtures.AMEX_NO_SPACES
@@ -839,6 +840,28 @@ internal class CardNumberEditTextTest {
             .hasSize(1)
         assertThat(analyticsRequests.first().params["event"])
             .isEqualTo("stripe_android.card_metadata_loaded_too_slow")
+    }
+
+    @Test
+    fun `onCardMetadataLoadedTooSlow() when publishable key is unavailable uses undefined publishable key`() {
+        val analyticsRequests = mutableListOf<AnalyticsRequest>()
+
+        CardNumberEditText(
+            context,
+            workContext = testDispatcher,
+            cardAccountRangeRepository = cardAccountRangeRepository,
+            analyticsRequestExecutor = {
+                analyticsRequests.add(it)
+            },
+            analyticsRequestFactory = analyticsRequestFactory,
+            analyticsDataFactory = analyticsDataFactory,
+            publishableKeySupplier = {
+                throw RuntimeException()
+            }
+        ).onCardMetadataLoadedTooSlow()
+
+        assertThat(analyticsRequests.first().options.apiKey)
+            .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
     }
 
     private fun verifyCardBrandBin(


### PR DESCRIPTION
The card service integration requires a publishable key. When the
publishable key is not defined via `PaymentConfiguration.init()`,
instead of crashing, do not call the card service
(see `DefaultCardAccountRangeRepositoryFactory`).

Additionally, for analytics requests, default to an undefined
publishable key when a publishable key is not available.