### PR TITLE
Simplify StripeGooglePayContract

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -30,6 +30,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
 
     private val viewModel: SourceViewModel by viewModels()
     private val sourcesAdapter: SourcesAdapter by lazy {
+
         SourcesAdapter()
     }
     private val stripe: Stripe by lazy {

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -17,9 +17,7 @@ import org.json.JSONObject
 
 /**
  * [StripeGooglePayActivity] is used to return the result of a Google Pay operation.
- *
- * When started with [StripeGooglePayContract.Args.PaymentData], the activity
- * will return payment data via [StripeGooglePayContract.Result.PaymentData].
+ * The activity will return payment data via [StripeGooglePayContract.Result.PaymentData].
  *
  * Use [StripeGooglePayContract] to start [StripeGooglePayActivity].
  *

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -8,13 +8,8 @@ import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
 import com.google.android.gms.wallet.PaymentsClient
-import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.PaymentIntentResult
-import com.stripe.android.Stripe
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.GooglePayResult
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.ShippingInformation
@@ -22,10 +17,6 @@ import org.json.JSONObject
 
 /**
  * [StripeGooglePayActivity] is used to return the result of a Google Pay operation.
- *
- * When started with [StripeGooglePayContract.Args.ConfirmPaymentIntent], the activity
- * will confirm a [PaymentIntent] using Google Pay and return the result via
- * will return payment data via [StripeGooglePayContract.Result.PaymentIntent].
  *
  * When started with [StripeGooglePayContract.Args.PaymentData], the activity
  * will return payment data via [StripeGooglePayContract.Result.PaymentData].
@@ -42,7 +33,6 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
     private val publishableKey: String by lazy {
         PaymentConfiguration.getInstance(this).publishableKey
     }
-    private val stripe: Stripe by lazy { Stripe(this, publishableKey) }
     private val viewModel: StripeGooglePayViewModel by viewModels {
         StripeGooglePayViewModel.Factory(
             application,
@@ -82,33 +72,16 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
 
         if (!viewModel.hasLaunched) {
             viewModel.hasLaunched = true
-            startGooglePay(args)
+
+            isReadyToPay(
+                viewModel.createPaymentDataRequestForPaymentIntentArgs()
+            )
         }
     }
 
     override fun finish() {
         super.finish()
         overridePendingTransition(0, 0)
-    }
-
-    private fun startGooglePay(
-        args: StripeGooglePayContract.Args
-    ) {
-        if (args is StripeGooglePayContract.Args.ConfirmPaymentIntent &&
-            args.paymentIntent.confirmationMethod == PaymentIntent.ConfirmationMethod.Manual
-        ) {
-            viewModel.updateGooglePayResult(
-                StripeGooglePayContract.Result.Error(
-                    RuntimeException(
-                        "StripeGooglePayActivity requires a PaymentIntent with automatic confirmation."
-                    )
-                )
-            )
-        } else {
-            isReadyToPay(
-                viewModel.createPaymentDataRequestForPaymentIntentArgs()
-            )
-        }
     }
 
     /**
@@ -177,39 +150,6 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
                     )
                 }
             }
-        } else {
-            onPaymentResult(requestCode, data)
-        }
-    }
-
-    private fun onPaymentResult(requestCode: Int, data: Intent?) {
-        val isPaymentResult = stripe.onPaymentResult(
-            requestCode,
-            data,
-            object : ApiResultCallback<PaymentIntentResult> {
-                override fun onSuccess(result: PaymentIntentResult) {
-                    viewModel.updateGooglePayResult(
-                        StripeGooglePayContract.Result.PaymentIntent(result)
-                    )
-                }
-
-                override fun onError(e: Exception) {
-                    viewModel.updateGooglePayResult(
-                        StripeGooglePayContract.Result.Error(
-                            e,
-                            paymentMethod = viewModel.paymentMethod
-                        )
-                    )
-                }
-            }
-        )
-
-        if (!isPaymentResult) {
-            viewModel.updateGooglePayResult(
-                StripeGooglePayContract.Result.Error(
-                    RuntimeException("Unable to confirm the PaymentIntent.")
-                )
-            )
         }
     }
 
@@ -233,7 +173,6 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
             result?.fold(
                 onSuccess = {
                     onPaymentMethodCreated(
-                        args,
                         it,
                         shippingInformation
                     )
@@ -249,36 +188,15 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
     }
 
     private fun onPaymentMethodCreated(
-        args: StripeGooglePayContract.Args,
         paymentMethod: PaymentMethod,
         shippingInformation: ShippingInformation?
     ) {
         viewModel.paymentMethod = paymentMethod
 
-        when (args) {
-            is StripeGooglePayContract.Args.PaymentData -> {
-                viewModel.updateGooglePayResult(
-                    StripeGooglePayContract.Result.PaymentData(
-                        paymentMethod,
-                        shippingInformation
-                    )
-                )
-            }
-            is StripeGooglePayContract.Args.ConfirmPaymentIntent -> {
-                confirmIntent(args.paymentIntent.clientSecret.orEmpty(), paymentMethod)
-            }
-        }
-    }
-
-    private fun confirmIntent(
-        clientSecret: String,
-        paymentMethod: PaymentMethod
-    ) {
-        stripe.confirmPayment(
-            this,
-            ConfirmPaymentIntentParams.createWithPaymentMethodId(
-                paymentMethodId = paymentMethod.id.orEmpty(),
-                clientSecret = clientSecret
+        viewModel.updateGooglePayResult(
+            StripeGooglePayContract.Result.PaymentData(
+                paymentMethod,
+                shippingInformation
             )
         )
     }

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
@@ -8,7 +8,6 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
 import com.google.android.gms.common.api.Status
-import com.stripe.android.PaymentIntentResult
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
@@ -34,30 +33,15 @@ internal class StripeGooglePayContract :
         return Result.fromIntent(intent)
     }
 
-    sealed class Args : ActivityStarter.Args {
-        abstract var paymentIntent: PaymentIntent
-        abstract var config: GooglePayConfig
-
-        /**
-         * Args to start [StripeGooglePayActivity] and collect payment data. If successful, the
-         * result will be returned through [Result.PaymentData].
-         */
-        @Parcelize
-        data class PaymentData(
-            override var paymentIntent: PaymentIntent,
-            override var config: GooglePayConfig
-        ) : Args()
-
-        /**
-         * Args to start [StripeGooglePayActivity] and confirm the [paymentIntent] with the
-         * selected payment data. If successful, the result will be returned through
-         * [Result.PaymentIntent].
-         */
-        @Parcelize
-        data class ConfirmPaymentIntent(
-            override var paymentIntent: PaymentIntent,
-            override var config: GooglePayConfig
-        ) : Args()
+    /**
+     * Args to start [StripeGooglePayActivity] and collect payment data. If successful, the
+     * result will be returned through [Result.PaymentData].
+     */
+    @Parcelize
+    data class Args(
+        var paymentIntent: PaymentIntent,
+        var config: GooglePayConfig
+    ) : ActivityStarter.Args {
 
         companion object {
             @JvmSynthetic
@@ -110,14 +94,6 @@ internal class StripeGooglePayContract :
                 }
             }
         }
-
-        /**
-         * See [Args.ConfirmPaymentIntent]
-         */
-        @Parcelize
-        data class PaymentIntent(
-            val paymentIntentResult: PaymentIntentResult
-        ) : Result()
 
         /**
          * See [Args.PaymentData]

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -170,8 +170,6 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
         }
         bottomSheetController.setup()
 
-        viewModel.googlePayCompletion.observe(this, ::onActionCompleted)
-
         setupBuyButton()
         supportFragmentManager.commit {
             replace(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -57,9 +57,6 @@ internal class PaymentSheetViewModel internal constructor(
         args.clientSecret
     )
 
-    private val _googlePayCompletion = MutableLiveData<PaymentIntentResult>()
-    internal val googlePayCompletion: LiveData<PaymentIntentResult> = _googlePayCompletion
-
     private val _startConfirm = MutableLiveData<ConfirmPaymentIntentParams>()
     internal val startConfirm: LiveData<ConfirmPaymentIntentParams> = _startConfirm
 
@@ -149,7 +146,7 @@ internal class PaymentSheetViewModel internal constructor(
 
         if (paymentSelection is PaymentSelection.GooglePay) {
             paymentIntent.value?.let { paymentIntent ->
-                _launchGooglePay.value = StripeGooglePayContract.Args.PaymentData(
+                _launchGooglePay.value = StripeGooglePayContract.Args(
                     paymentIntent = paymentIntent,
                     config = StripeGooglePayContract.GooglePayConfig(
                         environment = when (args.config?.googlePay?.environment) {
@@ -207,10 +204,6 @@ internal class PaymentSheetViewModel internal constructor(
         googlePayResult: StripeGooglePayContract.Result
     ) {
         when (googlePayResult) {
-            is StripeGooglePayContract.Result.PaymentIntent -> {
-                eventReporter.onPaymentSuccess(PaymentSelection.GooglePay)
-                _googlePayCompletion.value = googlePayResult.paymentIntentResult
-            }
             is StripeGooglePayContract.Result.PaymentData -> {
                 val paymentSelection = PaymentSelection.Saved(
                     googlePayResult.paymentMethod

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -168,7 +168,7 @@ internal class DefaultFlowController internal constructor(
         val paymentSelection = viewModel.paymentSelection
         if (paymentSelection == PaymentSelection.GooglePay) {
             googlePayLauncher(
-                StripeGooglePayContract.Args.PaymentData(
+                StripeGooglePayContract.Args(
                     paymentIntent = initData.paymentIntent,
                     config = StripeGooglePayContract.GooglePayConfig(
                         environment = when (config?.googlePay?.environment) {
@@ -219,19 +219,6 @@ internal class DefaultFlowController internal constructor(
         googlePayResult: StripeGooglePayContract.Result
     ) {
         when (googlePayResult) {
-            is StripeGooglePayContract.Result.PaymentIntent -> {
-                val paymentIntentResult = googlePayResult.paymentIntentResult
-                val paymentIntent = paymentIntentResult.intent
-
-                if (paymentIntent.status == StripeIntent.Status.Succeeded) {
-                    eventReporter.onPaymentSuccess(PaymentSelection.GooglePay)
-                } else {
-                    eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
-                }
-
-                val paymentResult = createPaymentResult(paymentIntentResult)
-                paymentResultCallback.onPaymentResult(paymentResult)
-            }
             is StripeGooglePayContract.Result.PaymentData -> {
                 runCatching {
                     viewModel.initData

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
@@ -32,28 +32,11 @@ class StripeGooglePayActivityTest {
     @Ignore("failing in CI but not locally")
     fun `successful start should return Unavailable result`() {
         createActivity(
-            PAYMENT_DATA_ARGS
+            ARGS
         ) { activityScenario ->
             // Google Pay is only available on a real device
             assertThat(parseResult(activityScenario))
                 .isInstanceOf(StripeGooglePayContract.Result.Unavailable::class.java)
-        }
-    }
-
-    @Test
-    fun `start should ConfirmPaymentIntent args and manual confirmation should finish with Error result`() {
-        createActivity(
-            CONFIRM_ARGS.copy(
-                paymentIntent = PAYMENT_INTENT.copy(
-                    confirmationMethod = PaymentIntent.ConfirmationMethod.Manual
-                )
-            )
-        ) { activityScenario ->
-            val result = parseResult(activityScenario) as StripeGooglePayContract.Result.Error
-            assertThat(result.exception.message)
-                .isEqualTo(
-                    "StripeGooglePayActivity requires a PaymentIntent with automatic confirmation."
-                )
         }
     }
 
@@ -106,12 +89,7 @@ class StripeGooglePayActivityTest {
             confirmationMethod = PaymentIntent.ConfirmationMethod.Automatic
         )
 
-        private val PAYMENT_DATA_ARGS = StripeGooglePayContract.Args.PaymentData(
-            paymentIntent = PAYMENT_INTENT,
-            config = CONFIG
-        )
-
-        private val CONFIRM_ARGS = StripeGooglePayContract.Args.ConfirmPaymentIntent(
+        private val ARGS = StripeGooglePayContract.Args(
             paymentIntent = PAYMENT_INTENT,
             config = CONFIG
         )

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -177,7 +177,7 @@ class StripeGooglePayViewModelTest {
             isEmailRequired = true
         )
 
-        private val ARGS = StripeGooglePayContract.Args.ConfirmPaymentIntent(
+        private val ARGS = StripeGooglePayContract.Args(
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             config = CONFIG
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
-import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -239,25 +238,6 @@ internal class PaymentSheetViewModelTest {
             .isEqualTo(
                 SheetViewModel.UserMessage.Error("Your card was declined.")
             )
-    }
-
-    @Test
-    fun `onGooglePayResult() with successful Google Pay result should emit on googlePayCompletion`() {
-        val paymentIntentResults = mutableListOf<PaymentIntentResult>()
-        viewModel.googlePayCompletion.observeForever { paymentIntentResult ->
-            if (paymentIntentResult != null) {
-                paymentIntentResults.add(paymentIntentResult)
-            }
-        }
-        viewModel.onGooglePayResult(
-            StripeGooglePayContract.Result.PaymentIntent(PAYMENT_INTENT_RESULT)
-        )
-
-        assertThat(paymentIntentResults)
-            .containsExactly(PAYMENT_INTENT_RESULT)
-
-        verify(eventReporter)
-            .onPaymentSuccess(PaymentSelection.GooglePay)
     }
 
     @Test


### PR DESCRIPTION
# Motivation
We will no longer be confirming PaymentIntents in
`StripeGooglePayActivity`, so
`StripeGooglePayContract.Args.ConfirmPaymentIntent` and
`StripeGooglePayActivity.Result.PaymentIntent` can be removed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

