### PR TITLE
In the custom workflow restore saved card to the select list

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.bundleOf
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -16,10 +17,25 @@ internal sealed class PaymentOptionResult(
         return bundleOf(EXTRA_RESULT to this)
     }
 
-    @Parcelize
-    data class Succeeded(
-        val paymentSelection: PaymentSelection
-    ) : PaymentOptionResult(Activity.RESULT_OK)
+    internal sealed class Succeeded : PaymentOptionResult(Activity.RESULT_OK) {
+        abstract val paymentSelection: PaymentSelection
+
+        @Parcelize
+        data class Unsaved(
+            override val paymentSelection: PaymentSelection,
+        ) : Succeeded()
+
+        @Parcelize
+        data class Existing(
+            override val paymentSelection: PaymentSelection,
+        ) : Succeeded()
+
+        @Parcelize
+        data class NewlySaved(
+            override val paymentSelection: PaymentSelection,
+            val newSavedPaymentMethod: PaymentMethod
+        ) : Succeeded()
+    }
 
     @Parcelize
     data class Failed(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.lifecycle.ViewModel
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class FlowControllerViewModel : ViewModel() {
     private var _initData: InitData? = null
 
     var paymentSelection: PaymentSelection? = null
+    val newlySavedPaymentMethods = mutableListOf<PaymentMethod>()
 
     fun setInitData(initData: InitData) {
         _initData = initData

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -238,7 +238,7 @@ class PaymentOptionsActivityTest {
             it.onActivity { activity ->
                 val paymentSelectionMock: PaymentSelection = PaymentSelection.GooglePay
                 viewModel._viewState.value = ViewState.PaymentOptions.ProcessResult(
-                    PaymentOptionResult.Succeeded(
+                    PaymentOptionResult.Succeeded.Unsaved(
                         paymentSelectionMock
                     )
                 )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -71,7 +71,7 @@ class PaymentOptionsViewModelTest {
         viewModel.onUserSelection()
 
         assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
-            .isEqualTo(PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD))
+            .isEqualTo(PaymentOptionResult.Succeeded.Existing(SELECTION_SAVED_PAYMENT_METHOD))
         verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
 
@@ -87,7 +87,11 @@ class PaymentOptionsViewModelTest {
             viewModel.onUserSelection()
 
             assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
-                .isEqualTo(PaymentOptionResult.Succeeded(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION))
+                .isEqualTo(
+                    PaymentOptionResult.Succeeded.Unsaved(
+                        NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION
+                    )
+                )
             verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION)
 
             assertThat(prefsRepository.getSavedSelection())
@@ -120,9 +124,11 @@ class PaymentOptionsViewModelTest {
 
             val paymentOptionResultSucceeded =
                 (viewState[3] as ViewState.PaymentOptions.ProcessResult)
-                    .result as PaymentOptionResult.Succeeded
+                    .result as PaymentOptionResult.Succeeded.NewlySaved
             assertThat((paymentOptionResultSucceeded).paymentSelection)
                 .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
+            assertThat((paymentOptionResultSucceeded).newSavedPaymentMethod)
+                .isEqualTo(paymentMethodRepository.savedPaymentMethod)
             verify(eventReporter).onSelectPaymentOption(paymentOptionResultSucceeded.paymentSelection)
 
             assertThat((prefsRepository.getSavedSelection() as SavedSelection.PaymentMethod).id)
@@ -148,7 +154,7 @@ class PaymentOptionsViewModelTest {
         assertThat(
             viewModel.getPaymentOptionResult()
         ).isEqualTo(
-            PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD)
+            PaymentOptionResult.Succeeded.Existing(SELECTION_SAVED_PAYMENT_METHOD)
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -21,9 +21,11 @@ import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.googlepay.StripeGooglePayContract
 import com.stripe.android.googlepay.StripeGooglePayEnvironment
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult
@@ -204,7 +206,7 @@ class DefaultFlowControllerTest {
         }
 
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded(
+            PaymentOptionResult.Succeeded.Existing(
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
         )
@@ -212,6 +214,45 @@ class DefaultFlowControllerTest {
         verify(paymentOptionCallback).onPaymentOption(VISA_PAYMENT_OPTION)
         assertThat(flowController.getPaymentOption())
             .isEqualTo(VISA_PAYMENT_OPTION)
+    }
+
+    @Test
+    fun `onPaymentOptionResult() adds payment method which is added on next open`() {
+        // Create a default flow controller with the paymentMethods initialized with cards.
+        val initialPaymentMethods = PaymentMethodFixtures.createCards(5)
+        val flowController = createFlowController(
+            paymentMethods = initialPaymentMethods,
+            savedSelection = SavedSelection.PaymentMethod(
+                requireNotNull(initialPaymentMethods.first().id)
+            )
+        )
+        flowController.configure(
+            PaymentSheetFixtures.CLIENT_SECRET,
+            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        ) { _, _ ->
+        }
+
+        // Add a saved card payment method so that we can make sure it is added when we open
+        // up the payment option launcher
+        val newSavedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded.NewlySaved(
+                SAVE_NEW_CARD_SELECTION,
+                newSavedPaymentMethod
+            )
+        )
+
+        // Save off the actual launch arguments when paymentOptionLauncher is called
+        var launchArgs: PaymentOptionContract.Args? = null
+        flowController.paymentOptionLauncher = {
+            launchArgs = it
+        }
+
+        flowController.presentPaymentOptions()
+
+        // Make sure that paymentMethods contains the new added payment methods and the initial payment methods.
+        assertThat(launchArgs!!.paymentMethods)
+            .isEqualTo(listOf(newSavedPaymentMethod).plus(initialPaymentMethods))
     }
 
     @Test
@@ -253,7 +294,7 @@ class DefaultFlowControllerTest {
         ) { _, _ ->
         }
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded(PaymentSelection.GooglePay)
+            PaymentOptionResult.Succeeded.Existing(PaymentSelection.GooglePay)
         )
         flowController.confirmPayment()
         assertThat(launchArgs)
@@ -498,6 +539,12 @@ class DefaultFlowControllerTest {
         private val VISA_PAYMENT_OPTION = PaymentOption(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
             label = "····4242"
+        )
+
+        private val SAVE_NEW_CARD_SELECTION = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            CardBrand.Visa,
+            shouldSavePaymentMethod = true
         )
     }
 }


### PR DESCRIPTION
# Summary
In the custom sheet when a card is saved, when clicking on select again the save card should be shown and default selected.

# Motivation
This completes a JIRA issue

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

