### PR TITLE
Cleanup names and warnings in billing address and card multiline widget.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -324,8 +324,8 @@ internal abstract class BaseAddCardFragment(
     private fun populateFieldsFromNewCard() {
         val paymentMethodCreateParams = sheetViewModel.newCard?.paymentMethodCreateParams
         saveCardCheckbox.isChecked = sheetViewModel.newCard?.shouldSavePaymentMethod ?: true
-        cardMultilineWidget.populateFromParams(paymentMethodCreateParams?.card)
-        billingAddressView.populateFromParams(paymentMethodCreateParams?.billingDetails?.address)
+        cardMultilineWidget.populate(paymentMethodCreateParams?.card)
+        billingAddressView.populate(paymentMethodCreateParams?.billingDetails?.address)
     }
 
     private fun onCardError(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -364,17 +364,17 @@ internal class BillingAddressView @JvmOverloads constructor(
         }
     }
 
-    internal fun populateFromParams(address: Address?) {
-        address?.let { address ->
-            address.country?.let {
-                this.selectedCountry = CountryUtils.getCountryByCode(address.country)
-                this.countryView.setText(CountryUtils.getDisplayCountry(address.country))
+    internal fun populate(address: Address?) {
+        address?.let { it ->
+            it.country?.let { countryCode ->
+                this.selectedCountry = CountryUtils.getCountryByCode(countryCode)
+                this.countryView.setText(CountryUtils.getDisplayCountry(countryCode))
             }
-            this.address1View.setText(address.line1)
-            this.address2View.setText(address.line2)
-            this.cityView.setText(address.city)
-            this.postalCodeView.setText(address.postalCode)
-            this.stateView.setText(address.state)
+            this.address1View.setText(it.line1)
+            this.address2View.setText(it.line2)
+            this.cityView.setText(it.city)
+            this.postalCodeView.setText(it.postalCode)
+            this.stateView.setText(it.state)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -442,7 +442,7 @@ class CardMultilineWidget @JvmOverloads constructor(
         cardNumberTextInputLayout.placeholderText = cardHint
     }
 
-    internal fun populateFromParams(card: PaymentMethodCreateParams.Card?) {
+    internal fun populate(card: PaymentMethodCreateParams.Card?) {
         card?.let { createParamsCard ->
             cardNumberEditText.setText(createParamsCard.number)
             cvcEditText.setText(createParamsCard.cvc)


### PR DESCRIPTION
# Summary / # Motivation
Cleanup errors and rename methods to populate.  Prior name incorrectly suggested paymentMethodParams was the parameters.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

