### PR TITLE
Set statusBarColor on StripeGooglePayActivity

### DIFF
--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -72,6 +72,10 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
         }
         args = nullableArgs
 
+        args.statusBarColor?.let {
+            window.statusBarColor = it
+        }
+
         viewModel.googlePayResult.observe(this) { googlePayResult ->
             googlePayResult?.let(::finishWithResult)
         }

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.ColorInt
 import androidx.core.os.bundleOf
 import com.google.android.gms.common.api.Status
 import com.stripe.android.model.PaymentIntent
@@ -40,7 +41,8 @@ internal class StripeGooglePayContract :
     @Parcelize
     data class Args(
         var paymentIntent: PaymentIntent,
-        var config: GooglePayConfig
+        var config: GooglePayConfig,
+        @ColorInt val statusBarColor: Int?
     ) : ActivityStarter.Args {
 
         companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -186,7 +186,8 @@ internal class PaymentSheetViewModel internal constructor(
                         },
                         countryCode = args.googlePayConfig?.countryCode.orEmpty(),
                         merchantName = args.config?.merchantDisplayName
-                    )
+                    ),
+                    statusBarColor = args.statusBarColor
                 )
             }
         } else {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -182,7 +182,8 @@ internal class DefaultFlowController internal constructor(
                         },
                         countryCode = config?.googlePay?.countryCode.orEmpty(),
                         merchantName = config?.merchantDisplayName
-                    )
+                    ),
+                    statusBarColor = statusBarColor()
                 )
             )
         } else {

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.googlepay
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -55,20 +56,40 @@ class StripeGooglePayActivityTest {
         }
     }
 
+    @Test
+    fun `should update statusBarColor`() {
+        runOnActivityScenario(ARGS) { activityScenario ->
+            activityScenario.onActivity { activity ->
+                assertThat(activity.window.statusBarColor)
+                    .isEqualTo(Color.RED)
+                activity.finish()
+            }
+        }
+    }
+
     private fun createActivity(
         args: StripeGooglePayContract.Args,
-        onCreated: (ActivityScenario<StripeGooglePayActivity>) -> Unit
+        onActivityScenario: (ActivityScenario<StripeGooglePayActivity>) -> Unit
+    ) {
+        runOnActivityScenario(args) { activityScenario ->
+            activityScenario.onActivity { activity ->
+                activity.finish()
+            }
+            onActivityScenario(activityScenario)
+        }
+    }
+
+    private fun runOnActivityScenario(
+        args: StripeGooglePayContract.Args,
+        onActivityScenario: (ActivityScenario<StripeGooglePayActivity>) -> Unit
     ) {
         ActivityScenario.launch<StripeGooglePayActivity>(
             contract.createIntent(
                 context,
                 args
             )
-        ).use { activityScenario ->
-            activityScenario.onActivity { activity ->
-                activity.finish()
-            }
-            onCreated(activityScenario)
+        ).use {
+            onActivityScenario(it)
         }
     }
 
@@ -91,7 +112,8 @@ class StripeGooglePayActivityTest {
 
         private val ARGS = StripeGooglePayContract.Args(
             paymentIntent = PAYMENT_INTENT,
-            config = CONFIG
+            config = CONFIG,
+            statusBarColor = Color.RED
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.googlepay
 
+import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -179,7 +180,8 @@ class StripeGooglePayViewModelTest {
 
         private val ARGS = StripeGooglePayContract.Args(
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
-            config = CONFIG
+            config = CONFIG,
+            statusBarColor = Color.RED
         )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.Context
+import android.graphics.Color
 import androidx.activity.ComponentActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
@@ -305,7 +306,8 @@ class DefaultFlowControllerTest {
                         environment = StripeGooglePayEnvironment.Test,
                         countryCode = "US",
                         merchantName = "Widget Store"
-                    )
+                    ),
+                    statusBarColor = Color.RED
                 )
             )
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.Context
-import android.graphics.Color
 import androidx.activity.ComponentActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
@@ -307,7 +306,10 @@ class DefaultFlowControllerTest {
                         countryCode = "US",
                         merchantName = "Widget Store"
                     ),
-                    statusBarColor = Color.RED
+                    statusBarColor = ContextCompat.getColor(
+                        activity,
+                        R.color.stripe_toolbar_color_default_dark
+                    )
                 )
             )
     }


### PR DESCRIPTION
Note that Google Pay SDK's sheet does not retain the previous Activity's
`statusBarColor`, so the actual color will not be correct.