### PR TITLE
Create new transparent theme for invisible activities

### DIFF
--- a/example/res/values/styles.xml
+++ b/example/res/values/styles.xml
@@ -22,16 +22,4 @@
         <item name="android:layout_height">1dp</item>
         <item name="android:background">?android:attr/listDivider</item>
     </style>
-
-    <style name="FlickerAppTheme" parent="Theme.AppCompat">
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:backgroundDimEnabled">true</item>
-        <item name="android:backgroundDimAmount">0.8</item>
-        <item name="android:windowAnimationStyle">@null</item>
-        <item name="android:windowActivityTransitions">true</item>
-        <item name="android:windowTransitionBackgroundFadeDuration">200</item>
-    </style>
 </resources>

--- a/example/res/values/styles.xml
+++ b/example/res/values/styles.xml
@@ -22,4 +22,16 @@
         <item name="android:layout_height">1dp</item>
         <item name="android:background">?android:attr/listDivider</item>
     </style>
+
+    <style name="FlickerAppTheme" parent="Theme.AppCompat">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:backgroundDimAmount">0.8</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowActivityTransitions">true</item>
+        <item name="android:windowTransitionBackgroundFadeDuration">200</item>
+    </style>
 </resources>

--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -18,7 +18,7 @@
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".view.PaymentRelayActivity"
-            android:theme="@style/StripeDefaultTheme" />
+            android:theme="@style/StripeTransparentTheme" />
         <activity
             android:name=".view.Stripe3ds2CompletionActivity"
             android:theme="@style/StripeDefaultTheme" />

--- a/stripe/res/values/themes.xml
+++ b/stripe/res/values/themes.xml
@@ -12,6 +12,16 @@
     <style name="StripeDefaultTheme" parent="StripeBaseTheme"/>
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 
+<!-- Theme used by Activities that do not show any UI, so the activity underneath them is still fully visible -->
+    <style name="StripeTransparentTheme" parent="Theme.AppCompat">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
     <style name="StripePaymentSheetBaseTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>

--- a/stripe/res/values/themes.xml
+++ b/stripe/res/values/themes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <style name="StripeBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorAccent">@color/stripe_accent_color_default</item>
         <item name="colorControlNormal">@color/stripe_control_normal_color_default</item>
@@ -9,10 +10,11 @@
         <item name="android:textColorSecondary">@color/stripe_text_color_secondary</item>
     </style>
 
-    <style name="StripeDefaultTheme" parent="StripeBaseTheme"/>
+    <style name="StripeDefaultTheme" parent="StripeBaseTheme" />
+
     <style name="StripeDefault3DS2Theme" parent="BaseStripe3DS2Theme" />
 
-<!-- Theme used by Activities that do not show any UI, so the activity underneath them is still fully visible -->
+    <!-- Theme used by Activities that do not show any UI, so the activity underneath them is still fully visible -->
     <style name="StripeTransparentTheme" parent="Theme.AppCompat">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>


### PR DESCRIPTION
# Summary
Create new transparent theme and use it in PaymentRelayActivity.

# Motivation
RUN_MOBILESDK-115
PaymentRelayActivity doesn't show any UI and is used only to return a result. Make it use a transparent theme so that the caller activity remains visible at all times.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
