### PR TITLE
Simplify PaymentSheetActivityTest's ViewModel creation

### DIFF
--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -8,6 +8,35 @@ internal object PaymentIntentFixtures {
 
     const val KEY_ID = "7c4debe3f4af7f9d1569a2ffea4343c2566826ee"
 
+    private val PI_SUCCEEDED_JSON = JSONObject(
+        """
+        {
+            "id": "pi_1IRg6VCRMbs6F",
+            "object": "payment_intent",
+            "amount": 1099,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "client_secret": "pi_1IRg6VCRMbs6F_secret_7oH5g4v8GaCrHfsGYS6kiSnwF",
+            "confirmation_method": "automatic",
+            "created": 1614960135,
+            "currency": "usd",
+            "description": "Example PaymentIntent",
+            "last_payment_error": null,
+            "livemode": false,
+            "next_action": null,
+            "payment_method": "pm_1IJs3ZCRMbs",
+            "payment_method_types": ["card"],
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": null,
+            "source": null,
+            "status": "succeeded"
+        }
+        """.trimIndent()
+    )
+    val PI_SUCCEEDED = requireNotNull(PARSER.parse(PI_SUCCEEDED_JSON))
+
     val PI_REQUIRES_MASTERCARD_3DS2_JSON = JSONObject(
         """
         {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -17,7 +17,9 @@ import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.databinding.PrimaryButtonBinding
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.FakePaymentFlowResultProcessor
@@ -55,22 +57,10 @@ internal class PaymentSheetActivityTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val paymentFlowResultProcessor = FakePaymentFlowResultProcessor()
     private val googlePayRepository = FakeGooglePayRepository(true)
     private val eventReporter = mock<EventReporter>()
 
-    private val viewModel = PaymentSheetViewModel(
-        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-        stripeAccountId = null,
-        paymentIntentRepository = PaymentIntentRepository.Static(PAYMENT_INTENT),
-        paymentMethodsRepository = PaymentMethodsRepository.Static(PAYMENT_METHODS),
-        paymentFlowResultProcessor = paymentFlowResultProcessor,
-        googlePayRepository = googlePayRepository,
-        prefsRepository = FakePrefsRepository(),
-        eventReporter = eventReporter,
-        args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
-        workContext = testDispatcher
-    )
+    private val viewModel = createViewModel()
 
     private val contract = PaymentSheetContract()
 
@@ -347,12 +337,11 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `successful payment should dismiss bottom sheet`() {
-        paymentFlowResultProcessor.paymentIntentResult = PaymentIntentResult(
-            intent = PAYMENT_INTENT.copy(status = StripeIntent.Status.Succeeded),
-            outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED
+        val viewModel = createViewModel(
+            paymentIntentResult = PaymentIntentResult(PaymentIntentFixtures.PI_SUCCEEDED)
         )
 
-        val scenario = activityScenario()
+        val scenario = activityScenario(viewModel)
         scenario.launch(intent).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -375,20 +364,11 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `shows add card fragment when no payment methods available`() {
-        val viewModel = PaymentSheetViewModel(
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            stripeAccountId = null,
-            paymentIntentRepository = PaymentIntentRepository.Static(PAYMENT_INTENT),
-            paymentMethodsRepository = PaymentMethodsRepository.Static(emptyList()),
-            paymentFlowResultProcessor = paymentFlowResultProcessor,
-            googlePayRepository = googlePayRepository,
-            prefsRepository = FakePrefsRepository(),
-            eventReporter = eventReporter,
-            args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
-            workContext = testDispatcher
+        val scenario = activityScenario(
+            createViewModel(
+                paymentMethods = emptyList()
+            )
         )
-
-        val scenario = activityScenario(viewModel)
         scenario.launch(intent).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -504,6 +484,29 @@ internal class PaymentSheetActivityTest {
                 viewModelFactory = viewModelFactoryFor(viewModel)
             }
         }
+    }
+
+    private fun createViewModel(
+        paymentIntent: PaymentIntent = PAYMENT_INTENT,
+        paymentMethods: List<PaymentMethod> = PAYMENT_METHODS,
+        paymentIntentResult: PaymentIntentResult = PaymentIntentResult(paymentIntent)
+    ): PaymentSheetViewModel {
+        val paymentFlowResultProcessor = FakePaymentFlowResultProcessor().also {
+            it.paymentIntentResult = paymentIntentResult
+        }
+
+        return PaymentSheetViewModel(
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            stripeAccountId = null,
+            paymentIntentRepository = PaymentIntentRepository.Static(paymentIntent),
+            paymentMethodsRepository = PaymentMethodsRepository.Static(paymentMethods),
+            paymentFlowResultProcessor = paymentFlowResultProcessor,
+            googlePayRepository = googlePayRepository,
+            prefsRepository = FakePrefsRepository(),
+            eventReporter = eventReporter,
+            args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
+            workContext = testDispatcher
+        )
     }
 
     private companion object {


### PR DESCRIPTION
Add `createViewModel()` to simplify object creation.