### PR TITLE
Add returnUrl in ConfirmParamsFactory

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactory.kt
@@ -9,8 +9,9 @@ internal class ConfirmParamsFactory(
         paymentSelection: PaymentSelection.Saved
     ): ConfirmPaymentIntentParams {
         return ConfirmPaymentIntentParams.createWithPaymentMethodId(
-            paymentSelection.paymentMethod.id.orEmpty(),
-            clientSecret
+            paymentMethodId = paymentSelection.paymentMethod.id.orEmpty(),
+            clientSecret = clientSecret,
+            returnUrl = RETURN_URL
         )
     }
 
@@ -18,12 +19,19 @@ internal class ConfirmParamsFactory(
         paymentSelection: PaymentSelection.New
     ): ConfirmPaymentIntentParams {
         return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-            paymentSelection.paymentMethodCreateParams,
-            clientSecret,
+            paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+            clientSecret = clientSecret,
+            returnUrl = RETURN_URL,
             setupFutureUsage = when (paymentSelection.shouldSavePaymentMethod) {
                 true -> ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                 false -> null
             }
         )
+    }
+
+    private companion object {
+        // the value of the return URL isn't significant, but a return URL must be specified
+        // to properly handle authentication
+        private const val RETURN_URL = "stripe://return_url"
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -223,7 +223,8 @@ internal class PaymentSheetActivityTest {
                 .isEqualTo(
                     ConfirmPaymentIntentParams(
                         clientSecret = "client_secret",
-                        paymentMethodId = "pm_123456789"
+                        paymentMethodId = "pm_123456789",
+                        returnUrl = "stripe://return_url"
                     )
                 )
         }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -140,7 +140,8 @@ internal class PaymentSheetViewModelTest {
             .containsExactly(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     requireNotNull(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id),
-                    CLIENT_SECRET
+                    CLIENT_SECRET,
+                    returnUrl = "stripe://return_url"
                 )
             )
     }
@@ -165,6 +166,7 @@ internal class PaymentSheetViewModelTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     CLIENT_SECRET,
+                    returnUrl = "stripe://return_url",
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                 )
             )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ConfirmParamsFactoryTest.kt
@@ -22,8 +22,9 @@ class ConfirmParamsFactoryTest {
             )
         ).isEqualTo(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                CLIENT_SECRET,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                clientSecret = CLIENT_SECRET,
+                returnUrl = "stripe://return_url",
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
             )
         )


### PR DESCRIPTION




# Summary
This is required to properly close out the 3DS1 web view
in `PaymentAuthWebViewActivity`.

# Motivation
MOBILESDK-184

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

