### PR TITLE
Fix issue with SessionId

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/SessionId.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/analytics/SessionId.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.UUID
 
 @Parcelize
-internal class SessionId private constructor(
+internal data class SessionId internal constructor(
     val value: String
 ) : Parcelable {
     internal constructor() : this(


### PR DESCRIPTION
`Parcelable` requires a non-private constructor