### PR TITLE
Crash fix for Parent already exist issue

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.children
 import androidx.core.view.updateLayoutParams
@@ -32,6 +33,9 @@ internal class CardNumberTextInputLayout @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+
+        // remove parent from the progress view if already attached earlier
+        (progressView.parent as? ViewGroup)?.removeView(progressView)
 
         // add the progress view to the `TextInputLayout`'s `FrameLayout` container
         (children.first() as FrameLayout).addView(progressView)


### PR DESCRIPTION
## Summary
Check for parent already exists before adding the CardLayout to parent

## Motivation
I have integrated the Stripe UI in react native application using the bridge and came across this error after upgrading to `16.0.1` from `15.1.0`. As I notice, this layout change has been done in `16.0.0` which caused the crash.

```log
2020-10-28 15:18:48.081 14287-14287/com.project.demo E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.project.demo, PID: 14287
    java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
        at android.view.ViewGroup.addViewInner(ViewGroup.java:5235)
        at android.view.ViewGroup.addView(ViewGroup.java:5064)
        at android.view.ViewGroup.addView(ViewGroup.java:5004)
        at android.view.ViewGroup.addView(ViewGroup.java:4976)
        at com.stripe.android.view.CardNumberTextInputLayout.onAttachedToWindow(CardNumberTextInputLayout.kt:37)
        at android.view.View.dispatchAttachedToWindow(View.java:20479)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3489)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3496)
        at android.view.ViewGroup.addViewInner(ViewGroup.java:5278)
        at android.view.ViewGroup.addView(ViewGroup.java:5064)
        at android.view.ViewGroup.addView(ViewGroup.java:5004)
        at androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(FragmentManager.java:1459)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1509)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2019)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1965)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
        at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

## Testing
Replicated the crash process with locally generated AAR file
