### PR TITLE
Make more StripeRepository methods suspending

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -31,7 +31,8 @@ internal interface PaymentController {
     fun startAuth(
         host: AuthActivityStarter.Host,
         clientSecret: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        type: StripeIntentType
     )
 
     fun startAuthenticateSource(
@@ -101,6 +102,11 @@ internal interface PaymentController {
         authenticator: AlipayAuthenticator,
         callback: ApiResultCallback<PaymentIntentResult>
     )
+
+    enum class StripeIntentType {
+        PaymentIntent,
+        SetupIntent
+    }
 
     /**
      * Represents the result of a [PaymentController] operation.

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -239,7 +239,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.PaymentIntent
         )
     }
 
@@ -268,7 +269,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.PaymentIntent
         )
     }
 
@@ -292,7 +294,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.PaymentIntent
         )
     }
 
@@ -321,7 +324,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.PaymentIntent
         )
     }
 
@@ -527,7 +531,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.SetupIntent
         )
     }
 
@@ -554,7 +559,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.SetupIntent
         )
     }
 
@@ -577,7 +583,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.SetupIntent
         )
     }
 
@@ -604,7 +611,8 @@ class Stripe internal constructor(
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            PaymentController.StripeIntentType.SetupIntent
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeRepository.kt
@@ -24,7 +24,6 @@ import com.stripe.android.model.Stripe3ds2AuthParams
 import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import org.json.JSONException
@@ -65,7 +64,7 @@ internal interface StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    fun cancelPaymentIntentSource(
+    suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
@@ -101,25 +100,11 @@ internal interface StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    fun cancelSetupIntentSource(
+    suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
     ): SetupIntent?
-
-    fun retrieveIntent(
-        clientSecret: String,
-        options: ApiRequest.Options,
-        expandFields: List<String> = emptyList(),
-        callback: ApiResultCallback<StripeIntent>
-    )
-
-    fun cancelIntent(
-        stripeIntent: StripeIntent,
-        sourceId: String,
-        options: ApiRequest.Options,
-        callback: ApiResultCallback<StripeIntent>
-    )
 
     @Throws(
         AuthenticationException::class,

--- a/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/AbsFakeStripeRepository.kt
@@ -21,7 +21,6 @@ import com.stripe.android.model.Stripe3ds2AuthParams
 import com.stripe.android.model.Stripe3ds2AuthResultFixtures
 import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import org.json.JSONObject
@@ -44,7 +43,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
-    override fun cancelPaymentIntentSource(
+    override suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
@@ -68,28 +67,12 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
-    override fun cancelSetupIntentSource(
+    override suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
     ): SetupIntent? {
         return null
-    }
-
-    override fun retrieveIntent(
-        clientSecret: String,
-        options: ApiRequest.Options,
-        expandFields: List<String>,
-        callback: ApiResultCallback<StripeIntent>
-    ) {
-    }
-
-    override fun cancelIntent(
-        stripeIntent: StripeIntent,
-        sourceId: String,
-        options: ApiRequest.Options,
-        callback: ApiResultCallback<StripeIntent>
-    ) {
     }
 
     override fun createSource(

--- a/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeApiRepositoryTest.kt
@@ -729,7 +729,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() {
+    fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() = testDispatcher.runBlockingTest {
         val exception = assertFailsWith<InvalidRequestException> {
             stripeApiRepository.cancelPaymentIntentSource(
                 "pi_1FejpSH8dsfnfKo38L276wr6",

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -18,9 +19,7 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarter
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import java.lang.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -77,7 +76,8 @@ class StripePaymentAuthTest {
         verify(paymentController).startAuth(
             hostArgumentCaptor.capture(),
             eq(clientSecret),
-            eq(REQUEST_OPTIONS)
+            eq(REQUEST_OPTIONS),
+            eq(PaymentController.StripeIntentType.PaymentIntent)
         )
         assertEquals(activity, hostArgumentCaptor.firstValue.activity)
     }
@@ -91,7 +91,8 @@ class StripePaymentAuthTest {
         verify(paymentController).startAuth(
             hostArgumentCaptor.capture(),
             eq(clientSecret),
-            eq(REQUEST_OPTIONS)
+            eq(REQUEST_OPTIONS),
+            eq(PaymentController.StripeIntentType.SetupIntent)
         )
         assertEquals(activity, hostArgumentCaptor.firstValue.activity)
     }
@@ -99,13 +100,13 @@ class StripePaymentAuthTest {
     @Test
     fun onPaymentResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
         val data = Intent()
-        `when`(
+        whenever(
             paymentController.shouldHandlePaymentResult(
                 StripePaymentController.PAYMENT_REQUEST_CODE,
                 data
             )
-        )
-            .thenReturn(true)
+        ).thenReturn(true)
+
         val stripe = createStripe()
         stripe.onPaymentResult(
             StripePaymentController.PAYMENT_REQUEST_CODE,
@@ -119,13 +120,13 @@ class StripePaymentAuthTest {
     @Test
     fun onSetupResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
         val data = Intent()
-        `when`(
+        whenever(
             paymentController.shouldHandleSetupResult(
                 StripePaymentController.SETUP_REQUEST_CODE,
                 data
             )
-        )
-            .thenReturn(true)
+        ).thenReturn(true)
+
         val stripe = createStripe()
         stripe.onSetupResult(
             StripePaymentController.SETUP_REQUEST_CODE,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -10,7 +10,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.AbsFakeStripeRepository
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.ApiRequest
-import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController
@@ -19,7 +18,6 @@ import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -323,15 +321,6 @@ internal class PaymentSheetActivityTest {
             expandFields: List<String>
         ): PaymentIntent? {
             return paymentIntent
-        }
-
-        override fun retrieveIntent(
-            clientSecret: String,
-            options: ApiRequest.Options,
-            expandFields: List<String>,
-            callback: ApiResultCallback<StripeIntent>
-        ) {
-            callback.onSuccess(paymentIntent)
         }
     }
 }


### PR DESCRIPTION
## Summary
- `cancelPaymentIntentSource()` and `cancelSetupIntentSource()` are
  now suspending
- `cancelIntent()` and `retrieveIntent()` have been removed
- Create `PaymentController.StripeIntentType` enum and pass to
  `PaymentController#startAuth()`

## Motivation
Use coroutines instead of callbacks inside of `StripePaymentController`

## Testing
- Updated tests
- Manually verified
