### PR TITLE
Update PaymentSheet UI

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
-    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -13,6 +12,7 @@
         android:layout_height="wrap_content"
         android:clipToPadding="true"
         android:background="?colorSurface"
+        android:paddingTop="@dimen/stripe_paymentsheet_padding_top"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <FrameLayout

--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -14,11 +14,18 @@
             android:id="@+id/add_card_header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/stripe_paymentsheet_add_payment_method"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:paddingBottom="10dp"
+            android:text="@string/stripe_paymentsheet_add_payment_method_title"
+            style="@style/StripePaymentSheetTitle"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/stripe_paymentsheet_add_payment_method_card_information"
+            style="@style/StripePaymentSheetLabel"
+            app:layout_constraintTop_toBottomOf="@+id/add_card_header"
             app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget"
             app:layout_constraintStart_toStartOf="parent" />
 
@@ -30,6 +37,15 @@
             app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
             app:layout_constraintStart_toStartOf="parent" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/stripe_paymentsheet_add_payment_method_country_or_region"
+            style="@style/StripePaymentSheetLabel"
+            app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget"
+            app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
+            app:layout_constraintStart_toStartOf="parent" />
+
         <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/save_card_checkbox"
             android:layout_width="wrap_content"
@@ -37,16 +53,7 @@
             android:checked="true"
             app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <TextView
-            android:id="@+id/save_card_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/stripe_paymentsheet_save_this_card"
-            android:labelFor="@+id/save_card_checkbox"
-            app:layout_constraintTop_toTopOf="@+id/save_card_checkbox"
-            app:layout_constraintBaseline_toBaselineOf="@+id/save_card_checkbox"
-            app:layout_constraintStart_toEndOf="@+id/save_card_checkbox" />
+            app:layout_constraintStart_toStartOf="parent"
+            android:text="@string/stripe_paymentsheet_save_this_card"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/stripe/res/layout/fragment_paymentsheet_payment_methods_list.xml
+++ b/stripe/res/layout/fragment_paymentsheet_payment_methods_list.xml
@@ -11,11 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/stripe_paymentsheet_pay_using"
-        android:textColor="@color/stripe_paymentsheet_text"
-        android:textSize="20sp"
-        android:lineSpacingExtra="9sp"
-        android:textStyle="bold"
-        android:layout_marginBottom="10dp"
+        style="@style/StripePaymentSheetTitle"
         />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/stripe/res/values/colors.xml
+++ b/stripe/res/values/colors.xml
@@ -21,8 +21,9 @@
     <color name="stripe_card_widget_progress_background">#4F566B</color>
 
     <!-- Payment Sheet -->
-    <color name="stripe_paymentsheet_text">#303030</color>
+    <color name="stripe_paymentsheet_title_text">#303030</color>
     <color name="stripe_paymentsheet_selected_payment_method">#1EA672</color>
+    <color name="stripe_paymentsheet_payment_method_label_text">#303030</color>
     <color name="stripe_paymentsheet_add_card_tint">#697386</color>
     <color name="stripe_paymentsheet_add_card_background">#E3E8EE</color>
     <color name="stripe_paymentsheet_buybutton_default_background">#0074D4</color>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -51,6 +51,7 @@
     <dimen name="stripe_card_widget_progress_size">12dp</dimen>
 
     <!-- PaymentSheet -->
+    <dimen name="stripe_paymentsheet_padding_top">12dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_height">59dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_width">88dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_radius">6dp</dimen>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -183,7 +183,9 @@
     <string name="stripe_paymentsheet_back" tools:ignore="MissingTranslation">Back</string>
     <string name="stripe_paymentsheet_close" tools:ignore="MissingTranslation">Close</string>
     <string name="stripe_paymentsheet_pay_using" tools:ignore="MissingTranslation">Pay using</string>
-    <string name="stripe_paymentsheet_add_payment_method" tools:ignore="MissingTranslation">Add payment method</string>
+    <string name="stripe_paymentsheet_add_payment_method_title" tools:ignore="MissingTranslation">Add payment method</string>
+    <string name="stripe_paymentsheet_add_payment_method_card_information" tools:ignore="MissingTranslation">Card information</string>
+    <string name="stripe_paymentsheet_add_payment_method_country_or_region" tools:ignore="MissingTranslation">Country or region</string>
     <string name="stripe_paymentsheet_add_payment_method_button" tools:ignore="MissingTranslation">+ Add new</string>
     <string name="stripe_paymentsheet_save_this_card" tools:ignore="MissingTranslation">Save this card</string>
 

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -58,9 +58,24 @@
     </style>
 
     <style name="StripePaymentSheetPaymentMethodsLabel">
-        <item name="android:textColor">@color/stripe_paymentsheet_text</item>
+        <item name="android:textColor">@color/stripe_paymentsheet_payment_method_label_text</item>
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:lineSpacingExtra">1sp</item>
+    </style>
+
+    <style name="StripePaymentSheetTitle">
+        <item name="android:textSize">20sp</item>
+        <item name="android:textColor">@color/stripe_paymentsheet_title_text</item>
+        <item name="android:lineSpacingExtra">9sp</item>
+        <item name="android:layout_marginBottom">10dp</item>
+    </style>
+
+    <style name="StripePaymentSheetLabel">
+        <item name="android:textSize">13sp</item>
+        <item name="android:letterSpacing">-0.01</item>
+        <item name="android:textColor">#565656</item>
+        <item name="android:lineSpacingExtra">5sp</item>
+        <item name="android:layout_marginTop">10dp</item>
     </style>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -170,6 +170,13 @@ internal class PaymentSheetActivity : AppCompatActivity() {
         viewBinding.buyButton.setOnClickListener {
             viewModel.checkout(this)
         }
+
+        viewModel.processing.observe(this) { isProcessing ->
+            viewBinding.close.isEnabled = !isProcessing
+            viewBinding.back.isEnabled = !isProcessing
+
+            viewBinding.buyButton.isEnabled = !isProcessing
+        }
     }
 
     private fun setupBottomSheet() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -58,5 +58,15 @@ internal class PaymentSheetAddCardFragment : Fragment(R.layout.fragment_payments
                 showSoftInput(binding.cardMultilineWidget.cardNumberEditText, InputMethodManager.SHOW_IMPLICIT)
             }
         }
+
+        activityViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->
+            binding.saveCardCheckbox.isEnabled = !isProcessing
+            binding.cardMultilineWidget.isEnabled = !isProcessing
+        }
+
+        activityViewModel.savePaymentMethod = binding.saveCardCheckbox.isChecked
+        binding.saveCardCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            activityViewModel.savePaymentMethod = isChecked
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -64,9 +64,9 @@ internal class PaymentSheetAddCardFragment : Fragment(R.layout.fragment_payments
             binding.cardMultilineWidget.isEnabled = !isProcessing
         }
 
-        activityViewModel.savePaymentMethod = binding.saveCardCheckbox.isChecked
+        activityViewModel.shouldSavePaymentMethod = binding.saveCardCheckbox.isChecked
         binding.saveCardCheckbox.setOnCheckedChangeListener { _, isChecked ->
-            activityViewModel.savePaymentMethod = isChecked
+            activityViewModel.shouldSavePaymentMethod = isChecked
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -52,6 +52,7 @@ internal class PaymentSheetViewModel internal constructor(
     private val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
     private val mutableSelection = MutableLiveData<PaymentSelection?>()
     private val mutableViewState = MutableLiveData<ViewState>(null)
+    private val mutableProcessing = MutableLiveData(false)
 
     internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
     internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
@@ -60,6 +61,9 @@ internal class PaymentSheetViewModel internal constructor(
     internal val selection: LiveData<PaymentSelection?> = mutableSelection
     internal val sheetMode: LiveData<SheetMode> = mutableSheetMode.distinctUntilChanged()
     internal val viewState: LiveData<ViewState> = mutableViewState.distinctUntilChanged()
+    internal val processing = mutableProcessing.distinctUntilChanged()
+
+    internal var savePaymentMethod: Boolean = false
 
     fun onError(throwable: Throwable) {
         mutableError.postValue(throwable)
@@ -133,38 +137,55 @@ internal class PaymentSheetViewModel internal constructor(
     }
 
     fun checkout(activity: Activity) {
+        mutableProcessing.value = true
+
         val args = getPaymentSheetActivityArgs(activity.intent) ?: return
 
-        val confirmParams = when (val selection = selection.value) {
+        val confirmParams = createConfirmParams(args.clientSecret)
+
+        when {
+            confirmParams != null -> {
+                mutableViewState.value = ViewState.Confirming
+                paymentController.startConfirmAndAuth(
+                    AuthActivityStarter.Host.create(activity),
+                    confirmParams,
+                    ApiRequest.Options(
+                        apiKey = publishableKey,
+                        stripeAccount = stripeAccountId
+                    )
+                )
+            }
+            else -> {
+                onError(
+                    IllegalStateException("checkout called when no payment method selected")
+                )
+            }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun createConfirmParams(
+        clientSecret: String
+    ): ConfirmPaymentIntentParams? {
+        return when (val selection = selection.value) {
             PaymentSelection.GooglePay -> TODO("smaskell: handle Google Pay confirmation")
             is PaymentSelection.Saved -> {
                 // TODO(smaskell): Properly set savePaymentMethod/setupFutureUsage
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     selection.paymentMethodId,
-                    args.clientSecret
+                    clientSecret
                 )
             }
             is PaymentSelection.New -> {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     selection.paymentMethodCreateParams,
-                    args.clientSecret
+                    clientSecret,
+                    savePaymentMethod = savePaymentMethod
                 )
             }
             null -> {
-                onError(IllegalStateException("checkout called when no payment method selected"))
                 null
             }
-        }
-        confirmParams?.let {
-            mutableViewState.value = ViewState.Confirming
-            paymentController.startConfirmAndAuth(
-                AuthActivityStarter.Host.create(activity),
-                it,
-                ApiRequest.Options(
-                    apiKey = publishableKey,
-                    stripeAccount = stripeAccountId
-                )
-            )
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -63,7 +63,7 @@ internal class PaymentSheetViewModel internal constructor(
     internal val viewState: LiveData<ViewState> = mutableViewState.distinctUntilChanged()
     internal val processing = mutableProcessing.distinctUntilChanged()
 
-    internal var savePaymentMethod: Boolean = false
+    internal var shouldSavePaymentMethod: Boolean = false
 
     fun onError(throwable: Throwable) {
         mutableError.postValue(throwable)
@@ -180,7 +180,10 @@ internal class PaymentSheetViewModel internal constructor(
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     selection.paymentMethodCreateParams,
                     clientSecret,
-                    savePaymentMethod = savePaymentMethod
+                    setupFutureUsage = when (shouldSavePaymentMethod) {
+                        true -> ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+                        false -> null
+                    }
                 )
             }
             null -> {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -4,6 +4,12 @@ import com.stripe.android.model.PaymentMethodCreateParams
 
 internal sealed class PaymentSelection {
     object GooglePay : PaymentSelection()
-    data class Saved(val paymentMethodId: String) : PaymentSelection()
-    data class New(val paymentMethodCreateParams: PaymentMethodCreateParams) : PaymentSelection()
+
+    data class Saved(
+        val paymentMethodId: String
+    ) : PaymentSelection()
+
+    data class New(
+        val paymentMethodCreateParams: PaymentMethodCreateParams
+    ) : PaymentSelection()
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -188,8 +188,14 @@ internal class PaymentSheetActivityTest {
             idleLooper()
 
             viewModel.updateSelection(PaymentSelection.Saved("saved_pm"))
+            assertThat(activity.viewBinding.buyButton.isEnabled)
+                .isTrue()
+
             activity.viewBinding.buyButton.performClick()
             idleLooper()
+
+            assertThat(activity.viewBinding.buyButton.isEnabled)
+                .isFalse()
 
             // payment intent was confirmed and result will be communicated through PaymentRelayActivity
             val nextActivity = shadowOf(activity).peekNextStartedActivity()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -143,7 +143,7 @@ internal class PaymentSheetViewModelTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     FAKE_CLIENT_SECRET,
-                    savePaymentMethod = false
+                    setupFutureUsage = null
                 )
             ),
             eq(
@@ -156,8 +156,8 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `createConfirmParams() when savePaymentMethod is true should create params with savePaymentMethod = true`() {
-        viewModel.savePaymentMethod = true
+    fun `createConfirmParams() when savePaymentMethod is true should create params with setupFutureUsage = OnSession`() {
+        viewModel.shouldSavePaymentMethod = true
         viewModel.updateSelection(
             PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
         )
@@ -166,7 +166,7 @@ internal class PaymentSheetViewModelTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     FAKE_CLIENT_SECRET,
-                    savePaymentMethod = true
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
                 )
             )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -23,7 +23,7 @@ import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.view.ActivityStarter
@@ -103,6 +103,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.error.observeForever {
             error = it
         }
+
         val activity: Activity = mock()
         whenever(activity.intent).thenReturn(Intent())
         viewModel.checkout(activity)
@@ -118,7 +119,7 @@ internal class PaymentSheetViewModelTest {
             eq(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     "saved_pm",
-                    "client_secret"
+                    FAKE_CLIENT_SECRET
                 )
             ),
             eq(
@@ -132,15 +133,17 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout should confirm new payment methods`() {
-        val createParams: PaymentMethodCreateParams = mock()
-        viewModel.updateSelection(PaymentSelection.New(createParams))
+        viewModel.updateSelection(
+            PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        )
         viewModel.checkout(activity)
         verify(paymentController).startConfirmAndAuth(
             any(),
             eq(
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                    createParams,
-                    "client_secret"
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    FAKE_CLIENT_SECRET,
+                    savePaymentMethod = false
                 )
             ),
             eq(
@@ -150,6 +153,22 @@ internal class PaymentSheetViewModelTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `createConfirmParams() when savePaymentMethod is true should create params with savePaymentMethod = true`() {
+        viewModel.savePaymentMethod = true
+        viewModel.updateSelection(
+            PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        )
+        assertThat(viewModel.createConfirmParams(FAKE_CLIENT_SECRET))
+            .isEqualTo(
+                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    FAKE_CLIENT_SECRET,
+                    savePaymentMethod = true
+                )
+            )
     }
 
     @Test
@@ -274,17 +293,22 @@ internal class PaymentSheetViewModelTest {
     }
 
     private companion object {
-        val FAKE_CARD = PaymentMethod("fake_pm", created = 0, liveMode = false, type = PaymentMethod.Type.Card)
+        val FAKE_CARD = PaymentMethod(
+            "fake_pm",
+            created = 0,
+            liveMode = false,
+            type = PaymentMethod.Type.Card
+        )
+
+        private const val FAKE_CLIENT_SECRET = "client_secret"
 
         private val DEFAULT_ARGS = PaymentSheetActivityStarter.Args.Default(
-            "client_secret",
+            FAKE_CLIENT_SECRET,
             "ephemeral_key",
             "customer_id"
         )
 
-        private val GUEST_ARGS = PaymentSheetActivityStarter.Args.Guest(
-            "client_secret"
-        )
+        private val GUEST_ARGS = PaymentSheetActivityStarter.Args.Guest(FAKE_CLIENT_SECRET)
 
         private val DEFAULT_ARGS_INTENT = Intent()
             .putExtra(


### PR DESCRIPTION
- Add "Save this card" checkbox and pass value to confirm call
- Disable UI (e.g. buy button, card widget) while processing (e.g. buy
  button clicked)
- Update styling to better match designs
