### PR TITLE
Wire billing details view in payment sheet's BaseAddCardFragment

### DIFF
--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -35,7 +35,8 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/add_card_header"
             app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:shouldShowPostalCode="false" />
 
         <TextView
             android:id="@+id/billing_address_label"

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -31,7 +31,7 @@ data class PaymentMethodCreateParams internal constructor(
     private val upi: Upi? = null,
     private val netbanking: Netbanking? = null,
 
-    private val billingDetails: PaymentMethod.BillingDetails? = null,
+    internal val billingDetails: PaymentMethod.BillingDetails? = null,
 
     private val metadata: Map<String, String>? = null,
     private val productUsage: Set<String> = emptySet()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -15,6 +15,7 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import com.stripe.android.R
 import com.stripe.android.databinding.StripeBillingAddressLayoutBinding
 import com.stripe.android.databinding.StripeCountryDropdownItemBinding
+import com.stripe.android.model.Address
 import com.stripe.android.view.Country
 import com.stripe.android.view.CountryAdapter
 import com.stripe.android.view.CountryAutoCompleteTextViewValidator
@@ -44,8 +45,19 @@ internal class BillingAddressView @JvmOverloads constructor(
         ).root
     }
 
+    internal val address: Address
+        get() {
+            return Address(
+                country = countryView.text.toString(),
+                postalCode = postalCodeView.text.toString()
+            )
+        }
+
+    @VisibleForTesting
     internal val countryView = viewBinding.country
-    private val postalCodeView = viewBinding.postalCode
+
+    @VisibleForTesting
+    internal val postalCodeView = viewBinding.postalCode
 
     private var selectedCountry: Country? = null
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -10,6 +10,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,6 +65,28 @@ class PaymentSheetAddCardFragmentTest {
             )
             assertThat(activityViewModel.shouldSavePaymentMethod)
                 .isTrue()
+        }
+    }
+
+    @Test
+    fun `paymentMethodParams with valid input should return object with expected billing details`() {
+        createScenario().onFragment { fragment ->
+            fragment.cardMultilineWidget.setCardNumber("4242424242424242")
+            fragment.cardMultilineWidget.setExpiryDate(1, 2030)
+            fragment.cardMultilineWidget.setCvcCode("123")
+            fragment.billingAddressView.countryView.setText("United States")
+            fragment.billingAddressView.postalCodeView.setText("94107")
+
+            val params = requireNotNull(fragment.paymentMethodParams)
+            assertThat(params.billingDetails)
+                .isEqualTo(
+                    PaymentMethod.BillingDetails(
+                        Address(
+                            country = "United States",
+                            postalCode = "94107"
+                        )
+                    )
+                )
         }
     }
 


### PR DESCRIPTION
## Summary
- Disable postal code in card widget
- Include billing details in `PaymentMethodCreateParams`

## Testing
Added unit test
