### PR TITLE
Implement PaymentOptionFactory for new cards

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -79,8 +79,11 @@ internal abstract class BaseAddCardFragment : Fragment() {
 
         cardMultilineWidget.setCardValidCallback { isValid, _ ->
             val selection = if (isValid) {
-                paymentMethodParams?.let {
-                    PaymentSelection.New(it)
+                paymentMethodParams?.let { params ->
+                    PaymentSelection.New.Card(
+                        params,
+                        cardMultilineWidget.brand
+                    )
                 }
             } else {
                 null

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.R
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 
 internal class PaymentOptionFactory {
@@ -30,9 +31,21 @@ internal class PaymentOptionFactory {
                     }
                 }
             }
-            is PaymentSelection.New -> {
-                // TODO(mshafrir-stripe): handle params
-                null
+            is PaymentSelection.New.Card -> {
+                val brand = selection.brand
+                PaymentOption(
+                    drawableResourceId = when (brand) {
+                        CardBrand.Visa -> R.drawable.stripe_ic_paymentsheet_card_visa
+                        CardBrand.AmericanExpress -> R.drawable.stripe_ic_paymentsheet_card_amex
+                        CardBrand.Discover -> R.drawable.stripe_ic_paymentsheet_card_discover
+                        CardBrand.JCB -> R.drawable.stripe_ic_paymentsheet_card_jcb
+                        CardBrand.DinersClub -> R.drawable.stripe_ic_paymentsheet_card_dinersclub
+                        CardBrand.MasterCard -> R.drawable.stripe_ic_paymentsheet_card_mastercard
+                        CardBrand.UnionPay -> R.drawable.stripe_ic_paymentsheet_card_unionpay
+                        CardBrand.Unknown -> R.drawable.stripe_ic_paymentsheet_card_unknown
+                    },
+                    label = brand.displayName
+                )
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import android.os.Parcelable
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import kotlinx.parcelize.Parcelize
@@ -14,8 +15,13 @@ internal sealed class PaymentSelection : Parcelable {
         val paymentMethod: PaymentMethod
     ) : PaymentSelection()
 
-    @Parcelize
-    data class New(
-        val paymentMethodCreateParams: PaymentMethodCreateParams
-    ) : PaymentSelection()
+    sealed class New : PaymentSelection() {
+        abstract val paymentMethodCreateParams: PaymentMethodCreateParams
+
+        @Parcelize
+        data class Card(
+            override val paymentMethodCreateParams: PaymentMethodCreateParams,
+            val brand: CardBrand
+        ) : New()
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -91,6 +91,10 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private var cardBrand: CardBrand = CardBrand.Unknown
 
+    internal val brand: CardBrand
+        @JvmSynthetic
+        get() = cardBrand
+
     @ColorInt
     private val tintColorInt: Int
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
@@ -141,7 +142,10 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should confirm new payment methods`() {
-        val paymentSelection = PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        val paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            CardBrand.Visa
+        )
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout(mock())
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -14,8 +15,9 @@ class ConfirmParamsFactoryTest {
         assertThat(
             factory.create(
                 clientSecret = CLIENT_SECRET,
-                paymentSelection = PaymentSelection.New(
-                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+                paymentSelection = PaymentSelection.New.Card(
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    CardBrand.Visa
                 ),
                 shouldSavePaymentMethod = true
             )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -47,11 +47,19 @@ class PaymentOptionFactoryTest {
     }
 
     @Test
-    fun `create() with card params should return null`() {
+    fun `create() with card params should return expected object`() {
         assertThat(
             PaymentOptionFactory().create(
-                PaymentSelection.New(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+                PaymentSelection.New.Card(
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    brand = CardBrand.Visa
+                )
             )
-        ).isNull()
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_ic_paymentsheet_card_visa,
+                "Visa"
+            )
+        )
     }
 }


### PR DESCRIPTION
Create `PaymentSelection.New.Card` class that includes `CardBrand`
property to correctly generate `PaymentOption`.