### PR TITLE
Update GooglePayConfig constructor

### DIFF
--- a/stripe/src/main/java/com/stripe/android/GooglePayConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayConfig.kt
@@ -11,7 +11,7 @@ class GooglePayConfig @JvmOverloads constructor(
     publishableKey: String,
     private val connectedAccountId: String? = null
 ) {
-    private val publishableKey: String = ApiKeyValidator.get().requireValid(publishableKey)
+    private val validPublishableKey: String = ApiKeyValidator.get().requireValid(publishableKey)
     private val apiVersion: String = ApiVersion.get().code
 
     /**
@@ -31,15 +31,28 @@ class GooglePayConfig @JvmOverloads constructor(
             )
 
     private val key: String
-        get() = connectedAccountId?.let { "$publishableKey/$it" } ?: publishableKey
+        get() = connectedAccountId?.let { "$validPublishableKey/$it" } ?: validPublishableKey
+
+    /**
+     * Instantiate with [PaymentConfiguration].
+     * [PaymentConfiguration] must be initialized.
+     */
+    constructor(context: Context) : this(
+        PaymentConfiguration.getInstance(context)
+    )
 
     /**
      * Instantiate with [PaymentConfiguration] and optional Connect Account Id.
      * [PaymentConfiguration] must be initialized.
      */
-    @JvmOverloads
+    @Deprecated("Configure connectedAccountId in PaymentConfiguration")
     constructor(context: Context, connectedAccountId: String? = null) : this(
-        PaymentConfiguration.getInstance(context).publishableKey,
-        connectedAccountId
+        publishableKey = PaymentConfiguration.getInstance(context).publishableKey,
+        connectedAccountId = connectedAccountId
+    )
+
+    private constructor(paymentConfiguration: PaymentConfiguration) : this(
+        publishableKey = paymentConfiguration.publishableKey,
+        connectedAccountId = paymentConfiguration.stripeAccountId
     )
 }

--- a/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.kt
+++ b/stripe/src/test/java/com/stripe/android/GooglePayConfigTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android
 
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayConfigTest {
@@ -19,18 +19,12 @@ class GooglePayConfigTest {
             GooglePayConfig(ApplicationProvider.getApplicationContext())
                 .tokenizationSpecification
         val params = tokenizationSpec.getJSONObject("parameters")
-        assertEquals(
-            "stripe",
-            params.getString("gateway")
-        )
-        assertEquals(
-            ApiVersion.get().code,
-            params.getString("stripe:version")
-        )
-        assertEquals(
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            params.getString("stripe:publishableKey")
-        )
+        assertThat(params.getString("gateway"))
+            .isEqualTo("stripe")
+        assertThat(params.getString("stripe:version"))
+            .isEqualTo(ApiVersion.get().code)
+        assertThat(params.getString("stripe:publishableKey"))
+            .isEqualTo(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
     }
 
     @Test
@@ -38,17 +32,11 @@ class GooglePayConfigTest {
         val tokenizationSpec = GooglePayConfig(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_1234")
             .tokenizationSpecification
         val params = tokenizationSpec.getJSONObject("parameters")
-        assertEquals(
-            "stripe",
-            params.getString("gateway")
-        )
-        assertEquals(
-            ApiVersion.get().code,
-            params.getString("stripe:version")
-        )
-        assertEquals(
-            "pk_test_123/acct_1234",
-            params.getString("stripe:publishableKey")
-        )
+        assertThat(params.getString("gateway"))
+            .isEqualTo("stripe")
+        assertThat(params.getString("stripe:version"))
+            .isEqualTo(ApiVersion.get().code)
+        assertThat(params.getString("stripe:publishableKey"))
+            .isEqualTo("pk_test_123/acct_1234")
     }
 }


### PR DESCRIPTION
Extract `connectedAccountId` from `PaymentConfiguration` if using
constructor with `Context`.