### PR TITLE
Add support for PaymentSheet.FlowController.create() with Fragment

### DIFF
--- a/.idea/codestyles/Project.xml
+++ b/.idea/codestyles/Project.xml
@@ -29,16 +29,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
@@ -161,7 +152,7 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />\
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.parcelize.Parcelize
@@ -161,7 +160,19 @@ class PaymentSheet internal constructor(
             ): FlowController {
                 return FlowControllerFactory(
                     activity,
-                    PaymentConfiguration.getInstance(activity),
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ).create()
+            }
+
+            @JvmStatic
+            fun create(
+                fragment: Fragment,
+                paymentOptionCallback: PaymentOptionCallback,
+                paymentResultCallback: PaymentSheetResultCallback
+            ): FlowController {
+                return FlowControllerFactory(
+                    fragment,
                     paymentOptionCallback,
                     paymentResultCallback
                 ).create()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/ActivityLauncherFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/ActivityLauncherFactory.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.fragment.app.Fragment
+
+sealed class ActivityLauncherFactory {
+    /**
+     * Registers a [callback] to handle the [contract] and returns an [ActivityResultLauncher].
+     */
+    abstract fun <I, O> create(
+        contract: ActivityResultContract<I, O>,
+        callback: ActivityResultCallback<O>
+    ): ActivityResultLauncher<I>
+
+    class ActivityHost(
+        private val activity: ComponentActivity
+    ) : ActivityLauncherFactory() {
+        override fun <I, O> create(
+            contract: ActivityResultContract<I, O>,
+            callback: ActivityResultCallback<O>
+        ): ActivityResultLauncher<I> {
+            return activity.registerForActivityResult(
+                contract,
+                callback
+            )
+        }
+    }
+
+    class FragmentHost(
+        private val fragment: Fragment
+    ) : ActivityLauncherFactory() {
+        override fun <I, O> create(
+            contract: ActivityResultContract<I, O>,
+            callback: ActivityResultCallback<O>
+        ): ActivityResultLauncher<I> {
+            return fragment.registerForActivityResult(
+                contract,
+                callback
+            )
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/ActivityLauncherFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/ActivityLauncherFactory.kt
@@ -6,7 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.fragment.app.Fragment
 
-sealed class ActivityLauncherFactory {
+internal sealed class ActivityLauncherFactory {
     /**
      * Registers a [callback] to handle the [contract] and returns an [ActivityResultLauncher].
      */
@@ -15,7 +15,7 @@ sealed class ActivityLauncherFactory {
         callback: ActivityResultCallback<O>
     ): ActivityResultLauncher<I>
 
-    class ActivityHost(
+    internal class ActivityHost(
         private val activity: ComponentActivity
     ) : ActivityLauncherFactory() {
         override fun <I, O> create(
@@ -29,7 +29,7 @@ sealed class ActivityLauncherFactory {
         }
     }
 
-    class FragmentHost(
+    internal class FragmentHost(
         private val fragment: Fragment
     ) : ActivityLauncherFactory() {
         override fun <I, O> create(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.StripeIntentResult

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -38,9 +38,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 
 internal class DefaultFlowController internal constructor(
-    private val viewModelStoreOwner: ViewModelStoreOwner,
+    viewModelStoreOwner: ViewModelStoreOwner,
     private val lifecycleScope: CoroutineScope,
-    private val activityLauncherFactory: ActivityLauncherFactory,
+    activityLauncherFactory: ActivityLauncherFactory,
     private val statusBarColor: () -> Int?,
     private val authHostSupplier: () -> AuthActivityStarter.Host,
     private val paymentOptionFactory: PaymentOptionFactory,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
+import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripePaymentController
@@ -16,28 +19,71 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
+import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
+import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 
 internal class FlowControllerFactory(
-    private val activity: ComponentActivity,
+    private val viewModelStoreOwner: ViewModelStoreOwner,
+    private val lifecycleScope: CoroutineScope,
+    private val appContext: Context,
+    private val activityLauncherFactory: ActivityLauncherFactory,
+    private val statusBarColor: () -> Int?,
+    private val authHostSupplier: () -> AuthActivityStarter.Host,
+    private val paymentOptionFactory: PaymentOptionFactory,
     private val config: PaymentConfiguration,
     private val paymentOptionCallback: PaymentOptionCallback,
     private val paymentResultCallback: PaymentSheetResultCallback
 ) {
+    constructor(
+        activity: ComponentActivity,
+        paymentOptionCallback: PaymentOptionCallback,
+        paymentResultCallback: PaymentSheetResultCallback
+    ) : this(
+        activity,
+        activity.lifecycleScope,
+        activity.applicationContext,
+        ActivityLauncherFactory.ActivityHost(activity),
+        { activity.window.statusBarColor },
+        { AuthActivityStarter.Host.create(activity) },
+        PaymentOptionFactory(activity.resources),
+        PaymentConfiguration.getInstance(activity),
+        paymentOptionCallback,
+        paymentResultCallback
+    )
+
+    constructor(
+        fragment: Fragment,
+        paymentOptionCallback: PaymentOptionCallback,
+        paymentResultCallback: PaymentSheetResultCallback
+    ) : this(
+        fragment,
+        fragment.lifecycleScope,
+        fragment.requireContext(),
+        ActivityLauncherFactory.FragmentHost(fragment),
+        { fragment.activity?.window?.statusBarColor },
+        { AuthActivityStarter.Host.create(fragment) },
+        PaymentOptionFactory(fragment.resources),
+        PaymentConfiguration.getInstance(fragment.requireContext()),
+        paymentOptionCallback,
+        paymentResultCallback
+    )
+
     fun create(): PaymentSheet.FlowController {
         val sessionId = SessionId()
 
         val stripeRepository = StripeApiRepository(
-            activity,
+            appContext,
             config.publishableKey
         )
 
         val paymentControllerFactory = PaymentControllerFactory { paymentRelayLauncher, paymentAuthWebViewLauncher, stripe3ds2ChallengeLauncher ->
             StripePaymentController(
-                activity,
+                appContext,
                 config.publishableKey,
                 stripeRepository,
                 enableLogging = true,
@@ -48,7 +94,7 @@ internal class FlowControllerFactory(
         }
 
         val paymentFlowResultProcessor = DefaultPaymentFlowResultProcessor(
-            activity,
+            appContext,
             config.publishableKey,
             stripeRepository,
             enableLogging = false,
@@ -58,7 +104,7 @@ internal class FlowControllerFactory(
         val isGooglePayReadySupplier: suspend (PaymentSheet.GooglePayConfiguration.Environment?) -> Boolean = { environment ->
             val googlePayRepository = environment?.let {
                 DefaultGooglePayRepository(
-                    activity,
+                    appContext,
                     it
                 )
             } ?: GooglePayRepository.Disabled
@@ -67,7 +113,7 @@ internal class FlowControllerFactory(
 
         val prefsRepositoryFactory = { customerId: String, isGooglePayReady: Boolean ->
             DefaultPrefsRepository(
-                activity,
+                appContext,
                 customerId,
                 { isGooglePayReady },
                 Dispatchers.IO
@@ -81,7 +127,7 @@ internal class FlowControllerFactory(
             workContext = Dispatchers.IO
         )
 
-        val paymentInteRepository = PaymentIntentRepository.Api(
+        val paymentIntentRepository = PaymentIntentRepository.Api(
             stripeRepository = stripeRepository,
             requestOptions = ApiRequest.Options(
                 config.publishableKey,
@@ -91,9 +137,14 @@ internal class FlowControllerFactory(
         )
 
         return DefaultFlowController(
-            activity = activity,
+            viewModelStoreOwner = viewModelStoreOwner,
+            lifecycleScope = lifecycleScope,
+            activityLauncherFactory = activityLauncherFactory,
+            statusBarColor = statusBarColor,
+            authHostSupplier = authHostSupplier,
+            paymentOptionFactory = paymentOptionFactory,
             flowControllerInitializer = DefaultFlowControllerInitializer(
-                paymentIntentRepository = paymentInteRepository,
+                paymentIntentRepository = paymentIntentRepository,
                 paymentMethodsRepository = paymentMethodsRepository,
                 prefsRepositoryFactory = prefsRepositoryFactory,
                 isGooglePayReadySupplier = isGooglePayReadySupplier,
@@ -104,12 +155,11 @@ internal class FlowControllerFactory(
             eventReporter = DefaultEventReporter(
                 mode = EventReporter.Mode.Custom,
                 sessionId,
-                activity
+                appContext
             ),
             publishableKey = config.publishableKey,
             stripeAccountId = config.stripeAccountId,
             sessionId = sessionId,
-            initScope = activity.lifecycleScope,
             paymentOptionCallback = paymentOptionCallback,
             paymentResultCallback = paymentResultCallback
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -37,9 +37,11 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.view.ActivityScenarioFactory
+import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -412,6 +414,11 @@ class DefaultFlowControllerTest {
     ): DefaultFlowController {
         return DefaultFlowController(
             activity,
+            testScope,
+            ActivityLauncherFactory.ActivityHost(activity),
+            statusBarColor = { activity.window.statusBarColor },
+            authHostSupplier = { AuthActivityStarter.Host.create(activity) },
+            paymentOptionFactory = PaymentOptionFactory(activity.resources),
             flowControllerInitializer,
             { _, _, _ -> paymentController },
             paymentFlowResultProcessor,
@@ -419,7 +426,6 @@ class DefaultFlowControllerTest {
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             null,
             sessionId = SESSION_ID,
-            testScope,
             paymentOptionCallback,
             paymentResultCallback
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactoryTest.kt
@@ -2,6 +2,9 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -12,6 +15,7 @@ import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -26,9 +30,6 @@ class FlowControllerFactoryTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val activityScenarioFactory = ActivityScenarioFactory(context)
-    private val factory: FlowControllerFactory by lazy {
-        createFactory()
-    }
 
     private lateinit var activityScenario: ActivityScenario<*>
     private lateinit var activity: ComponentActivity
@@ -51,21 +52,51 @@ class FlowControllerFactoryTest {
 
     @AfterTest
     fun cleanup() {
+        Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
     fun `create() should return a FlowController instance`() {
+        val factory = createFactory(activity)
         assertThat(factory.create())
             .isNotNull()
     }
 
-    private fun createFactory(): FlowControllerFactory {
+    @Test
+    fun `create() with Fragment should return a FlowController instance`() {
+        with(
+            launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
+                TestFragment()
+            }
+        ) {
+            onFragment { fragment ->
+                val factory = createFactory(fragment)
+                assertThat(factory.create())
+                    .isNotNull()
+            }
+        }
+    }
+
+    private fun createFactory(
+        activity: ComponentActivity
+    ): FlowControllerFactory {
         return FlowControllerFactory(
             activity,
-            PaymentConfiguration.getInstance(context),
             mock(),
             mock()
         )
     }
+
+    private fun createFactory(
+        fragment: Fragment
+    ): FlowControllerFactory {
+        return FlowControllerFactory(
+            fragment,
+            mock(),
+            mock()
+        )
+    }
+
+    internal class TestFragment : Fragment()
 }


### PR DESCRIPTION


# Summary
Refactor `DefaultFlowController` to not depend directly on
`Activity`.

# Motivation
Support fragments in `PaymentSheet.FlowController`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

