### PR TITLE
Create Stripe3ds2CompletionContract

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -26,6 +26,7 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.Stripe3ds2CompletionContract
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
@@ -75,6 +76,7 @@ internal class StripePaymentController internal constructor(
     private val alipayRepository: AlipayRepository = DefaultAlipayRepository(stripeRepository),
     private val paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>? = null,
     private val paymentAuthWebViewLauncher: ActivityResultLauncher<PaymentAuthWebViewContract.Args>? = null,
+    private val stripe3ds2ChallengeLauncher: ActivityResultLauncher<Intent>? = null,
     private val workContext: CoroutineContext = Dispatchers.IO,
     private val resources: Resources = context.applicationContext.resources
 ) : PaymentController {
@@ -818,11 +820,11 @@ internal class StripePaymentController internal constructor(
             stripe3ds2Fingerprint.directoryServerEncryption.keyId,
             challengeCompletionIntent = Intent(activity, Stripe3ds2CompletionActivity::class.java)
                 .putExtra(
-                    Stripe3ds2CompletionActivity.EXTRA_CLIENT_SECRET,
+                    Stripe3ds2CompletionContract.EXTRA_CLIENT_SECRET,
                     stripeIntent.clientSecret
                 )
                 .putExtra(
-                    Stripe3ds2CompletionActivity.EXTRA_STRIPE_ACCOUNT,
+                    Stripe3ds2CompletionContract.EXTRA_STRIPE_ACCOUNT,
                     requestOptions.stripeAccount
                 )
                 .addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT),

--- a/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.stripe3ds2.transaction.ChallengeCompletionIntentStarter
+import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
+import com.stripe.android.view.ActivityStarter
+import com.stripe.android.view.Stripe3ds2CompletionActivity
+
+internal class Stripe3ds2CompletionContract :
+    ActivityResultContract<Intent, PaymentFlowResult.Unvalidated>() {
+    override fun createIntent(
+        context: Context,
+        input: Intent?
+    ): Intent {
+        return Intent(context, Stripe3ds2CompletionActivity::class.java)
+            .putExtra(ActivityStarter.Args.EXTRA, input)
+            .addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?
+    ): PaymentFlowResult.Unvalidated {
+        return intent?.let {
+            parsePaymentFlowResult(it)
+        } ?: PaymentFlowResult.Unvalidated()
+    }
+
+    fun parsePaymentFlowResult(
+        intent: Intent
+    ): PaymentFlowResult.Unvalidated {
+        return PaymentFlowResult.Unvalidated(
+            clientSecret = intent.getStringExtra(EXTRA_CLIENT_SECRET),
+            flowOutcome = parseFlowOutcome(intent),
+            stripeAccountId = intent.getStringExtra(EXTRA_STRIPE_ACCOUNT)
+        )
+    }
+
+    private fun parseFlowOutcome(intent: Intent): Int {
+        val outcomeOrdinal = intent.getIntExtra(
+            ChallengeCompletionIntentStarter.EXTRA_OUTCOME,
+            UNKNOWN_FLOW_OUTCOME
+        )
+
+        return if (outcomeOrdinal == UNKNOWN_FLOW_OUTCOME) {
+            StripeIntentResult.Outcome.UNKNOWN
+        } else {
+            when (ChallengeFlowOutcome.values()[outcomeOrdinal]) {
+                ChallengeFlowOutcome.CompleteSuccessful ->
+                    StripeIntentResult.Outcome.SUCCEEDED
+                ChallengeFlowOutcome.Cancel ->
+                    StripeIntentResult.Outcome.CANCELED
+                ChallengeFlowOutcome.Timeout ->
+                    StripeIntentResult.Outcome.TIMEDOUT
+                ChallengeFlowOutcome.CompleteUnsuccessful,
+                ChallengeFlowOutcome.ProtocolError,
+                ChallengeFlowOutcome.RuntimeError ->
+                    StripeIntentResult.Outcome.FAILED
+            }
+        }
+    }
+
+    internal companion object {
+        const val EXTRA_CLIENT_SECRET = "extra_client_secret"
+        const val EXTRA_STRIPE_ACCOUNT = "extra_stripe_account"
+        private const val UNKNOWN_FLOW_OUTCOME = -1
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
@@ -48,7 +48,7 @@ internal class Stripe3ds2CompletionContract :
         return if (outcomeOrdinal == UNKNOWN_FLOW_OUTCOME) {
             StripeIntentResult.Outcome.UNKNOWN
         } else {
-            when (ChallengeFlowOutcome.values()[outcomeOrdinal]) {
+            when (ChallengeFlowOutcome.values().toList().getOrNull(outcomeOrdinal)) {
                 ChallengeFlowOutcome.CompleteSuccessful ->
                     StripeIntentResult.Outcome.SUCCEEDED
                 ChallengeFlowOutcome.Cancel ->
@@ -59,6 +59,7 @@ internal class Stripe3ds2CompletionContract :
                 ChallengeFlowOutcome.ProtocolError,
                 ChallengeFlowOutcome.RuntimeError ->
                     StripeIntentResult.Outcome.FAILED
+                else -> StripeIntentResult.Outcome.UNKNOWN
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -16,6 +16,7 @@ import com.stripe.android.googlepay.StripeGooglePayEnvironment
 import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.Stripe3ds2CompletionContract
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionResult
@@ -82,11 +83,18 @@ internal class DefaultFlowController internal constructor(
         // TODO(mshafrir-stripe): handle result
     }
 
+    private val stripe3ds2ChallengeLauncher = activity.registerForActivityResult(
+        Stripe3ds2CompletionContract()
+    ) { result ->
+        // TODO(mshafrir-stripe): handle result
+    }
+
     private val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
 
     private val paymentController = paymentControllerFactory.create(
         paymentRelayLauncher = paymentRelayLauncher,
-        paymentAuthWebViewLauncher = paymentAuthWebViewLauncher
+        paymentAuthWebViewLauncher = paymentAuthWebViewLauncher,
+        stripe3ds2ChallengeLauncher = stripe3ds2ChallengeLauncher
     )
 
     override fun init(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -28,14 +28,15 @@ internal class FlowControllerFactory(
             config.publishableKey
         )
 
-        val paymentControllerFactory = PaymentControllerFactory { paymentRelayLauncher, paymentAuthWebViewLauncher ->
+        val paymentControllerFactory = PaymentControllerFactory { paymentRelayLauncher, paymentAuthWebViewLauncher, stripe3ds2ChallengeLauncher ->
             StripePaymentController(
                 activity,
                 config.publishableKey,
                 stripeRepository,
                 enableLogging = true,
                 paymentRelayLauncher = paymentRelayLauncher,
-                paymentAuthWebViewLauncher = paymentAuthWebViewLauncher
+                paymentAuthWebViewLauncher = paymentAuthWebViewLauncher,
+                stripe3ds2ChallengeLauncher = stripe3ds2ChallengeLauncher
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
+import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentRelayStarter
@@ -8,6 +9,7 @@ import com.stripe.android.auth.PaymentAuthWebViewContract
 internal fun interface PaymentControllerFactory {
     fun create(
         paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>,
-        paymentAuthWebViewLauncher: ActivityResultLauncher<PaymentAuthWebViewContract.Args>
+        paymentAuthWebViewLauncher: ActivityResultLauncher<PaymentAuthWebViewContract.Args>,
+        stripe3ds2ChallengeLauncher: ActivityResultLauncher<Intent>
     ): PaymentController
 }

--- a/stripe/src/main/java/com/stripe/android/view/Stripe3ds2CompletionActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/Stripe3ds2CompletionActivity.kt
@@ -5,45 +5,13 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import com.stripe.android.StripeIntentResult
-import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.stripe3ds2.transaction.ChallengeCompletionIntentStarter
-import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
+import com.stripe.android.payments.Stripe3ds2CompletionContract
 import com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION
 
 class Stripe3ds2CompletionActivity : AppCompatActivity() {
-
-    private val flowOutcome: Int by lazy {
-        val outcomeOrdinal = intent.getIntExtra(
-            ChallengeCompletionIntentStarter.EXTRA_OUTCOME,
-            UNKNOWN_FLOW_OUTCOME
-        )
-
-        if (outcomeOrdinal == UNKNOWN_FLOW_OUTCOME) {
-            StripeIntentResult.Outcome.UNKNOWN
-        } else {
-            when (ChallengeFlowOutcome.values()[outcomeOrdinal]) {
-                ChallengeFlowOutcome.CompleteSuccessful ->
-                    StripeIntentResult.Outcome.SUCCEEDED
-                ChallengeFlowOutcome.Cancel ->
-                    StripeIntentResult.Outcome.CANCELED
-                ChallengeFlowOutcome.Timeout ->
-                    StripeIntentResult.Outcome.TIMEDOUT
-                ChallengeFlowOutcome.CompleteUnsuccessful,
-                ChallengeFlowOutcome.ProtocolError,
-                ChallengeFlowOutcome.RuntimeError ->
-                    StripeIntentResult.Outcome.FAILED
-            }
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val result = PaymentFlowResult.Unvalidated(
-            clientSecret = intent.getStringExtra(EXTRA_CLIENT_SECRET),
-            flowOutcome = flowOutcome,
-            stripeAccountId = intent.getStringExtra(EXTRA_STRIPE_ACCOUNT)
-        )
+        val result = Stripe3ds2CompletionContract().parsePaymentFlowResult(intent)
 
         LocalBroadcastManager.getInstance(this)
             .sendBroadcast(Intent().setAction(UL_HANDLE_CHALLENGE_ACTION))
@@ -53,11 +21,5 @@ class Stripe3ds2CompletionActivity : AppCompatActivity() {
                 .putExtras(result.toBundle())
         )
         finish()
-    }
-
-    internal companion object {
-        const val EXTRA_CLIENT_SECRET = "extra_client_secret"
-        const val EXTRA_STRIPE_ACCOUNT = "extra_stripe_account"
-        private const val UNKNOWN_FLOW_OUTCOME = -1
     }
 }

--- a/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.payments
+
+import android.app.Activity
+import android.content.Intent
+import androidx.core.os.bundleOf
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class Stripe3ds2CompletionContractTest {
+
+    @Test
+    fun `parseResult() with populated extras should return valid PaymentFlowResult`() {
+        assertThat(
+            Stripe3ds2CompletionContract().parseResult(
+                Activity.RESULT_OK,
+                Intent()
+                    .putExtras(
+                        bundleOf(
+                            "extra_client_secret" to "client_secret_123",
+                            "extra_outcome" to ChallengeFlowOutcome.Timeout.ordinal,
+                            "extra_stripe_account" to "acct_123"
+                        )
+                    )
+            ).validate()
+        ).isEqualTo(
+            PaymentFlowResult.Validated(
+                clientSecret = "client_secret_123",
+                flowOutcome = StripeIntentResult.Outcome.TIMEDOUT,
+                stripeAccountId = "acct_123"
+            )
+        )
+    }
+
+    @Test
+    fun `parseResult() with empty Intent should return empty unvalidated PaymentFlowResult`() {
+        assertThat(
+            Stripe3ds2CompletionContract().parseResult(
+                Activity.RESULT_OK,
+                Intent()
+            )
+        ).isEqualTo(
+            PaymentFlowResult.Unvalidated()
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
@@ -37,6 +37,29 @@ class Stripe3ds2CompletionContractTest {
     }
 
     @Test
+    fun `parseResult() with out of bounds ordinal should return valid PaymentFlowResult`() {
+        assertThat(
+            Stripe3ds2CompletionContract().parseResult(
+                Activity.RESULT_OK,
+                Intent()
+                    .putExtras(
+                        bundleOf(
+                            "extra_client_secret" to "client_secret_123",
+                            "extra_outcome" to 5000,
+                            "extra_stripe_account" to "acct_123"
+                        )
+                    )
+            ).validate()
+        ).isEqualTo(
+            PaymentFlowResult.Validated(
+                clientSecret = "client_secret_123",
+                flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
+                stripeAccountId = "acct_123"
+            )
+        )
+    }
+
+    @Test
     fun `parseResult() with empty Intent should return empty unvalidated PaymentFlowResult`() {
         assertThat(
             Stripe3ds2CompletionContract().parseResult(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -421,7 +421,7 @@ class DefaultFlowControllerTest {
         return DefaultFlowController(
             activity,
             flowControllerInitializer,
-            { _, _ -> paymentController },
+            { _, _, _ -> paymentController },
             eventReporter,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             null,


### PR DESCRIPTION
## Summary
- Create activity launcher and pass to `StripePaymentController`
  via `DefaultFlowController`
- Move parsing logic to `Stripe3ds2CompletionContract`

## Motivation
This will be used to start `Stripe3ds2CompletionActivity` by way
of the 3DS2 SDK in a future PR.

## Testing
Add unit tests
