### PR TITLE
Fix Google Pay completion

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -121,6 +121,12 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         }
         bottomSheetController.setup()
 
+        viewModel.googlePayCompletion.observe(this) { paymentIntentResult ->
+            if (paymentIntentResult != null) {
+                onActionCompleted(paymentIntentResult)
+            }
+        }
+
         setupBuyButton()
         supportFragmentManager.commit {
             replace(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -121,11 +121,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         }
         bottomSheetController.setup()
 
-        viewModel.googlePayCompletion.observe(this) { paymentIntentResult ->
-            if (paymentIntentResult != null) {
-                onActionCompleted(paymentIntentResult)
-            }
-        }
+        viewModel.googlePayCompletion.observe(this, ::onActionCompleted)
 
         setupBuyButton()
         supportFragmentManager.commit {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -54,7 +54,7 @@ internal class PaymentSheetViewModel internal constructor(
         args.clientSecret
     )
 
-    private val mutableGooglePayCompletion = MutableLiveData<PaymentIntentResult>(null)
+    private val mutableGooglePayCompletion = MutableLiveData<PaymentIntentResult>()
     internal val googlePayCompletion: LiveData<PaymentIntentResult> = mutableGooglePayCompletion
 
     fun updatePaymentMethods() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -51,6 +53,9 @@ internal class PaymentSheetViewModel internal constructor(
     private val confirmParamsFactory = ConfirmParamsFactory(
         args.clientSecret
     )
+
+    private val mutableGooglePayCompletion = MutableLiveData<PaymentIntentResult>(null)
+    internal val googlePayCompletion: LiveData<PaymentIntentResult> = mutableGooglePayCompletion
 
     fun updatePaymentMethods() {
         customerConfig?.let {
@@ -197,7 +202,7 @@ internal class PaymentSheetViewModel internal constructor(
         val googlePayResult = StripeGooglePayLauncher.Result.fromIntent(data)
         when (googlePayResult) {
             is StripeGooglePayLauncher.Result.PaymentIntent -> {
-                mutableViewState.value = ViewState.Completed(googlePayResult.paymentIntentResult)
+                mutableGooglePayCompletion.value = googlePayResult.paymentIntentResult
             }
             else -> {
                 // TODO(mshafrir-stripe): handle error


### PR DESCRIPTION
## Motivation
When completing Payment Sheet with Google Pay, the sheet does not
dismiss. Fix this with a new `LiveData` specifically for Google Pay
completion.

## Testing
Add unit test
