### PR TITLE
Fix BillingAddressView.address logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/Address.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Address.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 @Parcelize
 data class Address internal constructor(
     val city: String? = null,
-    val country: String? = null,
+    val country: String? = null, // two-character country code
     val line1: String? = null,
     val line2: String? = null,
     val postalCode: String? = null,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -48,7 +48,7 @@ internal class BillingAddressView @JvmOverloads constructor(
     internal val address: Address
         get() {
             return Address(
-                country = countryView.text.toString(),
+                country = selectedCountry?.code,
                 postalCode = postalCodeView.text.toString()
             )
         }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,13 +77,14 @@ class PaymentSheetAddCardFragmentTest {
             fragment.cardMultilineWidget.setCvcCode("123")
             fragment.billingAddressView.countryView.setText("United States")
             fragment.billingAddressView.postalCodeView.setText("94107")
+            idleLooper()
 
             val params = requireNotNull(fragment.paymentMethodParams)
             assertThat(params.billingDetails)
                 .isEqualTo(
                     PaymentMethod.BillingDetails(
                         Address(
-                            country = "United States",
+                            country = "US",
                             postalCode = "94107"
                         )
                     )


### PR DESCRIPTION
Address should be populated with two-character country code instead
of country name.