### PR TITLE
Update ExpiryDateEditText allowlist

### DIFF
--- a/stripe/res/layout/card_input_widget.xml
+++ b/stripe/res/layout/card_input_widget.xml
@@ -76,8 +76,7 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
                 android:imeOptions="actionNext"
-                android:inputType="date"
-                android:maxLength="5"
+                android:digits="@string/stripe_expiration_date_allowlist"
                 android:hint="@string/expiry_date_hint"
                 style="@style/Stripe.CardInputWidget.EditText"
                 />

--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -49,8 +49,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:imeOptions="actionNext"
-                android:inputType="date"
-                android:maxLength="@integer/stripe_date_length"
+                android:digits="@string/stripe_expiration_date_allowlist"
                 android:nextFocusDown="@+id/et_cvc"
                 android:nextFocusForward="@+id/et_cvc"
                 />

--- a/stripe/res/values/donottranslate.xml
+++ b/stripe/res/values/donottranslate.xml
@@ -5,6 +5,7 @@
     <string name="cvc_amex_hint">CVV</string>
     <string name="cvc_multiline_helper">123</string>
     <string name="cvc_multiline_helper_amex">1234</string>
+    <string name="stripe_expiration_date_allowlist">0123456789/</string>
     <string name="zip_helper">12345</string>
     <string name="paymentsheet_payment_method_item_card_number" translatable="false">····%1$s</string>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -3,6 +3,8 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Build
 import android.text.Editable
+import android.text.InputFilter
+import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
@@ -20,6 +22,13 @@ class ExpiryDateEditText @JvmOverloads constructor(
 ) : StripeEditText(context, attrs, defStyleAttr) {
 
     init {
+        inputType = InputType.TYPE_CLASS_NUMBER
+        filters = listOf(
+            InputFilter.LengthFilter(
+                context.resources.getInteger(R.integer.stripe_date_length)
+            )
+        ).toTypedArray()
+
         setErrorMessage(resources.getString(R.string.invalid_expiry_year))
         listenForTextChanges()
 


### PR DESCRIPTION
Only allow digits and `/` by setting the input type to `number`
and setting `android:digits` to the allowlist.

This prevents `.` and `-` from being entered as input.

Fixes #2972