### PR TITLE
Fix CvcEditText layout issues in CardMultilineWidget

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -363,9 +363,10 @@ class CardMultilineWidget @JvmOverloads constructor(
         isEnabled = true
     }
 
-    override fun onFinishInflate() {
-        super.onFinishInflate()
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
         postalCodeEditText.config = PostalCodeEditText.Config.Global
+        cvcEditText.hint = null
     }
 
     /**


### PR DESCRIPTION
`CvcEditText` sets hint text by default, but this clashes with
the `CvcEditText`'s `TextInputLayout` in `CardMultilineWidget`.

Remove hint text from the `CvcEditText`.

Use `onAttachedToWindow()` instead of `onFinishInflate()` to handle
`CardMultilineWidget` instantiated via layout or in code.

Fixes #3147