### PR TITLE
Add support for configuring a footer layout in payment methods screen

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentSessionActivity.kt
@@ -119,6 +119,7 @@ class PaymentSessionActivity : AppCompatActivity() {
         return PaymentSession(
             activity = this,
             config = PaymentSessionConfig.Builder()
+                .setPaymentMethodsFooter(R.layout.add_payment_method_footer)
                 .setAddPaymentMethodFooter(R.layout.add_payment_method_footer)
                 .setPrepopulatedShippingInfo(EXAMPLE_SHIPPING_INFO)
                 .setHiddenShippingInfoFields()

--- a/stripe/res/layout/payment_methods_activity.xml
+++ b/stripe/res/layout/payment_methods_activity.xml
@@ -28,12 +28,21 @@
             android:layout_below="@id/toolbar"
             android:visibility="gone" />
 
+        <FrameLayout
+            android:id="@+id/footer_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:visibility="gone"/>
+
         <com.stripe.android.view.PaymentMethodsRecyclerView
             android:id="@+id/recycler"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@id/toolbar"
-            android:layout_marginTop="@dimen/stripe_list_top_margin" />
+            android:layout_above="@+id/footer_container"
+            android:layout_marginTop="@dimen/stripe_list_top_margin"
+            android:layout_marginBottom="@dimen/stripe_list_top_margin"/>
     </RelativeLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/stripe/res/values/ids.xml
+++ b/stripe/res/values/ids.xml
@@ -6,4 +6,5 @@
     <item type="id" name="stripe_payment_methods_add_fpx" />
     <item type="id" name="stripe_add_payment_method_form" />
     <item type="id" name="stripe_add_payment_method_footer" />
+    <item type="id" name="stripe_payment_methods_footer" />
 </resources>

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -233,6 +233,7 @@ class PaymentSession @VisibleForTesting internal constructor(
                 .setInitialPaymentMethodId(
                     viewModel.getSelectedPaymentMethodId(selectedPaymentMethodId)
                 )
+                .setPaymentMethodsFooter(config.paymentMethodsFooterLayoutId)
                 .setAddPaymentMethodFooter(config.addPaymentMethodFooterLayoutId)
                 .setIsPaymentSessionActive(true)
                 .setPaymentConfiguration(PaymentConfiguration.getInstance(context))

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -28,9 +28,15 @@ data class PaymentSessionConfig internal constructor(
     val prepopulatedShippingInfo: ShippingInformation? = null,
     val isShippingInfoRequired: Boolean = false,
     val isShippingMethodRequired: Boolean = false,
+
+    @LayoutRes
+    @get:LayoutRes
+    val paymentMethodsFooterLayoutId: Int = 0,
+
     @LayoutRes
     @get:LayoutRes
     val addPaymentMethodFooterLayoutId: Int = 0,
+
     val paymentMethodTypes: List<PaymentMethod.Type> = listOf(PaymentMethod.Type.Card),
     val shouldShowGooglePay: Boolean = false,
     val allowedShippingCountryCodes: Set<String> = emptySet(),
@@ -105,6 +111,9 @@ data class PaymentSessionConfig internal constructor(
         private var canDeletePaymentMethods: Boolean = true
 
         @LayoutRes
+        private var paymentMethodsFooterLayoutId: Int = 0
+
+        @LayoutRes
         private var addPaymentMethodFooterLayoutId: Int = 0
 
         /**
@@ -162,6 +171,16 @@ data class PaymentSessionConfig internal constructor(
          */
         fun setShippingMethodsRequired(shippingMethodsRequired: Boolean): Builder = apply {
             this.shippingMethodsRequired = shippingMethodsRequired
+        }
+
+        /**
+         * @param paymentMethodsFooterLayoutId optional layout id that will be inflated and
+         * displayed beneath the payment method selection list on [PaymentMethodsActivity]
+         */
+        fun setPaymentMethodsFooter(
+            @LayoutRes paymentMethodsFooterLayoutId: Int
+        ): Builder = apply {
+            this.paymentMethodsFooterLayoutId = paymentMethodsFooterLayoutId
         }
 
         /**
@@ -266,6 +285,7 @@ data class PaymentSessionConfig internal constructor(
                 prepopulatedShippingInfo = shippingInformation,
                 isShippingInfoRequired = shippingInfoRequired,
                 isShippingMethodRequired = shippingMethodsRequired,
+                paymentMethodsFooterLayoutId = paymentMethodsFooterLayoutId,
                 addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId,
                 paymentMethodTypes = paymentMethodTypes,
                 shouldShowGooglePay = shouldShowGooglePay,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -2,12 +2,20 @@ package com.stripe.android.view
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
+import android.text.util.Linkify
 import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.util.LinkifyCompat
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.CustomerSession
+import com.stripe.android.R
 import com.stripe.android.databinding.PaymentMethodsActivityBinding
 import com.stripe.android.exception.StripeException
 import com.stripe.android.model.PaymentMethod
@@ -112,6 +120,15 @@ class PaymentMethodsActivity : AppCompatActivity() {
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+        }
+
+        createFooterView(viewBinding.footerContainer)?.let { footer ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                viewBinding.recycler.accessibilityTraversalBefore = footer.id
+                footer.accessibilityTraversalAfter = viewBinding.recycler.id
+            }
+            viewBinding.footerContainer.addView(footer)
+            viewBinding.footerContainer.visibility = View.VISIBLE
         }
 
         fetchCustomerPaymentMethods()
@@ -258,6 +275,27 @@ class PaymentMethodsActivity : AppCompatActivity() {
         )
 
         finish()
+    }
+
+    private fun createFooterView(
+        contentRoot: ViewGroup
+    ): View? {
+        return if (args.paymentMethodsFooterLayoutId > 0) {
+            val footerView = layoutInflater.inflate(
+                args.paymentMethodsFooterLayoutId,
+                contentRoot,
+                false
+            )
+            footerView.id = R.id.stripe_payment_methods_footer
+            if (footerView is TextView) {
+                LinkifyCompat.addLinks(footerView, Linkify.ALL)
+                ViewCompat.enableAccessibleClickableSpanSupport(footerView)
+                footerView.movementMethod = LinkMovementMethod.getInstance()
+            }
+            footerView
+        } else {
+            null
+        }
     }
 
     override fun onDestroy() {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -39,6 +39,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
     @Parcelize
     data class Args internal constructor(
         internal val initialPaymentMethodId: String?,
+        @LayoutRes val paymentMethodsFooterLayoutId: Int,
         @LayoutRes val addPaymentMethodFooterLayoutId: Int,
         internal val isPaymentSessionActive: Boolean,
         internal val paymentMethodTypes: List<PaymentMethod.Type>,
@@ -60,6 +61,9 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             private var canDeletePaymentMethods: Boolean = true
             private var paymentConfiguration: PaymentConfiguration? = null
             private var windowFlags: Int? = null
+
+            @LayoutRes
+            private var paymentMethodsFooterLayoutId: Int = 0
 
             @LayoutRes
             private var addPaymentMethodFooterLayoutId: Int = 0
@@ -114,6 +118,16 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
             }
 
             /**
+             * @param paymentMethodsFooterLayoutId optional layout id that will be inflated and
+             * displayed beneath the payment method selection list on [PaymentMethodsActivity]
+             */
+            fun setPaymentMethodsFooter(
+                @LayoutRes paymentMethodsFooterLayoutId: Int
+            ): Builder = apply {
+                this.paymentMethodsFooterLayoutId = paymentMethodsFooterLayoutId
+            }
+
+            /**
              * @param addPaymentMethodFooterLayoutId optional layout id that will be inflated and
              * displayed beneath the payment details collection form on [AddPaymentMethodActivity]
              */
@@ -148,6 +162,7 @@ class PaymentMethodsActivityStarter : ActivityStarter<PaymentMethodsActivity, Ar
                     shouldShowGooglePay = shouldShowGooglePay,
                     useGooglePay = useGooglePay,
                     paymentConfiguration = paymentConfiguration,
+                    paymentMethodsFooterLayoutId = paymentMethodsFooterLayoutId,
                     addPaymentMethodFooterLayoutId = addPaymentMethodFooterLayoutId,
                     windowFlags = windowFlags,
                     billingAddressFields = billingAddressFields,


### PR DESCRIPTION
## Summary
The footer layout id can be specified via
- `PaymentSessionConfig.Builder#setPaymentMethodsFooter()`
- `PaymentMethodsActivityStarter.Args.Builder#setPaymentMethodsFooter()`

## Motivation
ANDROID-576

## Demo
![footer](https://user-images.githubusercontent.com/45020849/94154551-000c5800-fe4c-11ea-8eae-399937f5244b.gif)
