### PR TITLE
Update the error message margins on the PaymentSheet, and show a formatted authentication error message to the user. (MOBILESDK-166, MOBILESK-167)

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -48,7 +48,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 android:layout_marginVertical="2dp"
-                android:layout_marginHorizontal="23dp"
+                android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
                 style="@style/StripePaymentSheetErrorMessage" />
         </LinearLayout>
 

--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -48,7 +48,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 android:layout_marginVertical="2dp"
-                android:layout_marginHorizontal="10dp"
+                android:layout_marginHorizontal="23dp"
                 style="@style/StripePaymentSheetErrorMessage" />
         </LinearLayout>
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -201,7 +201,7 @@ internal class PaymentSheetViewModel internal constructor(
                 eventReporter.onPaymentFailure(selection.value)
 
                 val paymentIntent = paymentIntentResult.intent
-                onApiError(paymentIntent.lastPaymentError?.message)
+                onApiError(paymentIntentResult.failureMessage)
                 onPaymentIntentResponse(paymentIntentResult.intent)
             }
         }


### PR DESCRIPTION
## Summary
Update the horizontal margin on the error text.

## Motivation
It looks weirdly spaced on the screen (MOBILESDK-166)

## Testing
- Tested adding a new card that is already in the list, but results in 3DS2 authentication failure
- Tested adding a new card that is already in the list, and results in 3DS2 authentication success
- Test use a card in the list and fail 3DS2 authentication
- Test paste in an invalid card number AT611904300234573201 -> 611904300234573201
- Test server side incorrect_CVC, processing_error, card declined (new cards)
- Test client side incorrect number, expired
- Test with different countries

It seems like this is never causing an error (not sure if this is an error with the card number, not even on web checkout)
4000000000000028 | Charge succeeds but the address_line1_check verification fails.



