### PR TITLE
Create PaymentOptionsAdapter.Config and fetch in SheetViewModel

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -57,17 +57,10 @@ internal abstract class BasePaymentMethodsListFragment(
         )
         viewBinding.recycler.adapter = adapter
 
-        sheetViewModel.getDefaultPaymentMethodId()
-            .observe(viewLifecycleOwner) { defaultPaymentMethodId ->
-                adapter.defaultPaymentMethodId = defaultPaymentMethodId
-            }
-
-        sheetViewModel.paymentMethods.observe(viewLifecycleOwner) { paymentMethods ->
-            adapter.paymentMethods = paymentMethods
-        }
-
-        sheetViewModel.isGooglePayReady.observe(viewLifecycleOwner) { isGooglePayReady ->
-            adapter.shouldShowGooglePay = isGooglePayReady
+        sheetViewModel.getPaymentOptionsConfig().observe(viewLifecycleOwner) { config ->
+            adapter.paymentMethods = config.paymentMethods
+            adapter.shouldShowGooglePay = config.shouldShowGooglePay
+            adapter.defaultPaymentMethodId = config.defaultPaymentMethodId
         }
 
         eventReporter.onShowExistingPaymentOptions()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -289,6 +289,12 @@ internal class PaymentOptionsAdapter(
         }
     }
 
+    internal data class Config(
+        val paymentMethods: List<PaymentMethod>,
+        val shouldShowGooglePay: Boolean,
+        val defaultPaymentMethodId: String?
+    )
+
     internal enum class ViewType {
         Card,
         AddCard,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.GooglePayRepository
+import com.stripe.android.paymentsheet.PaymentOptionsAdapter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
@@ -159,12 +160,26 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
         _userMessage.value = null
     }
 
-    fun getDefaultPaymentMethodId() = liveData {
+    private fun getDefaultPaymentMethodId() = liveData {
         emit(
             withContext(workContext) {
                 prefsRepository.getDefaultPaymentMethodId()
             }
         )
+    }
+
+    fun getPaymentOptionsConfig() = paymentMethods.switchMap { paymentMethods ->
+        isGooglePayReady.switchMap { isGooglePayReady ->
+            getDefaultPaymentMethodId().switchMap { defaultPaymentMethodId ->
+                MutableLiveData(
+                    PaymentOptionsAdapter.Config(
+                        paymentMethods,
+                        isGooglePayReady,
+                        defaultPaymentMethodId ?: paymentMethods.firstOrNull()?.id
+                    )
+                )
+            }
+        }
     }
 
     sealed class UserMessage {


### PR DESCRIPTION
Consolidate all `PaymentOptionsAdapter` configuration data into a single
object, `PaymentOptionsAdapter.Config`, and fetch via
`getPaymentOptionsConfig()`.

Also, if `defaultPaymentMethodId` is unavailable, set it to the first
payment method.