### PR TITLE
Create RequestHeadersFactory.Analytics and use for analytics requests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -192,8 +192,7 @@ internal class StripePaymentController internal constructor(
                 analyticsDataFactory.createAuthSourceParams(
                     AnalyticsEvent.AuthSourceStart,
                     source.id
-                ),
-                requestOptions
+                )
             )
         )
 
@@ -232,8 +231,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.createAuthSourceParams(
                         AnalyticsEvent.AuthSourceRedirect,
                         source.id
-                    ),
-                    requestOptions
+                    )
                 )
             )
 
@@ -424,8 +422,7 @@ internal class StripePaymentController internal constructor(
                 analyticsDataFactory.createAuthSourceParams(
                     AnalyticsEvent.AuthSourceResult,
                     sourceId
-                ),
-                requestOptions
+                )
             )
         )
 
@@ -675,8 +672,7 @@ internal class StripePaymentController internal constructor(
                             analyticsDataFactory.createAuthParams(
                                 AnalyticsEvent.Auth3ds2Fingerprint,
                                 stripeIntent.id.orEmpty()
-                            ),
-                            requestOptions
+                            )
                         )
                     )
                     try {
@@ -696,8 +692,7 @@ internal class StripePaymentController internal constructor(
                             analyticsDataFactory.createAuthParams(
                                 AnalyticsEvent.Auth3ds1Sdk,
                                 stripeIntent.id.orEmpty()
-                            ),
-                            requestOptions
+                            )
                         )
                     )
                     beginWebAuth(
@@ -717,8 +712,7 @@ internal class StripePaymentController internal constructor(
                             analyticsDataFactory.createAuthParams(
                                 AnalyticsEvent.AuthRedirect,
                                 stripeIntent.id.orEmpty()
-                            ),
-                            requestOptions
+                            )
                         )
                     )
 
@@ -744,8 +738,7 @@ internal class StripePaymentController internal constructor(
                             analyticsDataFactory.createAuthParams(
                                 AnalyticsEvent.AuthRedirect,
                                 stripeIntent.id.orEmpty()
-                            ),
-                            requestOptions
+                            )
                         )
                     )
 
@@ -940,8 +933,7 @@ internal class StripePaymentController internal constructor(
                         analyticsDataFactory.createAuthParams(
                             AnalyticsEvent.Auth3ds2Fallback,
                             stripeIntent.id.orEmpty()
-                        ),
-                        requestOptions
+                        )
                     )
                 )
                 beginWebAuth(
@@ -991,8 +983,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.createAuthParams(
                         AnalyticsEvent.Auth3ds2Frictionless,
                         stripeIntent.id.orEmpty()
-                    ),
-                    requestOptions
+                    )
                 )
             )
             paymentRelayStarter.start(PaymentRelayStarter.Args.create(stripeIntent))
@@ -1058,8 +1049,7 @@ internal class StripePaymentController internal constructor(
                         AnalyticsEvent.Auth3ds2ChallengeCompleted,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode
-                    ),
-                    requestOptions
+                    )
                 )
             )
             notifyCompletion(onReceiverCompleted)
@@ -1076,8 +1066,7 @@ internal class StripePaymentController internal constructor(
                         AnalyticsEvent.Auth3ds2ChallengeCanceled,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode
-                    ),
-                    requestOptions
+                    )
                 )
             )
             notifyCompletion(onReceiverCompleted)
@@ -1094,8 +1083,7 @@ internal class StripePaymentController internal constructor(
                         AnalyticsEvent.Auth3ds2ChallengeTimedOut,
                         stripeIntent.id.orEmpty(),
                         uiTypeCode
-                    ),
-                    requestOptions
+                    )
                 )
             )
             notifyCompletion(onReceiverCompleted)
@@ -1111,8 +1099,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeErrorParams(
                         stripeIntent.id.orEmpty(),
                         protocolErrorEvent
-                    ),
-                    requestOptions
+                    )
                 )
             )
             notifyCompletion(onReceiverCompleted)
@@ -1128,8 +1115,7 @@ internal class StripePaymentController internal constructor(
                     analyticsDataFactory.create3ds2ChallengeErrorParams(
                         stripeIntent.id.orEmpty(),
                         runtimeErrorEvent
-                    ),
-                    requestOptions
+                    )
                 )
             )
             notifyCompletion(onReceiverCompleted)
@@ -1142,8 +1128,7 @@ internal class StripePaymentController internal constructor(
                         AnalyticsEvent.Auth3ds2ChallengePresented,
                         stripeIntent.id.orEmpty(),
                         transaction.initialChallengeUiType.orEmpty()
-                    ),
-                    requestOptions
+                    )
                 )
             )
 

--- a/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -69,8 +69,7 @@ internal class DefaultCardAccountRangeRepositoryFactory(
                     DefaultCardAccountRangeStore(appContext),
                     AnalyticsRequestExecutor.Default(),
                     AnalyticsRequest.Factory(),
-                    AnalyticsDataFactory(appContext, publishableKey),
-                    publishableKey
+                    AnalyticsDataFactory(appContext, publishableKey)
                 )
             },
             onFailure = {
@@ -88,8 +87,7 @@ internal class DefaultCardAccountRangeRepositoryFactory(
                 AnalyticsDataFactory(
                     appContext,
                     publishableKey
-                ).createParams(event),
-                ApiRequest.Options(publishableKey)
+                ).createParams(event)
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/RemoteCardAccountRangeSource.kt
@@ -16,8 +16,7 @@ internal class RemoteCardAccountRangeSource(
     private val cardAccountRangeStore: CardAccountRangeStore,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequest.Factory,
-    private val analyticsDataFactory: AnalyticsDataFactory,
-    private val publishableKey: String
+    private val analyticsDataFactory: AnalyticsDataFactory
 ) : CardAccountRangeSource {
 
     private val mutableLoading = MutableStateFlow(false)
@@ -57,8 +56,7 @@ internal class RemoteCardAccountRangeSource(
     private fun onCardMetadataMissingRange() {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create(
-                analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataMissingRange),
-                ApiRequest.Options(publishableKey)
+                analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataMissingRange)
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequest.kt
@@ -1,36 +1,26 @@
 package com.stripe.android.networking
 
-import com.stripe.android.AppInfo
 import com.stripe.android.Logger
 
 internal data class AnalyticsRequest(
-    override val params: Map<String, *>,
-    internal val options: ApiRequest.Options,
-    internal val appInfo: AppInfo? = null
+    override val params: Map<String, *>
 ) : StripeRequest() {
     override val method: Method = Method.GET
     override val baseUrl: String = HOST
     override val mimeType: MimeType = MimeType.Form
-    override val headersFactory: RequestHeadersFactory = RequestHeadersFactory.Api(
-        options = options,
-        appInfo = appInfo
-    )
+    override val headersFactory: RequestHeadersFactory = RequestHeadersFactory.Analytics
 
     class Factory(
         private val logger: Logger = Logger.noop()
     ) {
         @JvmSynthetic
         internal fun create(
-            params: Map<String, *>,
-            options: ApiRequest.Options,
-            appInfo: AppInfo? = null
+            params: Map<String, *>
         ): AnalyticsRequest {
             logger.info("Event: ${params[AnalyticsDataFactory.FIELD_EVENT]}")
 
             return AnalyticsRequest(
-                params,
-                options,
-                appInfo
+                params
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/networking/RequestHeadersFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/RequestHeadersFactory.kt
@@ -100,6 +100,11 @@ internal sealed class RequestHeadersFactory {
         }
     }
 
+    object Analytics : RequestHeadersFactory() {
+        override val userAgent = getUserAgent(Stripe.VERSION)
+        override val extraHeaders = emptyMap<String, String>()
+    }
+
     internal companion object {
         internal fun getUserAgent(sdkVersion: String = Stripe.VERSION) = "Stripe/v1 $sdkVersion"
 

--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -132,8 +132,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             fireAnalyticsRequest(
                 analyticsDataFactory.createPaymentIntentConfirmationParams(
                     paymentMethodType
-                ),
-                options.apiKey
+                )
             )
 
             return fetchStripeModel(
@@ -168,8 +167,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
 
         fireFingerprintRequest()
         fireAnalyticsRequest(
-            analyticsDataFactory.createPaymentIntentRetrieveParams(paymentIntentId),
-            options.apiKey
+            analyticsDataFactory.createPaymentIntentRetrieveParams(paymentIntentId)
         )
 
         try {
@@ -202,7 +200,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         options: ApiRequest.Options
     ): PaymentIntent? {
         fireFingerprintRequest()
-        fireAnalyticsRequest(AnalyticsEvent.PaymentIntentCancelSource, options.apiKey)
+        fireAnalyticsRequest(AnalyticsEvent.PaymentIntentCancelSource)
 
         try {
             return fetchStripeModel(
@@ -247,8 +245,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createSetupIntentConfirmationParams(
                 confirmSetupIntentParams.paymentMethodCreateParams?.typeCode,
                 setupIntentId
-            ),
-            options.apiKey
+            )
         )
 
         try {
@@ -295,8 +292,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             fireAnalyticsRequest(
                 analyticsDataFactory.createSetupIntentRetrieveParams(
                     setupIntentId
-                ),
-                options.apiKey
+                )
             )
 
             return fetchStripeModel(
@@ -327,7 +323,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         sourceId: String,
         options: ApiRequest.Options
     ): SetupIntent? {
-        fireAnalyticsRequest(AnalyticsEvent.SetupIntentCancelSource, options.apiKey)
+        fireAnalyticsRequest(AnalyticsEvent.SetupIntentCancelSource)
 
         try {
             return fetchStripeModel(
@@ -368,8 +364,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createSourceCreationParams(
                 sourceParams.type,
                 sourceParams.attribution
-            ),
-            options.apiKey
+            )
         )
 
         try {
@@ -410,8 +405,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val apiUrl = getRetrieveSourceApiUrl(sourceId)
 
         fireAnalyticsRequest(
-            analyticsDataFactory.createSourceRetrieveParams(sourceId),
-            options.apiKey
+            analyticsDataFactory.createSourceRetrieveParams(sourceId)
         )
 
         try {
@@ -460,8 +454,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     paymentMethod?.id,
                     paymentMethod?.type,
                     productUsageTokens = paymentMethodCreateParams.attribution
-                ),
-                options.apiKey
+                )
             )
 
             return paymentMethod
@@ -499,8 +492,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createTokenCreationParams(
                 productUsageTokens = tokenParams.attribution,
                 tokenType = tokenParams.tokenType
-            ),
-            options.apiKey
+            )
         )
 
         return fetchStripeModel(
@@ -536,8 +528,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createAddSourceParams(
                 productUsageTokens,
                 sourceType
-            ),
-            publishableKey
+            )
         )
 
         return fetchStripeModel(
@@ -568,8 +559,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         requestOptions: ApiRequest.Options
     ): Source? {
         fireAnalyticsRequest(
-            analyticsDataFactory.createDeleteSourceParams(productUsageTokens),
-            publishableKey
+            analyticsDataFactory.createDeleteSourceParams(productUsageTokens)
         )
 
         return fetchStripeModel(
@@ -601,8 +591,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         fireFingerprintRequest()
         fireAnalyticsRequest(
             analyticsDataFactory
-                .createAttachPaymentMethodParams(productUsageTokens),
-            publishableKey
+                .createAttachPaymentMethodParams(productUsageTokens)
         )
 
         return fetchStripeModel(
@@ -633,8 +622,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     ): PaymentMethod? {
         fireAnalyticsRequest(
             analyticsDataFactory
-                .createDetachPaymentMethodParams(productUsageTokens),
-            publishableKey
+                .createDetachPaymentMethodParams(productUsageTokens)
         )
 
         return fetchStripeModel(
@@ -676,8 +664,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createParams(
                 AnalyticsEvent.CustomerRetrievePaymentMethods,
                 productUsageTokens = productUsageTokens
-            ),
-            publishableKey
+            )
         )
 
         return try {
@@ -713,8 +700,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 event = AnalyticsEvent.CustomerSetDefaultSource,
                 productUsageTokens = productUsageTokens,
                 sourceType = sourceType
-            ),
-            publishableKey
+            )
         )
 
         return fetchStripeModel(
@@ -748,8 +734,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createParams(
                 AnalyticsEvent.CustomerSetShippingInfo,
                 productUsageTokens = productUsageTokens
-            ),
-            publishableKey
+            )
         )
 
         return fetchStripeModel(
@@ -781,8 +766,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createParams(
                 AnalyticsEvent.CustomerRetrieve,
                 productUsageTokens = productUsageTokens
-            ),
-            requestOptions.apiKey
+            )
         )
 
         return fetchStripeModel(
@@ -812,8 +796,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         ephemeralKeySecret: String
     ): String {
         fireAnalyticsRequest(
-            AnalyticsEvent.IssuingRetrievePin,
-            publishableKey
+            AnalyticsEvent.IssuingRetrievePin
         )
 
         val response = makeApiRequest(
@@ -844,8 +827,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         ephemeralKeySecret: String
     ) {
         fireAnalyticsRequest(
-            AnalyticsEvent.IssuingUpdatePin,
-            publishableKey
+            AnalyticsEvent.IssuingUpdatePin
         )
 
         makeApiRequest(
@@ -893,8 +875,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             }
         }.onFailure {
             fireAnalyticsRequest(
-                AnalyticsEvent.CardMetadataLoadFailure,
-                options.apiKey
+                AnalyticsEvent.CardMetadataLoadFailure
             )
         }.getOrNull()
     }
@@ -912,8 +893,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             analyticsDataFactory.createAuthParams(
                 AnalyticsEvent.Auth3ds2Start,
                 stripeIntentId
-            ),
-            requestOptions.apiKey
+            )
         )
 
         val response = makeApiRequest(
@@ -951,7 +931,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         val response = makeFileUploadRequest(
             FileUploadRequest(fileParams, requestOptions, appInfo)
         )
-        fireAnalyticsRequest(AnalyticsEvent.FileCreate, requestOptions.apiKey)
+        fireAnalyticsRequest(AnalyticsEvent.FileCreate)
         return StripeFileJsonParser().parse(response.responseJson)
     }
 
@@ -1123,26 +1103,19 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     private fun fireAnalyticsRequest(
-        event: AnalyticsEvent,
-        publishableKey: String
+        event: AnalyticsEvent
     ) {
         fireAnalyticsRequest(
-            analyticsDataFactory.createParams(event),
-            publishableKey
+            analyticsDataFactory.createParams(event)
         )
     }
 
     @VisibleForTesting
     internal fun fireAnalyticsRequest(
-        params: Map<String, Any>,
-        publishableKey: String
+        params: Map<String, Any>
     ) {
         makeAnalyticsRequest(
-            analyticsRequestFactory.create(
-                params,
-                ApiRequest.Options(publishableKey),
-                appInfo
-            )
+            analyticsRequestFactory.create(params)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -23,7 +23,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.AnalyticsDataFactory
 import com.stripe.android.networking.AnalyticsRequest
 import com.stripe.android.networking.AnalyticsRequestExecutor
-import com.stripe.android.networking.ApiRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -47,8 +46,7 @@ class CardNumberEditText internal constructor(
     private val staticCardAccountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges(),
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequest.Factory,
-    private val analyticsDataFactory: AnalyticsDataFactory,
-    private val publishableKeySupplier: () -> String
+    private val analyticsDataFactory: AnalyticsDataFactory
 ) : StripeEditText(context, attrs, defStyleAttr) {
 
     @JvmOverloads
@@ -87,9 +85,7 @@ class CardNumberEditText internal constructor(
         AnalyticsDataFactory(
             context,
             publishableKeySupplier = publishableKeySupplier
-        ),
-
-        publishableKeySupplier
+        )
     )
 
     @VisibleForTesting
@@ -296,12 +292,7 @@ class CardNumberEditText internal constructor(
     internal fun onCardMetadataLoadedTooSlow() {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create(
-                analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataLoadedTooSlow),
-                ApiRequest.Options(
-                    runCatching {
-                        publishableKeySupplier()
-                    }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
-                )
+                analyticsDataFactory.createParams(AnalyticsEvent.CardMetadataLoadedTooSlow)
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -209,8 +209,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
             store,
             { },
             AnalyticsRequest.Factory(),
-            AnalyticsDataFactory(application, publishableKey),
-            publishableKey
+            AnalyticsDataFactory(application, publishableKey)
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/stripe/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -42,8 +42,7 @@ internal class RemoteCardAccountRangeSourceTest {
             AnalyticsDataFactory(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-            ),
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            )
         )
 
         assertThat(
@@ -78,8 +77,7 @@ internal class RemoteCardAccountRangeSourceTest {
             AnalyticsDataFactory(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-            ),
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            )
         )
 
         assertThat(
@@ -106,8 +104,7 @@ internal class RemoteCardAccountRangeSourceTest {
             AnalyticsDataFactory(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-            ),
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            )
         )
 
         assertThat(
@@ -150,8 +147,7 @@ internal class RemoteCardAccountRangeSourceTest {
             AnalyticsDataFactory(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-            ),
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            )
         )
 
         remoteCardAccountRangeSource.getAccountRange(

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
@@ -16,7 +16,7 @@ class AnalyticsRequestExecutorTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
-    fun execute_withFingerprintRequest_shouldReturnSuccessfully() {
+    fun execute_shouldReturnSuccessfully() {
         val responseCode = analyticsRequestExecutor.execute(
             AnalyticsRequest.Factory().create(
                 AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
@@ -24,8 +24,7 @@ class AnalyticsRequestExecutorTest {
                         "pm_12345",
                         PaymentMethod.Type.Card,
                         emptySet()
-                    ),
-                ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+                    )
             )
         )
         assertThat(responseCode)

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.AppInfoFixtures
 import com.stripe.android.Logger
 import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethod
@@ -30,9 +29,7 @@ class AnalyticsRequestTest {
                     "pm_12345",
                     PaymentMethod.Type.Card,
                     emptySet()
-                ),
-            options = ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-            appInfo = AppInfoFixtures.DEFAULT
+                )
         )
         assertThat(analyticsRequest.headers)
             .isEqualTo(
@@ -63,8 +60,7 @@ class AnalyticsRequestTest {
                     "pm_12345",
                     PaymentMethod.Type.Card,
                     emptySet()
-                ),
-            ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+                )
         )
 
         verify(logger).info(

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
@@ -34,15 +34,7 @@ class AnalyticsRequestTest {
         assertThat(analyticsRequest.headers)
             .isEqualTo(
                 mapOf(
-                    "Accept" to "application/json",
-                    "X-Stripe-Client-User-Agent" to
-                        """
-                    {"os.name":"android","os.version":"28","bindings.version":"$sdkVersion","lang":"Java","publisher":"Stripe","http.agent":"","application":{"name":"MyAwesomePlugin","version":"1.2.34","url":"https:\/\/myawesomeplugin.info","partner_id":"pp_partner_1234"}}
-                        """.trimIndent(),
-                    "Stripe-Version" to "2020-03-02",
-                    "Authorization" to "Bearer pk_test_123",
-                    "Accept-Language" to "en-US",
-                    "User-Agent" to "Stripe/v1 AndroidBindings/$sdkVersion MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",
+                    "User-Agent" to "Stripe/v1 AndroidBindings/$sdkVersion",
                     "Accept-Charset" to "UTF-8"
                 )
             )

--- a/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -350,8 +350,7 @@ internal class StripeApiRepositoryTest {
         // This is the one and only test where we actually log something, because
         // we are testing whether or not we log.
         stripeApiRepository.fireAnalyticsRequest(
-            emptyMap(),
-            DEFAULT_OPTIONS.apiKey
+            emptyMap()
         )
     }
 
@@ -469,8 +468,7 @@ internal class StripeApiRepositoryTest {
     fun fireAnalyticsRequest_whenShouldLogRequestIsFalse_doesNotCreateAConnection() {
         val stripeApiRepository = create()
         stripeApiRepository.fireAnalyticsRequest(
-            emptyMap(),
-            DEFAULT_OPTIONS.apiKey
+            emptyMap()
         )
         verifyNoMoreInteractions(stripeApiRequestExecutor)
     }

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -35,7 +35,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.AnalyticsDataFactory
 import com.stripe.android.networking.AnalyticsRequest
 import com.stripe.android.networking.AnalyticsRequestExecutor
-import com.stripe.android.networking.ApiRequest
 import com.stripe.android.testharness.ViewTestUtils
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
@@ -85,7 +84,6 @@ internal class CardNumberEditTextTest {
     private val analyticsRequestExecutor = AnalyticsRequestExecutor {}
     private val analyticsRequestFactory = AnalyticsRequest.Factory()
     private val analyticsDataFactory = AnalyticsDataFactory(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
-    private val publishableKeySupplier = { ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY }
 
     private val cardNumberEditText = CardNumberEditText(
         context,
@@ -93,8 +91,7 @@ internal class CardNumberEditTextTest {
         cardAccountRangeRepository = cardAccountRangeRepository,
         analyticsRequestExecutor = analyticsRequestExecutor,
         analyticsRequestFactory = analyticsRequestFactory,
-        analyticsDataFactory = analyticsDataFactory,
-        publishableKeySupplier = publishableKeySupplier
+        analyticsDataFactory = analyticsDataFactory
     ).also {
         it.completionCallback = completionCallback
         it.brandChangeCallback = brandChangeCallback
@@ -263,8 +260,7 @@ internal class CardNumberEditTextTest {
             cardAccountRangeRepository = NullCardAccountRangeRepository(),
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         var callbacks = 0
@@ -296,8 +292,7 @@ internal class CardNumberEditTextTest {
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         var callbacks = 0
@@ -329,8 +324,7 @@ internal class CardNumberEditTextTest {
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         cardNumberEditText.setText("6216828050000000000")
@@ -348,8 +342,7 @@ internal class CardNumberEditTextTest {
             cardAccountRangeRepository = NullCardAccountRangeRepository(),
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         cardNumberEditText.setText(UNIONPAY_NO_SPACES)
@@ -709,8 +702,7 @@ internal class CardNumberEditTextTest {
                         cardAccountRangeRepository = DelayedCardAccountRangeRepository(),
                         analyticsRequestExecutor = analyticsRequestExecutor,
                         analyticsRequestFactory = analyticsRequestFactory,
-                        analyticsDataFactory = analyticsDataFactory,
-                        publishableKeySupplier = publishableKeySupplier
+                        analyticsDataFactory = analyticsDataFactory
                     )
 
                     val root = activity.findViewById<ViewGroup>(R.id.add_payment_method_card).also {
@@ -747,8 +739,7 @@ internal class CardNumberEditTextTest {
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         cardNumberEditText.setText(VISA_BIN)
@@ -797,8 +788,7 @@ internal class CardNumberEditTextTest {
             },
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
 
         // 620000 - valid BIN, call repo
@@ -859,8 +849,7 @@ internal class CardNumberEditTextTest {
                 analyticsRequests.add(it)
             },
             analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = publishableKeySupplier
+            analyticsDataFactory = analyticsDataFactory
         )
         cardNumberEditText.setText(UNIONPAY_NO_SPACES)
         idleLooper()
@@ -868,28 +857,6 @@ internal class CardNumberEditTextTest {
             .hasSize(1)
         assertThat(analyticsRequests.first().params["event"])
             .isEqualTo("stripe_android.card_metadata_loaded_too_slow")
-    }
-
-    @Test
-    fun `onCardMetadataLoadedTooSlow() when publishable key is unavailable uses undefined publishable key`() {
-        val analyticsRequests = mutableListOf<AnalyticsRequest>()
-
-        CardNumberEditText(
-            context,
-            workContext = testDispatcher,
-            cardAccountRangeRepository = cardAccountRangeRepository,
-            analyticsRequestExecutor = {
-                analyticsRequests.add(it)
-            },
-            analyticsRequestFactory = analyticsRequestFactory,
-            analyticsDataFactory = analyticsDataFactory,
-            publishableKeySupplier = {
-                throw RuntimeException()
-            }
-        ).onCardMetadataLoadedTooSlow()
-
-        assertThat(analyticsRequests.first().options.apiKey)
-            .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
     }
 
     private fun verifyCardBrandBin(


### PR DESCRIPTION
## Summary
`AnalyticsRequest.Factory#create()` no longer takes
`ApiRequest.Options` and `AppInfo`

## Motivation
Send correct headers for analytics requests

## Testing
Update unit tests
