### PR TITLE
Re-render shipping methods screen when shipping methods change

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -246,16 +246,24 @@ class PaymentSessionActivity : AppCompatActivity() {
 
     private class ShippingInformationValidator : PaymentSessionConfig.ShippingInformationValidator {
         override fun isValid(shippingInformation: ShippingInformation): Boolean {
-            return shippingInformation.address?.country == Locale.US.country
+            return setOf(Locale.US.country, Locale.CANADA.country)
+                .contains(shippingInformation.address?.country.orEmpty())
         }
 
         override fun getErrorMessage(shippingInformation: ShippingInformation): String {
-            return "The country must be US."
+            return "The country must be US or Canada."
         }
     }
 
     private class ShippingMethodsFactory : PaymentSessionConfig.ShippingMethodsFactory {
-        override fun create(shippingInformation: ShippingInformation) = SHIPPING_METHODS
+        override fun create(
+            shippingInformation: ShippingInformation
+        ): List<ShippingMethod> {
+            return when (shippingInformation.address?.country) {
+                "CA" -> SHIPPING_METHODS_CA
+                else -> SHIPPING_METHODS_US
+            }
+        }
     }
 
     private fun hideProgressBar() {
@@ -327,7 +335,17 @@ class PaymentSessionActivity : AppCompatActivity() {
             "(555) 555-5555"
         )
 
-        private val SHIPPING_METHODS = listOf(
+        private val SHIPPING_METHODS_CA = listOf(
+            ShippingMethod(
+                "Canada Post",
+                "canada-post",
+                599,
+                "CAD",
+                "Arrives in 3-5 days"
+            )
+        )
+
+        private val SHIPPING_METHODS_US = listOf(
             ShippingMethod(
                 "UPS Ground",
                 "ups-ground",

--- a/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentFlowPagerAdapterTest.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.view
 
 import androidx.test.core.app.ApplicationProvider
-import com.nhaarman.mockitokotlin2.mock
-import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSessionFixtures
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -12,14 +10,10 @@ import kotlin.test.assertEquals
 @RunWith(RobolectricTestRunner::class)
 class PaymentFlowPagerAdapterTest {
 
-    private val customerSession: CustomerSession = mock()
-
-    private val adapter: PaymentFlowPagerAdapter by lazy {
-        PaymentFlowPagerAdapter(
-            ApplicationProvider.getApplicationContext(),
-            PaymentSessionFixtures.CONFIG
-        )
-    }
+    private val adapter = PaymentFlowPagerAdapter(
+        ApplicationProvider.getApplicationContext(),
+        PaymentSessionFixtures.CONFIG
+    )
 
     @Test
     fun pageCount_updatesAfterSavingShippingInfo() {


### PR DESCRIPTION
## Summary
`PagerAdapter` does not automatically recreate the views for its items
when `notifyDataSetChanged()` is called. Instead, mark the shipping
methods view as no longer valid in `getItemPosition()`.

## Motivation
Fix issue where only the first result from `ShippingMethodsFactory#create()`
is rendered.

## Testing
![shipping_methods](https://user-images.githubusercontent.com/45020849/94035768-80ba4e00-fd91-11ea-9bcb-e27d5e52c24e.gif)

