### PR TITLE
Add support for blik payment intent and payment method

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -2939,6 +2939,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public static final field AuBecsDebit Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field BacsDebit Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Bancontact Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Blik Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Card Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field CardPresent Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3042,6 +3043,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun createAlipay (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createBlik ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createBlik (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createBlik (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createCard (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -3201,6 +3205,10 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createBancontact (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createBancontact$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createBlik ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createBlik (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createBlik (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createBlik$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createCard (Lcom/stripe/android/model/CardParams;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createEps (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -3391,6 +3399,34 @@ public abstract class com/stripe/android/model/PaymentMethodOptionsParams : andr
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethod$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
 	public fun toParamMap ()Ljava/util/Map;
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik$Companion;
+	public static final field PARAM_CODE Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setCode (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Companion {
+}
+
+public class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : com/stripe/android/model/PaymentMethodOptionsParams {
@@ -4613,6 +4649,23 @@ public abstract interface class com/stripe/android/model/StripeIntent : com/stri
 public abstract class com/stripe/android/model/StripeIntent$NextActionData : com/stripe/android/model/StripeModel {
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails : com/stripe/android/model/StripeIntent$NextActionData {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
@@ -4748,6 +4801,7 @@ public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS
 
 public final class com/stripe/android/model/StripeIntent$NextActionType : java/lang/Enum {
 	public static final field AlipayRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field BlikAuthorize Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field Companion Lcom/stripe/android/model/StripeIntent$NextActionType$Companion;
 	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -3418,9 +3418,6 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Companion {
-}
-
 public class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -521,23 +521,5 @@ data class ConfirmPaymentIntentParams internal constructor(
                 returnUrl = "stripe://return_url"
             )
         }
-
-        /**
-         * Create the parameters necessary for confirming a [PaymentIntent] with Blik
-         *
-         * @param blikCode code generated from blik mobile banking app
-         * @param clientSecret client secret from the PaymentIntent that is to be confirmed
-         *
-         */
-        @JvmStatic
-        fun createBlik(
-            blikCode: String,
-            clientSecret: String
-        ): ConfirmPaymentIntentParams {
-            return ConfirmPaymentIntentParams(
-                clientSecret = clientSecret,
-                paymentMethodCreateParams = PaymentMethodCreateParams.createBlik(),
-            )
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -521,5 +521,24 @@ data class ConfirmPaymentIntentParams internal constructor(
                 returnUrl = "stripe://return_url"
             )
         }
+
+
+        /**
+         * Create the parameters necessary for confirming a [PaymentIntent] with Blik
+         *
+         * @param blikCode code generated from blik mobile banking app
+         * @param clientSecret client secret from the PaymentIntent that is to be confirmed
+         *
+         */
+        @JvmStatic
+        fun createBlik(
+            blikCode: String,
+            clientSecret: String
+        ): ConfirmPaymentIntentParams {
+            return ConfirmPaymentIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodCreateParams = PaymentMethodCreateParams.createBlik(),
+            )
+        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -522,7 +522,6 @@ data class ConfirmPaymentIntentParams internal constructor(
             )
         }
 
-
         /**
          * Create the parameters necessary for confirming a [PaymentIntent] with Blik
          *

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -141,7 +141,8 @@ data class PaymentMethod internal constructor(
         GrabPay("grabpay", isReusable = false),
         PayPal("paypal", isReusable = false),
         AfterpayClearpay("afterpay_clearpay", isReusable = false),
-        Netbanking("netbanking", isReusable = false);
+        Netbanking("netbanking", isReusable = false),
+        Blik("blik", isReusable = false);
 
         override fun toString(): String {
             return code

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -199,7 +199,8 @@ data class PaymentMethodCreateParams internal constructor(
         PayPal("paypal"),
         AfterpayClearpay("afterpay_clearpay"),
         Upi("upi"),
-        Netbanking("netbanking")
+        Netbanking("netbanking"),
+        Blik("blik")
     }
 
     @Parcelize
@@ -750,6 +751,19 @@ data class PaymentMethodCreateParams internal constructor(
                     email = googlePayResult.email,
                     phone = googlePayResult.phoneNumber
                 )
+            )
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun createBlik(
+            billingDetails: PaymentMethod.BillingDetails? = null,
+            metadata: Map<String, String>? = null
+        ): PaymentMethodCreateParams {
+            return PaymentMethodCreateParams(
+                type = Type.Blik,
+                billingDetails = billingDetails,
+                metadata = metadata
             )
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -50,7 +50,7 @@ sealed class PaymentMethodOptionsParams(
             )
         }
 
-        companion object {
+        internal companion object {
             const val PARAM_CODE = "code"
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -42,7 +42,7 @@ sealed class PaymentMethodOptionsParams(
 
     @Parcelize
     data class Blik(
-        var code: String? = null,
+        var code: String,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.Blik) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -39,4 +39,19 @@ sealed class PaymentMethodOptionsParams(
             private const val PARAM_NETWORK = "network"
         }
     }
+
+    @Parcelize
+    data class Blik(
+        var code: String? = null,
+    ) : PaymentMethodOptionsParams(PaymentMethod.Type.Blik) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_CODE to code,
+            )
+        }
+
+        companion object {
+            const val PARAM_CODE = "code"
+        }
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -230,7 +230,7 @@ interface StripeIntent : StripeModel {
                 return 0
             }
             override fun equals(other: Any?): Boolean {
-                return true
+                return this === other
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
 import android.net.Uri
-import android.os.Parcel
 import android.os.Parcelable
 import com.stripe.android.utils.StripeUrlUtils
 import kotlinx.parcelize.Parcelize

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -131,7 +131,7 @@ interface StripeIntent : StripeModel {
         }
     }
 
-    sealed class NextActionData() : StripeModel {
+    sealed class NextActionData : StripeModel {
 
         @Parcelize
         data class DisplayOxxoDetails(

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.net.Uri
+import android.os.Parcel
 import android.os.Parcelable
 import com.stripe.android.utils.StripeUrlUtils
 import kotlinx.parcelize.Parcelize
@@ -61,7 +62,8 @@ interface StripeIntent : StripeModel {
         RedirectToUrl("redirect_to_url"),
         UseStripeSdk("use_stripe_sdk"),
         DisplayOxxoDetails("display_oxxo_details"),
-        AlipayRedirect("alipay_handle_redirect");
+        AlipayRedirect("alipay_handle_redirect"),
+        BlikAuthorize("blik_authorize");
 
         override fun toString(): String {
             return code
@@ -130,7 +132,10 @@ interface StripeIntent : StripeModel {
         }
     }
 
-    sealed class NextActionData : StripeModel {
+    sealed class NextActionData() : StripeModel {
+        constructor(parcel: Parcel) : this() {
+        }
+
         @Parcelize
         data class DisplayOxxoDetails(
             /**
@@ -218,6 +223,16 @@ interface StripeIntent : StripeModel {
                     val rootCertsData: List<String>,
                     val keyId: String?
                 ) : Parcelable
+            }
+        }
+
+        @Parcelize
+        object BlikAuthorize : NextActionData() {
+            override fun hashCode(): Int {
+                return 0
+            }
+            override fun equals(other: Any?): Boolean {
+                return true
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/stripe/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -133,8 +133,6 @@ interface StripeIntent : StripeModel {
     }
 
     sealed class NextActionData() : StripeModel {
-        constructor(parcel: Parcel) : this() {
-        }
 
         @Parcelize
         data class DisplayOxxoDetails(

--- a/stripe/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -150,7 +150,6 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
         }
     }
 
-
     private companion object {
         private const val FIELD_NEXT_ACTION_TYPE = "type"
     }

--- a/stripe/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/stripe/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -18,6 +18,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             StripeIntent.NextActionType.RedirectToUrl -> RedirectToUrlParser()
             StripeIntent.NextActionType.UseStripeSdk -> SdkDataJsonParser()
             StripeIntent.NextActionType.AlipayRedirect -> AlipayRedirectParser()
+            StripeIntent.NextActionType.BlikAuthorize -> BlikAuthorizeParser()
             else -> return null
         }
         return parser.parse(json.optJSONObject(nextActionType.code) ?: JSONObject())
@@ -141,6 +142,14 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             private const val FIELD_STRIPE_JS = "stripe_js"
         }
     }
+
+    internal class BlikAuthorizeParser :
+        ModelJsonParser<StripeIntent.NextActionData.BlikAuthorize> {
+        override fun parse(json: JSONObject): StripeIntent.NextActionData.BlikAuthorize {
+            return StripeIntent.NextActionData.BlikAuthorize
+        }
+    }
+
 
     private companion object {
         private const val FIELD_NEXT_ACTION_TYPE = "type"

--- a/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -23,4 +23,5 @@ internal object ApiKeyFixtures {
     const val AFTERPAY_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val UPI_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
     const val NETBANKING_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
+    const val BLIK_PUBLISHABLE_KEY = "pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6" // mobile-payments-sdk-ci@stripe.com
 }

--- a/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -23,5 +23,5 @@ internal object ApiKeyFixtures {
     const val AFTERPAY_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val UPI_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
     const val NETBANKING_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
-    const val BLIK_PUBLISHABLE_KEY = "pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6" // mobile-payments-sdk-ci@stripe.com
+    const val BLIK_PUBLISHABLE_KEY = "pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -314,4 +314,14 @@ internal class PaymentMethodEndToEndTest {
         assertThat(missingAddressException.message)
             .isEqualTo("Missing required param: billing_details[address][line1].")
     }
+
+    @Test
+    fun createPaymentMethod_withBlik_shouldCreateObject() {
+        val params = PaymentMethodCreateParams.createBlik()
+        val paymentMethod =
+            Stripe(context, ApiKeyFixtures.BLIK_PUBLISHABLE_KEY)
+                .createPaymentMethodSynchronous(params)
+        assertThat(paymentMethod?.type)
+            .isEqualTo(PaymentMethod.Type.Blik)
+    }
 }

--- a/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -305,7 +305,7 @@ class ConfirmPaymentIntentParamsTest {
     }
 
     @Test
-    fun toParamMap_withPaymentMethodOptions_shouldCreateExpectedMap() {
+    fun toParamMap_withCardPaymentMethodOptions_shouldCreateExpectedMap() {
         assertThat(
             ConfirmPaymentIntentParams(
                 paymentMethodId = "pm_123",
@@ -318,6 +318,31 @@ class ConfirmPaymentIntentParamsTest {
             mapOf(
                 "payment_method" to "pm_123",
                 "payment_method_options" to mapOf("card" to mapOf("cvc" to "123")),
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false
+            )
+        )
+    }
+
+    @Test
+    fun toParamMap_withBlikPaymentMethodOptions_shouldCreateExpectedMap() {
+        val blikCode = "123456"
+        assertThat(
+            ConfirmPaymentIntentParams(
+                paymentMethodId = "pm_123",
+                paymentMethodOptions = PaymentMethodOptionsParams.Blik(
+                    code = blikCode
+                ),
+                clientSecret = CLIENT_SECRET
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "payment_method" to "pm_123",
+                "payment_method_options" to mapOf(
+                    PaymentMethod.Type.Blik.code to mapOf(
+                        PaymentMethodOptionsParams.Blik.PARAM_CODE to blikCode
+                    )
+                ),
                 "client_secret" to CLIENT_SECRET,
                 "use_stripe_sdk" to false
             )

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -872,4 +872,70 @@ internal object PaymentIntentFixtures {
     )
 
     val ALIPAY_TEST_MODE = PARSER.parse(ALIPAY_TEST_MODE_JSON)!!
+
+    val PI_REQUIRES_BLIK_AUTHORIZE_JSON = JSONObject(
+        """
+        {
+          "id": "pi_1IVmwXFY0qyl6XeWwxGWA04D",
+          "object": "payment_intent",
+          "amount": 1099,
+          "amount_capturable": 0,
+          "amount_received": 0,
+          "amount_subtotal": 1099,
+          "application": null,
+          "application_fee_amount": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "charges": {
+            "object": "list",
+            "data": [
+        
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges?payment_intent=pi_1IVmwXFY0qyl6XeWwxGWA04D"
+          },
+          "client_secret": "pi_1IVmwXFY0qyl6XeWwxGWA04D_secret_4U8cSCdPefr8LHtPsKvA3mcQz",
+          "confirmation_method": "automatic",
+          "created": 1615939737,
+          "currency": "pln",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "next_action": {
+            "type": "blik_authorize"
+          },
+          "on_behalf_of": null,
+          "payment_method": "pm_1IVnI3FY0qyl6XeWxJFdBh2g",
+          "payment_method_options": {
+            "blik": {
+            }
+          },
+          "payment_method_types": [
+            "blik"
+          ],
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_action",
+          "total_details": {
+            "amount_discount": 0,
+            "amount_tax": 0
+          },
+          "transfer_data": null,
+          "transfer_group": null
+        }
+        """.trimIndent()
+    )
+
+    val PI_REQUIRES_BLIK_AUTHORIZE = PARSER.parse(PI_REQUIRES_BLIK_AUTHORIZE_JSON)!!
 }

--- a/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -19,7 +19,7 @@ class PaymentIntentTest {
     }
 
     @Test
-    fun parsePaymentIntentWithPaymentMethods() {
+    fun parsePaymentIntentWith3DS2PaymentMethods() {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
         assertThat(paymentIntent.requiresAction())
             .isTrue()
@@ -37,6 +37,15 @@ class PaymentIntentTest {
             .isEqualTo("jenny@example.com")
         assertThat(paymentIntent.cancellationReason)
             .isNull()
+    }
+
+    @Test
+    fun parsePaymentIntentWithBlikPaymentMethods() {
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE
+        assertThat(paymentIntent.requiresAction())
+            .isTrue()
+        assertThat(paymentIntent.paymentMethodTypes)
+            .containsExactly("blik")
     }
 
     @Test
@@ -72,6 +81,13 @@ class PaymentIntentTest {
             )
         assertThat(redirectData.returnUrl)
             .isEqualTo("stripe://deeplink")
+    }
+
+    @Test
+    fun getNextActionData_whenBlikAuthorize() {
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE
+        assertThat(paymentIntent.nextActionData)
+            .isInstanceOf(StripeIntent.NextActionData.BlikAuthorize::class.java)
     }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
+++ b/stripe/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
@@ -21,6 +21,22 @@ class PaymentMethodOptionsParamsTest {
     }
 
     @Test
+    fun blikToParamMap_withCode_includeCode() {
+        val blikCode = "123456"
+        assertThat(
+            PaymentMethodOptionsParams.Blik(
+                code = blikCode
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                PaymentMethod.Type.Blik.code to mapOf(
+                    PaymentMethodOptionsParams.Blik.PARAM_CODE to blikCode
+                )
+            )
+        )
+    }
+
+    @Test
     fun cardToParamMap_withNoData_shouldHaveEmptyParams() {
         assertThat(
             PaymentMethodOptionsParams.Card()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add support for blik Single use. 

The following fields are added:
- a new type `blik` when creating a payment method
- a new payment method options `blik` with field `code` for blik mobile banking app code when confirming a payment
- a new `next_action` type `blik_authorize` on `PaymentIntent`


This PR does change any `SetupIntent`, which is required for blik, as it's not ready yet on pay server.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support blik on Android mobile SDK

# Testing

<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests

