### PR TITLE
Gracefully handle PaymentIntents that have been confirmed in payment sheet

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -153,6 +153,16 @@ data class PaymentIntent internal constructor(
     }
 
     /**
+     * Confirmation has succeeded and all required actions have been handled.
+     */
+    internal val isConfirmed: Boolean
+        get() = setOf(
+            StripeIntent.Status.Processing,
+            StripeIntent.Status.RequiresCapture,
+            StripeIntent.Status.Succeeded
+        ).contains(status)
+
+    /**
      * The payment error encountered in the previous [PaymentIntent] confirmation.
      *
      * See [last_payment_error](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-last_payment_error).

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.parcelize.Parcelize
@@ -25,7 +26,10 @@ class PaymentSheet internal constructor(
     )
 
     /**
-     * Create PaymentSheet with a Customer
+     * Create PaymentSheet with a [Configuration].
+     *
+     * If [paymentIntentClientSecret] represents a [PaymentIntent] that is already confirmed,
+     * [PaymentSheetResultCallback] will be invoked with [PaymentResult.Completed].
      */
     internal fun present(
         paymentIntentClientSecret: String,
@@ -35,7 +39,10 @@ class PaymentSheet internal constructor(
     }
 
     /**
-     * Create PaymentSheet without a Customer
+     * Create PaymentSheet without a [Configuration].
+     *
+     * If [paymentIntentClientSecret] represents a [PaymentIntent] that is already confirmed,
+     * [PaymentSheetResultCallback] will be invoked with [PaymentResult.Completed].
      */
     internal fun present(
         paymentIntentClientSecret: String

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -366,8 +366,8 @@ internal class PaymentSheetViewModel internal constructor(
                     application
                 ),
                 starterArgs,
-                logger =Logger.noop(),
-                Dispatchers.IO
+                logger = Logger.noop(),
+                workContext = Dispatchers.IO
             ) as T
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
@@ -48,6 +49,7 @@ internal class PaymentSheetViewModel internal constructor(
     prefsRepository: PrefsRepository,
     private val eventReporter: EventReporter,
     internal val args: PaymentSheetContract.Args,
+    private val logger: Logger = Logger.noop(),
     workContext: CoroutineContext
 ) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     config = args.config,
@@ -116,6 +118,11 @@ internal class PaymentSheetViewModel internal constructor(
 
     private fun onPaymentIntentResponse(paymentIntent: PaymentIntent) {
         if (paymentIntent.isConfirmed) {
+            logger.info(
+                """
+                PaymentIntent with id=${paymentIntent.id}" has already been confirmed.
+                """.trimIndent()
+            )
             // there's nothing left to be done if the PaymentIntent is confirmed
             _viewState.value = ViewState.PaymentSheet.FinishProcessing {
                 _viewState.value = ViewState.PaymentSheet.ProcessResult(
@@ -351,6 +358,7 @@ internal class PaymentSheetViewModel internal constructor(
                     application
                 ),
                 starterArgs,
+                Logger.real(),
                 Dispatchers.IO
             ) as T
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -366,7 +366,6 @@ internal class PaymentSheetViewModel internal constructor(
                     application
                 ),
                 starterArgs,
-                Logger.real(),
                 Dispatchers.IO
             ) as T
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -366,6 +366,7 @@ internal class PaymentSheetViewModel internal constructor(
                     application
                 ),
                 starterArgs,
+                logger =Logger.noop(),
                 Dispatchers.IO
             ) as T
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -118,20 +118,7 @@ internal class PaymentSheetViewModel internal constructor(
 
     private fun onPaymentIntentResponse(paymentIntent: PaymentIntent) {
         if (paymentIntent.isConfirmed) {
-            logger.info(
-                """
-                PaymentIntent with id=${paymentIntent.id}" has already been confirmed.
-                """.trimIndent()
-            )
-            // there's nothing left to be done if the PaymentIntent is confirmed
-            _viewState.value = ViewState.PaymentSheet.FinishProcessing {
-                _viewState.value = ViewState.PaymentSheet.ProcessResult(
-                    PaymentIntentResult(
-                        paymentIntent,
-                        StripeIntentResult.Outcome.SUCCEEDED
-                    )
-                )
-            }
+            onConfirmedPaymentIntent(paymentIntent)
         } else {
             runCatching {
                 paymentIntentValidator.requireValid(paymentIntent)
@@ -141,6 +128,27 @@ internal class PaymentSheetViewModel internal constructor(
                     resetViewState(paymentIntent)
                 },
                 onFailure = ::onFatal
+            )
+        }
+    }
+
+    /**
+     * There's nothing left to be done in payment sheet if the PaymentIntent is confirmed.
+     *
+     * See [How intents work](https://stripe.com/docs/payments/intents) for more details.
+     */
+    private fun onConfirmedPaymentIntent(paymentIntent: PaymentIntent) {
+        logger.info(
+            """
+            PaymentIntent with id=${paymentIntent.id}" has already been confirmed.
+            """.trimIndent()
+        )
+        _viewState.value = ViewState.PaymentSheet.FinishProcessing {
+            _viewState.value = ViewState.PaymentSheet.ProcessResult(
+                PaymentIntentResult(
+                    paymentIntent,
+                    StripeIntentResult.Outcome.SUCCEEDED
+                )
             )
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -473,6 +473,29 @@ internal class PaymentSheetActivityTest {
         }
     }
 
+    @Test
+    fun `if fetched PaymentIntent is confirmed then should return Completed result`() {
+        val scenario = activityScenario(
+            createViewModel(
+                paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED
+            )
+        )
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
+            activity.finish()
+        }
+
+        assertThat(
+            contract.parseResult(
+                scenario.getResult().resultCode,
+                scenario.getResult().resultData
+            )
+        ).isEqualTo(
+            PaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+    }
+
     private fun currentFragment(activity: PaymentSheetActivity) =
         activity.supportFragmentManager.findFragmentById(activity.viewBinding.fragmentContainer.id)
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -480,10 +480,12 @@ internal class PaymentSheetActivityTest {
                 paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED
             )
         )
-        scenario.launch(intent).onActivity { activity ->
-            // wait for bottom sheet to animate in
-            testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
-            activity.finish()
+        scenario.launch(intent).use {
+            it.onActivity { activity ->
+                // wait for bottom sheet to animate in
+                testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
+                activity.finish()
+            }
         }
 
         assertThat(


### PR DESCRIPTION
# Summary
Update the view state to completed if the `PaymentIntent` has already
been successfully confirmed. This will close out the PaymentSheet and
return `PaymentResult.Completed`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

