### PR TITLE
Remove PaymentOptionViewState.Processing state

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -57,6 +57,9 @@ internal class AddButton @JvmOverloads constructor(
     }
 
     fun onCompletedState(state: PaymentOptionViewState.Completed) {
+        viewBinding.lockIcon.visibility = View.GONE
+        viewBinding.confirmingIcon.visibility = View.VISIBLE
+
         setBackgroundResource(R.drawable.stripe_paymentsheet_buy_button_confirmed_background)
 
         animator.fadeOut(viewBinding.label)
@@ -91,9 +94,6 @@ internal class AddButton @JvmOverloads constructor(
         when (state) {
             PaymentOptionViewState.Ready -> {
                 onReadyState()
-            }
-            PaymentOptionViewState.Processing -> {
-                onProcessingState()
             }
             is PaymentOptionViewState.Completed -> {
                 onCompletedState(state)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -47,15 +47,6 @@ internal class AddButton @JvmOverloads constructor(
         viewBinding.confirmingIcon.visibility = View.GONE
     }
 
-    fun onProcessingState() {
-        viewBinding.lockIcon.visibility = View.GONE
-        viewBinding.confirmingIcon.visibility = View.VISIBLE
-
-        viewBinding.label.text = resources.getString(
-            R.string.stripe_paymentsheet_pay_button_processing
-        )
-    }
-
     fun onCompletedState(state: PaymentOptionViewState.Completed) {
         viewBinding.lockIcon.visibility = View.GONE
         viewBinding.confirmingIcon.visibility = View.VISIBLE

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentsheet.model
 internal sealed class PaymentOptionViewState {
     object Ready : PaymentOptionViewState()
 
-    object Processing : PaymentOptionViewState()
-
     data class Completed(
         val paymentSelection: PaymentSelection
     ) : PaymentOptionViewState()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.model.PaymentOptionViewState
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -28,12 +30,12 @@ class AddButtonTest {
     }
 
     @Test
-    fun `onProcessingState() should update label`() {
-        addButton.onProcessingState()
-        assertThat(
-            addButton.viewBinding.label.text.toString()
-        ).isEqualTo(
-            "Processing…"
+    fun `onCompletedState() should update view`() {
+        addButton.onCompletedState(
+            PaymentOptionViewState.Completed(PaymentSelection.GooglePay)
         )
+        assertThat(
+            addButton.viewBinding.lockIcon.isShown
+        ).isFalse()
     }
 }


### PR DESCRIPTION
There is no processing involved when selecting a payment option
