### PR TITLE
Fix CTA button being enabled by default

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -18,6 +18,7 @@ internal class PaymentOptionsViewModel(
     init {
         mutablePaymentIntent.value = args.paymentIntent
         mutablePaymentMethods.value = args.paymentMethods
+        mutableProcessing.postValue(false)
     }
 
     fun selectPaymentOption() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -108,6 +108,7 @@ internal class PaymentSheetViewModel internal constructor(
         val currencyCode = paymentIntent.currency
         if (amount != null && currencyCode != null) {
             mutableViewState.value = ViewState.Ready(amount, currencyCode)
+            mutableProcessing.value = false
         } else {
             onFatal(
                 IllegalStateException("PaymentIntent could not be parsed correctly.")

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -52,8 +52,8 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     private val mutableSheetMode = MutableLiveData<SheetMode>()
     val sheetMode: LiveData<SheetMode> = mutableSheetMode.distinctUntilChanged()
 
-    protected val mutableProcessing = MutableLiveData(false)
-    val processing = mutableProcessing.distinctUntilChanged()
+    protected val mutableProcessing = MutableLiveData(true)
+    val processing: LiveData<Boolean> = mutableProcessing
 
     protected val mutableViewState = MutableLiveData<ViewStateType>(null)
     internal val viewState: LiveData<ViewStateType> = mutableViewState.distinctUntilChanged()


### PR DESCRIPTION
The CTA button is enabled whenever processing has ended. Default
processing to `true` and flip it to `false` when appropriate.