### PR TITLE
Rename base payment sheet and base sheet view model so they are consistent

### DIFF
--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -11,7 +11,7 @@ is nested in a `BottomSheetBehavior`.
     android:layout_height="match_parent"
     android:layout_marginBottom="@dimen/stripe_paymentsheet_form_bottom_margin"
     android:nestedScrollingEnabled="false"
-    tools:context=".paymentsheet.PaymentSheetPaymentMethodsListFragment">
+    tools:context=".paymentsheet.PaymentSheetListFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/stripe/res/layout/fragment_paymentsheet_payment_methods_list.xml
+++ b/stripe/res/layout/fragment_paymentsheet_payment_methods_list.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical"
     android:layout_marginTop="@dimen/stripe_paymentsheet_paymentoptions_margin_top"
     android:layout_marginBottom="@dimen/stripe_paymentsheet_paymentoptions_margin_bottom"
-    tools:context=".paymentsheet.PaymentSheetPaymentMethodsListFragment">
+    tools:context=".paymentsheet.PaymentSheetListFragment">
 
     <TextView
         android:id="@+id/header"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -27,10 +27,10 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
+import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.BillingAddressView
 import com.stripe.android.paymentsheet.ui.SheetMode
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.view.CardInputListener
 import com.stripe.android.view.CardMultilineWidget
 import com.stripe.android.view.StripeEditText
@@ -41,7 +41,7 @@ import com.stripe.android.view.StripeEditText
 internal abstract class BaseAddCardFragment(
     private val eventReporter: EventReporter
 ) : Fragment() {
-    abstract val sheetViewModel: SheetViewModel<*>
+    abstract val sheetViewModel: BaseSheetViewModel<*>
 
     private lateinit var cardMultilineWidget: CardMultilineWidget
     private lateinit var billingAddressView: BillingAddressView
@@ -90,7 +90,7 @@ internal abstract class BaseAddCardFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val config = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
+        val config = arguments?.getParcelable<FragmentConfig>(BaseSheetActivity.EXTRA_FRAGMENT_CONFIG)
         if (activity == null || config == null) {
             sheetViewModel.onFatal(
                 IllegalArgumentException("Failed to start add payment option fragment.")

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -9,9 +9,9 @@ import com.stripe.android.databinding.FragmentPaymentsheetPaymentMethodsListBind
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
+import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.SheetMode
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
 internal abstract class BasePaymentMethodsListFragment(
     private val canClickSelectedItem: Boolean,
@@ -19,14 +19,14 @@ internal abstract class BasePaymentMethodsListFragment(
 ) : Fragment(
     R.layout.fragment_paymentsheet_payment_methods_list
 ) {
-    abstract val sheetViewModel: SheetViewModel<*>
+    abstract val sheetViewModel: BaseSheetViewModel<*>
 
     protected lateinit var config: FragmentConfig
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nullableConfig = arguments?.getParcelable<FragmentConfig>(BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG)
+        val nullableConfig = arguments?.getParcelable<FragmentConfig>(BaseSheetActivity.EXTRA_FRAGMENT_CONFIG)
         if (nullableConfig == null) {
             sheetViewModel.onFatal(
                 IllegalArgumentException("Failed to start existing payment options fragment.")

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -20,13 +20,13 @@ import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
-import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
+import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.Toolbar
 
 /**
  * An `Activity` for selecting a payment option.
  */
-internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionResult>() {
+internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>() {
     @VisibleForTesting
     internal val viewBinding by lazy {
         StripeActivityPaymentOptionsBinding.inflate(layoutInflater)
@@ -220,7 +220,7 @@ internal class PaymentOptionsActivity : BasePaymentSheetActivity<PaymentOptionRe
     }
 
     internal companion object {
-        internal const val EXTRA_FRAGMENT_CONFIG = BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG
-        internal const val EXTRA_STARTER_ARGS = BasePaymentSheetActivity.EXTRA_STARTER_ARGS
+        internal const val EXTRA_FRAGMENT_CONFIG = BaseSheetActivity.EXTRA_FRAGMENT_CONFIG
+        internal const val EXTRA_STARTER_ARGS = BaseSheetActivity.EXTRA_STARTER_ARGS
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -10,14 +10,14 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SheetMode
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import kotlinx.coroutines.Dispatchers
 
 internal class PaymentOptionsViewModel(
     args: PaymentOptionContract.Args,
     prefsRepository: PrefsRepository,
     private val eventReporter: EventReporter
-) : SheetViewModel<PaymentOptionsViewModel.TransitionTarget>(
+) : BaseSheetViewModel<PaymentOptionsViewModel.TransitionTarget>(
     config = args.config,
     prefsRepository = prefsRepository
 ) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -33,11 +33,11 @@ import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AnimationConstants
-import com.stripe.android.paymentsheet.ui.BasePaymentSheetActivity
+import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.Toolbar
 import com.stripe.android.view.AuthActivityStarter
 
-internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() {
+internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
     @VisibleForTesting
     internal var viewModelFactory: ViewModelProvider.Factory =
         PaymentSheetViewModel.Factory(
@@ -340,7 +340,7 @@ internal class PaymentSheetActivity : BasePaymentSheetActivity<PaymentResult>() 
     }
 
     internal companion object {
-        internal const val EXTRA_FRAGMENT_CONFIG = BasePaymentSheetActivity.EXTRA_FRAGMENT_CONFIG
-        internal const val EXTRA_STARTER_ARGS = BasePaymentSheetActivity.EXTRA_STARTER_ARGS
+        internal const val EXTRA_FRAGMENT_CONFIG = BaseSheetActivity.EXTRA_FRAGMENT_CONFIG
+        internal const val EXTRA_STARTER_ARGS = BaseSheetActivity.EXTRA_STARTER_ARGS
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -254,7 +254,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
                 is PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod -> {
                     replace(
                         fragmentContainerId,
-                        PaymentSheetPaymentMethodsListFragment::class.java,
+                        PaymentSheetListFragment::class.java,
                         fragmentArgs
                     )
                 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
@@ -6,7 +6,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import java.util.Currency
 import java.util.Locale
 
-internal class PaymentSheetPaymentMethodsListFragment(
+internal class PaymentSheetListFragment(
     eventReporter: EventReporter
 ) : BasePaymentMethodsListFragment(
     canClickSelectedItem = false,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -30,7 +30,7 @@ import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.paymentsheet.ui.SheetMode
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -48,7 +48,7 @@ internal class PaymentSheetViewModel internal constructor(
     private val eventReporter: EventReporter,
     internal val args: PaymentSheetContract.Args,
     workContext: CoroutineContext
-) : SheetViewModel<PaymentSheetViewModel.TransitionTarget>(
+) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     config = args.config,
     prefsRepository = prefsRepository,
     workContext = workContext

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -12,13 +12,13 @@ import com.google.android.material.appbar.AppBarLayout
 import com.stripe.android.R
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.view.KeyboardController
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-internal abstract class BasePaymentSheetActivity<ResultType> : AppCompatActivity() {
-    abstract val viewModel: SheetViewModel<*>
+internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
+    abstract val viewModel: BaseSheetViewModel<*>
     abstract val bottomSheetController: BottomSheetController
     abstract val eventReporter: EventReporter
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetFragmentFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetFragmentFactory.kt
@@ -5,8 +5,8 @@ import androidx.fragment.app.FragmentFactory
 import com.stripe.android.paymentsheet.PaymentOptionsAddCardFragment
 import com.stripe.android.paymentsheet.PaymentOptionsListFragment
 import com.stripe.android.paymentsheet.PaymentSheetAddCardFragment
+import com.stripe.android.paymentsheet.PaymentSheetListFragment
 import com.stripe.android.paymentsheet.PaymentSheetLoadingFragment
-import com.stripe.android.paymentsheet.PaymentSheetPaymentMethodsListFragment
 import com.stripe.android.paymentsheet.analytics.EventReporter
 
 internal class PaymentSheetFragmentFactory(
@@ -17,8 +17,8 @@ internal class PaymentSheetFragmentFactory(
             PaymentOptionsListFragment::class.java.name -> {
                 PaymentOptionsListFragment(eventReporter)
             }
-            PaymentSheetPaymentMethodsListFragment::class.java.name -> {
-                PaymentSheetPaymentMethodsListFragment(eventReporter)
+            PaymentSheetListFragment::class.java.name -> {
+                PaymentSheetListFragment(eventReporter)
             }
             PaymentSheetAddCardFragment::class.java.name -> {
                 PaymentSheetAddCardFragment(eventReporter)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Base `ViewModel` for activities that use `BottomSheet`.
  */
-internal abstract class SheetViewModel<TransitionTargetType>(
+internal abstract class BaseSheetViewModel<TransitionTargetType>(
     internal val config: PaymentSheet.Configuration?,
     protected val prefsRepository: PrefsRepository,
     protected val workContext: CoroutineContext = Dispatchers.IO

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -151,7 +151,7 @@ internal class PaymentSheetActivityTest {
             idleLooper()
 
             assertThat(currentFragment(activity))
-                .isInstanceOf(PaymentSheetPaymentMethodsListFragment::class.java)
+                .isInstanceOf(PaymentSheetListFragment::class.java)
             assertThat(activity.bottomSheetBehavior.state)
                 .isEqualTo(BottomSheetBehavior.STATE_COLLAPSED)
             assertThat(activity.viewBinding.bottomSheet.layoutParams.height)
@@ -173,7 +173,7 @@ internal class PaymentSheetActivityTest {
             activity.onBackPressed()
             idleLooper()
             assertThat(currentFragment(activity))
-                .isInstanceOf(PaymentSheetPaymentMethodsListFragment::class.java)
+                .isInstanceOf(PaymentSheetListFragment::class.java)
             assertThat(activity.bottomSheetBehavior.state)
                 .isEqualTo(BottomSheetBehavior.STATE_COLLAPSED)
             assertThat(activity.viewBinding.bottomSheet.layoutParams.height)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class PaymentSheetPaymentMethodsListFragmentTest {
+class PaymentSheetListFragmentTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
@@ -168,11 +168,11 @@ class PaymentSheetPaymentMethodsListFragmentTest {
         }
     }
 
-    private fun recyclerView(it: PaymentSheetPaymentMethodsListFragment) =
+    private fun recyclerView(it: PaymentSheetListFragment) =
         it.requireView().findViewById<RecyclerView>(R.id.recycler)
 
     private fun activityViewModel(
-        fragment: PaymentSheetPaymentMethodsListFragment
+        fragment: PaymentSheetListFragment
     ): PaymentSheetViewModel {
         return fragment.activityViewModels<PaymentSheetViewModel> {
             PaymentSheetViewModel.Factory(
@@ -184,8 +184,8 @@ class PaymentSheetPaymentMethodsListFragmentTest {
 
     private fun createScenario(
         fragmentConfig: FragmentConfig? = FRAGMENT_CONFIG
-    ): FragmentScenario<PaymentSheetPaymentMethodsListFragment> {
-        return launchFragmentInContainer<PaymentSheetPaymentMethodsListFragment>(
+    ): FragmentScenario<PaymentSheetListFragment> {
+        return launchFragmentInContainer<PaymentSheetListFragment>(
             bundleOf(
                 PaymentSheetActivity.EXTRA_FRAGMENT_CONFIG to fragmentConfig,
                 PaymentSheetActivity.EXTRA_STARTER_ARGS to PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -28,7 +28,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
-import com.stripe.android.paymentsheet.viewmodels.SheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -228,7 +228,7 @@ internal class PaymentSheetViewModelTest {
     fun `onPaymentFlowResult() should update emit API errors`() {
         paymentFlowResultProcessor.error = RuntimeException("Your card was declined.")
 
-        var userMessage: SheetViewModel.UserMessage? = null
+        var userMessage: BaseSheetViewModel.UserMessage? = null
         viewModel.userMessage.observeForever {
             userMessage = it
         }
@@ -237,7 +237,7 @@ internal class PaymentSheetViewModelTest {
         )
         assertThat(userMessage)
             .isEqualTo(
-                SheetViewModel.UserMessage.Error("Your card was declined.")
+                BaseSheetViewModel.UserMessage.Error("Your card was declined.")
             )
     }
 


### PR DESCRIPTION
# Summary / Motivation
Making the naming of the activity and associated view model consistent.  Also removing PaymentSheet from the Base to distinguish it from PaymentSheet.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
