### PR TITLE
Update FinishProcessing view states to be comparable

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -64,17 +64,25 @@ internal class PaymentOptionsViewModel(
                 ?: false
 
         if (requestSaveNewCard) {
-            // TODO: Update the returned value with the savedCard rather than the NewCard
-            // so that we don't jump the next time.
-            _viewState.value = ViewState.PaymentOptions.FinishProcessing {
-                _viewState.value = ViewState.PaymentOptions.ProcessResult(
-                    PaymentOptionResult.Succeeded(paymentSelection)
-                )
-            }
+            onSaveNewCard(
+                PaymentOptionResult.Succeeded(paymentSelection)
+            )
         } else {
             _viewState.value = ViewState.PaymentOptions.ProcessResult(
                 PaymentOptionResult.Succeeded(paymentSelection)
             )
+        }
+    }
+
+    private fun onSaveNewCard(
+        result: PaymentOptionResult
+    ) {
+        // TODO: Update the returned value with the savedCard rather than the NewCard
+        // so that we don't jump the next time.
+        _viewState.value = ViewState.PaymentOptions.FinishProcessing.create(
+            result
+        ) {
+            _viewState.value = ViewState.PaymentOptions.ProcessResult(result)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -190,10 +190,7 @@ internal class PaymentSheetViewModel internal constructor(
         when (paymentIntentResult.outcome) {
             StripeIntentResult.Outcome.SUCCEEDED -> {
                 eventReporter.onPaymentSuccess(selection.value)
-
-                _viewState.value = ViewState.PaymentSheet.FinishProcessing {
-                    _viewState.value = ViewState.PaymentSheet.ProcessResult(paymentIntentResult)
-                }
+                finishProcessing(paymentIntentResult)
             }
             else -> {
                 eventReporter.onPaymentFailure(selection.value)
@@ -201,6 +198,14 @@ internal class PaymentSheetViewModel internal constructor(
                 onApiError(paymentIntentResult.failureMessage)
                 onPaymentIntentResponse(paymentIntentResult.intent)
             }
+        }
+    }
+
+    private fun finishProcessing(paymentIntentResult: PaymentIntentResult) {
+        _viewState.value = ViewState.PaymentSheet.FinishProcessing.create(
+            paymentIntentResult
+        ) {
+            _viewState.value = ViewState.PaymentSheet.ProcessResult(paymentIntentResult)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -18,8 +18,23 @@ internal sealed class ViewState {
         object StartProcessing : PaymentSheet()
 
         data class FinishProcessing(
-            val onComplete: () -> Unit
-        ) : PaymentSheet()
+            val result: PaymentIntentResult
+        ) : PaymentSheet() {
+            var onComplete: () -> Unit = {}
+
+            internal companion object {
+                fun create(
+                    result: PaymentIntentResult,
+                    onComplete: () -> Unit
+                ): FinishProcessing {
+                    return FinishProcessing(
+                        result
+                    ).also {
+                        it.onComplete = onComplete
+                    }
+                }
+            }
+        }
 
         data class ProcessResult(
             val result: PaymentIntentResult
@@ -37,8 +52,23 @@ internal sealed class ViewState {
         object StartProcessing : PaymentOptions()
 
         data class FinishProcessing(
-            val onComplete: () -> Unit
-        ) : PaymentOptions()
+            val result: PaymentOptionResult
+        ) : PaymentOptions() {
+            var onComplete: () -> Unit = {}
+
+            internal companion object {
+                fun create(
+                    result: PaymentOptionResult,
+                    onComplete: () -> Unit
+                ): FinishProcessing {
+                    return FinishProcessing(
+                        result
+                    ).also {
+                        it.onComplete = onComplete
+                    }
+                }
+            }
+        }
 
         data class ProcessResult(
             val result: PaymentOptionResult

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -185,7 +185,9 @@ class PaymentOptionsActivityTest {
         ).use {
             it.onActivity {
                 var callbackCalled = false
-                viewModel._viewState.value = ViewState.PaymentOptions.FinishProcessing {
+                viewModel._viewState.value = ViewState.PaymentOptions.FinishProcessing.create(
+                    PaymentOptionResult.Succeeded(PaymentSelection.GooglePay)
+                ) {
                     callbackCalled = true
                 }
                 idleLooper()


### PR DESCRIPTION
# Summary
Make `ViewState.PaymentSheet.FinishProcessing`
and `ViewState.PaymentOptions.FinishProcessing` instances comparable.

Add `result` property to constructor and move `onComplete` property
out of constructor so that view state instances can be compared.

This is specifically useful for `_viewState.distinctUntilChanged()`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

