### PR TITLE
Refactor PaymentMethodRepository, removing test class

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentValidator
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsApiRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.paymentsheet.ui.SheetMode
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -339,7 +340,7 @@ internal class PaymentSheetViewModel internal constructor(
                 workContext = Dispatchers.IO
             )
 
-            val paymentMethodsRepository = PaymentMethodsRepository.Api(
+            val paymentMethodsRepository = PaymentMethodsApiRepository(
                 stripeRepository = stripeRepository,
                 publishableKey = publishableKey,
                 stripeAccountId = stripeAccountId,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -21,7 +21,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
-import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsApiRepository
 import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -122,7 +122,7 @@ internal class FlowControllerFactory(
             )
         }
 
-        val paymentMethodsRepository = PaymentMethodsRepository.Api(
+        val paymentMethodsRepository = PaymentMethodsApiRepository(
             stripeRepository = stripeRepository,
             publishableKey = config.publishableKey,
             stripeAccountId = config.stripeAccountId,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsApiRepository.kt
@@ -1,0 +1,86 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.Logger
+import com.stripe.android.exception.APIException
+import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+internal class PaymentMethodsApiRepository(
+    private val stripeRepository: StripeRepository,
+    private val publishableKey: String,
+    private val stripeAccountId: String?,
+    enableLogging: Boolean = false,
+    private val workContext: CoroutineContext
+) : PaymentMethodsRepository {
+    /**
+     * A [PaymentMethodsRepository] that uses the Stripe API.
+     */
+    private val logger = Logger.getInstance(enableLogging)
+
+    /**
+     * Retrieve a Customer's payment methods. Silently handle failures by returning an
+     * empty list.
+     */
+    override suspend fun get(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        type: PaymentMethod.Type
+    ): List<PaymentMethod> = withContext(workContext) {
+        runCatching {
+            stripeRepository.getPaymentMethods(
+                ListPaymentMethodsParams(
+                    customerId = customerConfig.id,
+                    paymentMethodType = type
+                ),
+                publishableKey,
+                PRODUCT_USAGE,
+                ApiRequest.Options(
+                    customerConfig.ephemeralKeySecret,
+                    stripeAccountId
+                )
+            )
+        }.onFailure {
+            logger.error("Failed to retrieve ${customerConfig.id}'s payment methods.", it)
+        }.getOrDefault(emptyList())
+    }
+
+    override suspend fun save(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        paymentMethodCreateParams: PaymentMethodCreateParams
+    ): PaymentMethod = withContext(workContext) {
+        runCatching {
+            stripeRepository.createPaymentMethod(
+                paymentMethodCreateParams,
+                ApiRequest.Options(
+                    publishableKey,
+                    stripeAccountId
+                )
+            )?.let { paymentMethod ->
+                paymentMethod.id?.let {
+                    stripeRepository.attachPaymentMethod(
+                        customerConfig.id,
+                        publishableKey,
+                        PRODUCT_USAGE,
+                        paymentMethod.id,
+                        ApiRequest.Options(
+                            customerConfig.ephemeralKeySecret,
+                            stripeAccountId
+                        )
+                    )
+                } ?: throw APIException(message = "Payment method could not be attached")
+            } ?: throw APIException(message = "Payment method could not be created")
+        }.onFailure {
+            logger.error("Failed to save ${customerConfig.id}'s payment methods.", it)
+            throw it
+        }.getOrThrow()
+    }
+
+    private companion object {
+        private val PRODUCT_USAGE = setOf("PaymentSheet")
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
@@ -1,72 +1,17 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.Logger
-import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.StripeRepository
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 
-internal sealed class PaymentMethodsRepository {
-    abstract suspend fun get(
+internal interface PaymentMethodsRepository {
+    suspend fun get(
         customerConfig: PaymentSheet.CustomerConfiguration,
         type: PaymentMethod.Type
     ): List<PaymentMethod>
 
-    /**
-     * A [PaymentMethodsRepository] that uses a pre-determined list of payment methods.
-     */
-    class Static(
-        private val paymentMethods: List<PaymentMethod>
-    ) : PaymentMethodsRepository() {
-        override suspend fun get(
-            customerConfig: PaymentSheet.CustomerConfiguration,
-            type: PaymentMethod.Type
-        ): List<PaymentMethod> = paymentMethods
-    }
-
-    /**
-     * A [PaymentMethodsRepository] that uses the Stripe API.
-     */
-    class Api(
-        private val stripeRepository: StripeRepository,
-        private val publishableKey: String,
-        private val stripeAccountId: String?,
-        enableLogging: Boolean = false,
-        private val workContext: CoroutineContext
-    ) : PaymentMethodsRepository() {
-        private val logger = Logger.getInstance(enableLogging)
-
-        /**
-         * Retrieve a Customer's payment methods. Silently handle failures by returning an
-         * empty list.
-         */
-        override suspend fun get(
-            customerConfig: PaymentSheet.CustomerConfiguration,
-            type: PaymentMethod.Type
-        ): List<PaymentMethod> = withContext(workContext) {
-            runCatching {
-                stripeRepository.getPaymentMethods(
-                    ListPaymentMethodsParams(
-                        customerId = customerConfig.id,
-                        paymentMethodType = type
-                    ),
-                    publishableKey,
-                    PRODUCT_USAGE,
-                    ApiRequest.Options(
-                        customerConfig.ephemeralKeySecret,
-                        stripeAccountId
-                    )
-                )
-            }.onFailure {
-                logger.error("Failed to retrieve ${customerConfig.id}'s payment methods.", it)
-            }.getOrDefault(emptyList())
-        }
-
-        private companion object {
-            private val PRODUCT_USAGE = setOf("PaymentSheet")
-        }
-    }
+    suspend fun save(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+    ): PaymentMethod
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/FakePaymentMethodsRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/FakePaymentMethodsRepository.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
+
+class FakePaymentMethodsRepository(
+    private val paymentMethods: List<PaymentMethod>
+) : PaymentMethodsRepository {
+    lateinit var savedPaymentMethod: PaymentMethod
+    var error: Throwable? = null
+    override suspend fun get(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        type: PaymentMethod.Type
+    ): List<PaymentMethod> = paymentMethods
+
+    override suspend fun save(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        paymentMethodCreateParams: PaymentMethodCreateParams
+    ): PaymentMethod {
+        return error?.let {
+            throw it
+        } ?: savedPaymentMethod
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
-import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -512,7 +511,7 @@ internal class PaymentSheetActivityTest {
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeAccountId = null,
             paymentIntentRepository = PaymentIntentRepository.Static(paymentIntent),
-            paymentMethodsRepository = PaymentMethodsRepository.Static(paymentMethods),
+            paymentMethodsRepository = FakePaymentMethodsRepository(paymentMethods),
             paymentFlowResultProcessor = paymentFlowResultProcessor,
             googlePayRepository = googlePayRepository,
             prefsRepository = FakePrefsRepository(),

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsApiRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import kotlinx.coroutines.Dispatchers
@@ -81,7 +82,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `updatePaymentMethods() with customer config and failing request should emit empty list`() {
         val viewModel = createViewModel(
-            paymentMethodsRepository = PaymentMethodsRepository.Api(
+            paymentMethodsRepository = PaymentMethodsApiRepository(
                 stripeRepository = FailingStripeRepository(),
                 publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                 stripeAccountId = null,
@@ -426,7 +427,7 @@ internal class PaymentSheetViewModelTest {
         paymentIntentRepository: PaymentIntentRepository = PaymentIntentRepository.Static(
             PAYMENT_INTENT
         ),
-        paymentMethodsRepository: PaymentMethodsRepository = PaymentMethodsRepository.Static(
+        paymentMethodsRepository: PaymentMethodsRepository = FakePaymentMethodsRepository(
             PAYMENT_METHODS
         )
     ): PaymentSheetViewModel {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
@@ -6,12 +6,12 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.FakePaymentMethodsRepository
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.PaymentIntentRepository
-import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
@@ -147,7 +147,7 @@ internal class DefaultFlowControllerInitializerTest {
     ): FlowControllerInitializer {
         return DefaultFlowControllerInitializer(
             PaymentIntentRepository.Static(paymentIntent),
-            PaymentMethodsRepository.Static(PAYMENT_METHODS),
+            FakePaymentMethodsRepository(PAYMENT_METHODS),
             { _, _ -> prefsRepository },
             { true },
             testDispatcher

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.Test
 internal class PaymentMethodsRepositoryTest {
     private val testDispatcher = TestCoroutineDispatcher()
     private val stripeRepository = FakeStripeRepository()
-    private val repository = PaymentMethodsRepository.Api(
+    private val repository = PaymentMethodsApiRepository(
         stripeRepository,
         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
         "acct_123",


### PR DESCRIPTION
# Summary
Make the PaymentRepository abstract base class into an interface.  Then move the api and static classes into their own classes that implement the interface.  

# Motivation
This will keep the test classes out of production code and make it easier to manipulate them for testing.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

