### PR TITLE
Fix "Add" Button visibility on custom flow

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
@@ -61,7 +60,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         @IdRes
         get() = viewBinding.fragmentContainer.id
 
-    override val rootView: View by lazy { viewBinding.root }
+    override val rootView: ViewGroup by lazy { viewBinding.root }
     override val bottomSheet: ViewGroup by lazy { viewBinding.bottomSheet }
     override val appbar: AppBarLayout by lazy { viewBinding.appbar }
     override val toolbar: Toolbar by lazy { viewBinding.toolbar }
@@ -219,6 +218,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             }
         }
 
+        // Execute transaction right away to avoid a two-step UI update
+        supportFragmentManager.executePendingTransactions()
         viewBinding.addButton.isVisible =
             transitionTarget !is PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -168,7 +168,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         supportFragmentManager.registerFragmentLifecycleCallbacks(
             object : FragmentManager.FragmentLifecycleCallbacks() {
                 override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
-                    viewBinding.addButton.isVisible = fragment !is PaymentOptionsListFragment
+                    viewBinding.addButton.isVisible = fragment is PaymentOptionsAddCardFragment
                 }
             },
             false

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -10,6 +10,8 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -162,6 +164,15 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                 }
             }
         }
+
+        supportFragmentManager.registerFragmentLifecycleCallbacks(
+            object : FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
+                    viewBinding.addButton.isVisible = fragment !is PaymentOptionsListFragment
+                }
+            },
+            false
+        )
     }
 
     private fun setupAddButton(addButton: PrimaryButton) {
@@ -217,11 +228,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                 }
             }
         }
-
-        // Execute transaction right away to avoid a two-step UI update
-        supportFragmentManager.executePendingTransactions()
-        viewBinding.addButton.isVisible =
-            transitionTarget !is PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod
     }
 
     private fun processResult(result: PaymentOptionResult) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
@@ -76,7 +75,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
         PaymentSheetContract.Args.fromIntent(intent)
     }
 
-    override val rootView: View by lazy { viewBinding.root }
+    override val rootView: ViewGroup by lazy { viewBinding.root }
     override val bottomSheet: ViewGroup by lazy { viewBinding.bottomSheet }
     override val appbar: AppBarLayout by lazy { viewBinding.appbar }
     override val toolbar: Toolbar by lazy { viewBinding.toolbar }
@@ -301,6 +300,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
             }
         }
 
+        // Execute transaction right away to avoid a two-step UI update
+        supportFragmentManager.executePendingTransactions()
         viewBinding.buyButton.isVisible = true
         appbar.isVisible = true
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.os.Bundle
-import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
@@ -19,7 +18,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val bottomSheetController: BottomSheetController
     abstract val eventReporter: EventReporter
 
-    abstract val rootView: View
+    abstract val rootView: ViewGroup
     abstract val bottomSheet: ViewGroup
     abstract val appbar: AppBarLayout
     abstract val scrollView: ScrollView

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -130,6 +130,42 @@ class PaymentOptionsActivityTest {
     }
 
     @Test
+    fun `AddButton should be hidden when returning to payment options`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent(PaymentMethodFixtures.createCards(5))
+        ).use {
+            it.onActivity { activity ->
+                // wait for bottom sheet to animate in
+                testDispatcher.advanceTimeBy(BottomSheetController.ANIMATE_IN_DELAY)
+                idleLooper()
+
+                assertThat(activity.viewBinding.addButton.isVisible)
+                    .isFalse()
+
+                // Navigate to "Add Payment Method" fragment
+                with(
+                    activity.supportFragmentManager.findFragmentById(R.id.fragment_container)
+                        as PaymentOptionsListFragment
+                ) {
+                    transitionToAddPaymentMethod()
+                }
+                idleLooper()
+
+                assertThat(activity.viewBinding.addButton.isVisible)
+                    .isTrue()
+
+                // Navigate back to payment options list
+                activity.onBackPressed()
+                idleLooper()
+
+                assertThat(activity.viewBinding.addButton.isVisible)
+                    .isFalse()
+            }
+        }
+    }
+
+    @Test
     fun `Verify Ready state updates the add button label`() {
         val scenario = activityScenario()
         scenario.launch(


### PR DESCRIPTION
# Summary
Use FragmentLifecycleCallbacks to show or hide "Add" Button on custom flow.
Fix PaymentSheet transition jumps.

# Motivation
MOBILESDK-173

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
