### PR TITLE
Don't show card brand when multiple accounts match

### DIFF
--- a/stripe/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
@@ -4,9 +4,13 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.BinRange
 
 internal class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
-    override fun match(
+    override fun first(
         cardNumber: CardNumber.Unvalidated
-    ) = ACCOUNTS.firstOrNull { it.binRange.matches(cardNumber) }
+    ) = filter(cardNumber).firstOrNull()
+
+    override fun filter(
+        cardNumber: CardNumber.Unvalidated
+    ): List<AccountRange> = ACCOUNTS.filter { it.binRange.matches(cardNumber) }
 
     internal companion object {
         private val VISA_ACCOUNTS =
@@ -59,7 +63,7 @@ internal class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
             )
         }
 
-        private val DISCOVER_ACCOUNTS = setOf(
+        internal val DISCOVER_ACCOUNTS = setOf(
             BinRange(
                 low = "6000000000000000",
                 high = "6099999999999999"

--- a/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRangeSource.kt
@@ -15,6 +15,6 @@ internal class StaticCardAccountRangeSource(
     override suspend fun getAccountRange(
         cardNumber: CardNumber.Unvalidated
     ): AccountRange? {
-        return accountRanges.match(cardNumber)
+        return accountRanges.first(cardNumber)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRanges.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/StaticCardAccountRanges.kt
@@ -3,7 +3,15 @@ package com.stripe.android.cards
 import com.stripe.android.model.AccountRange
 
 internal interface StaticCardAccountRanges {
-    fun match(
+    /**
+     * Return the first [AccountRange] that contains the given [cardNumber], or `null`.
+     */
+    fun first(
         cardNumber: CardNumber.Unvalidated
     ): AccountRange?
+
+    /**
+     * Return all [AccountRange]s that contain the given [cardNumber].
+     */
+    fun filter(cardNumber: CardNumber.Unvalidated): List<AccountRange>
 }

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -131,7 +131,7 @@ class CardNumberEditText internal constructor(
 
     internal val panLength: Int
         get() = accountRange?.panLength
-            ?: staticCardAccountRanges.match(unvalidatedCardNumber)?.panLength
+            ?: staticCardAccountRanges.first(unvalidatedCardNumber)?.panLength
             ?: CardNumber.DEFAULT_PAN_LENGTH
 
     private val formattedPanLength: Int
@@ -334,7 +334,14 @@ class CardNumberEditText internal constructor(
             }
 
             val cardNumber = CardNumber.Unvalidated(s?.toString().orEmpty())
-            val staticAccountRange = staticCardAccountRanges.match(cardNumber)
+            val staticAccountRange = staticCardAccountRanges.filter(cardNumber)
+                .let { accountRanges ->
+                    if (accountRanges.size == 1) {
+                        accountRanges.first()
+                    } else {
+                        null
+                    }
+                }
             if (staticAccountRange == null || shouldQueryRepository(staticAccountRange)) {
                 // query for AccountRange data
                 queryAccountRangeRepository(cardNumber)

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultStaticCardAccountRangesTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultStaticCardAccountRangesTest.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.cards
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
+import kotlin.test.Test
+
+class DefaultStaticCardAccountRangesTest {
+
+    @Test
+    fun `filter with matching accounts should return non-empty`() {
+        assertThat(
+            DefaultStaticCardAccountRanges().filter(
+                CardNumber.Unvalidated("6")
+            )
+        ).hasSize(4)
+    }
+
+    @Test
+    fun `first with matching accounts should return expected value`() {
+        assertThat(
+            DefaultStaticCardAccountRanges().first(
+                CardNumber.Unvalidated("6")
+            )
+        ).isEqualTo(
+            AccountRange(
+                binRange = BinRange(low = "6000000000000000", high = "6099999999999999"),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Discover,
+                country = null
+            )
+        )
+    }
+
+    @Test
+    fun `filter with no matching accounts should return empty`() {
+        assertThat(
+            DefaultStaticCardAccountRanges().filter(
+                CardNumber.Unvalidated("9")
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `first with no matching accounts should return null`() {
+        assertThat(
+            DefaultStaticCardAccountRanges().first(
+                CardNumber.Unvalidated("9")
+            )
+        ).isNull()
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -286,9 +286,13 @@ internal class CardNumberEditTextTest {
             workContext = testDispatcher,
             cardAccountRangeRepository = NullCardAccountRangeRepository(),
             staticCardAccountRanges = object : StaticCardAccountRanges {
-                override fun match(
+                override fun first(
                     cardNumber: CardNumber.Unvalidated
                 ): AccountRange? = AccountRangeFixtures.UNIONPAY19
+
+                override fun filter(
+                    cardNumber: CardNumber.Unvalidated
+                ): List<AccountRange> = listOf(AccountRangeFixtures.UNIONPAY19)
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
@@ -315,9 +319,13 @@ internal class CardNumberEditTextTest {
             workContext = testDispatcher,
             cardAccountRangeRepository = NullCardAccountRangeRepository(),
             staticCardAccountRanges = object : StaticCardAccountRanges {
-                override fun match(
+                override fun first(
                     cardNumber: CardNumber.Unvalidated
                 ): AccountRange? = null
+
+                override fun filter(
+                    cardNumber: CardNumber.Unvalidated
+                ): List<AccountRange> = emptyList()
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
@@ -747,6 +755,26 @@ internal class CardNumberEditTextTest {
         idleLooper()
         assertThat(repositoryCalls)
             .isEqualTo(0)
+    }
+
+    @Test
+    fun `when first digit matches a single account, show a card brand`() {
+        Dispatchers.setMain(testDispatcher)
+
+        // matches Visa
+        updateCardNumberAndIdle("4")
+        assertThat(lastBrandChangeCallbackInvocation)
+            .isEqualTo(CardBrand.Visa)
+    }
+
+    @Test
+    fun `when first digit matches multiple accounts, don't show a card brand`() {
+        Dispatchers.setMain(testDispatcher)
+
+        // matches Discover and Union Pay
+        updateCardNumberAndIdle("6")
+        assertThat(lastBrandChangeCallbackInvocation)
+            .isEqualTo(CardBrand.Unknown)
     }
 
     @Test


### PR DESCRIPTION
Previously, when typing `"6"` in `CardNumberEditText`, the Discover
logo was shown even though both Discover and UnionPay match. Only show
a logo if there is a single match.

| Before | After |
| - | - |
| ![Screenshot_1601923009](https://user-images.githubusercontent.com/45020849/95121155-a3971b80-071c-11eb-8476-9481bc6bedd3.png) | ![Screenshot_1601924943](https://user-images.githubusercontent.com/45020849/95121201-b7428200-071c-11eb-9996-d97b1702ca64.png) |

