### PR TITLE
Migrate PaymentMethodsActivity to use Activity Result API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     ktlintVersion = '0.40.0'
     materialVersion = '1.2.1'
 
-    fragmentVersion = '1.2.5'
+    fragmentVersion = '1.3.0-rc01'
 
     androidTestVersion = '1.3.0'
 }

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "androidx.fragment:fragment-testing:$fragmentVersion"
+    testImplementation "androidx.fragment:fragment-testing:1.2.5"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test:rules:$androidTestVersion"

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation "androidx.activity:activity-ktx:1.2.0-rc01"
 
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -48,8 +48,8 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
     protected val mutablePaymentMethods = MutableLiveData<List<PaymentMethod>>()
     internal val paymentMethods: LiveData<List<PaymentMethod>> = mutablePaymentMethods
 
-    private val mutableTransition = MutableLiveData<TransitionTargetType>()
-    internal val transition: LiveData<TransitionTargetType> = mutableTransition
+    private val mutableTransition = MutableLiveData<TransitionTargetType?>(null)
+    internal val transition: LiveData<TransitionTargetType?> = mutableTransition
 
     private val mutableSelection = MutableLiveData<PaymentSelection?>()
     internal val selection: LiveData<PaymentSelection?> = mutableSelection

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodContract.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodContract.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+
+internal class AddPaymentMethodContract :
+    ActivityResultContract<AddPaymentMethodActivityStarter.Args, AddPaymentMethodActivityStarter.Result>() {
+
+    override fun createIntent(
+        context: Context,
+        input: AddPaymentMethodActivityStarter.Args?
+    ): Intent {
+        return Intent(context, AddPaymentMethodActivity::class.java)
+            .putExtra(ActivityStarter.Args.EXTRA, input)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?
+    ): AddPaymentMethodActivityStarter.Result {
+        return AddPaymentMethodActivityStarter.Result.fromIntent(intent)
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodRowView.kt
@@ -1,22 +1,13 @@
 package com.stripe.android.view
 
-import android.app.Activity
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.annotation.IdRes
-import androidx.annotation.StringRes
-import com.stripe.android.R
 import com.stripe.android.databinding.AddPaymentMethodRowBinding
-import com.stripe.android.model.PaymentMethod
 
-@SuppressWarnings("ViewConstructor")
 internal class AddPaymentMethodRowView private constructor(
-    context: Context,
-    @IdRes idRes: Int,
-    @StringRes private val labelRes: Int,
-    private val args: AddPaymentMethodActivityStarter.Args
+    context: Context
 ) : FrameLayout(context) {
 
     private val viewBinding = AddPaymentMethodRowBinding.inflate(
@@ -25,62 +16,11 @@ internal class AddPaymentMethodRowView private constructor(
         true
     )
 
-    init {
-        id = idRes
-        layoutParams = ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+    internal val label = viewBinding.label
 
+    init {
+        layoutParams = ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         isFocusable = true
         isClickable = true
-
-        contentDescription = context.getString(labelRes)
-    }
-
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        viewBinding.label.setText(labelRes)
-
-        (context as? Activity)?.let { activity ->
-            setOnClickListener {
-                AddPaymentMethodActivityStarter(activity).startForResult(args)
-            }
-        }
-    }
-
-    internal companion object {
-        internal fun createCard(
-            activity: Activity,
-            args: PaymentMethodsActivityStarter.Args
-        ): AddPaymentMethodRowView {
-            return AddPaymentMethodRowView(
-                activity,
-                R.id.stripe_payment_methods_add_card,
-                R.string.payment_method_add_new_card,
-                AddPaymentMethodActivityStarter.Args.Builder()
-                    .setBillingAddressFields(args.billingAddressFields)
-                    .setShouldAttachToCustomer(true)
-                    .setIsPaymentSessionActive(args.isPaymentSessionActive)
-                    .setPaymentMethodType(PaymentMethod.Type.Card)
-                    .setAddPaymentMethodFooter(args.addPaymentMethodFooterLayoutId)
-                    .setPaymentConfiguration(args.paymentConfiguration)
-                    .setWindowFlags(args.windowFlags)
-                    .build()
-            )
-        }
-
-        internal fun createFpx(
-            activity: Activity,
-            args: PaymentMethodsActivityStarter.Args
-        ): AddPaymentMethodRowView {
-            return AddPaymentMethodRowView(
-                activity,
-                R.id.stripe_payment_methods_add_fpx,
-                R.string.payment_method_add_new_fpx,
-                AddPaymentMethodActivityStarter.Args.Builder()
-                    .setIsPaymentSessionActive(args.isPaymentSessionActive)
-                    .setPaymentMethodType(PaymentMethod.Type.Fpx)
-                    .setPaymentConfiguration(args.paymentConfiguration)
-                    .build()
-            )
-        }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -202,7 +202,7 @@ class PaymentSheetAddCardFragmentTest {
     private fun createScenario(
         args: PaymentSheetActivityStarter.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
     ): FragmentScenario<PaymentSheetAddCardFragment> {
-        return launchFragmentInContainer<PaymentSheetAddCardFragment>(
+        return launchFragmentInContainer(
             bundleOf(
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to args
             ),

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.view
 
 import android.app.Activity.RESULT_CANCELED
-import android.app.Activity.RESULT_OK
 import android.content.Context
-import android.content.Intent
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
@@ -145,6 +143,7 @@ class PaymentMethodsActivityTest {
                 val addCardView: View = activity
                     .findViewById(R.id.stripe_payment_methods_add_card)
                 addCardView.performClick()
+
                 val intentForResult = shadowOf(activity).nextStartedActivityForResult
                 val component = intentForResult.intent.component
                 assertEquals(AddPaymentMethodActivity::class.java.name, component?.className)
@@ -170,16 +169,10 @@ class PaymentMethodsActivityTest {
                 val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHODS[2]
                 assertNotNull(paymentMethod)
 
-                val resultIntent = Intent()
-                    .putExtras(
-                        AddPaymentMethodActivityStarter.Result.Success(paymentMethod)
-                            .toBundle()
-                    )
-                activity.onActivityResult(
-                    AddPaymentMethodActivityStarter.REQUEST_CODE,
-                    RESULT_OK,
-                    resultIntent
+                activity.onAddPaymentMethodResult(
+                    AddPaymentMethodActivityStarter.Result.Success(paymentMethod)
                 )
+
                 assertEquals(View.VISIBLE, progressBar.visibility)
                 verify(customerSession, times(2))
                     .getPaymentMethods(

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -1,12 +1,13 @@
 package com.stripe.android.view
 
-import android.content.Context
 import android.widget.FrameLayout
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import kotlinx.coroutines.Dispatchers
@@ -30,10 +31,15 @@ class PaymentMethodsAdapterTest {
     private val adapterDataObserver: RecyclerView.AdapterDataObserver = mock()
     private val listener: PaymentMethodsAdapter.Listener = mock()
 
-    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val context = ContextThemeWrapper(
+        ApplicationProvider.getApplicationContext(),
+        R.style.StripeDefaultTheme
+    )
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val paymentMethodsAdapter: PaymentMethodsAdapter = PaymentMethodsAdapter(
+    private val parentView = FrameLayout(context)
+
+    private val paymentMethodsAdapter = PaymentMethodsAdapter(
         ARGS,
         workContext = testDispatcher
     )
@@ -210,10 +216,7 @@ class PaymentMethodsAdapterTest {
         adapter.setPaymentMethods(PaymentMethodFixtures.CARD_PAYMENT_METHODS)
         adapter.listener = listener
 
-        val viewHolder = PaymentMethodsAdapter.ViewHolder.GooglePayViewHolder(
-            context,
-            FrameLayout(context)
-        )
+        val viewHolder = PaymentMethodsAdapter.ViewHolder.GooglePayViewHolder(context, parentView)
         adapter.onBindViewHolder(viewHolder, 0)
 
         viewHolder.itemView.performClick()
@@ -272,6 +275,54 @@ class PaymentMethodsAdapterTest {
         assertThat(adapter.paymentMethods)
             .doesNotContain(PaymentMethodFixtures.CARD_PAYMENT_METHODS.last())
         verify(adapterDataObserver).onItemRangeRemoved(3, 1)
+    }
+
+    @Test
+    fun `multiple clicks on add card view should emit single args`() {
+        val adapter = PaymentMethodsAdapter(ARGS, shouldShowGooglePay = true)
+
+        val argsList = mutableListOf<AddPaymentMethodActivityStarter.Args>()
+        adapter.addPaymentMethodArgs.observeForever { args ->
+            if (args != null) {
+                argsList.add(args)
+            }
+        }
+
+        val viewHolder = adapter.createViewHolder(
+            FrameLayout(context),
+            PaymentMethodsAdapter.ViewType.AddCard.ordinal
+        )
+        adapter.onBindViewHolder(viewHolder, 0)
+        viewHolder.itemView.performClick()
+        viewHolder.itemView.performClick()
+        viewHolder.itemView.performClick()
+
+        assertThat(argsList)
+            .containsExactly(adapter.addCardArgs)
+    }
+
+    @Test
+    fun `multiple clicks on add FPX view should emit single args`() {
+        val adapter = PaymentMethodsAdapter(ARGS, shouldShowGooglePay = true)
+
+        val argsList = mutableListOf<AddPaymentMethodActivityStarter.Args>()
+        adapter.addPaymentMethodArgs.observeForever { args ->
+            if (args != null) {
+                argsList.add(args)
+            }
+        }
+
+        val viewHolder = adapter.createViewHolder(
+            FrameLayout(context),
+            PaymentMethodsAdapter.ViewType.AddFpx.ordinal
+        )
+        adapter.onBindViewHolder(viewHolder, 0)
+        viewHolder.itemView.performClick()
+        viewHolder.itemView.performClick()
+        viewHolder.itemView.performClick()
+
+        assertThat(argsList)
+            .containsExactly(adapter.addFpxArgs)
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
This change requires refactoring `AddPaymentMethodRowView`

https://developer.android.com/training/basics/intents/result

## Motivation
Simplify API for receiving results from `AddPaymentMethodActivity`

## Testing
Added unit tests and manually verified
