### PR TITLE
Update payment sheet toolbar button visibility logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -7,9 +7,9 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
-import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.ui.Toolbar
 
 /**
@@ -46,9 +45,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     }
 
     @VisibleForTesting
-    internal val bottomSheetBehavior by lazy {
-        BottomSheetBehavior.from(viewBinding.bottomSheet)
-    }
+    internal val bottomSheetBehavior by lazy { BottomSheetBehavior.from(bottomSheet) }
 
     override val bottomSheetController: BottomSheetController by lazy {
         BottomSheetController(
@@ -63,7 +60,8 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         get() = viewBinding.fragmentContainer.id
 
     override val rootView: View by lazy { viewBinding.root }
-
+    override val bottomSheet: ConstraintLayout by lazy { viewBinding.bottomSheet }
+    override val toolbar: Toolbar by lazy { viewBinding.toolbar }
     override val messageView: TextView by lazy { viewBinding.message }
 
     override val eventReporter: EventReporter by lazy {
@@ -90,24 +88,6 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
             animateOut(
                 PaymentOptionResult.Failed(it)
             )
-        }
-        viewModel.sheetMode.observe(this) { mode ->
-            when (mode) {
-                SheetMode.Full,
-                SheetMode.FullCollapsed -> {
-                    viewBinding.toolbar.showBack()
-                }
-                SheetMode.Wrapped -> {
-                    viewBinding.toolbar.showClose()
-                }
-                else -> {
-                    // mode == null
-                }
-            }
-
-            viewBinding.bottomSheet.updateLayoutParams { height = mode.height }
-
-            bottomSheetController.updateState(mode)
         }
         bottomSheetController.shouldFinish.observe(this) { shouldFinish ->
             if (shouldFinish) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -7,9 +7,9 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -23,7 +23,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
-import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.ui.Toolbar
 
 internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() {
@@ -35,9 +34,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         )
 
     @VisibleForTesting
-    internal val bottomSheetBehavior by lazy {
-        BottomSheetBehavior.from(viewBinding.bottomSheet)
-    }
+    internal val bottomSheetBehavior by lazy { BottomSheetBehavior.from(bottomSheet) }
 
     override val bottomSheetController: BottomSheetController by lazy {
         BottomSheetController(
@@ -63,10 +60,9 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
     }
 
     override val rootView: View by lazy { viewBinding.root }
-
-    override val messageView: TextView by lazy {
-        viewBinding.message
-    }
+    override val bottomSheet: ConstraintLayout by lazy { viewBinding.bottomSheet }
+    override val toolbar: Toolbar by lazy { viewBinding.toolbar }
+    override val messageView: TextView by lazy { viewBinding.message }
 
     override val eventReporter: EventReporter by lazy {
         DefaultEventReporter(
@@ -114,24 +110,6 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
                     paymentIntent = viewModel.paymentIntent.value
                 )
             )
-        }
-        viewModel.sheetMode.observe(this) { mode ->
-            when (mode) {
-                SheetMode.Full -> {
-                    viewBinding.toolbar.showBack()
-                }
-                SheetMode.FullCollapsed,
-                SheetMode.Wrapped -> {
-                    viewBinding.toolbar.showClose()
-                }
-                else -> {
-                    // mode == null
-                }
-            }
-
-            viewBinding.bottomSheet.updateLayoutParams { height = mode.height }
-
-            bottomSheetController.updateState(mode)
         }
 
         bottomSheetController.shouldFinish.observe(this) { shouldFinish ->

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -19,6 +21,8 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
     abstract val eventReporter: EventReporter
 
     abstract val rootView: View
+    abstract val bottomSheet: ConstraintLayout
+    abstract val toolbar: Toolbar
     abstract val messageView: TextView
 
     abstract fun onUserCancel()
@@ -42,6 +46,17 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
         viewModel.processing.observe(this) { isProcessing ->
             bottomSheetController.setDraggable(!isProcessing)
             updateRootViewClickHandling(isProcessing)
+        }
+
+        viewModel.sheetMode.observe(this) { mode ->
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                toolbar.showClose()
+            } else {
+                toolbar.showBack()
+            }
+
+            bottomSheet.updateLayoutParams { height = mode.height }
+            bottomSheetController.updateState(mode)
         }
     }
 


### PR DESCRIPTION
Show the toolbar's close or back button based on
`supportFragmentManager.backStackEntryCount`.

Also move this logic to `BasePaymentSheetActivity`.