### PR TITLE
Make some StripeRepository methods suspend

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiRepository.kt
@@ -279,7 +279,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         APIConnectionException::class,
         APIException::class
     )
-    override fun retrieveSetupIntent(
+    override suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
@@ -423,7 +423,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         APIConnectionException::class,
         APIException::class
     )
-    override fun retrieveSource(
+    override suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
@@ -448,15 +448,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             // This particular kind of exception should not be possible from a Source API endpoint.
             throw APIException.create(unexpected)
         }
-    }
-
-    override fun retrieveSource(
-        sourceId: String,
-        clientSecret: String,
-        options: ApiRequest.Options,
-        callback: ApiResultCallback<Source>
-    ) {
-        RetrieveSourceTask(this, sourceId, clientSecret, options, callback).execute()
     }
 
     /**
@@ -1228,20 +1219,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     )
                 else -> null
             }
-        }
-    }
-
-    private class RetrieveSourceTask constructor(
-        private val stripeRepository: StripeRepository,
-        private val sourceId: String,
-        private val clientSecret: String,
-        private val requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<Source>
-    ) : ApiOperation<Source>(callback = callback) {
-
-        @Throws(StripeException::class)
-        override suspend fun getResult(): Source? {
-            return stripeRepository.retrieveSource(sourceId, clientSecret, requestOptions)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -89,7 +89,7 @@ internal interface StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    fun retrieveSetupIntent(
+    suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -138,21 +138,11 @@ internal interface StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    fun retrieveSource(
+    suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
     ): Source?
-
-    /**
-     * Retrieve a [Source] asynchronously
-     */
-    fun retrieveSource(
-        sourceId: String,
-        clientSecret: String,
-        options: ApiRequest.Options,
-        callback: ApiResultCallback<Source>
-    )
 
     @Throws(
         AuthenticationException::class,

--- a/stripe/src/main/java/com/stripe/android/exception/APIException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/APIException.kt
@@ -18,9 +18,9 @@ class APIException(
     cause = cause,
     message = message
 ) {
-    internal constructor(exception: Exception) : this(
-        message = exception.message,
-        cause = exception
+    internal constructor(throwable: Throwable) : this(
+        message = throwable.message,
+        cause = throwable
     )
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
+++ b/stripe/src/main/java/com/stripe/android/exception/StripeException.kt
@@ -3,7 +3,6 @@ package com.stripe.android.exception
 import com.stripe.android.StripeError
 import org.json.JSONException
 import java.io.IOException
-import java.lang.IllegalArgumentException
 import java.util.Objects
 
 /**
@@ -43,7 +42,7 @@ abstract class StripeException(
     }
 
     internal companion object {
-        fun create(throwable: Throwable): Throwable {
+        fun create(throwable: Throwable): StripeException {
             return when (throwable) {
                 is StripeException -> throwable
                 is JSONException -> APIException(throwable)
@@ -52,7 +51,7 @@ abstract class StripeException(
                     message = throwable.message,
                     cause = throwable
                 )
-                else -> throwable
+                else -> APIException(throwable)
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -60,7 +60,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
-    override fun retrieveSetupIntent(
+    override suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
@@ -99,20 +99,12 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
-    override fun retrieveSource(
+    override suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
     ): Source? {
         return null
-    }
-
-    override fun retrieveSource(
-        sourceId: String,
-        clientSecret: String,
-        options: ApiRequest.Options,
-        callback: ApiResultCallback<Source>
-    ) {
     }
 
     override fun createPaymentMethod(

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -265,7 +265,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun retrieveSource_shouldFireAnalytics_andReturnSource() {
+    fun retrieveSource_shouldFireAnalytics_andReturnSource() = testDispatcher.runBlockingTest {
         val stripeResponse = StripeResponse(
             200,
             SourceFixtures.SOURCE_CARD_JSON.toString(),
@@ -779,7 +779,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun apiRequest_withErrorResponse_onUnsupportedSdkVersion_shouldNotBeTranslated() {
+    fun apiRequest_withErrorResponse_onUnsupportedSdkVersion_shouldNotBeTranslated() = testDispatcher.runBlockingTest {
         Locale.setDefault(Locale.JAPAN)
 
         val stripeRepository = StripeApiRepository(
@@ -801,7 +801,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun apiRequest_withErrorResponse_onSupportedSdkVersion_shouldBeTranslated() {
+    fun apiRequest_withErrorResponse_onSupportedSdkVersion_shouldBeTranslated() = testDispatcher.runBlockingTest {
         Locale.setDefault(Locale.JAPAN)
 
         val stripeRepository = StripeApiRepository(

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -806,7 +806,7 @@ class StripePaymentControllerTest {
     }
 
     private class FakeStripeRepository : AbsFakeStripeRepository() {
-        override fun retrieveSetupIntent(
+        override suspend fun retrieveSetupIntent(
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
@@ -824,15 +824,12 @@ class StripePaymentControllerTest {
             callback.onSuccess(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
         }
 
-        override fun retrieveSource(
+        override suspend fun retrieveSource(
             sourceId: String,
             clientSecret: String,
-            options: ApiRequest.Options,
-            callback: ApiResultCallback<Source>
-        ) {
-            callback.onSuccess(
-                SourceFixtures.SOURCE_CARD.copy(status = Source.Status.Chargeable)
-            )
+            options: ApiRequest.Options
+        ): Source? {
+            return SourceFixtures.SOURCE_CARD.copy(status = Source.Status.Chargeable)
         }
     }
 


### PR DESCRIPTION
- Make `StripeRepository#retrieveSetupIntent()` a suspend fun
- Make `StripeRepository#retrieveSource()` a suspend fun
- Fix annotations on `Stripe#retrievePaymentIntent()`