### PR TITLE
Disable text input on country field in BillingAddressView

### DIFF
--- a/stripe/res/layout/stripe_billing_address_layout.xml
+++ b/stripe/res/layout/stripe_billing_address_layout.xml
@@ -25,6 +25,7 @@
                     style="@style/StripePaymentSheetTextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:inputType="none"
                     android:paddingVertical="13dp"
                     android:paddingHorizontal="12dp" />
             </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
The country representing the default locale is sorted to the top,
so in the vast majority of cases we expected the user's country will
be automatically selected.

Text input introduces validation complexities.