### PR TITLE
Fix CVC not masked like password issue

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -3,7 +3,8 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Build
 import android.text.InputFilter
-import android.text.InputType
+import android.text.InputType.TYPE_CLASS_NUMBER
+import android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
@@ -52,7 +53,7 @@ class CvcEditText @JvmOverloads constructor(
         maxLines = 1
         filters = createFilters(CardBrand.Unknown)
 
-        inputType = InputType.TYPE_CLASS_NUMBER
+        inputType = TYPE_CLASS_NUMBER or TYPE_NUMBER_VARIATION_PASSWORD
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE)


### PR DESCRIPTION
## Summary

<img width="757" alt="Screenshot 2020-11-09 at 8 32 19 AM" src="https://user-images.githubusercontent.com/43145538/98495455-1fcfd200-227a-11eb-8efe-b6cece143a44.png">

In the doc, we are expecting to mask the CVC field with password style "...", however it seems not working now 

## Motivation
Fix the UI so that it works as described in the doc for both `CardInputWidget` and `CardMultilineWidget`
<img width="445" alt="Screenshot 2020-11-09 at 10 58 08 AM" src="https://user-images.githubusercontent.com/43145538/98495604-7a692e00-227a-11eb-98bb-7428814baa58.png">


## Testing
Manual testing in example app's `payment_auth_activity`
