### PR TITLE
Use Kotlin official style defaults, set max_line_length=100.

### DIFF
--- a/.idea/codestyles/Project.xml
+++ b/.idea/codestyles/Project.xml
@@ -29,20 +29,12 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="WRAP_ON_TYPING" value="0" />
@@ -160,6 +152,7 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />\
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/example/.editorconfig
+++ b/example/.editorconfig
@@ -1,2 +1,3 @@
 [*.{kt,kts}]
 disabled_rules=import-ordering
+max_line_length=100

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
@@ -59,6 +59,11 @@ class CreateCardTokenActivityTest {
 
         // check that card token info has been added to the tokens list
         onView(withId(R.id.tokens_list))
-            .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    0,
+                    click()
+                )
+            )
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/NetbankingPaymentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/NetbankingPaymentActivity.kt
@@ -1,4 +1,5 @@
 package com.stripe.example.activity
+
 import android.os.Bundle
 import android.view.View
 import android.widget.ArrayAdapter
@@ -20,7 +21,11 @@ class NetbankingPaymentActivity : StripeIntentActivity() {
         viewModel.inProgress.observe(this, { enableUi(!it) })
         viewModel.status.observe(this, Observer(viewBinding.status::setText))
 
-        val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, arrayListOf("HDFC", "ICICI", "SBI", "Axis")).also { adapter ->
+        val adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            arrayListOf("HDFC", "ICICI", "SBI", "Axis")
+        ).also { adapter ->
             adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         }
 

--- a/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PayWithGoogleActivity.kt
@@ -103,7 +103,8 @@ class PayWithGoogleActivity : AppCompatActivity() {
                         transactionInfo = GooglePayJsonFactory.TransactionInfo(
                             currencyCode = "USD",
                             totalPrice = 10000,
-                            totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final
+                            totalPriceStatus = GooglePayJsonFactory
+                                .TransactionInfo.TotalPriceStatus.Final
                         ),
                         merchantInfo = GooglePayJsonFactory.MerchantInfo(
                             merchantName = "Widget Store"

--- a/example/src/main/java/com/stripe/example/activity/SimplePaymentMethodConfirmationActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SimplePaymentMethodConfirmationActivity.kt
@@ -111,7 +111,8 @@ class SimplePaymentMethodConfirmationActivity : StripeIntentActivity() {
         private enum class DropdownItem(
             val country: String,
             @DrawableRes val icon: Int,
-            val createParams: (PaymentMethod.BillingDetails, Map<String, String>?) -> PaymentMethodCreateParams,
+            val createParams:
+                (PaymentMethod.BillingDetails, Map<String, String>?) -> PaymentMethodCreateParams,
             val requiresName: Boolean = true,
             val requiresEmail: Boolean = false
         ) {

--- a/stripe/.editorconfiig
+++ b/stripe/.editorconfiig
@@ -1,2 +1,3 @@
 [*.{kt,kts}]
 disabled_rules=import-ordering
+max_line_length=100


### PR DESCRIPTION
# Summary
Use Kotlin official style defaults, set max_line_length=100.

# Motivation
Android Studio formatting now breaks lines longer than 100 characters.

# Testing
N/A
