### PR TITLE
Remove cardForegroundColor from PaymentMethodsAdapter cards

### DIFF
--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -70,8 +70,8 @@
         <item name="checkedIcon">@null</item>
         <item name="strokeWidth">1dp</item>
         <item name="strokeColor">@color/stripe_paymentsheet_card_stroke</item>
+        <item name="cardForegroundColor">@android:color/transparent</item>
     </style>
-
 
     <style name="StripePaymentOptionItemCardImage">
         <item name="android:layout_width">56dp</item>


### PR DESCRIPTION
Select state is shown through border and icon, so remove default
cardForegroundColor by setting to transparent.
