### PR TITLE
Improve BillingAddressView address validation

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -13,6 +13,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -46,8 +48,8 @@ internal abstract class BaseAddCardFragment : Fragment() {
     @VisibleForTesting
     internal val paymentMethodParams: PaymentMethodCreateParams?
         get() {
-            val cardParams = cardMultilineWidget.cardParams?.also { cardParams ->
-                billingAddressView.address?.let { billingAddress ->
+            val cardParams = billingAddressView.address.value?.let { billingAddress ->
+                cardMultilineWidget.cardParams?.also { cardParams ->
                     cardParams.address = billingAddress
                 }
             }
@@ -62,6 +64,8 @@ internal abstract class BaseAddCardFragment : Fragment() {
 
     @VisibleForTesting
     internal val saveCardCheckbox: CheckBox by lazy { viewBinding.saveCardCheckbox }
+
+    private val addCardViewModel: AddCardViewModel by viewModels()
 
     abstract fun onGooglePaySelected()
 
@@ -106,19 +110,13 @@ internal abstract class BaseAddCardFragment : Fragment() {
             )
         }
 
+        billingAddressView.address.observe(viewLifecycleOwner) {
+            updateSelection()
+        }
+
         cardMultilineWidget.setCardValidCallback { isValid, _ ->
-            val selection = if (isValid) {
-                paymentMethodParams?.let { params ->
-                    PaymentSelection.New.Card(
-                        params,
-                        cardMultilineWidget.brand,
-                        shouldSavePaymentMethod = shouldSaveCard()
-                    )
-                }
-            } else {
-                null
-            }
-            sheetViewModel.updateSelection(selection)
+            addCardViewModel.isCardValid = isValid
+            updateSelection()
         }
 
         cardMultilineWidget.setCardInputListener(object : CardInputListener {
@@ -163,6 +161,22 @@ internal abstract class BaseAddCardFragment : Fragment() {
         }
     }
 
+    private fun updateSelection() {
+        sheetViewModel.updateSelection(
+            if (addCardViewModel.isCardValid) {
+                paymentMethodParams?.let { params ->
+                    PaymentSelection.New.Card(
+                        params,
+                        cardMultilineWidget.brand,
+                        shouldSavePaymentMethod = shouldSaveCard()
+                    )
+                }
+            } else {
+                null
+            }
+        )
+    }
+
     private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {
         saveCardCheckbox.isVisible = sheetViewModel.customerConfig != null
 
@@ -197,4 +211,8 @@ internal abstract class BaseAddCardFragment : Fragment() {
     }
 
     private fun shouldSaveCard() = saveCardCheckbox.isShown && saveCardCheckbox.isChecked
+
+    internal class AddCardViewModel : ViewModel() {
+        var isCardValid: Boolean = false
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -45,6 +45,10 @@ internal abstract class BaseAddCardFragment : Fragment() {
         viewBinding.billingAddress
     }
 
+    /**
+     * A [PaymentMethodCreateParams] instance of card and billing address details are valid;
+     * otherwise, `null`.
+     */
     @VisibleForTesting
     internal val paymentMethodParams: PaymentMethodCreateParams?
         get() {
@@ -111,10 +115,12 @@ internal abstract class BaseAddCardFragment : Fragment() {
         }
 
         billingAddressView.address.observe(viewLifecycleOwner) {
+            // update selection whenever billing address changes
             updateSelection()
         }
 
         cardMultilineWidget.setCardValidCallback { isValid, _ ->
+            // update selection whenever card details changes
             addCardViewModel.isCardValid = isValid
             updateSelection()
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -47,7 +47,9 @@ internal abstract class BaseAddCardFragment : Fragment() {
     internal val paymentMethodParams: PaymentMethodCreateParams?
         get() {
             val cardParams = cardMultilineWidget.cardParams?.also { cardParams ->
-                cardParams.address = billingAddressView.address
+                billingAddressView.address?.let { billingAddress ->
+                    cardParams.address = billingAddress
+                }
             }
 
             return cardParams?.let {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -17,6 +17,7 @@ import com.stripe.android.view.Country
 import com.stripe.android.view.CountryAdapter
 import com.stripe.android.view.CountryAutoCompleteTextViewValidator
 import com.stripe.android.view.CountryUtils
+import com.stripe.android.view.PostalCodeValidator
 import kotlin.properties.Delegates
 
 internal class BillingAddressView @JvmOverloads constructor(
@@ -43,14 +44,25 @@ internal class BillingAddressView @JvmOverloads constructor(
         ).root
     }
 
-    internal val address: Address
+    private val postalCodeValidator = PostalCodeValidator()
+
+    internal val address: Address?
         get() {
-            return Address(
-                country = selectedCountry?.code,
-                postalCode = postalCodeView.text.toString().takeUnless { postalCode ->
-                    postalCode.isBlank()
+            return selectedCountry?.code?.let { countryCode ->
+                val postalCode = postalCodeView.text.toString()
+                val isPostalCodeValid = postalCodeValidator.isValid(
+                    postalCode = postalCode,
+                    countryCode = countryCode
+                )
+                if (isPostalCodeValid) {
+                    Address(
+                        country = countryCode,
+                        postalCode = postalCode.takeUnless { it.isBlank() }
+                    )
+                } else {
+                    null
                 }
-            )
+            }
         }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -49,24 +49,6 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     private val postalCodeValidator = PostalCodeValidator()
 
-    private fun createAddress(): Address? {
-        return selectedCountry?.code?.let { countryCode ->
-            val postalCode = postalCodeView.text.toString()
-            val isPostalCodeValid = postalCodeValidator.isValid(
-                postalCode = postalCode,
-                countryCode = countryCode
-            )
-            if (isPostalCodeValid) {
-                Address(
-                    country = countryCode,
-                    postalCode = postalCode.takeUnless { it.isBlank() }
-                )
-            } else {
-                null
-            }
-        }
-    }
-
     private val _address = MutableLiveData<Address?>(null)
     internal val address: LiveData<Address?> = _address
 
@@ -153,5 +135,26 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     internal fun validateCountry() {
         countryView.performValidation()
+    }
+
+    /**
+     * An [Address] if the country and postal code are valid; otherwise `null`.
+     */
+    private fun createAddress(): Address? {
+        return selectedCountry?.code?.let { countryCode ->
+            val postalCode = postalCodeView.text.toString()
+            val isPostalCodeValid = postalCodeValidator.isValid(
+                postalCode = postalCode,
+                countryCode = countryCode
+            )
+            if (isPostalCodeValid) {
+                Address(
+                    country = countryCode,
+                    postalCode = postalCode.takeUnless { it.isBlank() }
+                )
+            } else {
+                null
+            }
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
@@ -8,6 +8,19 @@ import java.util.regex.Pattern
  */
 internal class PostalCodeValidator {
 
+    /**
+     * 1. if there is a regex for the country code, validate the postal code against it
+     * 2. if the country does not use a postal code, treat postal code as valid
+     * 3. otherwise, postal code must be not-blank
+     */
+    fun isValid(
+        postalCode: String,
+        countryCode: String
+    ): Boolean {
+        return POSTAL_CODE_PATTERNS[countryCode]?.matcher(postalCode)?.matches()
+            ?: (!CountryUtils.doesCountryUsePostalCode(countryCode) || postalCode.isNotBlank())
+    }
+
     fun isValid(
         postalCode: String,
         countryCode: String?,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -101,9 +102,10 @@ class PaymentSheetAddCardFragmentTest {
             fragment.cardMultilineWidget.setCvcCode("123")
             fragment.billingAddressView.countryView.setText("United States")
             fragment.billingAddressView.postalCodeView.setText("94107")
+            idleLooper()
 
-            val newPaymentSelection = paymentSelection as PaymentSelection.New.Card
-            assertThat(newPaymentSelection.shouldSavePaymentMethod)
+            val newPaymentSelection = paymentSelection as? PaymentSelection.New.Card
+            assertThat(newPaymentSelection?.shouldSavePaymentMethod)
                 .isTrue()
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -102,10 +101,9 @@ class PaymentSheetAddCardFragmentTest {
             fragment.cardMultilineWidget.setCvcCode("123")
             fragment.billingAddressView.countryView.setText("United States")
             fragment.billingAddressView.postalCodeView.setText("94107")
-            idleLooper()
 
-            val newPaymentSelection = paymentSelection as? PaymentSelection.New.Card
-            assertThat(newPaymentSelection?.shouldSavePaymentMethod)
+            val newPaymentSelection = paymentSelection as PaymentSelection.New.Card
+            assertThat(newPaymentSelection.shouldSavePaymentMethod)
                 .isTrue()
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -82,14 +82,14 @@ class BillingAddressViewTest {
     }
 
     @Test
-    fun `address with postal code country and no postal code should return null`() {
+    fun `address with validated postal code country and no postal code should return null`() {
         billingAddressView.selectedCountry = USA
         assertThat(billingAddressView.address.value)
             .isNull()
     }
 
     @Test
-    fun `address with postal code country and invalid postal code should return null`() {
+    fun `address with validated postal code country and invalid postal code should return null`() {
         billingAddressView.selectedCountry = USA
         billingAddressView.postalCodeView.setText("abc")
         assertThat(billingAddressView.address.value)
@@ -97,7 +97,7 @@ class BillingAddressViewTest {
     }
 
     @Test
-    fun `address with postal code country and valid postal code should return expected value`() {
+    fun `address with validated postal code country and valid postal code should return expected value`() {
         billingAddressView.selectedCountry = USA
         billingAddressView.postalCodeView.setText("94107-1234")
         assertThat(billingAddressView.address.value)
@@ -109,9 +109,31 @@ class BillingAddressViewTest {
             )
     }
 
+    @Test
+    fun `address with unvalidated postal code country and null postal code should return null`() {
+        billingAddressView.selectedCountry = MEXICO
+        billingAddressView.postalCodeView.setText("    ")
+        assertThat(billingAddressView.address.value)
+            .isNull()
+    }
+
+    @Test
+    fun `address with unvalidated postal code country and non-empty postal code should return expected value`() {
+        billingAddressView.selectedCountry = MEXICO
+        billingAddressView.postalCodeView.setText("12345")
+        assertThat(billingAddressView.address.value)
+            .isEqualTo(
+                Address(
+                    country = "MX",
+                    postalCode = "12345"
+                )
+            )
+    }
+
     private companion object {
         private val USA = Country("US", "United States")
         private val FRANCE = Country("FR", "France")
         private val ZIMBABWE = Country("ZW", "Zimbabwe")
+        private val MEXICO = Country("MX", "Mexico")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.Address
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
 import com.stripe.android.view.Country
@@ -39,7 +40,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `changing selectedCountry to country without postal code should hide postal code view`() {
-        billingAddressView.selectedCountry = Country("ZW", "Zimbabwe")
+        billingAddressView.selectedCountry = ZIMBABWE
         idleLooper()
         assertThat(billingAddressView.postalCodeLayout.isVisible)
             .isFalse()
@@ -47,7 +48,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `changing selectedCountry to France should show postal code view`() {
-        billingAddressView.selectedCountry = Country("FR", "France")
+        billingAddressView.selectedCountry = FRANCE
         idleLooper()
         assertThat(billingAddressView.postalCodeLayout.isVisible)
             .isTrue()
@@ -55,7 +56,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `changing selectedCountry to US should show postal code view`() {
-        billingAddressView.selectedCountry = Country("US", "United States")
+        billingAddressView.selectedCountry = USA
         idleLooper()
         assertThat(billingAddressView.postalCodeLayout.isVisible)
             .isTrue()
@@ -67,5 +68,50 @@ class BillingAddressViewTest {
         idleLooper()
         assertThat(billingAddressView.postalCodeLayout.isVisible)
             .isTrue()
+    }
+
+    @Test
+    fun `address with no postal code country and no postal code should return expected value`() {
+        billingAddressView.selectedCountry = ZIMBABWE
+        assertThat(billingAddressView.address)
+            .isEqualTo(
+                Address(
+                    country = "ZW"
+                )
+            )
+    }
+
+    @Test
+    fun `address with postal code country and no postal code should return null`() {
+        billingAddressView.selectedCountry = USA
+        assertThat(billingAddressView.address)
+            .isNull()
+    }
+
+    @Test
+    fun `address with postal code country and invalid postal code should return null`() {
+        billingAddressView.selectedCountry = USA
+        billingAddressView.postalCodeView.setText("abc")
+        assertThat(billingAddressView.address)
+            .isNull()
+    }
+
+    @Test
+    fun `address with postal code country and valid postal code should return expected value`() {
+        billingAddressView.selectedCountry = USA
+        billingAddressView.postalCodeView.setText("94107-1234")
+        assertThat(billingAddressView.address)
+            .isEqualTo(
+                Address(
+                    country = "US",
+                    postalCode = "94107-1234"
+                )
+            )
+    }
+
+    private companion object {
+        private val USA = Country("US", "United States")
+        private val FRANCE = Country("FR", "France")
+        private val ZIMBABWE = Country("ZW", "Zimbabwe")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -73,7 +73,7 @@ class BillingAddressViewTest {
     @Test
     fun `address with no postal code country and no postal code should return expected value`() {
         billingAddressView.selectedCountry = ZIMBABWE
-        assertThat(billingAddressView.address)
+        assertThat(billingAddressView.address.value)
             .isEqualTo(
                 Address(
                     country = "ZW"
@@ -84,7 +84,7 @@ class BillingAddressViewTest {
     @Test
     fun `address with postal code country and no postal code should return null`() {
         billingAddressView.selectedCountry = USA
-        assertThat(billingAddressView.address)
+        assertThat(billingAddressView.address.value)
             .isNull()
     }
 
@@ -92,7 +92,7 @@ class BillingAddressViewTest {
     fun `address with postal code country and invalid postal code should return null`() {
         billingAddressView.selectedCountry = USA
         billingAddressView.postalCodeView.setText("abc")
-        assertThat(billingAddressView.address)
+        assertThat(billingAddressView.address.value)
             .isNull()
     }
 
@@ -100,7 +100,7 @@ class BillingAddressViewTest {
     fun `address with postal code country and valid postal code should return expected value`() {
         billingAddressView.selectedCountry = USA
         billingAddressView.postalCodeView.setText("94107-1234")
-        assertThat(billingAddressView.address)
+        assertThat(billingAddressView.address.value)
             .isEqualTo(
                 Address(
                     country = "US",


### PR DESCRIPTION
Require a valid country code and postal code.

Update `BillingAddressView.address` to be a `LiveData` that
emits the current `Address` value.