### PR TITLE
Add DeviceId to payment sheet analytics

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsDataFactory.kt
@@ -10,6 +10,7 @@ import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
+import com.stripe.android.paymentsheet.analytics.DeviceId
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent
@@ -293,11 +294,14 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createParams(
         event: PaymentSheetEvent,
-        sessionId: SessionId?
+        sessionId: SessionId?,
+        deviceId: DeviceId
     ): Map<String, Any> {
         return createParams(
             event.toString(),
             requestId = null
+        ).plus(
+            FIELD_DEVICE_ID to deviceId.value
         ).plus(
             sessionId?.let {
                 mapOf(FIELD_SESSION_ID to sessionId.value)
@@ -430,6 +434,7 @@ internal class AnalyticsDataFactory @VisibleForTesting internal constructor(
         internal const val FIELD_APP_NAME = "app_name"
         internal const val FIELD_APP_VERSION = "app_version"
         internal const val FIELD_BINDINGS_VERSION = "bindings_version"
+        internal const val FIELD_DEVICE_ID = "device_id"
         internal const val FIELD_DEVICE_TYPE = "device_type"
         internal const val FIELD_EVENT = "event"
         internal const val FIELD_ERROR_DATA = "error"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
@@ -32,7 +32,7 @@ internal class DefaultDeviceIdRepository(
     }
 
     private companion object {
-        private const val PREF_FILE = "pref_file"
+        private const val PREF_FILE = "DefaultDeviceIdRepository"
         private const val KEY_DEVICE_ID = "device_id"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
@@ -25,7 +25,7 @@ internal class DefaultDeviceIdRepository(
 
     private fun createDeviceId(): DeviceId {
         val deviceId = DeviceId()
-        prefs.edit {
+        prefs.edit(commit = true) {
             putString(KEY_DEVICE_ID, deviceId.value)
         }
         return deviceId

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepository.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.paymentsheet.analytics
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultDeviceIdRepository(
+    private val context: Context,
+    private val workContext: CoroutineContext
+) : DeviceIdRepository {
+    private val prefs: SharedPreferences by lazy {
+        context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE)
+    }
+
+    override suspend fun get(): DeviceId = withContext(workContext) {
+        val deviceIdValue = prefs.getString(KEY_DEVICE_ID, null)
+        if (deviceIdValue != null) {
+            DeviceId(deviceIdValue)
+        } else {
+            createDeviceId()
+        }
+    }
+
+    private fun createDeviceId(): DeviceId {
+        val deviceId = DeviceId()
+        prefs.edit {
+            putString(KEY_DEVICE_ID, deviceId.value)
+        }
+        return deviceId
+    }
+
+    private companion object {
+        private const val PREF_FILE = "pref_file"
+        private const val KEY_DEVICE_ID = "device_id"
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceId.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceId.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet.analytics
+
+import java.util.UUID
+
+internal class DeviceId internal constructor(
+    val value: String
+) {
+    constructor() : this(
+        UUID.randomUUID().toString()
+    )
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceId.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceId.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.analytics
 
 import java.util.UUID
 
-internal class DeviceId internal constructor(
+internal data class DeviceId internal constructor(
     val value: String
 ) {
     constructor() : this(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceIdRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/DeviceIdRepository.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.paymentsheet.analytics
+
+internal interface DeviceIdRepository {
+    suspend fun get(): DeviceId
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultDeviceIdRepositoryTest.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentsheet.analytics
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+internal class DefaultDeviceIdRepositoryTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val defaultDeviceIdRepository = DefaultDeviceIdRepository(
+        ApplicationProvider.getApplicationContext(),
+        testDispatcher
+    )
+
+    @Test
+    fun `get() should return same value across multiple calls`() = testDispatcher.runBlockingTest {
+        assertThat(defaultDeviceIdRepository.get())
+            .isEqualTo(defaultDeviceIdRepository.get())
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -11,12 +11,17 @@ import com.stripe.android.networking.AnalyticsRequest
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class DefaultEventReporterTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
     private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
     private val analyticsRequestFactory = AnalyticsRequest.Factory()
     private val analyticsDataFactory = AnalyticsDataFactory(
@@ -30,9 +35,11 @@ class DefaultEventReporterTest {
         DefaultEventReporter(
             mode,
             sessionId,
+            FakeDeviceIdRepository(),
             analyticsRequestExecutor,
             analyticsRequestFactory,
-            analyticsDataFactory
+            analyticsDataFactory,
+            testDispatcher
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.UUID
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
@@ -88,6 +89,19 @@ class DefaultEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.compactParams?.get("session_id") == sessionId.value
+            }
+        )
+    }
+
+    @Test
+    fun `onPaymentSuccess() should fire analytics request with valid device id`() {
+        completeEventReporter.onPaymentSuccess(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                val deviceIdValue = requireNotNull(req.compactParams?.get("device_id")).toString()
+                UUID.fromString(deviceIdValue) != null
             }
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/FakeDeviceIdRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/FakeDeviceIdRepository.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.paymentsheet.analytics
+
+internal class FakeDeviceIdRepository : DeviceIdRepository {
+    override suspend fun get(): DeviceId = DeviceId()
+}


### PR DESCRIPTION
Associate same-device payment sheet events using `DeviceId`
