### PR TITLE
Simplify CardMultilineWidget placeholder logic

### DIFF
--- a/stripe/res/layout/card_multiline_widget.xml
+++ b/stripe/res/layout/card_multiline_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
        android:layout_width="match_parent"
        android:layout_height="wrap_content">
 
@@ -40,6 +41,7 @@
             android:layout_marginEnd="@dimen/stripe_add_card_expiry_middle_margin"
             android:layout_weight="1"
             android:hint="@string/acc_label_expiry_date"
+            app:placeholderText="@string/expiry_date_hint"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             >
 
@@ -63,6 +65,7 @@
             android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin"
             android:layout_marginEnd="@dimen/stripe_add_card_expiry_middle_margin"
             android:layout_weight="1"
+            app:placeholderText="@string/cvc_multiline_helper"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             >
 
@@ -84,6 +87,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin"
+            app:placeholderText="@string/stripe_postalcode_placeholder"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             >
 

--- a/stripe/res/values/donottranslate.xml
+++ b/stripe/res/values/donottranslate.xml
@@ -6,7 +6,7 @@
     <string name="cvc_multiline_helper">123</string>
     <string name="cvc_multiline_helper_amex">1234</string>
     <string name="stripe_expiration_date_allowlist">0123456789/</string>
-    <string name="zip_helper">12345</string>
+    <string name="stripe_postalcode_placeholder">12345</string>
     <string name="paymentsheet_payment_method_item_card_number" translatable="false">····%1$s</string>
 
     <!-- Google Pay -->

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -96,8 +96,6 @@ class CardMultilineWidget @JvmOverloads constructor(
     @ColorInt
     private val tintColorInt: Int
 
-    private var cardHintText: String = resources.getString(R.string.card_number_hint)
-
     /**
      * If [shouldShowPostalCode] is true and [postalCodeRequired] is true, then postal code is a
      * required field.
@@ -286,8 +284,11 @@ class CardMultilineWidget @JvmOverloads constructor(
             }
         }
 
-    @StringRes
-    internal var expirationDateHintRes = R.string.expiry_date_hint
+    internal var expirationDateHintRes: Int by Delegates.observable(
+        R.string.expiry_date_hint
+    ) { _, _, newValue ->
+        expiryTextInputLayout.placeholderText = resources.getString(newValue)
+    }
 
     private var showCvcIconInCvcField: Boolean = false
 
@@ -407,7 +408,7 @@ class CardMultilineWidget @JvmOverloads constructor(
     }
 
     override fun setCardHint(cardHint: String) {
-        cardHintText = cardHint
+        cardNumberTextInputLayout.placeholderText = cardHint
     }
 
     /**
@@ -645,19 +646,13 @@ class CardMultilineWidget @JvmOverloads constructor(
     private fun initFocusChangeListeners() {
         cardNumberEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                cardNumberEditText.setHintDelayed(cardHintText, CARD_NUMBER_HINT_DELAY)
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.CardNumber)
-            } else {
-                cardNumberEditText.hint = ""
             }
         }
 
         expiryDateEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                expiryDateEditText.setHintDelayed(expirationDateHintRes, COMMON_HINT_DELAY)
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.ExpiryDate)
-            } else {
-                expiryDateEditText.hint = ""
             }
         }
 
@@ -666,23 +661,15 @@ class CardMultilineWidget @JvmOverloads constructor(
                 if (!showCvcIconInCvcField) {
                     flipToCvcIconIfNotFinished()
                 }
-                cvcEditText.setHintDelayed(cvcHelperText, COMMON_HINT_DELAY)
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.Cvc)
             } else {
                 updateBrandUi()
-                cvcEditText.hint = ""
             }
         }
 
         postalCodeEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-            if (!shouldShowPostalCode) {
-                return@OnFocusChangeListener
-            }
-            if (hasFocus) {
-                postalCodeEditText.setHintDelayed(R.string.zip_helper, COMMON_HINT_DELAY)
+            if (shouldShowPostalCode && hasFocus) {
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.PostalCode)
-            } else {
-                postalCodeEditText.hint = ""
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -61,6 +61,13 @@ class CardMultilineWidget @JvmOverloads constructor(
     internal val cvcInputLayout = viewBinding.tlCvc
     internal val postalInputLayout = viewBinding.tlPostalCode
 
+    private val textInputLayouts = listOf(
+        cardNumberTextInputLayout,
+        expiryTextInputLayout,
+        cvcInputLayout,
+        postalInputLayout
+    )
+
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
     private val cardValidTextWatcher = object : StripeTextWatcher() {
@@ -324,6 +331,10 @@ class CardMultilineWidget @JvmOverloads constructor(
 
         tintColorInt = cardNumberEditText.hintTextColors.defaultColor
 
+        textInputLayouts.forEach {
+            it.placeholderTextColor = it.editText?.hintTextColors
+        }
+
         // This sets the value of shouldShowPostalCode
         attrs?.let { checkAttributeSet(it) }
 
@@ -550,10 +561,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-        expiryTextInputLayout.isEnabled = enabled
-        cardNumberTextInputLayout.isEnabled = enabled
-        cvcInputLayout.isEnabled = enabled
-        postalInputLayout.isEnabled = enabled
+        textInputLayouts.forEach { it.isEnabled = enabled }
         isEnabled = enabled
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberTextInputLayout.kt
@@ -37,6 +37,8 @@ internal class CardNumberTextInputLayout @JvmOverloads constructor(
         doOnNextLayout {
             attachProgressView()
         }
+
+        placeholderText = resources.getString(R.string.card_number_hint)
     }
 
     private fun attachProgressView() {

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -95,6 +95,13 @@ class CvcEditText @JvmOverloads constructor(
 
         if (textInputLayout != null) {
             textInputLayout.hint = hintText
+
+            textInputLayout.placeholderText = resources.getString(
+                when (cardBrand) {
+                    CardBrand.AmericanExpress -> R.string.cvc_multiline_helper_amex
+                    else -> R.string.cvc_multiline_helper
+                }
+            )
         } else {
             this.hint = hintText
         }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -9,18 +9,10 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputConnectionWrapper
 import androidx.annotation.ColorInt
-import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputEditText
 import com.stripe.android.R
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Extension of [TextInputEditText] that listens for users pressing the delete key when
@@ -32,11 +24,8 @@ import kotlin.coroutines.CoroutineContext
 open class StripeEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle,
-    private val workContext: CoroutineContext = Dispatchers.IO
+    defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle
 ) : TextInputEditText(context, attrs, defStyleAttr) {
-    internal var job: Job? = null
-
     protected var isLastKeyDelete: Boolean = false
 
     private var afterTextChangedListener: AfterTextChangedListener? = null
@@ -149,53 +138,11 @@ open class StripeEditText @JvmOverloads constructor(
         this.errorColor = errorColor
     }
 
-    /**
-     * Change the hint value of this control after a delay.
-     *
-     * @param hintResource the string resource for the hint text
-     * @param delayMilliseconds a delay period, measured in milliseconds
-     */
-    fun setHintDelayed(@StringRes hintResource: Int, delayMilliseconds: Long) {
-        setHintDelayed(resources.getText(hintResource), delayMilliseconds)
-    }
-
-    /**
-     * Change the hint value of this control after a delay.
-     *
-     * @param hint the hint text
-     * @param delayMilliseconds a delay period, measured in milliseconds
-     */
-    fun setHintDelayed(hint: CharSequence, delayMilliseconds: Long) {
-        job?.cancel()
-        job = CoroutineScope(workContext).launch {
-            delay(delayMilliseconds)
-
-            withContext(Dispatchers.Main) {
-                setHintSafely(hint)
-            }
-        }
-    }
-
-    /**
-     * Call setHint() and guard against NPE. This is a workaround for a
-     * [known issue on Samsung devices](https://issuetracker.google.com/issues/37127697).
-     */
-    private fun setHintSafely(hint: CharSequence) {
-        runCatching {
-            setHint(hint)
-        }
-    }
-
     override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
         super.onInitializeAccessibilityNodeInfo(info)
         info.isContentInvalid = shouldShowError
         accessibilityText?.let { info.text = it }
         info.error = errorMessage.takeIf { shouldShowError }
-    }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        job?.cancel()
     }
 
     private fun determineDefaultErrorColor() {

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -10,14 +10,11 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.R
 import com.stripe.android.testharness.ViewTestUtils
-import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.AfterTest
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
@@ -32,16 +29,10 @@ internal class StripeEditTextTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val editText = StripeEditText(
-        context,
-        workContext = testDispatcher
+        context
     ).also {
         it.setDeleteEmptyListener(deleteEmptyListener)
         it.setAfterTextChangedListener(afterTextChangedListener)
-    }
-
-    @AfterTest
-    fun cleanup() {
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
@@ -141,32 +132,6 @@ internal class StripeEditTextTest {
         editText.shouldShowError = false
         assertThat(editText.currentTextColor)
             .isEqualTo(-570425344)
-    }
-
-    @Test
-    fun `setHintDelayed should set hint after delay`() = testDispatcher.runBlockingTest {
-        assertThat(editText.hint)
-            .isNull()
-
-        editText.setHintDelayed("Here's a hint", DELAY)
-        testDispatcher.advanceTimeBy(DELAY + 10)
-        idleLooper()
-
-        assertThat(editText.hint)
-            .isEqualTo("Here's a hint")
-    }
-
-    @Test
-    fun `setHintDelayed when Job is canceled before delay should not set hint`() {
-        assertThat(editText.hint)
-            .isNull()
-        editText.setHintDelayed("Here's a hint", DELAY)
-        testDispatcher.advanceTimeBy(DELAY - 10)
-
-        requireNotNull(editText.job).cancel()
-
-        assertThat(editText.hint)
-            .isNull()
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -10,15 +10,12 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.R
 import com.stripe.android.testharness.ViewTestUtils
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
-@ExperimentalCoroutinesApi
 internal class StripeEditTextTest {
     private val context: Context = ContextThemeWrapper(
         ApplicationProvider.getApplicationContext(),
@@ -26,7 +23,6 @@ internal class StripeEditTextTest {
     )
     private val afterTextChangedListener: StripeEditText.AfterTextChangedListener = mock()
     private val deleteEmptyListener: StripeEditText.DeleteEmptyListener = mock()
-    private val testDispatcher = TestCoroutineDispatcher()
 
     private val editText = StripeEditText(
         context
@@ -132,9 +128,5 @@ internal class StripeEditTextTest {
         editText.shouldShowError = false
         assertThat(editText.currentTextColor)
             .isEqualTo(-570425344)
-    }
-
-    private companion object {
-        private const val DELAY = 100L
     }
 }


### PR DESCRIPTION
Previously, CardMultilineWidget fields used custom logic to show hint
text on both the `TextInputLayout` and `EditText`. This can be more
simply achieved by setting placeholder text on the `TextInputLayout`.

| Before | After |
| - | - |
| ![placeholder_before](https://user-images.githubusercontent.com/45020849/104512689-99f33e80-55bc-11eb-83cb-abf3d8fd2f0c.gif) | ![placeholder](https://user-images.githubusercontent.com/45020849/104523024-85b73d80-55cc-11eb-9f1a-99ace13aa57b.gif)|



