### PR TITLE
Add PaymentSheetFlowController.onPaymentOptionResult()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.paymentsheet
 
+import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
+import com.stripe.android.R
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.parcelize.Parcelize
 
 internal class DefaultPaymentSheetFlowController internal constructor(
@@ -11,6 +15,7 @@ internal class DefaultPaymentSheetFlowController internal constructor(
     private val paymentMethods: List<PaymentMethod>,
     private val defaultPaymentMethodId: String?
 ) : PaymentSheetFlowController {
+    private var paymentSelection: PaymentSelection? = null
 
     override fun presentPaymentOptions(
         activity: ComponentActivity,
@@ -33,6 +38,22 @@ internal class DefaultPaymentSheetFlowController internal constructor(
             )
 
         onComplete(null)
+    }
+
+    override fun onPaymentOptionResult(intent: Intent?): PaymentOption? {
+        val paymentSelection =
+            (PaymentOptionResult.fromIntent(intent) as? PaymentOptionResult.Succeeded)?.paymentSelection
+        return paymentSelection?.let(::createPaymentOption)
+    }
+
+    private fun createPaymentOption(
+        paymentSelection: PaymentSelection
+    ): PaymentOption {
+        // TODO(mshafrir-stripe): derive PaymentOption from PaymentSelection
+        return PaymentOption(
+            drawableResourceId = R.drawable.stripe_ic_visa,
+            label = CardBrand.Visa.displayName
+        )
     }
 
     override fun confirmPayment(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
@@ -35,8 +35,8 @@ internal sealed class PaymentOptionResult(
         private const val EXTRA_RESULT = ActivityStarter.Result.EXTRA
 
         @JvmSynthetic
-        internal fun fromIntent(intent: Intent): PaymentOptionResult? {
-            return intent.getParcelableExtra(EXTRA_RESULT)
+        internal fun fromIntent(intent: Intent?): PaymentOptionResult? {
+            return intent?.getParcelableExtra(EXTRA_RESULT)
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowController.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import android.content.Context
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import com.stripe.android.paymentsheet.model.PaymentOption
 
@@ -10,6 +11,8 @@ internal interface PaymentSheetFlowController {
         activity: ComponentActivity,
         onComplete: (PaymentOption?) -> Unit
     )
+
+    fun onPaymentOptionResult(intent: Intent?): PaymentOption?
 
     fun confirmPayment(
         activity: ComponentActivity,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.runner.RunWith
@@ -40,7 +41,7 @@ class DefaultPaymentSheetFlowControllerTest {
         val paymentOption = flowController.onPaymentOptionResult(
             Intent().putExtras(
                 PaymentOptionResult.Succeeded(
-                    PaymentSelection.Saved("pm_123")
+                    PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
                 ).toBundle()
             )
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
@@ -1,8 +1,12 @@
 package com.stripe.android.paymentsheet
 
+import android.content.Intent
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.R
+import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -10,23 +14,52 @@ import kotlin.test.Test
 @RunWith(RobolectricTestRunner::class)
 class DefaultPaymentSheetFlowControllerTest {
 
+    private val flowController = DefaultPaymentSheetFlowController(
+        DefaultPaymentSheetFlowController.Args.Default(
+            "client_secret",
+            "ephkey",
+            "cus_123"
+        ),
+        emptyList(),
+        null
+    )
+
     @Test
     fun `presentPaymentOptions() should call onComplete() with null`() {
-        val flowController = DefaultPaymentSheetFlowController(
-            DefaultPaymentSheetFlowController.Args.Default(
-                "client_secret",
-                "ephkey",
-                "cus_123"
-            ),
-            emptyList(),
-            null
-        )
-
         var paymentOption: PaymentOption? = null
         flowController.presentPaymentOptions(mock()) {
             paymentOption = it
         }
 
+        assertThat(paymentOption)
+            .isNull()
+    }
+
+    @Test
+    fun `onPaymentOptionResult() with saved payment method selection result should return payment option`() {
+        val paymentOption = flowController.onPaymentOptionResult(
+            Intent().putExtras(
+                PaymentOptionResult.Succeeded(
+                    PaymentSelection.Saved("pm_123")
+                ).toBundle()
+            )
+        )
+        assertThat(paymentOption)
+            .isEqualTo(
+                PaymentOption(
+                    drawableResourceId = R.drawable.stripe_ic_visa,
+                    label = CardBrand.Visa.displayName
+                )
+            )
+    }
+
+    @Test
+    fun `onPaymentOptionResult() with cancelled result should return null`() {
+        val paymentOption = flowController.onPaymentOptionResult(
+            Intent().putExtras(
+                PaymentOptionResult.Cancelled(null).toBundle()
+            )
+        )
         assertThat(paymentOption)
             .isNull()
     }


### PR DESCRIPTION
## Motivation
Method that handles the result (i.e. `onActivityResult()`) after
presenting payment options.

## Testing
Added tests
