### PR TITLE
Inject EventReporter into payment sheet fragments

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.BillingAddressView
@@ -31,7 +32,9 @@ import com.stripe.android.view.CardMultilineWidget
 /**
  * A `Fragment` for adding new card payment method.
  */
-internal abstract class BaseAddCardFragment : Fragment() {
+internal abstract class BaseAddCardFragment(
+    private val eventReporter: EventReporter
+) : Fragment() {
     abstract val sheetViewModel: SheetViewModel<*, *>
 
     private var _viewBinding: FragmentPaymentsheetAddCardBinding? = null
@@ -183,6 +186,8 @@ internal abstract class BaseAddCardFragment : Fragment() {
                 onGooglePaySelected()
             }
         }
+
+        eventReporter.onShowNewPaymentOptionForm()
     }
 
     private fun updateSelection() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -8,11 +8,14 @@ import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetPaymentMethodsListBinding
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
-internal abstract class BasePaymentMethodsListFragment : Fragment(
+internal abstract class BasePaymentMethodsListFragment(
+    private val eventReporter: EventReporter
+) : Fragment(
     R.layout.fragment_paymentsheet_payment_methods_list
 ) {
     abstract val sheetViewModel: SheetViewModel<*, *>
@@ -66,6 +69,8 @@ internal abstract class BasePaymentMethodsListFragment : Fragment(
         sheetViewModel.isGooglePayReady.observe(viewLifecycleOwner) { isGooglePayReady ->
             adapter.shouldShowGooglePay = isGooglePayReady
         }
+
+        eventReporter.onShowExistingPaymentOptions()
     }
 
     override fun onDestroyView() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -13,6 +13,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.databinding.StripeActivityPaymentOptionsBinding
+import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
@@ -61,6 +63,13 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     override val rootView: View by lazy { viewBinding.root }
 
     override val messageView: TextView by lazy { viewBinding.message }
+
+    override val eventReporter: EventReporter by lazy {
+        DefaultEventReporter(
+            mode = EventReporter.Mode.Custom,
+            application
+        )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -177,25 +186,22 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
 
                     replace(
                         fragmentContainerId,
-                        PaymentOptionsAddCardFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentOptionsAddCardFragment::class.java,
+                        fragmentArgs
                     )
                 }
                 PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
                     replace(
                         fragmentContainerId,
-                        PaymentOptionsListFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentOptionsListFragment::class.java,
+                        fragmentArgs
                     )
                 }
                 PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodSheet -> {
                     replace(
                         fragmentContainerId,
-                        PaymentOptionsAddCardFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentOptionsAddCardFragment::class.java,
+                        fragmentArgs
                     )
                 }
             }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
+import com.stripe.android.paymentsheet.analytics.EventReporter
 
-internal class PaymentOptionsAddCardFragment : BaseAddCardFragment() {
+internal class PaymentOptionsAddCardFragment(
+    eventReporter: EventReporter
+) : BaseAddCardFragment(eventReporter) {
     override val sheetViewModel by activityViewModels<PaymentOptionsViewModel> {
         PaymentOptionsViewModel.Factory(
             { requireActivity().application },

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -4,8 +4,11 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
+import com.stripe.android.paymentsheet.analytics.EventReporter
 
-internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment() {
+internal class PaymentOptionsListFragment(
+    eventReporter: EventReporter
+) : BasePaymentMethodsListFragment(eventReporter) {
     private val activityViewModel by activityViewModels<PaymentOptionsViewModel> {
         PaymentOptionsViewModel.Factory(
             { requireActivity().application },

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -17,6 +17,8 @@ import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.googlepay.StripeGooglePayContract
+import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
@@ -63,6 +65,13 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
 
     override val messageView: TextView by lazy {
         viewBinding.message
+    }
+
+    override val eventReporter: EventReporter by lazy {
+        DefaultEventReporter(
+            mode = EventReporter.Mode.Complete,
+            application
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -138,7 +147,8 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         supportFragmentManager.commit {
             replace(
                 fragmentContainerId,
-                PaymentSheetLoadingFragment()
+                PaymentSheetLoadingFragment::class.java,
+                null
             )
         }
 
@@ -190,25 +200,22 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
                     addToBackStack(null)
                     replace(
                         fragmentContainerId,
-                        PaymentSheetAddCardFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentSheetAddCardFragment::class.java,
+                        fragmentArgs
                     )
                 }
                 PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
                     replace(
                         fragmentContainerId,
-                        PaymentSheetPaymentMethodsListFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentSheetPaymentMethodsListFragment::class.java,
+                        fragmentArgs
                     )
                 }
                 PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet -> {
                     replace(
                         fragmentContainerId,
-                        PaymentSheetAddCardFragment().also {
-                            it.arguments = fragmentArgs
-                        }
+                        PaymentSheetAddCardFragment::class.java,
+                        fragmentArgs
                     )
                 }
             }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -2,11 +2,14 @@ package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import java.util.Currency
 import java.util.Locale
 
-internal class PaymentSheetAddCardFragment : BaseAddCardFragment() {
+internal class PaymentSheetAddCardFragment(
+    eventReporter: EventReporter
+) : BaseAddCardFragment(eventReporter) {
     override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(
             { requireActivity().application },

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -6,10 +6,13 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import java.util.Currency
 import java.util.Locale
 
-internal class PaymentSheetPaymentMethodsListFragment : BasePaymentMethodsListFragment() {
+internal class PaymentSheetPaymentMethodsListFragment(
+    eventReporter: EventReporter
+) : BasePaymentMethodsListFragment(eventReporter) {
     private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory(
             { requireActivity().application },

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.paymentsheet.BottomSheetController
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 import com.stripe.android.view.KeyboardController
 import kotlinx.coroutines.delay
@@ -15,6 +16,7 @@ import kotlinx.coroutines.launch
 internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity() {
     abstract val viewModel: SheetViewModel<*, *>
     abstract val bottomSheetController: BottomSheetController
+    abstract val eventReporter: EventReporter
 
     abstract val rootView: View
     abstract val messageView: TextView
@@ -28,6 +30,8 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        supportFragmentManager.fragmentFactory = PaymentSheetFragmentFactory(eventReporter)
+
         super.onCreate(savedInstanceState)
 
         viewModel.userMessage.observe(this) { userMessage ->

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetFragmentFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetFragmentFactory.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import com.stripe.android.paymentsheet.PaymentOptionsAddCardFragment
+import com.stripe.android.paymentsheet.PaymentOptionsListFragment
+import com.stripe.android.paymentsheet.PaymentSheetAddCardFragment
+import com.stripe.android.paymentsheet.PaymentSheetLoadingFragment
+import com.stripe.android.paymentsheet.PaymentSheetPaymentMethodsListFragment
+import com.stripe.android.paymentsheet.analytics.EventReporter
+
+internal class PaymentSheetFragmentFactory(
+    private val eventReporter: EventReporter
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return when (className) {
+            PaymentOptionsListFragment::class.java.name -> {
+                PaymentOptionsListFragment(eventReporter)
+            }
+            PaymentSheetPaymentMethodsListFragment::class.java.name -> {
+                PaymentSheetPaymentMethodsListFragment(eventReporter)
+            }
+            PaymentSheetAddCardFragment::class.java.name -> {
+                PaymentSheetAddCardFragment(eventReporter)
+            }
+            PaymentOptionsAddCardFragment::class.java.name -> {
+                PaymentOptionsAddCardFragment(eventReporter)
+            }
+            PaymentSheetLoadingFragment::class.java.name -> {
+                PaymentSheetLoadingFragment()
+            }
+            else -> {
+                super.instantiate(classLoader, className)
+            }
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -9,6 +9,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController
@@ -88,6 +89,11 @@ internal class PaymentSheetActivityTest {
     @BeforeTest
     fun before() {
         Dispatchers.setMain(testCoroutineDispatcher)
+
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
     }
 
     @AfterTest

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -7,14 +7,18 @@ import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +26,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSheetAddCardFragmentTest {
+    private val eventReporter = mock<EventReporter>()
 
     @Before
     fun setup() {
@@ -187,6 +192,13 @@ class PaymentSheetAddCardFragmentTest {
         }
     }
 
+    @Test
+    fun `started fragment should report onShowNewPaymentOptionForm() event`() {
+        createScenario().onFragment {
+            verify(eventReporter).onShowNewPaymentOptionForm()
+        }
+    }
+
     private fun activityViewModel(
         fragment: PaymentSheetAddCardFragment,
         args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
@@ -202,11 +214,12 @@ class PaymentSheetAddCardFragmentTest {
     private fun createScenario(
         args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
     ): FragmentScenario<PaymentSheetAddCardFragment> {
-        return launchFragmentInContainer(
+        return launchFragmentInContainer<PaymentSheetAddCardFragment>(
             bundleOf(
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to args
             ),
-            R.style.StripePaymentSheetDefaultTheme
+            R.style.StripePaymentSheetDefaultTheme,
+            factory = PaymentSheetFragmentFactory(eventReporter)
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -9,12 +9,16 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
 import org.junit.Test
@@ -23,6 +27,8 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSheetPaymentMethodsListFragmentTest {
+    private val eventReporter = mock<EventReporter>()
+
     private val paymentMethods = listOf(
         PaymentMethod("one", 0, false, PaymentMethod.Type.Card),
         PaymentMethod("two", 0, false, PaymentMethod.Type.Card)
@@ -141,6 +147,13 @@ class PaymentSheetPaymentMethodsListFragmentTest {
         }
     }
 
+    @Test
+    fun `started fragment should report onShowExistingPaymentOptions() event`() {
+        createScenario().onFragment {
+            verify(eventReporter).onShowExistingPaymentOptions()
+        }
+    }
+
     private fun recyclerView(it: PaymentSheetPaymentMethodsListFragment) =
         it.requireView().findViewById<RecyclerView>(R.id.recycler)
 
@@ -164,7 +177,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             bundleOf(
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
             ),
-            R.style.StripePaymentSheetDefaultTheme
+            R.style.StripePaymentSheetDefaultTheme,
+            factory = PaymentSheetFragmentFactory(eventReporter)
         )
     }
 }


### PR DESCRIPTION


## Summary
Create `PaymentSheetFragmentFactory` as `FragmentFactory` for payment
sheet views. [0]

[0] https://developer.android.com/reference/androidx/fragment/app/FragmentFactory

## Motivation
Use `eventReporter` to log some view events.

## Testing
Added unit tests and manually verified
