### PR TITLE
Rename PaymentSheetPaymentMethodsAdapter to PaymentMethodsAdapter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsAdapter.kt
@@ -12,7 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlin.properties.Delegates
 
-internal class PaymentSheetPaymentMethodsAdapter(
+internal class PaymentMethodsAdapter(
     selectedPaymentMethod: PaymentSelection?,
     val paymentMethodSelectedListener: (PaymentSelection) -> Unit,
     val addCardClickListener: View.OnClickListener

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -28,8 +28,8 @@ internal class PaymentSheetPaymentMethodsListFragment : Fragment(
 
     private val fragmentViewModel by viewModels<PaymentMethodsViewModel>()
 
-    private val adapter: PaymentSheetPaymentMethodsAdapter by lazy {
-        PaymentSheetPaymentMethodsAdapter(
+    private val adapter: PaymentMethodsAdapter by lazy {
+        PaymentMethodsAdapter(
             fragmentViewModel.selectedPaymentMethod,
             paymentMethodSelectedListener = {
                 fragmentViewModel.selectedPaymentMethod = it

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -53,7 +53,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
     fun `sets up adapter`() {
         createScenario().onFragment {
             val recycler = recyclerView(it)
-            val adapter = recycler.adapter as PaymentSheetPaymentMethodsAdapter
+            val adapter = recycler.adapter as PaymentMethodsAdapter
             assertThat(adapter.paymentMethods)
                 .isEmpty()
 
@@ -75,8 +75,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             idleLooper()
 
             val recycler = recyclerView(it)
-            assertThat(recycler.adapter).isInstanceOf(PaymentSheetPaymentMethodsAdapter::class.java)
-            val adapter = recycler.adapter as PaymentSheetPaymentMethodsAdapter
+            assertThat(recycler.adapter).isInstanceOf(PaymentMethodsAdapter::class.java)
+            val adapter = recycler.adapter as PaymentMethodsAdapter
             adapter.paymentMethodSelectedListener(savedPaymentMethod)
             idleLooper()
 
@@ -97,8 +97,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             idleLooper()
 
             val recycler = recyclerView(it)
-            assertThat(recycler.adapter).isInstanceOf(PaymentSheetPaymentMethodsAdapter::class.java)
-            val adapter = recycler.adapter as PaymentSheetPaymentMethodsAdapter
+            assertThat(recycler.adapter).isInstanceOf(PaymentMethodsAdapter::class.java)
+            val adapter = recycler.adapter as PaymentMethodsAdapter
             adapter.addCardClickListener.onClick(it.requireView())
             idleLooper()
 


### PR DESCRIPTION
`PaymentMethodsAdapter` will be used in `PaymentSheetActivity`
and `PaymentOptionsActivity`