### PR TITLE
Add isGoogleReady property to PaymentOptionContract.Args

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
@@ -4,14 +4,13 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 internal class DefaultPrefsRepository(
     private val context: Context,
     private val customerId: String,
-    private val googlePayRepository: GooglePayRepository,
+    private val isGooglePayReady: suspend () -> Boolean,
     private val workContext: CoroutineContext
 ) : PrefsRepository {
     private val prefs: SharedPreferences by lazy {
@@ -23,9 +22,7 @@ internal class DefaultPrefsRepository(
         val key = prefData.firstOrNull()
         when (key) {
             "google_pay" -> {
-                SavedSelection.GooglePay.takeIf {
-                    googlePayRepository.isReady().first()
-                }
+                SavedSelection.GooglePay.takeIf { isGooglePayReady() }
             }
             "payment_method" -> {
                 prefData.getOrNull(1)?.let {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.flowOf
 interface GooglePayRepository {
     fun isReady(): Flow<Boolean>
 
-    class Disabled : GooglePayRepository {
+    object Disabled : GooglePayRepository {
         override fun isReady(): Flow<Boolean> = flowOf(false)
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -30,7 +30,8 @@ internal class PaymentOptionContract : ActivityResultContract<PaymentOptionContr
         val paymentIntent: PaymentIntent,
         val paymentMethods: List<PaymentMethod>,
         val sessionId: SessionId,
-        val config: PaymentSheet.Configuration?
+        val config: PaymentSheet.Configuration?,
+        val isGooglePayReady: Boolean
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -147,7 +147,8 @@ internal class DefaultFlowController internal constructor(
                 paymentIntent = initData.paymentIntent,
                 paymentMethods = initData.paymentMethods,
                 sessionId = sessionId,
-                config = initData.config
+                config = initData.config,
+                isGooglePayReady = initData.isGooglePayReady
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/InitData.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/InitData.kt
@@ -15,5 +15,6 @@ internal data class InitData(
     val paymentMethodTypes: List<PaymentMethod.Type>,
     // the customer's existing payment methods
     val paymentMethods: List<PaymentMethod>,
-    val savedSelection: SavedSelection?
+    val savedSelection: SavedSelection?,
+    val isGooglePayReady: Boolean
 ) : Parcelable

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
@@ -17,11 +17,11 @@ import kotlin.test.Test
 internal class DefaultPrefsRepositoryTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val googlePayRepository = FakeGooglePayRepository(true)
+    private var isGooglePayReady = true
     private val prefsRepository = DefaultPrefsRepository(
         ApplicationProvider.getApplicationContext(),
         "cus_123",
-        googlePayRepository,
+        { isGooglePayReady },
         testDispatcher
     )
 
@@ -39,7 +39,7 @@ internal class DefaultPrefsRepositoryTest {
 
     @Test
     fun `save then get GooglePay should return null if Google Pay is not available`() = testDispatcher.runBlockingTest {
-        googlePayRepository.isReady = false
+        isGooglePayReady = false
 
         prefsRepository.savePaymentSelection(
             PaymentSelection.GooglePay

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -42,9 +42,9 @@ class PaymentOptionsActivityTest {
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
             sessionId = SessionId(),
-            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
+            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+            isGooglePayReady = false
         ),
-        googlePayRepository = FakeGooglePayRepository(false),
         prefsRepository = mock(),
         eventReporter = eventReporter
     )
@@ -131,7 +131,8 @@ class PaymentOptionsActivityTest {
                 paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 paymentMethods = paymentMethods,
                 sessionId = SessionId(),
-                config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
+                config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+                isGooglePayReady = false
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -25,9 +25,9 @@ class PaymentOptionsViewModelTest {
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentMethods = emptyList(),
             sessionId = SessionId(),
-            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY
+            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+            isGooglePayReady = true
         ),
-        googlePayRepository = mock(),
         prefsRepository = mock(),
         eventReporter = eventReporter
     )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentSessionPrefs
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -41,7 +40,8 @@ internal class DefaultFlowControllerInitializerTest {
                     PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     listOf(PaymentMethod.Type.Card),
                     emptyList(),
-                    null
+                    null,
+                    isGooglePayReady = false
                 )
             )
         )
@@ -67,7 +67,8 @@ internal class DefaultFlowControllerInitializerTest {
                     PAYMENT_METHODS,
                     SavedSelection.PaymentMethod(
                         id = "pm_123456789"
-                    )
+                    ),
+                    isGooglePayReady = true
                 )
             )
         )
@@ -90,7 +91,8 @@ internal class DefaultFlowControllerInitializerTest {
                     PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     listOf(PaymentMethod.Type.Card),
                     PAYMENT_METHODS,
-                    SavedSelection.PaymentMethod("pm_123456789")
+                    SavedSelection.PaymentMethod("pm_123456789"),
+                    isGooglePayReady = true
                 )
             )
         )
@@ -138,6 +140,7 @@ internal class DefaultFlowControllerInitializerTest {
         return DefaultFlowControllerInitializer(
             FakeStripeRepository(paymentIntent),
             { _, _ -> prefsRepository },
+            { true },
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             null,
             testDispatcher
@@ -160,22 +163,6 @@ internal class DefaultFlowControllerInitializerTest {
             requestOptions: ApiRequest.Options
         ): List<PaymentMethod> {
             return PAYMENT_METHODS
-        }
-    }
-
-    private class FakePaymentSessionPrefs : PaymentSessionPrefs {
-        var paymentMethodId: String? = null
-        val savedPaymentMethodIds = mutableListOf<Pair<String, String?>>()
-
-        override fun getPaymentMethodId(
-            customerId: String?
-        ): String? = paymentMethodId
-
-        override fun savePaymentMethodId(
-            customerId: String,
-            paymentMethodId: String?
-        ) {
-            savedPaymentMethodIds.add(customerId to paymentMethodId)
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -173,7 +173,8 @@ class DefaultFlowControllerTest {
                     paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     paymentMethods = emptyList(),
                     sessionId = SESSION_ID,
-                    config = null
+                    config = null,
+                    isGooglePayReady = false
                 )
             )
     }
@@ -467,7 +468,8 @@ class DefaultFlowControllerTest {
                     PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     listOf(PaymentMethod.Type.Card),
                     paymentMethods,
-                    savedSelection
+                    savedSelection,
+                    isGooglePayReady = false
                 )
             )
         }
@@ -482,7 +484,8 @@ class DefaultFlowControllerTest {
                     PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     listOf(PaymentMethod.Type.Card),
                     emptyList(),
-                    null
+                    null,
+                    isGooglePayReady = false
                 )
             )
         }


### PR DESCRIPTION
## Summary
Google Pay's availability is determined in `DefaultFlowController`.
Pass this value to `PaymentOptionContract.Args` via `InitData`.

This simplifies `SheetViewModel` - the Google Pay-related logic
can now be moved to `PaymentSheetViewModel`.

## Motivation
Simplify `PaymentOptionsActivity`

## Testing
Tested on real device with Google Pay enabled.
