### PR TITLE
Update PaymentOptionsActivity onUserCancel() logic

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -214,11 +214,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     }
 
     override fun onUserCancel() {
-        animateOut(
-            PaymentOptionResult.Canceled(
-                mostRecentError = viewModel.fatal.value
-            )
-        )
+        animateOut(viewModel.getPaymentOptionResult())
     }
 
     override fun hideSheet() {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -48,6 +48,14 @@ internal class PaymentOptionsViewModel(
         _userSelection.value = paymentSelection
     }
 
+    fun getPaymentOptionResult(): PaymentOptionResult {
+        return selection.value?.let {
+            PaymentOptionResult.Succeeded(it)
+        } ?: PaymentOptionResult.Canceled(
+            mostRecentError = fatal.value
+        )
+    }
+
     internal enum class TransitionTarget(
         val sheetMode: SheetMode
     ) {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -60,6 +60,26 @@ class PaymentOptionsViewModelTest {
             .isNull()
     }
 
+    @Test
+    fun `getPaymentOptionResult() after selection is set should return Succeeded`() {
+        viewModel.updateSelection(SELECTION_SAVED_PAYMENT_METHOD)
+
+        assertThat(
+            viewModel.getPaymentOptionResult()
+        ).isEqualTo(
+            PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD)
+        )
+    }
+
+    @Test
+    fun `getPaymentOptionResult() when selection is not set should return Canceled`() {
+        assertThat(
+            viewModel.getPaymentOptionResult()
+        ).isEqualTo(
+            PaymentOptionResult.Canceled(null)
+        )
+    }
+
     private companion object {
         private val SELECTION_SAVED_PAYMENT_METHOD = PaymentSelection.Saved(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD


### PR DESCRIPTION
## Summary
When user cancels the payment options selection sheet, the
`PaymentOptionResult` should represent the currently selected option
if one is available.

## Motivation
Better user experience.

## Testing
Unit + manual testing.