### PR TITLE
Always use PaymentSheet as expanded, move button into scrollview.

### DIFF
--- a/stripe/res/layout/activity_payment_sheet.xml
+++ b/stripe/res/layout/activity_payment_sheet.xml
@@ -5,76 +5,74 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipToPadding="true"
+        android:orientation="vertical"
         android:background="?colorSurface"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
-        <LinearLayout
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/button_container"
-            app:layout_constraintVertical_bias="0">
-            <com.google.android.material.appbar.AppBarLayout
-                android:id="@+id/appbar"
+            app:elevation="0dp">
+
+            <com.stripe.android.paymentsheet.ui.Toolbar
+                android:id="@+id/toolbar"
+                style="@style/Widget.MaterialComponents.Toolbar.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:elevation="0dp">
+                android:background="?colorSurface" />
 
-                <com.stripe.android.paymentsheet.ui.Toolbar
-                    android:id="@+id/toolbar"
-                    style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/fragment_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <TextView
+                    android:id="@+id/message"
+                    style="@style/StripePaymentSheetErrorMessage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    android:layout_marginVertical="2dp"
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
+
+                <FrameLayout
+                    android:id="@+id/button_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?colorSurface"/>
+                    android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom">
 
-            </com.google.android.material.appbar.AppBarLayout>
+                    <com.stripe.android.paymentsheet.BuyButton
+                        android:id="@+id/buy_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="@dimen/stripe_paymentsheet_primarybutton_margin"
+                        android:visibility="gone" />
 
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/fragment_container"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/message"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                android:layout_marginVertical="2dp"
-                android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                style="@style/StripePaymentSheetErrorMessage" />
-        </LinearLayout>
-
-        <FrameLayout
-            android:id="@+id/button_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-            android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-            android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
-            app:layout_constraintVertical_bias="1"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
-            <com.stripe.android.paymentsheet.BuyButton
-                android:id="@+id/buy_button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/stripe_paymentsheet_primarybutton_margin"
-                android:visibility="gone" />
-
-            <com.stripe.android.paymentsheet.ui.GooglePayButton
-                android:id="@+id/google_pay_button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone" />
-        </FrameLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                    <com.stripe.android.paymentsheet.ui.GooglePayButton
+                        android:id="@+id/google_pay_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone" />
+                </FrameLayout>
+            </LinearLayout>
+        </ScrollView>
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -1,123 +1,115 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-`android:nestedScrollingEnabled=false` is required to prevent dragging when a `ScrollViews
-is nested in a `BottomSheetBehavior`.
--->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginBottom="@dimen/stripe_paymentsheet_form_bottom_margin"
-    android:nestedScrollingEnabled="false"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/stripe_paymentsheet_outer_spacing_top"
+    android:paddingHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
     tools:context=".paymentsheet.PaymentSheetListFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
+        android:id="@+id/top_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/stripe_paymentsheet_outer_spacing_top"
-        android:paddingHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal">
-        <LinearLayout
-            android:id="@+id/top_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/card_info_label"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintVertical_chainStyle="spread_inside">
-            <TextView
-                android:id="@+id/add_card_header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/stripe_paymentsheet_add_payment_method_title"
-                style="@style/StripePaymentSheetTitle"/>
-
-            <com.stripe.android.paymentsheet.ui.GooglePayButton
-                android:id="@+id/google_pay_button"
-                android:visibility="gone"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <com.stripe.android.paymentsheet.ui.GooglePayDivider
-                android:id="@+id/google_pay_divider"
-                android:visibility="gone"
-                android:layout_marginTop="8dp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/card_info_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0"
+        app:layout_constraintVertical_chainStyle="spread_inside">
 
         <TextView
-            android:id="@+id/card_info_label"
-            android:layout_width="match_parent"
+            android:id="@+id/add_card_header"
+            style="@style/StripePaymentSheetTitle"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/stripe_paymentsheet_add_payment_method_card_information"
-            style="@style/StripePaymentSheetLabel"
-            app:layout_constraintTop_toBottomOf="@+id/top_container"
-            app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget_container"
-            app:layout_constraintStart_toStartOf="parent" />
+            android:text="@string/stripe_paymentsheet_add_payment_method_title" />
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/card_multiline_widget_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/StripePaymentAddPaymentMethodMaterialCard"
-            app:layout_constraintTop_toBottomOf="@+id/card_info_label"
-            app:layout_constraintBottom_toTopOf="@+id/billing_address_label"
-            app:layout_constraintStart_toStartOf="parent">
-            <com.stripe.android.view.CardMultilineWidget
-                android:id="@+id/card_multiline_widget"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:shouldShowPostalCode="false" />
-        </com.google.android.material.card.MaterialCardView>
-
-        <TextView
-            android:id="@+id/card_errors"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+        <com.stripe.android.paymentsheet.ui.GooglePayButton
+            android:id="@+id/google_pay_button"
             android:visibility="gone"
-            android:textColor="@color/stripe_paymentsheet_form_error"
-            android:textSize="13sp"
-            android:lineSpacingExtra="5sp"
-            android:layout_marginTop="2dp"
-            android:layout_marginBottom="12dp"
-            android:layout_marginHorizontal="3dp"
-            app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget_container"
-            app:layout_constraintBottom_toTopOf="@+id/billing_address_label"
-            app:layout_constraintStart_toStartOf="parent" />
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-        <TextView
-            android:id="@+id/billing_address_label"
+        <com.stripe.android.paymentsheet.ui.GooglePayDivider
+            android:id="@+id/google_pay_divider"
+            android:visibility="gone"
+            android:layout_marginTop="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/card_info_label"
+        style="@style/StripePaymentSheetLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/stripe_paymentsheet_add_payment_method_card_information"
+        app:layout_constraintBottom_toTopOf="@+id/card_multiline_widget_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_container" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_multiline_widget_container"
+        style="@style/StripePaymentAddPaymentMethodMaterialCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/billing_address_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_info_label">
+
+        <com.stripe.android.view.CardMultilineWidget
+            android:id="@+id/card_multiline_widget"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/stripe_paymentsheet_add_payment_method_country_or_region"
-            android:layout_marginTop="14dp"
-            style="@style/StripePaymentSheetLabel"
-            app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget_container"
-            app:layout_constraintBottom_toTopOf="@+id/billing_address"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:shouldShowPostalCode="false" />
+    </com.google.android.material.card.MaterialCardView>
 
-        <com.stripe.android.paymentsheet.ui.BillingAddressView
-            android:id="@+id/billing_address"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/billing_address_label"
-            app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
-            app:layout_constraintStart_toStartOf="parent"/>
+    <TextView
+        android:id="@+id/card_errors"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:textColor="@color/stripe_paymentsheet_form_error"
+        android:textSize="13sp"
+        android:lineSpacingExtra="5sp"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="12dp"
+        android:layout_marginHorizontal="3dp"
+        app:layout_constraintBottom_toTopOf="@+id/billing_address_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget_container" />
 
-        <com.google.android.material.checkbox.MaterialCheckBox
-            android:id="@+id/save_card_checkbox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:layout_marginStart="-6dp"
-            app:layout_constraintTop_toBottomOf="@+id/billing_address"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:text="@string/stripe_paymentsheet_save_this_card"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+    <TextView
+        android:id="@+id/billing_address_label"
+        style="@style/StripePaymentSheetLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/stripe_paymentsheet_add_payment_method_country_or_region"
+        android:layout_marginTop="14dp"
+        app:layout_constraintBottom_toTopOf="@+id/billing_address"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_multiline_widget_container" />
+
+    <com.stripe.android.paymentsheet.ui.BillingAddressView
+        android:id="@+id/billing_address"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/save_card_checkbox"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/billing_address_label" />
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/save_card_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:layout_marginStart="-6dp"
+        android:text="@string/stripe_paymentsheet_save_this_card"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/billing_address" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/stripe/res/layout/stripe_activity_payment_options.xml
+++ b/stripe/res/layout/stripe_activity_payment_options.xml
@@ -6,13 +6,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="true"
         android:background="?colorSurface"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -65,5 +66,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/stripe/res/values/dimens.xml
+++ b/stripe/res/values/dimens.xml
@@ -77,8 +77,6 @@
     <dimen name="stripe_paymentsheet_cardwidget_margin_vertical">4dp</dimen>
     <dimen name="stripe_paymentsheet_cardwidget_margin_horizontal">12dp</dimen>
     <dimen name="stripe_paymentsheet_add_payment_method_form_stroke_width">0dp</dimen>
-    <!-- Avoid collisions with CTA button -->
-    <dimen name="stripe_paymentsheet_form_bottom_margin">84dp</dimen>
 
     <dimen name="stripe_card_number_text_input_layout_progress_end_margin">14dp</dimen>
     <dimen name="stripe_card_number_text_input_layout_progress_top_margin">10dp</dimen>

--- a/stripe/res/values/themes.xml
+++ b/stripe/res/values/themes.xml
@@ -28,10 +28,6 @@
     <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
     <style name="StripePaymentSheetAddCardTheme">
-        <!-- Required so that keyboard does not cover bottom sheet -->
-        <item name="android:windowSoftInputMode">adjustResize</item>
-        <item name="android:windowIsFloating">false</item>
-
         <item name="colorOnSurface">@color/stripe_paymentsheet_form</item>
         <item name="colorPrimary">@color/stripe_paymentsheet_form</item>
         <item name="colorAccent">@color/stripe_paymentsheet_form</item>

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
-import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
 internal abstract class BasePaymentMethodsListFragment(
@@ -35,9 +34,6 @@ internal abstract class BasePaymentMethodsListFragment(
         }
 
         this.config = nullableConfig
-
-        // reset the mode in case we're returning from the back stack
-        sheetViewModel.updateMode(SheetMode.Wrapped)
 
         val viewBinding = FragmentPaymentsheetPaymentMethodsListBinding.bind(view)
         viewBinding.recycler.layoutManager = LinearLayoutManager(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BottomSheetController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BottomSheetController.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.LinearLayout
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
@@ -12,7 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal class BottomSheetController(
-    private val bottomSheetBehavior: BottomSheetBehavior<ConstraintLayout>,
+    private val bottomSheetBehavior: BottomSheetBehavior<LinearLayout>,
     private val sheetModeLiveData: LiveData<SheetMode>,
     private val lifecycleScope: CoroutineScope
 ) {
@@ -20,7 +20,6 @@ internal class BottomSheetController(
     internal val shouldFinish = _shouldFinish.distinctUntilChanged()
 
     fun setup() {
-        bottomSheetBehavior.peekHeight = BottomSheetBehavior.PEEK_HEIGHT_AUTO
         bottomSheetBehavior.isHideable = true
         bottomSheetBehavior.isDraggable = false
         // Start hidden and then animate in after delay

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -3,11 +3,11 @@ package com.stripe.android.paymentsheet
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.commit
@@ -61,7 +61,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         get() = viewBinding.fragmentContainer.id
 
     override val rootView: View by lazy { viewBinding.root }
-    override val bottomSheet: ConstraintLayout by lazy { viewBinding.bottomSheet }
+    override val bottomSheet: LinearLayout by lazy { viewBinding.bottomSheet }
     override val appbar: AppBarLayout by lazy { viewBinding.appbar }
     override val toolbar: Toolbar by lazy { viewBinding.toolbar }
     override val messageView: TextView by lazy { viewBinding.message }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -4,11 +4,11 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -72,7 +72,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
     }
 
     override val rootView: View by lazy { viewBinding.root }
-    override val bottomSheet: ConstraintLayout by lazy { viewBinding.bottomSheet }
+    override val bottomSheet: LinearLayout by lazy { viewBinding.bottomSheet }
     override val appbar: AppBarLayout by lazy { viewBinding.appbar }
     override val toolbar: Toolbar by lazy { viewBinding.toolbar }
     override val messageView: TextView by lazy { viewBinding.message }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -2,11 +2,10 @@ package com.stripe.android.paymentsheet.ui
 
 import android.os.Bundle
 import android.view.View
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
 import com.stripe.android.R
@@ -23,7 +22,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val eventReporter: EventReporter
 
     abstract val rootView: View
-    abstract val bottomSheet: ConstraintLayout
+    abstract val bottomSheet: LinearLayout
     abstract val appbar: AppBarLayout
     abstract val toolbar: Toolbar
     abstract val messageView: TextView
@@ -62,7 +61,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 toolbar.showBack()
             }
 
-            bottomSheet.updateLayoutParams { height = mode.height }
             bottomSheetController.updateState(mode)
         }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/SheetMode.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/SheetMode.kt
@@ -14,11 +14,11 @@ internal enum class SheetMode(
 
     FullCollapsed(
         ViewGroup.LayoutParams.MATCH_PARENT,
-        BottomSheetBehavior.STATE_COLLAPSED
+        BottomSheetBehavior.STATE_EXPANDED
     ),
 
     Wrapped(
         ViewGroup.LayoutParams.WRAP_CONTENT,
-        BottomSheetBehavior.STATE_COLLAPSED
+        BottomSheetBehavior.STATE_EXPANDED
     )
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
-import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -75,8 +74,6 @@ class PaymentOptionsActivityTest {
             testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
             idleLooper()
 
-            viewModel.updateMode(SheetMode.Wrapped)
-
             activity.viewBinding.root.performClick()
             activity.finish()
         }
@@ -98,8 +95,6 @@ class PaymentOptionsActivityTest {
             testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
             idleLooper()
 
-            viewModel.updateMode(SheetMode.Wrapped)
-
             assertThat(activity.viewBinding.addButton.isVisible)
                 .isFalse()
         }
@@ -114,8 +109,6 @@ class PaymentOptionsActivityTest {
             // wait for bottom sheet to animate in
             testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
             idleLooper()
-
-            viewModel.updateMode(SheetMode.Wrapped)
 
             assertThat(activity.viewBinding.addButton.isVisible)
                 .isTrue()


### PR DESCRIPTION
# Summary
PaymentSheet height is automatically adjusted to wrap content.

# Motivation
Fixes MOBILESDK-176, MOBILESDK-178

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
