### PR TITLE
Report failures out from the paymentOptionCallback.

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LaunchPaymentSheetCustomActivity.kt
@@ -63,24 +63,45 @@ internal class LaunchPaymentSheetCustomActivity : BasePaymentSheetActivity() {
     }
 
     private fun onPaymentOption(paymentOption: PaymentOption?) {
-        if (paymentOption != null) {
-            viewBinding.paymentMethod.text = paymentOption.label
-            viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                paymentOption.drawableResourceId,
-                0,
-                0,
-                0
+        when (paymentOption) {
+            is PaymentOption.Succeeded -> handlePaymentOptionSuccess(
+                paymentOption
             )
-            viewBinding.buyButton.isEnabled = true
-        } else {
-            viewBinding.paymentMethod.text = "Select"
-            viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                null,
-                null,
-                null,
-                null
+            is PaymentOption.Failed -> handlePaymentOptionFailure(
+                paymentOption.error.localizedMessage
             )
-            viewBinding.buyButton.isEnabled = false
+            is PaymentOption.Canceled -> handlePaymentOptionFailure(
+                paymentOption.mostRecentError?.localizedMessage
+            )
+            // TODO(michelleb-stripe): This is not a handled card type, or nothing has ever been selected
+            // See DefaultFlowController.getPaymentOption and PaymentOptionFactory.create
+            null -> handlePaymentOptionFailure(null)
+        }
+    }
+
+    private fun handlePaymentOptionSuccess(paymentOption: PaymentOption.Succeeded) {
+        viewBinding.paymentMethod.text = paymentOption.label
+        viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            paymentOption.drawableResourceId,
+            0,
+            0,
+            0
+        )
+        viewBinding.buyButton.isEnabled = true
+    }
+
+    private fun handlePaymentOptionFailure(failureMessage: String?) {
+        viewBinding.paymentMethod.text = "Select"
+        viewBinding.paymentMethod.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            null,
+            null,
+            null,
+            null
+        )
+        viewBinding.buyButton.isEnabled = false
+
+        failureMessage?.let {
+            viewBinding.status.text = it
         }
     }
 

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5240,12 +5240,37 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResu
 	public abstract fun onPaymentResult (Lcom/stripe/android/paymentsheet/PaymentResult;)V
 }
 
-public final class com/stripe/android/paymentsheet/model/PaymentOption {
+public abstract class com/stripe/android/paymentsheet/model/PaymentOption {
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Canceled : com/stripe/android/paymentsheet/model/PaymentOption {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Canceled;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMostRecentError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Failed : com/stripe/android/paymentsheet/model/PaymentOption {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentOption$Succeeded : com/stripe/android/paymentsheet/model/PaymentOption {
 	public fun <init> (ILjava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
+	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption$Succeeded;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDrawableResourceId ()I
 	public final fun getLabel ()Ljava/lang/String;

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -97,8 +97,14 @@ internal class PaymentOptionsViewModel(
                         )
                     }
                 },
-                onFailure = {
-                    // TODO(michelleb-stripe): Handle failure cases
+                onFailure = { throwable ->
+                    // TODO(michelleb-stripe): Failed to create payment method or attach it to the payment should we report it as success anyway?
+
+                    _viewState.value = ViewState.PaymentOptions.FinishProcessing {
+                        _viewState.value = ViewState.PaymentOptions.ProcessResult(
+                            PaymentOptionResult.Failed(throwable)
+                        )
+                    }
                 }
             )
         }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -5,16 +5,27 @@ import androidx.annotation.DrawableRes
 /**
  * The customer's selected payment option.
  */
-data class PaymentOption(
-    /**
-     * The drawable resource id of the icon that represents the payment option.
-     */
-    @DrawableRes val drawableResourceId: Int,
+sealed class PaymentOption {
 
-    /**
-     * A label that describes the payment option.
-     *
-     * For example, "····4242" for a Visa ending in 4242.
-     */
-    val label: String
-)
+    data class Succeeded(
+        /**
+         * The drawable resource id of the icon that represents the payment option.
+         */
+        @DrawableRes val drawableResourceId: Int,
+
+        /**
+         * A label that describes the payment option.
+         *
+         * For example, "····4242" for a Visa ending in 4242.
+         */
+        val label: String
+    ) : PaymentOption()
+
+    data class Failed(
+        val error: Throwable
+    ) : PaymentOption()
+
+    data class Canceled(
+        val mostRecentError: Throwable?
+    ) : PaymentOption()
+}

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -12,7 +12,7 @@ internal class PaymentOptionFactory(
         return when (selection) {
             PaymentSelection.GooglePay -> {
                 // TODO(mshafrir-stripe): update values
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = R.drawable.stripe_google_pay_mark,
                     label = "Google Pay"
                 )
@@ -21,7 +21,7 @@ internal class PaymentOptionFactory(
                 when (selection.paymentMethod.type) {
                     PaymentMethod.Type.Card -> {
                         selection.paymentMethod.card?.let { card ->
-                            PaymentOption(
+                            PaymentOption.Succeeded(
                                 drawableResourceId = getIcon(card.brand),
                                 label = createCardLabel(card.last4)
                             )
@@ -35,7 +35,7 @@ internal class PaymentOptionFactory(
             }
             is PaymentSelection.New.Card -> {
                 val brand = selection.brand
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = getIcon(brand),
                     label = createCardLabel(selection.paymentMethodCreateParams.card?.last4)
                 )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -8,7 +8,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argWhere
-import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -132,7 +131,7 @@ class DefaultFlowControllerTest {
         }
         assertThat(flowController.getPaymentOption())
             .isEqualTo(
-                PaymentOption(
+                PaymentOption.Succeeded(
                     drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
                     label = "····$last4"
                 )
@@ -226,7 +225,9 @@ class DefaultFlowControllerTest {
             PaymentOptionResult.Canceled(null)
         )
 
-        verify(paymentOptionCallback).onPaymentOption(isNull())
+        verify(paymentOptionCallback).onPaymentOption(
+            PaymentOption.Canceled(null)
+        )
     }
 
     @Test
@@ -495,7 +496,7 @@ class DefaultFlowControllerTest {
     private companion object {
         private val SESSION_ID = SessionId()
 
-        private val VISA_PAYMENT_OPTION = PaymentOption(
+        private val VISA_PAYMENT_OPTION = PaymentOption.Succeeded(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
             label = "····4242"
         )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -25,7 +25,7 @@ class PaymentOptionFactoryTest {
                 PaymentSelection.GooglePay
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_google_pay_mark,
                 "Google Pay"
             )
@@ -39,7 +39,7 @@ class PaymentOptionFactoryTest {
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_ic_paymentsheet_card_visa,
                 "····4242"
             )
@@ -66,7 +66,7 @@ class PaymentOptionFactoryTest {
                 )
             )
         ).isEqualTo(
-            PaymentOption(
+            PaymentOption.Succeeded(
                 R.drawable.stripe_ic_paymentsheet_card_visa,
                 "····4242"
             )


### PR DESCRIPTION
# Summary
In the custom sheet when there is a fatal error nothing was reported back to the client.  With this change the error will be reported back to the client.

The existing PaymentOption class was modified to include several classes that can be success, failure, or cancelled.  The success case will contain a drawable and label as the PaymentOption used to provide.

It would be nice to come up with a better name that indicates the Resulting status, but PaymentOptionResult is already taking to pass the status with the paymentSelection from the view model to the default flow controller.

I wonder if it would make sense to have a package that just contains the objects that can be passed back to the client.  Right now PaymentOption is in the paymentsheet.model package, but PaymentResult (returned in the complete or custom buy workflow) is in paymentsheet.

Would it make sense to put the existing PaymentOptionResult inside the viewModel since they are pretty closely related?  The downside is that the defaultFlowController and PaymentOption would all know/depend on the viewmodel.

Any renaming will happen in a separate PR.


# Motivation
This fixes the problem of failures not being reported to the user of the custom payment sheet.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

