### PR TITLE
Refactor BasePaymentMethodsListFragment header rendering

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -23,11 +23,6 @@ internal abstract class BasePaymentMethodsListFragment(
 
     protected lateinit var config: FragmentConfig
 
-    private var _viewBinding: FragmentPaymentsheetPaymentMethodsListBinding? = null
-    protected val viewBinding get() = requireNotNull(_viewBinding)
-
-    abstract fun transitionToAddPaymentMethod()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -36,20 +31,15 @@ internal abstract class BasePaymentMethodsListFragment(
             sheetViewModel.onFatal(
                 IllegalArgumentException("Failed to start existing payment options fragment.")
             )
-        } else {
-            this.config = nullableConfig
-            onPostViewCreated(view, nullableConfig)
+            return
         }
-    }
 
-    open fun onPostViewCreated(
-        view: View,
-        fragmentConfig: FragmentConfig
-    ) {
+        this.config = nullableConfig
+
         // reset the mode in case we're returning from the back stack
         sheetViewModel.updateMode(SheetMode.Wrapped)
 
-        _viewBinding = FragmentPaymentsheetPaymentMethodsListBinding.bind(view)
+        val viewBinding = FragmentPaymentsheetPaymentMethodsListBinding.bind(view)
         viewBinding.recycler.layoutManager = LinearLayoutManager(
             activity,
             LinearLayoutManager.HORIZONTAL,
@@ -72,12 +62,12 @@ internal abstract class BasePaymentMethodsListFragment(
         )
 
         eventReporter.onShowExistingPaymentOptions()
+
+        viewBinding.header.text = createHeaderText()
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _viewBinding = null
-    }
+    abstract fun transitionToAddPaymentMethod()
+    abstract fun createHeaderText(): String
 
     open fun onPaymentOptionSelected(
         paymentSelection: PaymentSelection,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.paymentsheet
 
-import android.view.View
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class PaymentOptionsListFragment(
@@ -32,13 +30,7 @@ internal class PaymentOptionsListFragment(
         )
     }
 
-    override fun onPostViewCreated(
-        view: View,
-        fragmentConfig: FragmentConfig
-    ) {
-        super.onPostViewCreated(view, fragmentConfig)
-        viewBinding.header.setText(R.string.stripe_paymentsheet_select_payment_method)
-    }
+    override fun createHeaderText() = getString(R.string.stripe_paymentsheet_select_payment_method)
 
     override fun onPaymentOptionSelected(
         paymentSelection: PaymentSelection,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragment.kt
@@ -1,11 +1,8 @@
 package com.stripe.android.paymentsheet
 
-import android.view.View
-import android.widget.TextView
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.FragmentConfig
 import java.util.Currency
 import java.util.Locale
 
@@ -30,36 +27,22 @@ internal class PaymentSheetPaymentMethodsListFragment(
 
     private val currencyFormatter = CurrencyFormatter()
 
-    internal val header: TextView by lazy { viewBinding.header }
-
     override fun transitionToAddPaymentMethod() {
         activityViewModel.transitionTo(
             PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(config)
         )
     }
 
-    override fun onPostViewCreated(
-        view: View,
-        fragmentConfig: FragmentConfig
-    ) {
-        super.onPostViewCreated(view, fragmentConfig)
-
-        val paymentIntent = fragmentConfig.paymentIntent
-        if (paymentIntent.currency != null && paymentIntent.amount != null) {
-            updateHeader(paymentIntent.amount, paymentIntent.currency)
+    override fun createHeaderText(): String {
+        val paymentIntent = config.paymentIntent
+        return if (paymentIntent.currency != null && paymentIntent.amount != null) {
+            val currency = Currency.getInstance(paymentIntent.currency.toUpperCase(Locale.ROOT))
+            getString(
+                R.string.stripe_paymentsheet_pay_using_with_amount,
+                currencyFormatter.format(paymentIntent.amount, currency)
+            )
         } else {
-            viewBinding.header.setText(R.string.stripe_paymentsheet_pay_using)
+            getString(R.string.stripe_paymentsheet_pay_using)
         }
-    }
-
-    private fun updateHeader(
-        amount: Long,
-        currencyCode: String
-    ) {
-        val currency = Currency.getInstance(currencyCode.toUpperCase(Locale.ROOT))
-        header.text = getString(
-            R.string.stripe_paymentsheet_pay_using_with_amount,
-            currencyFormatter.format(amount, currency)
-        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetPaymentMethodsListFragmentTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import android.widget.TextView
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.os.bundleOf
 import androidx.core.view.children
 import androidx.fragment.app.activityViewModels
@@ -23,12 +25,16 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSheetPaymentMethodsListFragmentTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
     private val eventReporter = mock<EventReporter>()
 
     @Before
@@ -139,7 +145,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
     @Test
     fun `updateHeader() should update header view`() {
         createScenario().onFragment { fragment ->
-            assertThat(fragment.header.text.toString())
+            val header = requireNotNull(fragment.view?.findViewById<TextView>(R.id.header))
+            assertThat(header.text.toString())
                 .isEqualTo("Pay $10.99 using")
         }
     }


### PR DESCRIPTION
This removes the need for a `viewBinding` property in
`BasePaymentMethodsListFragment`.