### PR TITLE
Integrate PaymentFlowResultProcessor in DefaultFlowController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -24,9 +24,9 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.DefaultPaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowFailureMessageFactory
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
@@ -79,7 +79,7 @@ internal class StripePaymentController internal constructor(
     private val workContext: CoroutineContext = Dispatchers.IO
 ) : PaymentController {
     private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
-    private val paymentFlowResultProcessor = PaymentFlowResultProcessor(
+    private val paymentFlowResultProcessor = DefaultPaymentFlowResultProcessor(
         context,
         publishableKey,
         stripeRepository,

--- a/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
@@ -10,7 +10,7 @@ import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import com.stripe.android.view.PaymentAuthWebViewActivity
 import kotlinx.parcelize.Parcelize
 
-internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWebViewContract.Args, PaymentFlowResult>() {
+internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWebViewContract.Args, PaymentFlowResult.Unvalidated>() {
     override fun createIntent(
         context: Context,
         input: Args?
@@ -32,7 +32,7 @@ internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWe
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): PaymentFlowResult? {
+    ): PaymentFlowResult.Unvalidated? {
         return intent?.getParcelableExtra(EXTRA_ARGS)
     }
 

--- a/stripe/src/main/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessor.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessor.kt
@@ -1,0 +1,129 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import com.stripe.android.Logger
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.SetupIntentResult
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultPaymentFlowResultProcessor(
+    context: Context,
+    private val publishableKey: String,
+    private val stripeRepository: StripeRepository,
+    enableLogging: Boolean,
+    private val workContext: CoroutineContext
+) : PaymentFlowResultProcessor {
+    private val logger = Logger.getInstance(enableLogging)
+    private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
+
+    override suspend fun processPaymentIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): PaymentIntentResult = withContext(workContext) {
+        val result = unvalidatedResult.validate()
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = result.stripeAccountId
+        )
+
+        requireNotNull(
+            stripeRepository.retrievePaymentIntent(
+                result.clientSecret,
+                requestOptions,
+                expandFields = EXPAND_PAYMENT_METHOD
+            )
+        ).let { paymentIntent ->
+            if (result.shouldCancelSource && paymentIntent.requiresAction()) {
+                cancelPaymentIntent(
+                    paymentIntent,
+                    requestOptions,
+                    result.sourceId.orEmpty(),
+                )
+            } else {
+                paymentIntent
+            }
+        }.let { paymentIntent ->
+            PaymentIntentResult(
+                paymentIntent,
+                result.flowOutcome,
+                failureMessageFactory.create(paymentIntent, result.flowOutcome)
+            )
+        }
+    }
+
+    override suspend fun processSetupIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): SetupIntentResult = withContext(workContext) {
+        val result = unvalidatedResult.validate()
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = result.stripeAccountId
+        )
+
+        requireNotNull(
+            stripeRepository.retrieveSetupIntent(
+                result.clientSecret,
+                requestOptions,
+                expandFields = EXPAND_PAYMENT_METHOD
+            )
+        ).let { setupIntent ->
+            if (result.shouldCancelSource && setupIntent.requiresAction()) {
+                cancelSetupIntent(
+                    setupIntent,
+                    requestOptions,
+                    result.sourceId.orEmpty(),
+                )
+            } else {
+                setupIntent
+            }
+        }.let { setupIntent ->
+            SetupIntentResult(
+                setupIntent,
+                result.flowOutcome,
+                failureMessageFactory.create(setupIntent, result.flowOutcome)
+            )
+        }
+    }
+
+    private suspend fun cancelPaymentIntent(
+        paymentIntent: PaymentIntent,
+        requestOptions: ApiRequest.Options,
+        sourceId: String
+    ): PaymentIntent {
+        logger.debug("Canceling source '$sourceId' for PaymentIntent")
+
+        return requireNotNull(
+            stripeRepository.cancelPaymentIntentSource(
+                paymentIntent.id.orEmpty(),
+                sourceId,
+                requestOptions,
+            )
+        )
+    }
+
+    private suspend fun cancelSetupIntent(
+        setupIntent: SetupIntent,
+        requestOptions: ApiRequest.Options,
+        sourceId: String
+    ): SetupIntent {
+        logger.debug("Canceling source '$sourceId' for SetupIntent")
+
+        return requireNotNull(
+            stripeRepository.cancelSetupIntentSource(
+                setupIntent.id.orEmpty(),
+                sourceId,
+                requestOptions,
+            )
+        )
+    }
+
+    private companion object {
+        private val EXPAND_PAYMENT_METHOD = listOf("payment_method")
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -1,129 +1,14 @@
 package com.stripe.android.payments
 
-import android.content.Context
-import com.stripe.android.Logger
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.SetupIntentResult
-import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.SetupIntent
-import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.StripeRepository
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 
-internal class PaymentFlowResultProcessor(
-    context: Context,
-    private val publishableKey: String,
-    private val stripeRepository: StripeRepository,
-    enableLogging: Boolean,
-    private val workContext: CoroutineContext
-) {
-    private val logger = Logger.getInstance(enableLogging)
-    private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
-
-    internal suspend fun processPaymentIntent(
+internal interface PaymentFlowResultProcessor {
+    suspend fun processPaymentIntent(
         unvalidatedResult: PaymentFlowResult.Unvalidated
-    ): PaymentIntentResult = withContext(workContext) {
-        val result = unvalidatedResult.validate()
+    ): PaymentIntentResult
 
-        val requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = result.stripeAccountId
-        )
-
-        requireNotNull(
-            stripeRepository.retrievePaymentIntent(
-                result.clientSecret,
-                requestOptions,
-                expandFields = EXPAND_PAYMENT_METHOD
-            )
-        ).let { paymentIntent ->
-            if (result.shouldCancelSource && paymentIntent.requiresAction()) {
-                cancelPaymentIntent(
-                    paymentIntent,
-                    requestOptions,
-                    result.sourceId.orEmpty(),
-                )
-            } else {
-                paymentIntent
-            }
-        }.let { paymentIntent ->
-            PaymentIntentResult(
-                paymentIntent,
-                result.flowOutcome,
-                failureMessageFactory.create(paymentIntent, result.flowOutcome)
-            )
-        }
-    }
-
-    internal suspend fun processSetupIntent(
+    suspend fun processSetupIntent(
         unvalidatedResult: PaymentFlowResult.Unvalidated
-    ): SetupIntentResult = withContext(workContext) {
-        val result = unvalidatedResult.validate()
-
-        val requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = result.stripeAccountId
-        )
-
-        requireNotNull(
-            stripeRepository.retrieveSetupIntent(
-                result.clientSecret,
-                requestOptions,
-                expandFields = EXPAND_PAYMENT_METHOD
-            )
-        ).let { setupIntent ->
-            if (result.shouldCancelSource && setupIntent.requiresAction()) {
-                cancelSetupIntent(
-                    setupIntent,
-                    requestOptions,
-                    result.sourceId.orEmpty(),
-                )
-            } else {
-                setupIntent
-            }
-        }.let { setupIntent ->
-            SetupIntentResult(
-                setupIntent,
-                result.flowOutcome,
-                failureMessageFactory.create(setupIntent, result.flowOutcome)
-            )
-        }
-    }
-
-    private suspend fun cancelPaymentIntent(
-        paymentIntent: PaymentIntent,
-        requestOptions: ApiRequest.Options,
-        sourceId: String
-    ): PaymentIntent {
-        logger.debug("Canceling source '$sourceId' for PaymentIntent")
-
-        return requireNotNull(
-            stripeRepository.cancelPaymentIntentSource(
-                paymentIntent.id.orEmpty(),
-                sourceId,
-                requestOptions,
-            )
-        )
-    }
-
-    private suspend fun cancelSetupIntent(
-        setupIntent: SetupIntent,
-        requestOptions: ApiRequest.Options,
-        sourceId: String
-    ): SetupIntent {
-        logger.debug("Canceling source '$sourceId' for SetupIntent")
-
-        return requireNotNull(
-            stripeRepository.cancelSetupIntentSource(
-                setupIntent.id.orEmpty(),
-                sourceId,
-                requestOptions,
-            )
-        )
-    }
-
-    private companion object {
-        private val EXPAND_PAYMENT_METHOD = listOf("payment_method")
-    }
+    ): SetupIntentResult
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -6,6 +6,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSessionPrefs
 import com.stripe.android.StripePaymentController
 import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.payments.DefaultPaymentFlowResultProcessor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
@@ -39,6 +40,14 @@ internal class FlowControllerFactory(
             )
         }
 
+        val paymentFlowResultProcessor = DefaultPaymentFlowResultProcessor(
+            activity,
+            config.publishableKey,
+            stripeRepository,
+            enableLogging = false,
+            Dispatchers.IO
+        )
+
         return DefaultFlowController(
             activity = activity,
             flowControllerInitializer = DefaultFlowControllerInitializer(
@@ -49,6 +58,7 @@ internal class FlowControllerFactory(
                 workContext = Dispatchers.IO
             ),
             paymentControllerFactory = paymentControllerFactory,
+            paymentFlowResultProcessor = paymentFlowResultProcessor,
             eventReporter = DefaultEventReporter(
                 mode = EventReporter.Mode.Custom,
                 sessionId,

--- a/stripe/src/test/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessorTest.kt
@@ -19,10 +19,10 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-internal class PaymentFlowResultProcessorTest {
+internal class DefaultPaymentFlowResultProcessorTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val processor = PaymentFlowResultProcessor(
+    private val processor = DefaultPaymentFlowResultProcessor(
         ApplicationProvider.getApplicationContext(),
         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         FakeStripeRepository(),


### PR DESCRIPTION
Convert `PaymentFlowResultProcessor` to an interface and move
implementation to `DefaultPaymentFlowResultProcessor`.

This allows `DefaultFlowController` to handle payment authentication
results.