### PR TITLE
Update payment method analytics

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
@@ -134,17 +134,13 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createPaymentMethodCreationParams(
-        paymentMethodId: String?,
         paymentMethodType: PaymentMethod.Type?,
         productUsageTokens: Set<String>?
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.PaymentMethodCreate,
             sourceType = paymentMethodType?.code,
-            productUsageTokens = productUsageTokens,
-            extraParams = paymentMethodId?.let {
-                mapOf(FIELD_PAYMENT_METHOD_ID to it)
-            }
+            productUsageTokens = productUsageTokens
         )
     }
 
@@ -237,12 +233,8 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     ): Map<String, Any> {
         return createParams(
             AnalyticsEvent.SetupIntentConfirm,
+            sourceType = paymentMethodType,
             extraParams = createIntentParam(intentId)
-                .plus(
-                    paymentMethodType?.let {
-                        mapOf(FIELD_PAYMENT_METHOD_TYPE to it)
-                    }.orEmpty()
-                )
         )
     }
 
@@ -364,8 +356,6 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         internal const val FIELD_OS_NAME = "os_name"
         internal const val FIELD_OS_RELEASE = "os_release"
         internal const val FIELD_OS_VERSION = "os_version"
-        internal const val FIELD_PAYMENT_METHOD_ID = "payment_method_id"
-        internal const val FIELD_PAYMENT_METHOD_TYPE = "payment_method_type"
         internal const val FIELD_PUBLISHABLE_KEY = "publishable_key"
         internal const val FIELD_SOURCE_ID = "source_id"
         internal const val FIELD_SOURCE_TYPE = "source_type"

--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -452,7 +452,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
 
             fireAnalyticsRequest(
                 analyticsDataFactory.createPaymentMethodCreationParams(
-                    paymentMethod?.id,
                     paymentMethod?.type,
                     productUsageTokens = paymentMethodCreateParams.attribution
                 )

--- a/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsDataFactoryTest.kt
@@ -92,31 +92,28 @@ class AnalyticsDataFactoryTest {
 
     @Test
     fun getPaymentMethodCreationParams() {
-        val expectedParams = mapOf(
-            "analytics_ua" to "analytics.stripe_android-1.0",
-            "event" to "stripe_android.payment_method_creation",
-            "publishable_key" to "pk_abc123",
-            "os_name" to "REL",
-            "os_release" to "9",
-            "os_version" to 28,
-            "device_type" to "unknown_Android_robolectric",
-            "bindings_version" to Stripe.VERSION_NAME,
-            "app_name" to "com.stripe.android.test",
-            "app_version" to 0,
-            "product_usage" to ATTRIBUTION.toList(),
-            "source_type" to "card",
-            "payment_method_id" to "pm_12345"
-        )
-
-        val actualParams = analyticsDataFactory
-            .createPaymentMethodCreationParams(
-                "pm_12345",
-                PaymentMethod.Type.Card,
-                ATTRIBUTION
+        assertThat(
+            analyticsDataFactory
+                .createPaymentMethodCreationParams(
+                    PaymentMethod.Type.Card,
+                    ATTRIBUTION
+                )
+        ).isEqualTo(
+            mapOf(
+                "analytics_ua" to "analytics.stripe_android-1.0",
+                "event" to "stripe_android.payment_method_creation",
+                "publishable_key" to "pk_abc123",
+                "os_name" to "REL",
+                "os_release" to "9",
+                "os_version" to 28,
+                "device_type" to "unknown_Android_robolectric",
+                "bindings_version" to Stripe.VERSION_NAME,
+                "app_name" to "com.stripe.android.test",
+                "app_version" to 0,
+                "product_usage" to ATTRIBUTION.toList(),
+                "source_type" to "card"
             )
-
-        assertThat(actualParams)
-            .isEqualTo(expectedParams)
+        )
     }
 
     @Test
@@ -164,7 +161,8 @@ class AnalyticsDataFactoryTest {
             PaymentMethod.Type.Card.code,
             "seti_12345"
         )
-        assertEquals("card", params[AnalyticsDataFactory.FIELD_PAYMENT_METHOD_TYPE])
+        assertThat(params[AnalyticsDataFactory.FIELD_SOURCE_TYPE])
+            .isEqualTo("card")
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -38,7 +38,6 @@ import com.stripe.android.networking.ApiRequestExecutor;
 import com.stripe.android.networking.FakeAnalyticsRequestExecutor;
 import com.stripe.android.networking.StripeApiRepository;
 import com.stripe.android.networking.StripeRepository;
-import com.stripe.android.networking.StripeRequest;
 
 import java.io.File;
 import java.util.HashMap;
@@ -1131,13 +1130,13 @@ public class StripeTest {
 
         verify(analyticsRequestExecutor)
                 .executeAsync(analyticsRequestArgumentCaptor.capture());
-        final StripeRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
-        assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
-        assertEquals(
-                createdPaymentMethod.id,
+        final AnalyticsRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
+        assertThat(analyticsRequest.getBaseUrl())
+                .isEqualTo(AnalyticsRequest.HOST);
+        assertThat(
                 Objects.requireNonNull(analyticsRequest.getParams())
-                        .get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID)
-        );
+                        .get(AnalyticsDataFactory.FIELD_SOURCE_TYPE)
+        ).isEqualTo("card");
     }
 
     @Test
@@ -1164,13 +1163,15 @@ public class StripeTest {
 
         verify(analyticsRequestExecutor)
                 .executeAsync(analyticsRequestArgumentCaptor.capture());
-        final StripeRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
-        assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
-        assertEquals(
-                createdPaymentMethod.id,
+
+        final AnalyticsRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
+        assertThat(analyticsRequest.getBaseUrl())
+                .isEqualTo(AnalyticsRequest.HOST);
+
+        assertThat(
                 Objects.requireNonNull(analyticsRequest.getParams())
-                        .get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID)
-        );
+                        .get(AnalyticsDataFactory.FIELD_SOURCE_TYPE)
+        ).isEqualTo("ideal");
     }
 
     @Test
@@ -1194,13 +1195,12 @@ public class StripeTest {
 
         verify(analyticsRequestExecutor)
                 .executeAsync(analyticsRequestArgumentCaptor.capture());
-        final StripeRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
+        final AnalyticsRequest analyticsRequest = analyticsRequestArgumentCaptor.getValue();
         assertEquals(AnalyticsRequest.HOST, analyticsRequest.getBaseUrl());
-        assertEquals(
-                createdPaymentMethod.id,
+        assertThat(
                 Objects.requireNonNull(analyticsRequest.getParams())
-                        .get(AnalyticsDataFactory.FIELD_PAYMENT_METHOD_ID)
-        );
+                        .get(AnalyticsDataFactory.FIELD_SOURCE_TYPE)
+        ).isEqualTo("fpx");
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
@@ -21,7 +21,6 @@ class AnalyticsRequestExecutorTest {
             AnalyticsRequest.Factory().create(
                 AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                     .createPaymentMethodCreationParams(
-                        "pm_12345",
                         PaymentMethod.Type.Card,
                         emptySet()
                     )

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestTest.kt
@@ -26,7 +26,6 @@ class AnalyticsRequestTest {
         val analyticsRequest = factory.create(
             params = AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 .createPaymentMethodCreationParams(
-                    "pm_12345",
                     PaymentMethod.Type.Card,
                     emptySet()
                 )
@@ -41,7 +40,7 @@ class AnalyticsRequestTest {
         val requestUrl = analyticsRequest.url
 
         assertThat(requestUrl)
-            .isEqualTo("https://q.stripe.com?publishable_key=pk_test_123&app_version=0&bindings_version=$sdkVersion&os_version=28&os_release=9&device_type=unknown_Android_robolectric&source_type=card&app_name=com.stripe.android.test&payment_method_id=pm_12345&analytics_ua=analytics.stripe_android-1.0&os_name=REL&event=stripe_android.payment_method_creation")
+            .isEqualTo("https://q.stripe.com?app_name=com.stripe.android.test&publishable_key=pk_test_123&app_version=0&bindings_version=16.1.0&os_version=28&analytics_ua=analytics.stripe_android-1.0&os_name=REL&os_release=9&device_type=unknown_Android_robolectric&source_type=card&event=stripe_android.payment_method_creation")
     }
 
     @Test
@@ -49,7 +48,6 @@ class AnalyticsRequestTest {
         factory.create(
             AnalyticsDataFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 .createPaymentMethodCreationParams(
-                    "pm_12345",
                     PaymentMethod.Type.Card,
                     emptySet()
                 )


### PR DESCRIPTION
- Remove `payment_method_id` field
- Use `source_type` instead of `payment_method_type`