### PR TITLE
Fix PaymentRelayActivity intent parsing

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentRelayContract.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.view.ActivityStarter
 import com.stripe.android.view.PaymentRelayActivity
 
 internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter.Args, PaymentFlowResult.Unvalidated>() {
@@ -12,8 +11,9 @@ internal class PaymentRelayContract : ActivityResultContract<PaymentRelayStarter
         context: Context,
         input: PaymentRelayStarter.Args?
     ): Intent {
+        val paymentFlowResult = input?.toResult() ?: PaymentFlowResult.Unvalidated()
         return Intent(context, PaymentRelayActivity::class.java)
-            .putExtra(ActivityStarter.Args.EXTRA, input)
+            .putExtras(paymentFlowResult.toBundle())
     }
 
     override fun parseResult(

--- a/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentRelayActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.stripe.android.payments.PaymentFlowResult
 import com.ults.listeners.SdkChallengeInterface.UL_HANDLE_CHALLENGE_ACTION
 
 /**
@@ -15,15 +16,18 @@ internal class PaymentRelayActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         LocalBroadcastManager.getInstance(this)
             .sendBroadcast(Intent().setAction(UL_HANDLE_CHALLENGE_ACTION))
+
+        val paymentFlowResult = PaymentFlowResult.Unvalidated.fromIntent(intent)
+
         setResult(
             Activity.RESULT_OK,
             Intent()
-                .apply {
-                    intent.extras?.let {
-                        putExtras(it)
-                    }
-                }
+                .putExtras(paymentFlowResult.toBundle())
         )
+    }
+
+    override fun onResume() {
+        super.onResume()
         finish()
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.view
 
-import android.app.Activity
 import android.content.Context
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -27,14 +26,13 @@ class PaymentRelayActivityTest {
             PaymentRelayStarter.Args.PaymentIntentArgs(
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
             )
-        ) { activity ->
-            assertThat(
-                contract.parseResult(0, Shadows.shadowOf(activity).resultIntent)
-            ).isEqualTo(
-                PaymentFlowResult.Unvalidated(
-                    clientSecret = "pi_1ExkUeAWhjPjYwPiXph9ouXa_secret_nGTdfGlzL9Uop59wN55LraiC7"
+        ) { paymentFlowResult ->
+            assertThat(paymentFlowResult)
+                .isEqualTo(
+                    PaymentFlowResult.Unvalidated(
+                        clientSecret = "pi_1ExkUeAWhjPjYwPiXph9ouXa_secret_nGTdfGlzL9Uop59wN55LraiC7"
+                    )
                 )
-            )
         }
     }
 
@@ -48,20 +46,19 @@ class PaymentRelayActivityTest {
                 exception,
                 requestCode = 50000
             )
-        ) { activity ->
-            assertThat(
-                contract.parseResult(0, Shadows.shadowOf(activity).resultIntent)
-            ).isEqualTo(
-                PaymentFlowResult.Unvalidated(
-                    exception = exception
+        ) { paymentFlowResult ->
+            assertThat(paymentFlowResult)
+                .isEqualTo(
+                    PaymentFlowResult.Unvalidated(
+                        exception = exception
+                    )
                 )
-            )
         }
     }
 
     private fun createActivity(
         args: PaymentRelayStarter.Args,
-        onActivity: (Activity) -> Unit
+        onComplete: (PaymentFlowResult.Unvalidated) -> Unit
     ) {
         ActivityScenario.launch<PaymentRelayActivity>(
             contract.createIntent(
@@ -70,7 +67,9 @@ class PaymentRelayActivityTest {
             )
         ).use { activityScenario ->
             activityScenario.onActivity { activity ->
-                onActivity(activity)
+                onComplete(
+                    contract.parseResult(0, Shadows.shadowOf(activity).resultIntent)
+                )
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
@@ -1,0 +1,77 @@
+package com.stripe.android.view
+
+import android.app.Activity
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentRelayContract
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripeErrorFixtures
+import com.stripe.android.exception.PermissionException
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.payments.PaymentFlowResult
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentRelayActivityTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val contract = PaymentRelayContract()
+
+    @Test
+    fun `activity started with PaymentIntentArgs should finish with expected result`() {
+        createActivity(
+            PaymentRelayStarter.Args.PaymentIntentArgs(
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
+            )
+        ) { activity ->
+            assertThat(
+                contract.parseResult(0, Shadows.shadowOf(activity).resultIntent)
+            ).isEqualTo(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = "pi_1ExkUeAWhjPjYwPiXph9ouXa_secret_nGTdfGlzL9Uop59wN55LraiC7"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `activity started with ErrorArgs should finish with expected result`() {
+        val exception = PermissionException(
+            stripeError = StripeErrorFixtures.INVALID_REQUEST_ERROR
+        )
+        createActivity(
+            PaymentRelayStarter.Args.ErrorArgs(
+                exception,
+                requestCode = 50000
+            )
+        ) { activity ->
+            assertThat(
+                contract.parseResult(0, Shadows.shadowOf(activity).resultIntent)
+            ).isEqualTo(
+                PaymentFlowResult.Unvalidated(
+                    exception = exception
+                )
+            )
+        }
+    }
+
+    private fun createActivity(
+        args: PaymentRelayStarter.Args,
+        onActivity: (Activity) -> Unit
+    ) {
+        ActivityScenario.launch<PaymentRelayActivity>(
+            contract.createIntent(
+                context,
+                args
+            )
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                onActivity(activity)
+            }
+        }
+    }
+}


### PR DESCRIPTION


## Summary
Ensure that the same extra key is used regardless of how
`PaymentRelayActivity` is started.


## Testing
Unit tests + manually verified
