### PR TITLE
Refactor PaymentRelayStarter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
@@ -1,0 +1,26 @@
+package com.stripe.android
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.view.ActivityStarter
+import com.stripe.android.view.PaymentRelayActivity
+
+internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter.Args, PaymentController.Result>() {
+    override fun createIntent(
+        context: Context,
+        input: PaymentRelayStarter.Args?
+    ): Intent {
+        return Intent(context, PaymentRelayActivity::class.java)
+            .putExtra(ActivityStarter.Args.EXTRA, input)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?
+    ): PaymentController.Result {
+        return intent?.let {
+            PaymentController.Result.fromIntent(it)
+        } ?: PaymentController.Result()
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/FakeActivityResultLauncher.kt
+++ b/stripe/src/test/java/com/stripe/android/FakeActivityResultLauncher.kt
@@ -1,0 +1,27 @@
+package com.stripe.android
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+
+internal class FakeActivityResultLauncher<I>(
+    private val contract: ActivityResultContract<I, *>
+) : ActivityResultLauncher<I>() {
+    val launchArgs = mutableListOf<I>()
+    var unregisterInvocations = 0
+
+    override fun launch(
+        input: I,
+        options: ActivityOptionsCompat?
+    ) {
+        launchArgs.add(input)
+    }
+
+    override fun unregister() {
+        unregisterInvocations++
+    }
+
+    override fun getContract(): ActivityResultContract<I, *> {
+        return contract
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
@@ -23,9 +23,8 @@ import kotlin.test.Test
 class PaymentRelayStarterTest {
     private val activity = mock<Activity>()
     private val intentArgumentCaptor = argumentCaptor<Intent>()
-    private val starter = PaymentRelayStarter.create(
-        AuthActivityStarter.Host.create(activity),
-        500
+    private val starter = PaymentRelayStarter.Legacy(
+        AuthActivityStarter.Host.create(activity)
     )
 
     @Test
@@ -33,7 +32,10 @@ class PaymentRelayStarterTest {
         starter.start(
             PaymentRelayStarter.Args.create(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
         )
-        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        verify(activity).startActivityForResult(
+            intentArgumentCaptor.capture(),
+            eq(50000)
+        )
 
         assertThat(result.clientSecret).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret)
         assertThat(result.flowOutcome).isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
@@ -43,8 +45,16 @@ class PaymentRelayStarterTest {
     @Test
     fun start_withException_shouldSetCorrectIntentExtras() {
         val exception = APIException(RuntimeException())
-        starter.start(PaymentRelayStarter.Args.ErrorArgs(exception))
-        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        starter.start(
+            PaymentRelayStarter.Args.ErrorArgs(
+                exception,
+                50000
+            )
+        )
+        verify(activity).startActivityForResult(
+            intentArgumentCaptor.capture(),
+            eq(50000)
+        )
 
         assertThat(result.clientSecret).isNull()
         assertThat(result.flowOutcome).isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
@@ -56,8 +66,16 @@ class PaymentRelayStarterTest {
         val exception = PermissionException(
             stripeError = StripeErrorFixtures.INVALID_REQUEST_ERROR
         )
-        starter.start(PaymentRelayStarter.Args.ErrorArgs(exception))
-        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), eq(500))
+        starter.start(
+            PaymentRelayStarter.Args.ErrorArgs(
+                exception,
+                50000
+            )
+        )
+        verify(activity).startActivityForResult(
+            intentArgumentCaptor.capture(),
+            eq(50000)
+        )
 
         assertThat(result.clientSecret).isNull()
         assertThat(result.flowOutcome).isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
@@ -99,7 +117,8 @@ class PaymentRelayStarterTest {
                 exception = InvalidRequestException(
                     stripeError = StripeErrorFixtures.INVALID_REQUEST_ERROR,
                     cause = IllegalArgumentException()
-                )
+                ),
+                requestCode = 50000
             )
         )
     }


### PR DESCRIPTION
## Summary
- Create `PaymentRelayContract`.
- Create `Legacy` and `Modern` subclasses of `PaymentRelayStarter`
  sealed class. Use `Modern` when a `ActivityResultLauncher` is
  available; otherwise, use `Legacy`.
- Move request codes to `PaymentRelayStarter.Args`.

## Motivation
Enable using `ActivityResultLauncher` to launch `PaymentRelayActivity` 

## Testing
Added unit tests and manually verified