### PR TITLE
Remove unused methods from PaymentSheet.FlowController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import com.stripe.android.PaymentConfiguration
@@ -129,17 +128,6 @@ internal class PaymentSheet internal constructor(
         fun presentPaymentOptions()
 
         fun confirmPayment()
-
-        fun isPaymentResult(
-            requestCode: Int,
-            intent: Intent?
-        ): Boolean
-
-        fun onPaymentResult(
-            requestCode: Int,
-            intent: Intent?,
-            callback: PaymentSheetResultCallback
-        )
 
         sealed class Result {
             object Success : Result()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.Context
-import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
@@ -20,7 +19,6 @@ import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.googlepay.StripeGooglePayEnvironment
-import com.stripe.android.googlepay.StripeGooglePayLauncher
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -254,56 +252,6 @@ class DefaultFlowControllerTest {
                     merchantName = "Widget Store"
                 )
             )
-    }
-
-    @Test
-    fun `isPaymentResult with Google Pay request code should return true`() {
-        assertThat(
-            flowController.isPaymentResult(
-                StripeGooglePayLauncher.REQUEST_CODE,
-                Intent()
-            )
-        ).isTrue()
-    }
-
-    @Test
-    fun `onPaymentResult with Google Pay PaymentIntent result should invoke callback with Succeeded`() {
-        val callback = mock<PaymentSheetResultCallback>()
-        flowController.onPaymentResult(
-            StripeGooglePayLauncher.REQUEST_CODE,
-            Intent().putExtras(
-                StripeGooglePayContract.Result.PaymentIntent(
-                    paymentIntentResult = PAYMENT_INTENT_RESULT
-                ).toBundle()
-            ),
-            callback = callback
-        )
-
-        verify(eventReporter).onPaymentSuccess(PaymentSelection.GooglePay)
-        verify(callback).onPaymentResult(
-            PaymentResult.Succeeded(PAYMENT_INTENT)
-        )
-    }
-
-    @Test
-    fun `onPaymentResult with Google Pay Error result should invoke callback with Failed()`() {
-        val callback = mock<PaymentSheetResultCallback>()
-        flowController.onPaymentResult(
-            StripeGooglePayLauncher.REQUEST_CODE,
-            Intent().putExtras(
-                StripeGooglePayContract.Result.Error(
-                    exception = RuntimeException("Google Pay failed")
-                ).toBundle()
-            ),
-            callback = callback
-        )
-
-        verify(eventReporter).onPaymentFailure(PaymentSelection.GooglePay)
-        verify(callback).onPaymentResult(
-            argWhere { paymentResult ->
-                (paymentResult as? PaymentResult.Failed)?.error?.message == "Google Pay failed"
-            }
-        )
     }
 
     @Test
@@ -558,7 +506,6 @@ class DefaultFlowControllerTest {
         private val SESSION_ID = SessionId()
 
         private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        private val PAYMENT_INTENT_RESULT = PaymentIntentResult(PAYMENT_INTENT)
 
         private val VISA_PAYMENT_OPTION = PaymentOption(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,


### PR DESCRIPTION
`isPaymentResult()` and `onPaymentResult()` are no longer necessary
now that `DefaultFlowController` is using the Activity Result API.