### PR TITLE
Update PaymentSelection.Saved to have a PaymentMethod

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsAdapter.kt
@@ -23,7 +23,7 @@ internal class PaymentMethodsAdapter(
         notifyDataSetChanged()
     }
 
-    private var selectedPaymentMethodId: String? = (selectedPaymentMethod as? PaymentSelection.Saved)?.paymentMethodId
+    private var selectedPaymentMethod: PaymentMethod? = (selectedPaymentMethod as? PaymentSelection.Saved)?.paymentMethod
 
     init {
         setHasStableIds(true)
@@ -31,14 +31,14 @@ internal class PaymentMethodsAdapter(
 
     private fun updateSelectedPaymentMethod(position: Int) {
         val currentlySelectedPosition = paymentMethods.indexOfFirst {
-            it.id == selectedPaymentMethodId
+            it.id == selectedPaymentMethod?.id
         }
         if (currentlySelectedPosition != position) {
             // selected a new Payment Method
             notifyItemChanged(currentlySelectedPosition)
             notifyItemChanged(position)
-            selectedPaymentMethodId = paymentMethods.getOrNull(position)?.id
-            selectedPaymentMethodId?.let {
+            selectedPaymentMethod = paymentMethods.getOrNull(position)
+            selectedPaymentMethod?.let {
                 paymentMethodSelectedListener(PaymentSelection.Saved(it))
             }
         }
@@ -79,7 +79,7 @@ internal class PaymentMethodsAdapter(
         if (holder is CardViewHolder) {
             val paymentMethod = paymentMethods[position]
             holder.setPaymentMethod(paymentMethod)
-            holder.setSelected(paymentMethod.id == selectedPaymentMethodId)
+            holder.setSelected(paymentMethod.id == selectedPaymentMethod?.id)
             holder.itemView.setOnClickListener {
                 updateSelectedPaymentMethod(holder.adapterPosition)
             }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -134,7 +134,7 @@ internal class PaymentSheetViewModel internal constructor(
             is PaymentSelection.Saved -> {
                 // TODO(smaskell): Properly set savePaymentMethod/setupFutureUsage
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
-                    selection.paymentMethodId,
+                    selection.paymentMethod.id.orEmpty(),
                     clientSecret
                 )
             }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import android.os.Parcelable
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import kotlinx.parcelize.Parcelize
 
@@ -10,7 +11,7 @@ internal sealed class PaymentSelection : Parcelable {
 
     @Parcelize
     data class Saved(
-        val paymentMethodId: String
+        val paymentMethod: PaymentMethod
     ) : PaymentSelection()
 
     @Parcelize

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.Rule
@@ -48,6 +49,8 @@ class PaymentOptionsViewModelTest {
     }
 
     private companion object {
-        private val SELECTION_SAVED_PAYMENT_METHOD = PaymentSelection.Saved("pm_123")
+        private val SELECTION_SAVED_PAYMENT_METHOD = PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -186,7 +187,9 @@ internal class PaymentSheetActivityTest {
             testCoroutineDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
             idleLooper()
 
-            viewModel.updateSelection(PaymentSelection.Saved("saved_pm"))
+            viewModel.updateSelection(
+                PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            )
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isTrue()
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
@@ -36,7 +37,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
 
     @Test
     fun `resets payment method selection when shown`() {
-        val savedPaymentMethod = PaymentSelection.Saved("test_payment_method")
+        val savedPaymentMethod = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
         val scenario = createScenario()
         scenario.onFragment {
@@ -67,7 +68,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
 
     @Test
     fun `updates selection on click`() {
-        val savedPaymentMethod = PaymentSelection.Saved("test_payment_method")
+        val savedPaymentMethod = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)
@@ -87,7 +88,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
 
     @Test
     fun `posts transition when add card clicked`() {
-        val savedPaymentMethod = PaymentSelection.Saved("test_payment_method")
+        val savedPaymentMethod = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -109,13 +109,15 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should confirm saved payment methods`() {
-        viewModel.updateSelection(PaymentSelection.Saved("saved_pm"))
+        viewModel.updateSelection(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
         viewModel.checkout(mock())
         verify(paymentController).startConfirmAndAuth(
             any(),
             eq(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
-                    "saved_pm",
+                    requireNotNull(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id),
                     CLIENT_SECRET
                 )
             ),


### PR DESCRIPTION
Previously `PaymentSelection.Saved` only referenced a payment method id.
The full `PaymentMethod` is necessary.