### PR TITLE
Fix view tests

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -159,7 +159,7 @@ class CardNumberEditText internal constructor(
     @JvmSynthetic
     internal var isLoadingCallback: (Boolean) -> Unit = {}
 
-    private val loadingJob: Job
+    private var loadingJob: Job? = null
 
     init {
         inputType = InputType.TYPE_CLASS_NUMBER
@@ -171,7 +171,10 @@ class CardNumberEditText internal constructor(
         }
 
         updateLengthFilter()
+    }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
         loadingJob = CoroutineScope(workContext).launch {
             cardAccountRangeRepository.loading.collect {
                 withContext(Dispatchers.Main) {
@@ -187,7 +190,9 @@ class CardNumberEditText internal constructor(
         }
 
     override fun onDetachedFromWindow() {
-        loadingJob.cancel()
+        loadingJob?.cancel()
+        loadingJob = null
+
         cancelAccountRangeRepositoryJob()
 
         super.onDetachedFromWindow()

--- a/stripe/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
@@ -14,8 +14,10 @@ import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -29,6 +31,11 @@ internal class CustomerSessionOperationExecutorTest {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        Dispatchers.resetMain()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
@@ -8,15 +8,12 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.PaymentIntentFixtures
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.BeforeTest
 import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
@@ -26,11 +23,6 @@ internal class DefaultAlipayRepositoryTest {
     private val repository = DefaultAlipayRepository(stripeRepository)
 
     private val testDispatcher = TestCoroutineDispatcher()
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
 
     @Test
     fun `authenticate() should handle success`() = testDispatcher.runBlockingTest {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -29,12 +29,14 @@ import com.stripe.android.view.PaymentRelayActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
 @ExperimentalCoroutinesApi
@@ -84,6 +86,11 @@ internal class PaymentSheetActivityTest {
     @BeforeTest
     fun before() {
         Dispatchers.setMain(testCoroutineDispatcher)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        Dispatchers.resetMain()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.CardNumberFixtures.DINERS_CLUB_14_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.R
 import com.stripe.android.cards.AccountRangeFixtures
 import com.stripe.android.cards.DefaultCardAccountRangeStore
 import com.stripe.android.model.Address
@@ -51,11 +50,13 @@ internal class CardInputWidgetTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val activityScenarioFactory = ActivityScenarioFactory(context)
 
-    private lateinit var cardInputWidget: CardInputWidget
-    private val cardNumberEditText: CardNumberEditText by lazy {
-        cardInputWidget.cardNumberEditText.also {
-            it.workContext = testDispatcher
+    private val cardInputWidget: CardInputWidget by lazy {
+        activityScenarioFactory.createView {
+            createCardInputWidget(it)
         }
+    }
+    private val cardNumberEditText: CardNumberEditText by lazy {
+        cardInputWidget.cardNumberEditText
     }
     private val expiryEditText: StripeEditText by lazy {
         cardInputWidget.expiryDateEditText
@@ -93,22 +94,6 @@ internal class CardInputWidgetTest {
             BinFixtures.DINERSCLUB14,
             listOf(AccountRangeFixtures.DINERSCLUB14)
         )
-
-        activityScenarioFactory.create<AddPaymentMethodActivity>(
-            AddPaymentMethodActivityStarter.Args.Builder()
-                .setPaymentMethodType(PaymentMethod.Type.Card)
-                .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-                .setBillingAddressFields(BillingAddressFields.PostalCode)
-                .build()
-        ).use { activityScenario ->
-            activityScenario.onActivity { activity ->
-                activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
-                    root.removeAllViews()
-                    cardInputWidget = createCardInputWidget(activity)
-                    root.addView(cardInputWidget)
-                }
-            }
-        }
     }
 
     @AfterTest
@@ -137,6 +122,8 @@ internal class CardInputWidgetTest {
 
             it.viewTreeObserver
                 .addOnGlobalFocusChangeListener(onGlobalFocusChangeListener)
+
+            it.cardNumberEditText.workContext = testDispatcher
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.LooperMode
@@ -130,7 +129,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun calculateCursorPosition_whenAmEx_increasesIndexWhenGoingPastTheSpaces() = testDispatcher.runBlockingTest {
-        Dispatchers.setMain(testDispatcher)
         cardNumberEditText.onAccountRangeResult(
             AccountRangeFixtures.AMERICANEXPRESS
         )
@@ -145,7 +143,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun calculateCursorPosition_whenDinersClub16_decreasesIndexWhenDeletingPastTheSpaces() = testDispatcher.runBlockingTest {
-        Dispatchers.setMain(testDispatcher)
         cardNumberEditText.onAccountRangeResult(
             AccountRangeFixtures.DINERSCLUB16
         )
@@ -163,7 +160,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun calculateCursorPosition_whenDeletingNotOnGaps_doesNotDecreaseIndex() = testDispatcher.runBlockingTest {
-        Dispatchers.setMain(testDispatcher)
         cardNumberEditText.onAccountRangeResult(
             AccountRangeFixtures.DINERSCLUB14
         )
@@ -175,7 +171,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun calculateCursorPosition_whenAmEx_decreasesIndexWhenDeletingPastTheSpaces() = testDispatcher.runBlockingTest {
-        Dispatchers.setMain(testDispatcher)
         cardNumberEditText.onAccountRangeResult(
             AccountRangeFixtures.AMERICANEXPRESS
         )
@@ -190,7 +185,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun calculateCursorPosition_whenSelectionInTheMiddle_increasesIndexOverASpace() = testDispatcher.runBlockingTest {
-        Dispatchers.setMain(testDispatcher)
         cardNumberEditText.onAccountRangeResult(
             AccountRangeFixtures.VISA
         )
@@ -229,7 +223,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun setText_whenTextIsValidCommonLengthNumber_changesCardValidState() {
-        Dispatchers.setMain(testDispatcher)
         updateCardNumberAndIdle(VISA_WITH_SPACES)
 
         assertThat(cardNumberEditText.isCardNumberValid)
@@ -240,7 +233,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun setText_whenTextIsSpacelessValidNumber_changesToSpaceNumberAndValidates() {
-        Dispatchers.setMain(testDispatcher)
         updateCardNumberAndIdle(VISA_NO_SPACES)
 
         assertThat(cardNumberEditText.isCardNumberValid)
@@ -367,7 +359,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun `full Amex typed typed at once should change isCardNumberValid to true and invoke completion callback`() {
-        Dispatchers.setMain(testDispatcher)
         updateCardNumberAndIdle(AMEX_NO_SPACES)
         idleLooper()
 
@@ -747,8 +738,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun `when first digit matches a single account, show a card brand`() {
-        Dispatchers.setMain(testDispatcher)
-
         // matches Visa
         updateCardNumberAndIdle("4")
         assertThat(lastBrandChangeCallbackInvocation)
@@ -757,8 +746,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun `when first digit matches multiple accounts, don't show a card brand`() {
-        Dispatchers.setMain(testDispatcher)
-
         // matches Discover and Union Pay
         updateCardNumberAndIdle("6")
         assertThat(lastBrandChangeCallbackInvocation)
@@ -767,8 +754,6 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun `getAccountRange() should only be called when necessary`() {
-        Dispatchers.setMain(testDispatcher)
-
         var repositoryCalls = 0
         val cardNumberEditText = CardNumberEditText(
             context,

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -12,10 +12,12 @@ import com.stripe.android.model.PaymentMethodFixtures
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.mockito.Mockito.times
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -40,6 +42,11 @@ class PaymentMethodsAdapterTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         paymentMethodsAdapter.registerAdapterDataObserver(adapterDataObserver)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        Dispatchers.resetMain()
     }
 
     @Test


### PR DESCRIPTION
Previously, `CardNumberEditText` started loading callback logic
immediately (i.e. in the constructor), which means that there wasn't
an opportunity to configure `workContext` in tests that relied on
view inflation.

Refactor `CardNumberEditText` to start loading callback logic in
`onAttachedToWindow()`. Then configure `CardNumberEditText#workContext`
in `CardInputWidgetTest` and `CardMultilineWidgetTest`.

Also
- Use `ActivityScenarioFactory#createView()` in
  `CardInputWidgetTest` and `CardMultilineWidgetTest` to simplify
  view creation logic
- Update tests to call `Dispatchers.resetMain()` in `@AfterTest`
  if they call `Dispatchers.setMain()` in `@BeforeTest`
- Remove unnecessary `Dispatchers.setMain()` calls in
  `CardNumberEditTextTest`