### PR TITLE
Specify context for suspend functions in StripeApiRepository

### DIFF
--- a/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -13,11 +12,11 @@ class GooglePayConfigTest {
     @Test
     fun getTokenizationSpecification_withoutConnectedAccount() {
         PaymentConfiguration.init(
-            ApplicationProvider.getApplicationContext<Context>(),
+            ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
         val tokenizationSpec =
-            GooglePayConfig(ApplicationProvider.getApplicationContext<Context>())
+            GooglePayConfig(ApplicationProvider.getApplicationContext())
                 .tokenizationSpecification
         val params = tokenizationSpec.getJSONObject("parameters")
         assertEquals(

--- a/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
-class PaymentMethodEndToEndTest {
+internal class PaymentMethodEndToEndTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -222,7 +222,8 @@ class PaymentMethodEndToEndTest {
     fun createPaymentMethod_withGrabPay_shouldCreateObject() = testDispatcher.runBlockingTest {
         val repository = StripeApiRepository(
             context,
-            ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY
+            ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY,
+            workContext = testDispatcher
         )
 
         val params = PaymentMethodCreateParamsFixtures.GRABPAY
@@ -238,7 +239,8 @@ class PaymentMethodEndToEndTest {
     fun `createPaymentMethod() with PayPal PaymentMethod should create expected object`() = testDispatcher.runBlockingTest {
         val paymentMethod = StripeApiRepository(
             context,
-            ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY
+            ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY,
+            workContext = testDispatcher
         ).createPaymentMethod(
             PaymentMethodCreateParams.createPayPal(),
             ApiRequest.Options(ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY)
@@ -275,7 +277,8 @@ class PaymentMethodEndToEndTest {
                 )
         }
 
-        assertThat(missingNameException.message).isEqualTo("Missing required param: billing_details[name].")
+        assertThat(missingNameException.message)
+            .isEqualTo("Missing required param: billing_details[name].")
 
         val missingEmailException = assertFailsWith<InvalidRequestException>(
             "Email is required to create an Afterpay payment method"
@@ -288,7 +291,8 @@ class PaymentMethodEndToEndTest {
                 )
         }
 
-        assertThat(missingEmailException.message).isEqualTo("Missing required param: billing_details[email].")
+        assertThat(missingEmailException.message)
+            .isEqualTo("Missing required param: billing_details[email].")
 
         val missingAddressException = assertFailsWith<InvalidRequestException>(
             "Email is required to create an Afterpay payment method"
@@ -301,6 +305,7 @@ class PaymentMethodEndToEndTest {
                 )
         }
 
-        assertThat(missingAddressException.message).isEqualTo("Missing required param: billing_details[address][line1].")
+        assertThat(missingAddressException.message)
+            .isEqualTo("Missing required param: billing_details[address][line1].")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -215,7 +215,11 @@ internal class StripeEndToEndTest {
     private fun createStripeWithTestScope(
         publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     ): Stripe {
-        val stripeRepository = StripeApiRepository(context, publishableKey)
+        val stripeRepository = StripeApiRepository(
+            context,
+            publishableKey,
+            workContext = testDispatcher
+        )
         return Stripe(
             stripeRepository = stripeRepository,
             paymentController = StripePaymentController.create(

--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -78,6 +78,8 @@ import static org.robolectric.Shadows.shadowOf;
 public class StripeTest {
     private static final CardParams CARD_PARAMS = CardParamsFixtures.MINIMUM;
 
+    private final CoroutineDispatcher testDispatcher = new TestCoroutineDispatcher();
+
     @NonNull
     private final Context context = ApplicationProvider.getApplicationContext();
     @NonNull
@@ -103,8 +105,6 @@ public class StripeTest {
     private ArgumentCaptor<Source> sourceArgumentCaptor;
     @Captor
     private ArgumentCaptor<StripeFile> stripeFileArgumentCaptor;
-
-    private final CoroutineDispatcher testDispatcher = new TestCoroutineDispatcher();
 
     @Before
     public void setup() {
@@ -1321,6 +1321,7 @@ public class StripeTest {
     ) {
         final StripeRepository stripeRepository = createStripeRepository(
                 publishableKey,
+                testDispatcher,
                 analyticsRequestExecutor,
                 fingerprintDataRepository
         );
@@ -1336,6 +1337,7 @@ public class StripeTest {
     private Stripe createStripe(@NonNull CoroutineDispatcher workDispatcher) {
         final StripeRepository stripeRepository = createStripeRepository(
                 ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+                workDispatcher,
                 new FakeAnalyticsRequestExecutor(),
                 defaultFingerprintDataRepository
         );
@@ -1355,6 +1357,7 @@ public class StripeTest {
     @NonNull
     private StripeRepository createStripeRepository(
             @NonNull final String publishableKey,
+            @NonNull CoroutineDispatcher workDispatcher,
             @NonNull AnalyticsRequestExecutor analyticsRequestExecutor,
             @NonNull FingerprintDataRepository fingerprintDataRepository
     ) {
@@ -1363,6 +1366,7 @@ public class StripeTest {
                 publishableKey,
                 null,
                 new FakeLogger(),
+                workDispatcher,
                 new ApiRequestExecutor.Default(),
                 analyticsRequestExecutor,
                 fingerprintDataRepository

--- a/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -65,7 +65,8 @@ internal class StripeApiRepositoryTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val stripeApiRepository = StripeApiRepository(
         context,
-        DEFAULT_OPTIONS.apiKey
+        DEFAULT_OPTIONS.apiKey,
+        workContext = testDispatcher
     )
     private val fileFactory = FileFactory(context)
 
@@ -355,7 +356,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun requestData_withConnectAccount_shouldReturnCorrectResponseHeaders() {
+    fun requestData_withConnectAccount_shouldReturnCorrectResponseHeaders() = testDispatcher.runBlockingTest {
         val connectAccountId = "acct_1Acj2PBUgO3KuWzz"
         var requestId: RequestId? = null
         val response = stripeApiRepository.makeApiRequest(
@@ -459,6 +460,7 @@ internal class StripeApiRepositoryTest {
         val stripeApiRepository = StripeApiRepository(
             context,
             DEFAULT_OPTIONS.apiKey,
+            workContext = testDispatcher,
             stripeApiRequestExecutor = ApiRequestExecutor.Default(),
             analyticsRequestExecutor = analyticsRequestExecutor,
             fingerprintDataRepository = fingerprintDataRepository
@@ -800,6 +802,7 @@ internal class StripeApiRepositoryTest {
         val stripeRepository = StripeApiRepository(
             context,
             DEFAULT_OPTIONS.apiKey,
+            workContext = testDispatcher,
             sdkVersion = "AndroidBindings/13.0.0"
         )
 
@@ -822,6 +825,7 @@ internal class StripeApiRepositoryTest {
         val stripeRepository = StripeApiRepository(
             context,
             DEFAULT_OPTIONS.apiKey,
+            workContext = testDispatcher,
             sdkVersion = "AndroidBindings/14.0.0"
         )
 
@@ -960,6 +964,7 @@ internal class StripeApiRepositoryTest {
         return StripeApiRepository(
             context,
             DEFAULT_OPTIONS.apiKey,
+            workContext = testDispatcher,
             stripeApiRequestExecutor = stripeApiRequestExecutor,
             analyticsRequestExecutor = analyticsRequestExecutor,
             fingerprintDataRepository = fingerprintDataRepository,

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitBanksTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitBanksTest.kt
@@ -30,7 +30,7 @@ class BecsDebitBanksTest {
     @Test
     fun shouldIncludeTestBank_shouldConditionallyAddTestBank() {
         val testBank = BecsDebitBanks(
-            context = ApplicationProvider.getApplicationContext<Context>(),
+            context = ApplicationProvider.getApplicationContext(),
             shouldIncludeTestBank = true
         ).byPrefix("STRIPE")
         assertThat(testBank)


### PR DESCRIPTION
This ensures that API requests are always run on `Dispatchers.IO`,
in the case that the context isn't specified by the consumer of
`StripeApiRepository`.