### PR TITLE
Return errors as needed from the custom sheet to the PaymentOptionCallback.

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
@@ -64,9 +64,15 @@ internal class LaunchPaymentSheetCustomActivity : BasePaymentSheetActivity() {
 
     private fun onPaymentOption(paymentOption: PaymentOption?) {
         when (paymentOption) {
-            is PaymentOption.Succeeded -> handlePaymentOptionSuccess(paymentOption)
-            is PaymentOption.Failed -> handlePaymentOptionFailure(paymentOption.error.localizedMessage)
-            is PaymentOption.Canceled -> handlePaymentOptionFailure(paymentOption.mostRecentError?.localizedMessage)
+            is PaymentOption.Succeeded -> handlePaymentOptionSuccess(
+                paymentOption
+            )
+            is PaymentOption.Failed -> handlePaymentOptionFailure(
+                paymentOption.error.localizedMessage
+            )
+            is PaymentOption.Canceled -> handlePaymentOptionFailure(
+                paymentOption.mostRecentError?.localizedMessage
+            )
             // TODO(michelleb-stripe): This is not a handled card type, or nothing has ever been selected
             // See DefaultFlowController.getPaymentOption and PaymentOptionFactory.create
             null -> handlePaymentOptionFailure(null)

--- a/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
@@ -63,24 +63,39 @@ internal class LaunchPaymentSheetCustomActivity : BasePaymentSheetActivity() {
     }
 
     private fun onPaymentOption(paymentOption: PaymentOption?) {
-        if (paymentOption != null) {
-            viewBinding.paymentMethod.text = paymentOption.label
-            viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                paymentOption.drawableResourceId,
-                0,
-                0,
-                0
-            )
-            viewBinding.buyButton.isEnabled = true
-        } else {
-            viewBinding.paymentMethod.text = "Select"
-            viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                null,
-                null,
-                null,
-                null
-            )
-            viewBinding.buyButton.isEnabled = false
+        when (paymentOption) {
+            is PaymentOption.Succeeded -> handlePaymentOptionSuccess(paymentOption)
+            is PaymentOption.Failed -> handlePaymentOptionFailure(paymentOption.error.localizedMessage)
+            is PaymentOption.Canceled -> handlePaymentOptionFailure(paymentOption.mostRecentError?.localizedMessage)
+            // TODO(michelleb-stripe): This is not a handled card type, or nothing has ever been selected
+            // See DefaultFlowController.getPaymentOption and PaymentOptionFactory.create
+            null -> handlePaymentOptionFailure(null)
+        }
+    }
+
+    private fun handlePaymentOptionSuccess(paymentOption: PaymentOption.Succeeded) {
+        viewBinding.paymentMethod.text = paymentOption.label
+        viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            paymentOption.drawableResourceId,
+            0,
+            0,
+            0
+        )
+        viewBinding.buyButton.isEnabled = true
+    }
+
+    private fun handlePaymentOptionFailure(failureMessage: String?) {
+        viewBinding.paymentMethod.text = "Select"
+        viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            null,
+            null,
+            null,
+            null
+        )
+        viewBinding.buyButton.isEnabled = false
+
+        failureMessage?.let {
+            viewBinding.status.text = it
         }
     }
 

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5240,12 +5240,37 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResu
 	public abstract fun onPaymentResult (Lcom/stripe/android/paymentsheet/PaymentResult;)V
 }
 
-public final class com/stripe/android/paymentsheet/model/PaymentOption {
+public abstract class com/stripe/android/paymentsheet/model/PaymentOption {
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Canceled : com/stripe/android/paymentsheet/model/PaymentOption {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMostRecentError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Failed : com/stripe/android/paymentsheet/model/PaymentOption {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Succeeded : com/stripe/android/paymentsheet/model/PaymentOption {
 	public fun <init> (ILjava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
+	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDrawableResourceId ()I
 	public final fun getLabel ()Ljava/lang/String;

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -97,8 +97,14 @@ internal class PaymentOptionsViewModel(
                         )
                     }
                 },
-                onFailure = {
-                    // TODO(michelleb-stripe): Handle failure cases
+                onFailure = { throwable ->
+                    // TODO(michelleb-stripe): Failed to create payment method or attach it to the payment should we report it as success anyway?
+
+                    _viewState.value = ViewState.PaymentOptions.FinishProcessing {
+                        _viewState.value = ViewState.PaymentOptions.ProcessResult(
+                            PaymentOptionResult.Failed(throwable)
+                        )
+                    }
                 }
             )
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -341,7 +341,6 @@ internal class DefaultFlowController internal constructor(
                         )
                     )
                 }
-
             }
         )
         viewModel.paymentSelection = receivedPaymentSelection

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -315,12 +315,36 @@ internal class DefaultFlowController internal constructor(
     internal fun onPaymentOptionResult(
         paymentOptionResult: PaymentOptionResult?
     ) {
-        val paymentSelection =
-            (paymentOptionResult as? PaymentOptionResult.Succeeded)?.paymentSelection
-        viewModel.paymentSelection = paymentSelection
+        var receivedPaymentSelection: PaymentSelection? = null
+        // Convert from viewModel paymentOptionResult to external paymentOptionResult
         paymentOptionCallback.onPaymentOption(
-            paymentSelection?.let(paymentOptionFactory::create)
+            when (paymentOptionResult) {
+                is PaymentOptionResult.Succeeded -> {
+                    receivedPaymentSelection = paymentOptionResult.paymentSelection
+                    paymentOptionFactory.create(paymentOptionResult.paymentSelection)
+                }
+                is PaymentOptionResult.Failed -> {
+                    PaymentOption.Failed(
+                        paymentOptionResult.error
+                    )
+                }
+                is PaymentOptionResult.Canceled -> {
+                    PaymentOption.Canceled(
+                        paymentOptionResult.mostRecentError
+                    )
+                }
+                null -> {
+                    PaymentOption.Failed(
+                        Exception(
+                            "This should be removed when PaymentResultFactory handles" +
+                                "other payment types."
+                        )
+                    )
+                }
+
+            }
         )
+        viewModel.paymentSelection = receivedPaymentSelection
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -5,16 +5,27 @@ import androidx.annotation.DrawableRes
 /**
  * The customer's selected payment option.
  */
-data class PaymentOption(
-    /**
-     * The drawable resource id of the icon that represents the payment option.
-     */
-    @DrawableRes val drawableResourceId: Int,
+sealed class PaymentOption {
 
-    /**
-     * A label that describes the payment option.
-     *
-     * For example, "····4242" for a Visa ending in 4242.
-     */
-    val label: String
-)
+    data class Succeeded(
+        /**
+         * The drawable resource id of the icon that represents the payment option.
+         */
+        @DrawableRes val drawableResourceId: Int,
+
+        /**
+         * A label that describes the payment option.
+         *
+         * For example, "····4242" for a Visa ending in 4242.
+         */
+        val label: String
+    ) : PaymentOption()
+
+    data class Failed(
+        val error: Throwable
+    ) : PaymentOption()
+
+    data class Canceled(
+        val mostRecentError: Throwable?
+    ) : PaymentOption()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod
 internal class PaymentOptionFactory(
     private val resources: Resources
 ) {
-    fun create(selection: PaymentSelection): PaymentOption {
+    fun create(selection: PaymentSelection): PaymentOption? {
         return when (selection) {
             PaymentSelection.GooglePay -> {
                 // TODO(mshafrir-stripe): update values
@@ -18,17 +18,20 @@ internal class PaymentOptionFactory(
                 )
             }
             is PaymentSelection.Saved -> {
-                var drawableResourceId = R.drawable.stripe_ic_unknown
-                var label = selection.paymentMethod.type?.name ?: ""
-
-                if (selection.paymentMethod.type == PaymentMethod.Type.Card) {
-                    selection.paymentMethod.card?.let { card ->
-                        drawableResourceId = getIcon(card.brand)
-                        label = createCardLabel(card.last4)
+                when (selection.paymentMethod.type) {
+                    PaymentMethod.Type.Card -> {
+                        selection.paymentMethod.card?.let { card ->
+                            PaymentOption.Succeeded(
+                                drawableResourceId = getIcon(card.brand),
+                                label = createCardLabel(card.last4)
+                            )
+                        }
+                    }
+                    else -> {
+                        // TODO(mshafrir-stripe): handle other types
+                        null
                     }
                 }
-
-                PaymentOption.Succeeded(drawableResourceId, label)
             }
             is PaymentSelection.New.Card -> {
                 val brand = selection.brand

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -8,34 +8,31 @@ import com.stripe.android.model.PaymentMethod
 internal class PaymentOptionFactory(
     private val resources: Resources
 ) {
-    fun create(selection: PaymentSelection): PaymentOption? {
+    fun create(selection: PaymentSelection): PaymentOption {
         return when (selection) {
             PaymentSelection.GooglePay -> {
                 // TODO(mshafrir-stripe): update values
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = R.drawable.stripe_google_pay_mark,
                     label = "Google Pay"
                 )
             }
             is PaymentSelection.Saved -> {
-                when (selection.paymentMethod.type) {
-                    PaymentMethod.Type.Card -> {
-                        selection.paymentMethod.card?.let { card ->
-                            PaymentOption(
-                                drawableResourceId = getIcon(card.brand),
-                                label = createCardLabel(card.last4)
-                            )
-                        }
-                    }
-                    else -> {
-                        // TODO(mshafrir-stripe): handle other types
-                        null
+                var drawableResourceId = R.drawable.stripe_ic_unknown
+                var label = selection.paymentMethod.type?.name ?: ""
+
+                if (selection.paymentMethod.type == PaymentMethod.Type.Card) {
+                    selection.paymentMethod.card?.let { card ->
+                        drawableResourceId = getIcon(card.brand)
+                        label = createCardLabel(card.last4)
                     }
                 }
+
+                PaymentOption.Succeeded(drawableResourceId, label)
             }
             is PaymentSelection.New.Card -> {
                 val brand = selection.brand
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = getIcon(brand),
                     label = createCardLabel(selection.paymentMethodCreateParams.card?.last4)
                 )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -8,7 +8,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argWhere
-import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -132,7 +131,7 @@ class DefaultFlowControllerTest {
         }
         assertThat(flowController.getPaymentOption())
             .isEqualTo(
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
                     label = "····$last4"
                 )
@@ -226,7 +225,9 @@ class DefaultFlowControllerTest {
             PaymentOptionResult.Canceled(null)
         )
 
-        verify(paymentOptionCallback).onPaymentOption(isNull())
+        verify(paymentOptionCallback).onPaymentOption(
+            PaymentOption.Canceled(null)
+        )
     }
 
     @Test
@@ -495,7 +496,7 @@ class DefaultFlowControllerTest {
     private companion object {
         private val SESSION_ID = SessionId()
 
-        private val VISA_PAYMENT_OPTION = PaymentOption(
+        private val VISA_PAYMENT_OPTION = PaymentOption.Succeeded(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
             label = "····4242"
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -25,7 +25,7 @@ class PaymentOptionFactoryTest {
                 PaymentSelection.GooglePay
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_google_pay_mark,
                 "Google Pay"
             )
@@ -39,7 +39,7 @@ class PaymentOptionFactoryTest {
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_ic_paymentsheet_card_visa,
                 "····4242"
             )
@@ -66,7 +66,7 @@ class PaymentOptionFactoryTest {
                 )
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_ic_paymentsheet_card_visa,
                 "····4242"
             )


### PR DESCRIPTION
# Summary
Prior to this change when there was a fatal error or processing didn't complete successfully the error was dropped.  Now with this change errors will be sent back to the application.  In order to do this the PaymentOption had a status object added. 

Future action: Rename PaymentOption - PaymentOptionResult is already in used communicating between the PaymentSheetViewModel and the DefaultFlowController.

# Motivation
This completes a JIRA issue

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

