### PR TITLE
Rename close sheet

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -88,7 +88,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             is ViewState.PaymentOptions.FinishProcessing -> addButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
             )
-            is ViewState.PaymentOptions.ProcessResult -> handleResult(
+            is ViewState.PaymentOptions.ProcessResult -> processResult(
                 viewState.result
             )
         }
@@ -230,7 +230,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         viewModel.updateMode(transitionTarget.sheetMode)
     }
 
-    private fun handleResult(result: PaymentOptionResult) {
+    private fun processResult(result: PaymentOptionResult) {
         closeSheet(result)
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -88,7 +88,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             is ViewState.PaymentOptions.FinishProcessing -> addButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
             )
-            is ViewState.PaymentOptions.CloseSheet -> handleResult(
+            is ViewState.PaymentOptions.ProcessResult -> handleResult(
                 viewState.result
             )
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -67,12 +67,12 @@ internal class PaymentOptionsViewModel(
             // TODO: Update the returned value with the savedCard rather than the NewCard
             // so that we don't jump the next time.
             _viewState.value = ViewState.PaymentOptions.FinishProcessing {
-                _viewState.value = ViewState.PaymentOptions.CloseSheet(
+                _viewState.value = ViewState.PaymentOptions.ProcessResult(
                     PaymentOptionResult.Succeeded(paymentSelection)
                 )
             }
         } else {
-            _viewState.value = ViewState.PaymentOptions.CloseSheet(
+            _viewState.value = ViewState.PaymentOptions.ProcessResult(
                 PaymentOptionResult.Succeeded(paymentSelection)
             )
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -127,7 +127,6 @@ internal class PaymentOptionsViewModel(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> PaymentOptionContract.Args
     ) : ViewModelProvider.Factory {
-
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             val starterArgs = starterArgsSupplier()
             val application = applicationSupplier()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -119,7 +119,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
             is ViewState.PaymentSheet.FinishProcessing -> viewBinding.buyButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
             )
-            is ViewState.PaymentSheet.ProcessResult -> handleResult(
+            is ViewState.PaymentSheet.ProcessResult -> processResult(
                 viewState.result
             )
         }
@@ -339,7 +339,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
         }
     }
 
-    private fun handleResult(paymentIntentResult: PaymentIntentResult) {
+    private fun processResult(paymentIntentResult: PaymentIntentResult) {
         when (paymentIntentResult.outcome) {
             StripeIntentResult.Outcome.SUCCEEDED -> {
                 closeSheet(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -119,7 +119,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
             is ViewState.PaymentSheet.FinishProcessing -> viewBinding.buyButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
             )
-            is ViewState.PaymentSheet.CloseSheet -> handleResult(
+            is ViewState.PaymentSheet.ProcessResult -> handleResult(
                 viewState.result
             )
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -192,7 +192,7 @@ internal class PaymentSheetViewModel internal constructor(
                 eventReporter.onPaymentSuccess(selection.value)
 
                 _viewState.value = ViewState.PaymentSheet.FinishProcessing {
-                    _viewState.value = ViewState.PaymentSheet.CloseSheet(paymentIntentResult)
+                    _viewState.value = ViewState.PaymentSheet.ProcessResult(paymentIntentResult)
                 }
             }
             else -> {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -277,7 +277,6 @@ internal class PaymentSheetViewModel internal constructor(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> PaymentSheetContract.Args,
     ) : ViewModelProvider.Factory {
-
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             val application = applicationSupplier()
             val config = PaymentConfiguration.getInstance(application)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -22,7 +22,7 @@ internal sealed class ViewState {
             val onComplete: () -> Unit
         ) : PaymentSheet()
 
-        data class CloseSheet(
+        data class ProcessResult(
             val result: PaymentIntentResult
         ) : PaymentSheet()
     }
@@ -41,7 +41,7 @@ internal sealed class ViewState {
             val onComplete: () -> Unit
         ) : PaymentOptions()
 
-        data class CloseSheet(
+        data class ProcessResult(
             val result: PaymentOptionResult
         ) : PaymentOptions()
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -4,11 +4,10 @@ import com.stripe.android.PaymentIntentResult
 import com.stripe.android.paymentsheet.PaymentOptionResult
 
 internal sealed class ViewState {
-
     /**
      * The PaymentSheet view state is a little different from the PaymentOptions because the
      * PaymentSheet must always go through the processing state.
-     * The states always progress as follows: Ready -> StartProcessing -> FinishProcessing -> CloseSheet
+     * The states always progress as follows: Ready -> StartProcessing -> FinishProcessing -> ProcessResult
      */
     internal sealed class PaymentSheet : ViewState() {
         data class Ready(
@@ -29,8 +28,8 @@ internal sealed class ViewState {
 
     /**
      * The PaymentOptions may or may not go through a processing state. The possible state transitions are:
-     * Ready -> CloseSheet, if no save card is required
-     * Ready -> StartProcessing -> FinishProcessing -> CloseSheet, if requested to save a new card
+     * Ready -> ProcessResult, if no save card is required
+     * Ready -> StartProcessing -> FinishProcessing -> ProcessResult, if requested to save a new card
      */
     internal sealed class PaymentOptions : ViewState() {
         object Ready : PaymentOptions()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -206,7 +206,7 @@ class PaymentOptionsActivityTest {
         ).use {
             it.onActivity { activity ->
                 val paymentSelectionMock: PaymentSelection = PaymentSelection.GooglePay
-                viewModel._viewState.value = ViewState.PaymentOptions.CloseSheet(
+                viewModel._viewState.value = ViewState.PaymentOptions.ProcessResult(
                     PaymentOptionResult.Succeeded(
                         paymentSelectionMock
                     )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -199,7 +199,7 @@ class PaymentOptionsActivityTest {
     }
 
     @Test
-    fun `Verify CloseSheet state closes the sheet`() {
+    fun `Verify ProcessResult state closes the sheet`() {
         val scenario = activityScenario()
         scenario.launch(
             createIntent(emptyList())

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -47,7 +47,7 @@ class PaymentOptionsViewModelTest {
     )
 
     @Test
-    fun `onUserSelection() when selection has been made should emit on userSelection`() {
+    fun `onUserSelection() when selection has been made should set the view state to process result`() {
         var viewState: ViewState? = null
         viewModel.viewState.observeForever {
             viewState = it
@@ -62,7 +62,7 @@ class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `onUserSelection() when new card selection with no save should set the view state to close sheet`() {
+    fun `onUserSelection() when new card selection with no save should set the view state to process result`() {
         var viewState: ViewState? = null
         viewModel.viewState.observeForever {
             viewState = it
@@ -77,7 +77,7 @@ class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `onUserSelection() new card with save should be finish processing and close the sheet`() {
+    fun `onUserSelection() new card with save should finish processing, and when called back, process the result`() {
         val viewState: MutableList<ViewState?> = mutableListOf()
         viewModel.viewState.observeForever {
             viewState.add(it)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -56,7 +56,7 @@ class PaymentOptionsViewModelTest {
 
         viewModel.onUserSelection()
 
-        assertThat((viewState as ViewState.PaymentOptions.CloseSheet).result)
+        assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
             .isEqualTo(PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD))
         verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
@@ -71,7 +71,7 @@ class PaymentOptionsViewModelTest {
 
         viewModel.onUserSelection()
 
-        assertThat((viewState as ViewState.PaymentOptions.CloseSheet).result)
+        assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
             .isEqualTo(PaymentOptionResult.Succeeded(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION))
         verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION)
     }
@@ -94,7 +94,7 @@ class PaymentOptionsViewModelTest {
         (viewState[1] as ViewState.PaymentOptions.FinishProcessing).onComplete()
 
         val paymentOptionResultSucceeded =
-            (viewState[2] as ViewState.PaymentOptions.CloseSheet)
+            (viewState[2] as ViewState.PaymentOptions.ProcessResult)
                 .result as PaymentOptionResult.Succeeded
         assertThat((paymentOptionResultSucceeded).paymentSelection)
             .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -317,7 +317,7 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
-    fun `Verify CloseSheet state closes the sheet`() {
+    fun `Verify ProcessResult state closes the sheet`() {
         val scenario = activityScenario()
         scenario.launch(intent).use {
             it.onActivity { activity ->

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -325,7 +325,7 @@ internal class PaymentSheetActivityTest {
                 testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
                 idleLooper()
 
-                viewModel._viewState.value = ViewState.PaymentSheet.CloseSheet(
+                viewModel._viewState.value = ViewState.PaymentSheet.ProcessResult(
                     PaymentIntentResult(
                         intent = PAYMENT_INTENT.copy(status = StripeIntent.Status.Succeeded),
                         outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -179,7 +179,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `onPaymentFlowResult() should update ViewState LiveData`() {
+    fun `onPaymentFlowResult() should update ViewState`() {
         paymentFlowResultProcessor.paymentIntentResult = PAYMENT_INTENT_RESULT
 
         val confirmParams = mutableListOf<ConfirmPaymentIntentParams>()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -206,7 +206,7 @@ internal class PaymentSheetViewModelTest {
 
         (viewState[1] as ViewState.PaymentSheet.FinishProcessing).onComplete()
 
-        assertThat((viewState[2] as ViewState.PaymentSheet.CloseSheet).result)
+        assertThat((viewState[2] as ViewState.PaymentSheet.ProcessResult).result)
             .isEqualTo(PAYMENT_INTENT_RESULT)
 
         verify(eventReporter)


### PR DESCRIPTION
# Summary
Changed rename close sheet to process result.

# Motivation
Rather than the event being named after the observed behavior it would be better to name it on the request.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
