### PR TITLE
Improve Google Pay handling in PaymentOptionsAdapter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -27,12 +27,13 @@ internal abstract class BasePaymentMethodsListFragment(
     protected val adapter: PaymentOptionsAdapter by lazy {
         PaymentOptionsAdapter(
             canClickSelectedItem,
-            fragmentViewModel.currentPaymentSelection,
             paymentOptionSelectedListener = ::onPaymentOptionSelected,
             addCardClickListener = {
                 transitionToAddPaymentMethod()
             }
-        )
+        ).also {
+            it.paymentSelection = fragmentViewModel.currentPaymentSelection
+        }
     }
 
     private var _viewBinding: FragmentPaymentsheetPaymentMethodsListBinding? = null
@@ -59,11 +60,15 @@ internal abstract class BasePaymentMethodsListFragment(
 
         sheetViewModel.getSavedSelection()
             .observe(viewLifecycleOwner) { savedSelection ->
-                adapter.defaultPaymentMethodId = when (savedSelection) {
-                    is SavedSelection.PaymentMethod -> savedSelection.id
+                when (savedSelection) {
+                    SavedSelection.GooglePay -> {
+                        adapter.paymentSelection = PaymentSelection.GooglePay
+                    }
+                    is SavedSelection.PaymentMethod -> {
+                        adapter.defaultPaymentMethodId = savedSelection.id
+                    }
                     else -> {
-                        // TODO(mshafrir-stripe): add support for Google Pay
-                        null
+                        // noop
                     }
                 }
             }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -132,6 +132,19 @@ class PaymentOptionsAdapterTest {
             .isEmpty()
     }
 
+    @Test
+    fun `updating paymentSelection to GooglePay should invoke paymentMethodSelectedListener`() {
+        val adapter = createAdapter().also {
+            it.shouldShowGooglePay = true
+        }
+
+        adapter.paymentSelection = PaymentSelection.GooglePay
+        adapter.paymentSelection = PaymentSelection.GooglePay
+        adapter.paymentSelection = PaymentSelection.GooglePay
+        assertThat(paymentSelections)
+            .containsExactly(PaymentSelection.GooglePay)
+    }
+
     private fun createConfiguredAdapter(
         shouldShowGooglePay: Boolean,
         paymentMethodsCount: Int = 6
@@ -145,7 +158,6 @@ class PaymentOptionsAdapterTest {
     private fun createAdapter(): PaymentOptionsAdapter {
         return PaymentOptionsAdapter(
             canClickSelectedItem = false,
-            paymentSelection = null,
             paymentOptionSelectedListener = { paymentSelection, _ ->
                 paymentSelections.add(paymentSelection)
             },


### PR DESCRIPTION
## Summary
Previously, if the customer's saved selection was Google Pay,
the payment options carousel would not automatically select the Google
Pay item. The issue is fixed in this PR.

## Motivation
Improve UX

## Testing
Added unit test + manually verified
