### PR TITLE
Refactor PaymentOptionsAdapter

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import com.stripe.android.CardUtils
 import com.stripe.android.ObjectBuilder
 import com.stripe.android.Stripe
 import kotlinx.parcelize.Parcelize
@@ -211,6 +212,7 @@ data class PaymentMethodCreateParams internal constructor(
 
         internal val attribution: Set<String>? = null
     ) : StripeParamsModel, Parcelable {
+        internal val brand: CardBrand get() = CardUtils.getPossibleCardBrand(number)
         internal val last4: String? get() = number?.takeLast(4)
 
         override fun toParamMap(): Map<String, Any> {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -106,15 +106,13 @@ internal abstract class BaseAddCardFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
-        if (activity == null || nullableConfig == null) {
+        val config = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
+        if (activity == null || config == null) {
             sheetViewModel.onFatal(
                 IllegalArgumentException("Failed to start add payment option fragment.")
             )
             return
         }
-
-        val config = nullableConfig
 
         _viewBinding = FragmentPaymentsheetAddCardBinding.bind(view)
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.SessionId
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -31,7 +32,8 @@ internal class PaymentOptionContract : ActivityResultContract<PaymentOptionContr
         val paymentMethods: List<PaymentMethod>,
         val sessionId: SessionId,
         val config: PaymentSheet.Configuration?,
-        val isGooglePayReady: Boolean
+        val isGooglePayReady: Boolean,
+        val newCard: PaymentSelection.New.Card?
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -114,7 +114,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
         viewModel.fetchFragmentConfig().observe(this) { config ->
             if (config != null) {
                 viewModel.transitionTo(
-                    if (starterArgs.paymentMethods.isEmpty()) {
+                    if (starterArgs.paymentMethods.isEmpty() && starterArgs.newCard == null) {
                         PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodSheet(config)
                     } else {
                         PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod(config)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -91,7 +91,7 @@ internal class PaymentOptionsAdapter(
 
             // the first payment method
             items.indexOfFirst { it is Item.ExistingPaymentMethod }.takeIf { it != -1 }
-        ).firstOrNull() ?: -1
+        ).firstOrNull() ?: NO_POSITION
     }
 
     private fun onItemSelected(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -5,244 +5,170 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import com.stripe.android.R
 import com.stripe.android.databinding.LayoutPaymentsheetAddCardItemBinding
 import com.stripe.android.databinding.LayoutPaymentsheetGooglePayItemBinding
 import com.stripe.android.databinding.LayoutPaymentsheetPaymentMethodItemBinding
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import kotlin.properties.Delegates
+import com.stripe.android.paymentsheet.model.SavedSelection
 
 internal class PaymentOptionsAdapter(
     private val canClickSelectedItem: Boolean,
     val paymentOptionSelectedListener: (paymentSelection: PaymentSelection, isClick: Boolean) -> Unit,
     val addCardClickListener: View.OnClickListener
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    var shouldShowGooglePay: Boolean by Delegates.observable(false) { _, _, _ ->
-        notifyDataSetChanged()
-    }
+    private var items: List<Item> = emptyList()
 
-    var paymentMethods: List<PaymentMethod> = emptyList()
-        set(value) {
-            val sortedPaymentMethods = sortPaymentMethods(value)
+    private var selectedItemPosition: Int = NO_POSITION
 
-            if (sortedPaymentMethods != field) {
-                field = sortedPaymentMethods
-                notifyDataSetChanged()
-
-                if (paymentSelection == null) {
-                    updatePaymentSelection(defaultPaymentMethodId)
-                }
-            }
-        }
-
-    var defaultPaymentMethodId: String? by Delegates.observable(
-        null
-    ) { _, oldDefaultPaymentMethodId, newDefaultPaymentMethodId ->
-        updatePaymentSelection(newDefaultPaymentMethodId)
-
-        paymentMethods = sortPaymentMethods(paymentMethods)
-        if (newDefaultPaymentMethodId != oldDefaultPaymentMethodId) {
-            notifyDataSetChanged()
-        }
-    }
-
-    internal var paymentSelection: PaymentSelection? by Delegates.observable(
-        null
-    ) { _, oldValue, newValue ->
-        if (oldValue != newValue) {
-            when (newValue) {
-                PaymentSelection.GooglePay -> {
-                    onGooglePaySelected(
-                        isNewSelection = true,
-                        isClick = false
-                    )
-                }
-                else -> {
-                    // noop
-                }
-            }
-        }
-    }
-
-    private val addNewPosition = 0
-    private val googlePayPosition get() = 1.takeIf { shouldShowGooglePay } ?: -1
-
-    private val googlePayCount: Int get() = 1.takeIf { shouldShowGooglePay } ?: 0
+    internal val selectedItem: Item? get() = items.getOrNull(selectedItemPosition)
 
     init {
         setHasStableIds(true)
     }
 
-    private fun onPaymentMethodSelected(
-        clickedPaymentMethod: PaymentMethod,
+    fun update(
+        config: FragmentConfig,
+        newCard: PaymentSelection.New.Card?,
     ) {
-        val currentSelectedPaymentMethod = (paymentSelection as? PaymentSelection.Saved)?.paymentMethod
-
-        // allowed to click the selected item or a new Payment Method was selected
-        if (canClickSelectedItem || currentSelectedPaymentMethod?.id != clickedPaymentMethod.id
-        ) {
-            currentSelectedPaymentMethod?.let {
-                notifyItemChanged(getPosition(it))
+        val items = listOfNotNull(
+            Item.AddCard,
+            Item.GooglePay.takeIf { config.isGooglePayReady },
+            newCard?.let {
+                Item.NewCard(it)
             }
-            notifyItemChanged(getPosition(clickedPaymentMethod))
-            val paymentSelection = PaymentSelection.Saved(clickedPaymentMethod).also {
-                this.paymentSelection = it
-            }
-
-            // unselect Google Pay if Google Pay is enabled
-            if (shouldShowGooglePay) {
-                notifyItemChanged(googlePayPosition)
-            }
-
-            paymentOptionSelectedListener(
-                paymentSelection,
-                true
-            )
+        ) + config.sortedPaymentMethods.map {
+            Item.ExistingPaymentMethod(it)
         }
+
+        this.items = items
+
+        onItemSelected(
+            position = findInitialSelectedPosition(config.savedSelection),
+            isClick = false
+        )
+
+        notifyDataSetChanged()
     }
 
-    private fun onGooglePaySelected(
-        isNewSelection: Boolean,
+    /**
+     * The initial selection position follows this prioritization:
+     * 1. The index of [Item.NewCard] if it exists
+     * 2. The index of [Item.ExistingPaymentMethod] if it matches the [SavedSelection]
+     * 3. The index of [Item.GooglePay] if it exists
+     * 4. The index of the first [Item.ExistingPaymentMethod]
+     * 5. None (-1)
+     */
+    private fun findInitialSelectedPosition(
+        savedSelection: SavedSelection
+    ): Int {
+        return listOfNotNull(
+            // new card
+            items.indexOfFirst { it is Item.NewCard }.takeIf { it != -1 },
+
+            // saved selection
+            items.indexOfFirst { item ->
+                when (savedSelection) {
+                    SavedSelection.GooglePay -> item is Item.GooglePay
+                    is SavedSelection.PaymentMethod -> {
+                        when (item) {
+                            is Item.ExistingPaymentMethod -> {
+                                savedSelection.id == item.paymentMethod.id
+                            }
+                            else -> false
+                        }
+                    }
+                    SavedSelection.None -> false
+                }
+            }.takeIf { it != -1 },
+
+            // Google Pay
+            items.indexOfFirst { it is Item.GooglePay }.takeIf { it != -1 },
+
+            // the first payment method
+            items.indexOfFirst { it is Item.ExistingPaymentMethod }.takeIf { it != -1 }
+        ).firstOrNull() ?: -1
+    }
+
+    private fun onItemSelected(
+        position: Int,
         isClick: Boolean
     ) {
-        if (canClickSelectedItem || isNewSelection) {
-            // unselect previous item
-            val previousPaymentSelection = paymentSelection
-            paymentSelection = PaymentSelection.GooglePay
+        if (position != NO_POSITION && (canClickSelectedItem || position != selectedItemPosition)) {
+            val previousSelectedIndex = selectedItemPosition
+            selectedItemPosition = position
 
-            if (previousPaymentSelection is PaymentSelection.Saved) {
-                notifyItemChanged(getPosition(previousPaymentSelection.paymentMethod))
-            }
+            notifyItemChanged(previousSelectedIndex)
+            notifyItemChanged(position)
 
-            // select Google Pay item
-            notifyItemChanged(googlePayPosition)
-            paymentOptionSelectedListener(PaymentSelection.GooglePay, isClick)
-        }
-    }
+            val newSelectedItem = items[position]
 
-    override fun getItemId(position: Int): Long {
-        return if (shouldShowGooglePay) {
-            when (position) {
-                addNewPosition -> ADD_NEW_ID
-                googlePayPosition -> GOOGLE_PAY_ID
-                else -> getPaymentMethodAtPosition(position).hashCode().toLong()
-            }
-        } else {
-            when (position) {
-                addNewPosition -> ADD_NEW_ID
-                else -> getPaymentMethodAtPosition(position).hashCode().toLong()
+            when (newSelectedItem) {
+                Item.AddCard -> null
+                Item.GooglePay -> PaymentSelection.GooglePay
+                is Item.NewCard -> newSelectedItem.newCard
+                is Item.ExistingPaymentMethod -> PaymentSelection.Saved(newSelectedItem.paymentMethod)
+            }?.let { paymentSelection ->
+                paymentOptionSelectedListener(
+                    paymentSelection,
+                    isClick
+                )
             }
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+    override fun getItemId(position: Int): Long = items[position].hashCode().toLong()
+    override fun getItemCount(): Int = items.size
+    override fun getItemViewType(position: Int): Int = items[position].viewType.ordinal
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): RecyclerView.ViewHolder {
         return when (ViewType.values()[viewType]) {
-            ViewType.GooglePay -> GooglePayViewHolder(parent)
-            ViewType.Card -> CardViewHolder(parent)
             ViewType.AddCard -> AddCardViewHolder(parent).apply {
                 itemView.setOnClickListener(addCardClickListener)
             }
+            ViewType.GooglePay -> GooglePayViewHolder(parent)
+            ViewType.NewCard,
+            ViewType.Card -> CardViewHolder(parent)
         }
     }
 
-    override fun getItemCount(): Int {
-        return listOfNotNull(
-            1, // Add new item
-            googlePayCount, // Google Pay item
-            paymentMethods.size
-        ).sum()
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        val type = if (shouldShowGooglePay) {
-            when (position) {
-                addNewPosition -> ViewType.AddCard
-                googlePayPosition -> ViewType.GooglePay
-                else -> ViewType.Card
-            }
-        } else {
-            when (position) {
-                addNewPosition -> ViewType.AddCard
-                else -> ViewType.Card
-            }
-        }
-        return type.ordinal
-    }
-
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int
+    ) {
+        val item = items[position]
         if (holder is CardViewHolder) {
-            val paymentMethod = getPaymentMethodAtPosition(position)
-            holder.setPaymentMethod(paymentMethod)
-
-            (paymentSelection as? PaymentSelection.Saved)?.let {
-                holder.setSelected(paymentMethod.id == it.paymentMethod.id)
+            holder.setSelected(position == selectedItemPosition)
+            holder.itemView.setOnClickListener {
+                onItemSelected(holder.adapterPosition, isClick = true)
             }
 
-            holder.itemView.setOnClickListener {
-                onPaymentMethodSelected(
-                    clickedPaymentMethod = getPaymentMethodAtPosition(holder.adapterPosition)
-                )
+            when (item) {
+                is Item.NewCard -> {
+                    holder.bindNewCard(item.newCard)
+                }
+                is Item.ExistingPaymentMethod -> {
+                    holder.bindPaymentMethod(item.paymentMethod)
+                }
+                else -> {
+                    // noop
+                }
             }
         } else if (holder is GooglePayViewHolder) {
-            holder.setSelected(paymentSelection == PaymentSelection.GooglePay)
+            holder.setSelected(position == selectedItemPosition)
             holder.itemView.setOnClickListener {
-                onGooglePaySelected(
-                    isNewSelection = paymentSelection != PaymentSelection.GooglePay,
+                onItemSelected(
+                    holder.adapterPosition,
                     isClick = true
                 )
             }
-        }
-    }
-
-    /**
-     * Given an adapter position, translate to a `paymentMethods` element
-     */
-    @JvmSynthetic
-    internal fun getPaymentMethodAtPosition(position: Int): PaymentMethod {
-        return paymentMethods[getPaymentMethodIndex(position)]
-    }
-
-    /**
-     * Given an adapter position, translate to a `paymentMethods` index
-     */
-    private fun getPaymentMethodIndex(position: Int): Int {
-        return position - googlePayCount - 1
-    }
-
-    private fun getPosition(paymentMethod: PaymentMethod): Int {
-        return paymentMethods.indexOf(paymentMethod).let {
-            it + googlePayCount + 1
-        }
-    }
-
-    private fun updatePaymentSelection(
-        paymentMethodId: String?
-    ) {
-        paymentSelection = paymentMethods.firstOrNull { it.id == paymentMethodId }?.let {
-            PaymentSelection.Saved(it)
-        }
-        paymentSelection?.let {
-            paymentOptionSelectedListener(it, false)
-        }
-    }
-
-    private fun sortPaymentMethods(
-        paymentMethods: List<PaymentMethod>
-    ): List<PaymentMethod> {
-        val primaryPaymentMethodIndex = paymentMethods.indexOfFirst {
-            it.id == defaultPaymentMethodId
-        }
-        return if (primaryPaymentMethodIndex != -1) {
-            val mutablePaymentMethods = paymentMethods.toMutableList()
-            mutablePaymentMethods.removeAt(primaryPaymentMethodIndex)
-                .also { primaryPaymentMethod ->
-                    mutablePaymentMethods.add(0, primaryPaymentMethod)
-                }
-            mutablePaymentMethods
-        } else {
-            paymentMethods
         }
     }
 
@@ -267,24 +193,45 @@ internal class PaymentOptionsAdapter(
             binding.checkIcon.elevation = binding.card.elevation + 1
         }
 
-        fun setPaymentMethod(method: PaymentMethod) {
+        fun bindPaymentMethod(method: PaymentMethod) {
             // TODO: Communicate error if card data not present
             method.card?.let { card ->
-                binding.brandIcon.setImageResource(
-                    when (card.brand) {
-                        CardBrand.Visa -> R.drawable.stripe_ic_paymentsheet_card_visa
-                        CardBrand.AmericanExpress -> R.drawable.stripe_ic_paymentsheet_card_amex
-                        CardBrand.Discover -> R.drawable.stripe_ic_paymentsheet_card_discover
-                        CardBrand.JCB -> R.drawable.stripe_ic_paymentsheet_card_jcb
-                        CardBrand.DinersClub -> R.drawable.stripe_ic_paymentsheet_card_dinersclub
-                        CardBrand.MasterCard -> R.drawable.stripe_ic_paymentsheet_card_mastercard
-                        CardBrand.UnionPay -> R.drawable.stripe_ic_paymentsheet_card_unionpay
-                        CardBrand.Unknown -> R.drawable.stripe_ic_paymentsheet_card_unknown
-                    }
+                bind(
+                    brand = card.brand,
+                    last4 = card.last4
                 )
-                binding.label.text = itemView.context
-                    .getString(R.string.paymentsheet_payment_method_item_card_number, card.last4)
             }
+        }
+
+        fun bindNewCard(
+            newCard: PaymentSelection.New.Card
+        ) {
+            newCard.paymentMethodCreateParams.card?.let { card ->
+                bind(
+                    brand = card.brand,
+                    last4 = card.last4
+                )
+            }
+        }
+
+        private fun bind(
+            brand: CardBrand,
+            last4: String?
+        ) {
+            binding.brandIcon.setImageResource(
+                when (brand) {
+                    CardBrand.Visa -> R.drawable.stripe_ic_paymentsheet_card_visa
+                    CardBrand.AmericanExpress -> R.drawable.stripe_ic_paymentsheet_card_amex
+                    CardBrand.Discover -> R.drawable.stripe_ic_paymentsheet_card_discover
+                    CardBrand.JCB -> R.drawable.stripe_ic_paymentsheet_card_jcb
+                    CardBrand.DinersClub -> R.drawable.stripe_ic_paymentsheet_card_dinersclub
+                    CardBrand.MasterCard -> R.drawable.stripe_ic_paymentsheet_card_mastercard
+                    CardBrand.UnionPay -> R.drawable.stripe_ic_paymentsheet_card_unionpay
+                    CardBrand.Unknown -> R.drawable.stripe_ic_paymentsheet_card_unknown
+                }
+            )
+            binding.label.text = itemView.context
+                .getString(R.string.paymentsheet_payment_method_item_card_number, last4)
         }
 
         fun setSelected(selected: Boolean) {
@@ -331,11 +278,31 @@ internal class PaymentOptionsAdapter(
     internal enum class ViewType {
         Card,
         AddCard,
-        GooglePay
+        GooglePay,
+        NewCard
     }
 
-    internal companion object {
-        internal const val ADD_NEW_ID = 1234L
-        internal const val GOOGLE_PAY_ID = 1235L
+    internal sealed class Item {
+        abstract val viewType: ViewType
+
+        object AddCard : Item() {
+            override val viewType: ViewType = ViewType.AddCard
+        }
+
+        object GooglePay : Item() {
+            override val viewType: ViewType = ViewType.GooglePay
+        }
+
+        data class NewCard(
+            val newCard: PaymentSelection.New.Card
+        ) : Item() {
+            override val viewType: ViewType = ViewType.NewCard
+        }
+
+        data class ExistingPaymentMethod(
+            val paymentMethod: PaymentMethod
+        ) : Item() {
+            override val viewType: ViewType = ViewType.Card
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -24,6 +24,8 @@ internal class PaymentOptionsViewModel(
     private val _userSelection = MutableLiveData<PaymentSelection>()
     val userSelection: LiveData<PaymentSelection> = _userSelection
 
+    override val newCard = args.newCard
+
     init {
         _isGooglePayReady.value = args.isGooglePayReady
         _paymentIntent.value = args.paymentIntent

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -68,6 +68,8 @@ internal class PaymentSheetViewModel internal constructor(
     private val _viewState = MutableLiveData<ViewState>(null)
     internal val viewState: LiveData<ViewState> = _viewState.distinctUntilChanged()
 
+    override val newCard: PaymentSelection.New.Card? = null
+
     private val paymentIntentValidator = PaymentIntentValidator()
 
     init {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -148,7 +148,8 @@ internal class DefaultFlowController internal constructor(
                 paymentMethods = initData.paymentMethods,
                 sessionId = sessionId,
                 config = initData.config,
-                isGooglePayReady = initData.isGooglePayReady
+                isGooglePayReady = initData.isGooglePayReady,
+                newCard = viewModel.paymentSelection as? PaymentSelection.New.Card
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
@@ -19,4 +19,26 @@ internal data class FragmentConfig(
 ) : Parcelable {
     val shouldShowGooglePayButton: Boolean
         get() = isGooglePayReady && paymentMethods.isEmpty()
+
+    val sortedPaymentMethods: List<PaymentMethod>
+        get() {
+            val primaryPaymentMethodIndex = when (savedSelection) {
+                is SavedSelection.PaymentMethod -> {
+                    paymentMethods.indexOfFirst {
+                        it.id == savedSelection.id
+                    }
+                }
+                else -> -1
+            }
+            return if (primaryPaymentMethodIndex != -1) {
+                val mutablePaymentMethods = paymentMethods.toMutableList()
+                mutablePaymentMethods.removeAt(primaryPaymentMethodIndex)
+                    .also { primaryPaymentMethod ->
+                        mutablePaymentMethods.add(0, primaryPaymentMethod)
+                    }
+                mutablePaymentMethods
+            } else {
+                paymentMethods
+            }
+        }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/SheetViewModel.kt
@@ -66,6 +66,8 @@ internal abstract class SheetViewModel<TransitionTargetType>(
     protected val _userMessage = MutableLiveData<UserMessage?>()
     internal val userMessage: LiveData<UserMessage?> = _userMessage
 
+    abstract val newCard: PaymentSelection.New.Card?
+
     val ctaEnabled: LiveData<Boolean> = processing.switchMap { isProcessing ->
         transition.switchMap { transitionTarget ->
             selection.switchMap { paymentSelection ->

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -44,7 +44,8 @@ class PaymentOptionsActivityTest {
             paymentMethods = emptyList(),
             sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-            isGooglePayReady = false
+            isGooglePayReady = false,
+            newCard = null
         ),
         prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter
@@ -134,7 +135,8 @@ class PaymentOptionsActivityTest {
                         paymentMethods = paymentMethods,
                         sessionId = SessionId(),
                         config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                        isGooglePayReady = false
+                        isGooglePayReady = false,
+                        newCard = null
                     )
             )
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -26,7 +26,8 @@ class PaymentOptionsViewModelTest {
             paymentMethods = emptyList(),
             sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-            isGooglePayReady = true
+            isGooglePayReady = true,
+            newCard = null
         ),
         prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -132,7 +132,8 @@ internal class PaymentSheetActivityTest {
     fun `updates buy button state`() {
         val scenario = activityScenario()
         scenario.launch(intent).onActivity { activity ->
-            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
+            assertThat(activity.viewBinding.buyButton.isEnabled)
+                .isTrue()
 
             viewModel.updateSelection(PaymentSelection.GooglePay)
             assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
@@ -311,13 +312,13 @@ internal class PaymentSheetActivityTest {
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
             assertThat(activity.viewBinding.buyButton.isEnabled)
-                .isFalse()
+                .isTrue()
             // wait for bottom sheet to animate in
             testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
             idleLooper()
 
             assertThat(activity.viewBinding.buyButton.isEnabled)
-                .isFalse()
+                .isTrue()
 
             viewModel.updateSelection(PaymentSelection.GooglePay)
             idleLooper()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -174,7 +174,8 @@ class DefaultFlowControllerTest {
                     paymentMethods = emptyList(),
                     sessionId = SESSION_ID,
                     config = null,
-                    isGooglePayReady = false
+                    isGooglePayReady = false,
+                    newCard = null
                 )
             )
     }


### PR DESCRIPTION
All data necessary to configure `PaymentOptionsAdapter` is now
available through `FragmentConfig`. Update `PaymentOptionsAdapter`
in one pass through the `update()` method.

Additionally, wire through an optional `PaymentSelection.New.Card` that
represents a new card form entry that hasn't been yet turned into a
PaymentMethod API object.