### PR TITLE
Update DefaultPrefsRepository and DefaultGooglePayRepository

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultGooglePayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultGooglePayRepository.kt
@@ -10,6 +10,7 @@ import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 
 internal class DefaultGooglePayRepository(
     private val context: Context,
@@ -33,7 +34,7 @@ internal class DefaultGooglePayRepository(
         Wallet.getPaymentsClient(context, options)
     }
 
-    override fun isReady(): Flow<Boolean?> {
+    override fun isReady(): Flow<Boolean> {
         val isReadyState = MutableStateFlow<Boolean?>(null)
 
         val request = IsReadyToPayRequest.fromJson(
@@ -51,6 +52,6 @@ internal class DefaultGooglePayRepository(
                 isReadyState.value = isReady
             }
 
-        return isReadyState
+        return isReadyState.filterNotNull()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
@@ -1,7 +1,12 @@
 package com.stripe.android.paymentsheet
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 interface GooglePayRepository {
-    fun isReady(): Flow<Boolean?>
+    fun isReady(): Flow<Boolean>
+
+    class Disabled : GooglePayRepository {
+        override fun isReady(): Flow<Boolean> = flowOf(false)
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import kotlinx.coroutines.Dispatchers
 
 internal class PaymentOptionsViewModel(
     args: PaymentOptionContract.Args,
@@ -76,15 +77,19 @@ internal class PaymentOptionsViewModel(
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             val starterArgs = starterArgsSupplier()
             val application = applicationSupplier()
-            val googlePayRepository = DefaultGooglePayRepository(
-                application,
-                starterArgs.config?.googlePay?.environment ?: PaymentSheet.GooglePayConfiguration.Environment.Test
-            )
+            val googlePayRepository = starterArgs.config?.googlePay?.environment?.let { environment ->
+                DefaultGooglePayRepository(
+                    application,
+                    environment
+                )
+            } ?: GooglePayRepository.Disabled()
 
             val prefsRepository = starterArgs.config?.customer?.let { (id) ->
                 DefaultPrefsRepository(
                     application,
-                    customerId = id
+                    customerId = id,
+                    googlePayRepository = googlePayRepository,
+                    workContext = Dispatchers.IO
                 )
             } ?: PrefsRepository.Noop()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.GooglePayConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
@@ -295,16 +294,20 @@ internal class PaymentSheetViewModel internal constructor(
             )
 
             val starterArgs = starterArgsSupplier()
-            val googlePayRepository = DefaultGooglePayRepository(
-                application,
-                starterArgs.config?.googlePay?.environment
-                    ?: PaymentSheet.GooglePayConfiguration.Environment.Test
-            )
+
+            val googlePayRepository = starterArgs.config?.googlePay?.environment?.let { environment ->
+                DefaultGooglePayRepository(
+                    application,
+                    environment
+                )
+            } ?: GooglePayRepository.Disabled()
 
             val prefsRepository = starterArgs.config?.customer?.let { (id) ->
                 DefaultPrefsRepository(
                     application,
-                    customerId = id
+                    customerId = id,
+                    googlePayRepository = googlePayRepository,
+                    workContext = Dispatchers.IO
                 )
             } ?: PrefsRepository.Noop()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.model.ConfirmParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -266,11 +267,20 @@ internal class DefaultFlowController internal constructor(
     ) {
         eventReporter.onInit(initData.config)
 
-        val defaultPaymentMethod = initData.paymentMethods.firstOrNull {
-            it.id == initData.defaultPaymentMethodId
-        }
-        viewModel.paymentSelection = defaultPaymentMethod?.let {
-            PaymentSelection.Saved(it)
+        when (val savedString = initData.savedSelection) {
+            SavedSelection.GooglePay -> {
+                PaymentSelection.GooglePay
+            }
+            is SavedSelection.PaymentMethod -> {
+                initData.paymentMethods.firstOrNull {
+                    it.id == savedString.id
+                }?.let {
+                    PaymentSelection.Saved(it)
+                }
+            }
+            else -> null
+        }?.let {
+            viewModel.paymentSelection = it
         }
 
         viewModel.setInitData(initData)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/InitData.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/InitData.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.SavedSelection
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -14,5 +15,5 @@ internal data class InitData(
     val paymentMethodTypes: List<PaymentMethod.Type>,
     // the customer's existing payment methods
     val paymentMethods: List<PaymentMethod>,
-    val defaultPaymentMethodId: String?,
+    val savedSelection: SavedSelection?
 ) : Parcelable

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -123,7 +122,7 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
                 viewModelScope.launch {
                     withContext(workContext) {
                         _isGooglePayReady.postValue(
-                            googlePayRepository.isReady().filterNotNull().first()
+                            googlePayRepository.isReady().first()
                         )
                     }
                 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
@@ -17,9 +17,12 @@ import kotlin.test.Test
 internal class DefaultPrefsRepositoryTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
+    private val googlePayRepository = FakeGooglePayRepository(true)
     private val prefsRepository = DefaultPrefsRepository(
         ApplicationProvider.getApplicationContext(),
-        "cus_123"
+        "cus_123",
+        googlePayRepository,
+        testDispatcher
     )
 
     @Test
@@ -32,6 +35,18 @@ internal class DefaultPrefsRepositoryTest {
         ).isEqualTo(
             SavedSelection.GooglePay
         )
+    }
+
+    @Test
+    fun `save then get GooglePay should return null if Google Pay is not available`() = testDispatcher.runBlockingTest {
+        googlePayRepository.isReady = false
+
+        prefsRepository.savePaymentSelection(
+            PaymentSelection.GooglePay
+        )
+        assertThat(
+            prefsRepository.getSavedSelection()
+        ).isNull()
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/FakeGooglePayRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/FakeGooglePayRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 internal class FakeGooglePayRepository(
-    private val isReady: Boolean
+    internal var isReady: Boolean
 ) : GooglePayRepository {
-    override fun isReady(): Flow<Boolean?> = flowOf(isReady)
+    override fun isReady(): Flow<Boolean> = flowOf(isReady)
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
+
+internal class FakePrefsRepository : PrefsRepository {
+    private var savedSelection: SavedSelection? = null
+
+    override suspend fun getSavedSelection(): SavedSelection? = savedSelection
+
+    override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
+        when (paymentSelection) {
+            PaymentSelection.GooglePay -> {
+                SavedSelection.GooglePay
+            }
+            is PaymentSelection.Saved -> {
+                SavedSelection.PaymentMethod(paymentSelection.paymentMethod.id.orEmpty())
+            }
+            else -> null
+        }.let {
+            savedSelection = it
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -116,7 +117,9 @@ class DefaultFlowControllerTest {
 
         val flowController = createFlowController(
             paymentMethods = paymentMethods,
-            defaultPaymentMethodId = paymentMethods.first().id
+            savedSelection = SavedSelection.PaymentMethod(
+                requireNotNull(paymentMethods.first().id)
+            )
         )
         flowController.configure(
             PaymentSheetFixtures.CLIENT_SECRET,
@@ -420,12 +423,12 @@ class DefaultFlowControllerTest {
 
     private fun createFlowController(
         paymentMethods: List<PaymentMethod> = emptyList(),
-        defaultPaymentMethodId: String? = null
+        savedSelection: SavedSelection? = null
     ): DefaultFlowController {
         return createFlowController(
             FakeFlowControllerInitializer(
                 paymentMethods,
-                defaultPaymentMethodId
+                savedSelection
             )
         )
     }
@@ -450,7 +453,7 @@ class DefaultFlowControllerTest {
 
     private class FakeFlowControllerInitializer(
         private val paymentMethods: List<PaymentMethod>,
-        private val defaultPaymentMethodId: String? = null,
+        private val savedSelection: SavedSelection? = null,
         private val delayMillis: Long = 0L
     ) : FlowControllerInitializer {
         override suspend fun init(
@@ -464,7 +467,7 @@ class DefaultFlowControllerTest {
                     PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     listOf(PaymentMethod.Type.Card),
                     paymentMethods,
-                    defaultPaymentMethodId
+                    savedSelection
                 )
             )
         }


### PR DESCRIPTION


## Summary
- Add `GooglePayRepository` as a dependency of `DefaultPrefsRepository`.
  `SavedSelection.GooglePay` will only be returned if Google Pay is
  available.

- Only create `DefaultGooglePayRepository` if GooglePay has been
  enabled in the configuration.


## Testing
Updated unit tests and manually verified
