### PR TITLE
Refactor Alipay integration in StripePaymentController

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AlipayAuthenticator.kt
+++ b/stripe/src/main/java/com/stripe/android/AlipayAuthenticator.kt
@@ -18,7 +18,7 @@ import com.stripe.android.model.PaymentIntent
  * }
  * </pre>
  */
-interface AlipayAuthenticator {
+fun interface AlipayAuthenticator {
     @WorkerThread
     fun onAuthenticationRequest(data: String): Map<String, String>
 }

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import android.content.Intent
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
@@ -17,10 +18,11 @@ internal interface PaymentController {
         requestOptions: ApiRequest.Options
     )
 
-    fun startConfirm(
-        confirmStripeIntentParams: ConfirmStripeIntentParams,
+    fun startConfirmAlipay(
+        confirmPaymentIntentParams: ConfirmPaymentIntentParams,
+        authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options,
-        callback: ApiResultCallback<StripeIntent>
+        callback: ApiResultCallback<PaymentIntentResult>
     )
 
     fun startAuth(
@@ -89,13 +91,6 @@ internal interface PaymentController {
         host: AuthActivityStarter.Host,
         stripeIntent: StripeIntent,
         requestOptions: ApiRequest.Options
-    )
-
-    fun authenticateAlipay(
-        intent: StripeIntent,
-        stripeAccountId: String?,
-        authenticator: AlipayAuthenticator,
-        callback: ApiResultCallback<PaymentIntentResult>
     )
 
     enum class StripeIntentType {

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -31,7 +31,6 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeModel
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
@@ -176,24 +175,14 @@ class Stripe internal constructor(
         stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<PaymentIntentResult>
     ) {
-        paymentController.startConfirm(
+        paymentController.startConfirmAlipay(
             confirmPaymentIntentParams,
+            authenticator,
             ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
             ),
-            object : ApiResultCallback<StripeIntent> {
-                override fun onSuccess(result: StripeIntent) {
-                    paymentController.authenticateAlipay(
-                        result,
-                        stripeAccountId,
-                        authenticator,
-                        callback
-                    )
-                }
-
-                override fun onError(e: Exception) = callback.onError(e)
-            }
+            callback
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/networking/AlipayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AlipayRepository.kt
@@ -2,11 +2,11 @@ package com.stripe.android.networking
 
 import com.stripe.android.AlipayAuthenticator
 import com.stripe.android.model.AlipayAuthResult
-import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.PaymentIntent
 
 internal interface AlipayRepository {
     suspend fun authenticate(
-        intent: StripeIntent,
+        paymentIntent: PaymentIntent,
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
     ): AlipayAuthResult

--- a/stripe/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
@@ -3,17 +3,18 @@ package com.stripe.android.networking
 import com.stripe.android.AlipayAuthenticator
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.AlipayAuthResult
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 
 internal class DefaultAlipayRepository(
     private val stripeRepository: StripeRepository
 ) : AlipayRepository {
     override suspend fun authenticate(
-        intent: StripeIntent,
+        paymentIntent: PaymentIntent,
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
     ): AlipayAuthResult {
-        if (intent.paymentMethod?.liveMode == false) {
+        if (paymentIntent.paymentMethod?.liveMode == false) {
             throw IllegalArgumentException(
                 "Attempted to authenticate test mode " +
                     "PaymentIntent with the Alipay SDK.\n" +
@@ -21,7 +22,7 @@ internal class DefaultAlipayRepository(
             )
         }
 
-        val nextActionData = intent.nextActionData
+        val nextActionData = paymentIntent.nextActionData
         if (nextActionData is StripeIntent.NextActionData.AlipayRedirect) {
             val output =
                 authenticator.onAuthenticationRequest(nextActionData.data)

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -1027,7 +1027,7 @@ internal class StripePaymentControllerTest {
 
     private class FakeAlipayRepostiory : AlipayRepository {
         override suspend fun authenticate(
-            intent: StripeIntent,
+            paymentIntent: PaymentIntent,
             authenticator: AlipayAuthenticator,
             requestOptions: ApiRequest.Options
         ) = AlipayAuthResult(StripeIntentResult.Outcome.SUCCEEDED)

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -876,23 +876,27 @@ internal class StripePaymentControllerTest {
 
     @Test
     fun `authenticateAlipay() should return expected outcome`() = testDispatcher.runBlockingTest {
-        var actualResult: Result<PaymentIntentResult>? = null
+        val results = mutableListOf<Result<PaymentIntentResult>>()
         controller.authenticateAlipay(
             PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION,
-            null,
-            mock(),
+            {
+                mapOf("key" to "value")
+            },
+            REQUEST_OPTIONS,
             object : ApiResultCallback<PaymentIntentResult> {
                 override fun onSuccess(result: PaymentIntentResult) {
-                    actualResult = Result.success(result)
+                    results.add(Result.success(result))
                 }
 
                 override fun onError(e: Exception) {
-                    actualResult = Result.failure(e)
+                    results.add(Result.failure(e))
                 }
             }
         )
 
-        val paymentIntentResult = requireNotNull(actualResult?.getOrNull())
+        assertThat(results)
+            .hasSize(1)
+        val paymentIntentResult = requireNotNull(results.first().getOrNull())
         assertThat(paymentIntentResult.outcome)
             .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
     }

--- a/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
@@ -121,10 +121,10 @@ internal class DefaultAlipayRepositoryTest {
             )
     }
 
-    private fun createAuthenticator(resultCode: String?) = object : AlipayAuthenticator {
-        override fun onAuthenticationRequest(data: String): Map<String, String> {
-            return resultCode?.let { mapOf("resultStatus" to it) }.orEmpty()
-        }
+    private fun createAuthenticator(resultCode: String?) = AlipayAuthenticator { data ->
+        resultCode?.let {
+            mapOf("resultStatus" to data)
+        }.orEmpty()
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
@@ -121,9 +121,9 @@ internal class DefaultAlipayRepositoryTest {
             )
     }
 
-    private fun createAuthenticator(resultCode: String?) = AlipayAuthenticator { data ->
+    private fun createAuthenticator(resultCode: String?) = AlipayAuthenticator {
         resultCode?.let {
-            mapOf("resultStatus" to data)
+            mapOf("resultStatus" to it)
         }.orEmpty()
     }
 


### PR DESCRIPTION
## Summary
- Rename `startConfirm()` to `startConfirmAlipay()`
- Make `authenticateAlipay()` a `suspend fun`
- Remove trivial test from `StripePaymentAuthTest`. This was testing
  `Stripe#confirmAlipayPayment()`, which now has a trivial
  implementation.

## Motivation
Simplify `StripePaymentController`

## Testing
Update unit tests
