### PR TITLE
Update PaymentSession.handlePaymentData() to take a nullable Intent

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -155,7 +155,9 @@ class PaymentSession @VisibleForTesting internal constructor(
         resultCode: Int,
         data: Intent?
     ): Boolean {
-        if (data == null || !VALID_REQUEST_CODES.contains(requestCode)) {
+        if (data == null) {
+            return false
+        } else if (!isValidRequestCode(requestCode)) {
             return false
         }
 
@@ -327,6 +329,10 @@ class PaymentSession @VisibleForTesting internal constructor(
         internal const val PRODUCT_TOKEN: String = "PaymentSession"
 
         internal const val EXTRA_PAYMENT_SESSION_DATA: String = "extra_payment_session_data"
+
+        private fun isValidRequestCode(
+            requestCode: Int
+        ) = VALID_REQUEST_CODES.contains(requestCode)
 
         private val VALID_REQUEST_CODES = setOf(
             PaymentMethodsActivityStarter.REQUEST_CODE,

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -155,9 +155,13 @@ class PaymentSession @VisibleForTesting internal constructor(
         resultCode: Int,
         data: Intent?
     ): Boolean {
+        // validate Intent
         if (data == null) {
             return false
-        } else if (!isValidRequestCode(requestCode)) {
+        }
+
+        // validate requestCode
+        if (!isValidRequestCode(requestCode)) {
             return false
         }
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSession.kt
@@ -150,8 +150,12 @@ class PaymentSession @VisibleForTesting internal constructor(
      * @return `true` if the activity result was handled by this function,
      * otherwise `false`
      */
-    fun handlePaymentData(requestCode: Int, resultCode: Int, data: Intent): Boolean {
-        if (!VALID_REQUEST_CODES.contains(requestCode)) {
+    fun handlePaymentData(
+        requestCode: Int,
+        resultCode: Int,
+        data: Intent?
+    ): Boolean {
+        if (data == null || !VALID_REQUEST_CODES.contains(requestCode)) {
             return false
         }
 


### PR DESCRIPTION
`handlePaymentData()` is typically called from `onActivityResult()`.
`onActivityResult()` can receive a null `Intent` instance, so make
`handlePaymentData()` match this.

Fixes #2987
