### PR TITLE
Fix ExpiryDateEditText error messages

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -97,7 +97,12 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 private var newCursorPosition: Int? = null
                 private var formattedDate: String? = null
 
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                override fun beforeTextChanged(
+                    s: CharSequence?,
+                    start: Int,
+                    count: Int,
+                    after: Int
+                ) {
                     if (ignoreChanges) {
                         return
                     }
@@ -212,9 +217,14 @@ class ExpiryDateEditText @JvmOverloads constructor(
 
                     setErrorMessage(
                         resources.getString(
-                            if (!expirationDate.isMonthValid) R.string.invalid_expiry_month else R.string.invalid_expiry_year
+                            if (!expirationDate.isMonthValid) {
+                                R.string.invalid_expiry_month
+                            } else {
+                                R.string.invalid_expiry_year
+                            }
                         )
                     )
+
                     this@ExpiryDateEditText.shouldShowError = shouldShowError
 
                     formattedDate = null
@@ -228,7 +238,6 @@ class ExpiryDateEditText @JvmOverloads constructor(
         inputType = InputType.TYPE_CLASS_NUMBER
         updateSeparatorUi()
 
-        setErrorMessage(resources.getString(R.string.invalid_expiry_year))
         listenForTextChanges()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -192,6 +192,9 @@ class ExpiryDateEditText @JvmOverloads constructor(
                     val month = expirationDate.month
                     val year = expirationDate.year
                     var shouldShowError = month.length == 2 && !expirationDate.isMonthValid
+                    if (shouldShowError) {
+                        setErrorMessage(resources.getString(R.string.invalid_expiry_month))
+                    }
 
                     // Note that we have to check the parts array because afterTextChanged has odd
                     // behavior when it comes to pasting, where a paste of "1212" triggers this
@@ -203,6 +206,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                         // Here, we have a complete date, so if we've made an invalid one, we want
                         // to show an error.
                         shouldShowError = !isDateValid
+                        setErrorMessage(resources.getString(R.string.invalid_expiry_year))
                         if (!wasComplete && isDateValid) {
                             completionCallback()
                         }

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -192,9 +192,6 @@ class ExpiryDateEditText @JvmOverloads constructor(
                     val month = expirationDate.month
                     val year = expirationDate.year
                     var shouldShowError = month.length == 2 && !expirationDate.isMonthValid
-                    if (shouldShowError) {
-                        setErrorMessage(resources.getString(R.string.invalid_expiry_month))
-                    }
 
                     // Note that we have to check the parts array because afterTextChanged has odd
                     // behavior when it comes to pasting, where a paste of "1212" triggers this
@@ -206,7 +203,6 @@ class ExpiryDateEditText @JvmOverloads constructor(
                         // Here, we have a complete date, so if we've made an invalid one, we want
                         // to show an error.
                         shouldShowError = !isDateValid
-                        setErrorMessage(resources.getString(R.string.invalid_expiry_year))
                         if (!wasComplete && isDateValid) {
                             completionCallback()
                         }
@@ -214,6 +210,11 @@ class ExpiryDateEditText @JvmOverloads constructor(
                         isDateValid = false
                     }
 
+                    setErrorMessage(
+                        resources.getString(
+                            if (!expirationDate.isMonthValid) R.string.invalid_expiry_month else R.string.invalid_expiry_year
+                        )
+                    )
                     this@ExpiryDateEditText.shouldShowError = shouldShowError
 
                     formattedDate = null

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -268,6 +268,17 @@ class ExpiryDateEditTextTest {
     }
 
     @Test
+    fun inputCompleteDate_whenMonthInvalid_showsInvalidMonth() {
+        expiryDateEditText.append("15")
+        expiryDateEditText.append("50")
+
+        assertThat(expiryDateEditText.shouldShowError)
+            .isTrue()
+        assertThat(expiryDateEditText.errorMessage)
+            .isEqualTo(context.getString(R.string.invalid_expiry_month))
+    }
+
+    @Test
     fun validatedDate_whenDataIsValid_returnsExpectedValues() {
         // This test will be invalid if run after the year 2050. Please update the code.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
@@ -288,7 +299,7 @@ class ExpiryDateEditTextTest {
 
     @Test
     fun validatedDate_whenDateIsValidFormatButExpired_returnsNull() {
-        // This test will be invalid if run after the year 2050. Please update the code.
+        // This test will be invalid if run after the year 2080. Please update the code.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2080)
             .isTrue()
 

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import android.content.Context
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -16,6 +17,7 @@ import kotlin.test.Test
  */
 @RunWith(RobolectricTestRunner::class)
 class ExpiryDateEditTextTest {
+    private val context: Context = ApplicationProvider.getApplicationContext<Context>()
     private val expiryDateEditText = ExpiryDateEditText(
         ContextThemeWrapper(
             ApplicationProvider.getApplicationContext(),
@@ -185,6 +187,8 @@ class ExpiryDateEditTextTest {
 
         assertThat(expiryDateEditText.shouldShowError)
             .isTrue()
+        assertThat(expiryDateEditText.errorMessage)
+            .isEqualTo(context.getString(R.string.invalid_expiry_month))
         assertThat(expiryDateEditText.text.toString())
             .isEqualTo("14")
     }
@@ -195,6 +199,8 @@ class ExpiryDateEditTextTest {
 
         assertThat(expiryDateEditText.shouldShowError)
             .isTrue()
+        assertThat(expiryDateEditText.errorMessage)
+            .isEqualTo(context.getString(R.string.invalid_expiry_month))
         assertThat(expiryDateEditText.text.toString())
             .isEqualTo("14/3")
     }
@@ -226,6 +232,8 @@ class ExpiryDateEditTextTest {
 
         assertThat(expiryDateEditText.shouldShowError)
             .isTrue()
+        assertThat(expiryDateEditText.errorMessage)
+            .isEqualTo(context.getString(R.string.invalid_expiry_year))
         assertThat(invocations)
             .isEqualTo(0)
     }
@@ -245,6 +253,8 @@ class ExpiryDateEditTextTest {
         expiryDateEditText.append("12/12")
         assertThat(expiryDateEditText.shouldShowError)
             .isTrue()
+        assertThat(expiryDateEditText.errorMessage)
+            .isEqualTo(context.getString(R.string.invalid_expiry_year))
 
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
         assertThat(expiryDateEditText.text.toString())


### PR DESCRIPTION
# Summary
Fix ExpiryDateEditText error messages.

# Motivation
Message was always "Your card's expiration year is invalid", even when it was the month that was invalid.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
