### PR TITLE
Continue to refactor PaymentAuthWebView and related classes

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebChromeClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebChromeClient.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.view
+
+import android.app.Activity
+import android.webkit.ConsoleMessage
+import android.webkit.JsResult
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.appcompat.app.AlertDialog
+import com.stripe.android.Logger
+import com.stripe.android.R
+
+internal class PaymentAuthWebChromeClient(
+    private val activity: Activity,
+    private val logger: Logger
+) : WebChromeClient() {
+    override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
+        consoleMessage?.message()?.let(logger::debug)
+        return super.onConsoleMessage(consoleMessage)
+    }
+
+    override fun onJsConfirm(
+        view: WebView?,
+        url: String?,
+        message: String?,
+        result: JsResult?
+    ): Boolean {
+        AlertDialog.Builder(activity, R.style.AlertDialogStyle)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok) { _, _ -> result?.confirm() }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> result?.cancel() }
+            .create()
+            .show()
+        return true
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -1,26 +1,10 @@
 package com.stripe.android.view
 
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
-import android.app.Activity
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.os.Build
 import android.util.AttributeSet
-import android.webkit.ConsoleMessage
-import android.webkit.JsResult
-import android.webkit.URLUtil
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
 import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.appcompat.app.AlertDialog
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.distinctUntilChanged
-import com.stripe.android.Logger
-import com.stripe.android.R
-import com.stripe.android.view.PaymentAuthWebView.PaymentAuthWebViewClient.Companion.BLANK_PAGE
+import com.stripe.android.view.PaymentAuthWebViewClient.Companion.BLANK_PAGE
 
 /**
  * A `WebView` used for authenticating payment details
@@ -30,55 +14,10 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : WebView(context, attrs, defStyleAttr) {
-    private var webViewClient: PaymentAuthWebViewClient? = null
-
-    private val _isPageLoaded = MutableLiveData(false)
-    val isPageLoaded = _isPageLoaded.distinctUntilChanged()
+    internal var onLoadBlank = {}
 
     init {
         configureSettings()
-    }
-
-    fun init(
-        activity: Activity,
-        logger: Logger,
-        clientSecret: String,
-        returnUrl: String? = null
-    ) {
-        val webViewClient = PaymentAuthWebViewClient(
-            { intent -> activity.startActivity(intent) },
-            { activity.finish() },
-            logger,
-            _isPageLoaded,
-            clientSecret,
-            returnUrl
-        )
-        setWebViewClient(webViewClient)
-        this.webViewClient = webViewClient
-
-        webChromeClient = object : WebChromeClient() {
-            override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-                consoleMessage?.message()?.let {
-                    logger.debug(it)
-                }
-                return super.onConsoleMessage(consoleMessage)
-            }
-
-            override fun onJsConfirm(
-                view: WebView?,
-                url: String?,
-                message: String?,
-                result: JsResult?
-            ): Boolean {
-                AlertDialog.Builder(activity, R.style.AlertDialogStyle)
-                    .setMessage(message)
-                    .setPositiveButton(android.R.string.ok) { _, _ -> result?.confirm() }
-                    .setNegativeButton(android.R.string.cancel) { _, _ -> result?.cancel() }
-                    .create()
-                    .show()
-                return true
-            }
-        }
     }
 
     override fun destroy() {
@@ -89,7 +28,10 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     // inspired by https://stackoverflow.com/a/17458577/11103900
     private fun cleanup() {
         clearHistory()
-        loadBlank()
+
+        onLoadBlank()
+        loadUrl(BLANK_PAGE)
+
         onPause()
         removeAllViews()
         destroyDrawingCache()
@@ -100,203 +42,5 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
         settings.javaScriptEnabled = true
         settings.allowContentAccess = false
         settings.domStorageEnabled = true
-    }
-
-    private fun loadBlank() {
-        webViewClient?.let {
-            it.hasLoadedBlank = true
-        }
-        loadUrl(BLANK_PAGE)
-    }
-
-    internal class PaymentAuthWebViewClient(
-        private val activityStarter: (Intent) -> Unit,
-        private val activityFinisher: () -> Unit,
-        private val logger: Logger,
-        private val isPageLoaded: MutableLiveData<Boolean>,
-        private val clientSecret: String,
-        returnUrl: String?
-    ) : WebViewClient() {
-        // user-specified return URL
-        private val userReturnUri: Uri? = returnUrl?.let { Uri.parse(it) }
-
-        var completionUrlParam: String? = null
-            private set
-
-        internal var hasLoadedBlank: Boolean = false
-
-        override fun onPageFinished(view: WebView, url: String?) {
-            logger.debug("PaymentAuthWebViewClient#onPageFinished() - $url")
-            super.onPageFinished(view, url)
-
-            if (!hasLoadedBlank) {
-                // hide the progress bar here because doing it in `onPageCommitVisible()`
-                // potentially causes a crash
-                hideProgressBar()
-            }
-
-            if (url != null && isCompletionUrl(url)) {
-                onAuthCompleted()
-            }
-        }
-
-        private fun hideProgressBar() {
-            logger.debug("PaymentAuthWebViewClient#hideProgressBar()")
-
-            isPageLoaded.value = true
-        }
-
-        private fun isAuthenticateUrl(url: String) = isAllowedUrl(url, AUTHENTICATE_URLS)
-
-        private fun isCompletionUrl(url: String) = isAllowedUrl(url, COMPLETION_URLS)
-
-        private fun isAllowedUrl(url: String, allowedUrls: Set<String>): Boolean {
-            for (completionUrl in allowedUrls) {
-                if (url.startsWith(completionUrl)) {
-                    return true
-                }
-            }
-
-            return false
-        }
-
-        override fun shouldOverrideUrlLoading(view: WebView, urlString: String): Boolean {
-            logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - $urlString")
-            val uri = Uri.parse(urlString)
-            updateCompletionUrl(uri)
-
-            return if (isReturnUrl(uri)) {
-                logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - handle return URL")
-                onAuthCompleted()
-                true
-            } else if ("intent".equals(uri.scheme, ignoreCase = true)) {
-                openIntentScheme(uri)
-                true
-            } else if (!URLUtil.isNetworkUrl(uri.toString())) {
-                // Non-network URLs are likely deep-links into banking apps. If the deep-link can be
-                // opened via an Intent, start it. Otherwise, stop the authentication attempt.
-                openIntent(Intent(Intent.ACTION_VIEW, uri))
-                true
-            } else {
-                super.shouldOverrideUrlLoading(view, urlString)
-            }
-        }
-
-        private fun openIntentScheme(uri: Uri) {
-            logger.debug("PaymentAuthWebViewClient#openIntentScheme()")
-            runCatching {
-                openIntent(Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME))
-            }.onFailure {
-                logger.error("Failed to start Intent.", it)
-                onAuthCompleted()
-            }
-        }
-
-        /**
-         * See https://developer.android.com/training/basics/intents/package-visibility-use-cases
-         * for more details on app-to-app interaction.
-         */
-        private fun openIntent(intent: Intent) {
-            logger.debug("PaymentAuthWebViewClient#openIntent()")
-
-            runCatching {
-                activityStarter(intent)
-            }.onFailure {
-                logger.error("Failed to start Intent.", it)
-
-                if (intent.scheme != "alipays") {
-                    // complete auth if the deep-link can't be opened unless it is Alipay.
-                    // The Alipay web view tries to open the Alipay app as soon as it is opened
-                    // irrespective of whether or not the app is installed.
-                    // If this intent fails to resolve, we should still let the user
-                    // continue on the mobile site.
-                    onAuthCompleted()
-                }
-            }
-        }
-
-        private fun updateCompletionUrl(uri: Uri) {
-            logger.debug("PaymentAuthWebViewClient#updateCompletionUrl()")
-            val returnUrlParam = if (isAuthenticateUrl(uri.toString())) {
-                uri.getQueryParameter(PARAM_RETURN_URL)
-            } else {
-                null
-            }
-
-            if (!returnUrlParam.isNullOrBlank()) {
-                completionUrlParam = returnUrlParam
-            }
-        }
-
-        @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-        override fun shouldOverrideUrlLoading(
-            view: WebView,
-            request: WebResourceRequest
-        ): Boolean {
-            logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(WebResourceRequest)")
-            return shouldOverrideUrlLoading(view, request.url.toString())
-        }
-
-        private fun isReturnUrl(uri: Uri): Boolean {
-            logger.debug("PaymentAuthWebViewClient#isReturnUrl()")
-            when {
-                isPredefinedReturnUrl(uri) -> return true
-
-                // If the `userReturnUri` is known, look for URIs that match it.
-                userReturnUri != null ->
-                    return userReturnUri.scheme != null &&
-                        userReturnUri.scheme == uri.scheme &&
-                        userReturnUri.host != null &&
-                        userReturnUri.host == uri.host
-                else -> {
-                    // Skip opaque (i.e. non-hierarchical) URIs
-                    if (uri.isOpaque) {
-                        return false
-                    }
-
-                    // If the `userReturnUri` is unknown, look for URIs that contain a
-                    // `payment_intent_client_secret` or `setup_intent_client_secret`
-                    // query parameter, and check if its values matches the given `clientSecret`
-                    // as a query parameter.
-                    val paramNames = uri.queryParameterNames
-                    val clientSecret = when {
-                        paramNames.contains(PARAM_PAYMENT_CLIENT_SECRET) ->
-                            uri.getQueryParameter(PARAM_PAYMENT_CLIENT_SECRET)
-                        paramNames.contains(PARAM_SETUP_CLIENT_SECRET) ->
-                            uri.getQueryParameter(PARAM_SETUP_CLIENT_SECRET)
-                        else -> null
-                    }
-                    return this.clientSecret == clientSecret
-                }
-            }
-        }
-
-        // pre-defined return URLs
-        private fun isPredefinedReturnUrl(uri: Uri): Boolean {
-            return "stripejs://use_stripe_sdk/return_url" == uri.toString()
-        }
-
-        private fun onAuthCompleted() {
-            logger.debug("PaymentAuthWebViewClient#onAuthCompleted()")
-            activityFinisher()
-        }
-
-        internal companion object {
-            internal const val PARAM_PAYMENT_CLIENT_SECRET = "payment_intent_client_secret"
-            internal const val PARAM_SETUP_CLIENT_SECRET = "setup_intent_client_secret"
-
-            private val AUTHENTICATE_URLS = setOf(
-                "https://hooks.stripe.com/three_d_secure/authenticate"
-            )
-
-            private val COMPLETION_URLS = setOf(
-                "https://hooks.stripe.com/redirect/complete/src_",
-                "https://hooks.stripe.com/3d_secure/complete/tdsrc_"
-            )
-
-            private const val PARAM_RETURN_URL = "return_url"
-
-            internal const val BLANK_PAGE = "about:blank"
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -33,7 +33,7 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     private var webViewClient: PaymentAuthWebViewClient? = null
 
     private val _isPageLoaded = MutableLiveData(false)
-    val isLoadedPage = _isPageLoaded.distinctUntilChanged()
+    val isPageLoaded = _isPageLoaded.distinctUntilChanged()
 
     init {
         configureSettings()

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -15,9 +15,9 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.ProgressBar
 import androidx.appcompat.app.AlertDialog
-import androidx.core.view.isGone
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
 import com.stripe.android.Logger
 import com.stripe.android.R
 import com.stripe.android.view.PaymentAuthWebView.PaymentAuthWebViewClient.Companion.BLANK_PAGE
@@ -32,6 +32,9 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
 ) : WebView(context, attrs, defStyleAttr) {
     private var webViewClient: PaymentAuthWebViewClient? = null
 
+    private val _isPageLoaded = MutableLiveData(false)
+    val isLoadedPage = _isPageLoaded.distinctUntilChanged()
+
     init {
         configureSettings()
     }
@@ -39,14 +42,14 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     fun init(
         activity: Activity,
         logger: Logger,
-        progressBar: ProgressBar,
         clientSecret: String,
         returnUrl: String? = null
     ) {
         val webViewClient = PaymentAuthWebViewClient(
-            activity,
+            { intent -> activity.startActivity(intent) },
+            { activity.finish() },
             logger,
-            progressBar,
+            _isPageLoaded,
             clientSecret,
             returnUrl
         )
@@ -107,9 +110,10 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
     }
 
     internal class PaymentAuthWebViewClient(
-        private val activity: Activity,
+        private val activityStarter: (Intent) -> Unit,
+        private val activityFinisher: () -> Unit,
         private val logger: Logger,
-        private val progressBar: ProgressBar,
+        private val isPageLoaded: MutableLiveData<Boolean>,
         private val clientSecret: String,
         returnUrl: String?
     ) : WebViewClient() {
@@ -138,7 +142,8 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
 
         private fun hideProgressBar() {
             logger.debug("PaymentAuthWebViewClient#hideProgressBar()")
-            progressBar.isGone = true
+
+            isPageLoaded.value = true
         }
 
         private fun isAuthenticateUrl(url: String) = isAllowedUrl(url, AUTHENTICATE_URLS)
@@ -195,7 +200,7 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
             logger.debug("PaymentAuthWebViewClient#openIntent()")
 
             runCatching {
-                activity.startActivity(intent)
+                activityStarter(intent)
             }.onFailure {
                 logger.error("Failed to start Intent.", it)
 
@@ -273,7 +278,7 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
 
         private fun onAuthCompleted() {
             logger.debug("PaymentAuthWebViewClient#onAuthCompleted()")
-            activity.finish()
+            activityFinisher()
         }
 
         internal companion object {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isGone
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.Logger
 import com.stripe.android.R
@@ -64,10 +65,16 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         }
 
         logger.debug("PaymentAuthWebViewActivity#onCreate() - PaymentAuthWebView init and loadUrl")
+
+        viewBinding.webView.isLoadedPage.observe(this) { shouldHide ->
+            if (shouldHide) {
+                viewBinding.progressBar.isGone = true
+            }
+        }
+
         viewBinding.webView.init(
             this,
             logger,
-            viewBinding.progressBar,
             clientSecret,
             args.returnUrl
         )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -66,7 +66,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
 
         logger.debug("PaymentAuthWebViewActivity#onCreate() - PaymentAuthWebView init and loadUrl")
 
-        viewBinding.webView.isLoadedPage.observe(this) { shouldHide ->
+        viewBinding.webView.isPageLoaded.observe(this) { shouldHide ->
             if (shouldHide) {
                 viewBinding.progressBar.isGone = true
             }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -1,0 +1,203 @@
+package com.stripe.android.view
+
+import android.annotation.TargetApi
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.webkit.URLUtil
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.lifecycle.MutableLiveData
+import com.stripe.android.Logger
+
+internal class PaymentAuthWebViewClient(
+    private val activityStarter: (Intent) -> Unit,
+    private val activityFinisher: () -> Unit,
+    private val logger: Logger,
+    private val isPageLoaded: MutableLiveData<Boolean>,
+    private val clientSecret: String,
+    returnUrl: String?
+) : WebViewClient() {
+    // user-specified return URL
+    private val userReturnUri: Uri? = returnUrl?.let { Uri.parse(it) }
+
+    var completionUrlParam: String? = null
+        private set
+
+    internal var hasLoadedBlank: Boolean = false
+
+    override fun onPageFinished(view: WebView, url: String?) {
+        logger.debug("PaymentAuthWebViewClient#onPageFinished() - $url")
+        super.onPageFinished(view, url)
+
+        if (!hasLoadedBlank) {
+            // hide the progress bar here because doing it in `onPageCommitVisible()`
+            // potentially causes a crash
+            hideProgressBar()
+        }
+
+        if (url != null && isCompletionUrl(url)) {
+            onAuthCompleted()
+        }
+    }
+
+    private fun hideProgressBar() {
+        logger.debug("PaymentAuthWebViewClient#hideProgressBar()")
+
+        isPageLoaded.value = true
+    }
+
+    private fun isAuthenticateUrl(url: String) = isAllowedUrl(url, AUTHENTICATE_URLS)
+
+    private fun isCompletionUrl(url: String) = isAllowedUrl(url, COMPLETION_URLS)
+
+    private fun isAllowedUrl(url: String, allowedUrls: Set<String>): Boolean {
+        for (completionUrl in allowedUrls) {
+            if (url.startsWith(completionUrl)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, urlString: String): Boolean {
+        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - $urlString")
+        val uri = Uri.parse(urlString)
+        updateCompletionUrl(uri)
+
+        return if (isReturnUrl(uri)) {
+            logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - handle return URL")
+            onAuthCompleted()
+            true
+        } else if ("intent".equals(uri.scheme, ignoreCase = true)) {
+            openIntentScheme(uri)
+            true
+        } else if (!URLUtil.isNetworkUrl(uri.toString())) {
+            // Non-network URLs are likely deep-links into banking apps. If the deep-link can be
+            // opened via an Intent, start it. Otherwise, stop the authentication attempt.
+            openIntent(Intent(Intent.ACTION_VIEW, uri))
+            true
+        } else {
+            super.shouldOverrideUrlLoading(view, urlString)
+        }
+    }
+
+    private fun openIntentScheme(uri: Uri) {
+        logger.debug("PaymentAuthWebViewClient#openIntentScheme()")
+        runCatching {
+            openIntent(Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME))
+        }.onFailure {
+            logger.error("Failed to start Intent.", it)
+            onAuthCompleted()
+        }
+    }
+
+    /**
+     * See https://developer.android.com/training/basics/intents/package-visibility-use-cases
+     * for more details on app-to-app interaction.
+     */
+    private fun openIntent(intent: Intent) {
+        logger.debug("PaymentAuthWebViewClient#openIntent()")
+
+        runCatching {
+            activityStarter(intent)
+        }.onFailure {
+            logger.error("Failed to start Intent.", it)
+
+            if (intent.scheme != "alipays") {
+                // complete auth if the deep-link can't be opened unless it is Alipay.
+                // The Alipay web view tries to open the Alipay app as soon as it is opened
+                // irrespective of whether or not the app is installed.
+                // If this intent fails to resolve, we should still let the user
+                // continue on the mobile site.
+                onAuthCompleted()
+            }
+        }
+    }
+
+    private fun updateCompletionUrl(uri: Uri) {
+        logger.debug("PaymentAuthWebViewClient#updateCompletionUrl()")
+        val returnUrlParam = if (isAuthenticateUrl(uri.toString())) {
+            uri.getQueryParameter(PARAM_RETURN_URL)
+        } else {
+            null
+        }
+
+        if (!returnUrlParam.isNullOrBlank()) {
+            completionUrlParam = returnUrlParam
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    override fun shouldOverrideUrlLoading(
+        view: WebView,
+        request: WebResourceRequest
+    ): Boolean {
+        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(WebResourceRequest)")
+        return shouldOverrideUrlLoading(view, request.url.toString())
+    }
+
+    private fun isReturnUrl(uri: Uri): Boolean {
+        logger.debug("PaymentAuthWebViewClient#isReturnUrl()")
+        when {
+            isPredefinedReturnUrl(uri) -> return true
+
+            // If the `userReturnUri` is known, look for URIs that match it.
+            userReturnUri != null ->
+                return userReturnUri.scheme != null &&
+                    userReturnUri.scheme == uri.scheme &&
+                    userReturnUri.host != null &&
+                    userReturnUri.host == uri.host
+            else -> {
+                // Skip opaque (i.e. non-hierarchical) URIs
+                if (uri.isOpaque) {
+                    return false
+                }
+
+                // If the `userReturnUri` is unknown, look for URIs that contain a
+                // `payment_intent_client_secret` or `setup_intent_client_secret`
+                // query parameter, and check if its values matches the given `clientSecret`
+                // as a query parameter.
+                val paramNames = uri.queryParameterNames
+                val clientSecret = when {
+                    paramNames.contains(PARAM_PAYMENT_CLIENT_SECRET) ->
+                        uri.getQueryParameter(PARAM_PAYMENT_CLIENT_SECRET)
+                    paramNames.contains(PARAM_SETUP_CLIENT_SECRET) ->
+                        uri.getQueryParameter(PARAM_SETUP_CLIENT_SECRET)
+                    else -> null
+                }
+                return this.clientSecret == clientSecret
+            }
+        }
+    }
+
+    // pre-defined return URLs
+    private fun isPredefinedReturnUrl(uri: Uri): Boolean {
+        return "stripejs://use_stripe_sdk/return_url" == uri.toString()
+    }
+
+    private fun onAuthCompleted() {
+        logger.debug("PaymentAuthWebViewClient#onAuthCompleted()")
+        activityFinisher()
+    }
+
+    internal companion object {
+        internal const val PARAM_PAYMENT_CLIENT_SECRET = "payment_intent_client_secret"
+        internal const val PARAM_SETUP_CLIENT_SECRET = "setup_intent_client_secret"
+
+        private val AUTHENTICATE_URLS = setOf(
+            "https://hooks.stripe.com/three_d_secure/authenticate"
+        )
+
+        private val COMPLETION_URLS = setOf(
+            "https://hooks.stripe.com/redirect/complete/src_",
+            "https://hooks.stripe.com/3d_secure/complete/tdsrc_"
+        )
+
+        private const val PARAM_RETURN_URL = "return_url"
+
+        internal const val BLANK_PAGE = "about:blank"
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/FakeLogger.kt
+++ b/stripe/src/test/java/com/stripe/android/FakeLogger.kt
@@ -1,12 +1,19 @@
 package com.stripe.android
 
 internal class FakeLogger : Logger {
+    val debugLogs = mutableListOf<String>()
+    val infoLogs = mutableListOf<String>()
+    val errorLogs = mutableListOf<Pair<String, Throwable?>>()
+
     override fun debug(msg: String) {
+        debugLogs.add(msg)
     }
 
     override fun error(msg: String, t: Throwable?) {
+        errorLogs.add(msg to t)
     }
 
     override fun info(msg: String) {
+        infoLogs.add(msg)
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebChromeClientTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebChromeClientTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.view
+
+import android.webkit.ConsoleMessage
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.stripe.android.FakeLogger
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentAuthWebChromeClientTest {
+
+    private val logger = FakeLogger()
+    private val webChromeClient = PaymentAuthWebChromeClient(
+        mock(),
+        logger
+    )
+
+    @Test
+    fun foo() {
+        webChromeClient.onConsoleMessage(
+            ConsoleMessage("hello world", "", 0, ConsoleMessage.MessageLevel.DEBUG)
+        )
+        assertThat(logger.debugLogs)
+            .containsExactly("hello world")
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebChromeClientTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebChromeClientTest.kt
@@ -18,7 +18,7 @@ class PaymentAuthWebChromeClientTest {
     )
 
     @Test
-    fun foo() {
+    fun `onConsoleMessage should write to logger`() {
         webChromeClient.onConsoleMessage(
             ConsoleMessage("hello world", "", 0, ConsoleMessage.MessageLevel.DEBUG)
         )

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
-class PaymentAuthWebViewTest {
+class PaymentAuthWebViewClientTest {
 
     private lateinit var activity: Activity
     private lateinit var webView: WebView
@@ -214,8 +214,8 @@ class PaymentAuthWebViewTest {
         activityStarter: (Intent) -> Unit = {},
         activityFinisher: () -> Unit = { activity.finish() },
         returnUrl: String? = null
-    ): PaymentAuthWebView.PaymentAuthWebViewClient {
-        return PaymentAuthWebView.PaymentAuthWebViewClient(
+    ): PaymentAuthWebViewClient {
+        return PaymentAuthWebViewClient(
             activityStarter,
             activityFinisher,
             FakeLogger(),

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -2,75 +2,103 @@ package com.stripe.android.view
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.webkit.WebView
-import android.widget.ProgressBar
-import com.nhaarman.mockitokotlin2.KArgumentCaptor
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import androidx.lifecycle.MutableLiveData
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.FakeLogger
+import com.stripe.android.PaymentConfiguration
 import org.junit.runner.RunWith
-import org.mockito.Mockito.never
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentAuthWebViewTest {
 
-    private val activity: Activity = mock()
-    private val progressBar: ProgressBar = mock()
-    private val webView: WebView = mock()
+    private lateinit var activity: Activity
+    private lateinit var webView: WebView
 
-    private val intentArgumentCaptor: KArgumentCaptor<Intent> = argumentCaptor()
+    private val isPageLoaded = MutableLiveData(false)
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    @BeforeTest
+    fun setup() {
+        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+
+        activityScenarioFactory.createAddPaymentMethodActivity().use {
+            it.onActivity { activity ->
+                webView = WebView(activity)
+                this.activity = activity
+            }
+        }
+    }
 
     @Test
     fun shouldOverrideUrlLoading_withPaymentIntent_shouldSetResult() {
-        val url = "stripe://payment_intent_return?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
+        val url =
+            "stripe://payment_intent_return?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient(
             "pi_123_secret_456",
-            "stripe://payment_intent_return"
+            returnUrl = "stripe://payment_intent_return"
         )
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withSetupIntent_shouldSetResult() {
-        val url = "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
-        val paymentAuthWebViewClient = createWebViewClient("seti_1234_secret_5678", "stripe://payment_auth")
+        val url =
+            "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
+        val paymentAuthWebViewClient = createWebViewClient(
+            "seti_1234_secret_5678",
+            returnUrl = "stripe://payment_auth"
+        )
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withoutReturnUrl_onPaymentIntentImplicitReturnUrl_shouldSetResult() {
-        val url = "stripe://payment_intent_return?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
+        val url =
+            "stripe://payment_intent_return?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withoutReturnUrl_onSetupIntentImplicitReturnUrl_shouldSetResult() {
-        val url = "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
+        val url =
+            "stripe://payment_auth?setup_intent=seti_1234" + "&setup_intent_client_secret=seti_1234_secret_5678&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("seti_1234_secret_5678")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity).finish()
+
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withoutReturnUrl_shouldNotAutoFinishActivity() {
-        val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
+        var activityFinisherInvoked = false
+        val paymentAuthWebViewClient = createWebViewClient(
+            "pi_123_secret_456",
+            activityFinisher = { activityFinisherInvoked = true }
+        )
         paymentAuthWebViewClient.shouldOverrideUrlLoading(
             webView,
             "https://example.com"
         )
-        verify(activity, never()).finish()
+        assertThat(activityFinisherInvoked)
+            .isFalse()
     }
 
     @Test
@@ -80,17 +108,21 @@ class PaymentAuthWebViewTest {
             webView,
             "stripejs://use_stripe_sdk/return_url"
         )
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
-    fun onPageFinished_wit3DSecureCompleteUrl_shouldFinish() {
+    fun onPageFinished_wit3DSecureCompleteUrl_shouldHideProgressAndFinish() {
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.onPageFinished(
             webView,
             "https://hooks.stripe.com/3d_secure/complete/tdsrc_1ExLWoCRMbs6FrXfjPJRYtng"
         )
-        verify(activity).finish()
+        assertThat(isPageLoaded.value)
+            .isTrue()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
@@ -100,25 +132,28 @@ class PaymentAuthWebViewTest {
             webView,
             "https://hooks.stripe.com/redirect/complete/src_1ExLWoCRMbs6FrXfjPJRYtng"
         )
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withOpaqueUri_shouldNotCrash() {
-        val url = "mailto:patrick@example.com?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
+        val url =
+            "mailto:patrick@example.com?payment_intent=pi_123&" + "payment_intent_client_secret=pi_123_secret_456&source_type=card"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
     }
 
     @Test
     fun shouldOverrideUrlLoading_withUnsupportedDeeplink_shouldFinish() {
-        whenever(activity.startActivity(any()))
-            .thenThrow(ActivityNotFoundException())
-
         val url = "deep://link"
-        val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
+        val paymentAuthWebViewClient = createWebViewClient(
+            "pi_123_secret_456",
+            activityStarter = { throw ActivityNotFoundException() }
+        )
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
@@ -126,52 +161,65 @@ class PaymentAuthWebViewTest {
         val url = "alipays://link"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        verify(activity, never()).finish()
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withIntentUri_shouldParseUri() {
-        whenever(activity.startActivity(any()))
-            .thenThrow(ActivityNotFoundException())
+        val capturedIntents = mutableListOf<Intent>()
 
-        val deepLink = "intent://example.com/#Intent;scheme=https;action=android.intent.action.VIEW;end"
-        val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
-        paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, deepLink)
-        verify(activity).startActivity(
-            intentArgumentCaptor.capture()
+        val deepLink =
+            "intent://example.com/#Intent;scheme=https;action=android.intent.action.VIEW;end"
+        val paymentAuthWebViewClient = createWebViewClient(
+            "pi_123_secret_456",
+            activityStarter = {
+                capturedIntents.add(it)
+                throw ActivityNotFoundException()
+            }
         )
-        val intent = intentArgumentCaptor.firstValue
-        assertEquals("https://example.com/", intent.dataString)
-        verify(activity).finish()
+        paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, deepLink)
+
+        val intent = capturedIntents.first()
+        assertThat(intent.dataString)
+            .isEqualTo("https://example.com/")
+        assertThat(activity.isFinishing)
+            .isTrue()
     }
 
     @Test
     fun shouldOverrideUrlLoading_withAuthenticationUrlWithReturnUrlParam_shouldPopulateCompletionUrl() {
-        val url = "https://hooks.stripe.com/three_d_secure/authenticate?amount=1250&client_secret=src_client_secret_abc123&return_url=https%3A%2F%2Fhooks.stripe.com%2Fredirect%2Fcomplete%2Fsrc_X9Y8Z7%3Fclient_secret%3Dsrc_client_secret_abc123&source=src_X9Y8Z7&usage=single_use"
+        val url =
+            "https://hooks.stripe.com/three_d_secure/authenticate?amount=1250&client_secret=src_client_secret_abc123&return_url=https%3A%2F%2Fhooks.stripe.com%2Fredirect%2Fcomplete%2Fsrc_X9Y8Z7%3Fclient_secret%3Dsrc_client_secret_abc123&source=src_X9Y8Z7&usage=single_use"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        assertEquals(
-            "https://hooks.stripe.com/redirect/complete/src_X9Y8Z7?client_secret=src_client_secret_abc123",
-            paymentAuthWebViewClient.completionUrlParam
-        )
+        assertThat(paymentAuthWebViewClient.completionUrlParam)
+            .isEqualTo(
+                "https://hooks.stripe.com/redirect/complete/src_X9Y8Z7?client_secret=src_client_secret_abc123"
+            )
     }
 
     @Test
     fun shouldOverrideUrlLoading_withAuthenticationUrlWithoutReturnUrlParam_shouldNotPopulateCompletionUrl() {
-        val url = "https://hooks.stripe.com/three_d_secure/authenticate?amount=1250&client_secret=src_client_secret_abc123&return_url=&source=src_X9Y8Z7&usage=single_use"
+        val url =
+            "https://hooks.stripe.com/three_d_secure/authenticate?amount=1250&client_secret=src_client_secret_abc123&return_url=&source=src_X9Y8Z7&usage=single_use"
         val paymentAuthWebViewClient = createWebViewClient("pi_123_secret_456")
         paymentAuthWebViewClient.shouldOverrideUrlLoading(webView, url)
-        assertNull(paymentAuthWebViewClient.completionUrlParam)
+        assertThat(paymentAuthWebViewClient.completionUrlParam)
+            .isNull()
     }
 
     private fun createWebViewClient(
         clientSecret: String,
+        activityStarter: (Intent) -> Unit = {},
+        activityFinisher: () -> Unit = { activity.finish() },
         returnUrl: String? = null
     ): PaymentAuthWebView.PaymentAuthWebViewClient {
         return PaymentAuthWebView.PaymentAuthWebViewClient(
-            activity,
+            activityStarter,
+            activityFinisher,
             FakeLogger(),
-            progressBar,
+            isPageLoaded,
             clientSecret,
             returnUrl
         )


### PR DESCRIPTION


# Summary
- Move `PaymentAuthWebViewClient` to its own class
- Create `PaymentAuthWebChromeClient`
- Remove `PaymentAuthWebView#init`


# Motivation
In a follow up PR, will call `setResult` in `PaymentAuthWebViewActivity`
that correctly reflects the result of the authentication attempt (e.g.
include any encountered exceptions).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
