### PR TITLE
Update Kotlin version to 1.4.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlinVersion = '1.4.21'
+    ext.kotlinVersion = '1.4.31'
     ext.dokkaVersion = '1.4.20'
 
     repositories {


### PR DESCRIPTION
# Summary
Update Kotlin version to 1.4.31.

# Motivation
We've been using older version because of debugger and cross reference issues. This worked for me:

- In project-level `build.gradle`, set `buildscript.ext.kotlinVersion = '1.4.31'` (this PR)
- Make sure you have the matching Kotlin plugin version:
  - `Tools > Kotlin > Configure Kotlin Plugin Updates `
  - From `Stable` channel, install version `1.4.31-release-Studio4.1-1`
- `File > Invalidate Caches / Restart ... > Invalidate and Restart`

# Testing
N/A
