### PR TITLE
Add PaymentSheet constructor that takes Fragment

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
 import androidx.fragment.app.Fragment
 import com.stripe.android.paymentsheet.analytics.SessionId
+import org.jetbrains.annotations.TestOnly
 
 internal class DefaultPaymentSheetLauncher(
     private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContract.Args>,
@@ -19,23 +20,6 @@ internal class DefaultPaymentSheetLauncher(
     ) : this(
         activity.registerForActivityResult(
             PaymentSheetContract()
-        ) {
-            callback.onPaymentResult(it)
-        },
-
-        // lazily access the statusBarColor in case the value changes between when this
-        // class is instantiated and the payment sheet is launched
-        { getStatusBarColor(activity) }
-    )
-
-    constructor(
-        activity: ComponentActivity,
-        registry: ActivityResultRegistry,
-        callback: PaymentSheetResultCallback
-    ) : this(
-        activity.registerForActivityResult(
-            PaymentSheetContract(),
-            registry
         ) {
             callback.onPaymentResult(it)
         },
@@ -60,6 +44,7 @@ internal class DefaultPaymentSheetLauncher(
         { getStatusBarColor(fragment.activity) }
     )
 
+    @TestOnly
     constructor(
         fragment: Fragment,
         registry: ActivityResultRegistry,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.paymentsheet
 
+import android.app.Activity
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
+import androidx.fragment.app.Fragment
 import com.stripe.android.paymentsheet.analytics.SessionId
 
 internal class DefaultPaymentSheetLauncher(
@@ -22,7 +25,56 @@ internal class DefaultPaymentSheetLauncher(
 
         // lazily access the statusBarColor in case the value changes between when this
         // class is instantiated and the payment sheet is launched
-        { activity.window.statusBarColor }
+        { getStatusColor(activity) }
+    )
+
+    constructor(
+        activity: ComponentActivity,
+        registry: ActivityResultRegistry,
+        callback: PaymentSheetResultCallback
+    ) : this(
+        activity.registerForActivityResult(
+            PaymentSheetContract(),
+            registry
+        ) {
+            callback.onPaymentResult(it)
+        },
+
+        // lazily access the statusBarColor in case the value changes between when this
+        // class is instantiated and the payment sheet is launched
+        { getStatusColor(activity) }
+    )
+
+    constructor(
+        fragment: Fragment,
+        callback: PaymentSheetResultCallback
+    ) : this(
+        fragment.registerForActivityResult(
+            PaymentSheetContract()
+        ) {
+            callback.onPaymentResult(it)
+        },
+
+        // lazily access the statusBarColor in case the value changes between when this
+        // class is instantiated and the payment sheet is launched
+        { getStatusColor(fragment.activity) }
+    )
+
+    constructor(
+        fragment: Fragment,
+        registry: ActivityResultRegistry,
+        callback: PaymentSheetResultCallback
+    ) : this(
+        fragment.registerForActivityResult(
+            PaymentSheetContract(),
+            registry
+        ) {
+            callback.onPaymentResult(it)
+        },
+
+        // lazily access the statusBarColor in case the value changes between when this
+        // class is instantiated and the payment sheet is launched
+        { getStatusColor(fragment.activity) }
     )
 
     override fun present(
@@ -50,5 +102,9 @@ internal class DefaultPaymentSheetLauncher(
 
     private fun present(args: PaymentSheetContract.Args) {
         activityResultLauncher.launch(args)
+    }
+
+    private companion object {
+        private fun getStatusColor(activity: Activity?) = activity?.window?.statusBarColor
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -25,7 +25,7 @@ internal class DefaultPaymentSheetLauncher(
 
         // lazily access the statusBarColor in case the value changes between when this
         // class is instantiated and the payment sheet is launched
-        { getStatusColor(activity) }
+        { getStatusBarColor(activity) }
     )
 
     constructor(
@@ -42,7 +42,7 @@ internal class DefaultPaymentSheetLauncher(
 
         // lazily access the statusBarColor in case the value changes between when this
         // class is instantiated and the payment sheet is launched
-        { getStatusColor(activity) }
+        { getStatusBarColor(activity) }
     )
 
     constructor(
@@ -57,7 +57,7 @@ internal class DefaultPaymentSheetLauncher(
 
         // lazily access the statusBarColor in case the value changes between when this
         // class is instantiated and the payment sheet is launched
-        { getStatusColor(fragment.activity) }
+        { getStatusBarColor(fragment.activity) }
     )
 
     constructor(
@@ -74,7 +74,7 @@ internal class DefaultPaymentSheetLauncher(
 
         // lazily access the statusBarColor in case the value changes between when this
         // class is instantiated and the payment sheet is launched
-        { getStatusColor(fragment.activity) }
+        { getStatusBarColor(fragment.activity) }
     )
 
     override fun present(
@@ -105,6 +105,6 @@ internal class DefaultPaymentSheetLauncher(
     }
 
     private companion object {
-        private fun getStatusColor(activity: Activity?) = activity?.window?.statusBarColor
+        private fun getStatusBarColor(activity: Activity?) = activity?.window?.statusBarColor
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -15,6 +16,13 @@ class PaymentSheet internal constructor(
         callback: PaymentSheetResultCallback
     ) : this(
         DefaultPaymentSheetLauncher(activity, callback)
+    )
+
+    internal constructor(
+        fragment: Fragment,
+        callback: PaymentSheetResultCallback
+    ) : this(
+        DefaultPaymentSheetLauncher(fragment, callback)
     )
 
     /**

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentIntentFixtures
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultPaymentSheetLauncherTest {
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+    }
+
+    @Test
+    fun `init and present should return expected PaymentResult`() {
+        val testRegistry = FakeActivityResultRegistry(PAYMENT_RESULT_COMPLETED)
+
+        with(
+            launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
+                TestFragment()
+            }
+        ) {
+            onFragment { fragment ->
+                val results = mutableListOf<PaymentResult>()
+                val launcher = DefaultPaymentSheetLauncher(fragment, testRegistry) {
+                    results.add(it)
+                }
+
+                moveToState(Lifecycle.State.RESUMED)
+                launcher.present("pi_fake")
+                assertThat(results)
+                    .containsExactly(PAYMENT_RESULT_COMPLETED)
+            }
+        }
+    }
+
+    private class FakeActivityResultRegistry(
+        private val result: PaymentResult
+    ) : ActivityResultRegistry() {
+        override fun <I, O> onLaunch(
+            requestCode: Int,
+            contract: ActivityResultContract<I, O>,
+            input: I,
+            options: ActivityOptionsCompat?
+        ) {
+            dispatchResult(
+                requestCode,
+                result
+            )
+        }
+    }
+
+    internal class TestFragment : Fragment()
+
+    private companion object {
+        private val PAYMENT_RESULT_COMPLETED = PaymentResult.Completed(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Update `PaymentSheet` and `DefaultPaymentSheetLauncher` to take `Fragment` constructor argument.
Add test for `DefaultPaymentSheetLauncher` that verifies activity result behavior.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

