### PR TITLE
Add SessionId to payment sheet analytics

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent
 import com.stripe.android.stripe3ds2.transaction.RuntimeErrorEvent
 import com.stripe.android.utils.ContextUtils.packageInfo
@@ -292,10 +293,15 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createParams(
         event: PaymentSheetEvent,
+        sessionId: SessionId?
     ): Map<String, Any> {
         return createParams(
             event.toString(),
             requestId = null
+        ).plus(
+            sessionId?.let {
+                mapOf(FIELD_SESSION_ID to sessionId.value)
+            }.orEmpty()
         )
     }
 
@@ -433,6 +439,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         internal const val FIELD_OS_VERSION = "os_version"
         internal const val FIELD_PUBLISHABLE_KEY = "publishable_key"
         internal const val FIELD_REQUEST_ID = "request_id"
+        internal const val FIELD_SESSION_ID = "session_id"
         internal const val FIELD_SOURCE_ID = "source_id"
         internal const val FIELD_SOURCE_TYPE = "source_type"
         internal const val FIELD_3DS2_UI_TYPE = "3ds2_ui_type"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.ConfirmParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
@@ -31,6 +32,7 @@ internal class DefaultPaymentSheetFlowController internal constructor(
     internal val paymentMethodTypes: List<PaymentMethod.Type>,
     // the customer's existing payment methods
     internal val paymentMethods: List<PaymentMethod>,
+    private val sessionId: SessionId,
     private val googlePayLauncherFactory: (ComponentActivity) -> StripeGooglePayLauncher = {
         StripeGooglePayLauncher(it)
     },
@@ -64,6 +66,7 @@ internal class DefaultPaymentSheetFlowController internal constructor(
                 PaymentOptionsActivityStarter.Args(
                     paymentIntent = paymentIntent,
                     paymentMethods = paymentMethods,
+                    sessionId = sessionId,
                     config = args.config
                 )
             )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -2,10 +2,13 @@ package com.stripe.android.paymentsheet
 
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.paymentsheet.analytics.SessionId
 
 internal class DefaultPaymentSheetLauncher(
     private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContract.Args>
 ) : PaymentSheetLauncher {
+    private val sessionId: SessionId = SessionId()
+
     constructor(
         activity: ComponentActivity,
         callback: PaymentSheetResultCallback
@@ -19,10 +22,12 @@ internal class DefaultPaymentSheetLauncher(
 
     override fun present(
         paymentIntentClientSecret: String,
+
         configuration: PaymentSheet.Configuration
     ) = present(
         PaymentSheetContract.Args(
             paymentIntentClientSecret,
+            sessionId,
             configuration
         )
     )
@@ -32,6 +37,7 @@ internal class DefaultPaymentSheetLauncher(
     ) = present(
         PaymentSheetContract.Args(
             paymentIntentClientSecret,
+            sessionId,
             config = null
         )
     )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -68,6 +68,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     override val eventReporter: EventReporter by lazy {
         DefaultEventReporter(
             mode = EventReporter.Mode.Custom,
+            starterArgs?.sessionId,
             application
         )
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityStarter.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -18,6 +19,7 @@ internal class PaymentOptionsActivityStarter internal constructor(
     data class Args(
         val paymentIntent: PaymentIntent,
         val paymentMethods: List<PaymentMethod>,
+        val sessionId: SessionId,
         val config: PaymentSheet.Configuration?
     ) : ActivityStarter.Args {
         internal companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -74,6 +74,7 @@ internal class PaymentOptionsViewModel(
                 prefsRepository,
                 DefaultEventReporter(
                     mode = EventReporter.Mode.Custom,
+                    starterArgs.sessionId,
                     application
                 )
             ) as T

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -71,6 +71,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
     override val eventReporter: EventReporter by lazy {
         DefaultEventReporter(
             mode = EventReporter.Mode.Complete,
+            starterArgs?.sessionId,
             application
         )
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -31,6 +32,7 @@ internal class PaymentSheetContract : ActivityResultContract<PaymentSheetContrac
     @Parcelize
     internal data class Args(
         val clientSecret: String,
+        val sessionId: SessionId,
         val config: PaymentSheet.Configuration?
     ) : ActivityStarter.Args {
         val googlePayConfig: PaymentSheet.GooglePayConfiguration? get() = config?.googlePay

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetFlowControllerFactory.kt
@@ -16,6 +16,7 @@ import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentIntentValidator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,7 @@ internal class PaymentSheetFlowControllerFactory(
     private val paymentSessionPrefs: PaymentSessionPrefs,
     private val workContext: CoroutineContext
 ) {
+    private val sessionId = SessionId()
     private val paymentIntentValidator = PaymentIntentValidator()
 
     constructor(
@@ -137,6 +139,7 @@ internal class PaymentSheetFlowControllerFactory(
                             paymentController = createPaymentController(),
                             eventReporter = DefaultEventReporter(
                                 mode = EventReporter.Mode.Custom,
+                                sessionId,
                                 activity
                             ),
                             args = DefaultPaymentSheetFlowController.Args(
@@ -148,7 +151,8 @@ internal class PaymentSheetFlowControllerFactory(
                             paymentIntent = paymentIntent,
                             paymentMethodTypes = paymentMethodTypes,
                             paymentMethods = paymentMethods,
-                            defaultPaymentMethodId = defaultPaymentMethodId
+                            defaultPaymentMethodId = defaultPaymentMethodId,
+                            sessionId = sessionId
                         )
                     )
                 }
@@ -177,6 +181,7 @@ internal class PaymentSheetFlowControllerFactory(
                         paymentController = createPaymentController(),
                         eventReporter = DefaultEventReporter(
                             mode = EventReporter.Mode.Custom,
+                            sessionId,
                             activity
                         ),
                         publishableKey = publishableKey,
@@ -188,6 +193,7 @@ internal class PaymentSheetFlowControllerFactory(
                         paymentIntent = paymentIntent,
                         paymentMethodTypes = paymentMethodTypes,
                         paymentMethods = emptyList(),
+                        sessionId = sessionId,
                         defaultPaymentMethodId = null
                     )
                 )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -309,6 +309,7 @@ internal class PaymentSheetViewModel internal constructor(
                 prefsRepository,
                 DefaultEventReporter(
                     mode = EventReporter.Mode.Complete,
+                    starterArgs.sessionId,
                     application
                 ),
                 starterArgs,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class DefaultEventReporter internal constructor(
     private val mode: EventReporter.Mode,
+    private val sessionId: SessionId?,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequest.Factory,
     private val analyticsDataFactory: AnalyticsDataFactory
@@ -17,9 +18,11 @@ internal class DefaultEventReporter internal constructor(
 
     internal constructor(
         mode: EventReporter.Mode,
+        sessionId: SessionId?,
         context: Context
     ) : this(
         mode,
+        sessionId,
         AnalyticsRequestExecutor.Default(),
         AnalyticsRequest.Factory(),
         AnalyticsDataFactory(
@@ -93,7 +96,10 @@ internal class DefaultEventReporter internal constructor(
     private fun fireEvent(event: PaymentSheetEvent) {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create(
-                analyticsDataFactory.createParams(event)
+                analyticsDataFactory.createParams(
+                    event,
+                    sessionId
+                )
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/SessionId.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/SessionId.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.paymentsheet.analytics
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.util.UUID
+
+@Parcelize
+internal class SessionId private constructor(
+    val value: String
+) : Parcelable {
+    internal constructor() : this(
+        UUID.randomUUID().toString()
+    )
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowControllerTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.runner.RunWith
@@ -172,6 +173,7 @@ class DefaultPaymentSheetFlowControllerTest {
             paymentMethodTypes = listOf(PaymentMethod.Type.Card),
             paymentMethods = paymentMethods,
             googlePayLauncherFactory = { googlePayLauncher },
+            sessionId = SessionId(),
             defaultPaymentMethodId = defaultPaymentMethodId
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -34,6 +35,7 @@ class PaymentOptionsActivityTest {
         args = PaymentOptionsActivityStarter.Args(
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
+            sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
         ),
         googlePayRepository = FakeGooglePayRepository(false),
@@ -51,6 +53,7 @@ class PaymentOptionsActivityTest {
             PaymentOptionsActivityStarter.Args(
                 paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 paymentMethods = emptyList(),
+                sessionId = SessionId(),
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
             )
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.Rule
@@ -24,6 +25,7 @@ class PaymentOptionsViewModelTest {
         args = PaymentOptionsActivityStarter.Args(
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
+            sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
         ),
         googlePayRepository = mock(),

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -82,6 +83,7 @@ internal class PaymentSheetActivityTest {
         context,
         PaymentSheetContract.Args(
             "client_secret",
+            sessionId = SessionId(),
             PaymentSheetFixtures.CONFIG_CUSTOMER
         )
     )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.paymentsheet.analytics.SessionId
+
 internal object PaymentSheetFixtures {
     private const val MERCHANT_DISPLAY_NAME = "Widget Store"
     internal const val CLIENT_SECRET = "client_secret"
@@ -27,16 +29,19 @@ internal object PaymentSheetFixtures {
 
     internal val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetContract.Args(
         CLIENT_SECRET,
+        SessionId(),
         CONFIG_CUSTOMER_WITH_GOOGLEPAY
     )
 
     internal val ARGS_CUSTOMER_WITHOUT_GOOGLEPAY = PaymentSheetContract.Args(
         CLIENT_SECRET,
+        SessionId(),
         CONFIG_CUSTOMER
     )
 
     internal val ARGS_WITHOUT_CUSTOMER = PaymentSheetContract.Args(
         CLIENT_SECRET,
+        SessionId(),
         config = null
     )
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -24,9 +24,12 @@ class DefaultEventReporterTest {
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     )
 
+    private val sessionId = SessionId()
+
     private val eventReporterFactory: (EventReporter.Mode) -> EventReporter = { mode ->
         DefaultEventReporter(
             mode,
+            sessionId,
             analyticsRequestExecutor,
             analyticsRequestFactory,
             analyticsDataFactory
@@ -66,6 +69,18 @@ class DefaultEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.compactParams?.get("event") == "mc_custom_paymentoption_savedpm_select"
+            }
+        )
+    }
+
+    @Test
+    fun `onPaymentSuccess() should fire analytics request with session id`() {
+        completeEventReporter.onPaymentSuccess(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.compactParams?.get("session_id") == sessionId.value
             }
         )
     }


### PR DESCRIPTION
Associate same-session payment sheet events using `SessionId`
