### PR TITLE
Consolidate payment sheet PaymentIntent validation logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentIntentValidator.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentIntentValidator.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.paymentsheet.model
+
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.StripeIntent
+
+/**
+ * Validator for [PaymentIntent] instances used in PaymentSheet.
+ */
+internal class PaymentIntentValidator {
+    @JvmSynthetic
+    fun requireValid(
+        paymentIntent: PaymentIntent
+    ): PaymentIntent {
+        when {
+            paymentIntent.confirmationMethod != PaymentIntent.ConfirmationMethod.Automatic -> {
+                error(
+                    """
+                        PaymentIntent with confirmation_method='automatic' is required.
+                        See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-confirmation_method.
+                    """.trimIndent()
+                )
+            }
+            paymentIntent.status != StripeIntent.Status.RequiresPaymentMethod -> {
+                error(
+                    """
+                        A PaymentIntent with status='requires_payment_method' is required.
+                        The current PaymentIntent has status ${paymentIntent.status}.
+                        See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status.
+                    """.trimIndent()
+                )
+            }
+            else -> {
+                // valid
+            }
+        }
+
+        return paymentIntent
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -267,6 +267,37 @@ internal object PaymentIntentFixtures {
         )
     )!!
 
+    val PI_REQUIRES_PAYMENT_METHOD = PARSER.parse(
+        JSONObject(
+            """
+        {
+            "id": "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
+            "object": "payment_intent",
+            "amount": 1099,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "manual",
+            "client_secret": "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+            "confirmation_method": "automatic",
+            "created": 1565775850,
+            "currency": "usd",
+            "description": "Example PaymentIntent",
+            "livemode": false,
+            "next_action": null,
+            "payment_method": null,
+            "payment_method_types": [
+                "card"
+            ],
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": null,
+            "source": null,
+            "status": "requires_payment_method"
+        }
+            """.trimIndent()
+        )
+    )!!
+
     val PI_WITH_LAST_PAYMENT_ERROR = PARSER.parse(
         JSONObject(
             """

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -49,14 +49,12 @@ internal class PaymentSheetActivityTest {
 
     private val testCoroutineDispatcher = TestCoroutineDispatcher()
 
-    private val paymentIntent = PaymentIntentFixtures.PI_WITH_SHIPPING
-
     private val paymentMethods = listOf(
         PaymentMethod("payment_method_id", 0, false, PaymentMethod.Type.Card)
     )
 
     private val googlePayRepository = FakeGooglePayRepository(true)
-    private val stripeRepository = FakeStripeRepository(paymentIntent, paymentMethods)
+    private val stripeRepository = FakeStripeRepository(PAYMENT_INTENT, paymentMethods)
     private val eventReporter = mock<EventReporter>()
 
     private val viewModel = PaymentSheetViewModel(
@@ -118,7 +116,7 @@ internal class PaymentSheetActivityTest {
                 PaymentSheet.Result(
                     PaymentResult.Cancelled(
                         null,
-                        paymentIntent
+                        PAYMENT_INTENT
                     )
                 )
             )
@@ -183,7 +181,7 @@ internal class PaymentSheetActivityTest {
                 PaymentSheet.Result(
                     PaymentResult.Cancelled(
                         null,
-                        paymentIntent
+                        PAYMENT_INTENT
                     )
                 )
             )
@@ -243,7 +241,7 @@ internal class PaymentSheetActivityTest {
             assertThat(PaymentSheet.Result.fromIntent(shadowOf(activity).resultIntent))
                 .isEqualTo(
                     PaymentSheet.Result(
-                        PaymentResult.Succeeded(paymentIntent)
+                        PaymentResult.Succeeded(PAYMENT_INTENT)
                     )
                 )
         }
@@ -254,7 +252,7 @@ internal class PaymentSheetActivityTest {
         val viewModel = PaymentSheetViewModel(
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeAccountId = null,
-            stripeRepository = FakeStripeRepository(paymentIntent, listOf()),
+            stripeRepository = FakeStripeRepository(PAYMENT_INTENT, listOf()),
             paymentController = StripePaymentController(
                 ApplicationProvider.getApplicationContext(),
                 ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
@@ -293,7 +291,7 @@ internal class PaymentSheetActivityTest {
                 PaymentSheet.Result(
                     PaymentResult.Cancelled(
                         null,
-                        paymentIntent
+                        PAYMENT_INTENT
                     )
                 )
             )
@@ -337,5 +335,9 @@ internal class PaymentSheetActivityTest {
             options: ApiRequest.Options,
             expandFields: List<String>
         ): PaymentIntent = paymentIntent
+    }
+
+    private companion object {
+        private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentIntentValidatorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentIntentValidatorTest.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.paymentsheet.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.StripeIntent
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentIntentValidatorTest {
+    private val validator = PaymentIntentValidator()
+
+    @Test
+    fun `requireValid() should return original PaymentIntent when valid`() {
+        assertThat(
+            validator.requireValid(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        ).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun `requireValid() requires confirmationMethod = Automatic`() {
+        assertFails {
+            validator.requireValid(
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
+                    confirmationMethod = PaymentIntent.ConfirmationMethod.Manual
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `requireValid() requires status = RequiresPaymentMethod`() {
+        assertFails {
+            validator.requireValid(
+                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    status = StripeIntent.Status.Processing
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
Create `PaymentIntentValidator` and use after retrieving
a `PaymentIntent`.

Add unit tests.