### PR TITLE
Add expand icon to country autocomplete view

### DIFF
--- a/stripe/res/layout/stripe_billing_address_layout.xml
+++ b/stripe/res/layout/stripe_billing_address_layout.xml
@@ -14,7 +14,7 @@
             android:orientation="vertical">
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/StripePaymentSheetTextInputLayout"
+                style="@style/StripePaymentSheetAutocompleteTextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:labelFor="@+id/country"

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -122,6 +122,13 @@
         <item name="android:layout_marginBottom">4dp</item>
     </style>
 
+    <style name="StripePaymentSheetAutocompleteTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+        <item name="boxStrokeColor">@android:color/transparent</item>
+        <item name="boxStrokeWidth">0dp</item>
+        <item name="android:layout_marginTop">4dp</item>
+        <item name="android:layout_marginBottom">4dp</item>
+    </style>
+
     <style name="StripePaymentSheetTextInputEditText">
         <item name="android:textSize">14sp</item>
         <item name="android:letterSpacing">-0.01</item>


### PR DESCRIPTION
Use `ExposedDropdownMenu` theme to add icon. [0]

[0] https://material.io/develop/android/components/menu#exposed-dropdown-menus