### PR TITLE
Use CircularProgressIndicator in PaymentSheetLoadingFragment

### DIFF
--- a/stripe/res/layout/fragment_payment_sheet_loading.xml
+++ b/stripe/res/layout/fragment_payment_sheet_loading.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".paymentsheet.PaymentSheetLoadingFragment">
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/loading_spinner"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:indeterminateTintMode="src_atop"
-        android:indeterminateTint="?colorOnSurface"
-        android:layout_gravity="center" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:layout_gravity="center"
+        app:indicatorSize="24dp"
+        app:trackThickness="2dp"
+        app:indicatorColor="?colorOnSurface"/>
 </FrameLayout>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -172,7 +172,9 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
             replace(
                 fragmentContainerId,
                 PaymentSheetLoadingFragment::class.java,
-                null
+                bundleOf(
+                    EXTRA_STARTER_ARGS to starterArgs
+                )
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLoadingFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLoadingFragment.kt
@@ -1,9 +1,37 @@
 package com.stripe.android.paymentsheet
 
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
+import com.stripe.android.databinding.FragmentPaymentSheetLoadingBinding
 
 /**
  * A `Fragment` that shows a progress indicator.
  */
-internal class PaymentSheetLoadingFragment : Fragment(R.layout.fragment_payment_sheet_loading)
+internal class PaymentSheetLoadingFragment : Fragment(R.layout.fragment_payment_sheet_loading) {
+
+    private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
+        PaymentSheetViewModel.Factory(
+            { requireActivity().application },
+            {
+                requireNotNull(
+                    requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
+                )
+            }
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val loadingSpinner = FragmentPaymentSheetLoadingBinding.bind(view).loadingSpinner
+        activityViewModel.transition.observe(viewLifecycleOwner) { target ->
+            if (target != null) {
+                loadingSpinner.isInvisible = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Additionally, hide the spinner when transitioning to a new fragment
to resolve some UI issues.