### PR TITLE
Configure add button in PaymentOptionsActivity

### DIFF
--- a/stripe/res/layout/stripe_activity_payment_options.xml
+++ b/stripe/res/layout/stripe_activity_payment_options.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content" />
 
         <com.stripe.android.paymentsheet.BuyButton
-            android:id="@+id/buy_button"
+            android:id="@+id/add_button"
             android:layout_margin="@dimen/stripe_paymentsheet_outer_spacing"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -17,7 +17,7 @@ import com.stripe.android.view.CardInputListener
  * A `Fragment` for adding new card payment method.
  */
 internal abstract class BaseAddCardFragment : Fragment(R.layout.fragment_paymentsheet_add_card) {
-    abstract val sheetViewModel: SheetViewModel<*>
+    abstract val sheetViewModel: SheetViewModel<*, *>
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.bundleOf
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
 import kotlinx.android.parcel.Parcelize
 
@@ -17,9 +16,7 @@ internal sealed class PaymentOptionResult(
     }
 
     @Parcelize
-    data class Succeeded(
-        val paymentMethod: PaymentMethod
-    ) : PaymentOptionResult(Activity.RESULT_OK)
+    object Succeeded : PaymentOptionResult(Activity.RESULT_OK)
 
     @Parcelize
     data class Failed(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -107,7 +107,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         }
         bottomSheetController.setup()
 
-        setupPrimaryButton()
+        setupAddButton(viewBinding.addButton)
 
         viewModel.transition.observe(this) { transitionTarget ->
             if (transitionTarget != null) {
@@ -137,8 +137,31 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         }
     }
 
-    private fun setupPrimaryButton() {
-        // TODO: implement
+    private fun setupAddButton(addButton: BuyButton) {
+        addButton.completedAnimation.observe(this) { completedState ->
+            onActionCompleted()
+        }
+
+        viewModel.viewState.observe(this) { state ->
+            if (state != null) {
+                // TODO(mshafrir-stripe): update button state
+                // addButton.updateState(state)
+            }
+        }
+
+        viewModel.selection.observe(this) { paymentSelection ->
+            // TODO(smaskell): show Google Pay button when GooglePay selected
+            addButton.isEnabled = paymentSelection != null
+        }
+        addButton.setOnClickListener {
+            viewModel.selectPaymentOption(this)
+        }
+
+        viewModel.processing.observe(this) { isProcessing ->
+            viewBinding.toolbar.updateProcessing(isProcessing)
+
+            addButton.isEnabled = !isProcessing
+        }
     }
 
     private fun onTransitionTarget(
@@ -177,6 +200,12 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
             }
         }
         viewModel.updateMode(transitionTarget.sheetMode)
+    }
+
+    private fun onActionCompleted() {
+        // TODO(mshafrir-stripe): handle other outcomes
+
+        animateOut(PaymentOptionResult.Succeeded)
     }
 
     override fun setActivityResult(result: PaymentOptionResult) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
 internal class PaymentOptionsAddCardFragment : BaseAddCardFragment() {
-    override val sheetViewModel: SheetViewModel<PaymentOptionsViewModel.TransitionTarget> by activityViewModels<PaymentOptionsViewModel> {
+    override val sheetViewModel by activityViewModels<PaymentOptionsViewModel> {
         PaymentOptionsViewModel.Factory(
             { requireActivity().application },
             {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentsheet
 
+import android.app.Activity
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
@@ -11,9 +13,14 @@ internal class PaymentOptionsViewModel(
     private val publishableKey: String,
     private val stripeAccountId: String?,
     private val args: PaymentOptionsActivityStarter.Args,
-) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget>(
+) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget, PaymentOptionViewState>(
     isGuestMode = args is PaymentOptionsActivityStarter.Args.Guest
 ) {
+    fun selectPaymentOption(
+        activity: Activity
+    ) {
+        // TODO(mshafrir-stripe): implement
+    }
 
     internal enum class TransitionTarget(
         val sheetMode: SheetMode

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
 internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
-    override val sheetViewModel: SheetViewModel<PaymentSheetViewModel.TransitionTarget> by activityViewModels<PaymentSheetViewModel> {
+    override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(
             { requireActivity().application },
             {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.ApiResultCallback
@@ -43,16 +42,14 @@ internal class PaymentSheetViewModel internal constructor(
     private val googlePayRepository: GooglePayRepository,
     internal val args: PaymentSheetActivityStarter.Args,
     private val workContext: CoroutineContext
-) : SheetViewModel<PaymentSheetViewModel.TransitionTarget>(
+) : SheetViewModel<PaymentSheetViewModel.TransitionTarget, ViewState>(
     isGuestMode = args is PaymentSheetActivityStarter.Args.Guest
 ) {
     private val mutablePaymentMethods = MutableLiveData<List<PaymentMethod>>()
     private val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
-    private val mutableViewState = MutableLiveData<ViewState>(null)
 
     internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
     internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
-    internal val viewState: LiveData<ViewState> = mutableViewState.distinctUntilChanged()
 
     fun updatePaymentMethods() {
         when (args) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentsheet.model
+
+internal sealed class PaymentOptionViewState {
+    object Ready : PaymentOptionViewState()
+
+    object Confirming : PaymentOptionViewState()
+
+    object Completed : PaymentOptionViewState()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -10,7 +10,7 @@ import com.stripe.android.paymentsheet.ui.SheetMode
 /**
  * Base `ViewModel` for activities that use `BottomSheet`.
  */
-internal abstract class SheetViewModel<TransitionTargetType>(
+internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     internal val isGuestMode: Boolean
 ) : ViewModel() {
 
@@ -28,6 +28,9 @@ internal abstract class SheetViewModel<TransitionTargetType>(
 
     protected val mutableProcessing = MutableLiveData(false)
     val processing = mutableProcessing.distinctUntilChanged()
+
+    protected val mutableViewState = MutableLiveData<ViewStateType>(null)
+    internal val viewState: LiveData<ViewStateType> = mutableViewState.distinctUntilChanged()
 
     internal var shouldSavePaymentMethod: Boolean = false
 


### PR DESCRIPTION
- Create `PaymentOptionViewState` to represent view states in
  `PaymentOptionsActivity`
- Temporarily remove `paymentMethod` field from `PaymentOptionResult.Succeeded`
- Move view state `LiveData` fields to `SheetViewModel`