### PR TITLE
Ignore flaky test in StripeTest

### DIFF
--- a/stripe/src/test/java/com/stripe/android/StripeTest.java
+++ b/stripe/src/test/java/com/stripe/android/StripeTest.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -372,7 +373,7 @@ public class StripeTest {
         assertEquals("stripe://start", alipaySource.getRedirect().getReturnUrl());
     }
 
-    @Test
+    @Ignore("Flaky test")
     public void createSourceSynchronous_withWeChatPayParams_passesIntegrationTest()
             throws StripeException {
         final String weChatAppId = "wx65997d6307c3827d";


### PR DESCRIPTION
Failing with:

```
Request-id: req_mFy8cYdF1ytI62
com.stripe.android.exception.CardException: There was an unexpected error while processing your request. Please contact us via https://support.stripe.com/contact if the error persists.
```