### PR TITLE
Use PaymentSheetResultCallback in PaymentSheetFlowController.onPaymentResult()

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetFlowController.kt
@@ -132,7 +132,7 @@ internal class DefaultPaymentSheetFlowController internal constructor(
     override fun onPaymentResult(
         requestCode: Int,
         data: Intent?,
-        callback: ApiResultCallback<PaymentIntentResult>
+        callback: PaymentSheetResultCallback
     ) {
         if (data != null && paymentController.shouldHandlePaymentResult(requestCode, data)) {
             paymentController.handlePaymentResult(
@@ -141,15 +141,26 @@ internal class DefaultPaymentSheetFlowController internal constructor(
                     override fun onSuccess(result: PaymentIntentResult) {
                         if (result.outcome == StripeIntentResult.Outcome.SUCCEEDED) {
                             eventReporter.onPaymentSuccess(paymentSelection)
+                            callback.onComplete(
+                                PaymentResult.Succeeded(result.intent)
+                            )
                         } else {
                             eventReporter.onPaymentFailure(paymentSelection)
+
+                            callback.onComplete(
+                                PaymentResult.Failed(
+                                    RuntimeException(result.failureMessage),
+                                    result.intent
+                                )
+                            )
                         }
-                        callback.onSuccess(result)
                     }
 
                     override fun onError(e: Exception) {
                         eventReporter.onPaymentFailure(paymentSelection)
-                        callback.onError(e)
+                        callback.onComplete(
+                            PaymentResult.Failed(e, null)
+                        )
                     }
                 }
             )
@@ -157,21 +168,30 @@ internal class DefaultPaymentSheetFlowController internal constructor(
             when (val googlePayResult = StripeGooglePayContract.Result.fromIntent(data)) {
                 is StripeGooglePayContract.Result.PaymentIntent -> {
                     eventReporter.onPaymentSuccess(PaymentSelection.GooglePay)
-                    callback.onSuccess(googlePayResult.paymentIntentResult)
+                    callback.onComplete(
+                        PaymentResult.Succeeded(
+                            googlePayResult.paymentIntentResult.intent
+                        )
+                    )
                 }
                 is StripeGooglePayContract.Result.Error -> {
                     eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
                     val exception = googlePayResult.exception
-                    callback.onError(
-                        when (exception) {
-                            is Exception -> exception
-                            else -> RuntimeException(exception)
-                        }
+                    callback.onComplete(
+                        PaymentResult.Failed(
+                            exception,
+                            null
+                        )
                     )
                 }
                 else -> {
                     eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
-                    // TODO(mshafrir-stripe): handle other outcomes; for now, treat these as payment failures
+                    callback.onComplete(
+                        PaymentResult.Failed(
+                            RuntimeException("Google Pay attempt failed"),
+                            null
+                        )
+                    )
                 }
             }
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentsheet
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
-import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentIntentResult
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.parcelize.Parcelize
 
@@ -129,7 +127,7 @@ internal class PaymentSheet internal constructor(
         fun onPaymentResult(
             requestCode: Int,
             data: Intent?,
-            callback: ApiResultCallback<PaymentIntentResult>
+            callback: PaymentSheetResultCallback
         )
 
         sealed class Result {


### PR DESCRIPTION
This unifies the callback mechanism.

Added unit tests