### PR TITLE
Refactor payment sheet's shouldSavePaymentMethod logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -9,6 +9,7 @@ import android.widget.CheckBox
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat.getSystemService
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.stripe.android.R
@@ -56,6 +57,9 @@ internal abstract class BaseAddCardFragment : Fragment() {
     @VisibleForTesting
     internal val googlePayButton: View by lazy { viewBinding.googlePayButton }
 
+    @VisibleForTesting
+    internal val saveCardCheckbox: CheckBox by lazy { viewBinding.saveCardCheckbox }
+
     abstract fun onGooglePaySelected()
 
     override fun onCreateView(
@@ -82,14 +86,13 @@ internal abstract class BaseAddCardFragment : Fragment() {
 
         _viewBinding = FragmentPaymentsheetAddCardBinding.bind(view)
 
-        val saveCardCheckbox = viewBinding.saveCardCheckbox
-
         cardMultilineWidget.setCardValidCallback { isValid, _ ->
             val selection = if (isValid) {
                 paymentMethodParams?.let { params ->
                     PaymentSelection.New.Card(
                         params,
-                        cardMultilineWidget.brand
+                        cardMultilineWidget.brand,
+                        shouldSavePaymentMethod = shouldSaveCard()
                     )
                 }
             } else {
@@ -141,14 +144,19 @@ internal abstract class BaseAddCardFragment : Fragment() {
     }
 
     private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {
-        saveCardCheckbox.visibility = when (sheetViewModel.isGuestMode) {
-            true -> View.GONE
-            false -> View.VISIBLE
-        }
+        saveCardCheckbox.isGone = sheetViewModel.isGuestMode
 
-        sheetViewModel.shouldSavePaymentMethod = saveCardCheckbox.isShown && saveCardCheckbox.isChecked
-        saveCardCheckbox.setOnCheckedChangeListener { _, isChecked ->
-            sheetViewModel.shouldSavePaymentMethod = isChecked
+        saveCardCheckbox.setOnCheckedChangeListener { _, _ ->
+            onSaveCardCheckboxChanged()
+        }
+    }
+
+    private fun onSaveCardCheckboxChanged() {
+        val selection = sheetViewModel.selection.value
+        if (selection is PaymentSelection.New.Card) {
+            sheetViewModel.updateSelection(
+                selection.copy(shouldSavePaymentMethod = shouldSaveCard())
+            )
         }
     }
 
@@ -167,4 +175,6 @@ internal abstract class BaseAddCardFragment : Fragment() {
         viewBinding.googlePayDivider.isVisible = shouldShowGooglePayButton
         viewBinding.addCardHeader.isVisible = !shouldShowGooglePayButton
     }
+
+    private fun shouldSaveCard() = saveCardCheckbox.isShown && saveCardCheckbox.isChecked
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
@@ -86,9 +86,7 @@ internal class DefaultPaymentSheetFlowController internal constructor(
             val confirmParams = paymentSelection?.let {
                 confirmParamsFactory.create(
                     args.clientSecret,
-                    it,
-                    // TODO(mshafrir-stripe): set correct value
-                    shouldSavePaymentMethod = false
+                    it
                 )
             }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -133,8 +133,7 @@ internal class PaymentSheetViewModel internal constructor(
             val confirmParams = selection.value?.let { paymentSelection ->
                 confirmParamsFactory.create(
                     args.clientSecret,
-                    paymentSelection,
-                    shouldSavePaymentMethod
+                    paymentSelection
                 )
             }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
@@ -6,8 +6,7 @@ internal class ConfirmParamsFactory {
 
     internal fun create(
         clientSecret: String,
-        paymentSelection: PaymentSelection,
-        shouldSavePaymentMethod: Boolean
+        paymentSelection: PaymentSelection
     ): ConfirmPaymentIntentParams {
         return when (paymentSelection) {
             PaymentSelection.GooglePay -> TODO("smaskell: handle Google Pay confirmation")
@@ -24,7 +23,7 @@ internal class ConfirmParamsFactory {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     paymentSelection.paymentMethodCreateParams,
                     clientSecret,
-                    setupFutureUsage = when (shouldSavePaymentMethod) {
+                    setupFutureUsage = when (paymentSelection.shouldSavePaymentMethod) {
                         true -> ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
                         false -> null
                     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
@@ -24,7 +24,7 @@ internal class ConfirmParamsFactory {
                     paymentSelection.paymentMethodCreateParams,
                     clientSecret,
                     setupFutureUsage = when (paymentSelection.shouldSavePaymentMethod) {
-                        true -> ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+                        true -> ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                         false -> null
                     }
                 )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -17,11 +17,13 @@ internal sealed class PaymentSelection : Parcelable {
 
     sealed class New : PaymentSelection() {
         abstract val paymentMethodCreateParams: PaymentMethodCreateParams
+        abstract val shouldSavePaymentMethod: Boolean
 
         @Parcelize
         data class Card(
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
-            val brand: CardBrand
+            val brand: CardBrand,
+            override val shouldSavePaymentMethod: Boolean
         ) : New()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -57,8 +57,6 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     protected val mutableViewState = MutableLiveData<ViewStateType>(null)
     internal val viewState: LiveData<ViewStateType> = mutableViewState.distinctUntilChanged()
 
-    internal var shouldSavePaymentMethod: Boolean = false
-
     // a message shown to the user
     protected val mutableUserMessage = MutableLiveData<UserMessage?>()
     internal val userMessage: LiveData<UserMessage?> = mutableUserMessage

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -168,7 +168,7 @@ internal class PaymentSheetViewModelTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     CLIENT_SECRET,
-                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                 )
             ),
             eq(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -155,7 +155,8 @@ internal class PaymentSheetViewModelTest {
     fun `checkout() should confirm new payment methods`() {
         val paymentSelection = PaymentSelection.New.Card(
             PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            CardBrand.Visa
+            CardBrand.Visa,
+            shouldSavePaymentMethod = true
         )
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout(mock())
@@ -167,7 +168,7 @@ internal class PaymentSheetViewModelTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     CLIENT_SECRET,
-                    setupFutureUsage = null
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
                 )
             ),
             eq(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
@@ -17,9 +17,9 @@ class ConfirmParamsFactoryTest {
                 clientSecret = CLIENT_SECRET,
                 paymentSelection = PaymentSelection.New.Card(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                    CardBrand.Visa
-                ),
-                shouldSavePaymentMethod = true
+                    CardBrand.Visa,
+                    shouldSavePaymentMethod = true
+                )
             )
         ).isEqualTo(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
@@ -25,7 +25,7 @@ class ConfirmParamsFactoryTest {
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 CLIENT_SECRET,
-                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -52,7 +52,8 @@ class PaymentOptionFactoryTest {
             PaymentOptionFactory().create(
                 PaymentSelection.New.Card(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                    brand = CardBrand.Visa
+                    brand = CardBrand.Visa,
+                    shouldSavePaymentMethod = true
                 )
             )
         ).isEqualTo(


### PR DESCRIPTION
Manage this state in `PaymentSelection.New` instead of on the
view model. This simplifies state management.

Update unit tests.