### PR TITLE
Move PaymentSheetViewModel#isGooglePayReady to SheetViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -12,8 +12,10 @@ internal class PaymentOptionsViewModel(
     private val publishableKey: String,
     private val stripeAccountId: String?,
     private val args: PaymentOptionsActivityStarter.Args,
+    googlePayRepository: GooglePayRepository
 ) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget, PaymentOptionViewState>(
-    isGuestMode = args is PaymentOptionsActivityStarter.Args.Guest
+    isGuestMode = args is PaymentOptionsActivityStarter.Args.Guest,
+    googlePayRepository = googlePayRepository
 ) {
     init {
         mutablePaymentMethods.value = args.paymentMethods
@@ -48,11 +50,13 @@ internal class PaymentOptionsViewModel(
             val config = PaymentConfiguration.getInstance(application)
             val publishableKey = config.publishableKey
             val stripeAccountId = config.stripeAccountId
+            val googlePayRepository = DefaultGooglePayRepository(application)
 
             return PaymentOptionsViewModel(
                 publishableKey,
                 stripeAccountId,
-                starterArgsSupplier()
+                starterArgsSupplier(),
+                googlePayRepository
             ) as T
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -32,8 +32,6 @@ import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -43,19 +41,18 @@ internal class PaymentSheetViewModel internal constructor(
     private val stripeAccountId: String?,
     private val stripeRepository: StripeRepository,
     private val paymentController: PaymentController,
-    private val googlePayRepository: GooglePayRepository,
+    googlePayRepository: GooglePayRepository,
     internal val args: PaymentSheetActivityStarter.Args,
-    private val workContext: CoroutineContext
+    workContext: CoroutineContext
 ) : SheetViewModel<PaymentSheetViewModel.TransitionTarget, ViewState>(
-    isGuestMode = args is PaymentSheetActivityStarter.Args.Guest
+    isGuestMode = args is PaymentSheetActivityStarter.Args.Guest,
+    googlePayRepository = googlePayRepository,
+    workContext = workContext
 ) {
     private val confirmParamsFactory = ConfirmParamsFactory()
 
     private val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
     internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
-
-    private val mutableIsGooglePayReady = MutableLiveData<Boolean>()
-    internal val isGooglePayReady: LiveData<Boolean> = mutableIsGooglePayReady.distinctUntilChanged()
 
     fun fetchAddPaymentMethodConfig() = liveData {
         emitSource(
@@ -211,16 +208,6 @@ internal class PaymentSheetViewModel internal constructor(
             }
             else -> {
                 // TODO(mshafrir-stripe): handle error
-            }
-        }
-    }
-
-    fun fetchIsGooglePayReady() {
-        viewModelScope.launch {
-            withContext(workContext) {
-                mutableIsGooglePayReady.postValue(
-                    googlePayRepository.isReady().filterNotNull().first()
-                )
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -29,7 +30,8 @@ class PaymentOptionsActivityTest {
     private val viewModel = PaymentOptionsViewModel(
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
-        args = PaymentOptionsActivityStarter.Args.Guest
+        args = PaymentOptionsActivityStarter.Args.Guest,
+        googlePayRepository = mock()
     )
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentOptionViewState
@@ -19,7 +20,8 @@ class PaymentOptionsViewModelTest {
     private val viewModel = PaymentOptionsViewModel(
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
-        args = PaymentOptionsActivityStarter.Args.Guest
+        args = PaymentOptionsActivityStarter.Args.Guest,
+        googlePayRepository = mock()
     )
 
     @Test


### PR DESCRIPTION


## Summary
Move code
Only update `isGooglePayReady` if needed.

## Motivation
This makes it reusable in `PaymentOptionsViewModel`

## Testing
Updated unit tests
