### PR TITLE
Create PaymentIntentRepository and PaymentMethodsRepository

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/GooglePayRepository.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-interface GooglePayRepository {
+fun interface GooglePayRepository {
     fun isReady(): Flow<Boolean>
 
     object Disabled : GooglePayRepository {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -4,6 +4,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripePaymentController
+import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.payments.DefaultPaymentFlowResultProcessor
 import com.stripe.android.paymentsheet.DefaultGooglePayRepository
@@ -15,6 +16,8 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
+import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 
@@ -71,14 +74,29 @@ internal class FlowControllerFactory(
             )
         }
 
+        val paymentMethodsRepository = PaymentMethodsRepository.Api(
+            stripeRepository = stripeRepository,
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId,
+            workContext = Dispatchers.IO
+        )
+
+        val paymentInteRepository = PaymentIntentRepository.Api(
+            stripeRepository = stripeRepository,
+            requestOptions = ApiRequest.Options(
+                config.publishableKey,
+                config.stripeAccountId
+            ),
+            workContext = Dispatchers.IO
+        )
+
         return DefaultFlowController(
             activity = activity,
             flowControllerInitializer = DefaultFlowControllerInitializer(
-                stripeRepository,
+                paymentIntentRepository = paymentInteRepository,
+                paymentMethodsRepository = paymentMethodsRepository,
                 prefsRepositoryFactory = prefsRepositoryFactory,
                 isGooglePayReadySupplier = isGooglePayReadySupplier,
-                publishableKey = config.publishableKey,
-                stripeAccountId = config.stripeAccountId,
                 workContext = Dispatchers.IO
             ),
             paymentControllerFactory = paymentControllerFactory,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/FragmentConfigRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/FragmentConfigRepository.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.paymentsheet.model.FragmentConfig
+
+internal interface FragmentConfigRepository {
+    suspend fun get(): FragmentConfig
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentIntentRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentIntentRepository.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal sealed class PaymentIntentRepository {
+    abstract suspend fun get(
+        clientSecret: String
+    ): PaymentIntent
+
+    /**
+     * Retrieve the [PaymentIntent] from a static source.
+     */
+    class Static(
+        private val paymentIntent: PaymentIntent
+    ) : PaymentIntentRepository() {
+        override suspend fun get(clientSecret: String): PaymentIntent = paymentIntent
+    }
+
+    /**
+     * Retrieve the [PaymentIntent] from the API.
+     */
+    class Api(
+        private val stripeRepository: StripeRepository,
+        private val requestOptions: ApiRequest.Options,
+        private val workContext: CoroutineContext
+    ) : PaymentIntentRepository() {
+        override suspend fun get(clientSecret: String) = withContext(workContext) {
+            val paymentIntent = stripeRepository.retrievePaymentIntent(
+                clientSecret,
+                requestOptions
+            )
+            requireNotNull(paymentIntent) {
+                "Could not parse PaymentIntent."
+            }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal sealed class PaymentMethodsRepository {
+    abstract suspend fun get(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        type: PaymentMethod.Type
+    ): List<PaymentMethod>
+
+    /**
+     * Retrieve the [PaymentMethod] list from a static source.
+     */
+    class Static(
+        private val paymentMethods: List<PaymentMethod>
+    ) : PaymentMethodsRepository() {
+        override suspend fun get(
+            customerConfig: PaymentSheet.CustomerConfiguration,
+            type: PaymentMethod.Type
+        ): List<PaymentMethod> = paymentMethods
+    }
+
+    /**
+     * Retrieve the [PaymentMethod] list from the API.
+     */
+    class Api(
+        private val stripeRepository: StripeRepository,
+        private val publishableKey: String,
+        private val stripeAccountId: String?,
+        private val workContext: CoroutineContext
+    ) : PaymentMethodsRepository() {
+        override suspend fun get(
+            customerConfig: PaymentSheet.CustomerConfiguration,
+            type: PaymentMethod.Type
+        ): List<PaymentMethod> = withContext(workContext) {
+            runCatching {
+                stripeRepository.getPaymentMethods(
+                    ListPaymentMethodsParams(
+                        customerId = customerConfig.id,
+                        paymentMethodType = type
+                    ),
+                    publishableKey,
+                    PRODUCT_USAGE,
+                    ApiRequest.Options(
+                        customerConfig.ephemeralKeySecret,
+                        stripeAccountId
+                    )
+                )
+            }.getOrDefault(emptyList())
+        }
+
+        private companion object {
+            private val PRODUCT_USAGE = setOf("PaymentSheet")
+        }
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -28,6 +28,8 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -55,13 +57,13 @@ internal class PaymentSheetActivityTest {
 
     private val paymentFlowResultProcessor = FakePaymentFlowResultProcessor()
     private val googlePayRepository = FakeGooglePayRepository(true)
-    private val stripeRepository = FakeStripeRepository(PAYMENT_INTENT, PAYMENT_METHODS)
     private val eventReporter = mock<EventReporter>()
 
     private val viewModel = PaymentSheetViewModel(
         publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         stripeAccountId = null,
-        stripeRepository = stripeRepository,
+        paymentIntentRepository = PaymentIntentRepository.Static(PAYMENT_INTENT),
+        paymentMethodsRepository = PaymentMethodsRepository.Static(PAYMENT_METHODS),
         paymentFlowResultProcessor = paymentFlowResultProcessor,
         googlePayRepository = googlePayRepository,
         prefsRepository = FakePrefsRepository(),
@@ -263,7 +265,8 @@ internal class PaymentSheetActivityTest {
         val viewModel = PaymentSheetViewModel(
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeAccountId = null,
-            stripeRepository = FakeStripeRepository(PAYMENT_INTENT, listOf()),
+            paymentIntentRepository = PaymentIntentRepository.Static(PAYMENT_INTENT),
+            paymentMethodsRepository = PaymentMethodsRepository.Static(emptyList()),
             paymentFlowResultProcessor = paymentFlowResultProcessor,
             googlePayRepository = googlePayRepository,
             prefsRepository = FakePrefsRepository(),

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
@@ -1,19 +1,17 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.networking.AbsFakeStripeRepository
-import com.stripe.android.networking.ApiRequest
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
@@ -138,32 +136,12 @@ internal class DefaultFlowControllerInitializerTest {
         paymentIntent: PaymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
     ): FlowControllerInitializer {
         return DefaultFlowControllerInitializer(
-            FakeStripeRepository(paymentIntent),
+            PaymentIntentRepository.Static(paymentIntent),
+            PaymentMethodsRepository.Static(PAYMENT_METHODS),
             { _, _ -> prefsRepository },
             { true },
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            null,
             testDispatcher
         )
-    }
-
-    private class FakeStripeRepository(
-        private val paymentIntent: PaymentIntent
-    ) : AbsFakeStripeRepository() {
-        override suspend fun retrievePaymentIntent(
-            clientSecret: String,
-            options: ApiRequest.Options,
-            expandFields: List<String>
-        ) = paymentIntent
-
-        override suspend fun getPaymentMethods(
-            listPaymentMethodsParams: ListPaymentMethodsParams,
-            publishableKey: String,
-            productUsageTokens: Set<String>,
-            requestOptions: ApiRequest.Options
-        ): List<PaymentMethod> {
-            return PAYMENT_METHODS
-        }
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+internal class PaymentMethodsRepositoryTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val stripeRepository = FakeStripeRepository()
+    private val repository = PaymentMethodsRepository.Api(
+        stripeRepository,
+        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        "acct_123",
+        testDispatcher
+    )
+
+    @AfterTest
+    fun cleanup() {
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `get() should create expected ListPaymentMethodsParams`() = testDispatcher.runBlockingTest {
+        repository.get(
+            PaymentSheet.CustomerConfiguration(
+                "customer_id",
+                "ephemeral_key"
+            ),
+            PaymentMethod.Type.Card
+        )
+
+        assertThat(stripeRepository.paramArgs)
+            .containsExactly(
+                ListPaymentMethodsParams(
+                    customerId = "customer_id",
+                    paymentMethodType = PaymentMethod.Type.Card
+                )
+            )
+    }
+
+    private class FakeStripeRepository : AbsFakeStripeRepository() {
+        var paymentMethods: List<PaymentMethod> = emptyList()
+
+        val paramArgs = mutableListOf<ListPaymentMethodsParams>()
+
+        override suspend fun getPaymentMethods(
+            listPaymentMethodsParams: ListPaymentMethodsParams,
+            publishableKey: String,
+            productUsageTokens: Set<String>,
+            requestOptions: ApiRequest.Options
+        ): List<PaymentMethod> {
+            paramArgs.add(listPaymentMethodsParams)
+            return paymentMethods
+        }
+    }
+}


### PR DESCRIPTION
Will be used in a future PR to create `FragmentConfigRepository`.

Create better abstraction for fetching PaymentIntents
and PaymentMethods.