### PR TITLE
Update integration for 3DS2 SDK 5.1.0

### DIFF
--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     implementation "com.google.android.material:material:$materialVersion"
 
-    implementation "com.stripe:stripe-3ds2-android:5.0.1"
+    implementation "com.stripe:stripe-3ds2-android:5.1.0"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionContract.kt
@@ -3,70 +3,34 @@ package com.stripe.android.payments
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
-import com.stripe.android.StripeIntentResult
-import com.stripe.android.stripe3ds2.transaction.ChallengeCompletionIntentStarter
-import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
-import com.stripe.android.view.ActivityStarter
 import com.stripe.android.view.Stripe3ds2CompletionActivity
 
 internal class Stripe3ds2CompletionContract :
-    ActivityResultContract<Intent, PaymentFlowResult.Unvalidated>() {
+    ActivityResultContract<PaymentFlowResult.Unvalidated, PaymentFlowResult.Unvalidated>() {
     override fun createIntent(
         context: Context,
-        input: Intent?
+        input: PaymentFlowResult.Unvalidated?
     ): Intent {
         return Intent(context, Stripe3ds2CompletionActivity::class.java)
-            .putExtra(ActivityStarter.Args.EXTRA, input)
-            .addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT)
+            .also { intent ->
+                if (input != null) {
+                    intent.putExtras(input.toBundle())
+                }
+            }
     }
 
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
     ): PaymentFlowResult.Unvalidated {
-        return intent?.let {
-            parsePaymentFlowResult(it)
-        } ?: PaymentFlowResult.Unvalidated()
+        return parsePaymentFlowResult(intent)
     }
 
-    fun parsePaymentFlowResult(
-        intent: Intent
-    ): PaymentFlowResult.Unvalidated {
-        return PaymentFlowResult.Unvalidated(
-            clientSecret = intent.getStringExtra(EXTRA_CLIENT_SECRET),
-            flowOutcome = parseFlowOutcome(intent),
-            stripeAccountId = intent.getStringExtra(EXTRA_STRIPE_ACCOUNT)
-        )
-    }
-
-    private fun parseFlowOutcome(intent: Intent): Int {
-        val outcomeOrdinal = intent.getIntExtra(
-            ChallengeCompletionIntentStarter.EXTRA_OUTCOME,
-            UNKNOWN_FLOW_OUTCOME
-        )
-
-        return if (outcomeOrdinal == UNKNOWN_FLOW_OUTCOME) {
-            StripeIntentResult.Outcome.UNKNOWN
-        } else {
-            when (ChallengeFlowOutcome.values().toList().getOrNull(outcomeOrdinal)) {
-                ChallengeFlowOutcome.CompleteSuccessful ->
-                    StripeIntentResult.Outcome.SUCCEEDED
-                ChallengeFlowOutcome.Cancel ->
-                    StripeIntentResult.Outcome.CANCELED
-                ChallengeFlowOutcome.Timeout ->
-                    StripeIntentResult.Outcome.TIMEDOUT
-                ChallengeFlowOutcome.CompleteUnsuccessful,
-                ChallengeFlowOutcome.ProtocolError,
-                ChallengeFlowOutcome.RuntimeError ->
-                    StripeIntentResult.Outcome.FAILED
-                else -> StripeIntentResult.Outcome.UNKNOWN
-            }
-        }
+    fun parsePaymentFlowResult(intent: Intent?): PaymentFlowResult.Unvalidated {
+        return intent?.getParcelableExtra(EXTRA_ARGS) ?: PaymentFlowResult.Unvalidated()
     }
 
     internal companion object {
-        const val EXTRA_CLIENT_SECRET = "extra_client_secret"
-        const val EXTRA_STRIPE_ACCOUNT = "extra_stripe_account"
-        private const val UNKNOWN_FLOW_OUTCOME = -1
+        const val EXTRA_ARGS = "extra_args"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/Stripe3ds2CompletionStarter.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.payments
+
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.view.AuthActivityStarter
+import com.stripe.android.view.Stripe3ds2CompletionActivity
+
+internal sealed class Stripe3ds2CompletionStarter : AuthActivityStarter<PaymentFlowResult.Unvalidated> {
+    class Modern(
+        private val launcher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>
+    ) : Stripe3ds2CompletionStarter() {
+        override fun start(args: PaymentFlowResult.Unvalidated) {
+            launcher.launch(args)
+        }
+    }
+
+    class Legacy(
+        private val host: AuthActivityStarter.Host,
+        private val requestCode: Int
+    ) : Stripe3ds2CompletionStarter() {
+        override fun start(args: PaymentFlowResult.Unvalidated) {
+            host.startActivityForResult(
+                Stripe3ds2CompletionActivity::class.java,
+                args.toBundle(),
+                requestCode
+            )
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -90,7 +90,7 @@ internal class DefaultFlowController internal constructor(
     private val stripe3ds2ChallengeLauncher = activity.registerForActivityResult(
         Stripe3ds2CompletionContract()
     ) { result ->
-        // TODO(mshafrir-stripe): handle result
+        onPaymentFlowResult(result)
     }
 
     private val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
@@ -407,7 +407,8 @@ internal class DefaultFlowController internal constructor(
     ): PaymentResult {
         val paymentIntent = paymentIntentResult.intent
         return when {
-            paymentIntent.status == StripeIntent.Status.Succeeded -> {
+            paymentIntent.status == StripeIntent.Status.Succeeded ||
+                paymentIntent.status == StripeIntent.Status.RequiresCapture -> {
                 PaymentResult.Succeeded(paymentIntent)
             }
             paymentIntentResult.outcome == StripeIntentResult.Outcome.CANCELED -> {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
@@ -1,15 +1,15 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
-import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.auth.PaymentAuthWebViewContract
+import com.stripe.android.payments.PaymentFlowResult
 
 internal fun interface PaymentControllerFactory {
     fun create(
         paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>,
         paymentAuthWebViewLauncher: ActivityResultLauncher<PaymentAuthWebViewContract.Args>,
-        stripe3ds2ChallengeLauncher: ActivityResultLauncher<Intent>
+        stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>
     ): PaymentController
 }

--- a/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/Stripe3ds2CompletionContractTest.kt
@@ -2,10 +2,8 @@ package com.stripe.android.payments
 
 import android.app.Activity
 import android.content.Intent
-import androidx.core.os.bundleOf
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.StripeIntentResult
-import com.stripe.android.stripe3ds2.transaction.ChallengeFlowOutcome
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -20,11 +18,11 @@ class Stripe3ds2CompletionContractTest {
                 Activity.RESULT_OK,
                 Intent()
                     .putExtras(
-                        bundleOf(
-                            "extra_client_secret" to "client_secret_123",
-                            "extra_outcome" to ChallengeFlowOutcome.Timeout.ordinal,
-                            "extra_stripe_account" to "acct_123"
-                        )
+                        PaymentFlowResult.Unvalidated(
+                            clientSecret = "client_secret_123",
+                            flowOutcome = StripeIntentResult.Outcome.TIMEDOUT,
+                            stripeAccountId = "acct_123"
+                        ).toBundle()
                     )
             ).validate()
         ).isEqualTo(
@@ -43,11 +41,11 @@ class Stripe3ds2CompletionContractTest {
                 Activity.RESULT_OK,
                 Intent()
                     .putExtras(
-                        bundleOf(
-                            "extra_client_secret" to "client_secret_123",
-                            "extra_outcome" to 5000,
-                            "extra_stripe_account" to "acct_123"
-                        )
+                        PaymentFlowResult.Unvalidated(
+                            clientSecret = "client_secret_123",
+                            flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
+                            stripeAccountId = "acct_123"
+                        ).toBundle()
                     )
             ).validate()
         ).isEqualTo(


### PR DESCRIPTION
- Update 3DS2 SDK to `5.1.0`
- Start `Stripe3ds2CompletionActivity` in `StripePaymentController`
  instead of in 3DS2 SDK
- Handle result of 3DS2 challenge flow in `DefaultFlowController`
- Treat `RequiresCapture` status as success in `DefaultFlowController`