### PR TITLE
Fix usages of Result.recover

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequestExecutor.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequestExecutor.kt
@@ -44,7 +44,7 @@ internal fun interface AnalyticsRequestExecutor {
             CoroutineScope(workContext).launch {
                 runCatching {
                     execute(request)
-                }.recover {
+                }.onFailure {
                     logger.error("Exception while making analytics request", it)
                 }
             }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -184,7 +184,7 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
             logger.debug("PaymentAuthWebViewClient#openIntentScheme()")
             runCatching {
                 openIntent(Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME))
-            }.recover {
+            }.onFailure {
                 onAuthCompleted()
             }
         }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -182,8 +182,6 @@ open class StripeEditText @JvmOverloads constructor(
     private fun setHintSafely(hint: CharSequence) {
         runCatching {
             setHint(hint)
-        }.recover {
-            it
         }
     }
 


### PR DESCRIPTION
`recover {}` should be used to transform a failure