### PR TITLE
Refactor payment methods logic for custom payment sheet

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -37,14 +37,14 @@ internal class AddButton @JvmOverloads constructor(
 
         isClickable = true
         isEnabled = false
-    }
-
-    fun onReadyState() {
-        viewBinding.confirmingIcon.visibility = View.GONE
 
         viewBinding.label.text = resources.getString(
             R.string.stripe_paymentsheet_add_button_label,
         )
+    }
+
+    fun onReadyState() {
+        viewBinding.confirmingIcon.visibility = View.GONE
     }
 
     fun onProcessingState() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -50,6 +50,10 @@ internal abstract class BasePaymentMethodsListFragment : Fragment(
             false
         )
         binding.recycler.adapter = adapter
+
+        sheetViewModel.paymentMethods.observe(viewLifecycleOwner) { paymentMethods ->
+            adapter.paymentMethods = paymentMethods
+        }
     }
 
     internal class PaymentMethodsViewModel : ViewModel() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -15,6 +15,10 @@ internal class PaymentOptionsViewModel(
 ) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget, PaymentOptionViewState>(
     isGuestMode = args is PaymentOptionsActivityStarter.Args.Guest
 ) {
+    init {
+        mutablePaymentMethods.value = args.paymentMethods
+    }
+
     fun selectPaymentOption() {
         selection.value?.let { paymentSelection ->
             mutableViewState.value = PaymentOptionViewState.Completed(paymentSelection)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -27,10 +27,6 @@ internal class PaymentSheetPaymentMethodsListFragment : BasePaymentMethodsListFr
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        activityViewModel.paymentMethods.observe(viewLifecycleOwner) { paymentMethods ->
-            adapter.paymentMethods = paymentMethods
-        }
-
         // Only fetch the payment methods list if we haven't already
         if (activityViewModel.paymentMethods.value == null) {
             activityViewModel.updatePaymentMethods()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -45,11 +45,9 @@ internal class PaymentSheetViewModel internal constructor(
 ) : SheetViewModel<PaymentSheetViewModel.TransitionTarget, ViewState>(
     isGuestMode = args is PaymentSheetActivityStarter.Args.Guest
 ) {
-    private val mutablePaymentMethods = MutableLiveData<List<PaymentMethod>>()
     private val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
 
     internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
-    internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
 
     fun updatePaymentMethods() {
         when (args) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 
@@ -13,9 +14,11 @@ import com.stripe.android.paymentsheet.ui.SheetMode
 internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     internal val isGuestMode: Boolean
 ) : ViewModel() {
-
     private val mutableError = MutableLiveData<Throwable>()
     internal val error: LiveData<Throwable> = mutableError
+
+    protected val mutablePaymentMethods = MutableLiveData<List<PaymentMethod>>()
+    internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
 
     private val mutableTransition = MutableLiveData<TransitionTargetType>()
     internal val transition: LiveData<TransitionTargetType> = mutableTransition


### PR DESCRIPTION
Move common logic from `PaymentSheetViewModel` to `SheetViewModel`
and from `PaymentSheetPaymentMethodsListFragment` to
`BasePaymentMethodsListFragment`.