### PR TITLE
Move VERSION_NAME to Stripe.kt

### DIFF
--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.stripe.android"
-    android:versionCode="110"
-    android:versionName="16.0.1">
+    package="com.stripe.android">
 
     <application>
         <activity

--- a/stripe/gradle.properties
+++ b/stripe/gradle.properties
@@ -1,3 +1,4 @@
+# Update Stripe.VERSION_NAME when publishing a new release
 VERSION_NAME=16.0.1
 POM_DESCRIPTION=Stripe Android Bindings
 POM_NAME=stripe-android

--- a/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsDataFactory.kt
@@ -304,7 +304,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
             FIELD_OS_RELEASE to Build.VERSION.RELEASE,
             FIELD_OS_VERSION to Build.VERSION.SDK_INT,
             FIELD_DEVICE_TYPE to DEVICE_TYPE,
-            FIELD_BINDINGS_VERSION to BuildConfig.VERSION_NAME
+            FIELD_BINDINGS_VERSION to Stripe.VERSION_NAME
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/FingerprintRequestParamsFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintRequestParamsFactory.kt
@@ -34,7 +34,7 @@ internal class FingerprintRequestParamsFactory @VisibleForTesting internal const
     internal fun createParams(fingerprintData: FingerprintData?): Map<String, Any> {
         return mapOf(
             "v2" to 1,
-            "tag" to BuildConfig.VERSION_NAME,
+            "tag" to Stripe.VERSION_NAME,
             "src" to "android-sdk",
             "a" to createFirstMap(),
             "b" to createSecondMap(fingerprintData)

--- a/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/RequestHeadersFactory.kt
@@ -65,7 +65,7 @@ internal sealed class RequestHeadersFactory {
                 mapOf(
                     "os.name" to "android",
                     "os.version" to Build.VERSION.SDK_INT.toString(),
-                    "bindings.version" to BuildConfig.VERSION_NAME,
+                    "bindings.version" to Stripe.VERSION_NAME,
                     "lang" to "Java",
                     "publisher" to "Stripe",
                     "http.agent" to systemPropertySupplier(PROP_USER_AGENT)

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -1715,7 +1715,8 @@ class Stripe internal constructor(
         @JvmField
         val API_VERSION: String = ApiVersion.get().code
 
-        const val VERSION: String = "AndroidBindings/${BuildConfig.VERSION_NAME}"
+        internal const val VERSION_NAME = "16.0.1"
+        const val VERSION: String = "AndroidBindings/$VERSION_NAME"
 
         /**
          * Setter for identifying your plug-in or library.

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -98,7 +98,7 @@ class AnalyticsDataFactoryTest {
             "os_release" to "9",
             "os_version" to 28,
             "device_type" to "unknown_Android_robolectric",
-            "bindings_version" to BuildConfig.VERSION_NAME,
+            "bindings_version" to Stripe.VERSION_NAME,
             "app_name" to "com.stripe.android.test",
             "app_version" to 0,
             "product_usage" to ATTRIBUTION.toList(),
@@ -195,7 +195,7 @@ class AnalyticsDataFactoryTest {
         assertEquals(versionCode, params[AnalyticsDataFactory.FIELD_APP_VERSION])
         assertEquals(BuildConfig.LIBRARY_PACKAGE_NAME, params[AnalyticsDataFactory.FIELD_APP_NAME])
 
-        assertEquals(BuildConfig.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
+        assertEquals(Stripe.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
         assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(expectedUaName, params[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
 
@@ -223,7 +223,7 @@ class AnalyticsDataFactoryTest {
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_RELEASE])
         assertNotNull(params[AnalyticsDataFactory.FIELD_OS_NAME])
 
-        assertEquals(BuildConfig.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
+        assertEquals(Stripe.VERSION_NAME, params[AnalyticsDataFactory.FIELD_BINDINGS_VERSION])
         assertEquals(expectedEventName, params[AnalyticsDataFactory.FIELD_EVENT])
         assertEquals(expectedUaName, params[AnalyticsDataFactory.FIELD_ANALYTICS_UA])
 

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestTest.kt
@@ -19,7 +19,7 @@ class AnalyticsRequestTest {
 
     @Test
     fun factoryCreate_createsExpectedObject() {
-        val sdkVersion = BuildConfig.VERSION_NAME
+        val sdkVersion = Stripe.VERSION_NAME
         val analyticsRequest = factory.create(
             params = AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 .createPaymentMethodCreationParams(

--- a/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiRequestHeadersFactoryTest.kt
@@ -52,19 +52,25 @@ class ApiRequestHeadersFactoryTest {
         val headers = createHeaders()
 
         val userAgentData = JSONObject(requireNotNull(headers[ApiRequest.HEADER_STRIPE_CLIENT_USER_AGENT]))
-        assertThat(userAgentData.getString("bindings.version")).isEqualTo(BuildConfig.VERSION_NAME)
-        assertThat(userAgentData.getString("lang")).isEqualTo("Java")
-        assertThat(userAgentData.getString("publisher")).isEqualTo("Stripe")
-        assertThat(userAgentData.getString("os.name")).isEqualTo("android")
-        assertThat(userAgentData.getString("os.version").toInt()).isEqualTo(Build.VERSION.SDK_INT)
-        assertThat(userAgentData.getString("http.agent").isNotBlank()).isTrue()
+        assertThat(userAgentData.getString("bindings.version"))
+            .isEqualTo(Stripe.VERSION_NAME)
+        assertThat(userAgentData.getString("lang"))
+            .isEqualTo("Java")
+        assertThat(userAgentData.getString("publisher"))
+            .isEqualTo("Stripe")
+        assertThat(userAgentData.getString("os.name"))
+            .isEqualTo("android")
+        assertThat(userAgentData.getString("os.version").toInt())
+            .isEqualTo(Build.VERSION.SDK_INT)
+        assertThat(userAgentData.getString("http.agent"))
+            .isNotEmpty()
     }
 
     @Test
     fun headers_correctlyAddsExpectedAdditionalParameters() {
         val headers = createHeaders()
 
-        val expectedUserAgent = "Stripe/v1 AndroidBindings/${BuildConfig.VERSION_NAME}"
+        val expectedUserAgent = "Stripe/v1 AndroidBindings/${Stripe.VERSION_NAME}"
         assertThat(headers["User-Agent"]).isEqualTo(expectedUserAgent)
         assertThat(headers["Accept"]).isEqualTo("application/json")
         assertThat(headers["Accept-Charset"]).isEqualTo("UTF-8")

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -107,7 +107,7 @@ public class StripeTest {
     @Test
     public void testVersion() {
         assertEquals(
-                String.format(Locale.ROOT, "AndroidBindings/%s", BuildConfig.VERSION_NAME),
+                String.format(Locale.ROOT, "AndroidBindings/%s", Stripe.VERSION_NAME),
                 Stripe.VERSION
         );
     }


### PR DESCRIPTION
Android Gradle Plugin 4.1.0 removes `BuildConfig.VERSION_NAME`
for library projects [0].

Remove references to `BuildConfig`. Also remove `versionName` and
`versionCode` from `AndroidManifest.xml`.

[0] https://developer.android.com/studio/releases/gradle-plugin#behavior_changes