### PR TITLE
Remove Google Pay from the custom sheet

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -43,7 +43,6 @@ internal abstract class BaseAddCardFragment(
     private lateinit var cardMultilineWidget: CardMultilineWidget
     private lateinit var billingAddressView: BillingAddressView
     private lateinit var cardErrors: TextView
-    private lateinit var googlePayButton: View
     private lateinit var saveCardCheckbox: CheckBox
     private lateinit var addCardHeader: TextView
 
@@ -66,7 +65,6 @@ internal abstract class BaseAddCardFragment(
 
     private val addCardViewModel: AddCardViewModel by viewModels()
 
-    abstract fun onGooglePaySelected()
     abstract fun createHeaderText(config: FragmentConfig): String
 
     override fun onCreateView(
@@ -101,7 +99,6 @@ internal abstract class BaseAddCardFragment(
         cardMultilineWidget = viewBinding.cardMultilineWidget
         billingAddressView = viewBinding.billingAddress
         cardErrors = viewBinding.cardErrors
-        googlePayButton = viewBinding.googlePayButton
         saveCardCheckbox = viewBinding.saveCardCheckbox
         addCardHeader = viewBinding.addCardHeader
 
@@ -147,20 +144,7 @@ internal abstract class BaseAddCardFragment(
 
         setupSaveCardCheckbox(saveCardCheckbox)
 
-        val shouldShowGooglePayButton = config.shouldShowGooglePayButton
-        googlePayButton.setOnClickListener {
-            sheetViewModel.updateSelection(PaymentSelection.GooglePay)
-        }
-        googlePayButton.isVisible = shouldShowGooglePayButton
-        viewBinding.googlePayDivider.isVisible = shouldShowGooglePayButton
-        addCardHeader.isVisible = !shouldShowGooglePayButton
         addCardHeader.text = createHeaderText(config)
-
-        sheetViewModel.selection.observe(viewLifecycleOwner) { paymentSelection ->
-            if (paymentSelection == PaymentSelection.GooglePay) {
-                onGooglePaySelected()
-            }
-        }
 
         eventReporter.onShowNewPaymentOptionForm()
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -143,7 +143,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                     // where we also jump to a new unsaved card. However this move require
                     // the transition target to specify when to and when not to add things to the
                     // backstack.
-                    if (starterArgs.paymentMethods.isEmpty()) {
+                    if (starterArgs.paymentMethods.isEmpty() && !config.isGooglePayReady) {
                         PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodSheet(config)
                     } else {
                         PaymentOptionsViewModel.TransitionTarget.SelectSavedPaymentMethod(config)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragment.kt
@@ -19,10 +19,6 @@ internal class PaymentOptionsAddCardFragment(
         )
     }
 
-    override fun onGooglePaySelected() {
-        sheetViewModel.onUserSelection()
-    }
-
     override fun createHeaderText(
         config: FragmentConfig
     ): String {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragment.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.paymentsheet
 
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.R
+import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import java.util.Currency
 import java.util.Locale
 
@@ -21,8 +27,34 @@ internal class PaymentSheetAddCardFragment(
         )
     }
 
-    override fun onGooglePaySelected() {
-        sheetViewModel.checkout()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val config = arguments?.getParcelable<FragmentConfig>(
+            BaseSheetActivity.EXTRA_FRAGMENT_CONFIG
+        )
+        val shouldShowGooglePayButton = config?.let {
+            config.isGooglePayReady && config.paymentMethods.isEmpty()
+        } ?: false
+
+        val viewBinding = FragmentPaymentsheetAddCardBinding.bind(view)
+        val googlePayButton = viewBinding.googlePayButton
+        val addCardHeader = viewBinding.addCardHeader
+        val googlePayDivider = viewBinding.googlePayDivider
+
+        googlePayButton.setOnClickListener {
+            sheetViewModel.updateSelection(PaymentSelection.GooglePay)
+        }
+
+        googlePayButton.isVisible = shouldShowGooglePayButton
+
+        googlePayDivider.isVisible = shouldShowGooglePayButton
+        addCardHeader.isVisible = !shouldShowGooglePayButton
+
+        sheetViewModel.selection.observe(viewLifecycleOwner) { paymentSelection ->
+            if (paymentSelection == PaymentSelection.GooglePay) {
+                sheetViewModel.checkout()
+            }
+        }
     }
 
     override fun createHeaderText(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
@@ -17,8 +17,6 @@ internal data class FragmentConfig(
     val isGooglePayReady: Boolean,
     val savedSelection: SavedSelection
 ) : Parcelable {
-    val shouldShowGooglePayButton: Boolean
-        get() = isGooglePayReady && paymentMethods.isEmpty()
 
     val sortedPaymentMethods: List<PaymentMethod>
         get() {

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -13,8 +13,8 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.databinding.PrimaryButtonBinding
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.PaymentOptionsViewModel.TransitionTarget
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -43,21 +43,7 @@ class PaymentOptionsActivityTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val eventReporter = mock<EventReporter>()
-    private val viewModel = PaymentOptionsViewModel(
-        args = PaymentOptionContract.Args(
-            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            paymentMethods = emptyList(),
-            sessionId = SessionId(),
-            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-            isGooglePayReady = false,
-            newCard = null,
-            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
-        ),
-        prefsRepository = FakePrefsRepository(),
-        paymentMethodsRepository = FakePaymentMethodsRepository(emptyList()),
-        eventReporter = eventReporter,
-        workContext = testDispatcher
-    )
+    private val viewModel = createViewModel()
 
     @BeforeTest
     fun setup() {
@@ -76,7 +62,7 @@ class PaymentOptionsActivityTest {
     fun `click outside of bottom sheet should return cancel result`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -99,7 +85,11 @@ class PaymentOptionsActivityTest {
     fun `AddButton should be hidden when showing payment options`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(PaymentMethodFixtures.createCards(5))
+            createIntent(
+                PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
+                    paymentMethods = PaymentMethodFixtures.createCards(5)
+                )
+            )
         ).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -116,7 +106,7 @@ class PaymentOptionsActivityTest {
     fun `AddButton should be visible when showing add payment method form`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -133,7 +123,11 @@ class PaymentOptionsActivityTest {
     fun `AddButton should be hidden when returning to payment options`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(PaymentMethodFixtures.createCards(5))
+            createIntent(
+                PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
+                    paymentMethods = PaymentMethodFixtures.createCards(5)
+                )
+            )
         ).use {
             it.onActivity { activity ->
                 // wait for bottom sheet to animate in
@@ -169,7 +163,7 @@ class PaymentOptionsActivityTest {
     fun `Verify Ready state updates the add button label`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity { activity ->
                 viewModel._viewState.value = ViewState.PaymentOptions.Ready
@@ -193,7 +187,7 @@ class PaymentOptionsActivityTest {
     fun `Verify StartProcessing state updates the add button label`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity { activity ->
                 viewModel._viewState.value = ViewState.PaymentOptions.StartProcessing
@@ -212,7 +206,7 @@ class PaymentOptionsActivityTest {
     fun `Verify FinishProcessing state calls the callback`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity {
                 var callbackCalled = false
@@ -230,10 +224,52 @@ class PaymentOptionsActivityTest {
     }
 
     @Test
+    fun `Verify if google pay is ready, stay on the select saved payment method`() {
+        val viewModel = createViewModel(
+            PAYMENT_OPTIONS_CONTRACT_ARGS.copy(isGooglePayReady = true)
+        )
+        val transitionTarget = mutableListOf<TransitionTarget?>()
+        viewModel.transition.observeForever {
+            transitionTarget.add(it)
+        }
+        val scenario = activityScenario(viewModel)
+        scenario.launch(
+            createIntent()
+        ).use {
+            idleLooper()
+            assertThat(transitionTarget[1])
+                .isInstanceOf(TransitionTarget.SelectSavedPaymentMethod::class.java)
+        }
+    }
+
+    @Test
+    fun `Verify if payment methods is not empty select, saved payment method`() {
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
+            isGooglePayReady = false,
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        val viewModel = createViewModel(args)
+        val transitionTarget = mutableListOf<TransitionTarget?>()
+        viewModel.transition.observeForever {
+            transitionTarget.add(it)
+        }
+
+        val scenario = activityScenario(viewModel)
+        scenario.launch(
+            createIntent(args)
+        ).use {
+            idleLooper()
+            assertThat(transitionTarget[1])
+                .isInstanceOf(TransitionTarget.SelectSavedPaymentMethod::class.java)
+        }
+    }
+
+    @Test
     fun `Verify ProcessResult state closes the sheet`() {
         val scenario = activityScenario()
         scenario.launch(
-            createIntent(emptyList())
+            createIntent()
         ).use {
             it.onActivity { activity ->
                 val paymentSelectionMock: PaymentSelection = PaymentSelection.GooglePay
@@ -251,24 +287,13 @@ class PaymentOptionsActivityTest {
     }
 
     private fun createIntent(
-        paymentMethods: List<PaymentMethod>
+        args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
     ): Intent {
         return Intent(
             ApplicationProvider.getApplicationContext(),
             PaymentOptionsActivity::class.java
         ).putExtras(
-            bundleOf(
-                ActivityStarter.Args.EXTRA to
-                    PaymentOptionContract.Args(
-                        paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                        paymentMethods = paymentMethods,
-                        sessionId = SessionId(),
-                        config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                        isGooglePayReady = false,
-                        newCard = null,
-                        statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
-                    )
-            )
+            bundleOf(ActivityStarter.Args.EXTRA to args)
         )
     }
 
@@ -280,5 +305,29 @@ class PaymentOptionsActivityTest {
                 viewModelFactory = viewModelFactoryFor(viewModel)
             }
         }
+    }
+
+    private fun createViewModel(
+        args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
+    ): PaymentOptionsViewModel {
+        return PaymentOptionsViewModel(
+            args = args,
+            prefsRepository = FakePrefsRepository(),
+            paymentMethodsRepository = FakePaymentMethodsRepository(args.paymentMethods),
+            eventReporter = eventReporter,
+            workContext = testDispatcher
+        )
+    }
+
+    private companion object {
+        private val PAYMENT_OPTIONS_CONTRACT_ARGS = PaymentOptionContract.Args(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentMethods = emptyList(),
+            sessionId = SessionId(),
+            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+            isGooglePayReady = false,
+            newCard = null,
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddCardFragmentTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.paymentsheet
+
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.R
+import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.SessionId
+import com.stripe.android.paymentsheet.model.FragmentConfig
+import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
+import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentOptionsAddCardFragmentTest {
+    private val eventReporter = mock<EventReporter>()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+    }
+
+    @Test
+    fun `when isGooglePayEnabled=true should still not display the Google Pay button`() {
+        createFragment { _, viewBinding ->
+            assertThat(viewBinding.googlePayButton.isVisible)
+                .isFalse()
+        }
+    }
+
+    private fun createFragment(
+        args: PaymentOptionContract.Args = PaymentOptionContract.Args(
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentMethods = emptyList(),
+            sessionId = SessionId(),
+            config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+            isGooglePayReady = false,
+            newCard = null,
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
+        ),
+        fragmentConfig: FragmentConfig? = FragmentConfigFixtures.DEFAULT,
+        onReady: (PaymentOptionsAddCardFragment, FragmentPaymentsheetAddCardBinding) -> Unit
+    ) {
+        launchFragmentInContainer<PaymentOptionsAddCardFragment>(
+            bundleOf(
+                PaymentOptionsActivity.EXTRA_FRAGMENT_CONFIG to fragmentConfig,
+                PaymentOptionsActivity.EXTRA_STARTER_ARGS to args
+            ),
+            R.style.StripePaymentSheetDefaultTheme,
+            factory = PaymentSheetFragmentFactory(eventReporter)
+        ).onFragment { fragment ->
+            onReady(
+                fragment,
+                FragmentPaymentsheetAddCardBinding.bind(
+                    requireNotNull(fragment.view)
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary
1. In the PaymentOptionsActivity we will make sure not to go to the add fragment if google pay is ready.
2. Moved all google pay button functionality out of the BaseAddFragment and into the PaymentSheetAddFragment

# Motivation
The look of the google pay button makes it feel like the authorization is going to happen and the payment go through at that time, which is not the case in the custom work flow.  By selecting google pay on the list, it is more clear that no payment is going to happen.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
