### PR TITLE
Add a few toString() methods to enumerations

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
+++ b/stripe/src/main/java/com/stripe/android/model/BankAccount.kt
@@ -97,6 +97,8 @@ data class BankAccount internal constructor(
         Company("company"),
         Individual("individual");
 
+        override fun toString(): String = code
+
         internal companion object {
             internal fun fromCode(code: String?) = values().firstOrNull { it.code == code }
         }
@@ -108,6 +110,8 @@ data class BankAccount internal constructor(
         Verified("verified"),
         VerificationFailed("verification_failed"),
         Errored("errored");
+
+        override fun toString(): String = code
 
         internal companion object {
             internal fun fromCode(code: String?): Status? {

--- a/stripe/src/main/java/com/stripe/android/model/Source.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Source.kt
@@ -212,6 +212,8 @@ data class Source internal constructor(
         Reusable("reusable"),
         SingleUse("single_use");
 
+        override fun toString(): String = code
+
         internal companion object {
             fun fromCode(code: String?) = values().firstOrNull { it.code == code }
         }
@@ -226,6 +228,8 @@ data class Source internal constructor(
         CodeVerification("code_verification"),
         None("none");
 
+        override fun toString(): String = code
+        
         internal companion object {
             fun fromCode(code: String?) = values().firstOrNull { it.code == code }
         }
@@ -298,6 +302,8 @@ data class Source internal constructor(
             Succeeded("succeeded"),
             Failed("failed");
 
+            override fun toString(): String = code
+            
             internal companion object {
                 fun fromCode(code: String?) = values().firstOrNull { it.code == code }
             }

--- a/stripe/src/main/java/com/stripe/android/model/Source.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Source.kt
@@ -229,7 +229,7 @@ data class Source internal constructor(
         None("none");
 
         override fun toString(): String = code
-        
+
         internal companion object {
             fun fromCode(code: String?) = values().firstOrNull { it.code == code }
         }
@@ -303,7 +303,7 @@ data class Source internal constructor(
             Failed("failed");
 
             override fun toString(): String = code
-            
+
             internal companion object {
                 fun fromCode(code: String?) = values().firstOrNull { it.code == code }
             }


### PR DESCRIPTION

## Summary

Just a few .toString methods to the enums.

## Motivation

Noticed they were missing and would make integration work easier. I'm currently integrating the SDKs into a Flutter plugin and would like to ensure the communication between native & flutter side is consistent.

## Testing

I did not see existing tests for `toString` in the project, so I did not add them.