### PR TITLE
Return focus to previously focused View after populating card info

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -444,9 +444,12 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     internal fun populate(card: PaymentMethodCreateParams.Card?) {
         card?.let { createParamsCard ->
+            // Keep track of currently focused view to return focus to it after populating
+            val focusedView = findFocus()
             cardNumberEditText.setText(createParamsCard.number)
             cvcEditText.setText(createParamsCard.cvc)
             expiryDateEditText.setText(createParamsCard.expiryMonth, createParamsCard.expiryYear)
+            focusedView?.requestFocus() ?: findFocus()?.clearFocus()
         }
     }
 


### PR DESCRIPTION
# Summary
Return focus to previously focused View after populating card info.

# Motivation
When pre-populating with card data, the TextView callbacks would request focus on the next View. Now we return the focus to the previously focused View, or none if none had focus.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
