### PR TITLE
Bump 3DS2 SDK to 5.0.1

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     implementation "com.google.android.material:material:$materialVersion"
 
-    implementation "com.stripe:stripe-3ds2-android:4.1.2"
+    implementation "com.stripe:stripe-3ds2-android:5.0.1"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/stripe/proguard-rules.txt
+++ b/stripe/proguard-rules.txt
@@ -1,8 +1,3 @@
-# Rules for BouncyCastle
--keep class org.bouncycastle.jcajce.provider.** { *; }
--keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi,org.bouncycastle.jce.provider.** { *; }
-
-
 -keep class com.stripe.android.** { *; }
 -dontwarn com.stripe.android.view.**
 


### PR DESCRIPTION
## Summary
The 3DS2 SDK now includes sources and defines its Proguard rules through
`consumerProguardFiles`.

## Testing
Manually verified.