### PR TITLE
Fix requestCode usage in StripePaymentController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -175,7 +175,18 @@ internal class StripePaymentController internal constructor(
                         handleNextAction(host, stripeIntent, requestOptions)
                     },
                     onFailure = {
-                        handleError(host, PAYMENT_REQUEST_CODE, it)
+                        handleError(
+                            host,
+                            when (type) {
+                                PaymentController.StripeIntentType.PaymentIntent -> {
+                                    PAYMENT_REQUEST_CODE
+                                }
+                                PaymentController.StripeIntentType.SetupIntent -> {
+                                    SETUP_REQUEST_CODE
+                                }
+                            },
+                            it
+                        )
                     }
                 )
             }


### PR DESCRIPTION
Decide which `requestCode` to use based on the `StripeIntentType`.