### PR TITLE
Fix PaymentMethodCreateParams annotations

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -673,7 +673,7 @@ data class PaymentMethodCreateParams internal constructor(
             )
         }
 
-        @JvmSynthetic
+        @JvmStatic
         @JvmOverloads
         fun createOxxo(
             billingDetails: PaymentMethod.BillingDetails,
@@ -686,7 +686,7 @@ data class PaymentMethodCreateParams internal constructor(
             )
         }
 
-        @JvmSynthetic
+        @JvmStatic
         @JvmOverloads
         fun createAlipay(
             metadata: Map<String, String>? = null
@@ -697,7 +697,7 @@ data class PaymentMethodCreateParams internal constructor(
             )
         }
 
-        @JvmSynthetic
+        @JvmStatic
         @JvmOverloads
         fun createPayPal(
             metadata: Map<String, String>? = null


### PR DESCRIPTION
Public `create()` methods should be annotated with `@JvmStatic`,
not `@JvmSynthetic`. Only internal methods should be annotated with
`@JvmSynthetic`.