### PR TITLE
Reset view state if payment authentication isn't successful

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
+import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController
 import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -199,7 +200,7 @@ internal class PaymentSheetViewModel internal constructor(
                 it,
                 object : ApiResultCallback<PaymentIntentResult> {
                     override fun onSuccess(result: PaymentIntentResult) {
-                        mutableViewState.value = ViewState.Completed(result)
+                        onPaymentIntentResult(result)
                     }
 
                     override fun onError(e: Exception) {
@@ -213,6 +214,18 @@ internal class PaymentSheetViewModel internal constructor(
             resultCode == Activity.RESULT_OK && data != null
         ) {
             onGooglePayResult(data)
+        }
+    }
+
+    private fun onPaymentIntentResult(paymentIntentResult: PaymentIntentResult) {
+        when (paymentIntentResult.outcome) {
+            StripeIntentResult.Outcome.SUCCEEDED -> {
+                mutableViewState.value = ViewState.Completed(paymentIntentResult)
+            }
+            else -> {
+                // TODO(mshafrir-stripe): show relevant error messages in sheet
+                onPaymentIntentResponse(paymentIntentResult.intent)
+            }
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -13,6 +13,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
+import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
@@ -168,7 +169,10 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `onActivityResult() should update ViewState LiveData`() {
-        val paymentIntentResult: PaymentIntentResult = mock()
+        val paymentIntentResult = PaymentIntentResult(
+            intent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED
+        )
         whenever(paymentController.handlePaymentResult(any(), callbackCaptor.capture())).doAnswer {
             callbackCaptor.lastValue.onSuccess(paymentIntentResult)
         }


### PR DESCRIPTION
Previously, any payment authentication result would attempt to
transition the view state to "Completed", which is incorrect.
