### PR TITLE
Restore selected payment method when navigating back to PaymentSheetPaymentMethodsListFragment

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsAdapter.kt
@@ -8,16 +8,16 @@ import com.stripe.android.R
 import com.stripe.android.databinding.LayoutPaymentsheetAddCardItemBinding
 import com.stripe.android.databinding.LayoutPaymentsheetPaymentMethodItemBinding
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.model.Selection
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import java.lang.IllegalStateException
 
 internal class PaymentSheetPaymentMethodsAdapter(
     val paymentMethods: List<PaymentMethod>,
-    selectedPaymentMethod: Selection?,
-    val paymentMethodSelectedListener: (Selection) -> Unit,
+    selectedPaymentMethod: PaymentSelection?,
+    val paymentMethodSelectedListener: (PaymentSelection) -> Unit,
     val addCardClickListener: View.OnClickListener
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private var selectedPaymentMethodId: String? = (selectedPaymentMethod as? Selection.Saved)?.paymentMethodId
+    private var selectedPaymentMethodId: String? = (selectedPaymentMethod as? PaymentSelection.Saved)?.paymentMethodId
 
     init {
         setHasStableIds(true)
@@ -33,7 +33,7 @@ internal class PaymentSheetPaymentMethodsAdapter(
             notifyItemChanged(position)
             selectedPaymentMethodId = paymentMethods.getOrNull(position)?.id
             selectedPaymentMethodId?.let {
-                paymentMethodSelectedListener(Selection.Saved(it))
+                paymentMethodSelectedListener(PaymentSelection.Saved(it))
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsAdapter.kt
@@ -8,10 +8,16 @@ import com.stripe.android.R
 import com.stripe.android.databinding.LayoutPaymentsheetAddCardItemBinding
 import com.stripe.android.databinding.LayoutPaymentsheetPaymentMethodItemBinding
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.Selection
 import java.lang.IllegalStateException
 
-internal class PaymentSheetPaymentMethodsAdapter(val paymentMethods: List<PaymentMethod>, val addCardClickListener: View.OnClickListener) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private var selectedPaymentMethodId: String? = null
+internal class PaymentSheetPaymentMethodsAdapter(
+    val paymentMethods: List<PaymentMethod>,
+    selectedPaymentMethod: Selection?,
+    val paymentMethodSelectedListener: (Selection) -> Unit,
+    val addCardClickListener: View.OnClickListener
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private var selectedPaymentMethodId: String? = (selectedPaymentMethod as? Selection.Saved)?.paymentMethodId
 
     init {
         setHasStableIds(true)
@@ -26,6 +32,9 @@ internal class PaymentSheetPaymentMethodsAdapter(val paymentMethods: List<Paymen
             notifyItemChanged(currentlySelectedPosition)
             notifyItemChanged(position)
             selectedPaymentMethodId = paymentMethods.getOrNull(position)?.id
+            selectedPaymentMethodId?.let {
+                paymentMethodSelectedListener(Selection.Saved(it))
+            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -1,23 +1,22 @@
 package com.stripe.android.paymentsheet
 
-import android.app.Application
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetPaymentMethodsListBinding
-import com.stripe.android.paymentsheet.model.Selection
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentSheetPaymentMethodsListFragment : Fragment(R.layout.fragment_paymentsheet_payment_methods_list) {
     private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(requireActivity().application)
     }
 
-    private val fragmentViewModel by viewModels<ViewModel>()
+    private val fragmentViewModel by viewModels<VM>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -48,7 +47,7 @@ internal class PaymentSheetPaymentMethodsListFragment : Fragment(R.layout.fragme
         }
     }
 
-    internal class ViewModel(application: Application) : AndroidViewModel(application) {
-        internal var selectedPaymentMethod: Selection? = null
+    internal class VM : ViewModel() {
+        internal var selectedPaymentMethod: PaymentSelection? = null
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentsheet.model
+
+import com.stripe.android.model.PaymentMethodCreateParams
+
+internal sealed class PaymentSelection {
+    object GooglePay : PaymentSelection()
+    data class Saved(val paymentMethodId: String) : PaymentSelection()
+    data class New(val paymentMethodCreateParams: PaymentMethodCreateParams) : PaymentSelection()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/Selection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/Selection.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentsheet.model
+
+import com.stripe.android.model.PaymentMethodCreateParams
+
+internal sealed class Selection {
+    object GooglePay : Selection()
+    data class Saved(val paymentMethodId: String) : Selection()
+    data class New(val paymentMethodCreateParams: PaymentMethodCreateParams) : Selection()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/Selection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/Selection.kt
@@ -1,9 +1,0 @@
-package com.stripe.android.paymentsheet.model
-
-import com.stripe.android.model.PaymentMethodCreateParams
-
-internal sealed class Selection {
-    object GooglePay : Selection()
-    data class Saved(val paymentMethodId: String) : Selection()
-    data class New(val paymentMethodCreateParams: PaymentMethodCreateParams) : Selection()
-}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Store the selected payment method locally in PaymentSheetPaymentMethodsListFragment so that it can be restored if the user navigates back

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
![mc-restore-selected-pm](https://user-images.githubusercontent.com/47332718/94754736-f3ee3200-0346-11eb-9f3a-575079d607d9.gif)

