### PR TITLE
Rename PaymentMethodsAdapter to PaymentOptionsAdapter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -19,8 +19,8 @@ internal abstract class BasePaymentMethodsListFragment : Fragment(
 
     private val fragmentViewModel by viewModels<PaymentMethodsViewModel>()
 
-    protected val adapter: PaymentMethodsAdapter by lazy {
-        PaymentMethodsAdapter(
+    protected val adapter: PaymentOptionsAdapter by lazy {
+        PaymentOptionsAdapter(
             fragmentViewModel.currentPaymentSelection,
             paymentMethodSelectedListener = {
                 fragmentViewModel.currentPaymentSelection = it

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -14,7 +14,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlin.properties.Delegates
 
-internal class PaymentMethodsAdapter(
+internal class PaymentOptionsAdapter(
     private var paymentSelection: PaymentSelection?,
     val paymentMethodSelectedListener: (PaymentSelection) -> Unit,
     val addCardClickListener: View.OnClickListener

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -12,7 +12,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
-class PaymentMethodsAdapterTest {
+class PaymentOptionsAdapterTest {
     private val context = ContextThemeWrapper(
         ApplicationProvider.getApplicationContext(),
         R.style.StripePaymentSheetDefaultTheme
@@ -39,40 +39,40 @@ class PaymentMethodsAdapterTest {
     fun `getItemId() when Google Pay is enabled should return expected value`() {
         val adapter = createConfiguredAdapter(shouldShowGooglePay = true)
         assertThat(adapter.getItemId(0))
-            .isEqualTo(PaymentMethodsAdapter.ADD_NEW_ID)
+            .isEqualTo(PaymentOptionsAdapter.ADD_NEW_ID)
         assertThat(adapter.getItemId(1))
-            .isEqualTo(PaymentMethodsAdapter.GOOGLE_PAY_ID)
+            .isEqualTo(PaymentOptionsAdapter.GOOGLE_PAY_ID)
     }
 
     @Test
     fun `getItemId() when Google Pay is disabled should return expected value`() {
         val adapter = createConfiguredAdapter(shouldShowGooglePay = false)
         assertThat(adapter.getItemId(0))
-            .isEqualTo(PaymentMethodsAdapter.ADD_NEW_ID)
+            .isEqualTo(PaymentOptionsAdapter.ADD_NEW_ID)
         assertThat(adapter.getItemId(1))
-            .isNotEqualTo(PaymentMethodsAdapter.GOOGLE_PAY_ID)
+            .isNotEqualTo(PaymentOptionsAdapter.GOOGLE_PAY_ID)
     }
 
     @Test
     fun `getItemViewType() when Google Pay is enabled should return expected value`() {
         val adapter = createConfiguredAdapter(shouldShowGooglePay = true)
         assertThat(adapter.getItemViewType(0))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.AddCard.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.AddCard.ordinal)
         assertThat(adapter.getItemViewType(1))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.GooglePay.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.GooglePay.ordinal)
         assertThat(adapter.getItemViewType(2))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.Card.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.Card.ordinal)
     }
 
     @Test
     fun `getItemViewType() when Google Pay is disabled should return expected value`() {
         val adapter = createConfiguredAdapter(shouldShowGooglePay = false)
         assertThat(adapter.getItemViewType(0))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.AddCard.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.AddCard.ordinal)
         assertThat(adapter.getItemViewType(1))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.Card.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.Card.ordinal)
         assertThat(adapter.getItemViewType(2))
-            .isEqualTo(PaymentMethodsAdapter.ViewType.Card.ordinal)
+            .isEqualTo(PaymentOptionsAdapter.ViewType.Card.ordinal)
     }
 
     @Test
@@ -135,15 +135,15 @@ class PaymentMethodsAdapterTest {
     private fun createConfiguredAdapter(
         shouldShowGooglePay: Boolean,
         paymentMethodsCount: Int = 6
-    ): PaymentMethodsAdapter {
+    ): PaymentOptionsAdapter {
         return createAdapter().also {
             it.shouldShowGooglePay = shouldShowGooglePay
             it.paymentMethods = PaymentMethodFixtures.createCards(paymentMethodsCount)
         }
     }
 
-    private fun createAdapter(): PaymentMethodsAdapter {
-        return PaymentMethodsAdapter(
+    private fun createAdapter(): PaymentOptionsAdapter {
+        return PaymentOptionsAdapter(
             paymentSelection = null,
             paymentMethodSelectedListener = {
                 paymentSelections.add(it)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -56,7 +56,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
     fun `sets up adapter`() {
         createScenario().onFragment {
             val recycler = recyclerView(it)
-            val adapter = recycler.adapter as PaymentMethodsAdapter
+            val adapter = recycler.adapter as PaymentOptionsAdapter
             assertThat(adapter.paymentMethods)
                 .isEmpty()
 
@@ -78,8 +78,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             idleLooper()
 
             val recycler = recyclerView(it)
-            assertThat(recycler.adapter).isInstanceOf(PaymentMethodsAdapter::class.java)
-            val adapter = recycler.adapter as PaymentMethodsAdapter
+            assertThat(recycler.adapter).isInstanceOf(PaymentOptionsAdapter::class.java)
+            val adapter = recycler.adapter as PaymentOptionsAdapter
             adapter.paymentMethodSelectedListener(savedPaymentMethod)
             idleLooper()
 
@@ -100,8 +100,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             idleLooper()
 
             val recycler = recyclerView(it)
-            assertThat(recycler.adapter).isInstanceOf(PaymentMethodsAdapter::class.java)
-            val adapter = recycler.adapter as PaymentMethodsAdapter
+            assertThat(recycler.adapter).isInstanceOf(PaymentOptionsAdapter::class.java)
+            val adapter = recycler.adapter as PaymentOptionsAdapter
             adapter.addCardClickListener.onClick(it.requireView())
             idleLooper()
 
@@ -118,7 +118,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             idleLooper()
 
             val recycler = recyclerView(fragment)
-            val adapter = recycler.adapter as PaymentMethodsAdapter
+            val adapter = recycler.adapter as PaymentOptionsAdapter
             adapter.shouldShowGooglePay = true
             idleLooper()
 

--- a/stripe/src/test/java/com/stripe/android/view/PaymentOptionsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentOptionsAdapterTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.Test
  */
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-class PaymentMethodsAdapterTest {
+class PaymentOptionsAdapterTest {
     private val adapterDataObserver: RecyclerView.AdapterDataObserver = mock()
     private val listener: PaymentMethodsAdapter.Listener = mock()
 


### PR DESCRIPTION
Name better reflects the items in the adapter