### PR TITLE
Update PaymentOptionsActivity user selection behavior

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
@@ -32,6 +33,7 @@ internal class AddButton @JvmOverloads constructor(
 
         isClickable = true
         isEnabled = false
+        isGone = true
     }
 
     fun onCompletedState(state: PaymentOptionViewState.Completed) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -25,10 +25,7 @@ internal abstract class BasePaymentMethodsListFragment(
     protected val adapter: PaymentOptionsAdapter by lazy {
         PaymentOptionsAdapter(
             fragmentViewModel.currentPaymentSelection,
-            paymentMethodSelectedListener = {
-                fragmentViewModel.currentPaymentSelection = it
-                sheetViewModel.updateSelection(it)
-            },
+            paymentOptionSelectedListener = ::onPaymentOptionSelected,
             addCardClickListener = {
                 transitionToAddPaymentMethod()
             }
@@ -76,6 +73,14 @@ internal abstract class BasePaymentMethodsListFragment(
     override fun onDestroyView() {
         super.onDestroyView()
         _viewBinding = null
+    }
+
+    open fun onPaymentOptionSelected(
+        paymentSelection: PaymentSelection,
+        isClick: Boolean
+    ) {
+        fragmentViewModel.currentPaymentSelection = paymentSelection
+        sheetViewModel.updateSelection(paymentSelection)
     }
 
     internal class PaymentMethodsViewModel : ViewModel() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
@@ -143,6 +144,12 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
                 }
             }
         }
+
+        viewModel.userSelection.observe(this) { paymentSelection ->
+            if (paymentSelection != null) {
+                onActionCompleted(paymentSelection)
+            }
+        }
     }
 
     private fun setupAddButton(addButton: AddButton) {
@@ -206,6 +213,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
                 }
             }
         }
+        viewBinding.addButton.isVisible = transitionTarget != PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod
         viewModel.updateMode(transitionTarget.sheetMode)
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -16,7 +16,7 @@ import kotlin.properties.Delegates
 
 internal class PaymentOptionsAdapter(
     private var paymentSelection: PaymentSelection?,
-    val paymentMethodSelectedListener: (PaymentSelection) -> Unit,
+    val paymentOptionSelectedListener: (PaymentSelection, Boolean) -> Unit,
     val addCardClickListener: View.OnClickListener
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     var shouldShowGooglePay: Boolean by Delegates.observable(false) { _, _, _ ->
@@ -54,7 +54,8 @@ internal class PaymentOptionsAdapter(
     }
 
     private fun onPaymentMethodSelected(
-        clickedPaymentMethod: PaymentMethod
+        clickedPaymentMethod: PaymentMethod,
+        isClick: Boolean
     ) {
         if (selectedPaymentMethod?.id != clickedPaymentMethod.id) {
             // selected a new Payment Method
@@ -71,7 +72,7 @@ internal class PaymentOptionsAdapter(
                 notifyItemChanged(GOOGLE_PAY_POSITION)
             }
 
-            paymentMethodSelectedListener(paymentSelection)
+            paymentOptionSelectedListener(paymentSelection, isClick)
         }
     }
 
@@ -86,7 +87,7 @@ internal class PaymentOptionsAdapter(
 
             // select Google Pay item
             notifyItemChanged(GOOGLE_PAY_POSITION)
-            paymentMethodSelectedListener(PaymentSelection.GooglePay)
+            paymentOptionSelectedListener(PaymentSelection.GooglePay, true)
         }
     }
 
@@ -146,7 +147,8 @@ internal class PaymentOptionsAdapter(
             holder.setSelected(paymentMethod.id == selectedPaymentMethod?.id)
             holder.itemView.setOnClickListener {
                 onPaymentMethodSelected(
-                    getPaymentMethodAtPosition(holder.adapterPosition)
+                    getPaymentMethodAtPosition(holder.adapterPosition),
+                    true
                 )
             }
         } else if (holder is GooglePayViewHolder) {
@@ -185,7 +187,7 @@ internal class PaymentOptionsAdapter(
             PaymentSelection.Saved(it)
         }
         paymentSelection?.let {
-            paymentMethodSelectedListener(it)
+            paymentOptionSelectedListener(it, false)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentOptionsListFragment(
     eventReporter: EventReporter
@@ -31,5 +32,16 @@ internal class PaymentOptionsListFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewBinding.header.setText(R.string.stripe_paymentsheet_select_payment_method)
+    }
+
+    override fun onPaymentOptionSelected(
+        paymentSelection: PaymentSelection,
+        isClick: Boolean
+    ) {
+        super.onPaymentOptionSelected(paymentSelection, isClick)
+        if (isClick) {
+            // this is a click-triggered selection
+            sheetViewModel.onUserSelection(paymentSelection)
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -1,12 +1,15 @@
 package com.stripe.android.paymentsheet
 
 import android.app.Application
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.PaymentSessionPrefs
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentOptionViewState
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
@@ -21,6 +24,9 @@ internal class PaymentOptionsViewModel(
     googlePayRepository = googlePayRepository,
     prefsRepository = prefsRepository
 ) {
+    private val _userSelection = MutableLiveData<PaymentSelection>()
+    val userSelection: LiveData<PaymentSelection> = _userSelection
+
     init {
         _paymentIntent.value = args.paymentIntent
         _paymentMethods.value = args.paymentMethods
@@ -33,6 +39,13 @@ internal class PaymentOptionsViewModel(
             prefsRepository.savePaymentSelection(paymentSelection)
             _viewState.value = PaymentOptionViewState.Completed(paymentSelection)
         }
+    }
+
+    fun onUserSelection(
+        paymentSelection: PaymentSelection
+    ) {
+        selectPaymentOption()
+        _userSelection.value = paymentSelection
     }
 
     internal enum class TransitionTarget(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -145,8 +145,8 @@ class PaymentOptionsAdapterTest {
     private fun createAdapter(): PaymentOptionsAdapter {
         return PaymentOptionsAdapter(
             paymentSelection = null,
-            paymentMethodSelectedListener = {
-                paymentSelections.add(it)
+            paymentOptionSelectedListener = { paymentSelection, _ ->
+                paymentSelections.add(paymentSelection)
             },
             addCardClickListener = {
                 addCardClicks++

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -86,7 +86,7 @@ class PaymentSheetPaymentMethodsListFragmentTest {
             val recycler = recyclerView(it)
             assertThat(recycler.adapter).isInstanceOf(PaymentOptionsAdapter::class.java)
             val adapter = recycler.adapter as PaymentOptionsAdapter
-            adapter.paymentMethodSelectedListener(savedPaymentMethod)
+            adapter.paymentOptionSelectedListener(savedPaymentMethod, true)
             idleLooper()
 
             assertThat(fragmentViewModel(it).currentPaymentSelection)

--- a/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.Test
  */
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-class PaymentOptionsAdapterTest {
+class PaymentMethodsAdapterTest {
     private val adapterDataObserver: RecyclerView.AdapterDataObserver = mock()
     private val listener: PaymentMethodsAdapter.Listener = mock()
 


### PR DESCRIPTION
## Summary
In `PaymentOptionsActivity`, only show the add button when adding a
card; hide it otherwise.

When on the payment options selection screen, a tap on an option will
record the option and dismiss the sheet.

## Motivation
Simplify user interaction

## Testing
Added unit tests and manually verified