### PR TITLE
Refactor PaymentOptionsActivity selection handling

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/AddButton.kt
@@ -5,11 +5,8 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.distinctUntilChanged
 import com.stripe.android.R
 import com.stripe.android.databinding.PaymentSheetAddButtonBinding
-import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 
 /**
@@ -19,14 +16,11 @@ internal class AddButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : PrimaryButton<PaymentOptionViewState>(context, attrs, defStyleAttr) {
+) : PrimaryButton(context, attrs, defStyleAttr) {
     internal val viewBinding = PaymentSheetAddButtonBinding.inflate(
         LayoutInflater.from(context),
         this
     )
-
-    private val _completed = MutableLiveData<PaymentOptionViewState.Completed>()
-    internal val completed = _completed.distinctUntilChanged()
 
     init {
         setBackgroundResource(R.drawable.stripe_paymentsheet_buy_button_default_background)
@@ -36,22 +30,14 @@ internal class AddButton @JvmOverloads constructor(
         isGone = true
     }
 
-    fun onCompletedState(state: PaymentOptionViewState.Completed) {
-        viewBinding.lockIcon.isVisible = false
-
-        setBackgroundResource(R.drawable.stripe_paymentsheet_buy_button_confirmed_background)
-
-        _completed.value = state
-    }
-
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
         viewBinding.lockIcon.isVisible = enabled
-    }
 
-    override fun updateState(viewState: PaymentOptionViewState) {
-        if (viewState is PaymentOptionViewState.Completed) {
-            onCompletedState(viewState)
+        viewBinding.label.alpha = if (isEnabled) {
+            1.0f
+        } else {
+            0.5f
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -41,7 +41,7 @@ import com.stripe.android.view.StripeEditText
 internal abstract class BaseAddCardFragment(
     private val eventReporter: EventReporter
 ) : Fragment() {
-    abstract val sheetViewModel: SheetViewModel<*, *>
+    abstract val sheetViewModel: SheetViewModel<*>
 
     private var _viewBinding: FragmentPaymentsheetAddCardBinding? = null
     protected val viewBinding get() = requireNotNull(_viewBinding)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -20,7 +20,7 @@ internal abstract class BasePaymentMethodsListFragment(
 ) : Fragment(
     R.layout.fragment_paymentsheet_payment_methods_list
 ) {
-    abstract val sheetViewModel: SheetViewModel<*, *>
+    abstract val sheetViewModel: SheetViewModel<*>
 
     private val fragmentViewModel by viewModels<PaymentMethodsViewModel>()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BuyButton.kt
@@ -21,7 +21,7 @@ internal class BuyButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : PrimaryButton<ViewState>(context, attrs, defStyleAttr) {
+) : PrimaryButton(context, attrs, defStyleAttr) {
     private val animator = PrimaryButtonAnimator(context)
 
     internal val viewBinding = PaymentSheetBuyButtonBinding.inflate(
@@ -87,7 +87,7 @@ internal class BuyButton @JvmOverloads constructor(
         updateAlpha()
     }
 
-    override fun updateState(viewState: ViewState) {
+    fun updateState(viewState: ViewState) {
         this.viewState = viewState
         updateAlpha()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -135,18 +135,8 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     }
 
     private fun setupAddButton(addButton: AddButton) {
-        addButton.completed.observe(this) { completedState ->
-            completedState?.paymentSelection?.let(::onActionCompleted)
-        }
-
-        viewModel.viewState.observe(this) { state ->
-            if (state != null) {
-                addButton.updateState(state)
-            }
-        }
-
         addButton.setOnClickListener {
-            viewModel.selectPaymentOption()
+            viewModel.onUserSelection()
         }
 
         viewModel.processing.observe(this) { isProcessing ->

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -18,6 +18,6 @@ internal class PaymentOptionsAddCardFragment(
     }
 
     override fun onGooglePaySelected() {
-        sheetViewModel.selectPaymentOption()
+        sheetViewModel.onUserSelection()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -44,7 +44,7 @@ internal class PaymentOptionsListFragment(
         super.onPaymentOptionSelected(paymentSelection, isClick)
         if (isClick) {
             // this is a click-triggered selection
-            sheetViewModel.onUserSelection(paymentSelection)
+            sheetViewModel.onUserSelection()
         }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
@@ -18,7 +17,7 @@ internal class PaymentOptionsViewModel(
     googlePayRepository: GooglePayRepository,
     prefsRepository: PrefsRepository,
     private val eventReporter: EventReporter
-) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget, PaymentOptionViewState>(
+) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget>(
     config = args.config,
     isGooglePayEnabled = args.config?.googlePay != null,
     googlePayRepository = googlePayRepository,
@@ -33,19 +32,12 @@ internal class PaymentOptionsViewModel(
         _processing.postValue(false)
     }
 
-    fun selectPaymentOption() {
+    fun onUserSelection() {
         selection.value?.let { paymentSelection ->
             eventReporter.onSelectPaymentOption(paymentSelection)
             prefsRepository.savePaymentSelection(paymentSelection)
-            _viewState.value = PaymentOptionViewState.Completed(paymentSelection)
+            _userSelection.value = paymentSelection
         }
-    }
-
-    fun onUserSelection(
-        paymentSelection: PaymentSelection
-    ) {
-        selectPaymentOption()
-        _userSelection.value = paymentSelection
     }
 
     fun getPaymentOptionResult(): PaymentOptionResult {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.PaymentConfiguration
@@ -48,7 +49,7 @@ internal class PaymentSheetViewModel internal constructor(
     internal val args: PaymentSheetContract.Args,
     private val animateOutMillis: Long,
     workContext: CoroutineContext
-) : SheetViewModel<PaymentSheetViewModel.TransitionTarget, ViewState>(
+) : SheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     config = args.config,
     isGooglePayEnabled = args.isGooglePayEnabled,
     googlePayRepository = googlePayRepository,
@@ -64,6 +65,9 @@ internal class PaymentSheetViewModel internal constructor(
 
     private val _startConfirm = MutableLiveData<ConfirmPaymentIntentParams>()
     internal val startConfirm: LiveData<ConfirmPaymentIntentParams> = _startConfirm
+
+    private val _viewState = MutableLiveData<ViewState>(null)
+    internal val viewState: LiveData<ViewState> = _viewState.distinctUntilChanged()
 
     private val paymentIntentValidator = PaymentIntentValidator()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionViewState.kt
@@ -1,7 +1,0 @@
-package com.stripe.android.paymentsheet.model
-
-internal sealed class PaymentOptionViewState {
-    data class Completed(
-        val paymentSelection: PaymentSelection
-    ) : PaymentOptionViewState()
-}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity() {
-    abstract val viewModel: SheetViewModel<*, *>
+    abstract val viewModel: SheetViewModel<*>
     abstract val bottomSheetController: BottomSheetController
     abstract val eventReporter: EventReporter
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -7,11 +7,8 @@ import android.widget.FrameLayout
 /**
  * The primary call-to-action for a payment sheet screen.
  */
-internal abstract class PrimaryButton<ViewStateType> @JvmOverloads constructor(
+internal abstract class PrimaryButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr) {
-
-    abstract fun updateState(viewState: ViewStateType)
-}
+) : FrameLayout(context, attrs, defStyleAttr)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Base `ViewModel` for activities that use `BottomSheet`.
  */
-internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
+internal abstract class SheetViewModel<TransitionTargetType>(
     internal val config: PaymentSheet.Configuration?,
     private val isGooglePayEnabled: Boolean,
     private val googlePayRepository: GooglePayRepository,
@@ -62,9 +62,6 @@ internal abstract class SheetViewModel<TransitionTargetType, ViewStateType>(
 
     protected val _processing = MutableLiveData(true)
     val processing: LiveData<Boolean> = _processing
-
-    protected val _viewState = MutableLiveData<ViewStateType>(null)
-    internal val viewState: LiveData<ViewStateType> = _viewState.distinctUntilChanged()
 
     // a message shown to the user
     protected val _userMessage = MutableLiveData<UserMessage?>()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/AddButtonTest.kt
@@ -2,8 +2,6 @@ package com.stripe.android.paymentsheet
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.model.PaymentOptionViewState
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -13,12 +11,15 @@ class AddButtonTest {
     private val addButton = AddButton(ApplicationProvider.getApplicationContext())
 
     @Test
-    fun `onCompletedState() should update view`() {
-        addButton.onCompletedState(
-            PaymentOptionViewState.Completed(PaymentSelection.GooglePay)
-        )
-        assertThat(
-            addButton.viewBinding.lockIcon.isShown
-        ).isFalse()
+    fun `initially, label alpha is 50%`() {
+        assertThat(addButton.viewBinding.label.alpha)
+            .isEqualTo(0.5f)
+    }
+
+    @Test
+    fun `after enabled, label alpha is 100%`() {
+        addButton.isEnabled = true
+        assertThat(addButton.viewBinding.label.alpha)
+            .isEqualTo(1.0f)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/BuyButtonTest.kt
@@ -40,7 +40,7 @@ class BuyButtonTest {
     }
 
     @Test
-    fun `after viewState ready and disabled, label alpha is 100%`() {
+    fun `after viewState ready and disabled, label alpha is 50%`() {
         buyButton.onReadyState(
             ViewState.Ready(amount = 1099, currencyCode = "usd")
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
-import com.stripe.android.paymentsheet.model.PaymentOptionViewState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -34,29 +33,29 @@ class PaymentOptionsViewModelTest {
     )
 
     @Test
-    fun `selectPaymentOption() when selection has been made should emit completion view state`() {
-        var viewState: PaymentOptionViewState? = null
-        viewModel.viewState.observeForever {
-            viewState = it
+    fun `onUserSelection() when selection has been made should emit on userSelection`() {
+        var paymentSelection: PaymentSelection? = null
+        viewModel.userSelection.observeForever {
+            paymentSelection = it
         }
         viewModel.updateSelection(SELECTION_SAVED_PAYMENT_METHOD)
 
-        viewModel.selectPaymentOption()
+        viewModel.onUserSelection()
 
-        assertThat(viewState)
-            .isEqualTo(PaymentOptionViewState.Completed(SELECTION_SAVED_PAYMENT_METHOD))
+        assertThat(paymentSelection)
+            .isEqualTo(SELECTION_SAVED_PAYMENT_METHOD)
         verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
 
     @Test
-    fun `selectPaymentOption() when selection has not been made should not emit`() {
-        var viewState: PaymentOptionViewState? = null
-        viewModel.viewState.observeForever {
-            viewState = it
+    fun `onUserSelection() when selection has not been made should not emit`() {
+        var paymentSelection: PaymentSelection? = null
+        viewModel.userSelection.observeForever {
+            paymentSelection = it
         }
-        viewModel.selectPaymentOption()
+        viewModel.onUserSelection()
 
-        assertThat(viewState)
+        assertThat(paymentSelection)
             .isNull()
     }
 


### PR DESCRIPTION


## Summary
- Remove `PaymentOptionViewState`
- Trigger all final sheet selection via
  `PaymentOptionsViewModel#onUserSelection()`
- Unlike `BuyButton`, `AddButton` does not animate. It can only be
  enabled or disabled. Remove unnecessary `ViewState` generic.
- Update alpha of `AddButton` label

## Testing
Manually verified
