### PR TITLE
Create daily CI job

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,28 @@
+name: Daily CI
+on:
+  schedule:
+    # every day at 8am
+    - cron: '0 8 * * *'
+jobs:
+  end-to-end-tests:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v1
+        with:
+          # use Java 8 for Locale and Currency compatibility with Android
+          java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Unit tests
+        run: ./gradlew :stripe-test-e2e:testDebugUnitTest
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: unit-test-report
+          path: stripe-test-e2e/build/reports/tests/testDebugUnitTest/


### PR DESCRIPTION
This job will run end to end tests on a daily schedule.

See [Events that trigger workflows](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule) for details on scheduled events in GitHub Actions.