### PR TITLE
Update FinishProcessing view states to be comparable

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -23,13 +23,9 @@ internal sealed class ViewState {
             /**
              * Do not compare [onComplete] as part of [equals].
              */
-            override fun equals(other: Any?): Boolean {
-                return other is FinishProcessing
-            }
+            override fun equals(other: Any?): Boolean = other is FinishProcessing
 
-            override fun hashCode(): Int {
-                return onComplete.hashCode()
-            }
+            override fun hashCode(): Int = onComplete.hashCode()
         }
 
         data class ProcessResult(
@@ -53,13 +49,9 @@ internal sealed class ViewState {
             /**
              * Do not compare [onComplete] as part of [equals].
              */
-            override fun equals(other: Any?): Boolean {
-                return other is FinishProcessing
-            }
+            override fun equals(other: Any?): Boolean = other is FinishProcessing
 
-            override fun hashCode(): Int {
-                return onComplete.hashCode()
-            }
+            override fun hashCode(): Int = onComplete.hashCode()
         }
 
         data class ProcessResult(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -17,9 +17,20 @@ internal sealed class ViewState {
 
         object StartProcessing : PaymentSheet()
 
-        data class FinishProcessing(
+        class FinishProcessing(
             val onComplete: () -> Unit
-        ) : PaymentSheet()
+        ) : PaymentSheet() {
+            /**
+             * Do not compare [onComplete] as part of [equals].
+             */
+            override fun equals(other: Any?): Boolean {
+                return other is FinishProcessing
+            }
+
+            override fun hashCode(): Int {
+                return onComplete.hashCode()
+            }
+        }
 
         data class ProcessResult(
             val result: PaymentIntentResult
@@ -36,9 +47,20 @@ internal sealed class ViewState {
 
         object StartProcessing : PaymentOptions()
 
-        data class FinishProcessing(
+        class FinishProcessing(
             val onComplete: () -> Unit
-        ) : PaymentOptions()
+        ) : PaymentOptions() {
+            /**
+             * Do not compare [onComplete] as part of [equals].
+             */
+            override fun equals(other: Any?): Boolean {
+                return other is FinishProcessing
+            }
+
+            override fun hashCode(): Int {
+                return onComplete.hashCode()
+            }
+        }
 
         data class ProcessResult(
             val result: PaymentOptionResult

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ViewStateTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ViewStateTest.kt
@@ -11,7 +11,7 @@ class ViewStateTest {
     }
 
     @Test
-    fun `FinishProcessing equals() with not FinishProcessing param should return true`() {
+    fun `FinishProcessing equals() with not FinishProcessing param should return false`() {
         assertThat(ViewState.PaymentSheet.FinishProcessing {})
             .isNotEqualTo(ViewState.PaymentSheet.StartProcessing)
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/ViewStateTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/ViewStateTest.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentsheet.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class ViewStateTest {
+    @Test
+    fun `FinishProcessing equals() with FinishProcessing param should return true`() {
+        assertThat(ViewState.PaymentSheet.FinishProcessing {})
+            .isEqualTo(ViewState.PaymentSheet.FinishProcessing {})
+    }
+
+    @Test
+    fun `FinishProcessing equals() with not FinishProcessing param should return true`() {
+        assertThat(ViewState.PaymentSheet.FinishProcessing {})
+            .isNotEqualTo(ViewState.PaymentSheet.StartProcessing)
+    }
+
+    @Test
+    fun `FinishProcessing hashCode() should return different values`() {
+        val viewState1 = ViewState.PaymentSheet.FinishProcessing {}
+        val viewState2 = ViewState.PaymentSheet.FinishProcessing {}
+
+        assertThat(viewState1.hashCode())
+            .isNotEqualTo(viewState2.hashCode())
+    }
+}


### PR DESCRIPTION
Make `ViewState.PaymentSheet.FinishProcessing`
and `ViewState.PaymentOptions.FinishProcessing`
instances comparable.

This is specifically useful for `_viewState.distinctUntilChanged()`.