### PR TITLE
Add support for separator with gaps in ExpiryDateEditTest

### DIFF
--- a/stripe/res/values/constants.xml
+++ b/stripe/res/values/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="stripe_date_length">5</integer>
+    <integer name="stripe_date_digits_length">4</integer>
     <integer name="stripe_light_text_alpha_hex">204</integer>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -114,6 +114,8 @@ internal abstract class BaseAddCardFragment(
 
         setupCardWidget()
 
+        cardMultilineWidget.expiryDateEditText.includeSeparatorGaps = true
+
         billingAddressView.address.observe(viewLifecycleOwner) {
             // update selection whenever billing address changes
             updateSelection()

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -12,6 +12,7 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.R
 import com.stripe.android.model.ExpirationDate
 import kotlin.math.min
+import kotlin.properties.Delegates
 
 /**
  * An [EditText] that handles putting numbers around a central divider character.
@@ -21,22 +22,6 @@ class ExpiryDateEditText @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle
 ) : StripeEditText(context, attrs, defStyleAttr) {
-
-    init {
-        inputType = InputType.TYPE_CLASS_NUMBER
-        filters = listOf(
-            InputFilter.LengthFilter(
-                context.resources.getInteger(R.integer.stripe_date_length)
-            )
-        ).toTypedArray()
-
-        setErrorMessage(resources.getString(R.string.invalid_expiry_year))
-        listenForTextChanges()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE)
-        }
-    }
 
     // invoked when a valid date has been entered
     @JvmSynthetic
@@ -68,10 +53,38 @@ class ExpiryDateEditText @JvmOverloads constructor(
             }
         }
 
-    override val accessibilityText: String?
+    override val accessibilityText: String
         get() {
             return resources.getString(R.string.acc_label_expiry_date_node, text)
         }
+
+    internal var includeSeparatorGaps: Boolean by Delegates.observable(
+        INCLUDE_SEPARATOR_GAPS_DEFAULT
+    ) { _, _, newValue ->
+        updateSeparatorUi(newValue)
+    }
+
+    private val dateDigitsLength = context.resources.getInteger(R.integer.stripe_date_digits_length)
+
+    private var separator = if (INCLUDE_SEPARATOR_GAPS_DEFAULT) {
+        SEPARATOR_WITH_GAPS
+    } else {
+        SEPARATOR_WITHOUT_GAPS
+    }
+
+    private fun updateSeparatorUi(
+        includeSeparatorGaps: Boolean = INCLUDE_SEPARATOR_GAPS_DEFAULT
+    ) {
+        separator = if (includeSeparatorGaps) {
+            SEPARATOR_WITH_GAPS
+        } else {
+            SEPARATOR_WITHOUT_GAPS
+        }
+
+        filters = listOf(
+            InputFilter.LengthFilter(dateDigitsLength + separator.length)
+        ).toTypedArray()
+    }
 
     private fun listenForTextChanges() {
         addTextChangedListener(
@@ -125,10 +138,11 @@ class ExpiryDateEditText @JvmOverloads constructor(
                         rawNumericInput = rawNumericInput.substring(0, 1)
                     }
 
-                    val expirationDate =
-                        ExpirationDate.Unvalidated.create(rawNumericInput).also {
-                            this.expirationDate = it
-                        }
+                    val expirationDate = ExpirationDate.Unvalidated.create(
+                        rawNumericInput
+                    ).also {
+                        this.expirationDate = it
+                    }
 
                     if (!expirationDate.isMonthValid) {
                         inErrorState = true
@@ -140,7 +154,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                     if (expirationDate.month.length == 2 && latestInsertionSize > 0 &&
                         !inErrorState || rawNumericInput.length > 2
                     ) {
-                        formattedDateBuilder.append(SEPARATOR)
+                        formattedDateBuilder.append(separator)
                     }
 
                     formattedDateBuilder.append(expirationDate.year)
@@ -150,7 +164,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                         formattedDate.length,
                         latestChangeStart,
                         latestInsertionSize,
-                        MAX_INPUT_LENGTH
+                        dateDigitsLength + separator.length
                     )
                     this.formattedDate = formattedDate
                 }
@@ -205,6 +219,18 @@ class ExpiryDateEditText @JvmOverloads constructor(
         )
     }
 
+    init {
+        inputType = InputType.TYPE_CLASS_NUMBER
+        updateSeparatorUi()
+
+        setErrorMessage(resources.getString(R.string.invalid_expiry_year))
+        listenForTextChanges()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE)
+        }
+    }
+
     /**
      * Updates the selection index based on the current (pre-edit) index, and
      * the size change of the number being input.
@@ -224,7 +250,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
         maxInputLength: Int
     ): Int {
         val gapsJumped = if (editActionStart <= 2 && editActionStart + editActionAddition >= 2) {
-            SEPARATOR.length
+            separator.length
         } else {
             0
         }
@@ -233,11 +259,11 @@ class ExpiryDateEditText @JvmOverloads constructor(
         // separator. For example, if the input text is currently "01/2" and a character is
         // deleted, both the '2' and the separator should be deleted.
         val isDelete = editActionAddition == 0
-        val shouldRemoveSeparator = isDelete && editActionStart == (2 + SEPARATOR.length)
+        val shouldRemoveSeparator = isDelete && editActionStart == (2 + separator.length)
 
         val newPosition = (editActionStart + editActionAddition + gapsJumped).let { newPosition ->
             newPosition - if (shouldRemoveSeparator && newPosition > 0) {
-                SEPARATOR.length
+                separator.length
             } else {
                 0
             }
@@ -268,8 +294,11 @@ class ExpiryDateEditText @JvmOverloads constructor(
     }
 
     private companion object {
-        private const val SEPARATOR = "/"
         private const val INVALID_INPUT = -1
-        private const val MAX_INPUT_LENGTH = 4 + SEPARATOR.length
+
+        private const val SEPARATOR_WITHOUT_GAPS = "/"
+        private const val SEPARATOR_WITH_GAPS = " / "
+
+        private const val INCLUDE_SEPARATOR_GAPS_DEFAULT = false
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -310,4 +310,43 @@ class ExpiryDateEditTextTest {
         assertThat(expiryDateEditText.validatedDate)
             .isNull()
     }
+
+    @Test
+    fun `input with includeSeparatorGaps=true should have expected fieldText and validatedDate values`() {
+        expiryDateEditText.includeSeparatorGaps = true
+        expiryDateEditText.append("12")
+        expiryDateEditText.append("50")
+
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 / 50")
+
+        assertThat(expiryDateEditText.validatedDate)
+            .isEqualTo(ExpirationDate.Validated(12, 2050))
+    }
+
+    @Test
+    fun `input with includeSeparatorGaps=true should correctly handle delete key`() {
+        expiryDateEditText.includeSeparatorGaps = true
+        expiryDateEditText.append("12")
+        expiryDateEditText.append("50")
+
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 / 50")
+
+        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 / 5")
+
+        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 / ")
+
+        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 /")
+
+        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
+        assertThat(expiryDateEditText.fieldText)
+            .isEqualTo("12 ")
+    }
 }


### PR DESCRIPTION
Payment sheet expiration date field should use `MM / YY` formatting
(current default is `MM/YY`).