### PR TITLE
Refactor PaymentFlowViewModel.validateShippingInformation()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -211,21 +211,20 @@ class PaymentFlowActivity : StripeActivity() {
             shippingInformation
         ).observe(
             this,
-            {
-                it.fold(
+            { result ->
+                result.fold(
                     // show shipping methods screen
                     onSuccess = ::onShippingInfoValidated,
 
-                    onFailure = { t ->
-                        // show error on current screen
-                        onShippingInfoError(t.message)
-                    }
+                    // show error on current screen
+                    onFailure = ::onShippingInfoError
                 )
             }
         )
     }
 
-    private fun onShippingInfoError(errorMessage: String?) {
+    private fun onShippingInfoError(error: Throwable) {
+        val errorMessage = error.message
         isProgressBarVisible = false
         if (!errorMessage.isNullOrEmpty()) {
             showError(errorMessage)

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.liveData
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession
 import com.stripe.android.PaymentSessionConfig
@@ -13,11 +13,14 @@ import com.stripe.android.StripeError
 import com.stripe.android.model.Customer
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 internal class PaymentFlowViewModel(
     private val customerSession: CustomerSession,
-    internal var paymentSessionData: PaymentSessionData
+    internal var paymentSessionData: PaymentSessionData,
+    private val workContext: CoroutineContext
 ) : ViewModel() {
     internal var shippingMethods: List<ShippingMethod> = emptyList()
     internal var isShippingInfoSubmitted: Boolean = false
@@ -64,22 +67,26 @@ internal class PaymentFlowViewModel(
         shippingInfoValidator: PaymentSessionConfig.ShippingInformationValidator,
         shippingMethodsFactory: PaymentSessionConfig.ShippingMethodsFactory?,
         shippingInformation: ShippingInformation
-    ): LiveData<Result<List<ShippingMethod>>> {
-        val resultData = MutableLiveData<Result<List<ShippingMethod>>>()
-        viewModelScope.launch {
+    ) = liveData {
+        val result = withContext(workContext) {
             val isValid = shippingInfoValidator.isValid(shippingInformation)
             if (isValid) {
-                val shippingMethods =
+                runCatching {
                     shippingMethodsFactory?.create(shippingInformation).orEmpty()
-                this@PaymentFlowViewModel.shippingMethods = shippingMethods
-                resultData.postValue(Result.success(shippingMethods))
+                }
             } else {
-                val errorMessage = shippingInfoValidator.getErrorMessage(shippingInformation)
-                this@PaymentFlowViewModel.shippingMethods = emptyList()
-                resultData.postValue(Result.failure(RuntimeException(errorMessage)))
+                runCatching {
+                    shippingInfoValidator.getErrorMessage(shippingInformation)
+                }.fold(
+                    onSuccess = { RuntimeException(it) },
+                    onFailure = { it }
+                ).let {
+                    Result.failure(it)
+                }
             }
         }
-        return resultData
+        shippingMethods = result.getOrDefault(emptyList())
+        emit(result)
     }
 
     internal class Factory(
@@ -89,7 +96,8 @@ internal class PaymentFlowViewModel(
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return PaymentFlowViewModel(
                 customerSession,
-                paymentSessionData
+                paymentSessionData,
+                Dispatchers.IO
             ) as T
         }
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowViewModelTest.kt
@@ -15,30 +15,28 @@ import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class PaymentFlowViewModelTest {
     private val customerSession: CustomerSession = mock()
-
     private val customerRetrievalListener = argumentCaptor<CustomerSession.CustomerRetrievalListener>()
 
-    private val viewModel: PaymentFlowViewModel by lazy {
-        PaymentFlowViewModel(
-            customerSession = customerSession,
-            paymentSessionData = PaymentSessionData(PaymentSessionFixtures.CONFIG)
-        )
-    }
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val viewModel = PaymentFlowViewModel(
+        customerSession = customerSession,
+        paymentSessionData = PaymentSessionData(PaymentSessionFixtures.CONFIG),
+        workContext = testDispatcher
+    )
 
     @Test
     fun saveCustomerShippingInformation_onSuccess_returnsExpectedData() {
-        assertFalse(viewModel.isShippingInfoSubmitted)
+        assertThat(viewModel.isShippingInfoSubmitted)
+            .isFalse()
 
         val result =
             viewModel.saveCustomerShippingInformation(ShippingInfoFixtures.DEFAULT)
@@ -54,8 +52,10 @@ class PaymentFlowViewModelTest {
         }
         customerRetrievalListener.firstValue.onCustomerRetrieved(CustomerFixtures.CUSTOMER)
 
-        assertNotNull(customer)
-        assertTrue(viewModel.isShippingInfoSubmitted)
+        assertThat(customer)
+            .isNotNull()
+        assertThat(viewModel.isShippingInfoSubmitted)
+            .isTrue()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Use `liveData` builder
- Do work on `Dispatchers.IO` instead of `viewModelScope`
- Wrap calls with `runCatching` to guard against crashes

## Testing
Manually verified
