### PR TITLE
Fix tint flicker in CardBrandView

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.doOnNextLayout
 import com.stripe.android.databinding.CardBrandViewBinding
 import com.stripe.android.model.CardBrand
 import kotlin.properties.Delegates
@@ -66,12 +67,10 @@ internal class CardBrandView @JvmOverloads constructor(
     init {
         isClickable = false
         isFocusable = false
-    }
 
-    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
-        super.onWindowFocusChanged(hasWindowFocus)
-        // needed to tint CardBrand.Unknown icon
-        updateIcon()
+        doOnNextLayout {
+            updateIcon()
+        }
     }
 
     private fun updateIcon() {


### PR DESCRIPTION


# Summary
Previously, tint was first applied in `onWindowFocusChanged()`. This
is late enough after the view is first rendered that a noticeable
"flicker" is seen.

Use `doOnNextLayout` to resolve.


# Screenshots
Before, the icon tint changes from black to gray.

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/45020849/110865807-3458c100-8292-11eb-94ae-8afa31f4229b.gif)| ![after](https://user-images.githubusercontent.com/45020849/110865835-3ae73880-8292-11eb-934d-9416ba68df57.gif) |



