### PR TITLE
Add Google Pay support to PaymentOptionsActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -9,10 +9,12 @@ import android.widget.CheckBox
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat.getSystemService
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.BillingAddressView
 import com.stripe.android.paymentsheet.ui.SheetMode
@@ -50,6 +52,11 @@ internal abstract class BaseAddCardFragment : Fragment() {
                 PaymentMethodCreateParams.createCard(it)
             }
         }
+
+    @VisibleForTesting
+    internal val googlePayButton: View by lazy { viewBinding.googlePayButton }
+
+    abstract fun onGooglePaySelected()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -116,6 +123,18 @@ internal abstract class BaseAddCardFragment : Fragment() {
         }
 
         setupSaveCardCheckbox(saveCardCheckbox)
+
+        sheetViewModel.fetchAddPaymentMethodConfig().observe(viewLifecycleOwner) { config ->
+            if (config != null) {
+                onConfigReady(config)
+            }
+        }
+
+        sheetViewModel.selection.observe(viewLifecycleOwner) { paymentSelection ->
+            if (paymentSelection == PaymentSelection.GooglePay) {
+                onGooglePaySelected()
+            }
+        }
     }
 
     private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {
@@ -133,5 +152,16 @@ internal abstract class BaseAddCardFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _viewBinding = null
+    }
+
+    @VisibleForTesting
+    fun onConfigReady(config: AddPaymentMethodConfig) {
+        val shouldShowGooglePayButton = config.shouldShowGooglePayButton
+        googlePayButton.setOnClickListener {
+            sheetViewModel.updateSelection(PaymentSelection.GooglePay)
+        }
+        googlePayButton.isVisible = shouldShowGooglePayButton
+        viewBinding.googlePayDivider.isVisible = shouldShowGooglePayButton
+        viewBinding.addCardHeader.isVisible = !shouldShowGooglePayButton
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.app.Activity
 import android.content.Intent
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -14,6 +15,7 @@ internal class PaymentOptionsActivityStarter internal constructor(
     REQUEST_CODE
 ) {
     sealed class Args : ActivityStarter.Args {
+        abstract val paymentIntent: PaymentIntent
         abstract val paymentMethods: List<PaymentMethod>
         abstract val googlePayConfig: PaymentSheetGooglePayConfig?
 
@@ -21,6 +23,7 @@ internal class PaymentOptionsActivityStarter internal constructor(
 
         @Parcelize
         data class Default(
+            override val paymentIntent: PaymentIntent,
             override val paymentMethods: List<PaymentMethod>,
             val ephemeralKey: String,
             val customerId: String,
@@ -29,6 +32,7 @@ internal class PaymentOptionsActivityStarter internal constructor(
 
         @Parcelize
         data class Guest(
+            override val paymentIntent: PaymentIntent,
             override val googlePayConfig: PaymentSheetGooglePayConfig?
         ) : Args() {
             override val paymentMethods: List<PaymentMethod>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -13,4 +13,8 @@ internal class PaymentOptionsAddCardFragment : BaseAddCardFragment() {
             }
         )
     }
+
+    override fun onGooglePaySelected() {
+        sheetViewModel.selectPaymentOption()
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -19,6 +19,7 @@ internal class PaymentOptionsViewModel(
     googlePayRepository = googlePayRepository
 ) {
     init {
+        mutablePaymentIntent.value = args.paymentIntent
         mutablePaymentMethods.value = args.paymentMethods
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -76,7 +76,6 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
             return
         }
 
-        viewModel.fetchIsGooglePayReady()
         viewModel.updatePaymentMethods()
         viewModel.fetchPaymentIntent()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -1,12 +1,6 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
-import android.view.View
-import androidx.annotation.VisibleForTesting
-import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
-import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
     override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
@@ -20,32 +14,7 @@ internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
         )
     }
 
-    @VisibleForTesting
-    internal val googlePayButton: View by lazy { viewBinding.googlePayButton }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        sheetViewModel.fetchAddPaymentMethodConfig().observe(viewLifecycleOwner) { config ->
-            if (config != null) {
-                onConfigReady(config)
-            }
-        }
-    }
-
-    @VisibleForTesting
-    fun onConfigReady(config: AddPaymentMethodConfig) {
-        val shouldShowGooglePayButton = config.shouldShowGooglePayButton
-        googlePayButton.setOnClickListener {
-            launchGooglePay()
-        }
-        googlePayButton.isVisible = shouldShowGooglePayButton
-        viewBinding.googlePayDivider.isVisible = shouldShowGooglePayButton
-        viewBinding.addCardHeader.isVisible = !shouldShowGooglePayButton
-    }
-
-    private fun launchGooglePay() {
-        sheetViewModel.updateSelection(PaymentSelection.GooglePay)
+    override fun onGooglePaySelected() {
         sheetViewModel.checkout(requireActivity())
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowControllerFactory.kt
@@ -135,6 +135,7 @@ internal class PaymentSheetFlowControllerFactory(
                             ),
                             publishableKey = publishableKey,
                             stripeAccountId = stripeAccountId,
+                            paymentIntent = paymentIntent,
                             paymentMethodTypes = paymentMethodTypes,
                             paymentMethods = paymentMethods,
                             googlePayConfig = googlePayConfig,
@@ -170,6 +171,7 @@ internal class PaymentSheetFlowControllerFactory(
                         DefaultPaymentSheetFlowController.Args.Guest(
                             clientSecret
                         ),
+                        paymentIntent = paymentIntent,
                         paymentMethodTypes = paymentMethodTypes,
                         paymentMethods = emptyList(),
                         googlePayConfig = googlePayConfig,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -4,13 +4,8 @@ import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
@@ -26,7 +21,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.ConfirmParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
@@ -54,41 +48,6 @@ internal class PaymentSheetViewModel internal constructor(
     workContext = workContext
 ) {
     private val confirmParamsFactory = ConfirmParamsFactory()
-
-    private val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
-    internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
-
-    fun fetchAddPaymentMethodConfig() = liveData {
-        emitSource(
-            MediatorLiveData<AddPaymentMethodConfig?>().also { configLiveData ->
-                listOf(paymentIntent, paymentMethods, isGooglePayReady).forEach { source ->
-                    configLiveData.addSource(source) {
-                        configLiveData.value = createAddPaymentMethodConfig()
-                    }
-                }
-            }.distinctUntilChanged()
-        )
-    }
-
-    private fun createAddPaymentMethodConfig(): AddPaymentMethodConfig? {
-        val paymentIntentValue = paymentIntent.value
-        val paymentMethodsValue = paymentMethods.value
-        val isGooglePayReadyValue = isGooglePayReady.value
-
-        return if (
-            paymentIntentValue != null &&
-            paymentMethodsValue != null &&
-            isGooglePayReadyValue != null
-        ) {
-            AddPaymentMethodConfig(
-                paymentIntent = paymentIntentValue,
-                paymentMethods = paymentMethodsValue,
-                isGooglePayReady = isGooglePayReadyValue
-            )
-        } else {
-            null
-        }
-    }
 
     fun updatePaymentMethods() {
         when (args) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.paymentsheet.viewmodels
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.GooglePayRepository
+import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +36,9 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     private val mutableIsGooglePayReady = MutableLiveData<Boolean>()
     internal val isGooglePayReady: LiveData<Boolean> = mutableIsGooglePayReady.distinctUntilChanged()
 
+    protected val mutablePaymentIntent = MutableLiveData<PaymentIntent?>()
+    internal val paymentIntent: LiveData<PaymentIntent?> = mutablePaymentIntent
+
     protected val mutablePaymentMethods = MutableLiveData<List<PaymentMethod>>()
     internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
 
@@ -55,6 +62,42 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     // a message shown to the user
     protected val mutableUserMessage = MutableLiveData<UserMessage?>()
     internal val userMessage: LiveData<UserMessage?> = mutableUserMessage
+
+    init {
+        fetchIsGooglePayReady()
+    }
+
+    fun fetchAddPaymentMethodConfig() = liveData {
+        emitSource(
+            MediatorLiveData<AddPaymentMethodConfig?>().also { configLiveData ->
+                listOf(paymentIntent, paymentMethods, isGooglePayReady).forEach { source ->
+                    configLiveData.addSource(source) {
+                        configLiveData.value = createAddPaymentMethodConfig()
+                    }
+                }
+            }.distinctUntilChanged()
+        )
+    }
+
+    private fun createAddPaymentMethodConfig(): AddPaymentMethodConfig? {
+        val paymentIntentValue = paymentIntent.value
+        val paymentMethodsValue = paymentMethods.value
+        val isGooglePayReadyValue = isGooglePayReady.value
+
+        return if (
+            paymentIntentValue != null &&
+            paymentMethodsValue != null &&
+            isGooglePayReadyValue != null
+        ) {
+            AddPaymentMethodConfig(
+                paymentIntent = paymentIntentValue,
+                paymentMethods = paymentMethodsValue,
+                isGooglePayReady = isGooglePayReadyValue
+            )
+        } else {
+            null
+        }
+    }
 
     fun fetchIsGooglePayReady() {
         if (isGooglePayReady.value == null) {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
@@ -3,11 +3,14 @@ package com.stripe.android.paymentsheet
 import android.content.Intent
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentController
 import com.stripe.android.R
+import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -18,6 +21,7 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultPaymentSheetFlowControllerTest {
+    private val googlePayLauncher = mock<StripeGooglePayLauncher>()
     private val paymentController = mock<PaymentController>()
     private val flowController = DefaultPaymentSheetFlowController(
         paymentController,
@@ -28,9 +32,11 @@ class DefaultPaymentSheetFlowControllerTest {
             "ephkey",
             "cus_123"
         ),
+        paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
         paymentMethodTypes = listOf(PaymentMethod.Type.Card),
         paymentMethods = emptyList(),
         googlePayConfig = PaymentSheetGooglePayConfigFixtures.DEFAULT,
+        googlePayLauncherFactory = { googlePayLauncher },
         defaultPaymentMethodId = null
     )
 
@@ -79,5 +85,24 @@ class DefaultPaymentSheetFlowControllerTest {
         verifyNoMoreInteractions(paymentController)
         flowController.confirmPayment(mock()) {
         }
+    }
+
+    @Test
+    fun `confirmPayment() with GooglePay should start StripeGooglePayLauncher`() {
+        flowController.onPaymentOptionResult(
+            Intent().putExtras(
+                PaymentOptionResult.Succeeded(
+                    PaymentSelection.GooglePay
+                ).toBundle()
+            )
+        )
+        flowController.confirmPayment(mock()) {
+        }
+        verify(googlePayLauncher).startForResult(
+            StripeGooglePayLauncher.Args(
+                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                countryCode = "US"
+            )
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -31,6 +32,7 @@ class PaymentOptionsActivityTest {
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
         args = PaymentOptionsActivityStarter.Args.Guest(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             googlePayConfig = PaymentSheetGooglePayConfigFixtures.DEFAULT
         ),
         googlePayRepository = mock()
@@ -44,6 +46,7 @@ class PaymentOptionsActivityTest {
         ).putExtra(
             ActivityStarter.Args.EXTRA,
             PaymentOptionsActivityStarter.Args.Guest(
+                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                 googlePayConfig = PaymentSheetGooglePayConfigFixtures.DEFAULT
             )
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -21,6 +22,7 @@ class PaymentOptionsViewModelTest {
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
         args = PaymentOptionsActivityStarter.Args.Guest(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             googlePayConfig = PaymentSheetGooglePayConfigFixtures.DEFAULT
         ),
         googlePayRepository = mock()


### PR DESCRIPTION
- Save `paymentSelection` in
  `DefaultPaymentSheetFlowController#onPaymentOptionResult()`
- Handle GooglePay selection in
  `DefaultPaymentSheetFlowController#confirmPayment()`
- Move logic from `PaymentSheetAddCardFragment` to `BaseAddCardFragment`
  and `PaymentSheetViewModel` to `SheetViewModel`
- Move `fetchIsGooglePayReady()` to `SheetViewModel#init()`