### PR TITLE
Update sheet dragging and dismissal logic

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -11,7 +11,6 @@
         android:layout_height="wrap_content"
         android:clipToPadding="true"
         android:background="?colorSurface"
-        android:paddingTop="@dimen/stripe_paymentsheet_padding_top"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <LinearLayout

--- a/stripe/res/layout/stripe_activity_payment_options.xml
+++ b/stripe/res/layout/stripe_activity_payment_options.xml
@@ -12,7 +12,6 @@
         android:layout_height="wrap_content"
         android:clipToPadding="true"
         android:background="?colorSurface"
-        android:paddingTop="@dimen/stripe_paymentsheet_padding_top"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <LinearLayout

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -51,7 +51,6 @@
     <dimen name="stripe_card_widget_progress_size">12dp</dimen>
 
     <!-- PaymentSheet -->
-    <dimen name="stripe_paymentsheet_padding_top">12dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_height">64dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_width">100dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_radius">6dp</dimen>

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -161,9 +161,9 @@
     </style>
 
     <style name="StripePaymentSheetToolbar">
-        <item name="android:layout_marginTop">4dp</item>
-        <item name="android:layout_marginStart">@dimen/stripe_paymentsheet_outer_spacing_horizontal</item>
-        <item name="android:layout_marginEnd">@dimen/stripe_paymentsheet_outer_spacing_horizontal</item>
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingStart">@dimen/stripe_paymentsheet_outer_spacing_horizontal</item>
+        <item name="android:paddingEnd">@dimen/stripe_paymentsheet_outer_spacing_horizontal</item>
         <item name="android:layout_marginBottom">12dp</item>
     </style>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BottomSheetController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BottomSheetController.kt
@@ -44,7 +44,6 @@ internal class BottomSheetController(
     }
 
     fun updateState(sheetMode: SheetMode) {
-        bottomSheetBehavior.isDraggable = sheetMode.isDraggable
         if (bottomSheetBehavior.state != BottomSheetBehavior.STATE_HIDDEN) {
             bottomSheetBehavior.state = sheetMode.behaviourState
         }
@@ -54,6 +53,10 @@ internal class BottomSheetController(
         // When the bottom sheet finishes animating to its new state,
         // the callback will finish the activity
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+    }
+
+    fun setDraggable(isDraggable: Boolean) {
+        bottomSheetBehavior.isDraggable = isDraggable
     }
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -46,7 +46,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         BottomSheetBehavior.from(viewBinding.bottomSheet)
     }
 
-    private val bottomSheetController: BottomSheetController by lazy {
+    override val bottomSheetController: BottomSheetController by lazy {
         BottomSheetController(
             bottomSheetBehavior = bottomSheetBehavior,
             sheetModeLiveData = viewModel.sheetMode,
@@ -98,8 +98,6 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
             }
 
             bottomSheetController.updateState(mode)
-
-            updateRootViewClickHandling(mode.isDraggable)
         }
         bottomSheetController.shouldFinish.observe(this) { shouldFinish ->
             if (shouldFinish) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -35,7 +35,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         BottomSheetBehavior.from(viewBinding.bottomSheet)
     }
 
-    private val bottomSheetController: BottomSheetController by lazy {
+    override val bottomSheetController: BottomSheetController by lazy {
         BottomSheetController(
             bottomSheetBehavior = bottomSheetBehavior,
             sheetModeLiveData = viewModel.sheetMode,
@@ -111,8 +111,6 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
             }
 
             bottomSheetController.updateState(mode)
-
-            updateRootViewClickHandling(mode.isDraggable)
         }
 
         bottomSheetController.shouldFinish.observe(this) { shouldFinish ->

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
@@ -6,6 +6,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 import com.stripe.android.view.KeyboardController
 import kotlinx.coroutines.delay
@@ -13,6 +14,7 @@ import kotlinx.coroutines.launch
 
 internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity() {
     abstract val viewModel: SheetViewModel<*, *>
+    abstract val bottomSheetController: BottomSheetController
 
     abstract val rootView: View
     abstract val messageView: TextView
@@ -33,7 +35,10 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
             messageView.text = userMessage?.message
         }
 
-        updateRootViewClickHandling(true)
+        viewModel.processing.observe(this) { isProcessing ->
+            bottomSheetController.setDraggable(!isProcessing)
+            updateRootViewClickHandling(isProcessing)
+        }
     }
 
     override fun finish() {
@@ -57,8 +62,8 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
         hideSheet()
     }
 
-    protected fun updateRootViewClickHandling(isDraggable: Boolean) {
-        if (isDraggable) {
+    private fun updateRootViewClickHandling(isProcessing: Boolean) {
+        if (!isProcessing) {
             // Handle taps outside of bottom sheet
             rootView.setOnClickListener {
                 onUserCancel()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/SheetMode.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/SheetMode.kt
@@ -5,24 +5,20 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 internal enum class SheetMode(
     val height: Int,
-    @BottomSheetBehavior.State val behaviourState: Int,
-    val isDraggable: Boolean
+    @BottomSheetBehavior.State val behaviourState: Int
 ) {
     Full(
         ViewGroup.LayoutParams.MATCH_PARENT,
-        BottomSheetBehavior.STATE_EXPANDED,
-        isDraggable = false
+        BottomSheetBehavior.STATE_EXPANDED
     ),
 
     FullCollapsed(
         ViewGroup.LayoutParams.MATCH_PARENT,
-        BottomSheetBehavior.STATE_COLLAPSED,
-        isDraggable = false
+        BottomSheetBehavior.STATE_COLLAPSED
     ),
 
     Wrapped(
         ViewGroup.LayoutParams.WRAP_CONTENT,
-        BottomSheetBehavior.STATE_COLLAPSED,
-        isDraggable = true
+        BottomSheetBehavior.STATE_COLLAPSED
     )
 }


### PR DESCRIPTION
- When processing, sheet is not draggable and not dismissable
- Update `Toolbar` layout so that it extends to the side and top edges
  of the sheet. This prevents clicks on the margins of the sheet causing
  dismissal.

Manually verified