### PR TITLE
Add GooglePayButton to PaymentSheetAddCardFragment

### DIFF
--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -10,24 +10,44 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <TextView
-            android:id="@+id/add_card_header"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/top_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/stripe_paymentsheet_add_payment_method_title"
-            style="@style/StripePaymentSheetTitle"
+            android:orientation="vertical"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget"
+            app:layout_constraintBottom_toTopOf="@+id/card_info_label"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintVertical_bias="0"
-            app:layout_constraintVertical_chainStyle="spread_inside"/>
+            app:layout_constraintVertical_chainStyle="spread_inside">
+            <TextView
+                android:id="@+id/add_card_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/stripe_paymentsheet_add_payment_method_title"
+                style="@style/StripePaymentSheetTitle"/>
+
+            <com.stripe.android.paymentsheet.ui.GooglePayButton
+                android:id="@+id/google_pay_button"
+                android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.stripe.android.paymentsheet.ui.GooglePayDivider
+                android:id="@+id/google_pay_divider"
+                android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
 
         <TextView
+            android:id="@+id/card_info_label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/stripe_paymentsheet_add_payment_method_card_information"
             style="@style/StripePaymentSheetLabel"
-            app:layout_constraintTop_toBottomOf="@+id/add_card_header"
+            app:layout_constraintTop_toBottomOf="@+id/top_container"
             app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget"
             app:layout_constraintStart_toStartOf="parent" />
 
@@ -35,8 +55,8 @@
             android:id="@+id/card_multiline_widget"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/add_card_header"
-            app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
+            app:layout_constraintTop_toBottomOf="@+id/card_info_label"
+            app:layout_constraintBottom_toTopOf="@+id/billing_address_label"
             app:layout_constraintStart_toStartOf="parent"
             app:shouldShowPostalCode="false" />
 

--- a/stripe/res/layout/stripe_google_pay_button_black.xml
+++ b/stripe/res/layout/stripe_google_pay_button_black.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:clickable="true"
-    android:focusable="true"
     android:layout_width="match_parent"
     android:layout_height="48sp"
     android:background="@drawable/stripe_googlepay_button_no_shadow_background_black"

--- a/stripe/res/layout/stripe_google_pay_divider.xml
+++ b/stripe/res/layout/stripe_google_pay_divider.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_margin="12dp"
+        android:background="@color/stripe_paymentsheet_googlepay_divider_line" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="2dp"
+        android:background="@color/stripe_paymentsheet_googlepay_divider_background"
+        android:textColor="@color/stripe_paymentsheet_googlepay_divider_text"
+        android:layout_centerHorizontal="true"
+        android:textSize="14sp"
+        android:text="@string/stripe_paymentsheet_or_pay_with" />
+</merge>

--- a/stripe/res/values/colors.xml
+++ b/stripe/res/values/colors.xml
@@ -32,4 +32,7 @@
     <color name="stripe_paymentsheet_buybutton_confirming_progress">#ffffff</color>
     <color name="stripe_paymentsheet_form_border">#44000000</color>
 
+    <color name="stripe_paymentsheet_googlepay_divider_line">#E7E7E7</color>
+    <color name="stripe_paymentsheet_googlepay_divider_background">@android:color/white</color>
+    <color name="stripe_paymentsheet_googlepay_divider_text">#757575</color>
 </resources>

--- a/stripe/res/values/strings.xml
+++ b/stripe/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="stripe_paymentsheet_add_payment_method_country_or_region" tools:ignore="MissingTranslation">Country or region</string>
     <string name="stripe_paymentsheet_add_payment_method_button" tools:ignore="MissingTranslation">+ Add new</string>
     <string name="stripe_paymentsheet_save_this_card" tools:ignore="MissingTranslation">Save this card</string>
+    <string name="stripe_paymentsheet_or_pay_with" tools:ignore="MissingTranslation">Or pay with</string>
 
     <!-- The payment amount (e.g. "Pay $25.00") -->
     <string name="stripe_paymentsheet_pay_button_amount" tools:ignore="MissingTranslation">Pay %s</string>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -27,7 +27,7 @@ internal abstract class BaseAddCardFragment : Fragment() {
     abstract val sheetViewModel: SheetViewModel<*, *>
 
     private var _viewBinding: FragmentPaymentsheetAddCardBinding? = null
-    private val viewBinding get() = requireNotNull(_viewBinding)
+    protected val viewBinding get() = requireNotNull(_viewBinding)
 
     @VisibleForTesting
     internal val cardMultilineWidget: CardMultilineWidget by lazy {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -1,6 +1,12 @@
 package com.stripe.android.paymentsheet
 
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
+import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
     override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
@@ -12,5 +18,34 @@ internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
                 )
             }
         )
+    }
+
+    @VisibleForTesting
+    internal val googlePayButton: View by lazy { viewBinding.googlePayButton }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        sheetViewModel.fetchAddPaymentMethodConfig().observe(viewLifecycleOwner) { config ->
+            if (config != null) {
+                onConfigReady(config)
+            }
+        }
+    }
+
+    @VisibleForTesting
+    fun onConfigReady(config: AddPaymentMethodConfig) {
+        val shouldShowGooglePayButton = config.shouldShowGooglePayButton
+        googlePayButton.setOnClickListener {
+            launchGooglePay()
+        }
+        googlePayButton.isVisible = shouldShowGooglePayButton
+        viewBinding.googlePayDivider.isVisible = shouldShowGooglePayButton
+        viewBinding.addCardHeader.isVisible = !shouldShowGooglePayButton
+    }
+
+    private fun launchGooglePay() {
+        sheetViewModel.updateSelection(PaymentSelection.GooglePay)
+        // TODO(mshafrir-stripe): start Google Pay
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLoadingFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLoadingFragment.kt
@@ -1,36 +1,9 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
-import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
-import com.stripe.android.paymentsheet.PaymentSheetViewModel.TransitionTarget
 
-class PaymentSheetLoadingFragment : Fragment(R.layout.fragment_payment_sheet_loading) {
-    private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
-        PaymentSheetViewModel.Factory(
-            { requireActivity().application },
-            {
-                requireNotNull(
-                    requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
-                )
-            }
-        )
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        activityViewModel.paymentMethods.observe(viewLifecycleOwner) { paymentMethods ->
-            val target = if (paymentMethods.isEmpty()) {
-                TransitionTarget.AddPaymentMethodSheet
-            } else {
-                TransitionTarget.SelectSavedPaymentMethod
-            }
-            activityViewModel.transitionTo(target)
-        }
-        activityViewModel.updatePaymentMethods()
-        activityViewModel.fetchPaymentIntent()
-    }
-}
+/**
+ * A `Fragment` that shows a progress indicator.
+ */
+internal class PaymentSheetLoadingFragment : Fragment(R.layout.fragment_payment_sheet_loading)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/AddPaymentMethodConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/AddPaymentMethodConfig.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.model
+
+import android.os.Parcelable
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Configuration data for `PaymentSheetAddCardFragment`.
+ */
+@Parcelize
+internal data class AddPaymentMethodConfig(
+    val paymentIntent: PaymentIntent,
+    val paymentMethods: List<PaymentMethod>,
+    val isGooglePayReady: Boolean
+) : Parcelable {
+    val shouldShowGooglePayButton: Boolean
+        get() = isGooglePayReady && paymentMethods.isEmpty()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
@@ -3,20 +3,19 @@ package com.stripe.android.paymentsheet.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.widget.FrameLayout
-import com.stripe.android.databinding.StripeGooglePayButtonBlackBinding
+import android.widget.RelativeLayout
+import com.stripe.android.databinding.StripeGooglePayDividerBinding
 
-class GooglePayButton @JvmOverloads constructor(
+internal class GooglePayDivider @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr) {
+) : RelativeLayout(context, attrs, defStyleAttr) {
 
     init {
-        StripeGooglePayButtonBlackBinding.inflate(
+        StripeGooglePayDividerBinding.inflate(
             LayoutInflater.from(context),
-            this,
-            true
+            this
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.widget.CheckBox
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
@@ -11,7 +12,10 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
 import org.junit.Test
@@ -89,6 +93,41 @@ class PaymentSheetAddCardFragmentTest {
                         )
                     )
                 )
+        }
+    }
+
+    @Test
+    fun `when isGooglePayEnabled=true should configure Google Pay button`() {
+        createScenario().onFragment { fragment ->
+            val activityViewModel = activityViewModel(
+                fragment,
+                PaymentSheetFixtures.DEFAULT_ARGS
+            )
+
+            fragment.onConfigReady(
+                AddPaymentMethodConfig(
+                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                    paymentMethods = emptyList(),
+                    isGooglePayReady = true
+                )
+            )
+            idleLooper()
+
+            val paymentSelections = mutableListOf<PaymentSelection>()
+            activityViewModel.selection.observeForever { paymentSelection ->
+                if (paymentSelection != null) {
+                    paymentSelections.add(paymentSelection)
+                }
+            }
+
+            assertThat(fragment.googlePayButton.isVisible)
+                .isTrue()
+
+            fragment.googlePayButton.performClick()
+            idleLooper()
+
+            assertThat(paymentSelections)
+                .containsExactly(PaymentSelection.GooglePay)
         }
     }
 


### PR DESCRIPTION
## Summary
- Show `GooglePayButton` and `GooglePayDivider` instead of header if
  Google Pay is enabled and there are no saved payment methods.
- Create `AddPaymentMethodConfig` model for configuration data needed by
  `PaymentSheetAddCardFragment`.
- Move data fetching logic from `PaymentSheetLoadingFragment` to
  `PaymentSheetActivity`.

## Testing
- Added unit tests
- Manually verified
