### PR TITLE
Update positioning of progress view in CardNumberTextInputLayout

### DIFF
--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -75,6 +75,6 @@
     <!-- Avoid collisions with CTA button -->
     <dimen name="stripe_paymentsheet_form_bottom_margin">84dp</dimen>
 
-    <dimen name="stripe_card_number_text_input_layout_progress_start_margin">25dp</dimen>
+    <dimen name="stripe_card_number_text_input_layout_progress_end_margin">14dp</dimen>
     <dimen name="stripe_card_number_text_input_layout_progress_top_margin">10dp</dimen>
 </resources>

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.children
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.updateLayoutParams
 import com.google.android.material.textfield.TextInputLayout
 import com.stripe.android.R
@@ -32,20 +33,26 @@ internal class CardNumberTextInputLayout @JvmOverloads constructor(
         }
     }
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
+    init {
+        doOnNextLayout {
+            attachProgressView()
+        }
+    }
 
+    private fun attachProgressView() {
         // remove parent from the progress view if already attached earlier
         (progressView.parent as? ViewGroup)?.removeView(progressView)
 
         // add the progress view to the `TextInputLayout`'s `FrameLayout` container
-        (children.first() as FrameLayout).addView(progressView)
+        val progressViewParent = children.first() as FrameLayout
+        progressViewParent.addView(progressView)
 
         // absolutely position the progress view over the brand icon
         progressView.updateLayoutParams<FrameLayout.LayoutParams> {
-            marginStart = resources.getDimensionPixelSize(
-                R.dimen.stripe_card_number_text_input_layout_progress_start_margin
-            )
+            marginStart = progressViewParent.width -
+                resources.getDimensionPixelSize(
+                    R.dimen.stripe_card_number_text_input_layout_progress_end_margin
+                )
             topMargin = resources.getDimensionPixelSize(
                 R.dimen.stripe_card_number_text_input_layout_progress_top_margin
             )

--- a/stripe/src/main/java/com/stripe/android/view/CardWidgetProgressView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardWidgetProgressView.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.FrameLayout
+import androidx.core.view.isInvisible
 import androidx.core.view.updateLayoutParams
 import com.stripe.android.R
 import com.stripe.android.databinding.CardWidgetProgressViewBinding
@@ -63,7 +64,7 @@ internal class CardWidgetProgressView @JvmOverloads constructor(
 
         setBackgroundResource(R.drawable.stripe_card_progress_background)
         clipToOutline = true
-        visibility = View.INVISIBLE
+        isInvisible = true
     }
 
     override fun onAttachedToWindow() {


### PR DESCRIPTION
In #3232, the card number field icon was moved to the end. The progress
view's alignment should have also been updated.

![progress](https://user-images.githubusercontent.com/45020849/104491138-d2d0ea80-559f-11eb-868b-7013c201efb4.gif)
