### PR TITLE
Refactor PaymentSheetActivity and view model

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -22,7 +22,7 @@ internal class PaymentSheetAddCardFragment(
     }
 
     override fun onGooglePaySelected() {
-        sheetViewModel.checkout(requireActivity())
+        sheetViewModel.checkout()
     }
 
     override fun onConfigReady(config: AddPaymentMethodConfig) {

--- a/stripe/src/test/java/com/stripe/android/payments/FakePaymentFlowResultProcessor.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/FakePaymentFlowResultProcessor.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.payments
+
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.SetupIntentResult
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+
+internal class FakePaymentFlowResultProcessor : PaymentFlowResultProcessor {
+    var error: Throwable? = null
+
+    var paymentIntentResult = PaymentIntentResult(
+        PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+        StripeIntentResult.Outcome.FAILED
+    )
+
+    var setupIntentResult = SetupIntentResult(
+        SetupIntentFixtures.SI_WITH_LAST_PAYMENT_ERROR,
+        StripeIntentResult.Outcome.FAILED
+    )
+
+    override suspend fun processPaymentIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): PaymentIntentResult {
+        return error?.let {
+            throw it
+        } ?: paymentIntentResult
+    }
+
+    override suspend fun processSetupIntent(
+        unvalidatedResult: PaymentFlowResult.Unvalidated
+    ): SetupIntentResult {
+        return error?.let {
+            throw it
+        } ?: setupIntentResult
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import android.content.Context
-import android.content.Intent
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -12,16 +11,18 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
-import com.stripe.android.StripePaymentController
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
@@ -30,7 +31,6 @@ import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
-import com.stripe.android.view.PaymentRelayActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -57,6 +57,7 @@ internal class PaymentSheetActivityTest {
         PaymentMethod("payment_method_id", 0, false, PaymentMethod.Type.Card)
     )
 
+    private val paymentFlowResultProcessor = FakePaymentFlowResultProcessor()
     private val googlePayRepository = FakeGooglePayRepository(true)
     private val stripeRepository = FakeStripeRepository(PAYMENT_INTENT, paymentMethods)
     private val eventReporter = mock<EventReporter>()
@@ -65,12 +66,7 @@ internal class PaymentSheetActivityTest {
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
         stripeRepository = stripeRepository,
-        paymentController = StripePaymentController(
-            context,
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            stripeRepository,
-            workContext = testDispatcher
-        ),
+        paymentFlowResultProcessor = paymentFlowResultProcessor,
         googlePayRepository = googlePayRepository,
         prefsRepository = mock(),
         eventReporter = eventReporter,
@@ -218,40 +214,39 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isFalse()
 
-            // payment intent was confirmed and result will be communicated through PaymentRelayActivity
-            val nextActivity = shadowOf(activity).peekNextStartedActivity()
-            assertThat(nextActivity.component?.className)
-                .isEqualTo(PaymentRelayActivity::class.java.name)
+            assertThat(viewModel.startConfirm.value)
+                .isEqualTo(
+                    ConfirmPaymentIntentParams(
+                        clientSecret = "client_secret",
+                        paymentMethodId = "pm_123456789"
+                    )
+                )
         }
     }
 
     @Test
-    fun `reports successful payment intent result`() {
+    fun `successful payment should dismiss bottom sheet`() {
+        paymentFlowResultProcessor.paymentIntentResult = PaymentIntentResult(
+            intent = PAYMENT_INTENT.copy(status = StripeIntent.Status.Succeeded),
+            outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED
+        )
+
         val scenario = activityScenario()
         scenario.launch(intent).onActivity { activity ->
             // wait for bottom sheet to animate in
             testDispatcher.advanceTimeBy(500)
             idleLooper()
 
-            viewModel.onActivityResult(
-                StripePaymentController.PAYMENT_REQUEST_CODE,
-                Intent().apply {
-                    putExtras(
-                        PaymentFlowResult.Unvalidated(
-                            "client_secret",
-                            StripeIntentResult.Outcome.SUCCEEDED
-                        ).toBundle()
-                    )
-                }
+            viewModel.onPaymentFlowResult(
+                PaymentFlowResult.Unvalidated(
+                    "client_secret",
+                    StripeIntentResult.Outcome.SUCCEEDED
+                )
             )
             idleLooper()
 
             assertThat(activity.bottomSheetBehavior.state)
                 .isEqualTo(BottomSheetBehavior.STATE_HIDDEN)
-            assertThat(contract.parseResult(0, shadowOf(activity).resultIntent))
-                .isEqualTo(
-                    PaymentResult.Succeeded(PAYMENT_INTENT)
-                )
         }
     }
 
@@ -261,12 +256,7 @@ internal class PaymentSheetActivityTest {
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeAccountId = null,
             stripeRepository = FakeStripeRepository(PAYMENT_INTENT, listOf()),
-            paymentController = StripePaymentController(
-                context,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                stripeRepository,
-                workContext = testDispatcher
-            ),
+            paymentFlowResultProcessor = paymentFlowResultProcessor,
             googlePayRepository = googlePayRepository,
             prefsRepository = mock(),
             eventReporter = eventReporter,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1,17 +1,9 @@
 package com.stripe.android.paymentsheet
 
-import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
-import com.stripe.android.ApiResultCallback
-import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.googlepay.StripeGooglePayContract
@@ -26,6 +18,8 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.FakePaymentFlowResultProcessor
+import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -38,10 +32,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.Mockito.verifyNoInteractions
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
@@ -54,18 +46,10 @@ internal class PaymentSheetViewModelTest {
 
     private val googlePayRepository = FakeGooglePayRepository(true)
     private val stripeRepository: StripeRepository = FakeStripeRepository(PAYMENT_INTENT)
-    private val paymentController: PaymentController = mock()
     private val prefsRepository = mock<PrefsRepository>()
     private val eventReporter = mock<EventReporter>()
     private val viewModel: PaymentSheetViewModel by lazy { createViewModel() }
-
-    private val callbackCaptor = argumentCaptor<ApiResultCallback<PaymentIntentResult>>()
-
-    @BeforeTest
-    fun before() {
-        whenever(paymentController.shouldHandlePaymentResult(any(), any()))
-            .thenReturn(true)
-    }
+    private val paymentFlowResultProcessor = FakePaymentFlowResultProcessor()
 
     @AfterTest
     fun cleanup() {
@@ -119,79 +103,82 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should not attempt to confirm when no payment selection has been mode`() {
-        verifyNoInteractions(paymentController)
-        viewModel.checkout(mock())
+        viewModel.checkout()
         verify(prefsRepository).savePaymentSelection(null)
     }
 
     @Test
     fun `checkout() should confirm saved payment methods`() {
+        val confirmParams = mutableListOf<ConfirmPaymentIntentParams>()
+        viewModel.startConfirm.observeForever {
+            confirmParams.add(it)
+        }
+
         val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(mock())
+        viewModel.checkout()
 
         verify(prefsRepository).savePaymentSelection(paymentSelection)
-        verify(paymentController).startConfirmAndAuth(
-            any(),
-            eq(
+
+        assertThat(confirmParams)
+            .containsExactly(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     requireNotNull(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id),
                     CLIENT_SECRET
                 )
-            ),
-            eq(
-                ApiRequest.Options(
-                    "publishable_key",
-                    "stripe_account_id",
-                )
             )
-        )
     }
 
     @Test
     fun `checkout() should confirm new payment methods`() {
+        val confirmParams = mutableListOf<ConfirmPaymentIntentParams>()
+        viewModel.startConfirm.observeForever {
+            confirmParams.add(it)
+        }
+
         val paymentSelection = PaymentSelection.New.Card(
             PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             CardBrand.Visa,
             shouldSavePaymentMethod = true
         )
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(mock())
+        viewModel.checkout()
 
-        verify(prefsRepository).savePaymentSelection(paymentSelection)
-        verify(paymentController).startConfirmAndAuth(
-            any(),
-            eq(
+        assertThat(confirmParams)
+            .containsExactly(
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     CLIENT_SECRET,
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                 )
-            ),
-            eq(
-                ApiRequest.Options(
-                    "publishable_key",
-                    "stripe_account_id",
-                )
             )
-        )
+
+        verify(prefsRepository).savePaymentSelection(paymentSelection)
     }
 
     @Test
-    fun `onActivityResult() should update ViewState LiveData`() {
+    fun `onPaymentFlowResult() should update ViewState LiveData`() {
+        paymentFlowResultProcessor.paymentIntentResult = PAYMENT_INTENT_RESULT
+
+        val confirmParams = mutableListOf<ConfirmPaymentIntentParams>()
+        viewModel.startConfirm.observeForever {
+            confirmParams.add(it)
+        }
+
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         viewModel.updateSelection(selection)
-
-        whenever(paymentController.handlePaymentResult(any(), callbackCaptor.capture())).doAnswer {
-            callbackCaptor.lastValue.onSuccess(PAYMENT_INTENT_RESULT)
-        }
 
         var viewState: ViewState? = null
         viewModel.viewState.observeForever {
             viewState = it
         }
 
-        viewModel.onActivityResult(0, Intent())
+        viewModel.onPaymentFlowResult(
+            PaymentFlowResult.Unvalidated(
+                "client_secret",
+                StripeIntentResult.Outcome.SUCCEEDED
+            )
+        )
         assertThat(viewState)
             .isEqualTo(
                 ViewState.Completed(PAYMENT_INTENT_RESULT)
@@ -202,35 +189,32 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `onActivityResult() with non-success outcome should report failure event`() {
+    fun `onPaymentFlowResult() with non-success outcome should report failure event`() {
+        paymentFlowResultProcessor.paymentIntentResult = PAYMENT_INTENT_RESULT.copy(
+            outcomeFromFlow = StripeIntentResult.Outcome.FAILED
+        )
+
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         viewModel.updateSelection(selection)
 
-        whenever(paymentController.handlePaymentResult(any(), callbackCaptor.capture())).doAnswer {
-            callbackCaptor.lastValue.onSuccess(
-                PAYMENT_INTENT_RESULT.copy(
-                    outcomeFromFlow = StripeIntentResult.Outcome.FAILED
-                )
-            )
-        }
-
-        viewModel.onActivityResult(0, Intent())
+        viewModel.onPaymentFlowResult(
+            PaymentFlowResult.Unvalidated()
+        )
         verify(eventReporter)
             .onPaymentFailure(selection)
     }
 
     @Test
-    fun `onActivityResult() should update emit API errors`() {
+    fun `onPaymentFlowResult() should update emit API errors`() {
+        paymentFlowResultProcessor.error = RuntimeException("Your card was declined.")
+
         var userMessage: SheetViewModel.UserMessage? = null
         viewModel.userMessage.observeForever {
             userMessage = it
         }
-        whenever(paymentController.handlePaymentResult(any(), callbackCaptor.capture())).doAnswer {
-            callbackCaptor.lastValue.onError(
-                RuntimeException("Your card was declined.")
-            )
-        }
-        viewModel.onActivityResult(0, Intent())
+        viewModel.onPaymentFlowResult(
+            PaymentFlowResult.Unvalidated()
+        )
         assertThat(userMessage)
             .isEqualTo(
                 SheetViewModel.UserMessage.Error("Your card was declined.")
@@ -238,7 +222,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `onActivityResult with successful Google Pay result should emit on googlePayCompletion`() {
+    fun `onGooglePayResult() with successful Google Pay result should emit on googlePayCompletion`() {
         val paymentIntentResults = mutableListOf<PaymentIntentResult>()
         viewModel.googlePayCompletion.observeForever { paymentIntentResult ->
             if (paymentIntentResult != null) {
@@ -405,7 +389,7 @@ internal class PaymentSheetViewModelTest {
             "publishable_key",
             "stripe_account_id",
             stripeRepository,
-            paymentController,
+            paymentFlowResultProcessor,
             googlePayRepository,
             prefsRepository,
             eventReporter,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.R
-import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.googlepay.StripeGooglePayEnvironment
@@ -25,10 +24,9 @@ import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionResult
@@ -554,26 +552,6 @@ class DefaultFlowControllerTest {
                 IllegalStateException("Failed to initialize")
             )
         }
-    }
-
-    private class FakePaymentFlowResultProcessor : PaymentFlowResultProcessor {
-        var paymentIntentResult = PaymentIntentResult(
-            PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-            StripeIntentResult.Outcome.FAILED
-        )
-
-        var setupIntentResult = SetupIntentResult(
-            SetupIntentFixtures.SI_WITH_LAST_PAYMENT_ERROR,
-            StripeIntentResult.Outcome.FAILED
-        )
-
-        override suspend fun processPaymentIntent(
-            unvalidatedResult: PaymentFlowResult.Unvalidated
-        ): PaymentIntentResult = paymentIntentResult
-
-        override suspend fun processSetupIntent(
-            unvalidatedResult: PaymentFlowResult.Unvalidated
-        ): SetupIntentResult = setupIntentResult
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
Use Activity Result API to start and handle results from various
payment authentication activities.

With this change we can remove `onActivityResult()`

## Motivation
Simplify

## Testing
Updated unit tests and manually verified
