### PR TITLE
Fix: cardInputWidget users can set the CVC text

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5469,7 +5469,9 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public fun setCardNumberTextWatcher (Landroid/text/TextWatcher;)V
 	public fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setCvcCode (Ljava/lang/String;)V
+	public final fun setCvcLabel (Ljava/lang/String;)V
 	public fun setCvcNumberTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setCvcPlaceholderText (Ljava/lang/String;)V
 	public fun setEnabled (Z)V
 	public fun setExpiryDate (II)V
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5471,7 +5471,6 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public fun setCvcCode (Ljava/lang/String;)V
 	public final fun setCvcLabel (Ljava/lang/String;)V
 	public fun setCvcNumberTextWatcher (Landroid/text/TextWatcher;)V
-	public final fun setCvcPlaceholderText (Ljava/lang/String;)V
 	public fun setEnabled (Z)V
 	public fun setExpiryDate (II)V
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -828,7 +828,7 @@ class CardInputWidget @JvmOverloads constructor(
     /**
      * Set an optional CVC placeholder text to override defaults, or `null` to use defaults.
      */
-    internal fun setCvcPlaceholderText(cvcPlaceholderText: String?) {
+    fun setCvcPlaceholderText(cvcPlaceholderText: String?) {
         customCvcPlaceholderText = cvcPlaceholderText
         updateCvc()
     }

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -57,6 +57,8 @@ class CardInputWidget @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr), CardWidget {
+    private var customCvcPlaceholderText: String? = null
+    private var customCvcLabel: String? = null
     private val viewBinding = CardInputWidgetBinding.inflate(
         LayoutInflater.from(context),
         this
@@ -794,7 +796,7 @@ class CardInputWidget @JvmOverloads constructor(
         cardNumberEditText.brandChangeCallback = { brand ->
             cardBrandView.brand = brand
             hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
-            cvcEditText.updateBrand(brand)
+            updateCvc()
         }
 
         expiryDateEditText.completionCallback = {
@@ -821,6 +823,31 @@ class CardInputWidget @JvmOverloads constructor(
         cardNumberEditText.isLoadingCallback = {
             cardBrandView.isLoading = it
         }
+    }
+
+    /**
+     * Set an optional CVC placeholder text to override defaults, or `null` to use defaults.
+     */
+    internal fun setCvcPlaceholderText(cvcPlaceholderText: String?) {
+        customCvcPlaceholderText = cvcPlaceholderText
+        updateCvc()
+    }
+
+    /**
+     * Set an optional CVC field label to override defaults, or `null` to use defaults.
+     */
+    fun setCvcLabel(cvcLabel: String?) {
+        customCvcLabel = cvcLabel
+        updateCvc()
+    }
+
+    private fun updateCvc() {
+        cvcEditText.updateBrand(
+            cardBrandView.brand,
+            customCvcLabel,
+            customCvcPlaceholderText,
+            cvcNumberTextInputLayout
+        )
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -57,7 +57,6 @@ class CardInputWidget @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr), CardWidget {
-    private var customCvcPlaceholderText: String? = null
     private var customCvcLabel: String? = null
     private val viewBinding = CardInputWidgetBinding.inflate(
         LayoutInflater.from(context),
@@ -826,14 +825,6 @@ class CardInputWidget @JvmOverloads constructor(
     }
 
     /**
-     * Set an optional CVC placeholder text to override defaults, or `null` to use defaults.
-     */
-    fun setCvcPlaceholderText(cvcPlaceholderText: String?) {
-        customCvcPlaceholderText = cvcPlaceholderText
-        updateCvc()
-    }
-
-    /**
      * Set an optional CVC field label to override defaults, or `null` to use defaults.
      */
     fun setCvcLabel(cvcLabel: String?) {
@@ -844,9 +835,7 @@ class CardInputWidget @JvmOverloads constructor(
     private fun updateCvc() {
         cvcEditText.updateBrand(
             cardBrandView.brand,
-            customCvcLabel,
-            customCvcPlaceholderText,
-            cvcNumberTextInputLayout
+            customCvcLabel
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1577,6 +1577,13 @@ internal class CardInputWidgetTest {
             )
     }
 
+    @Test
+    fun `setCvcLabel is not reset when card number entered`() {
+        cardInputWidget.setCvcLabel("123")
+        assertThat(cardInputWidget.cvcEditText.hint)
+            .isEqualTo("123")
+    }
+
     private fun updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)
         idleLooper()


### PR DESCRIPTION
# Summary / Motivation
User requested feature, that makes it consistent with ios

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
