### PR TITLE
Fix bug in Oreo related to translucent Activity

### DIFF
--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -25,17 +25,14 @@
 
         <activity
             android:name=".paymentsheet.PaymentSheetActivity"
-            android:theme="@style/StripePaymentSheetDefaultTheme"
-            android:screenOrientation="portrait" />
+            android:theme="@style/StripePaymentSheetDefaultTheme" />
         <activity
             android:name=".paymentsheet.PaymentOptionsActivity"
-            android:theme="@style/StripePaymentSheetDefaultTheme"
-            android:screenOrientation="portrait" />
+            android:theme="@style/StripePaymentSheetDefaultTheme" />
 
         <activity
             android:name=".googlepay.StripeGooglePayActivity"
-            android:theme="@style/StripeGooglePayDefaultTheme"
-            android:screenOrientation="portrait" />
+            android:theme="@style/StripeGooglePayDefaultTheme" />
     </application>
 
 </manifest>

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.googlepay
 
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -43,6 +45,12 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
+            // orientation. See https://stackoverflow.com/a/50832408/11103900
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        }
+
         overridePendingTransition(0, 0)
         setResult(
             RESULT_OK,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
+import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.ScrollView
@@ -36,6 +38,11 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         supportFragmentManager.fragmentFactory = PaymentSheetFragmentFactory(eventReporter)
 
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
+            // orientation. See https://stackoverflow.com/a/50832408/11103900
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        }
 
         supportFragmentManager.addOnBackStackChangedListener {
             if (supportFragmentManager.backStackEntryCount == 0) {


### PR DESCRIPTION
On Oreo devices, when requesting screen orientation on a
translucent Activity, an exception is thrown.

```
java.lang.IllegalStateException: Only fullscreen activities can request orientation
```

See https://stackoverflow.com/q/48072438/11103900 for more details.

The resolution is to conditionally request screen orientation based
on OS version.