### PR TITLE
Use consistent status bar color in payment sheet activities

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -5,7 +5,8 @@ import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.paymentsheet.analytics.SessionId
 
 internal class DefaultPaymentSheetLauncher(
-    private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContract.Args>
+    private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContract.Args>,
+    private val statusBarColor: () -> Int?
 ) : PaymentSheetLauncher {
     private val sessionId: SessionId = SessionId()
 
@@ -17,17 +18,21 @@ internal class DefaultPaymentSheetLauncher(
             PaymentSheetContract()
         ) {
             callback.onPaymentResult(it)
-        }
+        },
+
+        // lazily access the statusBarColor in case the value changes between when this
+        // class is instantiated and the payment sheet is launched
+        { activity.window.statusBarColor }
     )
 
     override fun present(
         paymentIntentClientSecret: String,
-
         configuration: PaymentSheet.Configuration
     ) = present(
         PaymentSheetContract.Args(
             paymentIntentClientSecret,
             sessionId,
+            statusBarColor(),
             configuration
         )
     )
@@ -38,6 +43,7 @@ internal class DefaultPaymentSheetLauncher(
         PaymentSheetContract.Args(
             paymentIntentClientSecret,
             sessionId,
+            statusBarColor(),
             config = null
         )
     )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.ColorInt
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.SessionId
@@ -33,7 +34,8 @@ internal class PaymentOptionContract : ActivityResultContract<PaymentOptionContr
         val sessionId: SessionId,
         val config: PaymentSheet.Configuration?,
         val isGooglePayReady: Boolean,
-        val newCard: PaymentSelection.New.Card?
+        val newCard: PaymentSelection.New.Card?,
+        @ColorInt val statusBarColor: Int?
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -83,6 +83,9 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
             return
         }
 
+        starterArgs.statusBarColor?.let {
+            window.statusBarColor = it
+        }
         setContentView(viewBinding.root)
 
         viewModel.fatal.observe(this) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -148,6 +148,9 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         viewModel.updatePaymentMethods()
         viewModel.fetchPaymentIntent()
 
+        starterArgs.statusBarColor?.let {
+            window.statusBarColor = it
+        }
         setContentView(viewBinding.root)
         appbar.isInvisible = true
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.ColorInt
 import androidx.core.os.bundleOf
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.view.ActivityStarter
@@ -33,6 +34,7 @@ internal class PaymentSheetContract : ActivityResultContract<PaymentSheetContrac
     internal data class Args(
         val clientSecret: String,
         val sessionId: SessionId,
+        @ColorInt val statusBarColor: Int?,
         val config: PaymentSheet.Configuration?
     ) : ActivityStarter.Args {
         val googlePayConfig: PaymentSheet.GooglePayConfiguration? get() = config?.googlePay

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -149,7 +149,8 @@ internal class DefaultFlowController internal constructor(
                 sessionId = sessionId,
                 config = initData.config,
                 isGooglePayReady = initData.isGooglePayReady,
-                newCard = viewModel.paymentSelection as? PaymentSelection.New.Card
+                newCard = viewModel.paymentSelection as? PaymentSelection.New.Card,
+                statusBarColor = activity.window.statusBarColor
             )
         )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -45,7 +45,8 @@ class PaymentOptionsActivityTest {
             sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
-            newCard = null
+            newCard = null,
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
         ),
         prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter
@@ -136,7 +137,8 @@ class PaymentOptionsActivityTest {
                         sessionId = SessionId(),
                         config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
                         isGooglePayReady = false,
-                        newCard = null
+                        newCard = null,
+                        statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
                     )
             )
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -27,7 +27,8 @@ class PaymentOptionsViewModelTest {
             sessionId = SessionId(),
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = true,
-            newCard = null
+            newCard = null,
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
         ),
         prefsRepository = FakePrefsRepository(),
         eventReporter = eventReporter

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -75,6 +75,7 @@ internal class PaymentSheetActivityTest {
         PaymentSheetContract.Args(
             "client_secret",
             sessionId = SessionId(),
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             PaymentSheetFixtures.CONFIG_CUSTOMER
         )
     )
@@ -323,6 +324,16 @@ internal class PaymentSheetActivityTest {
 
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isTrue()
+        }
+    }
+
+    @Test
+    fun `sets expected statusBarColor`() {
+        val scenario = activityScenario()
+        scenario.launch(intent).onActivity { activity ->
+            assertThat(activity.window.statusBarColor)
+                .isEqualTo(PaymentSheetFixtures.STATUS_BAR_COLOR)
+            scenario.moveToState(Lifecycle.State.DESTROYED)
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetContractTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetContractTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 class PaymentSheetContractTest {
 
     @Test
-    fun `parseResult() with missing data should return faile result`() {
+    fun `parseResult() with missing data should return failed result`() {
         assertThat(PaymentSheetContract().parseResult(0, Intent()))
             .isInstanceOf(PaymentResult.Failed::class.java)
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet
 
+import androidx.core.graphics.toColorInt
 import com.stripe.android.paymentsheet.analytics.SessionId
 
 internal object PaymentSheetFixtures {
+    internal val STATUS_BAR_COLOR = "#121212".toColorInt()
+
     private const val MERCHANT_DISPLAY_NAME = "Widget Store"
     internal const val CLIENT_SECRET = "client_secret"
 
@@ -30,18 +33,21 @@ internal object PaymentSheetFixtures {
     internal val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetContract.Args(
         CLIENT_SECRET,
         SessionId(),
+        STATUS_BAR_COLOR,
         CONFIG_CUSTOMER_WITH_GOOGLEPAY
     )
 
     internal val ARGS_CUSTOMER_WITHOUT_GOOGLEPAY = PaymentSheetContract.Args(
         CLIENT_SECRET,
         SessionId(),
+        STATUS_BAR_COLOR,
         CONFIG_CUSTOMER
     )
 
     internal val ARGS_WITHOUT_CUSTOMER = PaymentSheetContract.Args(
         CLIENT_SECRET,
         SessionId(),
+        STATUS_BAR_COLOR,
         config = null
     )
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -3,8 +3,11 @@ package com.stripe.android.paymentsheet.analytics
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
+@RunWith(RobolectricTestRunner::class)
 class PaymentSheetEventTest {
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -175,7 +176,8 @@ class DefaultFlowControllerTest {
                     sessionId = SESSION_ID,
                     config = null,
                     isGooglePayReady = false,
-                    newCard = null
+                    newCard = null,
+                    statusBarColor = ContextCompat.getColor(activity, R.color.stripe_toolbar_color_default_dark)
                 )
             )
     }


### PR DESCRIPTION
# Summary
Use the status bar color of the launching activity for
consistency/continuity.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

