### PR TITLE
Add address lines to BillingAddressView

### DIFF
--- a/stripe/res/layout/stripe_billing_address_layout.xml
+++ b/stripe/res/layout/stripe_billing_address_layout.xml
@@ -31,6 +31,45 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <View
+                android:id="@+id/address1_divider"
+                android:visibility="gone"
+                style="@style/StripePaymentSheetFormDivider" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/address1_layout"
+                style="@style/StripePaymentSheetTextInputLayout"
+                android:hint="@string/address_label_address_line1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/address1"
+                    style="@style/StripePaymentSheetTextInputEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <View
+                android:id="@+id/address2_divider"
+                android:visibility="gone"
+                style="@style/StripePaymentSheetFormDivider" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/address2_layout"
+                android:visibility="gone"
+                style="@style/StripePaymentSheetTextInputLayout"
+                android:hint="@string/address_label_address_line2_optional"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/address2"
+                    style="@style/StripePaymentSheetTextInputEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <View
                 android:id="@+id/postal_code_divider"
                 style="@style/StripePaymentSheetFormDivider" />
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.Address
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
 import com.stripe.android.view.Country
@@ -139,6 +140,35 @@ class BillingAddressViewTest {
         billingAddressView.selectedCountry = USA
         assertThat(billingAddressView.postalCodeView.inputType)
             .isEqualTo(BillingAddressView.PostalCodeConfig.UnitedStates.inputType)
+    }
+
+    @Test
+    fun `address value should react to level`() {
+        billingAddressView.selectedCountry = USA
+        billingAddressView.postalCodeView.setText("94107")
+
+        billingAddressView.address1View.setText("123 Main St")
+        billingAddressView.address2View.setText("Apt 4")
+
+        billingAddressView.level = PaymentSheet.BillingAddressCollectionLevel.Required
+        assertThat(billingAddressView.address.value)
+            .isEqualTo(
+                Address(
+                    line1 = "123 Main St",
+                    line2 = "Apt 4",
+                    country = "US",
+                    postalCode = "94107"
+                )
+            )
+
+        billingAddressView.level = PaymentSheet.BillingAddressCollectionLevel.Automatic
+        assertThat(billingAddressView.address.value)
+            .isEqualTo(
+                Address(
+                    country = "US",
+                    postalCode = "94107"
+                )
+            )
     }
 
     private companion object {


### PR DESCRIPTION
`BillingAddressView` reacts to its `PaymentSheet.BillingAddressCollectionLevel`.

Hide line1 and line2 when `Automatic` (default); show when `Required`.

Added unit tests.