### PR TITLE
Update PaymentIntentRepository.Api

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentIntentRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentIntentRepository.kt
@@ -31,7 +31,8 @@ internal sealed class PaymentIntentRepository {
         override suspend fun get(clientSecret: String) = withContext(workContext) {
             val paymentIntent = stripeRepository.retrievePaymentIntent(
                 clientSecret,
-                requestOptions
+                requestOptions,
+                expandFields = listOf("payment_method")
             )
             requireNotNull(paymentIntent) {
                 "Could not parse PaymentIntent."


### PR DESCRIPTION
Add `expandFields=payment_method` param so that the returned
`PaymentIntent` includes the expanded `PaymentMethod`, which is
consistent with `StripePaymentController#confirmPaymentIntent`.

See https://stripe.com/docs/api/expanding_objects for more context.