### PR TITLE
Add 3DS1 challenge analytics

### DIFF
--- a/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
+++ b/stripe/src/main/java/com/stripe/android/AnalyticsEvent.kt
@@ -40,6 +40,9 @@ internal enum class AnalyticsEvent(internal val code: String) {
 
     // 3DS1
     Auth3ds1Sdk("3ds1_sdk"),
+    Auth3ds1ChallengeStart("3ds1_challenge_start"),
+    Auth3ds1ChallengeError("3ds1_challenge_error"),
+    Auth3ds1ChallengeComplete("3ds1_challenge_complete"),
 
     // FPX
     FpxBankStatusesRetrieve("retrieve_fpx_bank_statuses"),

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -329,6 +329,7 @@ internal class StripePaymentController internal constructor(
 
             paymentAuthWebViewStarterFactory(host).start(
                 PaymentAuthWebViewContract.Args(
+                    objectId = source.id.orEmpty(),
                     requestCode = SOURCE_REQUEST_CODE,
                     clientSecret = source.clientSecret.orEmpty(),
                     url = source.redirect?.url.orEmpty(),
@@ -635,6 +636,7 @@ internal class StripePaymentController internal constructor(
         )
         beginWebAuth(
             paymentAuthWebViewStarterFactory(host),
+            stripeIntent,
             getRequestCode(stripeIntent),
             stripeIntent.clientSecret.orEmpty(),
             nextActionData.url,
@@ -662,6 +664,7 @@ internal class StripePaymentController internal constructor(
 
         beginWebAuth(
             paymentAuthWebViewStarterFactory(host),
+            stripeIntent,
             getRequestCode(stripeIntent),
             stripeIntent.clientSecret.orEmpty(),
             nextActionData.url.toString(),
@@ -694,6 +697,7 @@ internal class StripePaymentController internal constructor(
 
         beginWebAuth(
             paymentAuthWebViewStarterFactory(host),
+            stripeIntent,
             getRequestCode(stripeIntent),
             stripeIntent.clientSecret.orEmpty(),
             nextActionData.webViewUrl.toString(),
@@ -713,6 +717,7 @@ internal class StripePaymentController internal constructor(
         if (nextActionData.hostedVoucherUrl != null) {
             beginWebAuth(
                 paymentAuthWebViewStarterFactory(host),
+                stripeIntent,
                 getRequestCode(stripeIntent),
                 stripeIntent.clientSecret.orEmpty(),
                 nextActionData.hostedVoucherUrl,
@@ -905,6 +910,7 @@ internal class StripePaymentController internal constructor(
         )
         beginWebAuth(
             paymentAuthWebViewStarterFactory(host),
+            stripeIntent,
             getRequestCode(stripeIntent),
             stripeIntent.clientSecret.orEmpty(),
             fallbackRedirectUrl,
@@ -1212,6 +1218,7 @@ internal class StripePaymentController internal constructor(
          */
         private fun beginWebAuth(
             paymentWebWebViewStarter: PaymentAuthWebViewStarter,
+            stripeIntent: StripeIntent,
             requestCode: Int,
             clientSecret: String,
             authUrl: String,
@@ -1224,6 +1231,7 @@ internal class StripePaymentController internal constructor(
             Logger.getInstance(enableLogging).debug("PaymentAuthWebViewStarter#start()")
             paymentWebWebViewStarter.start(
                 PaymentAuthWebViewContract.Args(
+                    objectId = stripeIntent.id.orEmpty(),
                     requestCode,
                     clientSecret,
                     authUrl,

--- a/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
@@ -38,6 +38,7 @@ internal class PaymentAuthWebViewContract : ActivityResultContract<PaymentAuthWe
 
     @Parcelize
     internal data class Args(
+        val objectId: String,
         val requestCode: Int,
         val clientSecret: String,
         val url: String,

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -88,8 +88,8 @@ internal class PaymentAuthWebViewActivityViewModel(
                 args.objectId
             ).plus(
                 mapOf(
-                    "error_message" to error.message.orEmpty(),
-                    "error_stacktrace" to error.stackTraceToString()
+                    FIELD_ERROR_MESSAGE to error.message.orEmpty(),
+                    FIELD_ERROR_STACKTRACE to error.stackTraceToString()
                 )
             ),
             uri
@@ -123,7 +123,7 @@ internal class PaymentAuthWebViewActivityViewModel(
             analyticsRequestFactory.create(
                 event
                     .plus(
-                        mapOf("challenge_uri" to sanitizedUri)
+                        mapOf(FIELD_CHALLENGE_URI to sanitizedUri)
                     )
             )
         )
@@ -149,5 +149,11 @@ internal class PaymentAuthWebViewActivityViewModel(
                 AnalyticsDataFactory(application, publishableKey)
             ) as T
         }
+    }
+
+    private companion object {
+        private const val FIELD_CHALLENGE_URI = "challenge_uri"
+        private const val FIELD_ERROR_MESSAGE = "error_message"
+        private const val FIELD_ERROR_STACKTRACE = "error_stacktrace"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -1,16 +1,26 @@
 package com.stripe.android.view
 
+import android.app.Application
 import android.content.Intent
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.AnalyticsEvent
+import com.stripe.android.Logger
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentAuthWebViewContract
+import com.stripe.android.networking.AnalyticsDataFactory
+import com.stripe.android.networking.AnalyticsRequest
+import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 
 internal class PaymentAuthWebViewActivityViewModel(
-    private val args: PaymentAuthWebViewContract.Args
+    private val args: PaymentAuthWebViewContract.Args,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequest.Factory,
+    private val analyticsDataFactory: AnalyticsDataFactory
 ) : ViewModel() {
     @JvmSynthetic
     internal val buttonText = args.toolbarCustomization?.let { toolbarCustomization ->
@@ -52,16 +62,92 @@ internal class PaymentAuthWebViewActivityViewModel(
             )
         }
 
+    /**
+     * Log that 3DS1 challenge started.
+     */
+    fun logStart(uri: Uri?) {
+        fireAnalytics(
+            analyticsDataFactory.createAuthParams(
+                AnalyticsEvent.Auth3ds1ChallengeStart,
+                args.objectId
+            ),
+            uri
+        )
+    }
+
+    /**
+     * Log that 3DS1 challenge completed with an error.
+     */
+    fun logError(
+        uri: Uri?,
+        error: Throwable
+    ) {
+        fireAnalytics(
+            analyticsDataFactory.createAuthParams(
+                AnalyticsEvent.Auth3ds1ChallengeError,
+                args.objectId
+            ).plus(
+                mapOf(
+                    "error_message" to error.message.orEmpty(),
+                    "error_stacktrace" to error.stackTraceToString()
+                )
+            ),
+            uri
+        )
+    }
+
+    /**
+     * Log that 3DS1 challenge completed without an error.
+     */
+    fun logComplete(uri: Uri?) {
+        fireAnalytics(
+            analyticsDataFactory.createAuthParams(
+                AnalyticsEvent.Auth3ds1ChallengeComplete,
+                args.objectId
+            ),
+            uri
+        )
+    }
+
+    private fun fireAnalytics(
+        event: Map<String, Any>,
+        uri: Uri?
+    ) {
+        val sanitizedUri = if (uri != null) {
+            "${uri.scheme}://${uri.host}"
+        } else {
+            ""
+        }
+
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.create(
+                event
+                    .plus(
+                        mapOf("challenge_uri" to sanitizedUri)
+                    )
+            )
+        )
+    }
+
     internal data class ToolbarTitleData(
         internal val text: String,
         internal val toolbarCustomization: StripeToolbarCustomization
     )
 
     internal class Factory(
+        private val application: Application,
+        private val logger: Logger,
         private val args: PaymentAuthWebViewContract.Args
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return PaymentAuthWebViewActivityViewModel(args) as T
+            val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
+
+            return PaymentAuthWebViewActivityViewModel(
+                args,
+                AnalyticsRequestExecutor.Default(logger),
+                AnalyticsRequest.Factory(logger),
+                AnalyticsDataFactory(application, publishableKey)
+            ) as T
         }
     }
 }

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
@@ -63,6 +63,7 @@ class PaymentAuthWebViewStarterTest {
 
     private companion object {
         private val DATA = PaymentAuthWebViewContract.Args(
+            objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
             requestCode = 50000,
             clientSecret = "pi_1EceMnCRMbs6FrXfCXdF8dnx_secret_vew0L3IGaO0x9o0eyRMGzKr0k",
             url = "https://hooks.stripe.com/",

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -937,7 +937,7 @@ internal class StripePaymentControllerTest {
         assertThat(launcher.launchArgs)
             .containsExactly(
                 PaymentAuthWebViewContract.Args(
-                    objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
+                    objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
                     requestCode = 50000,
                     clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
                     stripeAccountId = ACCOUNT_ID,

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -937,6 +937,7 @@ internal class StripePaymentControllerTest {
         assertThat(launcher.launchArgs)
             .containsExactly(
                 PaymentAuthWebViewContract.Args(
+                    objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
                     requestCode = 50000,
                     clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
                     stripeAccountId = ACCOUNT_ID,

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -55,7 +56,10 @@ class PaymentAuthWebViewActivityTest {
     fun `setResult is expected value when onAuthComplete is invoked with error`() {
         runOnActivityScenario { activityScenario ->
             activityScenario.onActivity {
-                it.onAuthComplete(ActivityNotFoundException())
+                it.onAuthComplete(
+                    Uri.parse("https://example.com"),
+                    ActivityNotFoundException()
+                )
                 it.finish()
             }
 
@@ -90,6 +94,7 @@ class PaymentAuthWebViewActivityTest {
         private const val CLIENT_SECRET = "client_secret"
 
         private val ARGS = PaymentAuthWebViewContract.Args(
+            objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
             requestCode = REQUEST_CODE,
             clientSecret = CLIENT_SECRET,
             url = "https://example.com"


### PR DESCRIPTION
# Summary
New events:
- `3ds1_challenge_start`
- `3ds1_challenge_error`
- `3ds1_challenge_complete`

Add logs to determine success rate of 3DS1 challenge flow and detect
potential errors.

# Motivation
RUN_MOBILESDK-97

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
