### PR TITLE
Create PrefsRepository and add to PaymentSheetViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.PaymentSessionPrefs
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal class DefaultPrefsRepository(
+    private val customerId: String,
+    private val paymentSessionPrefs: PaymentSessionPrefs
+) : PrefsRepository {
+    override suspend fun getDefaultPaymentMethodId(): String? {
+        return paymentSessionPrefs.getPaymentMethodId(customerId)
+    }
+
+    override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
+        if (paymentSelection is PaymentSelection.Saved) {
+            paymentSessionPrefs.savePaymentMethodId(customerId, paymentSelection.paymentMethod.id)
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
@@ -32,12 +33,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
             { requireNotNull(starterArgs) }
         )
 
-    private val viewModel by lazy {
-        ViewModelProvider(
-            this,
-            viewModelFactory
-        )[PaymentOptionsViewModel::class.java]
-    }
+    private val viewModel: PaymentOptionsViewModel by viewModels { viewModelFactory }
 
     private val starterArgs: PaymentOptionsActivityStarter.Args? by lazy {
         PaymentOptionsActivityStarter.Args.fromIntent(intent)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
@@ -45,12 +46,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         ActivityPaymentSheetBinding.inflate(layoutInflater)
     }
 
-    private val viewModel by lazy {
-        ViewModelProvider(
-            this,
-            viewModelFactory
-        )[PaymentSheetViewModel::class.java]
-    }
+    private val viewModel: PaymentSheetViewModel by viewModels { viewModelFactory }
 
     private val fragmentContainerId: Int
         @IdRes

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
+import com.stripe.android.PaymentSessionPrefs
 import com.stripe.android.StripePaymentController
 import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -44,6 +45,7 @@ internal class PaymentSheetViewModel internal constructor(
     private val stripeRepository: StripeRepository,
     private val paymentController: PaymentController,
     private val googlePayRepository: GooglePayRepository,
+    private val prefsRepository: PrefsRepository,
     internal val args: PaymentSheetActivityStarter.Args,
     private val workContext: CoroutineContext
 ) : SheetViewModel<PaymentSheetViewModel.TransitionTarget, ViewState>(
@@ -153,6 +155,8 @@ internal class PaymentSheetViewModel internal constructor(
 
     fun checkout(activity: Activity) {
         mutableProcessing.value = true
+
+        prefsRepository.savePaymentSelection(selection.value)
 
         if (selection.value == PaymentSelection.GooglePay) {
             paymentIntent.value?.let { paymentIntent ->
@@ -305,13 +309,28 @@ internal class PaymentSheetViewModel internal constructor(
             )
             val googlePayRepository = DefaultGooglePayRepository(application)
 
+            val starterArgs = starterArgsSupplier()
+
+            val prefsRepository = when (starterArgs) {
+                is PaymentSheetActivityStarter.Args.Default -> {
+                    DefaultPrefsRepository(
+                        starterArgs.customerId,
+                        PaymentSessionPrefs.Default(application)
+                    )
+                }
+                is PaymentSheetActivityStarter.Args.Guest -> {
+                    PrefsRepository.Noop()
+                }
+            }
+
             return PaymentSheetViewModel(
                 publishableKey,
                 stripeAccountId,
                 stripeRepository,
                 paymentController,
                 googlePayRepository,
-                starterArgsSupplier(),
+                prefsRepository,
+                starterArgs,
                 Dispatchers.IO
             ) as T
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal interface PrefsRepository {
+    suspend fun getDefaultPaymentMethodId(): String?
+    fun savePaymentSelection(paymentSelection: PaymentSelection?)
+
+    class Noop : PrefsRepository {
+        override suspend fun getDefaultPaymentMethodId(): String? = null
+        override fun savePaymentSelection(paymentSelection: PaymentSelection?) {}
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -7,6 +7,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
@@ -67,6 +68,7 @@ internal class PaymentSheetActivityTest {
             workContext = testCoroutineDispatcher
         ),
         googlePayRepository = googlePayRepository,
+        prefsRepository = mock(),
         args = PaymentSheetFixtures.DEFAULT_ARGS,
         workContext = testCoroutineDispatcher
     )
@@ -258,6 +260,7 @@ internal class PaymentSheetActivityTest {
                 workContext = testCoroutineDispatcher
             ),
             googlePayRepository = googlePayRepository,
+            prefsRepository = mock(),
             args = PaymentSheetFixtures.DEFAULT_ARGS,
             workContext = testCoroutineDispatcher
         )
@@ -324,16 +327,12 @@ internal class PaymentSheetActivityTest {
             confirmPaymentIntentParams: ConfirmPaymentIntentParams,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ): PaymentIntent? {
-            return paymentIntent
-        }
+        ): PaymentIntent = paymentIntent
 
         override suspend fun retrievePaymentIntent(
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ): PaymentIntent? {
-            return paymentIntent
-        }
+        ): PaymentIntent = paymentIntent
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -47,12 +47,14 @@ internal class PaymentSheetViewModelTest {
     private val googlePayRepository = FakeGooglePayRepository(true)
     private val stripeRepository: StripeRepository = FakeStripeRepository(paymentIntent)
     private val paymentController: PaymentController = mock()
+    private val prefsRepository = mock<PrefsRepository>()
     private val viewModel = PaymentSheetViewModel(
         "publishable_key",
         "stripe_account_id",
         stripeRepository,
         paymentController,
         googlePayRepository,
+        prefsRepository,
         DEFAULT_ARGS,
         workContext = testCoroutineDispatcher
     )
@@ -84,6 +86,7 @@ internal class PaymentSheetViewModelTest {
             stripeRepository,
             paymentController,
             googlePayRepository,
+            prefsRepository,
             GUEST_ARGS,
             workContext = testCoroutineDispatcher
         )
@@ -104,16 +107,19 @@ internal class PaymentSheetViewModelTest {
         }
 
         viewModel.checkout(mock())
+
+        verify(prefsRepository).savePaymentSelection(null)
         assertThat(error)
             .isInstanceOf(IllegalStateException::class.java)
     }
 
     @Test
     fun `checkout() should confirm saved payment methods`() {
-        viewModel.updateSelection(
-            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        )
+        val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        viewModel.updateSelection(paymentSelection)
         viewModel.checkout(mock())
+
+        verify(prefsRepository).savePaymentSelection(paymentSelection)
         verify(paymentController).startConfirmAndAuth(
             any(),
             eq(
@@ -133,10 +139,11 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should confirm new payment methods`() {
-        viewModel.updateSelection(
-            PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
-        )
+        val paymentSelection = PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        viewModel.updateSelection(paymentSelection)
         viewModel.checkout(mock())
+
+        verify(prefsRepository).savePaymentSelection(paymentSelection)
         verify(paymentController).startConfirmAndAuth(
             any(),
             eq(
@@ -229,6 +236,7 @@ internal class PaymentSheetViewModelTest {
             },
             paymentController,
             googlePayRepository,
+            prefsRepository,
             DEFAULT_ARGS,
             workContext = testCoroutineDispatcher
         )
@@ -257,6 +265,7 @@ internal class PaymentSheetViewModelTest {
             },
             paymentController,
             googlePayRepository,
+            prefsRepository,
             DEFAULT_ARGS,
             workContext = testCoroutineDispatcher
         )


### PR DESCRIPTION
Used to save a user's payment selection after tapping buy button.
Currently only supports payment method id.