### PR TITLE
Create BaseAddCardFragment base class

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Bundle
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.CheckBox
+import androidx.core.content.ContextCompat.getSystemService
+import androidx.fragment.app.Fragment
+import com.stripe.android.R
+import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.SheetMode
+import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.view.CardInputListener
+
+/**
+ * A `Fragment` for adding new card payment method.
+ */
+internal abstract class BaseAddCardFragment : Fragment(R.layout.fragment_paymentsheet_add_card) {
+    abstract val sheetViewModel: SheetViewModel<*>
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (activity == null) {
+            return
+        }
+
+        val binding = FragmentPaymentsheetAddCardBinding.bind(view)
+        val cardMultilineWidget = binding.cardMultilineWidget
+        val saveCardCheckbox = binding.saveCardCheckbox
+
+        cardMultilineWidget.setCardValidCallback { isValid, _ ->
+            val selection = if (isValid) {
+                cardMultilineWidget.paymentMethodCreateParams?.let {
+                    PaymentSelection.New(it)
+                }
+            } else {
+                null
+            }
+            sheetViewModel.updateSelection(selection)
+        }
+
+        cardMultilineWidget.setCardInputListener(object : CardInputListener {
+            override fun onFocusChange(focusField: CardInputListener.FocusField) {
+                // If the user focuses any card field, expand to full screen
+                sheetViewModel.updateMode(SheetMode.Full)
+            }
+
+            override fun onCardComplete() {}
+
+            override fun onExpirationComplete() {}
+
+            override fun onCvcComplete() {}
+        })
+
+        // If we're launched in full expanded mode, focus the card number field
+        // and show the keyboard automatically
+        if (sheetViewModel.sheetMode.value == SheetMode.Full) {
+            cardMultilineWidget.cardNumberEditText.requestFocus()
+            getSystemService(requireContext(), InputMethodManager::class.java)?.apply {
+                showSoftInput(cardMultilineWidget.cardNumberEditText, InputMethodManager.SHOW_IMPLICIT)
+            }
+        }
+
+        sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->
+            saveCardCheckbox.isEnabled = !isProcessing
+            cardMultilineWidget.isEnabled = !isProcessing
+        }
+
+        setupSaveCardCheckbox(saveCardCheckbox)
+    }
+
+    private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {
+        saveCardCheckbox.visibility = when (sheetViewModel.isGuestMode) {
+            true -> View.GONE
+            false -> View.VISIBLE
+        }
+
+        sheetViewModel.shouldSavePaymentMethod = saveCardCheckbox.isShown && saveCardCheckbox.isChecked
+        saveCardCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            sheetViewModel.shouldSavePaymentMethod = isChecked
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.databinding.StripeActivityPaymentOptionsBinding
+import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.ui.Toolbar
@@ -147,13 +148,31 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         supportFragmentManager.commit {
             when (transitionTarget) {
                 PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodFull -> {
-                    // TODO: implement
+                    setCustomAnimations(
+                        AnimationConstants.FADE_IN,
+                        AnimationConstants.FADE_OUT,
+                        AnimationConstants.FADE_IN,
+                        AnimationConstants.FADE_OUT
+                    )
+                    addToBackStack(null)
+
+                    replace(
+                        fragmentContainerId,
+                        PaymentOptionsAddCardFragment().also {
+                            it.arguments = fragmentArgs
+                        }
+                    )
                 }
                 PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
                     // TODO: implement
                 }
                 PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodSheet -> {
-                    // TODO: implement
+                    replace(
+                        fragmentContainerId,
+                        PaymentOptionsAddCardFragment().also {
+                            it.arguments = fragmentArgs
+                        }
+                    )
                 }
             }
         }
@@ -178,5 +197,9 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
 
     override fun hideSheet() {
         bottomSheetController.hide()
+    }
+
+    internal companion object {
+        internal const val EXTRA_STARTER_ARGS = BasePaymentSheetActivity.EXTRA_STARTER_ARGS
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.activityViewModels
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
 internal class PaymentOptionsAddCardFragment : BaseAddCardFragment() {
-    override val sheetViewModel: SheetViewModel<*> by activityViewModels<PaymentOptionsViewModel> {
+    override val sheetViewModel: SheetViewModel<PaymentOptionsViewModel.TransitionTarget> by activityViewModels<PaymentOptionsViewModel> {
         PaymentOptionsViewModel.Factory(
             { requireActivity().application },
             {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet
+
+import androidx.fragment.app.activityViewModels
+import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+
+internal class PaymentOptionsAddCardFragment : BaseAddCardFragment() {
+    override val sheetViewModel: SheetViewModel<*> by activityViewModels<PaymentOptionsViewModel> {
+        PaymentOptionsViewModel.Factory(
+            { requireActivity().application },
+            {
+                requireNotNull(
+                    requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
+                )
+            }
+        )
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.activityViewModels
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
 internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
-    override val sheetViewModel: SheetViewModel<*> by activityViewModels<PaymentSheetViewModel> {
+    override val sheetViewModel: SheetViewModel<PaymentSheetViewModel.TransitionTarget> by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(
             { requireActivity().application },
             {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -1,21 +1,10 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
-import android.view.View
-import android.view.inputmethod.InputMethodManager
-import android.widget.CheckBox
-import androidx.core.content.ContextCompat.getSystemService
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.R
-import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
-import com.stripe.android.view.CardInputListener
 
-internal class PaymentSheetAddCardFragment : Fragment(R.layout.fragment_paymentsheet_add_card) {
-    private val sheetViewModel: SheetViewModel<*> by activityViewModels<PaymentSheetViewModel> {
+internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
+    override val sheetViewModel: SheetViewModel<*> by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(
             { requireActivity().application },
             {
@@ -24,69 +13,5 @@ internal class PaymentSheetAddCardFragment : Fragment(R.layout.fragment_payments
                 )
             }
         )
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        if (activity == null) {
-            return
-        }
-
-        val binding = FragmentPaymentsheetAddCardBinding.bind(view)
-        val cardMultilineWidget = binding.cardMultilineWidget
-        val saveCardCheckbox = binding.saveCardCheckbox
-
-        cardMultilineWidget.setCardValidCallback { isValid, _ ->
-            val selection = if (isValid) {
-                cardMultilineWidget.paymentMethodCreateParams?.let {
-                    PaymentSelection.New(it)
-                }
-            } else {
-                null
-            }
-            sheetViewModel.updateSelection(selection)
-        }
-
-        cardMultilineWidget.setCardInputListener(object : CardInputListener {
-            override fun onFocusChange(focusField: CardInputListener.FocusField) {
-                // If the user focuses any card field, expand to full screen
-                sheetViewModel.updateMode(SheetMode.Full)
-            }
-
-            override fun onCardComplete() {}
-
-            override fun onExpirationComplete() {}
-
-            override fun onCvcComplete() {}
-        })
-
-        // If we're launched in full expanded mode, focus the card number field
-        // and show the keyboard automatically
-        if (sheetViewModel.sheetMode.value == SheetMode.Full) {
-            cardMultilineWidget.cardNumberEditText.requestFocus()
-            getSystemService(requireContext(), InputMethodManager::class.java)?.apply {
-                showSoftInput(cardMultilineWidget.cardNumberEditText, InputMethodManager.SHOW_IMPLICIT)
-            }
-        }
-
-        sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->
-            saveCardCheckbox.isEnabled = !isProcessing
-            cardMultilineWidget.isEnabled = !isProcessing
-        }
-
-        setupSaveCardCheckbox(saveCardCheckbox)
-    }
-
-    private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {
-        saveCardCheckbox.visibility = when (sheetViewModel.isGuestMode) {
-            true -> View.GONE
-            false -> View.VISIBLE
-        }
-
-        sheetViewModel.shouldSavePaymentMethod = saveCardCheckbox.isShown && saveCardCheckbox.isChecked
-        saveCardCheckbox.setOnCheckedChangeListener { _, isChecked ->
-            sheetViewModel.shouldSavePaymentMethod = isChecked
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Create `BaseAddCardFragment` abstract class
- Move logic from `PaymentSheetAddCardFragment` to `BaseAddCardFragment`
- Create new `PaymentSheetAddCardFragment` and
  `PaymentOptionsAddCardFragment` that extend `BaseAddCardFragment`
- Use `PaymentOptionsAddCardFragment` in `PaymentOptionsActivity`

## Motivation
Reuse common UI behavior between PaymentSheet and PaymentOptions

## Testing
Manually verified
