### PR TITLE
Rename RequestHeadersFactory.Default to RequestHeadersFactory.Fingerprint

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/FingerprintRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/FingerprintRequest.kt
@@ -9,11 +9,11 @@ internal class FingerprintRequest(
     override val params: Map<String, Any>,
     guid: String
 ) : StripeRequest() {
-    override val method: Method = Method.POST
-    override val baseUrl: String = URL
-    override val mimeType: MimeType = MimeType.Json
-    override val headersFactory: RequestHeadersFactory = RequestHeadersFactory.Default(
-        mapOf("Cookie" to "m=$guid")
+    override val method = Method.POST
+    override val baseUrl = URL
+    override val mimeType = MimeType.Json
+    override val headersFactory = RequestHeadersFactory.Fingerprint(
+        guid = guid
     )
 
     override val body: String

--- a/stripe/src/main/java/com/stripe/android/networking/RequestHeadersFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/RequestHeadersFactory.kt
@@ -88,11 +88,16 @@ internal sealed class RequestHeadersFactory {
         }
     }
 
-    class Default(
-        override val extraHeaders: Map<String, String> = emptyMap(),
-        sdkVersion: String = Stripe.VERSION
+    class Fingerprint(
+        guid: String
     ) : RequestHeadersFactory() {
-        override val userAgent: String = getUserAgent(sdkVersion)
+        override val extraHeaders = mapOf(HEADER_COOKIE to "m=$guid")
+
+        override val userAgent = getUserAgent(Stripe.VERSION)
+
+        private companion object {
+            private const val HEADER_COOKIE = "Cookie"
+        }
     }
 
     internal companion object {

--- a/stripe/src/test/java/com/stripe/android/networking/ApiRequestHeadersFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/ApiRequestHeadersFactoryTest.kt
@@ -105,6 +105,17 @@ class ApiRequestHeadersFactoryTest {
             )
     }
 
+    @Test
+    fun `Fingerprint#create() should return expected map`() {
+        val guid = UUID.randomUUID().toString()
+        val headers = RequestHeadersFactory.Fingerprint(guid).create()
+        assertThat(
+            headers
+        ).containsKey("User-Agent")
+        assertThat(headers["Cookie"])
+            .isEqualTo("m=$guid")
+    }
+
     private fun createHeaders(
         locale: Locale = Locale.getDefault(),
         options: ApiRequest.Options = OPTIONS,

--- a/stripe/src/test/java/com/stripe/android/networking/StripeApiRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeApiRequestExecutorTest.kt
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.ByteArrayOutputStream
 import java.io.UnsupportedEncodingException
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -17,7 +18,9 @@ class StripeApiRequestExecutorTest {
             override val baseUrl: String = ApiRequest.API_HOST
             override val params: Map<String, *>? = null
             override val mimeType: MimeType = MimeType.Form
-            override val headersFactory = RequestHeadersFactory.Default()
+            override val headersFactory = RequestHeadersFactory.Fingerprint(
+                UUID.randomUUID().toString()
+            )
 
             override val body: String
                 get() {

--- a/stripe/src/test/java/com/stripe/android/networking/StripeRequestCompactParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeRequestCompactParamsTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.networking
 
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -65,13 +66,15 @@ class StripeRequestCompactParamsTest {
         return FakeRequest(params).compactParams.orEmpty()
     }
 
-    private class FakeRequest internal constructor(
+    private class FakeRequest(
         override val params: Map<String, *>?
     ) : StripeRequest() {
         override val method: Method = Method.POST
         override val baseUrl: String = "https://example.com"
         override val mimeType: MimeType = MimeType.Form
         override val body: String = ""
-        override val headersFactory = RequestHeadersFactory.Default()
+        override val headersFactory = RequestHeadersFactory.Fingerprint(
+            guid = UUID.randomUUID().toString()
+        )
     }
 }


### PR DESCRIPTION
## Summary
Update `RequestHeadersFactory.Fingerprint` to take a `guid` instead
of an arbitrary map of headers.

## Motivation
Improve name and simplify constructor

## Testing
Added unit test
