### PR TITLE
Update payment sheet styling

### DIFF
--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -54,7 +54,7 @@
 
     <style name="StripePaymentOptionItemContainer">
         <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">4dp</item>
+        <item name="android:paddingEnd">0dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
     </style>
@@ -62,7 +62,10 @@
     <style name="StripePaymentOptionItemCard">
         <item name="android:layout_width">@dimen/stripe_paymentsheet_paymentmethod_icon_width</item>
         <item name="android:layout_height">@dimen/stripe_paymentsheet_paymentmethod_icon_height</item>
-        <item name="android:layout_margin">8dp</item>
+        <item name="android:layout_marginStart">8dp</item>
+        <item name="android:layout_marginTop">8dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="android:layout_marginBottom">4dp</item>
         <item name="android:padding">4dp</item>
         <item name="android:clickable">false</item>
         <item name="android:focusable">false</item>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -67,13 +67,6 @@ internal class AddButton @JvmOverloads constructor(
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-
-        viewBinding.label.alpha = if (enabled) {
-            ALPHA_ENABLED
-        } else {
-            ALPHA_DISABLED
-        }
-
         viewBinding.lockIcon.isVisible = enabled
     }
 
@@ -86,10 +79,5 @@ internal class AddButton @JvmOverloads constructor(
                 onCompletedState(viewState)
             }
         }
-    }
-
-    private companion object {
-        private const val ALPHA_ENABLED = 1.0f
-        private const val ALPHA_DISABLED = 0.5f
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
@@ -81,13 +81,6 @@ internal class BuyButton @JvmOverloads constructor(
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-
-        viewBinding.label.alpha = if (enabled) {
-            ALPHA_ENABLED
-        } else {
-            ALPHA_DISABLED
-        }
-
         viewBinding.lockIcon.isVisible = enabled
     }
 
@@ -103,10 +96,5 @@ internal class BuyButton @JvmOverloads constructor(
                 onCompletedState(viewState)
             }
         }
-    }
-
-    private companion object {
-        private const val ALPHA_ENABLED = 1.0f
-        private const val ALPHA_DISABLED = 0.5f
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
@@ -13,13 +13,6 @@ class AddButtonTest {
     private val addButton = AddButton(ApplicationProvider.getApplicationContext())
 
     @Test
-    fun `disabling button should update label alpha`() {
-        addButton.isEnabled = false
-        assertThat(addButton.viewBinding.label.alpha)
-            .isEqualTo(0.5f)
-    }
-
-    @Test
     fun `onReadyState() should update label`() {
         addButton.onReadyState()
         assertThat(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
@@ -12,13 +12,6 @@ class BuyButtonTest {
     private val buyButton = BuyButton(ApplicationProvider.getApplicationContext())
 
     @Test
-    fun `disabling button should update label alpha`() {
-        buyButton.isEnabled = false
-        assertThat(buyButton.viewBinding.label.alpha)
-            .isEqualTo(0.5f)
-    }
-
-    @Test
     fun `onReadyState() should update label`() {
         buyButton.onReadyState(
             ViewState.Ready(amount = 1099, currencyCode = "usd")


### PR DESCRIPTION
- Reduce margin between card and label in carousel to 4dp
- Don't change alpha of primary button text
- Reduce spacing between carousel cards
