### PR TITLE
Update Fragment and Activity Versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     ktlintVersion = '0.40.0'
     materialVersion = '1.3.0'
 
-    fragmentVersion = '1.3.0-rc02'
+    fragmentVersion = '1.3.0'
 
     androidTestVersion = '1.3.0'
 }

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "androidx.activity:activity-ktx:1.2.0-rc01"
+    implementation "androidx.activity:activity-ktx:1.2.0"
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     implementation "com.google.android.material:material:$materialVersion"
 


### PR DESCRIPTION
## Summary
The release candidates are now stable: https://developer.android.com/jetpack/androidx/versions/all-channel#february_10_2021

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Moving to stable releases.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Existing unit tests.