### PR TITLE
MC: Fetch payment methods on background thread

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -11,11 +11,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.viewModelScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
-import com.google.android.material.bottomsheet.BottomSheetBehavior.State
 import com.stripe.android.ApiRequest
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
@@ -29,14 +27,17 @@ import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.lang.IllegalStateException
+import kotlin.coroutines.CoroutineContext
 
 internal class PaymentSheetViewModel internal constructor(
     private val publishableKey: String,
     private val stripeAccountId: String?,
     private val stripeRepository: StripeRepository,
-    private val paymentController: PaymentController
+    private val paymentController: PaymentController,
+    private val workContext: CoroutineContext = Dispatchers.IO
 ) : ViewModel() {
     private val mutableError = MutableLiveData<Throwable>()
     private val mutableTransition = MutableLiveData<TransitionTarget>()
@@ -146,7 +147,7 @@ internal class PaymentSheetViewModel internal constructor(
         customerId: String,
         stripeAccountId: String? = this.stripeAccountId
     ) {
-        viewModelScope.launch {
+        CoroutineScope(workContext).launch {
             val result = kotlin.runCatching {
                 stripeRepository.getPaymentMethods(
                     ListPaymentMethodsParams(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -63,8 +63,10 @@ class PaymentSheetActivityTest {
         paymentController = StripePaymentController(
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            stripeRepository
-        )
+            stripeRepository,
+            workContext = testCoroutineDispatcher
+        ),
+        workContext = testCoroutineDispatcher
     )
 
     private val intent = Intent(
@@ -207,8 +209,10 @@ class PaymentSheetActivityTest {
             paymentController = StripePaymentController(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                stripeRepository
-            )
+                stripeRepository,
+                workContext = testCoroutineDispatcher
+            ),
+            workContext = testCoroutineDispatcher
         )
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -24,16 +24,21 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentSheetViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    private val testCoroutineDispatcher = TestCoroutineDispatcher()
 
     private val intent = Intent().putExtra(
         ActivityStarter.Args.EXTRA,
@@ -49,7 +54,8 @@ internal class PaymentSheetViewModelTest {
         "publishable_key",
         "stripe_account_id",
         stripeRepository,
-        paymentController
+        paymentController,
+        workContext = testCoroutineDispatcher
     )
 
     private val activity: Activity = mock()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`getPaymentMethods` may be a `suspend` function but that doesn't mean it won't cause StrictMode violations if you call it on the `viewModelScope` instead of a background thread.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Existing tests pass