### PR TITLE
Create PaymentSheet Toolbar view

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -15,31 +15,14 @@
         android:paddingTop="@dimen/stripe_paymentsheet_padding_top"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
-        <FrameLayout
+        <com.stripe.android.paymentsheet.ui.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="10dp"
             app:layout_constraintBottom_toTopOf="@+id/fragment_container"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                android:id="@+id/close"
-                android:src="@drawable/stripe_ic_paymentsheet_close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/stripe_paymentsheet_close"
-                android:visibility="gone"/>
-
-            <ImageView
-                android:id="@+id/back"
-                android:src="@drawable/stripe_ic_paymentsheet_back"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/stripe_paymentsheet_back"
-                android:visibility="gone"/>
-        </FrameLayout>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.fragment.app.FragmentContainerView
             app:layout_constraintTop_toBottomOf="@id/toolbar"

--- a/stripe/res/layout/stripe_payment_sheet_toolbar.xml
+++ b/stripe/res/layout/stripe_payment_sheet_toolbar.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+    <ImageView
+        android:id="@+id/close"
+        android:src="@drawable/stripe_ic_paymentsheet_close"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/stripe_paymentsheet_close"
+        android:visibility="gone"/>
+
+    <ImageView
+        android:id="@+id/back"
+        android:src="@drawable/stripe_ic_paymentsheet_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/stripe_paymentsheet_back"
+        android:visibility="gone"/>
+</merge>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -19,6 +19,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.ui.SheetMode
+import com.stripe.android.paymentsheet.ui.Toolbar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -89,12 +90,10 @@ internal class PaymentSheetActivity : AppCompatActivity() {
             when (mode) {
                 SheetMode.Full,
                 SheetMode.FullCollapsed -> {
-                    viewBinding.close.visibility = View.GONE
-                    viewBinding.back.visibility = View.VISIBLE
+                    viewBinding.toolbar.showBack()
                 }
                 SheetMode.Wrapped -> {
-                    viewBinding.close.visibility = View.VISIBLE
-                    viewBinding.back.visibility = View.GONE
+                    viewBinding.toolbar.showClose()
                 }
                 else -> {
                     // mode == null
@@ -161,9 +160,17 @@ internal class PaymentSheetActivity : AppCompatActivity() {
             }
         }
 
-        viewBinding.close.setOnClickListener { onUserCancel() }
-        viewBinding.back.setOnClickListener {
-            viewModel.transitionTo(PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod)
+        viewBinding.toolbar.action.observe(this) { action ->
+            when (action) {
+                Toolbar.Action.Close -> {
+                    onUserCancel()
+                }
+                Toolbar.Action.Back -> {
+                    viewModel.transitionTo(
+                        PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod
+                    )
+                }
+            }
         }
     }
 
@@ -212,8 +219,7 @@ internal class PaymentSheetActivity : AppCompatActivity() {
         }
 
         viewModel.processing.observe(this) { isProcessing ->
-            viewBinding.close.isEnabled = !isProcessing
-            viewBinding.back.isEnabled = !isProcessing
+            viewBinding.toolbar.updateProcessing(isProcessing)
 
             viewBinding.buyButton.isEnabled = !isProcessing
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/Toolbar.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/Toolbar.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
+import com.stripe.android.databinding.StripePaymentSheetToolbarBinding
+
+internal class Toolbar @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val mutableAction = MutableLiveData<Action>()
+    internal val action = mutableAction.distinctUntilChanged()
+
+    private val viewBinding = StripePaymentSheetToolbarBinding.inflate(
+        LayoutInflater.from(context),
+        this
+    )
+    internal val closeButton = viewBinding.close
+    internal val backButton = viewBinding.back
+
+    init {
+        closeButton.setOnClickListener { mutableAction.value = Action.Close }
+        backButton.setOnClickListener { mutableAction.value = Action.Back }
+    }
+
+    fun showClose() {
+        closeButton.visibility = View.VISIBLE
+        backButton.visibility = View.GONE
+    }
+
+    fun showBack() {
+        closeButton.visibility = View.GONE
+        backButton.visibility = View.VISIBLE
+    }
+
+    fun updateProcessing(isProcessing: Boolean) {
+        closeButton.isEnabled = !isProcessing
+        backButton.isEnabled = !isProcessing
+    }
+
+    enum class Action {
+        Close,
+        Back
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/ToolbarTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/ToolbarTest.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class ToolbarTest {
+
+    private val toolbar = Toolbar(ApplicationProvider.getApplicationContext())
+
+    @Test
+    fun `buttons are enabled by default`() {
+        assertThat(toolbar.closeButton.isEnabled)
+            .isTrue()
+        assertThat(toolbar.backButton.isEnabled)
+            .isTrue()
+    }
+
+    @Test
+    fun `buttons are disabled when processing`() {
+        toolbar.updateProcessing(true)
+        assertThat(toolbar.closeButton.isEnabled)
+            .isFalse()
+        assertThat(toolbar.backButton.isEnabled)
+            .isFalse()
+    }
+
+    @Test
+    fun `action emits Back when back button is clicked`() {
+        var action: Toolbar.Action? = null
+        toolbar.action.observeForever {
+            action = it
+        }
+        toolbar.backButton.performClick()
+        assertThat(action)
+            .isEqualTo(Toolbar.Action.Back)
+    }
+}


### PR DESCRIPTION
Abstract PaymentSheet toolbar interaction logic from
`PaymentSheetActivity` to `Toolbar` so that it can be reused in other
activities.