### PR TITLE
Block interaction with payment methods list while processing

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -38,11 +38,19 @@ internal abstract class BasePaymentMethodsListFragment(
         this.config = nullableConfig
 
         val viewBinding = FragmentPaymentsheetPaymentMethodsListBinding.bind(view)
-        viewBinding.recycler.layoutManager = LinearLayoutManager(
+        val layoutManager = object : LinearLayoutManager(
             activity,
-            LinearLayoutManager.HORIZONTAL,
+            HORIZONTAL,
             false
-        )
+        ) {
+            var canScroll = true
+
+            override fun canScrollHorizontally(): Boolean {
+                return canScroll && super.canScrollHorizontally()
+            }
+        }.also {
+            viewBinding.recycler.layoutManager = it
+        }
 
         val adapter = PaymentOptionsAdapter(
             canClickSelectedItem,
@@ -61,6 +69,11 @@ internal abstract class BasePaymentMethodsListFragment(
         eventReporter.onShowExistingPaymentOptions()
 
         viewBinding.header.text = createHeaderText()
+
+        sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->
+            adapter.interactionEnabled = !isProcessing
+            layoutManager.canScroll = !isProcessing
+        }
     }
 
     abstract fun transitionToAddPaymentMethod()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.stripe.android.R
 import com.stripe.android.databinding.StripeActivityPaymentOptionsBinding
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -82,7 +83,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         val addButton = viewBinding.addButton
         when (viewState) {
             is ViewState.PaymentOptions.Ready -> addButton.updateState(
-                PrimaryButton.State.Ready()
+                PrimaryButton.State.Ready(getString(R.string.stripe_paymentsheet_add_button_label))
             )
             is ViewState.PaymentOptions.StartProcessing -> addButton.updateState(
                 PrimaryButton.State.StartProcessing

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -26,6 +26,7 @@ internal class PaymentOptionsAdapter(
     private var selectedItemPosition: Int = NO_POSITION
 
     internal val selectedItem: Item? get() = items.getOrNull(selectedItemPosition)
+    internal var interactionEnabled = true
 
     init {
         setHasStableIds(true)
@@ -90,7 +91,10 @@ internal class PaymentOptionsAdapter(
         position: Int,
         isClick: Boolean
     ) {
-        if (position != NO_POSITION && (canClickSelectedItem || position != selectedItemPosition)) {
+        if (interactionEnabled &&
+            position != NO_POSITION &&
+            (canClickSelectedItem || position != selectedItemPosition)
+        ) {
             val previousSelectedIndex = selectedItemPosition
             selectedItemPosition = position
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -115,6 +115,8 @@ internal class PaymentOptionsViewModel(
                     }
                 },
                 onFailure = {
+                    _processing.value = false
+                    _viewState.value = ViewState.PaymentOptions.Ready
                     // TODO(michelleb-stripe): Handle failure cases
                 }
             )

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -97,6 +97,7 @@ internal class PaymentOptionsViewModel(
     }
 
     private fun processSaveNewCard(paymentSelection: PaymentSelection) {
+        _processing.value = true
         _viewState.value = ViewState.PaymentOptions.StartProcessing
         savePaymentSelection(paymentSelection as PaymentSelection.New) { result ->
             result.fold(
@@ -104,6 +105,7 @@ internal class PaymentOptionsViewModel(
                     prefsRepository.savePaymentSelection(PaymentSelection.Saved(paymentMethod))
 
                     _viewState.value = ViewState.PaymentOptions.FinishProcessing {
+                        _processing.value = false
                         _viewState.value = ViewState.PaymentOptions.ProcessResult(
                             PaymentOptionResult.Succeeded.NewlySaved(
                                 paymentSelection,


### PR DESCRIPTION
# Summary
Block clicking on a payment method and scrolling through the list.

# Motivation
MOBILESDK-172

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Hard to add test to the Adapter because our onClickListener relies on ViewHolder.adapterPosition which relies on the actual host RecyclerView.
