### PR TITLE
Update androidx dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     ktlintVersion = '0.41.0'
     materialVersion = '1.3.0'
 
-    fragmentVersion = '1.3.0'
+    fragmentVersion = '1.3.2'
 
     androidTestVersion = '1.3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     compileSdkVersion = 30
 
     kotlinCoroutinesVersion = '1.4.3'
-    androidLifecycleVersion = '2.3.0'
+    androidLifecycleVersion = '2.3.1'
     espressoVersion = '3.3.0'
     ktlintVersion = '0.41.0'
     materialVersion = '1.3.0'

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -22,7 +22,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
@@ -31,7 +31,7 @@ dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "androidx.activity:activity-ktx:1.2.1"
+    implementation "androidx.activity:activity-ktx:1.2.2"
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     implementation "com.google.android.material:material:$materialVersion"
 
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
-    javadocDeps 'androidx.annotation:annotation:1.1.0'
+    javadocDeps 'androidx.annotation:annotation:1.2.0'
     javadocDeps 'androidx.appcompat:appcompat:1.2.0'
     javadocDeps "com.google.android.material:material:$materialVersion"
 


### PR DESCRIPTION
# Summary
Updated androidx dependencies.
https://developer.android.com/jetpack/androidx/versions/stable-channel#march_24_2021

# Motivation
Upstream bug fixes.
This also makes https://github.com/stripe/stripe-android/pull/3459 obsolete.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
Existing tests.