### PR TITLE
Create StripeGooglePayContract.Args.PaymentData

### DIFF
--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
@@ -51,20 +51,20 @@ internal class StripeGooglePayViewModel(
             transactionInfo = GooglePayJsonFactory.TransactionInfo(
                 currencyCode = paymentIntent.currency.orEmpty(),
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
-                countryCode = args.countryCode,
+                countryCode = args.config.countryCode,
                 transactionId = paymentIntent.id,
                 totalPrice = paymentIntent.amount?.toInt(),
                 checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
             ),
             merchantInfo = GooglePayJsonFactory.MerchantInfo(
-                merchantName = args.merchantName ?: appName
+                merchantName = args.config.merchantName ?: appName
             ),
             billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(
                 isRequired = true,
                 format = GooglePayJsonFactory.BillingAddressParameters.Format.Min,
                 isPhoneNumberRequired = false
             ),
-            isEmailRequired = args.isEmailRequired
+            isEmailRequired = args.config.isEmailRequired
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.GooglePayConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.PaymentSessionPrefs
@@ -136,16 +137,18 @@ internal class PaymentSheetViewModel internal constructor(
 
         if (paymentSelection is PaymentSelection.GooglePay) {
             paymentIntent.value?.let { paymentIntent ->
-                _launchGooglePay.value = StripeGooglePayContract.Args(
-                    environment = when (args.config?.googlePay?.environment) {
-                        PaymentSheet.GooglePayConfiguration.Environment.Production ->
-                            StripeGooglePayEnvironment.Production
-                        else ->
-                            StripeGooglePayEnvironment.Test
-                    },
+                _launchGooglePay.value = StripeGooglePayContract.Args.ConfirmPaymentIntent(
                     paymentIntent = paymentIntent,
-                    countryCode = args.googlePayConfig?.countryCode.orEmpty(),
-                    merchantName = args.config?.merchantDisplayName
+                    config = StripeGooglePayContract.GooglePayConfig(
+                        environment = when (args.config?.googlePay?.environment) {
+                            PaymentSheet.GooglePayConfiguration.Environment.Production ->
+                                StripeGooglePayEnvironment.Production
+                            else ->
+                                StripeGooglePayEnvironment.Test
+                        },
+                        countryCode = args.googlePayConfig?.countryCode.orEmpty(),
+                        merchantName = args.config?.merchantDisplayName
+                    )
                 )
             }
         } else {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -168,16 +168,18 @@ internal class DefaultFlowController internal constructor(
         val paymentSelection = viewModel.paymentSelection
         if (paymentSelection == PaymentSelection.GooglePay) {
             googlePayLauncher(
-                StripeGooglePayContract.Args(
-                    environment = when (config?.googlePay?.environment) {
-                        PaymentSheet.GooglePayConfiguration.Environment.Production ->
-                            StripeGooglePayEnvironment.Production
-                        else ->
-                            StripeGooglePayEnvironment.Test
-                    },
+                StripeGooglePayContract.Args.ConfirmPaymentIntent(
                     paymentIntent = initData.paymentIntent,
-                    countryCode = config?.googlePay?.countryCode.orEmpty(),
-                    merchantName = config?.merchantDisplayName
+                    config = StripeGooglePayContract.GooglePayConfig(
+                        environment = when (config?.googlePay?.environment) {
+                            PaymentSheet.GooglePayConfiguration.Environment.Production ->
+                                StripeGooglePayEnvironment.Production
+                            else ->
+                                StripeGooglePayEnvironment.Test
+                        },
+                        countryCode = config?.googlePay?.countryCode.orEmpty(),
+                        merchantName = config?.merchantDisplayName
+                    )
                 )
             )
         } else {

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
@@ -1,0 +1,117 @@
+package com.stripe.android.googlepay
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntentFixtures
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class StripeGooglePayActivityTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val contract = StripeGooglePayContract()
+
+    @BeforeTest
+    fun setup() {
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+    }
+
+    @Test
+    fun `successful start should return Unavailable result`() {
+        createActivity(
+            CONFIRM_ARGS
+        ) { activityScenario ->
+            // Google Pay is only available on a real device
+            assertThat(parseResult(activityScenario))
+                .isInstanceOf(StripeGooglePayContract.Result.Unavailable::class.java)
+        }
+    }
+
+    @Test
+    fun `start should ConfirmPaymentIntent args and manual confirmation should finish with Error result`() {
+        createActivity(
+            CONFIRM_ARGS.copy(
+                paymentIntent = PAYMENT_INTENT.copy(
+                    confirmationMethod = PaymentIntent.ConfirmationMethod.Manual
+                )
+            )
+        ) { activityScenario ->
+            val result = parseResult(activityScenario) as StripeGooglePayContract.Result.Error
+            assertThat(result.exception.message)
+                .isEqualTo(
+                    "StripeGooglePayActivity requires a PaymentIntent with automatic confirmation."
+                )
+        }
+    }
+
+    @Test
+    fun `start without args should finish with Error result`() {
+        ActivityScenario.launch<StripeGooglePayActivity>(
+            Intent(context, StripeGooglePayActivity::class.java)
+        ).use { activityScenario ->
+            assertThat(activityScenario.state)
+                .isEqualTo(Lifecycle.State.DESTROYED)
+            val result = parseResult(activityScenario) as StripeGooglePayContract.Result.Error
+            assertThat(result.exception.message)
+                .isEqualTo(
+                    "StripeGooglePayActivity was started without arguments."
+                )
+        }
+    }
+
+    private fun createActivity(
+        args: StripeGooglePayContract.Args,
+        onCreated: (ActivityScenario<StripeGooglePayActivity>) -> Unit
+    ) {
+        ActivityScenario.launch<StripeGooglePayActivity>(
+            contract.createIntent(
+                context,
+                args
+            )
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                onCreated(activityScenario)
+            }
+        }
+    }
+
+    private fun parseResult(
+        activityScenario: ActivityScenario<*>
+    ): StripeGooglePayContract.Result {
+        return contract.parseResult(0, activityScenario.result.resultData)
+    }
+
+    private companion object {
+        private val CONFIG = StripeGooglePayContract.GooglePayConfig(
+            environment = StripeGooglePayEnvironment.Test,
+            countryCode = "US",
+            isEmailRequired = true
+        )
+
+        private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
+            confirmationMethod = PaymentIntent.ConfirmationMethod.Automatic
+        )
+
+        private val PAYMENT_DATA_ARGS = StripeGooglePayContract.Args.PaymentData(
+            paymentIntent = PAYMENT_INTENT,
+            config = CONFIG
+        )
+
+        private val CONFIRM_ARGS = StripeGooglePayContract.Args.ConfirmPaymentIntent(
+            paymentIntent = PAYMENT_INTENT,
+            config = CONFIG
+        )
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
@@ -29,17 +29,6 @@ class StripeGooglePayActivityTest {
     }
 
     @Test
-    fun `successful start should return Unavailable result`() {
-        createActivity(
-            CONFIRM_ARGS
-        ) { activityScenario ->
-            // Google Pay is only available on a real device
-            assertThat(parseResult(activityScenario))
-                .isInstanceOf(StripeGooglePayContract.Result.Unavailable::class.java)
-        }
-    }
-
-    @Test
     fun `start should ConfirmPaymentIntent args and manual confirmation should finish with Error result`() {
         createActivity(
             CONFIRM_ARGS.copy(

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -105,7 +105,11 @@ class StripeGooglePayViewModelTest {
     fun `createPaymentDataRequestForPaymentIntentArgs() with merchant name should return expected JSON`() {
         assertThat(
             createViewModel(
-                ARGS.copy(merchantName = "Widgets, Inc.")
+                ARGS.copy(
+                    config = CONFIG.copy(
+                        merchantName = "Widgets, Inc."
+                    )
+                )
             ).createPaymentDataRequestForPaymentIntentArgs().toString()
         ).isEqualTo(
             JSONObject(
@@ -167,11 +171,15 @@ class StripeGooglePayViewModelTest {
     private class FakeStripeRepository : AbsFakeStripeRepository()
 
     private companion object {
-        private val ARGS = StripeGooglePayContract.Args(
+        private val CONFIG = StripeGooglePayContract.GooglePayConfig(
             environment = StripeGooglePayEnvironment.Test,
-            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             countryCode = "US",
             isEmailRequired = true
+        )
+
+        private val ARGS = StripeGooglePayContract.Args.ConfirmPaymentIntent(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            config = CONFIG
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -247,11 +247,13 @@ class DefaultFlowControllerTest {
         flowController.confirmPayment()
         assertThat(launchArgs)
             .isEqualTo(
-                StripeGooglePayContract.Args(
-                    environment = StripeGooglePayEnvironment.Test,
+                StripeGooglePayContract.Args.ConfirmPaymentIntent(
                     paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                    countryCode = "US",
-                    merchantName = "Widget Store"
+                    config = StripeGooglePayContract.GooglePayConfig(
+                        environment = StripeGooglePayEnvironment.Test,
+                        countryCode = "US",
+                        merchantName = "Widget Store"
+                    )
                 )
             )
     }


### PR DESCRIPTION
`StripeGooglePayActivity` can now handle both confirming a PaymentIntent
with payment data provided by Google Pay, and returning the payment data
without confirming the PaymentIntent. The latter will be used in
payment sheet.

In a follow up PR, will update `StripeGooglePayActivity`
and payment sheet to support the new args and result types.