### PR TITLE
Set minHeight on CardMultilineWidget second row fields

### DIFF
--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -52,6 +52,7 @@
                 android:digits="@string/stripe_expiration_date_allowlist"
                 android:nextFocusDown="@+id/et_cvc"
                 android:nextFocusForward="@+id/et_cvc"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight"
                 />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -73,6 +74,7 @@
                 android:imeOptions="actionNext"
                 android:nextFocusDown="@+id/et_postal_code"
                 android:nextFocusForward="@+id/et_postal_code"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight"
                 />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -91,6 +93,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:imeOptions="actionDone"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight"
                 />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -33,6 +33,8 @@
     <!-- Text size of CardInputWidget EditText views -->
     <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 
+    <dimen name="stripe_cmw_edit_text_minheight">48dp</dimen>
+
     <!-- Text size of BECS Debit Widget EditTexts -->
     <dimen name="stripe_becs_debit_widget_edit_text_size">14sp</dimen>
     <dimen name="stripe_becs_debit_widget_mandate_acceptance_padding_top">12dp</dimen>


### PR DESCRIPTION
The fields have a height of `45dp` without an end icon, and `48dp`
when an end icon is set. Set to `48dp` so that they are always the
same height.