### PR TITLE
Create StripeGooglePayActivity

### DIFF
--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -29,6 +29,10 @@
         <activity
             android:name=".paymentsheet.PaymentOptionsActivity"
             android:theme="@style/StripePaymentSheetDefaultTheme" />
+
+        <activity
+            android:name=".googlepay.StripeGooglePayActivity"
+            android:theme="@style/StripeGooglePayDefaultTheme" />
     </application>
 
 </manifest>

--- a/stripe/res/values/themes.xml
+++ b/stripe/res/values/themes.xml
@@ -24,6 +24,8 @@
 
     <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
+    <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
+
     <!-- Required so that keyboard does not cover bottom sheet -->
     <style name="StripePaymentSheetAddCardTheme">
         <item name="android:windowIsFloating">false</item>

--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -152,7 +152,9 @@ class GooglePayJsonFactory constructor(
                         "totalPrice",
                         PayWithGoogleUtils.getPriceString(
                             it,
-                            Currency.getInstance(transactionInfo.currencyCode)
+                            Currency.getInstance(
+                                transactionInfo.currencyCode.toUpperCase(Locale.ROOT)
+                            )
                         )
                     )
                 }

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -1,0 +1,261 @@
+package com.stripe.android.googlepay
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.wallet.AutoResolveHelper
+import com.google.android.gms.wallet.PaymentData
+import com.google.android.gms.wallet.PaymentDataRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.google.android.gms.wallet.WalletConstants
+import com.stripe.android.ApiResultCallback
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.Stripe
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.GooglePayResult
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import org.json.JSONObject
+
+/**
+ * [StripeGooglePayActivity] is used to confirm a `PaymentIntent` using Google Pay.
+ *
+ * Use [StripeGooglePayLauncher] to start [StripeGooglePayActivity].
+ *
+ * See [Troubleshooting](https://developers.google.com/pay/api/android/support/troubleshooting)
+ * for a guide to troubleshooting Google Pay issues.
+ */
+internal class StripeGooglePayActivity : AppCompatActivity() {
+    private val paymentsClient: PaymentsClient by lazy {
+        Wallet.getPaymentsClient(
+            this,
+            Wallet.WalletOptions.Builder()
+                .setEnvironment(WalletConstants.ENVIRONMENT_TEST)
+                .build()
+        )
+    }
+    private val publishableKey: String by lazy {
+        PaymentConfiguration.getInstance(this).publishableKey
+    }
+    private val stripe: Stripe by lazy { Stripe(this, publishableKey) }
+    private val args: StripeGooglePayLauncher.Args by lazy {
+        StripeGooglePayLauncher.Args.create(intent)
+    }
+    private val viewModel: StripeGooglePayViewModel by viewModels {
+        StripeGooglePayViewModel.Factory(
+            application,
+            publishableKey,
+            args
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        overridePendingTransition(0, 0)
+
+        setResult(
+            RESULT_OK,
+            Intent().putExtras(
+                StripeGooglePayLauncher.Result.Canceled.toBundle()
+            )
+        )
+
+        viewModel.googlePayResult.observe(this) { googlePayResult ->
+            googlePayResult?.let(::finishWithResult)
+        }
+
+        if (!viewModel.hasLaunched) {
+            viewModel.hasLaunched = true
+            startGooglePay(args.paymentIntent)
+        }
+    }
+
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(0, 0)
+    }
+
+    private fun startGooglePay(paymentIntent: PaymentIntent) {
+        if (paymentIntent.confirmationMethod == PaymentIntent.ConfirmationMethod.Manual) {
+            viewModel.updateGooglePayResult(
+                StripeGooglePayLauncher.Result.Error(
+                    RuntimeException(
+                        "StripeGooglePayActivity requires a PaymentIntent with automatic confirmation."
+                    )
+                )
+            )
+        } else {
+            isReadyToPay(
+                viewModel.createPaymentDataRequestForPaymentIntentArgs()
+            )
+        }
+    }
+
+    /**
+     * Check that Google Pay is available and ready
+     */
+    private fun isReadyToPay(paymentDataRequest: JSONObject) {
+        paymentsClient.isReadyToPay(
+            viewModel.createIsReadyToPayRequest()
+        ).addOnCompleteListener { task ->
+            runCatching {
+                if (task.isSuccessful) {
+                    payWithGoogle(paymentDataRequest)
+                } else {
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Unavailable
+                    )
+                }
+            }.onFailure {
+                viewModel.updateGooglePayResult(
+                    StripeGooglePayLauncher.Result.Error(it)
+                )
+            }
+        }
+    }
+
+    private fun payWithGoogle(paymentDataRequest: JSONObject) {
+        AutoResolveHelper.resolveTask(
+            paymentsClient.loadPaymentData(
+                PaymentDataRequest.fromJson(paymentDataRequest.toString())
+            ),
+            this,
+            LOAD_PAYMENT_DATA_REQUEST_CODE
+        )
+    }
+
+    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == LOAD_PAYMENT_DATA_REQUEST_CODE) {
+            when (resultCode) {
+                RESULT_OK -> {
+                    onGooglePayResult(data)
+                }
+                RESULT_CANCELED -> {
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Canceled
+                    )
+                }
+                AutoResolveHelper.RESULT_ERROR -> {
+                    val status = AutoResolveHelper.getStatusFromIntent(data)
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Error(
+                            RuntimeException(
+                                "Google Pay returned an error. See googlePayStatus property for more information."
+                            ),
+                            googlePayStatus = status
+                        )
+                    )
+                }
+                else -> {
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Error(
+                            RuntimeException(
+                                "Google Pay returned an expected result code."
+                            )
+                        )
+                    )
+                }
+            }
+        } else {
+            onPaymentResult(requestCode, data)
+        }
+    }
+
+    private fun onPaymentResult(requestCode: Int, data: Intent?) {
+        val isPaymentResult = stripe.onPaymentResult(
+            requestCode,
+            data,
+            object : ApiResultCallback<PaymentIntentResult> {
+                override fun onSuccess(result: PaymentIntentResult) {
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.PaymentIntent(result)
+                    )
+                }
+
+                override fun onError(e: Exception) {
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Error(
+                            e,
+                            paymentMethod = viewModel.paymentMethod
+                        )
+                    )
+                }
+            }
+        )
+
+        if (!isPaymentResult) {
+            viewModel.updateGooglePayResult(
+                StripeGooglePayLauncher.Result.Error(
+                    RuntimeException("Unable to confirm the PaymentIntent.")
+                )
+            )
+        }
+    }
+
+    private fun onGooglePayResult(data: Intent?) {
+        val paymentData = data?.let { PaymentData.getFromIntent(it) }
+        if (paymentData == null) {
+            viewModel.updateGooglePayResult(
+                StripeGooglePayLauncher.Result.Error(
+                    IllegalArgumentException("Google Pay data was not available")
+                )
+            )
+            return
+        }
+
+        val paymentDataJson = JSONObject(paymentData.toJson())
+        val shippingInformation =
+            GooglePayResult.fromJson(paymentDataJson).shippingInformation
+
+        val params = PaymentMethodCreateParams.createFromGooglePay(paymentDataJson)
+        viewModel.createPaymentMethod(params).observe(this) { result ->
+            result?.fold(
+                onSuccess = ::onPaymentMethodCreated,
+                onFailure = {
+                    viewModel.paymentMethod = null
+                    viewModel.updateGooglePayResult(
+                        StripeGooglePayLauncher.Result.Error(it)
+                    )
+                }
+            )
+        }
+    }
+
+    private fun onPaymentMethodCreated(paymentMethod: PaymentMethod) {
+        viewModel.paymentMethod = paymentMethod
+        confirmIntent(args.paymentIntent.clientSecret.orEmpty(), paymentMethod)
+    }
+
+    private fun confirmIntent(
+        clientSecret: String,
+        paymentMethod: PaymentMethod
+    ) {
+        stripe.confirmPayment(
+            this,
+            ConfirmPaymentIntentParams.createWithPaymentMethodId(
+                paymentMethodId = paymentMethod.id.orEmpty(),
+                clientSecret = clientSecret
+            )
+        )
+    }
+
+    private fun finishWithResult(result: StripeGooglePayLauncher.Result) {
+        setResult(
+            RESULT_OK,
+            Intent().putExtras(
+                result.toBundle()
+            )
+        )
+        finish()
+    }
+
+    private companion object {
+        private const val LOAD_PAYMENT_DATA_REQUEST_CODE = 4444
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayLauncher.kt
@@ -1,0 +1,109 @@
+package com.stripe.android.googlepay
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcel
+import androidx.fragment.app.Fragment
+import com.google.android.gms.common.api.Status
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
+import com.stripe.android.view.ActivityStarter
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
+
+internal class StripeGooglePayLauncher : ActivityStarter<StripeGooglePayActivity, StripeGooglePayLauncher.Args> {
+    constructor(activity: Activity) : super(
+        activity,
+        StripeGooglePayActivity::class.java,
+        REQUEST_CODE,
+        intentFlags = Intent.FLAG_ACTIVITY_NO_ANIMATION
+    )
+
+    constructor(fragment: Fragment) : super(
+        fragment,
+        StripeGooglePayActivity::class.java,
+        REQUEST_CODE,
+        intentFlags = Intent.FLAG_ACTIVITY_NO_ANIMATION
+    )
+
+    @Parcelize
+    data class Args(
+        internal var paymentIntent: PaymentIntent,
+
+        /**
+         * ISO 3166-1 alpha-2 country code where the transaction is processed.
+         */
+        internal var countryCode: String,
+
+        /**
+         * Set to true to request an email address.
+         */
+        internal var isEmailRequired: Boolean = false
+    ) : ActivityStarter.Args {
+
+        companion object {
+            @JvmSynthetic
+            internal fun create(intent: Intent): Args {
+                return requireNotNull(intent.getParcelableExtra(ActivityStarter.Args.EXTRA))
+            }
+        }
+    }
+
+    sealed class Result : ActivityStarter.Result {
+        override fun toBundle(): Bundle {
+            return Bundle().also {
+                it.putParcelable(ActivityStarter.Result.EXTRA, this)
+            }
+        }
+
+        @Parcelize
+        class Error(
+            val exception: Throwable,
+            val googlePayStatus: Status? = null,
+            val paymentMethod: PaymentMethod? = null,
+            val shippingInformation: ShippingInformation? = null
+        ) : Result() {
+            companion object : Parceler<Error> {
+                override fun create(parcel: Parcel): Error {
+                    return Error(
+                        exception = parcel.readSerializable() as Throwable,
+                        googlePayStatus = parcel.readParcelable(Status::class.java.classLoader)
+                    )
+                }
+
+                override fun Error.write(parcel: Parcel, flags: Int) {
+                    parcel.writeSerializable(exception)
+                    parcel.writeParcelable(googlePayStatus, flags)
+                }
+            }
+        }
+
+        @Parcelize
+        class PaymentIntent(
+            val paymentIntentResult: PaymentIntentResult
+        ) : Result()
+
+        @Parcelize
+        object Canceled : Result()
+
+        @Parcelize
+        object Unavailable : Result()
+
+        companion object {
+            /**
+             * @return the [Result] object from the given `Intent`
+             */
+            @JvmStatic
+            fun fromIntent(intent: Intent): Result? {
+                return intent.getParcelableExtra(ActivityStarter.Result.EXTRA)
+            }
+        }
+    }
+
+    companion object {
+        const val REQUEST_CODE: Int = 9004
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.googlepay
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.liveData
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import kotlin.coroutines.CoroutineContext
+
+internal class StripeGooglePayViewModel(
+    application: Application,
+    private val publishableKey: String,
+    private val args: StripeGooglePayLauncher.Args,
+    private val stripeRepository: StripeRepository,
+    private val appName: String,
+    private val workContext: CoroutineContext
+) : AndroidViewModel(application) {
+    var hasLaunched: Boolean = false
+    var paymentMethod: PaymentMethod? = null
+
+    private val googlePayJsonFactory = GooglePayJsonFactory(application)
+
+    private val _googleResult = MutableLiveData<StripeGooglePayLauncher.Result>()
+    internal val googlePayResult = _googleResult.distinctUntilChanged()
+
+    fun createIsReadyToPayRequest(): IsReadyToPayRequest {
+        return IsReadyToPayRequest.fromJson(
+            googlePayJsonFactory.createIsReadyToPayRequest().toString()
+        )
+    }
+
+    fun updateGooglePayResult(result: StripeGooglePayLauncher.Result) {
+        _googleResult.value = result
+    }
+
+    fun createPaymentDataRequestForPaymentIntentArgs(): JSONObject {
+        val paymentIntent = args.paymentIntent
+        return googlePayJsonFactory.createPaymentDataRequest(
+            transactionInfo = GooglePayJsonFactory.TransactionInfo(
+                currencyCode = paymentIntent.currency.orEmpty(),
+                totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
+                transactionId = paymentIntent.id,
+                totalPrice = paymentIntent.amount?.toInt(),
+                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                merchantName = appName
+            ),
+            billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(
+                isRequired = true,
+                format = GooglePayJsonFactory.BillingAddressParameters.Format.Min,
+                isPhoneNumberRequired = false
+            ),
+            isEmailRequired = args.isEmailRequired
+        )
+    }
+
+    fun createPaymentMethod(
+        params: PaymentMethodCreateParams
+    ) = liveData {
+        withContext(workContext) {
+            emit(
+                runCatching {
+                    requireNotNull(
+                        stripeRepository.createPaymentMethod(
+                            params,
+                            ApiRequest.Options(publishableKey)
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    internal class Factory(
+        private val application: Application,
+        private val publishableKey: String,
+        private val args: StripeGooglePayLauncher.Args
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            val appName = application.applicationInfo.loadLabel(application.packageManager).toString()
+            return StripeGooglePayViewModel(
+                application,
+                publishableKey,
+                args,
+                StripeApiRepository(application, publishableKey),
+                appName,
+                Dispatchers.IO
+            ) as T
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -46,6 +46,6 @@ internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
 
     private fun launchGooglePay() {
         sheetViewModel.updateSelection(PaymentSelection.GooglePay)
-        // TODO(mshafrir-stripe): start Google Pay
+        sheetViewModel.checkout(requireActivity())
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripePaymentController
+import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -22,6 +23,7 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.model.ConfirmParamsFactory
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
@@ -101,30 +103,41 @@ internal class PaymentSheetViewModel internal constructor(
     fun checkout(activity: Activity) {
         mutableProcessing.value = true
 
-        val confirmParams = selection.value?.let { paymentSelection ->
-            confirmParamsFactory.create(
-                args.clientSecret,
-                paymentSelection,
-                shouldSavePaymentMethod
-            )
-        }
-
-        when {
-            confirmParams != null -> {
-                mutableViewState.value = ViewState.Confirming
-                paymentController.startConfirmAndAuth(
-                    AuthActivityStarter.Host.create(activity),
-                    confirmParams,
-                    ApiRequest.Options(
-                        apiKey = publishableKey,
-                        stripeAccount = stripeAccountId
+        if (selection.value == PaymentSelection.GooglePay) {
+            paymentIntent.value?.let { paymentIntent ->
+                StripeGooglePayLauncher(activity).startForResult(
+                    StripeGooglePayLauncher.Args(
+                        paymentIntent = paymentIntent,
+                        countryCode = "US" // TODO(mshafrir-stripe): don't hardcode country
                     )
                 )
             }
-            else -> {
-                onError(
-                    IllegalStateException("checkout called when no payment method selected")
+        } else {
+            val confirmParams = selection.value?.let { paymentSelection ->
+                confirmParamsFactory.create(
+                    args.clientSecret,
+                    paymentSelection,
+                    shouldSavePaymentMethod
                 )
+            }
+
+            when {
+                confirmParams != null -> {
+                    mutableViewState.value = ViewState.Confirming
+                    paymentController.startConfirmAndAuth(
+                        AuthActivityStarter.Host.create(activity),
+                        confirmParams,
+                        ApiRequest.Options(
+                            apiKey = publishableKey,
+                            stripeAccount = stripeAccountId
+                        )
+                    )
+                }
+                else -> {
+                    onError(
+                        IllegalStateException("checkout called when no payment method selected")
+                    )
+                }
             }
         }
     }
@@ -143,6 +156,24 @@ internal class PaymentSheetViewModel internal constructor(
                     }
                 }
             )
+        }
+
+        if (requestCode == StripeGooglePayLauncher.REQUEST_CODE &&
+            resultCode == Activity.RESULT_OK && data != null
+        ) {
+            onGooglePayResult(data)
+        }
+    }
+
+    private fun onGooglePayResult(data: Intent) {
+        val googlePayResult = StripeGooglePayLauncher.Result.fromIntent(data)
+        when (googlePayResult) {
+            is StripeGooglePayLauncher.Result.PaymentIntent -> {
+                mutableViewState.value = ViewState.Completed(googlePayResult.paymentIntentResult)
+            }
+            else -> {
+                // TODO(mshafrir-stripe): handle error
+            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -50,6 +50,6 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     }
 
     fun updateSelection(selection: PaymentSelection?) {
-        mutableSelection.postValue(selection)
+        mutableSelection.value = selection
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ActivityStarter.kt
@@ -16,33 +16,43 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
     private val activity: Activity,
     private val fragment: Fragment? = null,
     private val targetClass: Class<TargetActivityType>,
-    private val requestCode: Int
+    private val requestCode: Int,
+    private val intentFlags: Int? = null
 ) {
     internal constructor(
         activity: Activity,
         targetClass: Class<TargetActivityType>,
-        requestCode: Int
+        requestCode: Int,
+        intentFlags: Int? = null
     ) : this(
         activity = activity,
         fragment = null,
         targetClass = targetClass,
-        requestCode = requestCode
+        requestCode = requestCode,
+        intentFlags = intentFlags
     )
 
     internal constructor(
         fragment: Fragment,
         targetClass: Class<TargetActivityType>,
-        requestCode: Int
+        requestCode: Int,
+        intentFlags: Int? = null
     ) : this(
         activity = fragment.requireActivity(),
         fragment = fragment,
         targetClass = targetClass,
-        requestCode = requestCode
+        requestCode = requestCode,
+        intentFlags = intentFlags
     )
 
     fun startForResult(args: ArgsType) {
         val intent = Intent(activity, targetClass)
             .putExtra(Args.EXTRA, args)
+            .also {
+                if (intentFlags != null) {
+                    it.addFlags(intentFlags)
+                }
+            }
 
         if (fragment != null) {
             fragment.startActivityForResult(intent, requestCode)

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -1,0 +1,115 @@
+package com.stripe.android.googlepay
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.StripeJsonUtils
+import com.stripe.android.networking.AbsFakeStripeRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.json.JSONObject
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class StripeGooglePayViewModelTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val viewModel: StripeGooglePayViewModel by lazy {
+        StripeGooglePayViewModel(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            ARGS,
+            FakeStripeRepository(),
+            "App Name",
+            testDispatcher
+        )
+    }
+
+    @BeforeTest
+    fun setup() {
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+    }
+
+    @Test
+    fun `createIsReadyToPayRequest() returns expected object`() {
+        val allowedPaymentMethods = JSONObject(viewModel.createIsReadyToPayRequest().toJson())
+            .getJSONArray("allowedPaymentMethods")
+        assertThat(allowedPaymentMethods.length())
+            .isEqualTo(1)
+        val allowedCardNetworks = allowedPaymentMethods
+            .getJSONObject(0)
+            .getJSONObject("parameters")
+            .getJSONArray("allowedCardNetworks")
+
+        assertThat(
+            StripeJsonUtils.jsonArrayToList(allowedCardNetworks)
+        ).isEqualTo(
+            listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA")
+        )
+    }
+
+    @Test
+    fun `createPaymentDataRequestForPaymentIntentArgs() should return expected JSON`() {
+        assertThat(viewModel.createPaymentDataRequestForPaymentIntentArgs().toString())
+            .isEqualTo(
+                JSONObject(
+                    """
+                    {
+                        "apiVersion": 2,
+                        "apiVersionMinor": 0,
+                        "allowedPaymentMethods": [{
+                            "type": "CARD",
+                            "parameters": {
+                                "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                                "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA"],
+                                "billingAddressRequired": true,
+                                "billingAddressParameters": {
+                                    "phoneNumberRequired": false,
+                                    "format": "MIN"
+                                }
+                            },
+                            "tokenizationSpecification": {
+                                "type": "PAYMENT_GATEWAY",
+                                "parameters": {
+                                    "gateway": "stripe",
+                                    "stripe:version": "2020-03-02",
+                                    "stripe:publishableKey": "pk_test_123"
+                                }
+                            }
+                        }],
+                        "transactionInfo": {
+                            "currencyCode": "USD",
+                            "totalPriceStatus": "FINAL",
+                            "transactionId": "pi_1ExkUeAWhjPjYwPiXph9ouXa",
+                            "totalPrice": "20.00",
+                            "checkoutOption": "COMPLETE_IMMEDIATE_PURCHASE"
+                        },
+                        "emailRequired": true,
+                        "merchantInfo": {
+                            "merchantName": "App Name"
+                        }
+                    }
+                    """.trimIndent()
+                ).toString()
+            )
+    }
+
+    private class FakeStripeRepository : AbsFakeStripeRepository()
+
+    private companion object {
+        private val ARGS = StripeGooglePayLauncher.Args(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            countryCode = "US",
+            isEmailRequired = true
+        )
+    }
+}


### PR DESCRIPTION
## Summary
`StripeGooglePayActivity` is used to confirm a `PaymentIntent` using
Google Pay.

`StripeGooglePayLauncher` is used to configure and start
`StripeGooglePayActivity`. The result of `StripeGooglePayActivity` is
represented by `StripeGooglePayLauncher.Result`.

## Motivation
Integrate in payment sheet.

## Testing
Unit tests + manually verified
