### PR TITLE
Update payment sheet analytics

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -12,7 +12,7 @@ import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 internal class PaymentOptionsViewModel(
     args: PaymentOptionsActivityStarter.Args,
     googlePayRepository: GooglePayRepository,
-    eventReporter: EventReporter
+    private val eventReporter: EventReporter
 ) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget, PaymentOptionViewState>(
     config = args.config,
     isGooglePayEnabled = args.config?.googlePay != null,
@@ -22,12 +22,11 @@ internal class PaymentOptionsViewModel(
         mutablePaymentIntent.value = args.paymentIntent
         mutablePaymentMethods.value = args.paymentMethods
         mutableProcessing.postValue(false)
-
-        eventReporter.onInit(config)
     }
 
     fun selectPaymentOption() {
         selection.value?.let { paymentSelection ->
+            eventReporter.onSelectPaymentOption(paymentSelection)
             mutableViewState.value = PaymentOptionViewState.Completed(paymentSelection)
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -201,16 +201,12 @@ internal class PaymentSheetViewModel internal constructor(
     private fun onPaymentIntentResult(paymentIntentResult: PaymentIntentResult) {
         when (paymentIntentResult.outcome) {
             StripeIntentResult.Outcome.SUCCEEDED -> {
-                selection.value?.let {
-                    eventReporter.onPaymentSuccess(it)
-                }
+                eventReporter.onPaymentSuccess(selection.value)
 
                 mutableViewState.value = ViewState.Completed(paymentIntentResult)
             }
             else -> {
-                selection.value?.let {
-                    eventReporter.onPaymentFailure(it)
-                }
+                eventReporter.onPaymentFailure(selection.value)
 
                 val paymentIntent = paymentIntentResult.intent
                 onApiError(paymentIntent.lastPaymentError?.message)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -61,7 +61,7 @@ internal class DefaultEventReporter internal constructor(
         )
     }
 
-    override fun onSelectPaymentOption(paymentSelection: PaymentSelection) {
+    override fun onSelectPaymentOption(paymentSelection: PaymentSelection?) {
         fireEvent(
             PaymentSheetEvent.SelectPaymentOption(
                 mode = mode,
@@ -70,7 +70,7 @@ internal class DefaultEventReporter internal constructor(
         )
     }
 
-    override fun onPaymentSuccess(paymentSelection: PaymentSelection) {
+    override fun onPaymentSuccess(paymentSelection: PaymentSelection?) {
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,
@@ -80,7 +80,7 @@ internal class DefaultEventReporter internal constructor(
         )
     }
 
-    override fun onPaymentFailure(paymentSelection: PaymentSelection) {
+    override fun onPaymentFailure(paymentSelection: PaymentSelection?) {
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -61,7 +61,7 @@ internal class DefaultEventReporter internal constructor(
         )
     }
 
-    override fun onSelectPaymentOption(paymentSelection: PaymentSelection?) {
+    override fun onSelectPaymentOption(paymentSelection: PaymentSelection) {
         fireEvent(
             PaymentSheetEvent.SelectPaymentOption(
                 mode = mode,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -12,7 +12,7 @@ internal interface EventReporter {
 
     fun onShowNewPaymentOptionForm()
 
-    fun onSelectPaymentOption(paymentSelection: PaymentSelection?)
+    fun onSelectPaymentOption(paymentSelection: PaymentSelection)
 
     fun onPaymentSuccess(paymentSelection: PaymentSelection?)
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -12,11 +12,11 @@ internal interface EventReporter {
 
     fun onShowNewPaymentOptionForm()
 
-    fun onSelectPaymentOption(paymentSelection: PaymentSelection)
+    fun onSelectPaymentOption(paymentSelection: PaymentSelection?)
 
-    fun onPaymentSuccess(paymentSelection: PaymentSelection)
+    fun onPaymentSuccess(paymentSelection: PaymentSelection?)
 
-    fun onPaymentFailure(paymentSelection: PaymentSelection)
+    fun onPaymentFailure(paymentSelection: PaymentSelection?)
 
     enum class Mode(val code: String) {
         Complete("complete"),

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -42,7 +42,7 @@ internal sealed class PaymentSheetEvent(
 
     class SelectPaymentOption(
         mode: EventReporter.Mode,
-        paymentSelection: PaymentSelection
+        paymentSelection: PaymentSelection?
     ) : PaymentSheetEvent(mode) {
         override val event: String = "paymentoption_${analyticsValue(paymentSelection)}_select"
     }
@@ -50,7 +50,7 @@ internal sealed class PaymentSheetEvent(
     class Payment(
         mode: EventReporter.Mode,
         result: Result,
-        paymentSelection: PaymentSelection
+        paymentSelection: PaymentSelection?
     ) : PaymentSheetEvent(mode) {
         override val event: String = "payment_${analyticsValue(paymentSelection)}_$result"
 
@@ -68,11 +68,12 @@ internal sealed class PaymentSheetEvent(
 
     private companion object {
         private fun analyticsValue(
-            paymentSelection: PaymentSelection
+            paymentSelection: PaymentSelection?
         ) = when (paymentSelection) {
             PaymentSelection.GooglePay -> "googlepay"
             is PaymentSelection.Saved -> "savedpm"
             is PaymentSelection.New -> "newpm"
+            else -> "unknown"
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -32,7 +32,7 @@ class PaymentOptionsActivityTest {
     private val eventReporter = mock<EventReporter>()
     private val viewModel = PaymentOptionsViewModel(
         args = PaymentOptionsActivityStarter.Args(
-            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
         ),
@@ -48,7 +48,7 @@ class PaymentOptionsActivityTest {
         ).putExtra(
             ActivityStarter.Args.EXTRA,
             PaymentOptionsActivityStarter.Args(
-                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 paymentMethods = emptyList(),
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
             )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -22,19 +22,13 @@ class PaymentOptionsViewModelTest {
     private val eventReporter = mock<EventReporter>()
     private val viewModel = PaymentOptionsViewModel(
         args = PaymentOptionsActivityStarter.Args(
-            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
         ),
         googlePayRepository = mock(),
         eventReporter = eventReporter
     )
-
-    @Test
-    fun `init should fire analytics event`() {
-        verify(eventReporter)
-            .onInit(PaymentSheetFixtures.CONFIG_GOOGLEPAY)
-    }
 
     @Test
     fun `selectPaymentOption() when selection has been made should emit completion view state`() {
@@ -48,6 +42,7 @@ class PaymentOptionsViewModelTest {
 
         assertThat(viewState)
             .isEqualTo(PaymentOptionViewState.Completed(SELECTION_SAVED_PAYMENT_METHOD))
+        verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -141,7 +141,7 @@ class PaymentSheetAddCardFragmentTest {
 
             fragment.onConfigReady(
                 AddPaymentMethodConfig(
-                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     paymentMethods = emptyList(),
                     isGooglePayReady = true
                 )
@@ -168,14 +168,14 @@ class PaymentSheetAddCardFragmentTest {
         createScenario().onFragment { fragment ->
             fragment.onConfigReady(
                 AddPaymentMethodConfig(
-                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     paymentMethods = emptyList(),
                     isGooglePayReady = true
                 )
             )
 
             assertThat(fragment.addCardHeader.text.toString())
-                .isEqualTo("Pay $20.00 using")
+                .isEqualTo("Pay $10.99 using")
         }
     }
 


### PR DESCRIPTION
- Support nullable `PaymentSelection`
- Move `onInit()` event from `PaymentOptionsViewModel` to
  `DefaultPaymentSheetFlowController`
- Add `onPaymentSuccess()`/`onPaymentFailure()` integration in
  `DefaultPaymentSheetFlowController`
- Update tests to use `PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD`