### PR TITLE
Only allow digits in BECS BSB and account number fields

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitAccountNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitAccountNumberEditText.kt
@@ -2,7 +2,7 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.text.InputFilter
-import android.text.method.DigitsKeyListener
+import android.text.InputType
 import android.util.AttributeSet
 import androidx.core.widget.doAfterTextChanged
 import com.stripe.android.R
@@ -33,7 +33,7 @@ internal class BecsDebitAccountNumberEditText @JvmOverloads constructor(
 
     init {
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH))
-        keyListener = DigitsKeyListener.getInstance(false, true)
+        inputType = InputType.TYPE_CLASS_NUMBER
 
         doAfterTextChanged {
             shouldShowError = false

--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
@@ -3,7 +3,7 @@ package com.stripe.android.view
 import android.content.Context
 import android.text.Editable
 import android.text.InputFilter
-import android.text.method.DigitsKeyListener
+import android.text.InputType
 import android.util.AttributeSet
 import com.stripe.android.R
 
@@ -50,7 +50,7 @@ internal class BecsDebitBsbEditText @JvmOverloads constructor(
 
     init {
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH))
-        keyListener = DigitsKeyListener.getInstance(false, true)
+        inputType = InputType.TYPE_CLASS_NUMBER
 
         addTextChangedListener(
             object : StripeTextWatcher() {
@@ -63,7 +63,7 @@ internal class BecsDebitBsbEditText @JvmOverloads constructor(
                         return
                     }
 
-// skip formatting if past the separator
+                    // skip formatting if past the separator
                     if (start > 4) {
                         return
                     }

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitAccountNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitAccountNumberEditTextTest.kt
@@ -45,4 +45,11 @@ class BecsDebitAccountNumberEditTextTest {
         assertThat(accountNumberEditText.errorMessage)
             .isNull()
     }
+
+    @Test
+    fun `field should remove non-digits from input`() {
+        accountNumberEditText.append("212.121")
+        assertThat(accountNumberEditText.fieldText)
+            .isEqualTo("212121")
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitBsbEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitBsbEditTextTest.kt
@@ -49,6 +49,13 @@ class BecsDebitBsbEditTextTest {
     }
 
     @Test
+    fun `field should remove non-digits from input`() {
+        bsbEditText.setText("212.121")
+        assertThat(bsbEditText.fieldText)
+            .isEqualTo("212-121")
+    }
+
+    @Test
     fun bsb_whenError_updatesErrorrMessage() {
         bsbEditText.bsb
         assertThat(bsbEditText.errorMessage)


### PR DESCRIPTION
Added unit tests

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/45020849/94281472-ae7fce00-ff1c-11ea-8fe7-53443218b77b.gif) | ![after](https://user-images.githubusercontent.com/45020849/94281483-b17abe80-ff1c-11ea-895c-8095d4255922.gif) |

