### PR TITLE
Create PaymentFlowResultProcessor

### DIFF
--- a/stripe/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import com.stripe.android.R
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+
+internal class PaymentFlowFailureMessageFactory(
+    private val context: Context
+) {
+    fun create(
+        intent: StripeIntent,
+        @StripeIntentResult.Outcome outcome: Int
+    ): String? {
+        return when {
+            intent.status == StripeIntent.Status.RequiresPaymentMethod -> {
+                when (intent) {
+                    is PaymentIntent -> {
+                        when {
+                            intent.lastPaymentError?.code == PaymentIntent.Error.CODE_AUTHENTICATION_ERROR -> {
+                                context.resources.getString(R.string.stripe_failure_reason_authentication)
+                            }
+                            intent.lastPaymentError?.type == PaymentIntent.Error.Type.CardError -> {
+                                intent.lastPaymentError.message
+                            }
+                            else -> {
+                                null
+                            }
+                        }
+                    }
+                    is SetupIntent -> {
+                        when {
+                            intent.lastSetupError?.code == SetupIntent.Error.CODE_AUTHENTICATION_ERROR -> {
+                                context.resources.getString(R.string.stripe_failure_reason_authentication)
+                            }
+                            intent.lastSetupError?.type == SetupIntent.Error.Type.CardError -> {
+                                intent.lastSetupError.message
+                            }
+                            else -> {
+                                null
+                            }
+                        }
+                    }
+                    else -> null
+                }
+            }
+            outcome == StripeIntentResult.Outcome.TIMEDOUT -> {
+                context.resources.getString(R.string.stripe_failure_reason_timed_out)
+            }
+            else -> {
+                null
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
@@ -13,45 +13,51 @@ internal class PaymentFlowFailureMessageFactory(
     fun create(
         intent: StripeIntent,
         @StripeIntentResult.Outcome outcome: Int
-    ): String? {
-        return when {
-            intent.status == StripeIntent.Status.RequiresPaymentMethod -> {
-                when (intent) {
-                    is PaymentIntent -> {
-                        when {
-                            intent.lastPaymentError?.code == PaymentIntent.Error.CODE_AUTHENTICATION_ERROR -> {
-                                context.resources.getString(R.string.stripe_failure_reason_authentication)
-                            }
-                            intent.lastPaymentError?.type == PaymentIntent.Error.Type.CardError -> {
-                                intent.lastPaymentError.message
-                            }
-                            else -> {
-                                null
-                            }
-                        }
-                    }
-                    is SetupIntent -> {
-                        when {
-                            intent.lastSetupError?.code == SetupIntent.Error.CODE_AUTHENTICATION_ERROR -> {
-                                context.resources.getString(R.string.stripe_failure_reason_authentication)
-                            }
-                            intent.lastSetupError?.type == SetupIntent.Error.Type.CardError -> {
-                                intent.lastSetupError.message
-                            }
-                            else -> {
-                                null
-                            }
-                        }
-                    }
-                    else -> null
+    ) = when {
+        intent.status == StripeIntent.Status.RequiresPaymentMethod -> {
+            when (intent) {
+                is PaymentIntent -> {
+                    createForPaymentIntent(intent)
                 }
+                is SetupIntent -> {
+                    createForSetupIntent(intent)
+                }
+                else -> null
             }
-            outcome == StripeIntentResult.Outcome.TIMEDOUT -> {
-                context.resources.getString(R.string.stripe_failure_reason_timed_out)
-            }
-            else -> {
-                null
-            }
+        }
+        outcome == StripeIntentResult.Outcome.TIMEDOUT -> {
+            context.resources.getString(R.string.stripe_failure_reason_timed_out)
+        }
+        else -> {
+            null
+        }
+    }
+
+    private fun createForPaymentIntent(
+        paymentIntent: PaymentIntent
+    ) = when {
+        paymentIntent.lastPaymentError?.code == PaymentIntent.Error.CODE_AUTHENTICATION_ERROR -> {
+            context.resources.getString(R.string.stripe_failure_reason_authentication)
+        }
+        paymentIntent.lastPaymentError?.type == PaymentIntent.Error.Type.CardError -> {
+            paymentIntent.lastPaymentError.message
+        }
+        else -> {
+            null
+        }
+    }
+
+    private fun createForSetupIntent(
+        setupIntent: SetupIntent
+    ) = when {
+        setupIntent.lastSetupError?.code == SetupIntent.Error.CODE_AUTHENTICATION_ERROR -> {
+            context.resources.getString(R.string.stripe_failure_reason_authentication)
+        }
+        setupIntent.lastSetupError?.type == SetupIntent.Error.Type.CardError -> {
+            setupIntent.lastSetupError.message
+        }
+        else -> {
+            null
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -1,0 +1,138 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import com.stripe.android.Logger
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.SetupIntentResult
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal class PaymentFlowResultProcessor(
+    context: Context,
+    private val publishableKey: String,
+    private val stripeRepository: StripeRepository,
+    enableLogging: Boolean,
+    private val workContext: CoroutineContext
+) {
+    private val logger = Logger.getInstance(enableLogging)
+    private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
+
+    internal suspend fun processPaymentIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): PaymentIntentResult = withContext(workContext) {
+        val result = unvalidatedResult.validate()
+
+        @StripeIntentResult.Outcome val flowOutcome = result.flowOutcome
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = result.stripeAccountId
+        )
+
+        val paymentIntent = requireNotNull(
+            stripeRepository.retrievePaymentIntent(
+                result.clientSecret,
+                requestOptions,
+                expandFields = EXPAND_PAYMENT_METHOD
+            )
+        )
+        if (result.shouldCancelSource && paymentIntent.requiresAction()) {
+            val canceledPaymentIntent = cancelPaymentIntent(
+                paymentIntent,
+                requestOptions,
+                result.sourceId.orEmpty(),
+            )
+            PaymentIntentResult(
+                canceledPaymentIntent,
+                flowOutcome,
+                failureMessageFactory.create(paymentIntent, flowOutcome)
+            )
+        } else {
+            PaymentIntentResult(
+                paymentIntent,
+                flowOutcome,
+                failureMessageFactory.create(paymentIntent, flowOutcome)
+            )
+        }
+    }
+
+    internal suspend fun processSetupIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): SetupIntentResult = withContext(workContext) {
+        val result = unvalidatedResult.validate()
+
+        @StripeIntentResult.Outcome val flowOutcome = result.flowOutcome
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = result.stripeAccountId
+        )
+
+        val setupIntent = requireNotNull(
+            stripeRepository.retrieveSetupIntent(
+                result.clientSecret,
+                requestOptions,
+                expandFields = EXPAND_PAYMENT_METHOD
+            )
+        )
+        if (result.shouldCancelSource && setupIntent.requiresAction()) {
+            val canceledSetupIntent = cancelSetupIntent(
+                setupIntent,
+                requestOptions,
+                result.sourceId.orEmpty(),
+            )
+            SetupIntentResult(
+                canceledSetupIntent,
+                flowOutcome,
+                failureMessageFactory.create(setupIntent, flowOutcome)
+            )
+        } else {
+            SetupIntentResult(
+                setupIntent,
+                flowOutcome,
+                failureMessageFactory.create(setupIntent, flowOutcome)
+            )
+        }
+    }
+
+    private suspend fun cancelPaymentIntent(
+        paymentIntent: PaymentIntent,
+        requestOptions: ApiRequest.Options,
+        sourceId: String
+    ): PaymentIntent {
+        logger.debug("Canceling source '$sourceId' for PaymentIntent")
+
+        return requireNotNull(
+            stripeRepository.cancelPaymentIntentSource(
+                paymentIntent.id.orEmpty(),
+                sourceId,
+                requestOptions,
+            )
+        )
+    }
+
+    private suspend fun cancelSetupIntent(
+        setupIntent: SetupIntent,
+        requestOptions: ApiRequest.Options,
+        sourceId: String
+    ): SetupIntent {
+        logger.debug("Canceling source '$sourceId' for SetupIntent")
+
+        return requireNotNull(
+            stripeRepository.cancelSetupIntentSource(
+                setupIntent.id.orEmpty(),
+                sourceId,
+                requestOptions,
+            )
+        )
+    }
+
+    private companion object {
+        private val EXPAND_PAYMENT_METHOD = listOf("payment_method")
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -926,42 +926,6 @@ internal class StripePaymentControllerTest {
             )
     }
 
-    @Test
-    fun `cancelPaymentIntent should call cancelPaymentIntentSource`() = testDispatcher.runBlockingTest {
-        controller.cancelPaymentIntent(
-            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            REQUEST_OPTIONS,
-            StripeIntentResult.Outcome.CANCELED,
-            "src_123",
-            paymentIntentResultCallback
-        )
-
-        verify(paymentIntentResultCallback).onSuccess(
-            argWhere { result ->
-                result.intent == PaymentIntentFixtures.CANCELLED &&
-                    result.outcome == StripeIntentResult.Outcome.CANCELED
-            }
-        )
-    }
-
-    @Test
-    fun `cancelSetupIntent should call cancelSetupIntentSource`() = testDispatcher.runBlockingTest {
-        controller.cancelSetupIntent(
-            SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
-            REQUEST_OPTIONS,
-            StripeIntentResult.Outcome.CANCELED,
-            "src_123",
-            setupIntentResultCallback
-        )
-
-        verify(setupIntentResultCallback).onSuccess(
-            argWhere { result ->
-                result.intent == SetupIntentFixtures.CANCELLED &&
-                    result.outcome == StripeIntentResult.Outcome.CANCELED
-            }
-        )
-    }
-
     private fun createController(
         stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>? = null,

--- a/stripe/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.payments
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentFlowFailureMessageFactoryTest {
+
+    private val factory = PaymentFlowFailureMessageFactory(
+        ApplicationProvider.getApplicationContext()
+    )
+
+    @Test
+    fun `create() with PaymentIntent with lastPaymentError`() {
+        assertThat(
+            factory.create(
+                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+                StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "We are unable to authenticate your payment method. Please choose a different payment method and try again."
+        )
+    }
+
+    @Test
+    fun `create() with SetupIntent with lastPaymentError`() {
+        assertThat(
+            factory.create(
+                SetupIntentFixtures.SI_WITH_LAST_PAYMENT_ERROR.copy(
+                    status = StripeIntent.Status.RequiresPaymentMethod
+                ),
+                StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "We are unable to authenticate your payment method. Please choose a different payment method and try again."
+        )
+    }
+
+    @Test
+    fun `create() with timed out outcome`() {
+        assertThat(
+            factory.create(
+                SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
+                StripeIntentResult.Outcome.TIMEDOUT
+            )
+        ).isEqualTo(
+            "Timed out authenticating your payment method -- try again"
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/payments/PaymentFlowResultProcessorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/PaymentFlowResultProcessorTest.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.payments
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.SetupIntentResult
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.networking.ApiRequest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+internal class PaymentFlowResultProcessorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val processor = PaymentFlowResultProcessor(
+        ApplicationProvider.getApplicationContext(),
+        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        FakeStripeRepository(),
+        false,
+        testDispatcher
+    )
+
+    @Test
+    fun `processPaymentIntent() when shouldCancelSource=true should return canceled PaymentIntent`() = testDispatcher.runBlockingTest {
+        val paymentIntentResult = processor.processPaymentIntent(
+            PaymentFlowResult.Unvalidated(
+                clientSecret = "client_secret",
+                flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                shouldCancelSource = true
+            )
+        )
+
+        assertThat(paymentIntentResult)
+            .isEqualTo(
+                PaymentIntentResult(
+                    intent = PaymentIntentFixtures.CANCELLED,
+                    outcomeFromFlow = StripeIntentResult.Outcome.CANCELED,
+                )
+            )
+    }
+
+    @Test
+    fun `processSetupIntent() when shouldCancelSource=true should return canceled SetupIntent`() = testDispatcher.runBlockingTest {
+        val setupIntentResult = processor.processSetupIntent(
+            PaymentFlowResult.Unvalidated(
+                clientSecret = "client_secret",
+                flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                shouldCancelSource = true
+            )
+        )
+
+        assertThat(setupIntentResult)
+            .isEqualTo(
+                SetupIntentResult(
+                    intent = SetupIntentFixtures.CANCELLED,
+                    outcomeFromFlow = StripeIntentResult.Outcome.CANCELED,
+                )
+            )
+    }
+
+    private class FakeStripeRepository : AbsFakeStripeRepository() {
+        override suspend fun retrieveSetupIntent(
+            clientSecret: String,
+            options: ApiRequest.Options,
+            expandFields: List<String>
+        ) = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT
+
+        override suspend fun retrievePaymentIntent(
+            clientSecret: String,
+            options: ApiRequest.Options,
+            expandFields: List<String>
+        ) = PaymentIntentFixtures.PI_REQUIRES_REDIRECT
+
+        override suspend fun cancelPaymentIntentSource(
+            paymentIntentId: String,
+            sourceId: String,
+            options: ApiRequest.Options
+        ) = PaymentIntentFixtures.CANCELLED
+
+        override suspend fun cancelSetupIntentSource(
+            setupIntentId: String,
+            sourceId: String,
+            options: ApiRequest.Options
+        ) = SetupIntentFixtures.CANCELLED
+    }
+}


### PR DESCRIPTION
Move payment handling logic from `StripePaymentController` to
`PaymentFlowResultProcessor`.

Move failure message creation logic to
`PaymentFlowFailureMessageFactory`.

This will also allow this logic to be reused in `DefaultFlowController`.