### PR TITLE
Update alpha of BuyButton label

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
@@ -36,6 +36,8 @@ internal class BuyButton @JvmOverloads constructor(
     private val _completedAnimation = MutableLiveData<ViewState.Completed>()
     internal val completedAnimation = _completedAnimation.distinctUntilChanged()
 
+    private var viewState: ViewState? = null
+
     init {
         setBackgroundResource(R.drawable.stripe_paymentsheet_buy_button_default_background)
 
@@ -82,9 +84,13 @@ internal class BuyButton @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
         viewBinding.lockIcon.isVisible = enabled
+        updateAlpha()
     }
 
     override fun updateState(viewState: ViewState) {
+        this.viewState = viewState
+        updateAlpha()
+
         when (viewState) {
             is ViewState.Ready -> {
                 onReadyState(viewState)
@@ -95,6 +101,14 @@ internal class BuyButton @JvmOverloads constructor(
             is ViewState.Completed -> {
                 onCompletedState(viewState)
             }
+        }
+    }
+
+    private fun updateAlpha() {
+        if ((viewState == null || viewState is ViewState.Ready) && !isEnabled) {
+            viewBinding.label.alpha = 0.5f
+        } else {
+            viewBinding.label.alpha = 1.0f
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
@@ -32,4 +32,29 @@ class BuyButtonTest {
             "Processing…"
         )
     }
+
+    @Test
+    fun `label alpha is initially 50%`() {
+        assertThat(buyButton.viewBinding.label.alpha)
+            .isEqualTo(0.5f)
+    }
+
+    @Test
+    fun `after viewState ready and disabled, label alpha is 100%`() {
+        buyButton.onReadyState(
+            ViewState.Ready(amount = 1099, currencyCode = "usd")
+        )
+        assertThat(buyButton.viewBinding.label.alpha)
+            .isEqualTo(0.5f)
+    }
+
+    @Test
+    fun `after viewState ready and enabled, label alpha is 100%`() {
+        buyButton.onReadyState(
+            ViewState.Ready(amount = 1099, currencyCode = "usd")
+        )
+        buyButton.isEnabled = true
+        assertThat(buyButton.viewBinding.label.alpha)
+            .isEqualTo(1.0f)
+    }
 }


### PR DESCRIPTION
Set label alpha to 50% when the view is disabled and not processing.