### PR TITLE
Migrate to Kotlin Parcelize plugin

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
     id 'checkstyle'
+    id 'org.jetbrains.kotlin.plugin.parcelize'
 }
 
 assemble.dependsOn('lint')
@@ -165,10 +165,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-}
-
-androidExtensions {
-    features = []
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
     id 'checkstyle'
     id 'org.jetbrains.dokka'
+    id 'org.jetbrains.kotlin.plugin.parcelize'
 
     id 'maven'
     id 'signing'
@@ -125,11 +125,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-}
-
-androidExtensions {
-    features = ['parcelize']
-    experimental = true
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/stripe/src/main/java/com/stripe/android/AppInfo.kt
+++ b/stripe/src/main/java/com/stripe/android/AppInfo.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Data for identifying your plug-in or library.

--- a/stripe/src/main/java/com/stripe/android/EphemeralKey.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralKey.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.StripeModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Represents an Ephemeral Key that can be used temporarily for API operations that typically

--- a/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
+++ b/stripe/src/main/java/com/stripe/android/EphemeralOperation.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.Source
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal sealed class EphemeralOperation : Parcelable {
     internal abstract val id: String

--- a/stripe/src/main/java/com/stripe/android/FingerprintData.kt
+++ b/stripe/src/main/java/com/stripe/android/FingerprintData.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.StripeModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
 

--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -2,7 +2,7 @@ package com.stripe.android
 
 import android.content.Context
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Currency

--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -5,7 +5,7 @@ import androidx.core.os.bundleOf
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.PaymentAuthWebViewActivity
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A class that manages starting a [PaymentAuthWebViewActivity] instance with the correct

--- a/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -3,7 +3,7 @@ package com.stripe.android
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class PaymentConfiguration internal constructor(

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -10,8 +10,8 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.view.AuthActivityStarter
-import kotlinx.android.parcel.Parceler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
 
 internal interface PaymentController {
     /**

--- a/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentIntentResult.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.PaymentIntent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A model representing the result of a [PaymentIntent] confirmation via [Stripe.confirmPayment]

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
@@ -9,8 +9,8 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.PaymentRelayActivity
-import kotlinx.android.parcel.Parceler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
 
 /**
  * Starts an instance of [PaymentRelayStarter].

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionConfig.kt
@@ -14,7 +14,7 @@ import com.stripe.android.view.PaymentMethodsActivity
 import com.stripe.android.view.SelectShippingMethodWidget
 import com.stripe.android.view.ShippingInfoWidget
 import com.stripe.android.view.ShippingInfoWidget.CustomizableShippingField
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 import java.util.Locale
 

--- a/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentSessionData.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.ShippingMethod
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A data class representing the state of the associated [PaymentSession].

--- a/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/SetupIntentResult.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.SetupIntent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A model representing the result of a [SetupIntent] confirmation via [Stripe.confirmSetupIntent]

--- a/stripe/src/main/java/com/stripe/android/StripeError.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeError.kt
@@ -1,7 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.StripeModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 
 /**

--- a/stripe/src/main/java/com/stripe/android/cards/Bin.kt
+++ b/stripe/src/main/java/com/stripe/android/cards/Bin.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.cards
 
 import com.stripe.android.model.StripeModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class Bin internal constructor(

--- a/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AccountParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [Create an account token](https://stripe.com/docs/api/tokens/create_account)

--- a/stripe/src/main/java/com/stripe/android/model/AccountRange.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AccountRange.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class AccountRange internal constructor(

--- a/stripe/src/main/java/com/stripe/android/model/Address.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Address.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.parsers.AddressJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Locale
 

--- a/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize

--- a/stripe/src/main/java/com/stripe/android/model/AlipayAuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AlipayAuthResult.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.StripeIntentResult
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class AlipayAuthResult(

--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import androidx.annotation.Size
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [The bank account object](https://stripe.com/docs/api/customer_bank_accounts/object)

--- a/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [Create a bank account token](https://stripe.com/docs/api/tokens/create_bank_account)

--- a/stripe/src/main/java/com/stripe/android/model/BinRange.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BinRange.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.cards.CardNumber
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class BinRange(

--- a/stripe/src/main/java/com/stripe/android/model/Card.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Card.kt
@@ -5,7 +5,7 @@ import androidx.annotation.Size
 import com.stripe.android.CardUtils
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.parsers.CardJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Calendar
 

--- a/stripe/src/main/java/com/stripe/android/model/CardMetadata.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardMetadata.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.cards.Bin
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class CardMetadata internal constructor(

--- a/stripe/src/main/java/com/stripe/android/model/CardParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CardParams.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [Create a card token](https://stripe.com/docs/api/tokens/create_card)

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing parameters for [confirming a PaymentIntent](https://stripe.com/docs/api/payment_intents/confirm).

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing parameters for [confirming a SetupIntent](https://stripe.com/docs/api/setup_intents/confirm).

--- a/stripe/src/main/java/com/stripe/android/model/Customer.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Customer.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.parsers.CustomerJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
 /**

--- a/stripe/src/main/java/com/stripe/android/model/CustomerSource.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CustomerSource.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model of the "data" object inside a [Customer] "source" object.

--- a/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CvcTokenParams.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CvcTokenParams(

--- a/stripe/src/main/java/com/stripe/android/model/DateOfBirth.kt
+++ b/stripe/src/main/java/com/stripe/android/model/DateOfBirth.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DateOfBirth(

--- a/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
+++ b/stripe/src/main/java/com/stripe/android/model/FpxBankStatuses.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.view.FpxBank
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.jetbrains.annotations.TestOnly
 
 @Parcelize

--- a/stripe/src/main/java/com/stripe/android/model/GooglePayResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/GooglePayResult.kt
@@ -3,7 +3,7 @@ package com.stripe.android.model
 import android.os.Parcelable
 import com.stripe.android.model.StripeJsonUtils.optString
 import com.stripe.android.model.parsers.TokenJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 

--- a/stripe/src/main/java/com/stripe/android/model/IssuingCardPin.kt
+++ b/stripe/src/main/java/com/stripe/android/model/IssuingCardPin.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class IssuingCardPin(

--- a/stripe/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.model.KlarnaSourceParams.LineItem
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing parameters for creating a Klarna Source.

--- a/stripe/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class ListPaymentMethodsParams(

--- a/stripe/src/main/java/com/stripe/android/model/MandateDataParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/MandateDataParams.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Mandate Data parameters for

--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import org.json.JSONObject
 import java.util.regex.Pattern
 

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.wallets.Wallet
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
 /**

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -3,7 +3,7 @@ package com.stripe.android.model
 import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.Stripe
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Locale

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 sealed class PaymentMethodOptionsParams(
     val type: PaymentMethod.Type

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodsList.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodsList.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class PaymentMethodsList(

--- a/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PersonTokenParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Creates a single-use token that represents the details for a person. Use this when creating or

--- a/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PiiTokenParams.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [TokenParams] for creating a PII token.

--- a/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.parsers.SetupIntentJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.regex.Pattern
 

--- a/stripe/src/main/java/com/stripe/android/model/ShippingInformation.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingInformation.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing a shipping address object

--- a/stripe/src/main/java/com/stripe/android/model/ShippingMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ShippingMethod.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import androidx.annotation.Size
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Currency
 
 /**

--- a/stripe/src/main/java/com/stripe/android/model/Source.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Source.kt
@@ -4,8 +4,8 @@ import androidx.annotation.StringDef
 import com.stripe.android.model.Source.Flow
 import com.stripe.android.model.Source.SourceType
 import com.stripe.android.model.parsers.SourceJsonParser
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import org.json.JSONObject
 
 /**

--- a/stripe/src/main/java/com/stripe/android/model/SourceOrder.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOrder.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.SourceOrder.Item.Type
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Information about the items and shipping associated with the source.

--- a/stripe/src/main/java/com/stripe/android/model/SourceOrderParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceOrderParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.model.SourceOrderParams.Item.Type
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Information about the items and shipping associated with the source. Required for transactional

--- a/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceParams.kt
@@ -5,7 +5,7 @@ import androidx.annotation.IntRange
 import androidx.annotation.Size
 import com.stripe.android.model.Source.Companion.asSourceType
 import com.stripe.android.model.Source.SourceType
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Objects

--- a/stripe/src/main/java/com/stripe/android/model/SourceTypeModel.kt
+++ b/stripe/src/main/java/com/stripe/android/model/SourceTypeModel.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Models for [Source] type-specific data

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthParams.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class Stripe3ds2AuthResult internal constructor(

--- a/stripe/src/main/java/com/stripe/android/model/StripeFile.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeFile.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [The file object](https://stripe.com/docs/api/files/object)

--- a/stripe/src/main/java/com/stripe/android/model/StripeFileParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeFileParams.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.io.File
 
 /**

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -3,7 +3,7 @@ package com.stripe.android.model
 import android.net.Uri
 import android.os.Parcelable
 import com.stripe.android.utils.StripeUrlUtils
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * An interface for methods available in [PaymentIntent] and [SetupIntent]

--- a/stripe/src/main/java/com/stripe/android/model/Token.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Token.kt
@@ -2,7 +2,7 @@ package com.stripe.android.model
 
 import com.stripe.android.model.Token.Type
 import com.stripe.android.model.parsers.TokenJsonParser
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Date
 

--- a/stripe/src/main/java/com/stripe/android/model/WeChat.kt
+++ b/stripe/src/main/java/com/stripe/android/model/WeChat.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * [WeChat Pay Payments with Sources](https://stripe.com/docs/sources/wechat-pay)

--- a/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.kt
+++ b/stripe/src/main/java/com/stripe/android/model/wallets/Wallet.kt
@@ -3,7 +3,7 @@ package com.stripe.android.model.wallets
 import android.os.Parcelable
 import com.stripe.android.model.Address
 import com.stripe.android.model.StripeModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Details of the card wallet.

--- a/stripe/src/main/java/com/stripe/android/networking/ApiRequest.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/ApiRequest.kt
@@ -6,7 +6,7 @@ import com.stripe.android.ApiVersion
 import com.stripe.android.AppInfo
 import com.stripe.android.Stripe
 import com.stripe.android.exception.InvalidRequestException
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.io.UnsupportedEncodingException
 
 /**

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentOption
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class DefaultPaymentSheetFlowController internal constructor(
     private val args: Args,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
@@ -7,7 +7,7 @@ import android.os.Parcelable
 import androidx.core.os.bundleOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal sealed class PaymentOptionResult(
     val resultCode: Int

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class PaymentOptionsActivityStarter internal constructor(
     activity: Activity

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentResult.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import android.app.Activity
 import android.os.Parcelable
 import com.stripe.android.model.PaymentIntent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal sealed class PaymentResult(
     val resultCode: Int

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.os.bundleOf
 import com.stripe.android.view.ActivityStarter
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class PaymentSheet internal constructor(
     private val args: PaymentSheetActivityStarter.Args

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivityStarter.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import android.app.Activity
 import android.content.Intent
 import com.stripe.android.view.ActivityStarter
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class PaymentSheetActivityStarter internal constructor(
     activity: Activity

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodActivityStarter.kt
@@ -12,7 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.AddPaymentMethodActivityStarter.Args
 import com.stripe.android.view.AddPaymentMethodActivityStarter.Companion.REQUEST_CODE
 import com.stripe.android.view.AddPaymentMethodActivityStarter.Result.Companion.fromIntent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A class to start [AddPaymentMethodActivity]. Arguments for the activity can be

--- a/stripe/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
+++ b/stripe/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
@@ -3,7 +3,7 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Parcelable
 import com.stripe.android.model.StripeJsonUtils
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Scanner
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentFlowActivityStarter.kt
@@ -6,7 +6,7 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.PaymentSessionConfig
 import com.stripe.android.PaymentSessionData
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class PaymentFlowActivityStarter :
     ActivityStarter<PaymentFlowActivity, PaymentFlowActivityStarter.Args> {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsActivityStarter.kt
@@ -13,7 +13,7 @@ import com.stripe.android.view.PaymentMethodsActivityStarter.Args
 import com.stripe.android.view.PaymentMethodsActivityStarter.Companion.REQUEST_CODE
 import com.stripe.android.view.PaymentMethodsActivityStarter.Result
 import com.stripe.android.view.PaymentMethodsActivityStarter.Result.Companion.fromIntent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * A class to start [PaymentMethodsActivity]. Arguments for the activity can be specified


### PR DESCRIPTION
`kotlin-android-extensions` is deprecated [0].
Use `org.jetbrains.kotlin.plugin.parcelize` instead.

[0] https://youtrack.jetbrains.com/issue/KT-42121