### PR TITLE
Switch primary button when Google Pay is selected

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -21,7 +21,7 @@
             android:orientation="vertical"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/buy_button"
+            app:layout_constraintBottom_toTopOf="@+id/button_container"
             app:layout_constraintVertical_bias="0">
             <com.stripe.android.paymentsheet.ui.Toolbar
                 android:id="@+id/toolbar"
@@ -36,14 +36,25 @@
                 android:layout_weight="1" />
         </LinearLayout>
 
-        <com.stripe.android.paymentsheet.BuyButton
-            android:id="@+id/buy_button"
-            android:layout_margin="@dimen/stripe_paymentsheet_outer_spacing"
+        <FrameLayout
+            android:id="@+id/button_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_margin="@dimen/stripe_paymentsheet_outer_spacing"
             app:layout_constraintVertical_bias="1"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent">
+            <com.stripe.android.paymentsheet.BuyButton
+                android:id="@+id/buy_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.stripe.android.paymentsheet.ui.GooglePayButton
+                android:id="@+id/google_pay_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"/>
+        </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -12,6 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.databinding.ActivityPaymentSheetBinding
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
 import com.stripe.android.paymentsheet.ui.SheetMode
@@ -221,9 +223,17 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         }
 
         viewModel.selection.observe(this) { paymentSelection ->
-            // TODO(smaskell): show Google Pay button when GooglePay selected
+            val shouldShowGooglePay = paymentSelection == PaymentSelection.GooglePay
+
+            viewBinding.googlePayButton.isVisible = shouldShowGooglePay
+            viewBinding.buyButton.isVisible = !shouldShowGooglePay
             viewBinding.buyButton.isEnabled = paymentSelection != null
         }
+
+        viewBinding.googlePayButton.setOnClickListener {
+            viewModel.checkout(this)
+        }
+
         viewBinding.buyButton.setOnClickListener {
             viewModel.checkout(this)
         }


### PR DESCRIPTION
Show Google Pay button when Google Pay carousel item is selected;
otherwise, show default primary button.