### PR TITLE
Create FragmentConfig and integrate in payment sheet base fragments

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -109,7 +109,7 @@ internal abstract class BaseAddCardFragment(
         val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
         if (activity == null || nullableConfig == null) {
             sheetViewModel.onFatal(
-                IllegalArgumentException("Failed to start paymnt options fragment.")
+                IllegalArgumentException("Failed to start add payment option fragment.")
             )
             return
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -26,8 +26,9 @@ import com.stripe.android.databinding.StripeVerticalDividerBinding
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
 import com.stripe.android.paymentsheet.ui.BillingAddressView
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
@@ -105,9 +106,15 @@ internal abstract class BaseAddCardFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (activity == null) {
+        val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
+        if (activity == null || nullableConfig == null) {
+            sheetViewModel.onFatal(
+                IllegalArgumentException("Failed to start paymnt options fragment.")
+            )
             return
         }
+
+        val config = nullableConfig
 
         _viewBinding = FragmentPaymentsheetAddCardBinding.bind(view)
 
@@ -162,11 +169,7 @@ internal abstract class BaseAddCardFragment(
 
         setupSaveCardCheckbox(saveCardCheckbox)
 
-        sheetViewModel.fetchAddPaymentMethodConfig().observe(viewLifecycleOwner) { config ->
-            if (config != null) {
-                onConfigReady(config)
-            }
-        }
+        onConfigReady(config)
 
         sheetViewModel.selection.observe(viewLifecycleOwner) { paymentSelection ->
             if (paymentSelection == PaymentSelection.GooglePay) {
@@ -325,7 +328,7 @@ internal abstract class BaseAddCardFragment(
         _viewBinding = null
     }
 
-    open fun onConfigReady(config: AddPaymentMethodConfig) {
+    open fun onConfigReady(config: FragmentConfig) {
         val shouldShowGooglePayButton = config.shouldShowGooglePayButton
         googlePayButton.setOnClickListener {
             sheetViewModel.updateSelection(PaymentSelection.GooglePay)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -9,8 +9,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetPaymentMethodsListBinding
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
 
@@ -21,8 +23,9 @@ internal abstract class BasePaymentMethodsListFragment(
     R.layout.fragment_paymentsheet_payment_methods_list
 ) {
     abstract val sheetViewModel: SheetViewModel<*>
-
     private val fragmentViewModel by viewModels<PaymentMethodsViewModel>()
+
+    protected lateinit var config: FragmentConfig
 
     protected val adapter: PaymentOptionsAdapter by lazy {
         PaymentOptionsAdapter(
@@ -44,6 +47,15 @@ internal abstract class BasePaymentMethodsListFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
+        if (nullableConfig == null) {
+            sheetViewModel.onFatal(
+                IllegalArgumentException("Failed to start paymnt options fragment.")
+            )
+            return
+        }
+        this.config = nullableConfig
+
         // If we're returning to this fragment from elsewhere, we need to reset the selection to
         // whatever the user had selected previously
         sheetViewModel.updateSelection(fragmentViewModel.currentPaymentSelection)
@@ -58,28 +70,19 @@ internal abstract class BasePaymentMethodsListFragment(
         )
         viewBinding.recycler.adapter = adapter
 
-        sheetViewModel.getSavedSelection()
-            .observe(viewLifecycleOwner) { savedSelection ->
-                when (savedSelection) {
-                    SavedSelection.GooglePay -> {
-                        adapter.paymentSelection = PaymentSelection.GooglePay
-                    }
-                    is SavedSelection.PaymentMethod -> {
-                        adapter.defaultPaymentMethodId = savedSelection.id
-                    }
-                    else -> {
-                        // noop
-                    }
-                }
+        when (val savedSelection = config.savedSelection) {
+            SavedSelection.GooglePay -> {
+                adapter.paymentSelection = PaymentSelection.GooglePay
             }
-
-        sheetViewModel.paymentMethods.observe(viewLifecycleOwner) { paymentMethods ->
-            adapter.paymentMethods = paymentMethods
+            is SavedSelection.PaymentMethod -> {
+                adapter.defaultPaymentMethodId = savedSelection.id
+            }
+            SavedSelection.None -> {
+                // noop
+            }
         }
-
-        sheetViewModel.isGooglePayReady.observe(viewLifecycleOwner) { isGooglePayReady ->
-            adapter.shouldShowGooglePay = isGooglePayReady
-        }
+        adapter.shouldShowGooglePay = config.isGooglePayReady
+        adapter.paymentMethods = config.paymentMethods
 
         eventReporter.onShowExistingPaymentOptions()
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -50,12 +50,18 @@ internal abstract class BasePaymentMethodsListFragment(
         val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
         if (nullableConfig == null) {
             sheetViewModel.onFatal(
-                IllegalArgumentException("Failed to start paymnt options fragment.")
+                IllegalArgumentException("Failed to start existing payment options fragment.")
             )
-            return
+        } else {
+            this.config = nullableConfig
+            onPostViewCreated(view, nullableConfig)
         }
-        this.config = nullableConfig
+    }
 
+    open fun onPostViewCreated(
+        view: View,
+        fragmentConfig: FragmentConfig
+    ) {
         // If we're returning to this fragment from elsewhere, we need to reset the selection to
         // whatever the user had selected previously
         sheetViewModel.updateSelection(fragmentViewModel.currentPaymentSelection)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -30,7 +30,10 @@ internal class PaymentOptionsAdapter(
             if (sortedPaymentMethods != field) {
                 field = sortedPaymentMethods
                 notifyDataSetChanged()
-                updatePaymentSelection(defaultPaymentMethodId)
+
+                if (paymentSelection == null) {
+                    updatePaymentSelection(defaultPaymentMethodId)
+                }
             }
         }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentOptionsListFragment(
@@ -32,8 +32,11 @@ internal class PaymentOptionsListFragment(
         )
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onPostViewCreated(
+        view: View,
+        fragmentConfig: FragmentConfig
+    ) {
+        super.onPostViewCreated(view, fragmentConfig)
         viewBinding.header.setText(R.string.stripe_paymentsheet_select_payment_method)
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -28,7 +28,7 @@ internal class PaymentOptionsListFragment(
 
     override fun transitionToAddPaymentMethod() {
         activityViewModel.transitionTo(
-            PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodFull
+            PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodFull(config)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
@@ -46,17 +47,30 @@ internal class PaymentOptionsViewModel(
         )
     }
 
-    internal enum class TransitionTarget(
-        val sheetMode: SheetMode
-    ) {
+    internal sealed class TransitionTarget {
+        abstract val fragmentConfig: FragmentConfig
+        abstract val sheetMode: SheetMode
+
         // User has saved PM's and is selected
-        SelectSavedPaymentMethod(SheetMode.Wrapped),
+        data class SelectSavedPaymentMethod(
+            override val fragmentConfig: FragmentConfig
+        ) : TransitionTarget() {
+            override val sheetMode = SheetMode.Wrapped
+        }
 
         // User has saved PM's and is adding a new one
-        AddPaymentMethodFull(SheetMode.Full),
+        data class AddPaymentMethodFull(
+            override val fragmentConfig: FragmentConfig
+        ) : TransitionTarget() {
+            override val sheetMode = SheetMode.Full
+        }
 
         // User has no saved PM's
-        AddPaymentMethodSheet(SheetMode.FullCollapsed)
+        data class AddPaymentMethodSheet(
+            override val fragmentConfig: FragmentConfig
+        ) : TransitionTarget() {
+            override val sheetMode = SheetMode.FullCollapsed
+        }
     }
 
     internal class Factory(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -179,7 +179,10 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
             if (transitionTarget != null) {
                 onTransitionTarget(
                     transitionTarget,
-                    bundleOf(EXTRA_STARTER_ARGS to starterArgs)
+                    bundleOf(
+                        EXTRA_STARTER_ARGS to starterArgs,
+                        EXTRA_FRAGMENT_CONFIG to transitionTarget.fragmentConfig
+                    )
                 )
             }
         }
@@ -195,12 +198,12 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
             }
         }
 
-        viewModel.fetchAddPaymentMethodConfig().observe(this) { config ->
+        viewModel.fetchFragmentConfig().observe(this) { config ->
             if (config != null) {
                 val target = if (config.paymentMethods.isEmpty()) {
-                    PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet
+                    PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet(config)
                 } else {
-                    PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod
+                    PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod(config)
                 }
                 viewModel.transitionTo(target)
             }
@@ -224,7 +227,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
     ) {
         supportFragmentManager.commit {
             when (transitionTarget) {
-                PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull -> {
+                is PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull -> {
                     setCustomAnimations(
                         AnimationConstants.FADE_IN,
                         AnimationConstants.FADE_OUT,
@@ -238,14 +241,14 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
                         fragmentArgs
                     )
                 }
-                PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
+                is PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
                     replace(
                         fragmentContainerId,
                         PaymentSheetPaymentMethodsListFragment::class.java,
                         fragmentArgs
                     )
                 }
-                PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet -> {
+                is PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet -> {
                     replace(
                         fragmentContainerId,
                         PaymentSheetAddCardFragment::class.java,
@@ -330,6 +333,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
     }
 
     internal companion object {
+        internal const val EXTRA_FRAGMENT_CONFIG = BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG
         internal const val EXTRA_STARTER_ARGS = BasePaymentSheetActivity.EXTRA_STARTER_ARGS
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import java.util.Currency
 import java.util.Locale
 
@@ -25,7 +25,7 @@ internal class PaymentSheetAddCardFragment(
         sheetViewModel.checkout()
     }
 
-    override fun onConfigReady(config: AddPaymentMethodConfig) {
+    override fun onConfigReady(config: FragmentConfig) {
         super.onConfigReady(config)
 
         val amount = config.paymentIntent.amount

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import java.util.Currency
 import java.util.Locale
 
@@ -39,8 +39,11 @@ internal class PaymentSheetPaymentMethodsListFragment(
         )
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onPostViewCreated(
+        view: View,
+        fragmentConfig: FragmentConfig
+    ) {
+        super.onPostViewCreated(view, fragmentConfig)
 
         // Only fetch the payment methods list if we haven't already
         if (activityViewModel.paymentMethods.value == null) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -35,7 +35,7 @@ internal class PaymentSheetPaymentMethodsListFragment(
 
     override fun transitionToAddPaymentMethod() {
         activityViewModel.transitionTo(
-            PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull
+            PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(config)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
@@ -3,16 +3,19 @@ package com.stripe.android.paymentsheet.model
 import android.os.Parcelable
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.BaseAddCardFragment
+import com.stripe.android.paymentsheet.BasePaymentMethodsListFragment
 import kotlinx.parcelize.Parcelize
 
 /**
- * Configuration data for `PaymentSheetAddCardFragment`.
+ * Configuration data for [BaseAddCardFragment] and [BasePaymentMethodsListFragment].
  */
 @Parcelize
-internal data class AddPaymentMethodConfig(
+internal data class FragmentConfig(
     val paymentIntent: PaymentIntent,
     val paymentMethods: List<PaymentMethod>,
-    val isGooglePayReady: Boolean
+    val isGooglePayReady: Boolean,
+    val savedSelection: SavedSelection
 ) : Parcelable {
     val shouldShowGooglePayButton: Boolean
         get() = isGooglePayReady && paymentMethods.isEmpty()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BasePaymentSheetActivity.kt
@@ -114,7 +114,8 @@ internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity
         }
     }
 
-    protected companion object {
+    internal companion object {
+        const val EXTRA_FRAGMENT_CONFIG = "com.stripe.android.paymentsheet.extra_fragment_config"
         const val EXTRA_STARTER_ARGS = "com.stripe.android.paymentsheet.extra_starter_args"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -144,9 +144,10 @@ internal abstract class SheetViewModel<TransitionTargetType>(
 
     private fun fetchSavedSelection() {
         viewModelScope.launch {
-            _savedSelection.value = withContext(workContext) {
+            val savedSelection = withContext(workContext) {
                 prefsRepository.getSavedSelection()
             }
+            _savedSelection.value = savedSelection
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -5,17 +5,19 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.liveData
 import androidx.lifecycle.switchMap
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
@@ -45,6 +47,9 @@ internal abstract class SheetViewModel<TransitionTargetType>(
     protected val _paymentMethods = MutableLiveData<List<PaymentMethod>>()
     internal val paymentMethods: LiveData<List<PaymentMethod>> = _paymentMethods
 
+    private val _savedSelection = MutableLiveData<SavedSelection>()
+    private val savedSelection: LiveData<SavedSelection> = _savedSelection
+
     private val _transition = MutableLiveData<TransitionTargetType?>(null)
     internal val transition: LiveData<TransitionTargetType?> = _transition
 
@@ -71,32 +76,40 @@ internal abstract class SheetViewModel<TransitionTargetType>(
         }
     }
 
-    fun fetchAddPaymentMethodConfig() = liveData {
-        emitSource(
-            MediatorLiveData<AddPaymentMethodConfig?>().also { configLiveData ->
-                listOf(paymentIntent, paymentMethods, isGooglePayReady).forEach { source ->
-                    configLiveData.addSource(source) {
-                        configLiveData.value = createAddPaymentMethodConfig()
-                    }
-                }
-            }.distinctUntilChanged()
-        )
+    init {
+        fetchSavedSelection()
     }
 
-    private fun createAddPaymentMethodConfig(): AddPaymentMethodConfig? {
+    fun fetchFragmentConfig() = MediatorLiveData<FragmentConfig?>().also { configLiveData ->
+        listOf(
+            savedSelection,
+            paymentIntent,
+            paymentMethods,
+            isGooglePayReady
+        ).forEach { source ->
+            configLiveData.addSource(source) {
+                configLiveData.value = createFragmentConfig()
+            }
+        }
+    }.distinctUntilChanged()
+
+    private fun createFragmentConfig(): FragmentConfig? {
         val paymentIntentValue = paymentIntent.value
         val paymentMethodsValue = paymentMethods.value
         val isGooglePayReadyValue = isGooglePayReady.value
+        val savedSelectionValue = savedSelection.value
 
         return if (
             paymentIntentValue != null &&
             paymentMethodsValue != null &&
-            isGooglePayReadyValue != null
+            isGooglePayReadyValue != null &&
+            savedSelectionValue != null
         ) {
-            AddPaymentMethodConfig(
+            FragmentConfig(
                 paymentIntent = paymentIntentValue,
                 paymentMethods = paymentMethodsValue,
-                isGooglePayReady = isGooglePayReadyValue
+                isGooglePayReady = isGooglePayReadyValue,
+                savedSelection = savedSelectionValue
             )
         } else {
             null
@@ -129,12 +142,12 @@ internal abstract class SheetViewModel<TransitionTargetType>(
         _userMessage.value = null
     }
 
-    fun getSavedSelection() = liveData {
-        emit(
-            withContext(workContext) {
+    private fun fetchSavedSelection() {
+        viewModelScope.launch {
+            _savedSelection.value = withContext(workContext) {
                 prefsRepository.getSavedSelection()
             }
-        )
+        }
     }
 
     sealed class UserMessage {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -4,11 +4,15 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 
 internal class FakePrefsRepository : PrefsRepository {
+    internal val paymentSelectionArgs = mutableListOf<PaymentSelection?>()
+
     private var savedSelection: SavedSelection = SavedSelection.None
 
     override suspend fun getSavedSelection(): SavedSelection = savedSelection
 
     override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
+        paymentSelectionArgs.add(paymentSelection)
+
         when (paymentSelection) {
             PaymentSelection.GooglePay -> {
                 SavedSelection.GooglePay

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -45,7 +46,7 @@ class PaymentOptionsActivityTest {
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = false
         ),
-        prefsRepository = mock(),
+        prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter
     )
 
@@ -125,14 +126,16 @@ class PaymentOptionsActivityTest {
         return Intent(
             ApplicationProvider.getApplicationContext(),
             PaymentOptionsActivity::class.java
-        ).putExtra(
-            ActivityStarter.Args.EXTRA,
-            PaymentOptionContract.Args(
-                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                paymentMethods = paymentMethods,
-                sessionId = SessionId(),
-                config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                isGooglePayReady = false
+        ).putExtras(
+            bundleOf(
+                ActivityStarter.Args.EXTRA to
+                    PaymentOptionContract.Args(
+                        paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                        paymentMethods = paymentMethods,
+                        sessionId = SessionId(),
+                        config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+                        isGooglePayReady = false
+                    )
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -28,7 +28,7 @@ class PaymentOptionsViewModelTest {
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = true
         ),
-        prefsRepository = mock(),
+        prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter
     )
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
+import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -52,13 +53,9 @@ internal class PaymentSheetActivityTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val paymentMethods = listOf(
-        PaymentMethod("payment_method_id", 0, false, PaymentMethod.Type.Card)
-    )
-
     private val paymentFlowResultProcessor = FakePaymentFlowResultProcessor()
     private val googlePayRepository = FakeGooglePayRepository(true)
-    private val stripeRepository = FakeStripeRepository(PAYMENT_INTENT, paymentMethods)
+    private val stripeRepository = FakeStripeRepository(PAYMENT_INTENT, PAYMENT_METHODS)
     private val eventReporter = mock<EventReporter>()
 
     private val viewModel = PaymentSheetViewModel(
@@ -67,7 +64,7 @@ internal class PaymentSheetActivityTest {
         stripeRepository = stripeRepository,
         paymentFlowResultProcessor = paymentFlowResultProcessor,
         googlePayRepository = googlePayRepository,
-        prefsRepository = mock(),
+        prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter,
         args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
         animateOutMillis = 0,
@@ -162,7 +159,11 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.bottomSheet.layoutParams.height)
                 .isEqualTo(WRAP_CONTENT)
 
-            viewModel.transitionTo(PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull)
+            viewModel.transitionTo(
+                PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(
+                    FragmentConfigFixtures.DEFAULT
+                )
+            )
             idleLooper()
             assertThat(currentFragment(activity))
                 .isInstanceOf(PaymentSheetAddCardFragment::class.java)
@@ -264,7 +265,7 @@ internal class PaymentSheetActivityTest {
             stripeRepository = FakeStripeRepository(PAYMENT_INTENT, listOf()),
             paymentFlowResultProcessor = paymentFlowResultProcessor,
             googlePayRepository = googlePayRepository,
-            prefsRepository = mock(),
+            prefsRepository = FakePrefsRepository(),
             eventReporter = eventReporter,
             args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
             animateOutMillis = 0,
@@ -367,5 +368,9 @@ internal class PaymentSheetActivityTest {
 
     private companion object {
         private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+
+        private val PAYMENT_METHODS = listOf(
+            PaymentMethod("payment_method_id", 0, false, PaymentMethod.Type.Card)
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -13,10 +13,9 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.Address
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.AddPaymentMethodConfig
+import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
 import org.junit.Before
@@ -144,13 +143,7 @@ class PaymentSheetAddCardFragmentTest {
         createScenario().onFragment { fragment ->
             val activityViewModel = activityViewModel(fragment)
 
-            fragment.onConfigReady(
-                AddPaymentMethodConfig(
-                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                    paymentMethods = emptyList(),
-                    isGooglePayReady = true
-                )
-            )
+            fragment.onConfigReady(FragmentConfigFixtures.DEFAULT)
             val paymentSelections = mutableListOf<PaymentSelection>()
             activityViewModel.selection.observeForever { paymentSelection ->
                 if (paymentSelection != null) {
@@ -171,13 +164,7 @@ class PaymentSheetAddCardFragmentTest {
     @Test
     fun `onConfigReady() should update header text`() {
         createScenario().onFragment { fragment ->
-            fragment.onConfigReady(
-                AddPaymentMethodConfig(
-                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                    paymentMethods = emptyList(),
-                    isGooglePayReady = true
-                )
-            )
+            fragment.onConfigReady(FragmentConfigFixtures.DEFAULT)
 
             assertThat(fragment.addCardHeader.text.toString())
                 .isEqualTo("Pay $10.99 using")
@@ -216,6 +203,7 @@ class PaymentSheetAddCardFragmentTest {
     ): FragmentScenario<PaymentSheetAddCardFragment> {
         return launchFragmentInContainer<PaymentSheetAddCardFragment>(
             bundleOf(
+                PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to FragmentConfigFixtures.DEFAULT,
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to args
             ),
             R.style.StripePaymentSheetDefaultTheme,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
@@ -186,6 +187,16 @@ class PaymentSheetAddCardFragmentTest {
         }
     }
 
+    @Test
+    fun `fragment started without FragmentConfig should emit fatal`() {
+        createScenario(
+            fragmentConfig = null
+        ).onFragment { fragment ->
+            assertThat(fragment.sheetViewModel.fatal.value)
+                .isEqualTo(IllegalArgumentException("Failed to start add payment option fragment."))
+        }
+    }
+
     private fun activityViewModel(
         fragment: PaymentSheetAddCardFragment,
         args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
@@ -199,11 +210,12 @@ class PaymentSheetAddCardFragmentTest {
     }
 
     private fun createScenario(
-        args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
+        args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
+        fragmentConfig: FragmentConfig? = FragmentConfigFixtures.DEFAULT
     ): FragmentScenario<PaymentSheetAddCardFragment> {
         return launchFragmentInContainer<PaymentSheetAddCardFragment>(
             bundleOf(
-                PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to FragmentConfigFixtures.DEFAULT,
+                PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to fragmentConfig,
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to args
             ),
             R.style.StripePaymentSheetDefaultTheme,

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -192,8 +192,8 @@ class PaymentSheetAddCardFragmentTest {
         createScenario(
             fragmentConfig = null
         ).onFragment { fragment ->
-            assertThat(fragment.sheetViewModel.fatal.value)
-                .isEqualTo(IllegalArgumentException("Failed to start add payment option fragment."))
+            assertThat(fragment.sheetViewModel.fatal.value?.message)
+                .isEqualTo("Failed to start add payment option fragment.")
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
@@ -150,6 +151,16 @@ class PaymentSheetPaymentMethodsListFragmentTest {
         }
     }
 
+    @Test
+    fun `fragment started without FragmentConfig should emit fatal`() {
+        createScenario(
+            fragmentConfig = null
+        ).onFragment { fragment ->
+            assertThat(fragment.sheetViewModel.fatal.value)
+                .isEqualTo(IllegalArgumentException("Failed to start existing payment options fragment."))
+        }
+    }
+
     private fun recyclerView(it: PaymentSheetPaymentMethodsListFragment) =
         it.requireView().findViewById<RecyclerView>(R.id.recycler)
 
@@ -169,13 +180,11 @@ class PaymentSheetPaymentMethodsListFragmentTest {
     ) = fragment.viewModels<BasePaymentMethodsListFragment.PaymentMethodsViewModel>().value
 
     private fun createScenario(
-        paymentMethods: List<PaymentMethod> = PAYMENT_METHODS
+        fragmentConfig: FragmentConfig? = FRAGMENT_CONFIG
     ): FragmentScenario<PaymentSheetPaymentMethodsListFragment> {
         return launchFragmentInContainer<PaymentSheetPaymentMethodsListFragment>(
             bundleOf(
-                PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to FragmentConfigFixtures.DEFAULT.copy(
-                    paymentMethods = paymentMethods
-                ),
+                PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to fragmentConfig,
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
             ),
             R.style.StripePaymentSheetDefaultTheme,
@@ -187,6 +196,10 @@ class PaymentSheetPaymentMethodsListFragmentTest {
         private val PAYMENT_METHODS = listOf(
             PaymentMethod("one", 0, false, PaymentMethod.Type.Card),
             PaymentMethod("two", 0, false, PaymentMethod.Type.Card)
+        )
+
+        private val FRAGMENT_CONFIG = FragmentConfigFixtures.DEFAULT.copy(
+            paymentMethods = PAYMENT_METHODS
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -156,8 +156,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
         createScenario(
             fragmentConfig = null
         ).onFragment { fragment ->
-            assertThat(fragment.sheetViewModel.fatal.value)
-                .isEqualTo(IllegalArgumentException("Failed to start existing payment options fragment."))
+            assertThat(fragment.sheetViewModel.fatal.value?.message)
+                .isEqualTo("Failed to start existing payment options fragment.")
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/FragmentConfigFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/FragmentConfigFixtures.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet.model
+
+import com.stripe.android.model.PaymentIntentFixtures
+
+internal object FragmentConfigFixtures {
+
+    val DEFAULT = FragmentConfig(
+        paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        paymentMethods = emptyList(),
+        isGooglePayReady = true,
+        savedSelection = SavedSelection.None
+    )
+}


### PR DESCRIPTION
Load all necessary data and pass to `BaseAddCardFragment` and
`BasePaymentMethodsListFragment` fragments as arguments. This simplifies
the fragment logic and ensures that all data is ready when the fragment
is started.

Updated unit tests and manually verified.