### PR TITLE
Create PaymentFlowResult sealed class

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -1,17 +1,11 @@
 package com.stripe.android
 
 import android.content.Intent
-import android.os.Parcel
-import android.os.Parcelable
-import androidx.core.os.bundleOf
-import com.stripe.android.exception.StripeException
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.view.AuthActivityStarter
-import kotlinx.parcelize.Parceler
-import kotlinx.parcelize.Parcelize
 
 internal interface PaymentController {
     /**
@@ -107,58 +101,5 @@ internal interface PaymentController {
     enum class StripeIntentType {
         PaymentIntent,
         SetupIntent
-    }
-
-    /**
-     * Represents the result of a [PaymentController] operation.
-     *
-     * This class is annotated with `@Parcelize` but uses custom parceling logic due to issues
-     * with parceling an `Exception` subclass. See
-     * [Parcel#writeException()](https://developer.android.com/reference/android/os/Parcel#writeException(java.lang.Exception))
-     * for more details.
-     */
-    @Parcelize
-    data class Result internal constructor(
-        internal val clientSecret: String? = null,
-        @StripeIntentResult.Outcome internal val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
-        internal val exception: StripeException? = null,
-        internal val shouldCancelSource: Boolean = false,
-        internal val sourceId: String? = null,
-        internal val source: Source? = null,
-        internal val stripeAccountId: String? = null
-    ) : Parcelable {
-        @JvmSynthetic
-        fun toBundle() = bundleOf(EXTRA to this)
-
-        internal companion object : Parceler<Result> {
-            override fun create(parcel: Parcel): Result {
-                return Result(
-                    clientSecret = parcel.readString(),
-                    flowOutcome = parcel.readInt(),
-                    exception = parcel.readSerializable() as? StripeException?,
-                    shouldCancelSource = parcel.readInt() == 1,
-                    sourceId = parcel.readString(),
-                    source = parcel.readParcelable(Source::class.java.classLoader),
-                    stripeAccountId = parcel.readString()
-                )
-            }
-
-            override fun Result.write(parcel: Parcel, flags: Int) {
-                parcel.writeString(clientSecret)
-                parcel.writeInt(flowOutcome)
-                parcel.writeSerializable(exception)
-                parcel.writeInt(1.takeIf { shouldCancelSource } ?: 0)
-                parcel.writeString(sourceId)
-                parcel.writeParcelable(source, flags)
-                parcel.writeString(stripeAccountId)
-            }
-
-            private const val EXTRA = "extra_args"
-
-            @JvmSynthetic
-            internal fun fromIntent(intent: Intent): Result? {
-                return intent.getParcelableExtra(EXTRA)
-            }
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
@@ -3,10 +3,11 @@ package com.stripe.android
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.view.ActivityStarter
 import com.stripe.android.view.PaymentRelayActivity
 
-internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter.Args, PaymentController.Result>() {
+internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter.Args, PaymentFlowResult.Unvalidated>() {
     override fun createIntent(
         context: Context,
         input: PaymentRelayStarter.Args?
@@ -18,9 +19,7 @@ internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): PaymentController.Result {
-        return intent?.let {
-            PaymentController.Result.fromIntent(it)
-        } ?: PaymentController.Result()
+    ): PaymentFlowResult.Unvalidated {
+        return PaymentFlowResult.Unvalidated.fromIntent(intent)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayStarter.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.view.AuthActivityStarter
 import com.stripe.android.view.PaymentRelayActivity
 import kotlinx.parcelize.Parceler
@@ -41,7 +42,7 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
     sealed class Args : Parcelable {
         abstract val requestCode: Int
 
-        abstract fun toResult(): PaymentController.Result
+        abstract fun toResult(): PaymentFlowResult.Unvalidated
 
         @Parcelize
         data class PaymentIntentArgs(
@@ -51,8 +52,8 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             override val requestCode: Int
                 get() = StripePaymentController.PAYMENT_REQUEST_CODE
 
-            override fun toResult(): PaymentController.Result {
-                return PaymentController.Result(
+            override fun toResult(): PaymentFlowResult.Unvalidated {
+                return PaymentFlowResult.Unvalidated(
                     clientSecret = paymentIntent.clientSecret,
                     stripeAccountId = stripeAccountId
                 )
@@ -67,8 +68,8 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             override val requestCode: Int
                 get() = StripePaymentController.SETUP_REQUEST_CODE
 
-            override fun toResult(): PaymentController.Result {
-                return PaymentController.Result(
+            override fun toResult(): PaymentFlowResult.Unvalidated {
+                return PaymentFlowResult.Unvalidated(
                     clientSecret = setupIntent.clientSecret,
                     stripeAccountId = stripeAccountId
                 )
@@ -83,8 +84,8 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             override val requestCode: Int
                 get() = StripePaymentController.SOURCE_REQUEST_CODE
 
-            override fun toResult(): PaymentController.Result {
-                return PaymentController.Result(
+            override fun toResult(): PaymentFlowResult.Unvalidated {
+                return PaymentFlowResult.Unvalidated(
                     source = source,
                     stripeAccountId = stripeAccountId
                 )
@@ -96,8 +97,8 @@ internal interface PaymentRelayStarter : AuthActivityStarter<PaymentRelayStarter
             internal val exception: StripeException,
             override val requestCode: Int
         ) : Args() {
-            override fun toResult(): PaymentController.Result {
-                return PaymentController.Result(
+            override fun toResult(): PaymentFlowResult.Unvalidated {
+                return PaymentFlowResult.Unvalidated(
                     exception = exception
                 )
             }

--- a/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
@@ -5,12 +5,12 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
-import com.stripe.android.PaymentController
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import com.stripe.android.view.PaymentAuthWebViewActivity
 import kotlinx.parcelize.Parcelize
 
-internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWebViewContract.Args, PaymentController.Result>() {
+internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWebViewContract.Args, PaymentFlowResult>() {
     override fun createIntent(
         context: Context,
         input: Args?
@@ -32,7 +32,7 @@ internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWe
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): PaymentController.Result? {
+    ): PaymentFlowResult? {
         return intent?.getParcelableExtra(EXTRA_ARGS)
     }
 

--- a/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.payments
+
+import android.content.Intent
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import com.stripe.android.PaymentController
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.exception.StripeException
+import com.stripe.android.model.Source
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents the result of a [PaymentController] operation.
+ *
+ * This class is annotated with `@Parcelize` but uses custom parceling logic due to issues
+ * with parceling an `Exception` subclass. See
+ * [Parcel#writeException()](https://developer.android.com/reference/android/os/Parcel#writeException(java.lang.Exception))
+ * for more details.
+ */
+
+sealed class PaymentFlowResult {
+    @Parcelize
+    internal data class Unvalidated internal constructor(
+        internal val clientSecret: String? = null,
+        @StripeIntentResult.Outcome internal val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
+        internal val exception: StripeException? = null,
+        internal val shouldCancelSource: Boolean = false,
+        internal val sourceId: String? = null,
+        internal val source: Source? = null,
+        internal val stripeAccountId: String? = null
+    ) : Parcelable {
+        @JvmSynthetic
+        fun toBundle() = bundleOf(EXTRA to this)
+
+        fun validate(): Validated {
+            if (exception is Throwable) {
+                throw exception
+            }
+            require(!clientSecret.isNullOrBlank()) {
+                CLIENT_SECRET_INTENT_ERROR
+            }
+
+            return Validated(
+                clientSecret = clientSecret,
+                flowOutcome = flowOutcome,
+                shouldCancelSource = shouldCancelSource,
+                sourceId = sourceId,
+                source = source,
+                stripeAccountId = stripeAccountId
+            )
+        }
+
+        internal companion object : Parceler<Unvalidated> {
+            override fun create(parcel: Parcel): Unvalidated {
+                return Unvalidated(
+                    clientSecret = parcel.readString(),
+                    flowOutcome = parcel.readInt(),
+                    exception = parcel.readSerializable() as? StripeException?,
+                    shouldCancelSource = parcel.readInt() == 1,
+                    sourceId = parcel.readString(),
+                    source = parcel.readParcelable(Source::class.java.classLoader),
+                    stripeAccountId = parcel.readString()
+                )
+            }
+
+            override fun Unvalidated.write(parcel: Parcel, flags: Int) {
+                parcel.writeString(clientSecret)
+                parcel.writeInt(flowOutcome)
+                parcel.writeSerializable(exception)
+                parcel.writeInt(1.takeIf { shouldCancelSource } ?: 0)
+                parcel.writeString(sourceId)
+                parcel.writeParcelable(source, flags)
+                parcel.writeString(stripeAccountId)
+            }
+
+            @JvmSynthetic
+            internal fun fromIntent(intent: Intent?): Unvalidated {
+                return intent?.getParcelableExtra(EXTRA) ?: Unvalidated()
+            }
+
+            private const val EXTRA = "extra_args"
+            private const val CLIENT_SECRET_INTENT_ERROR = "Invalid client_secret value in result Intent."
+        }
+    }
+
+    internal data class Validated internal constructor(
+        val clientSecret: String,
+        @StripeIntentResult.Outcome internal val flowOutcome: Int,
+        internal val shouldCancelSource: Boolean = false,
+        internal val sourceId: String? = null,
+        internal val source: Source? = null,
+        internal val stripeAccountId: String? = null
+    )
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentAuthWebViewContract
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 
 internal class PaymentAuthWebViewActivityViewModel(
@@ -27,10 +27,10 @@ internal class PaymentAuthWebViewActivityViewModel(
     @JvmSynthetic
     internal val toolbarBackgroundColor = args.toolbarCustomization?.backgroundColor
 
-    internal val paymentResult: PaymentController.Result
+    internal val paymentResult: PaymentFlowResult.Unvalidated
         @JvmSynthetic
         get() {
-            return PaymentController.Result(
+            return PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
                 sourceId = Uri.parse(args.url).lastPathSegment.orEmpty(),
                 stripeAccountId = args.stripeAccountId

--- a/stripe/src/main/java/com/stripe/android/view/Stripe3ds2CompletionActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/Stripe3ds2CompletionActivity.kt
@@ -5,8 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.transaction.ChallengeCompletionIntentStarter
 import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
 import com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION
@@ -39,7 +39,7 @@ class Stripe3ds2CompletionActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val result = PaymentController.Result(
+        val result = PaymentFlowResult.Unvalidated(
             clientSecret = intent.getStringExtra(EXTRA_CLIENT_SECRET),
             flowOutcome = flowOutcome,
             stripeAccountId = intent.getStringExtra(EXTRA_STRIPE_ACCOUNT)

--- a/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.exception.PermissionException
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.SourceFixtures
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.utils.ParcelUtils.verifyParcelRoundtrip
 import com.stripe.android.view.AuthActivityStarter
 import org.junit.runner.RunWith
@@ -123,10 +124,6 @@ class PaymentRelayStarterTest {
         )
     }
 
-    private val result: PaymentController.Result
-        get() {
-            return requireNotNull(
-                PaymentController.Result.fromIntent(intentArgumentCaptor.firstValue)
-            )
-        }
+    private val result: PaymentFlowResult.Unvalidated
+        get() = PaymentFlowResult.Unvalidated.fromIntent(intentArgumentCaptor.firstValue)
 }

--- a/stripe/src/test/java/com/stripe/android/payments/PaymentFlowResultTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/PaymentFlowResultTest.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.payments
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.exception.APIException
+import com.stripe.android.exception.StripeException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class PaymentFlowResultTest {
+
+    @Test
+    fun `validate() should fail if clientSecret is empty`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            PaymentFlowResult.Unvalidated(
+                clientSecret = "   "
+            ).validate()
+        }
+        assertThat(exception.message)
+            .isEqualTo("Invalid client_secret value in result Intent.")
+    }
+
+    @Test
+    fun `validate() should fail if exception is non-null`() {
+        val exception = assertFailsWith<APIException> {
+            PaymentFlowResult.Unvalidated(
+                exception = StripeException.create(RuntimeException("failure"))
+            ).validate()
+        }
+        assertThat(exception.message)
+            .isEqualTo("failure")
+    }
+
+    @Test
+    fun `validate() should return Validated instance if valid`() {
+        assertThat(
+            PaymentFlowResult.Unvalidated(
+                clientSecret = "client_secret"
+            ).validate()
+        ).isEqualTo(
+            PaymentFlowResult.Validated(
+                clientSecret = "client_secret",
+                flowOutcome = 0
+            )
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -12,7 +12,6 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -23,6 +22,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -236,7 +236,7 @@ internal class PaymentSheetActivityTest {
                 StripePaymentController.PAYMENT_REQUEST_CODE,
                 Intent().apply {
                     putExtras(
-                        PaymentController.Result(
+                        PaymentFlowResult.Unvalidated(
                             "client_secret",
                             StripeIntentResult.Outcome.SUCCEEDED
                         ).toBundle()

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.view
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentAuthWebViewContract
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -24,11 +24,11 @@ class PaymentAuthWebViewActivityViewModelTest {
         )
 
         val intent = viewModel.cancellationResult
-        val resultIntent = PaymentController.Result.fromIntent(intent)
-        assertThat(
-            resultIntent?.flowOutcome
-        ).isEqualTo(StripeIntentResult.Outcome.CANCELED)
-        assertThat(resultIntent?.shouldCancelSource).isTrue()
+        val resultIntent = PaymentFlowResult.Unvalidated.fromIntent(intent)
+        assertThat(resultIntent.flowOutcome)
+            .isEqualTo(StripeIntentResult.Outcome.CANCELED)
+        assertThat(resultIntent.shouldCancelSource)
+            .isTrue()
     }
 
     @Test
@@ -44,11 +44,11 @@ class PaymentAuthWebViewActivityViewModelTest {
         )
 
         val intent = viewModel.cancellationResult
-        val resultIntent = PaymentController.Result.fromIntent(requireNotNull(intent))
-        assertThat(
-            resultIntent?.flowOutcome
-        ).isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
-        assertThat(resultIntent?.shouldCancelSource).isTrue()
+        val resultIntent = PaymentFlowResult.Unvalidated.fromIntent(intent)
+        assertThat(resultIntent.flowOutcome)
+            .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
+        assertThat(resultIntent.shouldCancelSource)
+            .isTrue()
     }
 
     @Test


### PR DESCRIPTION
Move `PaymentController.Result` to `PaymentFlowResult` and make it a
sealed class with `Unvalidated` (existing implementation) and
`Validated` implementations.

This better models the validation that previously lived
in `StripePaymentController`.