### PR TITLE
Integrate binary-compatibility-validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
             - name: Lint
               run: ./gradlew lintRelease
 
+            # Check if there has been a binary incompatible change to the API.
+            # If this change is intentional, run `./gradlew apiDump` and commit the new API files.
+            - name: Check binary compatibility
+              run: ./gradlew apiCheck
+
     unit-tests:
         name: Unit tests
         runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0"
     }
 }
 
@@ -69,4 +70,10 @@ nexusStaging {
     username = project.hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
     password = project.hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
     packageGroup = GROUP
+}
+
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+    ignoredProjects += ["example"]
 }

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5594,6 +5594,107 @@ public class com/stripe/android/paymentsheet/PaymentResult$Failed$Creator : andr
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet {
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel : java/lang/Enum {
+	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+	public static final field Required Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBillingAddressCollection ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
+	public final fun getCustomer ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public final fun getGooglePay ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public final fun getMerchantDisplayName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setBillingAddressCollection (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)V
+	public final fun setCustomer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)V
+	public final fun setGooglePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
+	public final fun setMerchantDisplayName (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEphemeralKeySecret ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountryCode ()Ljava/lang/String;
+	public final fun getEnvironment ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment : java/lang/Enum {
+	public static final field Production Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public static final field Test Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+}
+
 public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResultCallback {
 	public abstract fun onPaymentResult (Lcom/stripe/android/paymentsheet/PaymentResult;)V
 }

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -1,0 +1,6235 @@
+public abstract interface class com/stripe/android/AlipayAuthenticator {
+	public abstract fun onAuthenticationRequest (Ljava/lang/String;)Ljava/util/Map;
+}
+
+public abstract interface class com/stripe/android/ApiResultCallback {
+	public abstract fun onError (Ljava/lang/Exception;)V
+	public abstract fun onSuccess (Lcom/stripe/android/model/StripeModel;)V
+}
+
+public final class com/stripe/android/AppInfo : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/AppInfo$Companion;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public static synthetic fun copy$default (Lcom/stripe/android/AppInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/AppInfo;
+	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/AppInfo$Companion {
+	public final fun create (Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
+	public static synthetic fun create$default (Lcom/stripe/android/AppInfo$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/AppInfo;
+}
+
+public class com/stripe/android/AppInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/AppInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/AppInfo;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/stripe/android/CardUtils {
+	public static final field INSTANCE Lcom/stripe/android/CardUtils;
+	public static final fun getPossibleCardBrand (Ljava/lang/String;)Lcom/stripe/android/model/CardBrand;
+	public static final fun isValidCardNumber (Ljava/lang/String;)Z
+}
+
+public final class com/stripe/android/CustomerSession {
+	public static final field Companion Lcom/stripe/android/CustomerSession$Companion;
+	public final fun addCustomerSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/CustomerSession$SourceRetrievalListener;)V
+	public final fun attachPaymentMethod (Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodRetrievalListener;)V
+	public static final fun cancelCallbacks ()V
+	public final fun deleteCustomerSource (Ljava/lang/String;Lcom/stripe/android/CustomerSession$SourceRetrievalListener;)V
+	public final fun detachPaymentMethod (Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodRetrievalListener;)V
+	public static final fun endCustomerSession ()V
+	public final fun getCachedCustomer ()Lcom/stripe/android/model/Customer;
+	public static final fun getInstance ()Lcom/stripe/android/CustomerSession;
+	public final fun getPaymentMethods (Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/CustomerSession$PaymentMethodsRetrievalListener;)V
+	public final fun getPaymentMethods (Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Lcom/stripe/android/CustomerSession$PaymentMethodsRetrievalListener;)V
+	public final fun getPaymentMethods (Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodsRetrievalListener;)V
+	public final fun getPaymentMethods (Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodsRetrievalListener;)V
+	public static synthetic fun getPaymentMethods$default (Lcom/stripe/android/CustomerSession;Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodsRetrievalListener;ILjava/lang/Object;)V
+	public static final fun initCustomerSession (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;)V
+	public static final fun initCustomerSession (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;Z)V
+	public final fun retrieveCurrentCustomer (Lcom/stripe/android/CustomerSession$CustomerRetrievalListener;)V
+	public final fun setCustomerDefaultSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/CustomerSession$CustomerRetrievalListener;)V
+	public final fun setCustomerShippingInformation (Lcom/stripe/android/model/ShippingInformation;Lcom/stripe/android/CustomerSession$CustomerRetrievalListener;)V
+	public final fun updateCurrentCustomer (Lcom/stripe/android/CustomerSession$CustomerRetrievalListener;)V
+}
+
+public final class com/stripe/android/CustomerSession$Companion {
+	public final fun cancelCallbacks ()V
+	public final fun endCustomerSession ()V
+	public final fun getInstance ()Lcom/stripe/android/CustomerSession;
+	public final fun initCustomerSession (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;)V
+	public final fun initCustomerSession (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;Z)V
+	public static synthetic fun initCustomerSession$default (Lcom/stripe/android/CustomerSession$Companion;Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;ZILjava/lang/Object;)V
+}
+
+public abstract interface class com/stripe/android/CustomerSession$CustomerRetrievalListener : com/stripe/android/CustomerSession$RetrievalListener {
+	public abstract fun onCustomerRetrieved (Lcom/stripe/android/model/Customer;)V
+}
+
+public abstract interface class com/stripe/android/CustomerSession$PaymentMethodRetrievalListener : com/stripe/android/CustomerSession$RetrievalListener {
+	public abstract fun onPaymentMethodRetrieved (Lcom/stripe/android/model/PaymentMethod;)V
+}
+
+public abstract interface class com/stripe/android/CustomerSession$PaymentMethodsRetrievalListener : com/stripe/android/CustomerSession$RetrievalListener {
+	public abstract fun onPaymentMethodsRetrieved (Ljava/util/List;)V
+}
+
+public abstract interface class com/stripe/android/CustomerSession$RetrievalListener {
+	public abstract fun onError (ILjava/lang/String;Lcom/stripe/android/StripeError;)V
+}
+
+public abstract interface class com/stripe/android/CustomerSession$SourceRetrievalListener : com/stripe/android/CustomerSession$RetrievalListener {
+	public abstract fun onSourceRetrieved (Lcom/stripe/android/model/Source;)V
+}
+
+public final class com/stripe/android/EphemeralKey : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JJLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/EphemeralKey;
+	public static synthetic fun copy$default (Lcom/stripe/android/EphemeralKey;Ljava/lang/String;JJLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/EphemeralKey;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSecret ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/EphemeralKey$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralKey;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralKey;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract interface class com/stripe/android/EphemeralKeyProvider {
+	public abstract fun createEphemeralKey (Ljava/lang/String;Lcom/stripe/android/EphemeralKeyUpdateListener;)V
+}
+
+public abstract interface class com/stripe/android/EphemeralKeyUpdateListener {
+	public abstract fun onKeyUpdate (Ljava/lang/String;)V
+	public abstract fun onKeyUpdateFailure (ILjava/lang/String;)V
+}
+
+public final class com/stripe/android/GooglePayConfig {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getTokenizationSpecification ()Lorg/json/JSONObject;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory {
+	public fun <init> (Landroid/content/Context;Z)V
+	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/GooglePayConfig;Z)V
+	public synthetic fun <init> (Lcom/stripe/android/GooglePayConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun createIsReadyToPayRequest ()Lorg/json/JSONObject;
+	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;)Lorg/json/JSONObject;
+	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Ljava/lang/Boolean;)Lorg/json/JSONObject;
+	public static synthetic fun createIsReadyToPayRequest$default (Lcom/stripe/android/GooglePayJsonFactory;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/json/JSONObject;
+	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;)Lorg/json/JSONObject;
+	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;)Lorg/json/JSONObject;
+	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;)Lorg/json/JSONObject;
+	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;Z)Lorg/json/JSONObject;
+	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$MerchantInfo;)Lorg/json/JSONObject;
+	public static synthetic fun createPaymentDataRequest$default (Lcom/stripe/android/GooglePayJsonFactory;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$MerchantInfo;ILjava/lang/Object;)Lorg/json/JSONObject;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;)V
+	public fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;Z)V
+	public synthetic fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;Z)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
+	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;ZILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format : java/lang/Enum {
+	public static final field Full Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;
+	public static final field Min Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;
+	public static fun values ()[Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
+	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/GooglePayJsonFactory$MerchantInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParameters : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZLjava/util/Set;)V
+	public fun <init> (ZLjava/util/Set;Z)V
+	public synthetic fun <init> (ZLjava/util/Set;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (ZLjava/util/Set;Z)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
+	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLjava/util/Set;ZILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/GooglePayJsonFactory$ShippingAddressParameters$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption : java/lang/Enum {
+	public static final field CompleteImmediatePurchase Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;
+	public static final field Default Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;
+	public static fun values ()[Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;
+}
+
+public class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus : java/lang/Enum {
+	public static final field Estimated Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+	public static final field Final Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+	public static final field NotCurrentlyKnown Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+	public static fun values ()[Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+}
+
+public final class com/stripe/android/IssuingCardPinService {
+	public static final field Companion Lcom/stripe/android/IssuingCardPinService$Companion;
+	public static final fun create (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
+	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
+	public final fun retrievePin (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/IssuingCardPinService$IssuingCardPinRetrievalListener;)V
+	public final fun updatePin (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/IssuingCardPinService$IssuingCardPinUpdateListener;)V
+}
+
+public final class com/stripe/android/IssuingCardPinService$CardPinActionError : java/lang/Enum {
+	public static final field EPHEMERAL_KEY_ERROR Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static final field ONE_TIME_CODE_ALREADY_REDEEMED Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static final field ONE_TIME_CODE_EXPIRED Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static final field ONE_TIME_CODE_INCORRECT Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static final field ONE_TIME_CODE_TOO_MANY_ATTEMPTS Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static final field UNKNOWN_ERROR Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+	public static fun values ()[Lcom/stripe/android/IssuingCardPinService$CardPinActionError;
+}
+
+public final class com/stripe/android/IssuingCardPinService$Companion {
+	public final fun create (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
+}
+
+public abstract interface class com/stripe/android/IssuingCardPinService$IssuingCardPinRetrievalListener : com/stripe/android/IssuingCardPinService$Listener {
+	public abstract fun onIssuingCardPinRetrieved (Ljava/lang/String;)V
+}
+
+public abstract interface class com/stripe/android/IssuingCardPinService$IssuingCardPinUpdateListener : com/stripe/android/IssuingCardPinService$Listener {
+	public abstract fun onIssuingCardPinUpdated ()V
+}
+
+public abstract interface class com/stripe/android/IssuingCardPinService$Listener {
+	public abstract fun onError (Lcom/stripe/android/IssuingCardPinService$CardPinActionError;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class com/stripe/android/PayWithGoogleUtils {
+	public static final field INSTANCE Lcom/stripe/android/PayWithGoogleUtils;
+	public static final fun getPriceString (ILjava/util/Currency;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig {
+	public static final field Companion Lcom/stripe/android/PaymentAuthConfig$Companion;
+	public synthetic fun <init> (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun get ()Lcom/stripe/android/PaymentAuthConfig;
+	public static final fun init (Lcom/stripe/android/PaymentAuthConfig;)V
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun set3ds2Config (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;)Lcom/stripe/android/PaymentAuthConfig$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Companion {
+	public final fun get ()Lcom/stripe/android/PaymentAuthConfig;
+	public final fun init (Lcom/stripe/android/PaymentAuthConfig;)V
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization {
+	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/ButtonCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;Lcom/stripe/android/stripe3ds2/init/ui/ButtonCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBackgroundColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder;
+	public final fun setCornerRadius (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder;
+	public final fun setTextColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder;
+	public final fun setTextFontName (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder;
+	public final fun setTextFontSize (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config {
+	public static final field Companion Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Companion;
+	public final fun copy (ILcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;ILcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setTimeout (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Builder;
+	public final fun setUiCustomization (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization {
+	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/LabelCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;Lcom/stripe/android/stripe3ds2/init/ui/LabelCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setHeadingTextColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+	public final fun setHeadingTextFontName (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+	public final fun setHeadingTextFontSize (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+	public final fun setTextColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+	public final fun setTextFontName (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+	public final fun setTextFontSize (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization {
+	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/TextBoxCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;Lcom/stripe/android/stripe3ds2/init/ui/TextBoxCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBorderColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+	public final fun setBorderWidth (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+	public final fun setCornerRadius (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+	public final fun setTextColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+	public final fun setTextFontName (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+	public final fun setTextFontSize (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization {
+	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/ToolbarCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;Lcom/stripe/android/stripe3ds2/init/ui/ToolbarCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBackgroundColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setButtonText (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setHeaderText (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setStatusBarColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setTextColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setTextFontName (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+	public final fun setTextFontSize (I)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization {
+	public final fun component1 ()Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;
+	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUiCustomization ()Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field Companion Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (Landroid/app/Activity;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;
+	public synthetic fun build ()Ljava/lang/Object;
+	public static final fun createWithAppTheme (Landroid/app/Activity;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+	public final fun setAccentColor (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+	public final fun setButtonCustomization (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+	public final fun setLabelCustomization (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+	public final fun setTextBoxCustomization (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+	public final fun setToolbarCustomization (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder$Companion {
+	public final fun createWithAppTheme (Landroid/app/Activity;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder;
+}
+
+public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType : java/lang/Enum {
+	public static final field CANCEL Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static final field CONTINUE Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static final field NEXT Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static final field RESEND Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static final field SELECT Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static final field SUBMIT Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+	public static fun values ()[Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$ButtonType;
+}
+
+public final class com/stripe/android/PaymentConfiguration : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/PaymentConfiguration$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/PaymentConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/PaymentConfiguration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun getInstance (Landroid/content/Context;)Lcom/stripe/android/PaymentConfiguration;
+	public final fun getPublishableKey ()Ljava/lang/String;
+	public final fun getStripeAccountId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun init (Landroid/content/Context;Ljava/lang/String;)V
+	public static final fun init (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/PaymentConfiguration$Companion {
+	public final fun getInstance (Landroid/content/Context;)Lcom/stripe/android/PaymentConfiguration;
+	public final fun init (Landroid/content/Context;Ljava/lang/String;)V
+	public final fun init (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun init$default (Lcom/stripe/android/PaymentConfiguration$Companion;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public class com/stripe/android/PaymentConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentIntentResult : com/stripe/android/StripeIntentResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;)Lcom/stripe/android/PaymentIntentResult;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentIntentResult;Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/PaymentIntentResult;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailureMessage ()Ljava/lang/String;
+	public fun getIntent ()Lcom/stripe/android/model/PaymentIntent;
+	public synthetic fun getIntent ()Lcom/stripe/android/model/StripeIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/PaymentIntentResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentIntentResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentIntentResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentSession {
+	public static final field Companion Lcom/stripe/android/PaymentSession$Companion;
+	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/PaymentSessionConfig;)V
+	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/PaymentSessionConfig;)V
+	public final fun clearPaymentMethod ()V
+	public final fun handlePaymentData (IILandroid/content/Intent;)Z
+	public final fun init (Lcom/stripe/android/PaymentSession$PaymentSessionListener;)V
+	public final fun onCompleted ()V
+	public final fun presentPaymentMethodSelection (Ljava/lang/String;)V
+	public static synthetic fun presentPaymentMethodSelection$default (Lcom/stripe/android/PaymentSession;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun presentShippingFlow ()V
+	public final fun setCartTotal (J)V
+}
+
+public abstract interface class com/stripe/android/PaymentSession$PaymentSessionListener {
+	public abstract fun onCommunicatingStateChanged (Z)V
+	public abstract fun onError (ILjava/lang/String;)V
+	public abstract fun onPaymentSessionDataChanged (Lcom/stripe/android/PaymentSessionData;)V
+}
+
+public final class com/stripe/android/PaymentSessionConfig : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/Set;
+	public final fun component11 ()Lcom/stripe/android/view/BillingAddressFields;
+	public final fun component12 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/ShippingInformation;ZZIILjava/util/List;ZLjava/util/Set;Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/PaymentSessionConfig$ShippingInformationValidator;Lcom/stripe/android/PaymentSessionConfig$ShippingMethodsFactory;Ljava/lang/Integer;)Lcom/stripe/android/PaymentSessionConfig;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentSessionConfig;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/ShippingInformation;ZZIILjava/util/List;ZLjava/util/Set;Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/PaymentSessionConfig$ShippingInformationValidator;Lcom/stripe/android/PaymentSessionConfig$ShippingMethodsFactory;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/PaymentSessionConfig;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddPaymentMethodFooterLayoutId ()I
+	public final fun getAllowedShippingCountryCodes ()Ljava/util/Set;
+	public final fun getBillingAddressFields ()Lcom/stripe/android/view/BillingAddressFields;
+	public final fun getCanDeletePaymentMethods ()Z
+	public final fun getHiddenShippingInfoFields ()Ljava/util/List;
+	public final fun getOptionalShippingInfoFields ()Ljava/util/List;
+	public final fun getPaymentMethodTypes ()Ljava/util/List;
+	public final fun getPaymentMethodsFooterLayoutId ()I
+	public final fun getPrepopulatedShippingInfo ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun getShouldShowGooglePay ()Z
+	public fun hashCode ()I
+	public final fun isShippingInfoRequired ()Z
+	public final fun isShippingMethodRequired ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/PaymentSessionConfig$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/PaymentSessionConfig;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddPaymentMethodFooter (I)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setAllowedShippingCountryCodes (Ljava/util/Set;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setBillingAddressFields (Lcom/stripe/android/view/BillingAddressFields;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setCanDeletePaymentMethods (Z)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setHiddenShippingInfoFields ([Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setOptionalShippingInfoFields ([Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setPaymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setPaymentMethodsFooter (I)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setPrepopulatedShippingInfo (Lcom/stripe/android/model/ShippingInformation;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShippingInfoRequired (Z)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShippingInformationValidator (Lcom/stripe/android/PaymentSessionConfig$ShippingInformationValidator;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShippingMethodsFactory (Lcom/stripe/android/PaymentSessionConfig$ShippingMethodsFactory;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShippingMethodsRequired (Z)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShouldPrefetchCustomer (Z)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setShouldShowGooglePay (Z)Lcom/stripe/android/PaymentSessionConfig$Builder;
+	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/PaymentSessionConfig$Builder;
+}
+
+public class com/stripe/android/PaymentSessionConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentSessionConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentSessionConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract interface class com/stripe/android/PaymentSessionConfig$ShippingInformationValidator : java/io/Serializable {
+	public abstract fun getErrorMessage (Lcom/stripe/android/model/ShippingInformation;)Ljava/lang/String;
+	public abstract fun isValid (Lcom/stripe/android/model/ShippingInformation;)Z
+}
+
+public abstract interface class com/stripe/android/PaymentSessionConfig$ShippingMethodsFactory : java/io/Serializable {
+	public abstract fun create (Lcom/stripe/android/model/ShippingInformation;)Ljava/util/List;
+}
+
+public final class com/stripe/android/PaymentSessionData : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun component6 ()Lcom/stripe/android/model/ShippingMethod;
+	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component8 ()Z
+	public final fun copy (ZZJJLcom/stripe/android/model/ShippingInformation;Lcom/stripe/android/model/ShippingMethod;Lcom/stripe/android/model/PaymentMethod;Z)Lcom/stripe/android/PaymentSessionData;
+	public static synthetic fun copy$default (Lcom/stripe/android/PaymentSessionData;ZZJJLcom/stripe/android/model/ShippingInformation;Lcom/stripe/android/model/ShippingMethod;Lcom/stripe/android/model/PaymentMethod;ZILjava/lang/Object;)Lcom/stripe/android/PaymentSessionData;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCartTotal ()J
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun getShippingInformation ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun getShippingMethod ()Lcom/stripe/android/model/ShippingMethod;
+	public final fun getShippingTotal ()J
+	public final fun getUseGooglePay ()Z
+	public fun hashCode ()I
+	public final fun isPaymentReadyToCharge ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/PaymentSessionData$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentSessionData;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentSessionData;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/SetupIntentResult : com/stripe/android/StripeIntentResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/SetupIntent;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/SetupIntent;ILjava/lang/String;)Lcom/stripe/android/SetupIntentResult;
+	public static synthetic fun copy$default (Lcom/stripe/android/SetupIntentResult;Lcom/stripe/android/model/SetupIntent;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/SetupIntentResult;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailureMessage ()Ljava/lang/String;
+	public fun getIntent ()Lcom/stripe/android/model/SetupIntent;
+	public synthetic fun getIntent ()Lcom/stripe/android/model/StripeIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/SetupIntentResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/SetupIntentResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/SetupIntentResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/Stripe {
+	public static final field API_VERSION Ljava/lang/String;
+	public static final field Companion Lcom/stripe/android/Stripe$Companion;
+	public static final field VERSION Ljava/lang/String;
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun authenticatePayment (Landroid/app/Activity;Ljava/lang/String;)V
+	public final fun authenticatePayment (Landroidx/fragment/app/Fragment;Ljava/lang/String;)V
+	public final fun authenticateSetup (Landroid/app/Activity;Ljava/lang/String;)V
+	public final fun authenticateSetup (Landroidx/fragment/app/Fragment;Ljava/lang/String;)V
+	public final fun authenticateSource (Landroid/app/Activity;Lcom/stripe/android/model/Source;)V
+	public final fun authenticateSource (Landroid/app/Activity;Lcom/stripe/android/model/Source;Ljava/lang/String;)V
+	public final fun authenticateSource (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/Source;)V
+	public final fun authenticateSource (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/Source;Ljava/lang/String;)V
+	public static synthetic fun authenticateSource$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Lcom/stripe/android/model/Source;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun authenticateSource$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/Source;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun confirmAlipayPayment (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/AlipayAuthenticator;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun confirmAlipayPayment (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/AlipayAuthenticator;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun confirmAlipayPayment$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/AlipayAuthenticator;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun confirmPayment (Landroid/app/Activity;Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
+	public final fun confirmPayment (Landroid/app/Activity;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;)V
+	public final fun confirmPayment (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
+	public final fun confirmPayment (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;)V
+	public static synthetic fun confirmPayment$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun confirmPayment$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun confirmPaymentIntentSynchronous (Lcom/stripe/android/model/ConfirmPaymentIntentParams;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun confirmPaymentIntentSynchronous (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun confirmPaymentIntentSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun confirmSetupIntent (Landroid/app/Activity;Lcom/stripe/android/model/ConfirmSetupIntentParams;)V
+	public final fun confirmSetupIntent (Landroid/app/Activity;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;)V
+	public final fun confirmSetupIntent (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmSetupIntentParams;)V
+	public final fun confirmSetupIntent (Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;)V
+	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun confirmSetupIntentSynchronous (Lcom/stripe/android/model/ConfirmSetupIntentParams;)Lcom/stripe/android/model/SetupIntent;
+	public final fun confirmSetupIntentSynchronous (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun confirmSetupIntentSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public final fun createAccountToken (Lcom/stripe/android/model/AccountParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createAccountToken (Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createAccountToken (Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createAccountToken$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createAccountTokenSynchronous (Lcom/stripe/android/model/AccountParams;)Lcom/stripe/android/model/Token;
+	public final fun createAccountTokenSynchronous (Lcom/stripe/android/model/AccountParams;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createAccountTokenSynchronous (Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createAccountTokenSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createBankAccountToken (Lcom/stripe/android/model/BankAccountTokenParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createBankAccountToken (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createBankAccountToken (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createBankAccountToken$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createBankAccountTokenSynchronous (Lcom/stripe/android/model/BankAccountTokenParams;)Lcom/stripe/android/model/Token;
+	public final fun createBankAccountTokenSynchronous (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createBankAccountTokenSynchronous (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createBankAccountTokenSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createCardToken (Lcom/stripe/android/model/Card;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCardToken (Lcom/stripe/android/model/Card;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCardToken (Lcom/stripe/android/model/Card;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCardToken (Lcom/stripe/android/model/CardParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCardToken (Lcom/stripe/android/model/CardParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCardToken (Lcom/stripe/android/model/CardParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createCardToken$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/Card;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public static synthetic fun createCardToken$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/CardParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/Token;
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/Card;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/Card;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/Token;
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/CardParams;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createCardTokenSynchronous (Lcom/stripe/android/model/CardParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createCardTokenSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/Card;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createCardTokenSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/CardParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createCvcUpdateToken (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCvcUpdateToken (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createCvcUpdateToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createCvcUpdateToken$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createCvcUpdateTokenSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createCvcUpdateTokenSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createCvcUpdateTokenSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createCvcUpdateTokenSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createFile (Lcom/stripe/android/model/StripeFileParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createFile (Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createFile (Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createFile$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createFileSynchronous (Lcom/stripe/android/model/StripeFileParams;)Lcom/stripe/android/model/StripeFile;
+	public final fun createFileSynchronous (Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;)Lcom/stripe/android/model/StripeFile;
+	public final fun createFileSynchronous (Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/StripeFile;
+	public static synthetic fun createFileSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/StripeFileParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeFile;
+	public final fun createPaymentMethod (Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPaymentMethod (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPaymentMethod (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createPaymentMethod$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createPaymentMethodSynchronous (Lcom/stripe/android/model/PaymentMethodCreateParams;)Lcom/stripe/android/model/PaymentMethod;
+	public final fun createPaymentMethodSynchronous (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod;
+	public final fun createPaymentMethodSynchronous (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod;
+	public static synthetic fun createPaymentMethodSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod;
+	public final fun createPersonToken (Lcom/stripe/android/model/PersonTokenParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPersonToken (Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPersonToken (Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createPersonToken$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createPersonTokenSynchronous (Lcom/stripe/android/model/PersonTokenParams;)Lcom/stripe/android/model/Token;
+	public final fun createPersonTokenSynchronous (Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createPersonTokenSynchronous (Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createPersonTokenSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/PersonTokenParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createPiiToken (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPiiToken (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createPiiToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createPiiToken$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createPiiTokenSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createPiiTokenSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public final fun createPiiTokenSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Token;
+	public static synthetic fun createPiiTokenSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public final fun createSource (Lcom/stripe/android/model/SourceParams;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createSource (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun createSource (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun createSource$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun createSourceSynchronous (Lcom/stripe/android/model/SourceParams;)Lcom/stripe/android/model/Source;
+	public final fun createSourceSynchronous (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;)Lcom/stripe/android/model/Source;
+	public final fun createSourceSynchronous (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Source;
+	public static synthetic fun createSourceSynchronous$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source;
+	public static final fun getAdvancedFraudSignalsEnabled ()Z
+	public static final fun getAppInfo ()Lcom/stripe/android/AppInfo;
+	public final fun handleNextActionForPayment (Landroid/app/Activity;Ljava/lang/String;)V
+	public final fun handleNextActionForPayment (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun handleNextActionForPayment (Landroidx/fragment/app/Fragment;Ljava/lang/String;)V
+	public final fun handleNextActionForPayment (Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun handleNextActionForPayment$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun handleNextActionForPayment$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun handleNextActionForSetupIntent (Landroid/app/Activity;Ljava/lang/String;)V
+	public final fun handleNextActionForSetupIntent (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun handleNextActionForSetupIntent (Landroidx/fragment/app/Fragment;Ljava/lang/String;)V
+	public final fun handleNextActionForSetupIntent (Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun isAuthenticateSourceResult (ILandroid/content/Intent;)Z
+	public final fun onAuthenticateSourceResult (Landroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun onPaymentResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
+	public final fun onSetupResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
+	public final fun retrievePaymentIntent (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun retrievePaymentIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun retrievePaymentIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun retrieveSetupIntent (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun retrieveSetupIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun retrieveSetupIntentSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
+	public final fun retrieveSetupIntentSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun retrieveSetupIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public final fun retrieveSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun retrieveSource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun retrieveSource$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun retrieveSourceSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Source;
+	public final fun retrieveSourceSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Source;
+	public static synthetic fun retrieveSourceSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source;
+	public static final fun setAdvancedFraudSignalsEnabled (Z)V
+	public static final fun setAppInfo (Lcom/stripe/android/AppInfo;)V
+}
+
+public final class com/stripe/android/Stripe$Companion {
+	public final fun getAdvancedFraudSignalsEnabled ()Z
+	public final fun getAppInfo ()Lcom/stripe/android/AppInfo;
+	public final fun setAdvancedFraudSignalsEnabled (Z)V
+	public final fun setAppInfo (Lcom/stripe/android/AppInfo;)V
+}
+
+public final class com/stripe/android/StripeError : com/stripe/android/model/StripeModel, java/io/Serializable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/StripeError;
+	public static synthetic fun copy$default (Lcom/stripe/android/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/StripeError;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCharge ()Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDeclineCode ()Ljava/lang/String;
+	public final fun getDocUrl ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getParam ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/StripeError$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/StripeError;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/StripeError;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/StripeIntentResult : com/stripe/android/model/StripeModel {
+	public abstract fun getIntent ()Lcom/stripe/android/model/StripeIntent;
+	public final fun getOutcome ()I
+}
+
+public abstract interface annotation class com/stripe/android/StripeIntentResult$Outcome : java/lang/annotation/Annotation {
+	public static final field CANCELED I
+	public static final field Companion Lcom/stripe/android/StripeIntentResult$Outcome$Companion;
+	public static final field FAILED I
+	public static final field SUCCEEDED I
+	public static final field TIMEDOUT I
+	public static final field UNKNOWN I
+}
+
+public final class com/stripe/android/StripeIntentResult$Outcome$Companion {
+	public static final field CANCELED I
+	public static final field FAILED I
+	public static final field SUCCEEDED I
+	public static final field TIMEDOUT I
+	public static final field UNKNOWN I
+}
+
+public final class com/stripe/android/StripeTextUtils {
+	public static final field INSTANCE Lcom/stripe/android/StripeTextUtils;
+	public static final fun removeSpacesAndHyphens (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/databinding/ActivityPaymentSheetBinding : androidx/viewbinding/ViewBinding {
+	public final field appbar Lcom/google/android/material/appbar/AppBarLayout;
+	public final field bottomSheet Landroidx/constraintlayout/widget/ConstraintLayout;
+	public final field buttonContainer Landroid/widget/FrameLayout;
+	public final field buyButton Lcom/stripe/android/paymentsheet/BuyButton;
+	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
+	public final field googlePayButton Lcom/stripe/android/paymentsheet/ui/GooglePayButton;
+	public final field message Landroid/widget/TextView;
+	public final field toolbar Lcom/stripe/android/paymentsheet/ui/Toolbar;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/ActivityPaymentSheetBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/ActivityPaymentSheetBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/ActivityPaymentSheetBinding;
+}
+
+public final class com/stripe/android/databinding/AddPaymentMethodActivityBinding : androidx/viewbinding/ViewBinding {
+	public final field root Landroid/widget/LinearLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/AddPaymentMethodActivityBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/ScrollView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/AddPaymentMethodActivityBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/AddPaymentMethodActivityBinding;
+}
+
+public final class com/stripe/android/databinding/AddPaymentMethodCardViewBinding : androidx/viewbinding/ViewBinding {
+	public final field addPaymentMethodCard Landroid/widget/LinearLayout;
+	public final field billingAddressWidget Lcom/stripe/android/view/ShippingInfoWidget;
+	public final field cardMultilineWidget Lcom/stripe/android/view/CardMultilineWidget;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/AddPaymentMethodCardViewBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/AddPaymentMethodCardViewBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/AddPaymentMethodCardViewBinding;
+}
+
+public final class com/stripe/android/databinding/AddPaymentMethodRowBinding : androidx/viewbinding/ViewBinding {
+	public final field label Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/AddPaymentMethodRowBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/AddPaymentMethodRowBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/AddPaymentMethodRowBinding;
+}
+
+public final class com/stripe/android/databinding/AddressWidgetBinding : androidx/viewbinding/ViewBinding {
+	public final field countryAutocompleteAaw Lcom/stripe/android/view/CountryAutoCompleteTextView;
+	public final field etAddressLineOneAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etAddressLineTwoAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etCityAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etNameAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etPhoneNumberAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etPostalCodeAaw Lcom/stripe/android/view/StripeEditText;
+	public final field etStateAaw Lcom/stripe/android/view/StripeEditText;
+	public final field tlAddressLine1Aaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlAddressLine2Aaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlCityAaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlNameAaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlPhoneNumberAaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlPostalCodeAaw Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlStateAaw Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/AddressWidgetBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/AddressWidgetBinding;
+}
+
+public final class com/stripe/android/databinding/BecsDebitWidgetBinding : androidx/viewbinding/ViewBinding {
+	public final field accountNumberEditText Lcom/stripe/android/view/BecsDebitAccountNumberEditText;
+	public final field accountNumberTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field bsbEditText Lcom/stripe/android/view/BecsDebitBsbEditText;
+	public final field bsbTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field emailEditText Lcom/stripe/android/view/EmailEditText;
+	public final field emailTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field mandateAcceptanceTextView Lcom/stripe/android/view/BecsDebitMandateAcceptanceTextView;
+	public final field nameEditText Lcom/stripe/android/view/StripeEditText;
+	public final field nameTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/BecsDebitWidgetBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/BecsDebitWidgetBinding;
+}
+
+public final class com/stripe/android/databinding/CardBrandSpinnerDropdownBinding : androidx/viewbinding/ViewBinding {
+	public final field textView Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardBrandSpinnerDropdownBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/CardBrandSpinnerDropdownBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/CardBrandSpinnerDropdownBinding;
+}
+
+public final class com/stripe/android/databinding/CardBrandSpinnerMainBinding : androidx/viewbinding/ViewBinding {
+	public final field image Landroidx/appcompat/widget/AppCompatImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardBrandSpinnerMainBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/appcompat/widget/AppCompatImageView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/CardBrandSpinnerMainBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/CardBrandSpinnerMainBinding;
+}
+
+public final class com/stripe/android/databinding/CardBrandViewBinding : androidx/viewbinding/ViewBinding {
+	public final field icon Landroid/widget/ImageView;
+	public final field progress Lcom/stripe/android/view/CardWidgetProgressView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardBrandViewBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/CardBrandViewBinding;
+}
+
+public final class com/stripe/android/databinding/CardInputWidgetBinding : androidx/viewbinding/ViewBinding {
+	public final field cardBrandView Lcom/stripe/android/view/CardBrandView;
+	public final field cardNumberEditText Lcom/stripe/android/view/CardNumberEditText;
+	public final field cardNumberTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field container Landroid/widget/FrameLayout;
+	public final field cvcEditText Lcom/stripe/android/view/CvcEditText;
+	public final field cvcTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field expiryDateEditText Lcom/stripe/android/view/ExpiryDateEditText;
+	public final field expiryDateTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field postalCodeEditText Lcom/stripe/android/view/PostalCodeEditText;
+	public final field postalCodeTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardInputWidgetBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/CardInputWidgetBinding;
+}
+
+public final class com/stripe/android/databinding/CardMultilineWidgetBinding : androidx/viewbinding/ViewBinding {
+	public final field etCardNumber Lcom/stripe/android/view/CardNumberEditText;
+	public final field etCvc Lcom/stripe/android/view/CvcEditText;
+	public final field etExpiry Lcom/stripe/android/view/ExpiryDateEditText;
+	public final field etPostalCode Lcom/stripe/android/view/PostalCodeEditText;
+	public final field secondRowLayout Landroid/widget/LinearLayout;
+	public final field tlCardNumber Lcom/stripe/android/view/CardNumberTextInputLayout;
+	public final field tlCvc Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlExpiry Lcom/google/android/material/textfield/TextInputLayout;
+	public final field tlPostalCode Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardMultilineWidgetBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/CardMultilineWidgetBinding;
+}
+
+public final class com/stripe/android/databinding/CardWidgetProgressViewBinding : androidx/viewbinding/ViewBinding {
+	public final field cardLoading Landroid/widget/ProgressBar;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CardWidgetProgressViewBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/CardWidgetProgressViewBinding;
+}
+
+public final class com/stripe/android/databinding/CountryAutocompleteViewBinding : androidx/viewbinding/ViewBinding {
+	public final field countryAutocomplete Landroid/widget/AutoCompleteTextView;
+	public final field countryTextInputLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CountryAutocompleteViewBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/CountryAutocompleteViewBinding;
+}
+
+public final class com/stripe/android/databinding/CountryTextViewBinding : androidx/viewbinding/ViewBinding {
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/CountryTextViewBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/TextView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/CountryTextViewBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/CountryTextViewBinding;
+}
+
+public final class com/stripe/android/databinding/FpxBankItemBinding : androidx/viewbinding/ViewBinding {
+	public final field checkIcon Landroidx/appcompat/widget/AppCompatImageView;
+	public final field icon Landroidx/appcompat/widget/AppCompatImageView;
+	public final field name Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/FpxBankItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/FpxBankItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/FpxBankItemBinding;
+}
+
+public final class com/stripe/android/databinding/FpxPaymentMethodBinding : androidx/viewbinding/ViewBinding {
+	public final field fpxList Landroidx/recyclerview/widget/RecyclerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/FpxPaymentMethodBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/FpxPaymentMethodBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/FpxPaymentMethodBinding;
+}
+
+public final class com/stripe/android/databinding/FragmentPaymentSheetLoadingBinding : androidx/viewbinding/ViewBinding {
+	public final field loadingSpinner Lcom/google/android/material/progressindicator/CircularProgressIndicator;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/FragmentPaymentSheetLoadingBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/FrameLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/FragmentPaymentSheetLoadingBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/FragmentPaymentSheetLoadingBinding;
+}
+
+public final class com/stripe/android/databinding/FragmentPaymentsheetAddCardBinding : androidx/viewbinding/ViewBinding {
+	public final field addCardHeader Landroid/widget/TextView;
+	public final field billingAddress Lcom/stripe/android/paymentsheet/ui/BillingAddressView;
+	public final field billingAddressLabel Landroid/widget/TextView;
+	public final field cardErrors Landroid/widget/TextView;
+	public final field cardInfoLabel Landroid/widget/TextView;
+	public final field cardMultilineWidget Lcom/stripe/android/view/CardMultilineWidget;
+	public final field cardMultilineWidgetContainer Lcom/google/android/material/card/MaterialCardView;
+	public final field googlePayButton Lcom/stripe/android/paymentsheet/ui/GooglePayButton;
+	public final field googlePayDivider Lcom/stripe/android/paymentsheet/ui/GooglePayDivider;
+	public final field saveCardCheckbox Lcom/google/android/material/checkbox/MaterialCheckBox;
+	public final field topContainer Landroid/widget/LinearLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/FragmentPaymentsheetAddCardBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/ScrollView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/FragmentPaymentsheetAddCardBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/FragmentPaymentsheetAddCardBinding;
+}
+
+public final class com/stripe/android/databinding/FragmentPaymentsheetPaymentMethodsListBinding : androidx/viewbinding/ViewBinding {
+	public final field header Landroid/widget/TextView;
+	public final field recycler Landroidx/recyclerview/widget/RecyclerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/FragmentPaymentsheetPaymentMethodsListBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/FragmentPaymentsheetPaymentMethodsListBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/FragmentPaymentsheetPaymentMethodsListBinding;
+}
+
+public final class com/stripe/android/databinding/GooglePayRowBinding : androidx/viewbinding/ViewBinding {
+	public final field checkIcon Landroidx/appcompat/widget/AppCompatImageView;
+	public final field label Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/GooglePayRowBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/GooglePayRowBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/GooglePayRowBinding;
+}
+
+public final class com/stripe/android/databinding/LayoutPaymentsheetAddCardItemBinding : androidx/viewbinding/ViewBinding {
+	public final field card Lcom/google/android/material/card/MaterialCardView;
+	public final field label Landroid/widget/TextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/LayoutPaymentsheetAddCardItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/LayoutPaymentsheetAddCardItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/LayoutPaymentsheetAddCardItemBinding;
+}
+
+public final class com/stripe/android/databinding/LayoutPaymentsheetGooglePayItemBinding : androidx/viewbinding/ViewBinding {
+	public final field card Lcom/google/android/material/card/MaterialCardView;
+	public final field checkIcon Landroid/widget/ImageView;
+	public final field label Landroid/widget/TextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/LayoutPaymentsheetGooglePayItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/LayoutPaymentsheetGooglePayItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/LayoutPaymentsheetGooglePayItemBinding;
+}
+
+public final class com/stripe/android/databinding/LayoutPaymentsheetPaymentMethodItemBinding : androidx/viewbinding/ViewBinding {
+	public final field brandIcon Landroid/widget/ImageView;
+	public final field card Lcom/google/android/material/card/MaterialCardView;
+	public final field checkIcon Landroid/widget/ImageView;
+	public final field label Landroid/widget/TextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/LayoutPaymentsheetPaymentMethodItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/LayoutPaymentsheetPaymentMethodItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/LayoutPaymentsheetPaymentMethodItemBinding;
+}
+
+public final class com/stripe/android/databinding/MaskedCardRowBinding : androidx/viewbinding/ViewBinding {
+	public final field maskedCardItem Lcom/stripe/android/view/MaskedCardView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/MaskedCardRowBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/FrameLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/MaskedCardRowBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/MaskedCardRowBinding;
+}
+
+public final class com/stripe/android/databinding/MaskedCardViewBinding : androidx/viewbinding/ViewBinding {
+	public final field brandIcon Landroidx/appcompat/widget/AppCompatImageView;
+	public final field checkIcon Landroidx/appcompat/widget/AppCompatImageView;
+	public final field details Landroidx/appcompat/widget/AppCompatTextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/MaskedCardViewBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/MaskedCardViewBinding;
+}
+
+public final class com/stripe/android/databinding/PaymentAuthWebViewActivityBinding : androidx/viewbinding/ViewBinding {
+	public final field progressBar Landroid/widget/ProgressBar;
+	public final field toolbar Landroidx/appcompat/widget/Toolbar;
+	public final field webView Lcom/stripe/android/view/PaymentAuthWebView;
+	public final field webViewContainer Landroid/widget/FrameLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/PaymentAuthWebViewActivityBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/PaymentAuthWebViewActivityBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/PaymentAuthWebViewActivityBinding;
+}
+
+public final class com/stripe/android/databinding/PaymentFlowActivityBinding : androidx/viewbinding/ViewBinding {
+	public final field shippingFlowViewpager Lcom/stripe/android/view/PaymentFlowViewPager;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/PaymentFlowActivityBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/FrameLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/PaymentFlowActivityBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/PaymentFlowActivityBinding;
+}
+
+public final class com/stripe/android/databinding/PaymentMethodsActivityBinding : androidx/viewbinding/ViewBinding {
+	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public final field footerContainer Landroid/widget/FrameLayout;
+	public final field progressBar Lcom/google/android/material/progressindicator/LinearProgressIndicator;
+	public final field recycler Lcom/stripe/android/view/PaymentMethodsRecyclerView;
+	public final field toolbar Landroidx/appcompat/widget/Toolbar;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/PaymentMethodsActivityBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/PaymentMethodsActivityBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/PaymentMethodsActivityBinding;
+}
+
+public final class com/stripe/android/databinding/PaymentSheetAddButtonBinding : androidx/viewbinding/ViewBinding {
+	public final field label Landroid/widget/TextView;
+	public final field lockIcon Landroid/widget/ImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/PaymentSheetAddButtonBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/PaymentSheetAddButtonBinding;
+}
+
+public final class com/stripe/android/databinding/PaymentSheetBuyButtonBinding : androidx/viewbinding/ViewBinding {
+	public final field confirmedIcon Landroid/widget/ImageView;
+	public final field confirmingIcon Lcom/google/android/material/progressindicator/CircularProgressIndicator;
+	public final field label Landroid/widget/TextView;
+	public final field lockIcon Landroid/widget/ImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/PaymentSheetBuyButtonBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/PaymentSheetBuyButtonBinding;
+}
+
+public final class com/stripe/android/databinding/ShippingInfoPageBinding : androidx/viewbinding/ViewBinding {
+	public final field shippingInfoWidget Lcom/stripe/android/view/ShippingInfoWidget;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/ShippingInfoPageBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/ScrollView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/ShippingInfoPageBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/ShippingInfoPageBinding;
+}
+
+public final class com/stripe/android/databinding/ShippingMethodPageBinding : androidx/viewbinding/ViewBinding {
+	public final field selectShippingMethodWidget Lcom/stripe/android/view/SelectShippingMethodWidget;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/ShippingMethodPageBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/FrameLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/ShippingMethodPageBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/ShippingMethodPageBinding;
+}
+
+public final class com/stripe/android/databinding/ShippingMethodViewBinding : androidx/viewbinding/ViewBinding {
+	public final field description Landroid/widget/TextView;
+	public final field name Landroid/widget/TextView;
+	public final field price Landroid/widget/TextView;
+	public final field selectedIcon Landroidx/appcompat/widget/AppCompatImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/ShippingMethodViewBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/ShippingMethodViewBinding;
+}
+
+public final class com/stripe/android/databinding/ShippingMethodWidgetBinding : androidx/viewbinding/ViewBinding {
+	public final field shippingMethods Landroidx/recyclerview/widget/RecyclerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/ShippingMethodWidgetBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/ShippingMethodWidgetBinding;
+}
+
+public final class com/stripe/android/databinding/StripeActivityBinding : androidx/viewbinding/ViewBinding {
+	public final field progressBar Landroid/widget/ProgressBar;
+	public final field toolbar Landroidx/appcompat/widget/Toolbar;
+	public final field viewStub Landroid/view/ViewStub;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeActivityBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/RelativeLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeActivityBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeActivityBinding;
+}
+
+public final class com/stripe/android/databinding/StripeActivityPaymentOptionsBinding : androidx/viewbinding/ViewBinding {
+	public final field addButton Lcom/stripe/android/paymentsheet/AddButton;
+	public final field appbar Lcom/google/android/material/appbar/AppBarLayout;
+	public final field bottomSheet Landroidx/constraintlayout/widget/ConstraintLayout;
+	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
+	public final field message Landroid/widget/TextView;
+	public final field toolbar Lcom/stripe/android/paymentsheet/ui/Toolbar;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeActivityPaymentOptionsBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeActivityPaymentOptionsBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeActivityPaymentOptionsBinding;
+}
+
+public final class com/stripe/android/databinding/StripeBillingAddressLayoutBinding : androidx/viewbinding/ViewBinding {
+	public final field address1 Lcom/google/android/material/textfield/TextInputEditText;
+	public final field address1Divider Landroid/view/View;
+	public final field address1Layout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field address2 Lcom/google/android/material/textfield/TextInputEditText;
+	public final field address2Divider Landroid/view/View;
+	public final field address2Layout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field city Lcom/google/android/material/textfield/TextInputEditText;
+	public final field cityLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field cityPostalContainer Landroid/widget/LinearLayout;
+	public final field cityPostalDivider Landroid/view/View;
+	public final field country Landroid/widget/AutoCompleteTextView;
+	public final field countryLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field postalCode Lcom/google/android/material/textfield/TextInputEditText;
+	public final field postalCodeLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public final field state Lcom/google/android/material/textfield/TextInputEditText;
+	public final field stateDivider Landroid/view/View;
+	public final field stateLayout Lcom/google/android/material/textfield/TextInputLayout;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeBillingAddressLayoutBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/StripeBillingAddressLayoutBinding;
+}
+
+public final class com/stripe/android/databinding/StripeCountryDropdownItemBinding : androidx/viewbinding/ViewBinding {
+	public final field text1 Landroid/widget/TextView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeCountryDropdownItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/TextView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeCountryDropdownItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeCountryDropdownItemBinding;
+}
+
+public final class com/stripe/android/databinding/StripeGooglePayButtonBlackBinding : androidx/viewbinding/ViewBinding {
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeGooglePayButtonBlackBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/RelativeLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeGooglePayButtonBlackBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeGooglePayButtonBlackBinding;
+}
+
+public final class com/stripe/android/databinding/StripeGooglePayDividerBinding : androidx/viewbinding/ViewBinding {
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeGooglePayDividerBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/StripeGooglePayDividerBinding;
+}
+
+public final class com/stripe/android/databinding/StripeHorizontalDividerBinding : androidx/viewbinding/ViewBinding {
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeHorizontalDividerBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeHorizontalDividerBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeHorizontalDividerBinding;
+}
+
+public final class com/stripe/android/databinding/StripePaymentSheetToolbarBinding : androidx/viewbinding/ViewBinding {
+	public final field back Landroid/widget/ImageView;
+	public final field close Landroid/widget/ImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripePaymentSheetToolbarBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/databinding/StripePaymentSheetToolbarBinding;
+}
+
+public final class com/stripe/android/databinding/StripeVerticalDividerBinding : androidx/viewbinding/ViewBinding {
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/databinding/StripeVerticalDividerBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/databinding/StripeVerticalDividerBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/databinding/StripeVerticalDividerBinding;
+}
+
+public final class com/stripe/android/exception/APIConnectionException : com/stripe/android/exception/StripeException {
+	public static final field Companion Lcom/stripe/android/exception/APIConnectionException$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/exception/APIException : com/stripe/android/exception/StripeException {
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/exception/AuthenticationException : com/stripe/android/exception/StripeException {
+}
+
+public final class com/stripe/android/exception/CardException : com/stripe/android/exception/StripeException {
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCharge ()Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDeclineCode ()Ljava/lang/String;
+	public final fun getParam ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/exception/InvalidRequestException : com/stripe/android/exception/StripeException {
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/exception/PermissionException : com/stripe/android/exception/StripeException {
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/exception/RateLimitException : com/stripe/android/exception/StripeException {
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/stripe/android/exception/StripeException : java/lang/Exception {
+	public static final field Companion Lcom/stripe/android/exception/StripeException$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/Throwable;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/Throwable;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestId ()Ljava/lang/String;
+	public final fun getStatusCode ()I
+	public final fun getStripeError ()Lcom/stripe/android/StripeError;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/AccountParams : com/stripe/android/model/TokenParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/AccountParams$Companion;
+	public final fun copy (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams;)Lcom/stripe/android/model/AccountParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams;ZLcom/stripe/android/model/AccountParams$BusinessTypeParams;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams;
+	public static final fun create (Z)Lcom/stripe/android/model/AccountParams;
+	public static final fun create (ZLcom/stripe/android/model/AccountParams$BusinessType;)Lcom/stripe/android/model/AccountParams;
+	public static final fun create (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;)Lcom/stripe/android/model/AccountParams;
+	public static final fun create (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;)Lcom/stripe/android/model/AccountParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessType : java/lang/Enum {
+	public static final field Company Lcom/stripe/android/model/AccountParams$BusinessType;
+	public static final field Individual Lcom/stripe/android/model/AccountParams$BusinessType;
+	public final fun getCode ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessType;
+	public static fun values ()[Lcom/stripe/android/model/AccountParams$BusinessType;
+}
+
+public abstract class com/stripe/android/model/AccountParams$BusinessTypeParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public abstract fun getParamsList ()Ljava/util/List;
+	public fun toParamMap ()Ljava/util/Map;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company : com/stripe/android/model/AccountParams$BusinessTypeParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getAddressKana ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getAddressKanji ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getDirectorsProvided ()Ljava/lang/Boolean;
+	public final fun getExecutivesProvided ()Ljava/lang/Boolean;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNameKana ()Ljava/lang/String;
+	public final fun getNameKanji ()Ljava/lang/String;
+	public final fun getOwnersProvided ()Ljava/lang/Boolean;
+	public fun getParamsList ()Ljava/util/List;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getTaxId ()Ljava/lang/String;
+	public final fun getTaxIdRegistrar ()Ljava/lang/String;
+	public final fun getVatId ()Ljava/lang/String;
+	public final fun getVerification ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public fun hashCode ()I
+	public final fun setAddress (Lcom/stripe/android/model/Address;)V
+	public final fun setAddressKana (Lcom/stripe/android/model/AddressJapanParams;)V
+	public final fun setAddressKanji (Lcom/stripe/android/model/AddressJapanParams;)V
+	public final fun setDirectorsProvided (Ljava/lang/Boolean;)V
+	public final fun setExecutivesProvided (Ljava/lang/Boolean;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNameKana (Ljava/lang/String;)V
+	public final fun setNameKanji (Ljava/lang/String;)V
+	public final fun setOwnersProvided (Ljava/lang/Boolean;)V
+	public final fun setPhone (Ljava/lang/String;)V
+	public final fun setTaxId (Ljava/lang/String;)V
+	public final fun setTaxIdRegistrar (Ljava/lang/String;)V
+	public final fun setVatId (Ljava/lang/String;)V
+	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddress (Lcom/stripe/android/model/Address;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setAddressKana (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setAddressKanji (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setDirectorsProvided (Ljava/lang/Boolean;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setExecutivesProvided (Ljava/lang/Boolean;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setName (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setNameKana (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setNameKanji (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setOwnersProvided (Ljava/lang/Boolean;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setPhone (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setTaxId (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setTaxIdRegistrar (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setVatId (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public final fun copy (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDocument ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
+	public fun hashCode ()I
+	public final fun setDocument (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual : com/stripe/android/model/AccountParams$BusinessTypeParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/Map;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component4 ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getAddressKana ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getAddressKanji ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getDateOfBirth ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getFirstName ()Ljava/lang/String;
+	public final fun getFirstNameKana ()Ljava/lang/String;
+	public final fun getFirstNameKanji ()Ljava/lang/String;
+	public final fun getGender ()Ljava/lang/String;
+	public final fun getIdNumber ()Ljava/lang/String;
+	public final fun getLastName ()Ljava/lang/String;
+	public final fun getLastNameKana ()Ljava/lang/String;
+	public final fun getLastNameKanji ()Ljava/lang/String;
+	public final fun getMaidenName ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
+	public fun getParamsList ()Ljava/util/List;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getSsnLast4 ()Ljava/lang/String;
+	public final fun getVerification ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public fun hashCode ()I
+	public final fun setAddress (Lcom/stripe/android/model/Address;)V
+	public final fun setAddressKana (Lcom/stripe/android/model/AddressJapanParams;)V
+	public final fun setAddressKanji (Lcom/stripe/android/model/AddressJapanParams;)V
+	public final fun setDateOfBirth (Lcom/stripe/android/model/DateOfBirth;)V
+	public final fun setEmail (Ljava/lang/String;)V
+	public final fun setFirstName (Ljava/lang/String;)V
+	public final fun setFirstNameKana (Ljava/lang/String;)V
+	public final fun setFirstNameKanji (Ljava/lang/String;)V
+	public final fun setGender (Ljava/lang/String;)V
+	public final fun setIdNumber (Ljava/lang/String;)V
+	public final fun setLastName (Ljava/lang/String;)V
+	public final fun setLastNameKana (Ljava/lang/String;)V
+	public final fun setLastNameKanji (Ljava/lang/String;)V
+	public final fun setMaidenName (Ljava/lang/String;)V
+	public final fun setMetadata (Ljava/util/Map;)V
+	public final fun setPhone (Ljava/lang/String;)V
+	public final fun setSsnLast4 (Ljava/lang/String;)V
+	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddress (Lcom/stripe/android/model/Address;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setAddressKana (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setAddressKanji (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setDateOfBirth (Lcom/stripe/android/model/DateOfBirth;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setEmail (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setFirstName (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setFirstNameKana (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setFirstNameKanji (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setGender (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setIdNumber (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setLastName (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setLastNameKana (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setLastNameKanji (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setMaidenName (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setMetadata (Ljava/util/Map;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setPhone (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setSsnLast4 (Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
+	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public final fun component2 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public final fun copy (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalDocument ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public final fun getDocument ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
+	public fun hashCode ()I
+	public final fun setAdditionalDocument (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
+	public final fun setDocument (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountParams$Companion {
+	public final fun create (Z)Lcom/stripe/android/model/AccountParams;
+	public final fun create (ZLcom/stripe/android/model/AccountParams$BusinessType;)Lcom/stripe/android/model/AccountParams;
+	public final fun create (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;)Lcom/stripe/android/model/AccountParams;
+	public final fun create (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;)Lcom/stripe/android/model/AccountParams;
+}
+
+public class com/stripe/android/model/AccountParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Address : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/Address$Companion;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Address;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Address;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
+	public final fun getCity ()Ljava/lang/String;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getLine1 ()Ljava/lang/String;
+	public final fun getLine2 ()Ljava/lang/String;
+	public final fun getPostalCode ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/Address$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/Address;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setCity (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setCountry (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setLine1 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setLine2 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setPostalCode (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setState (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
+}
+
+public final class com/stripe/android/model/Address$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
+}
+
+public class com/stripe/android/model/Address$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Address;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Address;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AddressJapanParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AddressJapanParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCity ()Ljava/lang/String;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getLine1 ()Ljava/lang/String;
+	public final fun getLine2 ()Ljava/lang/String;
+	public final fun getPostalCode ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public final fun getTown ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/AddressJapanParams$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/AddressJapanParams;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setCity (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setCountry (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setLine1 (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setLine2 (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setPostalCode (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setState (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+	public final fun setTown (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
+}
+
+public class com/stripe/android/model/AddressJapanParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AddressJapanParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AddressJapanParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/BankAccount : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/BankAccount$Status;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/BankAccount$Type;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccount$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccount$Status;)Lcom/stripe/android/model/BankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/BankAccount;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccount$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccount$Status;ILjava/lang/Object;)Lcom/stripe/android/model/BankAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountHolderName ()Ljava/lang/String;
+	public final fun getAccountHolderType ()Lcom/stripe/android/model/BankAccount$Type;
+	public final fun getBankName ()Ljava/lang/String;
+	public final fun getCountryCode ()Ljava/lang/String;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getFingerprint ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getRoutingNumber ()Ljava/lang/String;
+	public final fun getStatus ()Lcom/stripe/android/model/BankAccount$Status;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/BankAccount$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BankAccount;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/BankAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/BankAccount$Status : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/BankAccount$Status$Companion;
+	public static final field Errored Lcom/stripe/android/model/BankAccount$Status;
+	public static final field New Lcom/stripe/android/model/BankAccount$Status;
+	public static final field Validated Lcom/stripe/android/model/BankAccount$Status;
+	public static final field VerificationFailed Lcom/stripe/android/model/BankAccount$Status;
+	public static final field Verified Lcom/stripe/android/model/BankAccount$Status;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/BankAccount$Status;
+	public static fun values ()[Lcom/stripe/android/model/BankAccount$Status;
+}
+
+public final class com/stripe/android/model/BankAccount$Type : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/BankAccount$Type$Companion;
+	public static final field Company Lcom/stripe/android/model/BankAccount$Type;
+	public static final field Individual Lcom/stripe/android/model/BankAccount$Type;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/BankAccount$Type;
+	public static fun values ()[Lcom/stripe/android/model/BankAccount$Type;
+}
+
+public final class com/stripe/android/model/BankAccountTokenParams : com/stripe/android/model/TokenParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/BankAccountTokenParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/BankAccountTokenParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/BankAccountTokenParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BankAccountTokenParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/BankAccountTokenParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/BankAccountTokenParams$Type : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/BankAccountTokenParams$Type$Companion;
+	public static final field Company Lcom/stripe/android/model/BankAccountTokenParams$Type;
+	public static final field Individual Lcom/stripe/android/model/BankAccountTokenParams$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/BankAccountTokenParams$Type;
+	public static fun values ()[Lcom/stripe/android/model/BankAccountTokenParams$Type;
+}
+
+public final class com/stripe/android/model/BankAccountTokenParamsFixtures {
+	public static final field DEFAULT Lcom/stripe/android/model/BankAccountTokenParams;
+	public static final field INSTANCE Lcom/stripe/android/model/BankAccountTokenParamsFixtures;
+}
+
+public final class com/stripe/android/model/Card : com/stripe/android/model/TokenParams, com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/Card$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Lcom/stripe/android/model/CardBrand;
+	public final fun component16 ()Lcom/stripe/android/model/CardFunding;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component24 ()Lcom/stripe/android/model/TokenizationMethod;
+	public final fun component25 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/TokenizationMethod;Ljava/util/Map;)Lcom/stripe/android/model/Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Card;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/TokenizationMethod;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/Card;
+	public static final fun create (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lcom/stripe/android/model/Card;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Card;
+	public static final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Card;
+	public final fun getAddressCity ()Ljava/lang/String;
+	public final fun getAddressCountry ()Ljava/lang/String;
+	public final fun getAddressLine1 ()Ljava/lang/String;
+	public final fun getAddressLine1Check ()Ljava/lang/String;
+	public final fun getAddressLine2 ()Ljava/lang/String;
+	public final fun getAddressState ()Ljava/lang/String;
+	public final fun getAddressZip ()Ljava/lang/String;
+	public final fun getAddressZipCheck ()Ljava/lang/String;
+	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getCustomerId ()Ljava/lang/String;
+	public final fun getCvc ()Ljava/lang/String;
+	public final fun getCvcCheck ()Ljava/lang/String;
+	public final fun getExpMonth ()Ljava/lang/Integer;
+	public final fun getExpYear ()Ljava/lang/Integer;
+	public final fun getFingerprint ()Ljava/lang/String;
+	public final fun getFunding ()Lcom/stripe/android/model/CardFunding;
+	public fun getId ()Ljava/lang/String;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/String;
+	public final fun getTokenizationMethod ()Lcom/stripe/android/model/TokenizationMethod;
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun toBuilder ()Lcom/stripe/android/model/Card$Builder;
+	public final fun toPaymentMethodParamsCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public final fun toPaymentMethodsParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public fun toString ()Ljava/lang/String;
+	public final fun validateCVC ()Z
+	public final fun validateCard ()Z
+	public final fun validateExpMonth ()Z
+	public final fun validateExpiryDate ()Z
+	public final fun validateNumber ()Z
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/Card$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addressCity (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressCountry (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressLine1 (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressLine1Check (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressLine2 (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressState (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressZip (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun addressZipCheck (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun brand (Lcom/stripe/android/model/CardBrand;)Lcom/stripe/android/model/Card$Builder;
+	public fun build ()Lcom/stripe/android/model/Card;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun country (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun currency (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun customer (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun cvcCheck (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun fingerprint (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun funding (Lcom/stripe/android/model/CardFunding;)Lcom/stripe/android/model/Card$Builder;
+	public final fun id (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun last4 (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun loggingTokens (Ljava/util/Set;)Lcom/stripe/android/model/Card$Builder;
+	public final fun metadata (Ljava/util/Map;)Lcom/stripe/android/model/Card$Builder;
+	public final fun name (Ljava/lang/String;)Lcom/stripe/android/model/Card$Builder;
+	public final fun tokenizationMethod (Lcom/stripe/android/model/TokenizationMethod;)Lcom/stripe/android/model/Card$Builder;
+}
+
+public final class com/stripe/android/model/Card$Companion {
+	public final fun create (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lcom/stripe/android/model/Card;
+	public static synthetic fun create$default (Lcom/stripe/android/model/Card$Companion;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Card;
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Card;
+	public final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Card;
+}
+
+public class com/stripe/android/model/Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/CardBrand : java/lang/Enum {
+	public static final field AmericanExpress Lcom/stripe/android/model/CardBrand;
+	public static final field Companion Lcom/stripe/android/model/CardBrand$Companion;
+	public static final field DinersClub Lcom/stripe/android/model/CardBrand;
+	public static final field Discover Lcom/stripe/android/model/CardBrand;
+	public static final field JCB Lcom/stripe/android/model/CardBrand;
+	public static final field MasterCard Lcom/stripe/android/model/CardBrand;
+	public static final field UnionPay Lcom/stripe/android/model/CardBrand;
+	public static final field Unknown Lcom/stripe/android/model/CardBrand;
+	public static final field Visa Lcom/stripe/android/model/CardBrand;
+	public final fun formatNumber (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCvcIcon ()I
+	public final fun getCvcLength ()Ljava/util/Set;
+	public final fun getDefaultMaxLength ()I
+	public final fun getDefaultMaxLengthWithSpaces ()I
+	public final fun getDefaultSpacePositions ()Ljava/util/Set;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getErrorIcon ()I
+	public final fun getIcon ()I
+	public final fun getMaxCvcLength ()I
+	public final fun getMaxLengthForCardNumber (Ljava/lang/String;)I
+	public final fun getMaxLengthWithSpacesForCardNumber (Ljava/lang/String;)I
+	public final fun getPattern ()Ljava/util/regex/Pattern;
+	public final fun getSpacePositionsForCardNumber (Ljava/lang/String;)Ljava/util/Set;
+	public final fun groupNumber (Ljava/lang/String;)[Ljava/lang/String;
+	public final fun isMaxCvc (Ljava/lang/String;)Z
+	public final fun isValidCardNumberLength (Ljava/lang/String;)Z
+	public final fun isValidCvc (Ljava/lang/String;)Z
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/CardBrand;
+	public static fun values ()[Lcom/stripe/android/model/CardBrand;
+}
+
+public final class com/stripe/android/model/CardBrand$Companion {
+	public final fun fromCardNumber (Ljava/lang/String;)Lcom/stripe/android/model/CardBrand;
+	public final fun fromCode (Ljava/lang/String;)Lcom/stripe/android/model/CardBrand;
+}
+
+public final class com/stripe/android/model/CardFunding : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/CardFunding$Companion;
+	public static final field Credit Lcom/stripe/android/model/CardFunding;
+	public static final field Debit Lcom/stripe/android/model/CardFunding;
+	public static final field Prepaid Lcom/stripe/android/model/CardFunding;
+	public static final field Unknown Lcom/stripe/android/model/CardFunding;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/CardFunding;
+	public static fun values ()[Lcom/stripe/android/model/CardFunding;
+}
+
+public final class com/stripe/android/model/CardParams : com/stripe/android/model/TokenParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;II)V
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;)V
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/stripe/android/model/Address;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/CardBrand;Ljava/util/Set;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/model/CardParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/CardParams;Lcom/stripe/android/model/CardBrand;Ljava/util/Set;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/CardParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun setAddress (Lcom/stripe/android/model/Address;)V
+	public final fun setCurrency (Ljava/lang/String;)V
+	public final fun setMetadata (Ljava/util/Map;)V
+	public final fun setName (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/CardParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CardParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/CardParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/stripe/android/model/ConfirmStripeIntentParams {
+	public static final field Companion Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;
+	public final fun component1 ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun component10 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Lcom/stripe/android/model/MandateDataParams;
+	public final fun component13 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public final fun component14 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/SourceParams;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createAlipay (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getClientSecret ()Ljava/lang/String;
+	public final fun getExtraParams ()Ljava/util/Map;
+	public final fun getMandateData ()Lcom/stripe/android/model/MandateDataParams;
+	public final fun getMandateId ()Ljava/lang/String;
+	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun getPaymentMethodId ()Ljava/lang/String;
+	public final fun getPaymentMethodOptions ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
+	public final fun getReceiptEmail ()Ljava/lang/String;
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public final fun getSavePaymentMethod ()Ljava/lang/Boolean;
+	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public final fun getShipping ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public final fun getSourceId ()Ljava/lang/String;
+	public final fun getSourceParams ()Lcom/stripe/android/model/SourceParams;
+	public fun hashCode ()I
+	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V
+	public final fun setMandateId (Ljava/lang/String;)V
+	public final fun setPaymentMethodOptions (Lcom/stripe/android/model/PaymentMethodOptionsParams;)V
+	public final fun setReceiptEmail (Ljava/lang/String;)V
+	public final fun setReturnUrl (Ljava/lang/String;)V
+	public final fun setSavePaymentMethod (Ljava/lang/Boolean;)V
+	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
+	public final fun setShipping (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)V
+	public final fun shouldSavePaymentMethod ()Z
+	public fun shouldUseStripeSdk ()Z
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public synthetic fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmStripeIntentParams;
+}
+
+public final class com/stripe/android/model/ConfirmPaymentIntentParams$Companion {
+	public final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createAlipay (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithPaymentMethodCreateParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithPaymentMethodId$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithSourceId$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithSourceParams (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithSourceParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+}
+
+public final class com/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage : java/lang/Enum {
+	public static final field OffSession Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public static final field OnSession Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public static fun values ()[Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+}
+
+public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ConfirmSetupIntentParams : android/os/Parcelable, com/stripe/android/model/ConfirmStripeIntentParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun createWithoutPaymentMethod (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun createWithoutPaymentMethod (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getClientSecret ()Ljava/lang/String;
+	public final fun getMandateData ()Lcom/stripe/android/model/MandateDataParams;
+	public final fun getMandateId ()Ljava/lang/String;
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V
+	public final fun setMandateId (Ljava/lang/String;)V
+	public final fun setReturnUrl (Ljava/lang/String;)V
+	public fun shouldUseStripeSdk ()Z
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public synthetic fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmStripeIntentParams;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun createWithoutPaymentMethod (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun createWithoutPaymentMethod (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun createWithoutPaymentMethod$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+}
+
+public class com/stripe/android/model/ConfirmSetupIntentParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract interface class com/stripe/android/model/ConfirmStripeIntentParams : com/stripe/android/model/StripeParamsModel {
+	public static final field Companion Lcom/stripe/android/model/ConfirmStripeIntentParams$Companion;
+	public abstract fun getClientSecret ()Ljava/lang/String;
+	public abstract fun shouldUseStripeSdk ()Z
+	public abstract fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmStripeIntentParams;
+}
+
+public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion {
+}
+
+public final class com/stripe/android/model/Customer : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/Customer$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ShippingInformation;Ljava/util/List;ZLjava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lcom/stripe/android/model/Customer;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Customer;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ShippingInformation;Ljava/util/List;ZLjava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/Customer;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Customer;
+	public static final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Customer;
+	public final fun getDefaultSource ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getHasMore ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLiveMode ()Z
+	public final fun getShippingInformation ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun getSourceById (Ljava/lang/String;)Lcom/stripe/android/model/CustomerSource;
+	public final fun getSources ()Ljava/util/List;
+	public final fun getTotalCount ()Ljava/lang/Integer;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/Customer$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Customer;
+	public final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Customer;
+}
+
+public class com/stripe/android/model/Customer$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Customer;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Customer;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/CustomerSource : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun asCard ()Lcom/stripe/android/model/Card;
+	public final fun asSource ()Lcom/stripe/android/model/Source;
+	public final fun copy (Lcom/stripe/android/model/StripePaymentSource;)Lcom/stripe/android/model/CustomerSource;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/CustomerSource;Lcom/stripe/android/model/StripePaymentSource;ILjava/lang/Object;)Lcom/stripe/android/model/CustomerSource;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Ljava/lang/String;
+	public final fun getSourceType ()Ljava/lang/String;
+	public final fun getTokenizationMethod ()Lcom/stripe/android/model/TokenizationMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/CustomerSource$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CustomerSource;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/CustomerSource;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/CvcTokenParams : com/stripe/android/model/TokenParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/CvcTokenParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/CvcTokenParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/CvcTokenParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/CvcTokenParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CvcTokenParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/CvcTokenParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/DateOfBirth : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (III)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lcom/stripe/android/model/DateOfBirth;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/DateOfBirth;IIIILjava/lang/Object;)Lcom/stripe/android/model/DateOfBirth;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDay ()I
+	public final fun getMonth ()I
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/DateOfBirth$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/DateOfBirth;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/DateOfBirth;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/ExpirationDate {
+}
+
+public final class com/stripe/android/model/ExpirationDate$Validated : com/stripe/android/model/ExpirationDate {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lcom/stripe/android/model/ExpirationDate$Validated;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ExpirationDate$Validated;IIILjava/lang/Object;)Lcom/stripe/android/model/ExpirationDate$Validated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMonth ()I
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/GooglePayResult : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/GooglePayResult$Companion;
+	public fun <init> ()V
+	public final fun component1 ()Lcom/stripe/android/model/Token;
+	public final fun component2 ()Lcom/stripe/android/model/Address;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun copy (Lcom/stripe/android/model/Token;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ShippingInformation;)Lcom/stripe/android/model/GooglePayResult;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/GooglePayResult;Lcom/stripe/android/model/Token;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ShippingInformation;ILjava/lang/Object;)Lcom/stripe/android/model/GooglePayResult;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/GooglePayResult;
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhoneNumber ()Ljava/lang/String;
+	public final fun getShippingInformation ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun getToken ()Lcom/stripe/android/model/Token;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/GooglePayResult$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/GooglePayResult;
+}
+
+public class com/stripe/android/model/GooglePayResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/GooglePayResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/GooglePayResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/IssuingCardPin : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/IssuingCardPin;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/IssuingCardPin;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/IssuingCardPin;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPin ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/IssuingCardPin$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/IssuingCardPin;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/IssuingCardPin;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/stripe/android/model/Address;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;)Lcom/stripe/android/model/KlarnaSourceParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBillingAddress ()Lcom/stripe/android/model/Address;
+	public final fun getBillingDob ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun getBillingEmail ()Ljava/lang/String;
+	public final fun getBillingFirstName ()Ljava/lang/String;
+	public final fun getBillingLastName ()Ljava/lang/String;
+	public final fun getBillingPhone ()Ljava/lang/String;
+	public final fun getCustomPaymentMethods ()Ljava/util/Set;
+	public final fun getLineItems ()Ljava/util/List;
+	public final fun getPageOptions ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public final fun getPurchaseCountry ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/KlarnaSourceParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/KlarnaSourceParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams$CustomPaymentMethods : java/lang/Enum {
+	public static final field Installments Lcom/stripe/android/model/KlarnaSourceParams$CustomPaymentMethods;
+	public static final field PayIn4 Lcom/stripe/android/model/KlarnaSourceParams$CustomPaymentMethods;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/KlarnaSourceParams$CustomPaymentMethods;
+	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$CustomPaymentMethods;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams$LineItem : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;I)V
+	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams$LineItem;Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItemDescription ()Ljava/lang/String;
+	public final fun getItemType ()Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public final fun getQuantity ()Ljava/lang/Integer;
+	public final fun getTotalAmount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/KlarnaSourceParams$LineItem$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams$LineItem$Type : java/lang/Enum {
+	public static final field Shipping Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public static final field Sku Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public static final field Tax Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundImageUrl ()Ljava/lang/String;
+	public final fun getLogoUrl ()Ljava/lang/String;
+	public final fun getPageTitle ()Ljava/lang/String;
+	public final fun getPurchaseType ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType : java/lang/Enum {
+	public static final field Book Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Buy Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Continue Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Download Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Order Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Rent Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static final field Subscribe Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public final fun getCode ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
+}
+
+public final class com/stripe/android/model/MandateDataParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/MandateDataParams$Type;)V
+	public final fun copy (Lcom/stripe/android/model/MandateDataParams$Type;)Lcom/stripe/android/model/MandateDataParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/MandateDataParams$Type;ILjava/lang/Object;)Lcom/stripe/android/model/MandateDataParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/MandateDataParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MandateDataParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/MandateDataParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/MandateDataParams$Type : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/model/MandateDataParams$Type$Online : com/stripe/android/model/MandateDataParams$Type {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/MandateDataParams$Type$Online$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lcom/stripe/android/model/MandateDataParams$Type$Online;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/MandateDataParams$Type$Online;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/MandateDataParams$Type$Online;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/MandateDataParams$Type$Online$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MandateDataParams$Type$Online;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/MandateDataParams$Type$Online;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentIntent : com/stripe/android/model/StripeIntent {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Z
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Lcom/stripe/android/model/StripeIntent$Status;
+	public final fun component19 ()Lcom/stripe/android/model/PaymentIntent$Error;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public final fun component21 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()J
+	public final fun component5 ()Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public final fun component6 ()Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Long;
+	public final fun getCanceledAt ()J
+	public final fun getCancellationReason ()Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public final fun getCaptureMethod ()Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public fun getClientSecret ()Ljava/lang/String;
+	public final fun getConfirmationMethod ()Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+	public fun getCreated ()J
+	public final fun getCurrency ()Ljava/lang/String;
+	public fun getDescription ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public final fun getLastPaymentError ()Lcom/stripe/android/model/PaymentIntent$Error;
+	public final fun getNextAction ()Ljava/util/Map;
+	public fun getNextActionData ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public fun getNextActionType ()Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public fun getPaymentMethodId ()Ljava/lang/String;
+	public fun getPaymentMethodTypes ()Ljava/util/List;
+	public final fun getReceiptEmail ()Ljava/lang/String;
+	public final fun getShipping ()Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public fun getStatus ()Lcom/stripe/android/model/StripeIntent$Status;
+	public fun hashCode ()I
+	public fun isLiveMode ()Z
+	public fun requiresAction ()Z
+	public fun requiresConfirmation ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentIntent$CancellationReason : java/lang/Enum {
+	public static final field Abandoned Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field Automatic Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$CancellationReason$Companion;
+	public static final field Duplicate Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field FailedInvoice Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field Fraudulent Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field RequestedByCustomer Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static final field VoidInvoice Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$CancellationReason;
+}
+
+public final class com/stripe/android/model/PaymentIntent$CaptureMethod : java/lang/Enum {
+	public static final field Automatic Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$CaptureMethod$Companion;
+	public static final field Manual Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+}
+
+public final class com/stripe/android/model/PaymentIntent$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
+}
+
+public final class com/stripe/android/model/PaymentIntent$ConfirmationMethod : java/lang/Enum {
+	public static final field Automatic Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod$Companion;
+	public static final field Manual Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
+}
+
+public class com/stripe/android/model/PaymentIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentIntent$Error : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$Error$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod;Lcom/stripe/android/model/PaymentIntent$Error$Type;)Lcom/stripe/android/model/PaymentIntent$Error;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent$Error;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod;Lcom/stripe/android/model/PaymentIntent$Error$Type;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent$Error;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCharge ()Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDeclineCode ()Ljava/lang/String;
+	public final fun getDocUrl ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getParam ()Ljava/lang/String;
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun getType ()Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentIntent$Error$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent$Error;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentIntent$Error;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentIntent$Error$Type : java/lang/Enum {
+	public static final field ApiConnectionError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field ApiError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field AuthenticationError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field CardError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field Companion Lcom/stripe/android/model/PaymentIntent$Error$Type$Companion;
+	public static final field IdempotencyError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field InvalidRequestError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static final field RateLimitError Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public final fun getCode ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$Error$Type;
+	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$Error$Type;
+}
+
+public final class com/stripe/android/model/PaymentIntent$Shipping : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getCarrier ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getTrackingNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentIntent$Shipping$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentIntent$Shipping;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethod$Companion;
+	public final field auBecsDebit Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public final field bacsDebit Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public final field billingDetails Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public final field card Lcom/stripe/android/model/PaymentMethod$Card;
+	public final field cardPresent Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public final field created Ljava/lang/Long;
+	public final field customerId Ljava/lang/String;
+	public final field fpx Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public final field id Ljava/lang/String;
+	public final field ideal Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public final field liveMode Z
+	public final field metadata Ljava/util/Map;
+	public final field sepaDebit Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public final field sofort Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public final field type Lcom/stripe/android/model/PaymentMethod$Type;
+	public final field upi Lcom/stripe/android/model/PaymentMethod$Upi;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public final fun component11 ()Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public final fun component12 ()Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public final fun component13 ()Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public final fun component15 ()Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public final fun component16 ()Lcom/stripe/android/model/PaymentMethod$Upi;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Z
+	public final fun component4 ()Lcom/stripe/android/model/PaymentMethod$Type;
+	public final fun component5 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod$Card;
+	public final fun component9 ()Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;ZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;)Lcom/stripe/android/model/PaymentMethod;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/Long;ZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field bsbNumber Ljava/lang/String;
+	public final field fingerprint Ljava/lang/String;
+	public final field last4 Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$AuBecsDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field fingerprint Ljava/lang/String;
+	public final field last4 Ljava/lang/String;
+	public final field sortCode Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$BacsDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$BacsDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethod$BillingDetails$Companion;
+	public final field address Lcom/stripe/android/model/Address;
+	public final field email Ljava/lang/String;
+	public final field name Ljava/lang/String;
+	public final field phone Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun toBuilder ()Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$BillingDetails$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddress (Lcom/stripe/android/model/Address;)Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+	public final fun setEmail (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+	public final fun setName (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+	public final fun setPhone (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+}
+
+public class com/stripe/android/model/PaymentMethod$BillingDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethod;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAuBecsDebit (Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setBacsDebit (Lcom/stripe/android/model/PaymentMethod$BacsDebit;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setBillingDetails (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setCard (Lcom/stripe/android/model/PaymentMethod$Card;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setCardPresent (Lcom/stripe/android/model/PaymentMethod$CardPresent;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setCreated (Ljava/lang/Long;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setCustomerId (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setFpx (Lcom/stripe/android/model/PaymentMethod$Fpx;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setId (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setIdeal (Lcom/stripe/android/model/PaymentMethod$Ideal;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setLiveMode (Z)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setMetadata (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setNetbanking (Lcom/stripe/android/model/PaymentMethod$Netbanking;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setSepaDebit (Lcom/stripe/android/model/PaymentMethod$SepaDebit;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setSofort (Lcom/stripe/android/model/PaymentMethod$Sofort;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setType (Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setUpi (Lcom/stripe/android/model/PaymentMethod$Upi;)Lcom/stripe/android/model/PaymentMethod$Builder;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field brand Lcom/stripe/android/model/CardBrand;
+	public final field checks Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public final field country Ljava/lang/String;
+	public final field expiryMonth Ljava/lang/Integer;
+	public final field expiryYear Ljava/lang/Integer;
+	public final field funding Ljava/lang/String;
+	public final field last4 Ljava/lang/String;
+	public final field threeDSecureUsage Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public final field wallet Lcom/stripe/android/model/wallets/Wallet;
+	public fun <init> ()V
+	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
+	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public final fun component9 ()Lcom/stripe/android/model/wallets/Wallet;
+	public final fun copy (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;)Lcom/stripe/android/model/PaymentMethod$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethod$Card;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBrand (Lcom/stripe/android/model/CardBrand;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setChecks (Lcom/stripe/android/model/PaymentMethod$Card$Checks;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setCountry (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setExpiryMonth (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setExpiryYear (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setFunding (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setLast4 (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setThreeDSecureUsage (Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+	public final fun setWallet (Lcom/stripe/android/model/wallets/Wallet;)Lcom/stripe/android/model/PaymentMethod$Card$Builder;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field addressLine1Check Ljava/lang/String;
+	public final field addressPostalCodeCheck Ljava/lang/String;
+	public final field cvcCheck Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Card$Checks$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card$Checks;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public class com/stripe/android/model/PaymentMethod$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card$Networks : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Set;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;ZLjava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$Networks;Ljava/util/Set;ZLjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailable ()Ljava/util/Set;
+	public final fun getPreferred ()Ljava/lang/String;
+	public final fun getSelectionMandatory ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Card$Networks$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card$Networks;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field isSupported Z
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$CardPresent : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethod$CardPresent$Companion;
+	public fun <init> ()V
+	public final fun copy (Z)Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$CardPresent;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$CardPresent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$CardPresent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
+}
+
+public class com/stripe/android/model/PaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Fpx : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field accountHolderType Ljava/lang/String;
+	public final field bank Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Fpx;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Fpx$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Fpx;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Ideal : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field bank Ljava/lang/String;
+	public final field bankIdentifierCode Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Ideal;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Ideal$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Ideal;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Netbanking : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field bank Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Netbanking;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Netbanking;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Netbanking;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Netbanking$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Netbanking;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Netbanking;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field bankCode Ljava/lang/String;
+	public final field branchCode Ljava/lang/String;
+	public final field country Ljava/lang/String;
+	public final field fingerprint Ljava/lang/String;
+	public final field last4 Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$SepaDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$SepaDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Sofort : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field country Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Sofort;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Sofort$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Sofort;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum, android/os/Parcelable {
+	public static final field AfterpayClearpay Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Alipay Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field AuBecsDebit Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field BacsDebit Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Bancontact Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Card Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field CardPresent Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethod$Type$Companion;
+	public static final field Eps Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Fpx Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Giropay Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field GrabPay Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Ideal Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Netbanking Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Oxxo Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field P24 Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field PayPal Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field SepaDebit Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Sofort Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Upi Lcom/stripe/android/model/PaymentMethod$Type;
+	public final field code Ljava/lang/String;
+	public final field isReusable Z
+	public fun describeContents ()I
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Type;
+	public static fun values ()[Lcom/stripe/android/model/PaymentMethod$Type;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$Type$Companion {
+}
+
+public class com/stripe/android/model/PaymentMethod$Type$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Type;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Type;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field vpa Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Upi;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Upi;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Upi;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethod$Upi$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Upi;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Upi;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams$Type;Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/model/PaymentMethodCreateParams$Type;Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createAfterpayClearpay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createAfterpayClearpay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createAfterpayClearpay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createAlipay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createAlipay (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createCard (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createFromGooglePay (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createGiropay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createGiropay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createGrabPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createGrabPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createOxxo (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createOxxo (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createP24 (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createP24 (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createPayPal ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createPayPal (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypeCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountNumber ()Ljava/lang/String;
+	public final fun getBsbNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setAccountNumber (Ljava/lang/String;)V
+	public final fun setBsbNumber (Ljava/lang/String;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountNumber ()Ljava/lang/String;
+	public final fun getSortCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setAccountNumber (Ljava/lang/String;)V
+	public final fun setSortCode (Ljava/lang/String;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Companion;
+	public fun <init> ()V
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setCvc (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+	public final fun setExpiryMonth (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+	public final fun setExpiryYear (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+	public final fun setNumber (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Companion {
+	public final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Companion {
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createAfterpayClearpay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createAfterpayClearpay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createAfterpayClearpay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createAfterpayClearpay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createAlipay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createAlipay (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createAlipay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createBancontact$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createCard (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createEps$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createFromGooglePay (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createGiropay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createGiropay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createGiropay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createGrabPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createGrabPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createGrabPay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createOxxo (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createOxxo (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createOxxo$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createP24 (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createP24 (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createP24$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createPayPal ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createPayPal (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createPayPal$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBank ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setBank (Ljava/lang/String;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBank (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx$Builder;
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Fpx$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBank ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setBank (Ljava/lang/String;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setBank (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal$Builder;
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Ideal$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Netbanking$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIban ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setIban (Ljava/lang/String;)V
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setIban (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Builder;
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Sofort$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodCreateParams$Upi$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/PaymentMethodOptionsParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethod$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
+	public fun toParamMap ()Ljava/util/Map;
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCvc ()Ljava/lang/String;
+	public final fun getNetwork ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setCvc (Ljava/lang/String;)V
+	public final fun setNetwork (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PaymentMethodOptionsParams$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PersonTokenParams : com/stripe/android/model/TokenParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/Map;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun component4 ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;)Lcom/stripe/android/model/PersonTokenParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getAddressKana ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getAddressKanji ()Lcom/stripe/android/model/AddressJapanParams;
+	public final fun getDateOfBirth ()Lcom/stripe/android/model/DateOfBirth;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getFirstName ()Ljava/lang/String;
+	public final fun getFirstNameKana ()Ljava/lang/String;
+	public final fun getFirstNameKanji ()Ljava/lang/String;
+	public final fun getGender ()Ljava/lang/String;
+	public final fun getIdNumber ()Ljava/lang/String;
+	public final fun getLastName ()Ljava/lang/String;
+	public final fun getLastNameKana ()Ljava/lang/String;
+	public final fun getLastNameKanji ()Ljava/lang/String;
+	public final fun getMaidenName ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getRelationship ()Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public final fun getSsnLast4 ()Ljava/lang/String;
+	public fun getTypeDataParams ()Ljava/util/Map;
+	public final fun getVerification ()Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PersonTokenParams$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PersonTokenParams;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddress (Lcom/stripe/android/model/Address;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setAddressKana (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setAddressKanji (Lcom/stripe/android/model/AddressJapanParams;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setDateOfBirth (Lcom/stripe/android/model/DateOfBirth;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setEmail (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setFirstName (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setFirstNameKana (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setFirstNameKanji (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setGender (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setIdNumber (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setLastName (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setLastNameKana (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setLastNameKanji (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setMaidenName (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setMetadata (Ljava/util/Map;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setPhone (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setRelationship (Lcom/stripe/android/model/PersonTokenParams$Relationship;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setSsnLast4 (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+	public final fun setVerification (Lcom/stripe/android/model/PersonTokenParams$Verification;)Lcom/stripe/android/model/PersonTokenParams$Builder;
+}
+
+public class com/stripe/android/model/PersonTokenParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PersonTokenParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PersonTokenParams$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Document;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Document;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBack ()Ljava/lang/String;
+	public final fun getFront ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PersonTokenParams$Document$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Document;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PersonTokenParams$Document;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PersonTokenParams$Relationship : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirector ()Ljava/lang/Boolean;
+	public final fun getExecutive ()Ljava/lang/Boolean;
+	public final fun getOwner ()Ljava/lang/Boolean;
+	public final fun getPercentOwnership ()Ljava/lang/Integer;
+	public final fun getRepresentative ()Ljava/lang/Boolean;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PersonTokenParams$Relationship$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setDirector (Ljava/lang/Boolean;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+	public final fun setExecutive (Ljava/lang/Boolean;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+	public final fun setOwner (Ljava/lang/Boolean;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+	public final fun setPercentOwnership (Ljava/lang/Integer;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+	public final fun setRepresentative (Ljava/lang/Boolean;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+	public final fun setTitle (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
+}
+
+public class com/stripe/android/model/PersonTokenParams$Relationship$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PersonTokenParams$Relationship;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PersonTokenParams$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;)V
+	public fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/PersonTokenParams$Document;
+	public final fun component2 ()Lcom/stripe/android/model/PersonTokenParams$Document;
+	public final fun copy (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;)Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Verification;Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalDocument ()Lcom/stripe/android/model/PersonTokenParams$Document;
+	public final fun getDocument ()Lcom/stripe/android/model/PersonTokenParams$Document;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/PersonTokenParams$Verification$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SetupIntent : com/stripe/android/model/StripeIntent {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/SetupIntent$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/StripeIntent$Status;
+	public final fun component11 ()Lcom/stripe/android/model/StripeIntent$Usage;
+	public final fun component12 ()Lcom/stripe/android/model/SetupIntent$Error;
+	public final fun component13 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public final fun component2 ()Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Lcom/stripe/android/model/StripeIntent$NextActionData;)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Lcom/stripe/android/model/StripeIntent$NextActionData;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;
+	public final fun getCancellationReason ()Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public fun getClientSecret ()Ljava/lang/String;
+	public fun getCreated ()J
+	public fun getDescription ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public final fun getLastSetupError ()Lcom/stripe/android/model/SetupIntent$Error;
+	public fun getNextActionData ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public fun getNextActionType ()Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public fun getPaymentMethodId ()Ljava/lang/String;
+	public fun getPaymentMethodTypes ()Ljava/util/List;
+	public fun getStatus ()Lcom/stripe/android/model/StripeIntent$Status;
+	public final fun getUsage ()Lcom/stripe/android/model/StripeIntent$Usage;
+	public fun hashCode ()I
+	public fun isLiveMode ()Z
+	public fun requiresAction ()Z
+	public fun requiresConfirmation ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/SetupIntent$CancellationReason : java/lang/Enum {
+	public static final field Abandoned Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public static final field Companion Lcom/stripe/android/model/SetupIntent$CancellationReason$Companion;
+	public static final field Duplicate Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public static final field RequestedByCustomer Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent$CancellationReason;
+	public static fun values ()[Lcom/stripe/android/model/SetupIntent$CancellationReason;
+}
+
+public final class com/stripe/android/model/SetupIntent$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;
+}
+
+public class com/stripe/android/model/SetupIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SetupIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SetupIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SetupIntent$Error : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/SetupIntent$Error$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component7 ()Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod;Lcom/stripe/android/model/SetupIntent$Error$Type;)Lcom/stripe/android/model/SetupIntent$Error;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent$Error;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod;Lcom/stripe/android/model/SetupIntent$Error$Type;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent$Error;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDeclineCode ()Ljava/lang/String;
+	public final fun getDocUrl ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getParam ()Ljava/lang/String;
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun getType ()Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SetupIntent$Error$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SetupIntent$Error;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SetupIntent$Error;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SetupIntent$Error$Type : java/lang/Enum {
+	public static final field ApiConnectionError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field ApiError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field AuthenticationError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field CardError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field Companion Lcom/stripe/android/model/SetupIntent$Error$Type$Companion;
+	public static final field IdempotencyError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field InvalidRequestError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static final field RateLimitError Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public final fun getCode ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent$Error$Type;
+	public static fun values ()[Lcom/stripe/android/model/SetupIntent$Error$Type;
+}
+
+public final class com/stripe/android/model/ShippingInformation : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/ShippingInformation$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ShippingInformation;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ShippingInformation;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ShippingInformation;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/ShippingInformation$Companion {
+}
+
+public class com/stripe/android/model/ShippingInformation$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ShippingInformation;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ShippingInformation;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ShippingMethod : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/util/Currency;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;)Lcom/stripe/android/model/ShippingMethod;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ShippingMethod;Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ShippingMethod;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()J
+	public final fun getCurrency ()Ljava/util/Currency;
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getIdentifier ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/ShippingMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ShippingMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ShippingMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/Source$Companion;
+	public static final fun asSourceType (Ljava/lang/String;)Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/Source$Owner;
+	public final fun component11 ()Lcom/stripe/android/model/Source$Receiver;
+	public final fun component12 ()Lcom/stripe/android/model/Source$Redirect;
+	public final fun component13 ()Lcom/stripe/android/model/Source$Status;
+	public final fun component14 ()Ljava/util/Map;
+	public final fun component15 ()Lcom/stripe/android/model/SourceTypeModel;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lcom/stripe/android/model/Source$Usage;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component21 ()Lcom/stripe/android/model/SourceOrder;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/Source$CodeVerification;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/stripe/android/model/Source$Flow;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/Source$CodeVerification;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/Source$Flow;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/Source$Owner;Lcom/stripe/android/model/Source$Receiver;Lcom/stripe/android/model/Source$Redirect;Lcom/stripe/android/model/Source$Status;Ljava/util/Map;Lcom/stripe/android/model/SourceTypeModel;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Source$Usage;Lcom/stripe/android/model/WeChat;Lcom/stripe/android/model/Source$Klarna;Lcom/stripe/android/model/SourceOrder;Ljava/lang/String;)Lcom/stripe/android/model/Source;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/Source$CodeVerification;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/Source$Flow;Ljava/lang/Boolean;Ljava/util/Map;Lcom/stripe/android/model/Source$Owner;Lcom/stripe/android/model/Source$Receiver;Lcom/stripe/android/model/Source$Redirect;Lcom/stripe/android/model/Source$Status;Ljava/util/Map;Lcom/stripe/android/model/SourceTypeModel;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Source$Usage;Lcom/stripe/android/model/WeChat;Lcom/stripe/android/model/Source$Klarna;Lcom/stripe/android/model/SourceOrder;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Source;
+	public final fun getAmount ()Ljava/lang/Long;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getCodeVerification ()Lcom/stripe/android/model/Source$CodeVerification;
+	public final fun getCreated ()Ljava/lang/Long;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getFlow ()Lcom/stripe/android/model/Source$Flow;
+	public fun getId ()Ljava/lang/String;
+	public final fun getKlarna ()Lcom/stripe/android/model/Source$Klarna;
+	public final fun getMetaData ()Ljava/util/Map;
+	public final fun getOwner ()Lcom/stripe/android/model/Source$Owner;
+	public final fun getReceiver ()Lcom/stripe/android/model/Source$Receiver;
+	public final fun getRedirect ()Lcom/stripe/android/model/Source$Redirect;
+	public final fun getSourceOrder ()Lcom/stripe/android/model/SourceOrder;
+	public final fun getSourceTypeData ()Ljava/util/Map;
+	public final fun getSourceTypeModel ()Lcom/stripe/android/model/SourceTypeModel;
+	public final fun getStatementDescriptor ()Ljava/lang/String;
+	public final fun getStatus ()Lcom/stripe/android/model/Source$Status;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getTypeRaw ()Ljava/lang/String;
+	public final fun getUsage ()Lcom/stripe/android/model/Source$Usage;
+	public final fun getWeChat ()Lcom/stripe/android/model/WeChat;
+	public fun hashCode ()I
+	public final fun isLiveMode ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/Source$CodeVerification : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()I
+	public final fun component2 ()Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public final fun copy (ILcom/stripe/android/model/Source$CodeVerification$Status;)Lcom/stripe/android/model/Source$CodeVerification;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$CodeVerification;ILcom/stripe/android/model/Source$CodeVerification$Status;ILjava/lang/Object;)Lcom/stripe/android/model/Source$CodeVerification;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttemptsRemaining ()I
+	public final fun getStatus ()Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/Source$CodeVerification$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$CodeVerification;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source$CodeVerification;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$CodeVerification$Status : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/Source$CodeVerification$Status$Companion;
+	public static final field Failed Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public static final field Pending Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public static final field Succeeded Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Source$CodeVerification$Status;
+	public static fun values ()[Lcom/stripe/android/model/Source$CodeVerification$Status;
+}
+
+public final class com/stripe/android/model/Source$Companion {
+	public final fun asSourceType (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Source;
+}
+
+public class com/stripe/android/model/Source$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$Flow : java/lang/Enum {
+	public static final field CodeVerification Lcom/stripe/android/model/Source$Flow;
+	public static final field Companion Lcom/stripe/android/model/Source$Flow$Companion;
+	public static final field None Lcom/stripe/android/model/Source$Flow;
+	public static final field Receiver Lcom/stripe/android/model/Source$Flow;
+	public static final field Redirect Lcom/stripe/android/model/Source$Flow;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Source$Flow;
+	public static fun values ()[Lcom/stripe/android/model/Source$Flow;
+}
+
+public final class com/stripe/android/model/Source$Klarna : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/Set;
+	public final fun component18 ()Ljava/util/Set;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)Lcom/stripe/android/model/Source$Klarna;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Klarna;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/Source$Klarna;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientToken ()Ljava/lang/String;
+	public final fun getCustomPaymentMethods ()Ljava/util/Set;
+	public final fun getFirstName ()Ljava/lang/String;
+	public final fun getLastName ()Ljava/lang/String;
+	public final fun getPayLaterAssetUrlsDescriptive ()Ljava/lang/String;
+	public final fun getPayLaterAssetUrlsStandard ()Ljava/lang/String;
+	public final fun getPayLaterName ()Ljava/lang/String;
+	public final fun getPayLaterRedirectUrl ()Ljava/lang/String;
+	public final fun getPayNowAssetUrlsDescriptive ()Ljava/lang/String;
+	public final fun getPayNowAssetUrlsStandard ()Ljava/lang/String;
+	public final fun getPayNowName ()Ljava/lang/String;
+	public final fun getPayNowRedirectUrl ()Ljava/lang/String;
+	public final fun getPayOverTimeAssetUrlsDescriptive ()Ljava/lang/String;
+	public final fun getPayOverTimeAssetUrlsStandard ()Ljava/lang/String;
+	public final fun getPayOverTimeName ()Ljava/lang/String;
+	public final fun getPayOverTimeRedirectUrl ()Ljava/lang/String;
+	public final fun getPaymentMethodCategories ()Ljava/util/Set;
+	public final fun getPurchaseCountry ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/Source$Klarna$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Klarna;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source$Klarna;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$Owner : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/stripe/android/model/Address;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Source$Owner;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Owner;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source$Owner;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getVerifiedAddress ()Lcom/stripe/android/model/Address;
+	public final fun getVerifiedEmail ()Ljava/lang/String;
+	public final fun getVerifiedName ()Ljava/lang/String;
+	public final fun getVerifiedPhone ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/Source$Owner$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Owner;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source$Owner;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$Receiver : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (Ljava/lang/String;JJJ)Lcom/stripe/android/model/Source$Receiver;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Receiver;Ljava/lang/String;JJJILjava/lang/Object;)Lcom/stripe/android/model/Source$Receiver;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Ljava/lang/String;
+	public final fun getAmountCharged ()J
+	public final fun getAmountReceived ()J
+	public final fun getAmountReturned ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/Source$Receiver$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Receiver;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source$Receiver;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$Redirect : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/stripe/android/model/Source$Redirect$Status;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;)Lcom/stripe/android/model/Source$Redirect;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Redirect;Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source$Redirect;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public final fun getStatus ()Lcom/stripe/android/model/Source$Redirect$Status;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/Source$Redirect$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Redirect;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Source$Redirect;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Source$Redirect$Status : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/Source$Redirect$Status$Companion;
+	public static final field Failed Lcom/stripe/android/model/Source$Redirect$Status;
+	public static final field NotRequired Lcom/stripe/android/model/Source$Redirect$Status;
+	public static final field Pending Lcom/stripe/android/model/Source$Redirect$Status;
+	public static final field Succeeded Lcom/stripe/android/model/Source$Redirect$Status;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Source$Redirect$Status;
+	public static fun values ()[Lcom/stripe/android/model/Source$Redirect$Status;
+}
+
+public abstract interface annotation class com/stripe/android/model/Source$SourceType : java/lang/annotation/Annotation {
+	public static final field ALIPAY Ljava/lang/String;
+	public static final field BANCONTACT Ljava/lang/String;
+	public static final field CARD Ljava/lang/String;
+	public static final field Companion Lcom/stripe/android/model/Source$SourceType$Companion;
+	public static final field EPS Ljava/lang/String;
+	public static final field GIROPAY Ljava/lang/String;
+	public static final field IDEAL Ljava/lang/String;
+	public static final field KLARNA Ljava/lang/String;
+	public static final field MULTIBANCO Ljava/lang/String;
+	public static final field P24 Ljava/lang/String;
+	public static final field SEPA_DEBIT Ljava/lang/String;
+	public static final field SOFORT Ljava/lang/String;
+	public static final field THREE_D_SECURE Ljava/lang/String;
+	public static final field UNKNOWN Ljava/lang/String;
+	public static final field WECHAT Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/Source$SourceType$Companion {
+	public static final field ALIPAY Ljava/lang/String;
+	public static final field BANCONTACT Ljava/lang/String;
+	public static final field CARD Ljava/lang/String;
+	public static final field EPS Ljava/lang/String;
+	public static final field GIROPAY Ljava/lang/String;
+	public static final field IDEAL Ljava/lang/String;
+	public static final field KLARNA Ljava/lang/String;
+	public static final field MULTIBANCO Ljava/lang/String;
+	public static final field P24 Ljava/lang/String;
+	public static final field SEPA_DEBIT Ljava/lang/String;
+	public static final field SOFORT Ljava/lang/String;
+	public static final field THREE_D_SECURE Ljava/lang/String;
+	public static final field UNKNOWN Ljava/lang/String;
+	public static final field WECHAT Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/Source$Status : java/lang/Enum {
+	public static final field Canceled Lcom/stripe/android/model/Source$Status;
+	public static final field Chargeable Lcom/stripe/android/model/Source$Status;
+	public static final field Companion Lcom/stripe/android/model/Source$Status$Companion;
+	public static final field Consumed Lcom/stripe/android/model/Source$Status;
+	public static final field Failed Lcom/stripe/android/model/Source$Status;
+	public static final field Pending Lcom/stripe/android/model/Source$Status;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Source$Status;
+	public static fun values ()[Lcom/stripe/android/model/Source$Status;
+}
+
+public final class com/stripe/android/model/Source$Usage : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/Source$Usage$Companion;
+	public static final field Reusable Lcom/stripe/android/model/Source$Usage;
+	public static final field SingleUse Lcom/stripe/android/model/Source$Usage;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Source$Usage;
+	public static fun values ()[Lcom/stripe/android/model/Source$Usage;
+}
+
+public final class com/stripe/android/model/SourceOrder : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lcom/stripe/android/model/SourceOrder$Shipping;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/SourceOrder$Shipping;)Lcom/stripe/android/model/SourceOrder;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrder;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/SourceOrder$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrder;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Integer;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getItems ()Ljava/util/List;
+	public final fun getShipping ()Lcom/stripe/android/model/SourceOrder$Shipping;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrder$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrder;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceOrder$Item : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/stripe/android/model/SourceOrder$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/stripe/android/model/SourceOrder$Item;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrder$Item;Lcom/stripe/android/model/SourceOrder$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrder$Item;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Integer;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getQuantity ()Ljava/lang/Integer;
+	public final fun getType ()Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrder$Item$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder$Item;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrder$Item;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceOrder$Item$Type : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/SourceOrder$Item$Type$Companion;
+	public static final field Shipping Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public static final field Sku Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public static final field Tax Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/SourceOrder$Item$Type;
+	public static fun values ()[Lcom/stripe/android/model/SourceOrder$Item$Type;
+}
+
+public final class com/stripe/android/model/SourceOrder$Shipping : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceOrder$Shipping;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrder$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrder$Shipping;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getCarrier ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getTrackingNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrder$Shipping$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder$Shipping;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrder$Shipping;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceOrderParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;)V
+	public synthetic fun <init> (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public final fun copy (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;)Lcom/stripe/android/model/SourceOrderParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams;Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getShipping ()Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrderParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrderParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceOrderParams$Item : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/stripe/android/model/SourceOrderParams$Item;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams$Item;Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams$Item;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Integer;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getParent ()Ljava/lang/String;
+	public final fun getQuantity ()Ljava/lang/Integer;
+	public final fun getType ()Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrderParams$Item$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams$Item;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrderParams$Item;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceOrderParams$Item$Type : java/lang/Enum {
+	public static final field Shipping Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public static final field Sku Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public static final field Tax Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+	public static fun values ()[Lcom/stripe/android/model/SourceOrderParams$Item$Type;
+}
+
+public final class com/stripe/android/model/SourceOrderParams$Shipping : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getCarrier ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getTrackingNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceOrderParams$Shipping$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceOrderParams$Shipping;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceParams : com/stripe/android/model/StripeParamsModel {
+	public static final field Companion Lcom/stripe/android/model/SourceParams$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun createAlipayReusableParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createAlipaySingleUseParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createBancontactParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createCardParams (Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createCardParams (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createCardParamsFromGooglePay (Lorg/json/JSONObject;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createCustomParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createEPSParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createGiropayParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createIdealParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createKlarna (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createMasterpassParams (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createMultibancoParams (JLjava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createP24Params (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createRetrieveSourceParams (Ljava/lang/String;)Ljava/util/Map;
+	public static final fun createSepaDebitParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createSepaDebitParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createSofortParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createSourceFromTokenParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createThreeDSecureParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createVisaCheckoutParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static final fun createWeChatPayParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Long;
+	public final fun getApiParameterMap ()Ljava/util/Map;
+	public final fun getCurrency ()Ljava/lang/String;
+	public final fun getMetaData ()Ljava/util/Map;
+	public final fun getOwner ()Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getTypeRaw ()Ljava/lang/String;
+	public final fun getUsage ()Lcom/stripe/android/model/Source$Usage;
+	public fun hashCode ()I
+	public final fun setAmount (Ljava/lang/Long;)Lcom/stripe/android/model/SourceParams;
+	public final fun setApiParameterMap (Ljava/util/Map;)Lcom/stripe/android/model/SourceParams;
+	public final fun setCurrency (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun setExtraParams (Ljava/util/Map;)Lcom/stripe/android/model/SourceParams;
+	public final fun setMetaData (Ljava/util/Map;)Lcom/stripe/android/model/SourceParams;
+	public final fun setOwner (Lcom/stripe/android/model/SourceParams$OwnerParams;)Lcom/stripe/android/model/SourceParams;
+	public final fun setReturnUrl (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun setToken (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun setUsage (Lcom/stripe/android/model/Source$Usage;)Lcom/stripe/android/model/SourceParams;
+	public fun toParamMap ()Ljava/util/Map;
+}
+
+public final class com/stripe/android/model/SourceParams$Companion {
+	public final fun createAlipayReusableParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createAlipayReusableParams$default (Lcom/stripe/android/model/SourceParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createAlipaySingleUseParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createAlipaySingleUseParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createBancontactParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createBancontactParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createCardParams (Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/SourceParams;
+	public final fun createCardParams (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/SourceParams;
+	public final fun createCardParamsFromGooglePay (Lorg/json/JSONObject;)Lcom/stripe/android/model/SourceParams;
+	public final fun createCustomParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createEPSParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createEPSParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createGiropayParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createGiropayParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createIdealParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createIdealParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createKlarna (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams;)Lcom/stripe/android/model/SourceParams;
+	public final fun createMasterpassParams (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createMultibancoParams (JLjava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createP24Params (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createRetrieveSourceParams (Ljava/lang/String;)Ljava/util/Map;
+	public final fun createSepaDebitParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createSepaDebitParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createSofortParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createSofortParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+	public final fun createSourceFromTokenParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createThreeDSecureParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createVisaCheckoutParams (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public final fun createWeChatPayParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun createWeChatPayParams$default (Lcom/stripe/android/model/SourceParams$Companion;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
+}
+
+public final class com/stripe/android/model/SourceParams$OwnerParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/Address;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceParams$OwnerParams;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceParams$OwnerParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/SourceTypeModel : com/stripe/android/model/StripeModel {
+}
+
+public final class com/stripe/android/model/SourceTypeModel$Card : com/stripe/android/model/SourceTypeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public final fun component12 ()Lcom/stripe/android/model/TokenizationMethod;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/CardBrand;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lcom/stripe/android/model/CardFunding;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;Lcom/stripe/android/model/TokenizationMethod;)Lcom/stripe/android/model/SourceTypeModel$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceTypeModel$Card;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;Lcom/stripe/android/model/TokenizationMethod;ILjava/lang/Object;)Lcom/stripe/android/model/SourceTypeModel$Card;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddressLine1Check ()Ljava/lang/String;
+	public final fun getAddressZipCheck ()Ljava/lang/String;
+	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getCvcCheck ()Ljava/lang/String;
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public final fun getExpiryMonth ()Ljava/lang/Integer;
+	public final fun getExpiryYear ()Ljava/lang/Integer;
+	public final fun getFunding ()Lcom/stripe/android/model/CardFunding;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getThreeDSecureStatus ()Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public final fun getTokenizationMethod ()Lcom/stripe/android/model/TokenizationMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceTypeModel$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceTypeModel$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceTypeModel$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus$Companion;
+	public static final field NotSupported Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public static final field Optional Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public static final field Recommended Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public static final field Required Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public static final field Unknown Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+	public static fun values ()[Lcom/stripe/android/model/SourceTypeModel$Card$ThreeDSecureStatus;
+}
+
+public final class com/stripe/android/model/SourceTypeModel$SepaDebit : com/stripe/android/model/SourceTypeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceTypeModel$SepaDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBankCode ()Ljava/lang/String;
+	public final fun getBranchCode ()Ljava/lang/String;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getFingerPrint ()Ljava/lang/String;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getMandateReference ()Ljava/lang/String;
+	public final fun getMandateUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/SourceTypeModel$SepaDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeFile : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/StripeFilePurpose;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/StripeFilePurpose;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/StripeFile;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeFile;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/StripeFilePurpose;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeFile;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreated ()Ljava/lang/Long;
+	public final fun getFilename ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPurpose ()Lcom/stripe/android/model/StripeFilePurpose;
+	public final fun getSize ()Ljava/lang/Integer;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeFile$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeFile;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeFile;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeFileParams {
+	public fun <init> (Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;)V
+	public final fun copy (Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;)Lcom/stripe/android/model/StripeFileParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeFileParams;Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;ILjava/lang/Object;)Lcom/stripe/android/model/StripeFileParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/StripeFileParams$FileLink : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZLjava/lang/Long;)V
+	public fun <init> (ZLjava/lang/Long;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/lang/Long;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (ZLjava/lang/Long;Ljava/util/Map;)Lcom/stripe/android/model/StripeFileParams$FileLink;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeFileParams$FileLink;ZLjava/lang/Long;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/StripeFileParams$FileLink;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeFileParams$FileLink$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeFileParams$FileLink;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeFileParams$FileLink;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeFilePurpose : java/lang/Enum {
+	public static final field BusinessIcon Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field BusinessLogo Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field Companion Lcom/stripe/android/model/StripeFilePurpose$Companion;
+	public static final field CustomerSignature Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field DisputeEvidence Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field IdentityDocument Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field PciDocument Lcom/stripe/android/model/StripeFilePurpose;
+	public static final field TaxDocumentUserUpload Lcom/stripe/android/model/StripeFilePurpose;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/StripeFilePurpose;
+	public static fun values ()[Lcom/stripe/android/model/StripeFilePurpose;
+}
+
+public abstract interface class com/stripe/android/model/StripeIntent : com/stripe/android/model/StripeModel {
+	public abstract fun getClientSecret ()Ljava/lang/String;
+	public abstract fun getCreated ()J
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getNextActionData ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public abstract fun getNextActionType ()Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public abstract fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public abstract fun getPaymentMethodId ()Ljava/lang/String;
+	public abstract fun getPaymentMethodTypes ()Ljava/util/List;
+	public abstract fun getStatus ()Lcom/stripe/android/model/StripeIntent$Status;
+	public abstract fun isLiveMode ()Z
+	public abstract fun requiresAction ()Z
+	public abstract fun requiresConfirmation ()Z
+}
+
+public abstract class com/stripe/android/model/StripeIntent$NextActionData : com/stripe/android/model/StripeModel {
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpiresAfter ()I
+	public final fun getHostedVoucherUrl ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Landroid/net/Uri;Ljava/lang/String;)V
+	public final fun component1 ()Landroid/net/Uri;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Landroid/net/Uri;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;Landroid/net/Uri;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public final fun getUrl ()Landroid/net/Uri;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/StripeIntent$NextActionData$SdkData : com/stripe/android/model/StripeIntent$NextActionData {
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1 : com/stripe/android/model/StripeIntent$NextActionData$SdkData {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2 : com/stripe/android/model/StripeIntent$NextActionData$SdkData {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getServerEncryption ()Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public final fun getServerName ()Ljava/lang/String;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTransactionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirectoryServerId ()Ljava/lang/String;
+	public final fun getDsCertificateData ()Ljava/lang/String;
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getRootCertsData ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionType : java/lang/Enum {
+	public static final field AlipayRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field Companion Lcom/stripe/android/model/StripeIntent$NextActionType$Companion;
+	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field UseStripeSdk Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public final fun getCode ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static fun values ()[Lcom/stripe/android/model/StripeIntent$NextActionType;
+}
+
+public final class com/stripe/android/model/StripeIntent$Status : java/lang/Enum {
+	public static final field Canceled Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field Companion Lcom/stripe/android/model/StripeIntent$Status$Companion;
+	public static final field Processing Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field RequiresAction Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field RequiresCapture Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field RequiresConfirmation Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field RequiresPaymentMethod Lcom/stripe/android/model/StripeIntent$Status;
+	public static final field Succeeded Lcom/stripe/android/model/StripeIntent$Status;
+	public final fun getCode ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$Status;
+	public static fun values ()[Lcom/stripe/android/model/StripeIntent$Status;
+}
+
+public final class com/stripe/android/model/StripeIntent$Usage : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/model/StripeIntent$Usage$Companion;
+	public static final field OffSession Lcom/stripe/android/model/StripeIntent$Usage;
+	public static final field OnSession Lcom/stripe/android/model/StripeIntent$Usage;
+	public static final field OneTime Lcom/stripe/android/model/StripeIntent$Usage;
+	public final fun getCode ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$Usage;
+	public static fun values ()[Lcom/stripe/android/model/StripeIntent$Usage;
+}
+
+public abstract interface class com/stripe/android/model/StripeModel : android/os/Parcelable {
+	public abstract fun equals (Ljava/lang/Object;)Z
+	public abstract fun hashCode ()I
+}
+
+public abstract interface class com/stripe/android/model/StripeParamsModel {
+	public abstract fun toParamMap ()Ljava/util/Map;
+}
+
+public abstract interface class com/stripe/android/model/StripePaymentSource : android/os/Parcelable {
+	public abstract fun getId ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/model/Token : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/Token$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/stripe/android/model/Token$Type;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Lcom/stripe/android/model/BankAccount;
+	public final fun component7 ()Lcom/stripe/android/model/Card;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/Token$Type;Ljava/util/Date;ZZLcom/stripe/android/model/BankAccount;Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/Token;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/Token;Ljava/lang/String;Lcom/stripe/android/model/Token$Type;Ljava/util/Date;ZZLcom/stripe/android/model/BankAccount;Lcom/stripe/android/model/Card;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Token;
+	public final fun getBankAccount ()Lcom/stripe/android/model/BankAccount;
+	public final fun getCard ()Lcom/stripe/android/model/Card;
+	public final fun getCreated ()Ljava/util/Date;
+	public fun getId ()Ljava/lang/String;
+	public final fun getLivemode ()Z
+	public final fun getType ()Lcom/stripe/android/model/Token$Type;
+	public final fun getUsed ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/Token$Companion {
+	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Token;
+}
+
+public class com/stripe/android/model/Token$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Token;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Token;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Token$Type : java/lang/Enum {
+	public static final field Account Lcom/stripe/android/model/Token$Type;
+	public static final field BankAccount Lcom/stripe/android/model/Token$Type;
+	public static final field Card Lcom/stripe/android/model/Token$Type;
+	public static final field Companion Lcom/stripe/android/model/Token$Type$Companion;
+	public static final field CvcUpdate Lcom/stripe/android/model/Token$Type;
+	public static final field Person Lcom/stripe/android/model/Token$Type;
+	public static final field Pii Lcom/stripe/android/model/Token$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/Token$Type;
+	public static fun values ()[Lcom/stripe/android/model/Token$Type;
+}
+
+public abstract class com/stripe/android/model/TokenParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public fun <init> (Lcom/stripe/android/model/Token$Type;Ljava/util/Set;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/Token$Type;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public abstract fun getTypeDataParams ()Ljava/util/Map;
+	public fun toParamMap ()Ljava/util/Map;
+}
+
+public final class com/stripe/android/model/TokenizationMethod : java/lang/Enum {
+	public static final field ApplePay Lcom/stripe/android/model/TokenizationMethod;
+	public static final field Companion Lcom/stripe/android/model/TokenizationMethod$Companion;
+	public static final field GooglePay Lcom/stripe/android/model/TokenizationMethod;
+	public static final field Masterpass Lcom/stripe/android/model/TokenizationMethod;
+	public static final field VisaCheckout Lcom/stripe/android/model/TokenizationMethod;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/TokenizationMethod;
+	public static fun values ()[Lcom/stripe/android/model/TokenizationMethod;
+}
+
+public final class com/stripe/android/model/WeChat : com/stripe/android/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/WeChat;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/WeChat;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/WeChat;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppId ()Ljava/lang/String;
+	public final fun getNonce ()Ljava/lang/String;
+	public final fun getPackageValue ()Ljava/lang/String;
+	public final fun getPartnerId ()Ljava/lang/String;
+	public final fun getPrepayId ()Ljava/lang/String;
+	public final fun getQrCodeUrl ()Ljava/lang/String;
+	public final fun getSign ()Ljava/lang/String;
+	public final fun getStatementDescriptor ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/WeChat$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/WeChat;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/WeChat;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/model/wallets/Wallet : com/stripe/android/model/StripeModel {
+	public synthetic fun <init> (Lcom/stripe/android/model/wallets/Wallet$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$ApplePayWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com/stripe/android/model/wallets/Wallet, android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$GooglePayWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/Address;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;)Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBillingAddress ()Lcom/stripe/android/model/Address;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getShippingAddress ()Lcom/stripe/android/model/Address;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$MasterpassWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$SamsungPayWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/Address;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/stripe/android/model/Address;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBillingAddress ()Lcom/stripe/android/model/Address;
+	public final fun getDynamicLast4 ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getShippingAddress ()Lcom/stripe/android/model/Address;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/payments/PaymentFlowResult {
+}
+
+public abstract interface class com/stripe/android/paymentsheet/GooglePayRepository {
+	public abstract fun isReady ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/stripe/android/paymentsheet/GooglePayRepository$Disabled : com/stripe/android/paymentsheet/GooglePayRepository {
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/GooglePayRepository$Disabled;
+	public fun isReady ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {
+	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
+}
+
+public abstract class com/stripe/android/paymentsheet/PaymentResult : android/os/Parcelable {
+}
+
+public final class com/stripe/android/paymentsheet/PaymentResult$Canceled : com/stripe/android/paymentsheet/PaymentResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun component2 ()Lcom/stripe/android/model/PaymentIntent;
+	public final fun copy (Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;)Lcom/stripe/android/paymentsheet/PaymentResult$Canceled;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentResult$Canceled;Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentResult$Canceled;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMostRecentError ()Ljava/lang/Throwable;
+	public final fun getPaymentIntent ()Lcom/stripe/android/model/PaymentIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentResult$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentResult$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentResult$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentResult$Completed : com/stripe/android/paymentsheet/PaymentResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/PaymentIntent;)V
+	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
+	public final fun copy (Lcom/stripe/android/model/PaymentIntent;)Lcom/stripe/android/paymentsheet/PaymentResult$Completed;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentResult$Completed;Lcom/stripe/android/model/PaymentIntent;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentResult$Completed;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentIntent ()Lcom/stripe/android/model/PaymentIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentResult$Completed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentResult$Completed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentResult$Completed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentResult$Failed : com/stripe/android/paymentsheet/PaymentResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun component2 ()Lcom/stripe/android/model/PaymentIntent;
+	public final fun copy (Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;)Lcom/stripe/android/paymentsheet/PaymentResult$Failed;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentResult$Failed;Ljava/lang/Throwable;Lcom/stripe/android/model/PaymentIntent;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentResult$Failed;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public final fun getPaymentIntent ()Lcom/stripe/android/model/PaymentIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/paymentsheet/PaymentResult$Failed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentResult$Failed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentResult$Failed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResultCallback {
+	public abstract fun onPaymentResult (Lcom/stripe/android/paymentsheet/PaymentResult;)V
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption {
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDrawableResourceId ()I
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/stripe/android/paymentsheet/model/ViewState {
+}
+
+public final class com/stripe/android/paymentsheet/model/ViewState$Completed : com/stripe/android/paymentsheet/model/ViewState {
+	public fun <init> (Lcom/stripe/android/PaymentIntentResult;)V
+	public final fun component1 ()Lcom/stripe/android/PaymentIntentResult;
+	public final fun copy (Lcom/stripe/android/PaymentIntentResult;)Lcom/stripe/android/paymentsheet/model/ViewState$Completed;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/ViewState$Completed;Lcom/stripe/android/PaymentIntentResult;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/ViewState$Completed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentIntentResult ()Lcom/stripe/android/PaymentIntentResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/ViewState$Confirming : com/stripe/android/paymentsheet/model/ViewState {
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/model/ViewState$Confirming;
+}
+
+public final class com/stripe/android/paymentsheet/model/ViewState$Ready : com/stripe/android/paymentsheet/model/ViewState {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lcom/stripe/android/paymentsheet/model/ViewState$Ready;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/ViewState$Ready;JLjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/ViewState$Ready;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()J
+	public final fun getCurrencyCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/ui/GooglePayButton : android/widget/FrameLayout {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/stripe/android/view/ActivityStarter {
+	public final fun startForResult (Lcom/stripe/android/view/ActivityStarter$Args;)V
+}
+
+public abstract interface class com/stripe/android/view/ActivityStarter$Args : android/os/Parcelable {
+	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Args$Companion;
+}
+
+public final class com/stripe/android/view/ActivityStarter$Args$Companion {
+}
+
+public abstract interface class com/stripe/android/view/ActivityStarter$Result : android/os/Parcelable {
+	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Result$Companion;
+	public abstract fun toBundle ()Landroid/os/Bundle;
+}
+
+public final class com/stripe/android/view/ActivityStarter$Result$Companion {
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivity : com/stripe/android/view/StripeActivity {
+	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivity$Companion;
+	public fun <init> ()V
+	public fun onActionSave ()V
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Companion;
+	public static final field REQUEST_CODE I
+	public fun <init> (Landroid/app/Activity;)V
+	public fun <init> (Landroidx/fragment/app/Fragment;)V
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Companion;
+	public final fun copy (Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/PaymentConfiguration;ILjava/lang/Integer;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/PaymentConfiguration;ILjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddPaymentMethodFooter (I)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
+	public final fun setBillingAddressFields (Lcom/stripe/android/view/BillingAddressFields;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
+	public final fun setPaymentMethodType (Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
+	public final fun setShouldAttachToCustomer (Z)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
+	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
+}
+
+public class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Companion {
+}
+
+public abstract class com/stripe/android/view/AddPaymentMethodActivityStarter$Result : com/stripe/android/view/ActivityStarter$Result {
+	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Companion;
+	public static final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result;
+	public fun toBundle ()Landroid/os/Bundle;
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Companion {
+	public final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result;
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getException ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethod;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;Lcom/stripe/android/model/PaymentMethod;ILjava/lang/Object;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextFactory {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun create (Ljava/lang/String;)Ljava/lang/CharSequence;
+}
+
+public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextView : androidx/appcompat/widget/AppCompatTextView {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCompanyName ()Ljava/lang/String;
+	public final fun setCompanyName (Ljava/lang/String;)V
+}
+
+public final class com/stripe/android/view/BecsDebitWidget : android/widget/FrameLayout {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILjava/lang/String;)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun getValidParamsCallback ()Lcom/stripe/android/view/BecsDebitWidget$ValidParamsCallback;
+	public final fun setValidParamsCallback (Lcom/stripe/android/view/BecsDebitWidget$ValidParamsCallback;)V
+}
+
+public abstract interface class com/stripe/android/view/BecsDebitWidget$ValidParamsCallback {
+	public abstract fun onInputChanged (Z)V
+}
+
+public final class com/stripe/android/view/BillingAddressFields : java/lang/Enum {
+	public static final field Full Lcom/stripe/android/view/BillingAddressFields;
+	public static final field None Lcom/stripe/android/view/BillingAddressFields;
+	public static final field PostalCode Lcom/stripe/android/view/BillingAddressFields;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/BillingAddressFields;
+	public static fun values ()[Lcom/stripe/android/view/BillingAddressFields;
+}
+
+public abstract interface class com/stripe/android/view/CardInputListener {
+	public abstract fun onCardComplete ()V
+	public abstract fun onCvcComplete ()V
+	public abstract fun onExpirationComplete ()V
+	public abstract fun onFocusChange (Lcom/stripe/android/view/CardInputListener$FocusField;)V
+}
+
+public final class com/stripe/android/view/CardInputListener$FocusField : java/lang/Enum {
+	public static final field CardNumber Lcom/stripe/android/view/CardInputListener$FocusField;
+	public static final field Cvc Lcom/stripe/android/view/CardInputListener$FocusField;
+	public static final field ExpiryDate Lcom/stripe/android/view/CardInputListener$FocusField;
+	public static final field PostalCode Lcom/stripe/android/view/CardInputListener$FocusField;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/CardInputListener$FocusField;
+	public static fun values ()[Lcom/stripe/android/view/CardInputListener$FocusField;
+}
+
+public final class com/stripe/android/view/CardInputWidget : android/widget/LinearLayout, com/stripe/android/view/CardWidget {
+	public static final field Companion Lcom/stripe/android/view/CardInputWidget$Companion;
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public fun getCard ()Lcom/stripe/android/model/Card;
+	public fun getCardBuilder ()Lcom/stripe/android/model/Card$Builder;
+	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public fun getPaymentMethodCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun getPostalCodeEnabled ()Z
+	public final fun getPostalCodeRequired ()Z
+	public final fun getUsZipCodeRequired ()Z
+	public fun isEnabled ()Z
+	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z
+	public fun setCardHint (Ljava/lang/String;)V
+	public fun setCardInputListener (Lcom/stripe/android/view/CardInputListener;)V
+	public fun setCardNumber (Ljava/lang/String;)V
+	public fun setCardNumberTextWatcher (Landroid/text/TextWatcher;)V
+	public fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
+	public fun setCvcCode (Ljava/lang/String;)V
+	public fun setCvcNumberTextWatcher (Landroid/text/TextWatcher;)V
+	public fun setEnabled (Z)V
+	public fun setExpiryDate (II)V
+	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setPostalCodeEnabled (Z)V
+	public final fun setPostalCodeRequired (Z)V
+	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setUsZipCodeRequired (Z)V
+}
+
+public final class com/stripe/android/view/CardMultilineWidget : android/widget/LinearLayout, com/stripe/android/view/CardWidget {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IZ)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public fun getCard ()Lcom/stripe/android/model/Card;
+	public fun getCardBuilder ()Lcom/stripe/android/model/Card$Builder;
+	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public final fun getPaymentMethodBillingDetails ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public final fun getPaymentMethodBillingDetailsBuilder ()Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
+	public fun getPaymentMethodCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun getPostalCodeRequired ()Z
+	public final fun getUsZipCodeRequired ()Z
+	public fun isEnabled ()Z
+	public fun onWindowFocusChanged (Z)V
+	public fun setCardHint (Ljava/lang/String;)V
+	public fun setCardInputListener (Lcom/stripe/android/view/CardInputListener;)V
+	public fun setCardNumber (Ljava/lang/String;)V
+	public fun setCardNumberTextWatcher (Landroid/text/TextWatcher;)V
+	public fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
+	public fun setCvcCode (Ljava/lang/String;)V
+	public final fun setCvcLabel (Ljava/lang/String;)V
+	public fun setCvcNumberTextWatcher (Landroid/text/TextWatcher;)V
+	public fun setEnabled (Z)V
+	public fun setExpiryDate (II)V
+	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setPostalCodeRequired (Z)V
+	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setShouldShowPostalCode (Z)V
+	public final fun setUsZipCodeRequired (Z)V
+	public final fun validateAllFields ()Z
+	public final fun validateCardNumber ()Z
+}
+
+public final class com/stripe/android/view/CardNumberEditText : com/stripe/android/view/StripeEditText {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCardBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCardNumber ()Ljava/lang/String;
+	public final fun getLengthMax ()I
+	public final fun isCardNumberValid ()Z
+}
+
+public abstract interface class com/stripe/android/view/CardValidCallback {
+	public abstract fun onInputChanged (ZLjava/util/Set;)V
+}
+
+public final class com/stripe/android/view/CardValidCallback$Fields : java/lang/Enum {
+	public static final field Cvc Lcom/stripe/android/view/CardValidCallback$Fields;
+	public static final field Expiry Lcom/stripe/android/view/CardValidCallback$Fields;
+	public static final field Number Lcom/stripe/android/view/CardValidCallback$Fields;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/CardValidCallback$Fields;
+	public static fun values ()[Lcom/stripe/android/view/CardValidCallback$Fields;
+}
+
+public final class com/stripe/android/view/CvcEditText : com/stripe/android/view/StripeEditText {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCvcValue ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/view/ExpiryDateEditText : com/stripe/android/view/StripeEditText {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValidDateFields ()Lkotlin/Pair;
+	public final fun getValidatedDate ()Lcom/stripe/android/model/ExpirationDate$Validated;
+	public final fun isDateValid ()Z
+}
+
+public final class com/stripe/android/view/FpxBank : java/lang/Enum {
+	public static final field AffinBank Lcom/stripe/android/view/FpxBank;
+	public static final field AllianceBankBusiness Lcom/stripe/android/view/FpxBank;
+	public static final field AmBank Lcom/stripe/android/view/FpxBank;
+	public static final field BankIslam Lcom/stripe/android/view/FpxBank;
+	public static final field BankMuamalat Lcom/stripe/android/view/FpxBank;
+	public static final field BankRakyat Lcom/stripe/android/view/FpxBank;
+	public static final field Bsn Lcom/stripe/android/view/FpxBank;
+	public static final field Cimb Lcom/stripe/android/view/FpxBank;
+	public static final field Companion Lcom/stripe/android/view/FpxBank$Companion;
+	public static final field HongLeongBank Lcom/stripe/android/view/FpxBank;
+	public static final field Hsbc Lcom/stripe/android/view/FpxBank;
+	public static final field Kfh Lcom/stripe/android/view/FpxBank;
+	public static final field Maybank2E Lcom/stripe/android/view/FpxBank;
+	public static final field Maybank2U Lcom/stripe/android/view/FpxBank;
+	public static final field Ocbc Lcom/stripe/android/view/FpxBank;
+	public static final field PublicBank Lcom/stripe/android/view/FpxBank;
+	public static final field Rhb Lcom/stripe/android/view/FpxBank;
+	public static final field StandardChartered Lcom/stripe/android/view/FpxBank;
+	public static final field UobBank Lcom/stripe/android/view/FpxBank;
+	public static final fun get (Ljava/lang/String;)Lcom/stripe/android/view/FpxBank;
+	public final fun getBrandIconResId ()I
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/FpxBank;
+	public static fun values ()[Lcom/stripe/android/view/FpxBank;
+}
+
+public final class com/stripe/android/view/FpxBank$Companion {
+	public final fun get (Ljava/lang/String;)Lcom/stripe/android/view/FpxBank;
+}
+
+public final class com/stripe/android/view/PaymentAuthWebViewActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+	public fun onBackPressed ()V
+	public fun onCreateOptionsMenu (Landroid/view/Menu;)Z
+	public fun onOptionsItemSelected (Landroid/view/MenuItem;)Z
+}
+
+public final class com/stripe/android/view/PaymentFlowActivity : com/stripe/android/view/StripeActivity {
+	public static final field Companion Lcom/stripe/android/view/PaymentFlowActivity$Companion;
+	public fun <init> ()V
+	public fun onActionSave ()V
+	public fun onBackPressed ()V
+}
+
+public final class com/stripe/android/view/PaymentFlowActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field Companion Lcom/stripe/android/view/PaymentFlowActivityStarter$Companion;
+	public static final field REQUEST_CODE I
+	public fun <init> (Landroid/app/Activity;Lcom/stripe/android/PaymentSessionConfig;)V
+	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/PaymentSessionConfig;)V
+}
+
+public final class com/stripe/android/view/PaymentFlowActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Companion;
+	public final fun copy (Lcom/stripe/android/PaymentSessionConfig;Lcom/stripe/android/PaymentSessionData;ZLjava/lang/Integer;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;Lcom/stripe/android/PaymentSessionConfig;Lcom/stripe/android/PaymentSessionData;ZLjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public static final fun create (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/view/PaymentFlowActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setIsPaymentSessionActive (Z)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Builder;
+	public final fun setPaymentSessionConfig (Lcom/stripe/android/PaymentSessionConfig;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Builder;
+	public final fun setPaymentSessionData (Lcom/stripe/android/PaymentSessionData;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Builder;
+	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Builder;
+}
+
+public final class com/stripe/android/view/PaymentFlowActivityStarter$Args$Companion {
+	public final fun create (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+}
+
+public class com/stripe/android/view/PaymentFlowActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/PaymentFlowActivityStarter$Companion {
+}
+
+public final class com/stripe/android/view/PaymentFlowViewPager : androidx/viewpager/widget/ViewPager {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;Z)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z
+	public fun onTouchEvent (Landroid/view/MotionEvent;)Z
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivity$Companion;
+	public fun <init> ()V
+	public fun onBackPressed ()V
+	public fun onSupportNavigateUp ()Z
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivityStarter$Companion;
+	public static final field REQUEST_CODE I
+	public fun <init> (Landroid/app/Activity;)V
+	public fun <init> (Landroidx/fragment/app/Fragment;)V
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Companion;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;IIZLjava/util/List;Lcom/stripe/android/PaymentConfiguration;Ljava/lang/Integer;Lcom/stripe/android/view/BillingAddressFields;ZZZ)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;Ljava/lang/String;IIZLjava/util/List;Lcom/stripe/android/PaymentConfiguration;Ljava/lang/Integer;Lcom/stripe/android/view/BillingAddressFields;ZZZILjava/lang/Object;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddPaymentMethodFooterLayoutId ()I
+	public final fun getPaymentMethodsFooterLayoutId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public fun <init> ()V
+	public fun build ()Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
+	public synthetic fun build ()Ljava/lang/Object;
+	public final fun setAddPaymentMethodFooter (I)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setBillingAddressFields (Lcom/stripe/android/view/BillingAddressFields;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setCanDeletePaymentMethods (Z)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setInitialPaymentMethodId (Ljava/lang/String;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setIsPaymentSessionActive (Z)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setPaymentConfiguration (Lcom/stripe/android/PaymentConfiguration;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setPaymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setPaymentMethodsFooter (I)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setShouldShowGooglePay (Z)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
+}
+
+public class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Companion {
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result : com/stripe/android/view/ActivityStarter$Result {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result$Companion;
+	public final field paymentMethod Lcom/stripe/android/model/PaymentMethod;
+	public fun <init> ()V
+	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component2 ()Z
+	public final fun copy (Lcom/stripe/android/model/PaymentMethod;Z)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;Lcom/stripe/android/model/PaymentMethod;ZILjava/lang/Object;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+	public final fun getUseGooglePay ()Z
+	public fun hashCode ()I
+	public fun toBundle ()Landroid/os/Bundle;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result$Companion {
+	public final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+}
+
+public class com/stripe/android/view/PaymentMethodsActivityStarter$Result$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/PaymentUtils {
+	public static final field INSTANCE Lcom/stripe/android/view/PaymentUtils;
+	public static final fun formatPriceStringUsingFree (JLjava/util/Currency;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/view/PostalCodeEditText : com/stripe/android/view/StripeEditText {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/stripe/android/view/ShippingInfoWidget : android/widget/LinearLayout {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHiddenFields ()Ljava/util/List;
+	public final fun getOptionalFields ()Ljava/util/List;
+	public final fun getShippingInformation ()Lcom/stripe/android/model/ShippingInformation;
+	public final fun populateShippingInfo (Lcom/stripe/android/model/ShippingInformation;)V
+	public final fun setAllowedCountryCodes (Ljava/util/Set;)V
+	public final fun setHiddenFields (Ljava/util/List;)V
+	public final fun setOptionalFields (Ljava/util/List;)V
+	public final fun validateAllFields ()Z
+}
+
+public final class com/stripe/android/view/ShippingInfoWidget$CustomizableShippingField : java/lang/Enum {
+	public static final field City Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static final field Line1 Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static final field Line2 Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static final field Phone Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static final field PostalCode Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static final field State Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+	public static fun values ()[Lcom/stripe/android/view/ShippingInfoWidget$CustomizableShippingField;
+}
+
+public final class com/stripe/android/view/Stripe3ds2CompletionActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+}
+
+public abstract class com/stripe/android/view/StripeActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+	protected final fun isProgressBarVisible ()Z
+	protected abstract fun onActionSave ()V
+	protected fun onCreate (Landroid/os/Bundle;)V
+	public fun onCreateOptionsMenu (Landroid/view/Menu;)Z
+	public fun onOptionsItemSelected (Landroid/view/MenuItem;)Z
+	public fun onPrepareOptionsMenu (Landroid/view/Menu;)Z
+	protected fun onProgressBarVisibilityChanged (Z)V
+	protected final fun setProgressBarVisible (Z)V
+	protected final fun showError (Ljava/lang/String;)V
+}
+
+public class com/stripe/android/view/StripeEditText : com/google/android/material/textfield/TextInputEditText {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun getAccessibilityText ()Ljava/lang/String;
+	public final fun getCachedColorStateList ()Landroid/content/res/ColorStateList;
+	public final fun getDefaultErrorColorInt ()I
+	public final fun getShouldShowError ()Z
+	protected final fun isLastKeyDelete ()Z
+	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
+	public fun onInitializeAccessibilityNodeInfo (Landroid/view/accessibility/AccessibilityNodeInfo;)V
+	public final fun setAfterTextChangedListener (Lcom/stripe/android/view/StripeEditText$AfterTextChangedListener;)V
+	public final fun setDeleteEmptyListener (Lcom/stripe/android/view/StripeEditText$DeleteEmptyListener;)V
+	public final fun setErrorColor (I)V
+	public final fun setErrorMessage (Ljava/lang/String;)V
+	public final fun setErrorMessageListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
+	protected final fun setLastKeyDelete (Z)V
+	public final fun setShouldShowError (Z)V
+}
+
+public abstract interface class com/stripe/android/view/StripeEditText$AfterTextChangedListener {
+	public abstract fun onTextChanged (Ljava/lang/String;)V
+}
+
+public abstract interface class com/stripe/android/view/StripeEditText$DeleteEmptyListener {
+	public abstract fun onDeleteEmpty ()V
+}
+
+public abstract interface class com/stripe/android/view/StripeEditText$ErrorMessageListener {
+	public abstract fun displayErrorMessage (Ljava/lang/String;)V
+}
+
+public abstract interface class com/stripe/android/view/i18n/ErrorMessageTranslator {
+	public abstract fun translate (ILjava/lang/String;Lcom/stripe/android/StripeError;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/view/i18n/TranslatorManager {
+	public static final field INSTANCE Lcom/stripe/android/view/i18n/TranslatorManager;
+	public final fun getErrorMessageTranslator ()Lcom/stripe/android/view/i18n/ErrorMessageTranslator;
+	public final fun setErrorMessageTranslator (Lcom/stripe/android/view/i18n/ErrorMessageTranslator;)V
+}
+


### PR DESCRIPTION
https://github.com/Kotlin/binary-compatibility-validator

`binary-compatibility-validator` validates that the public binary API
wasn't changed in a way that make this change binary incompatible.

`stripe/api/stripe.api` is auto-generated from the current source by
running the `apiDump` task. `apiCheck` validates that the current
source matches `stripe.api`.