### PR TITLE
Improve CardMultilineWidget card number icon logic

### DIFF
--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -17,7 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawablePadding="@dimen/stripe_card_icon_multiline_padding"
-            android:drawableStart="@drawable/stripe_ic_unknown"
             android:imeOptions="actionNext"
             android:nextFocusDown="@+id/et_expiry"
             android:nextFocusForward="@+id/et_expiry"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -250,6 +250,8 @@ internal abstract class BaseAddCardFragment(
                 bottomMargin = layoutMarginVertical
             }
         }
+
+        cardMultilineWidget.iconPosition = CardMultilineWidget.IconPosition.End
     }
 
     private fun setupSaveCardCheckbox(saveCardCheckbox: CheckBox) {

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -308,6 +308,12 @@ class CardMultilineWidget @JvmOverloads constructor(
         updateCardBrandDrawableAnchor()
     }
 
+    private val cardNumberIcon: Drawable?
+        get() {
+            // there is at most a single non-null compound drawable
+            return cardNumberEditText.compoundDrawablesRelative.filterNotNull().firstOrNull()
+        }
+
     init {
         orientation = VERTICAL
 
@@ -717,44 +723,36 @@ class CardMultilineWidget @JvmOverloads constructor(
     }
 
     private fun updateCardBrandDrawableAnchor() {
-        // there should be, at most, a single non-null compound drawable
-        cardNumberEditText.compoundDrawables.firstOrNull { it != null }?.let {
-            updateCompoundDrawable(it)
-        }
+        cardNumberIcon?.let { updateCompoundDrawable(it) }
     }
 
     private fun updateCardNumberIcon(
         @DrawableRes iconResourceId: Int,
         shouldTint: Boolean
     ) {
-        val icon = ContextCompat.getDrawable(context, iconResourceId) ?: return
-        val original = cardNumberEditText.compoundDrawablesRelative[
-            iconPosition.compoundDrawablesIndex
-        ] ?: return
-
-        val iconPadding = cardNumberEditText.compoundDrawablePadding
-        icon.bounds = createDrawableBounds(original)
-
-        val compatIcon = DrawableCompat.wrap(icon)
-        if (shouldTint) {
-            DrawableCompat.setTint(compatIcon.mutate(), tintColorInt)
+        ContextCompat.getDrawable(context, iconResourceId)?.let { icon ->
+            updateCompoundDrawable(
+                if (shouldTint) {
+                    DrawableCompat.wrap(icon).also {
+                        it.setTint(tintColorInt)
+                    }
+                } else {
+                    icon
+                }
+            )
         }
-
-        cardNumberEditText.compoundDrawablePadding = iconPadding
-
-        updateCompoundDrawable(compatIcon)
     }
 
     private fun updateCompoundDrawable(drawable: Drawable) {
         if (iconPosition == IconPosition.Start) {
-            cardNumberEditText.setCompoundDrawablesRelative(
+            cardNumberEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(
                 drawable,
                 null,
                 null,
                 null
             )
         } else {
-            cardNumberEditText.setCompoundDrawablesRelative(
+            cardNumberEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(
                 null,
                 null,
                 drawable,


### PR DESCRIPTION
- Remove `startDrawable` from layout - it is already set via code
- Use `setCompoundDrawablesRelativeWithIntrinsicBounds` and remove
  custom bounds calculation logic
- Use `compoundDrawablesRelative` instead of `compoundDrawables`
- Use in `BaseAddCardFragment`