### PR TITLE
Call the card input widget focus listener when focus is gained.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -760,12 +760,19 @@ class CardInputWidget @JvmOverloads constructor(
             }
         }
 
-        expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
-            if (hasFocus) {
-                scrollEnd()
-                cardInputListener?.onFocusChange(CardInputListener.FocusField.ExpiryDate)
-            }
+      expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
+        if (hasFocus) {
+          scrollEnd()
+          cardInputListener?.onFocusChange(CardInputListener.FocusField.ExpiryDate)
         }
+      }
+
+      postalCodeEditText.internalFocusChangeListeners.add { _, hasFocus ->
+        if (hasFocus) {
+          scrollEnd()
+          cardInputListener?.onFocusChange(CardInputListener.FocusField.PostalCode)
+        }
+      }
 
         expiryDateEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(cardNumberEditText))
         cvcEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(expiryDateEditText))

--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -760,19 +760,19 @@ class CardInputWidget @JvmOverloads constructor(
             }
         }
 
-      expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
-        if (hasFocus) {
-          scrollEnd()
-          cardInputListener?.onFocusChange(CardInputListener.FocusField.ExpiryDate)
+        expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
+            if (hasFocus) {
+                scrollEnd()
+                cardInputListener?.onFocusChange(CardInputListener.FocusField.ExpiryDate)
+            }
         }
-      }
 
-      postalCodeEditText.internalFocusChangeListeners.add { _, hasFocus ->
-        if (hasFocus) {
-          scrollEnd()
-          cardInputListener?.onFocusChange(CardInputListener.FocusField.PostalCode)
+        postalCodeEditText.internalFocusChangeListeners.add { _, hasFocus ->
+            if (hasFocus) {
+                scrollEnd()
+                cardInputListener?.onFocusChange(CardInputListener.FocusField.PostalCode)
+            }
         }
-      }
 
         expiryDateEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(cardNumberEditText))
         cvcEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(expiryDateEditText))

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -780,6 +780,9 @@ internal class CardInputWidgetTest {
     }
 
     @Test
+    fun
+
+    @Test
     fun onUpdateIcon_forCommonLengthBrand_setsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.

--- a/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -780,9 +780,6 @@ internal class CardInputWidgetTest {
     }
 
     @Test
-    fun
-
-    @Test
     fun onUpdateIcon_forCommonLengthBrand_setsLengthOnCvc() {
         // This should set the brand to Visa. Note that more extensive brand checking occurs
         // in CardNumberEditTextTest.
@@ -1317,6 +1314,7 @@ internal class CardInputWidgetTest {
             .isEqualTo(
                 listOf(
                     CardInputListener.FocusField.Cvc,
+                    CardInputListener.FocusField.PostalCode,
                     CardInputListener.FocusField.CardNumber
                 )
             )
@@ -1585,6 +1583,38 @@ internal class CardInputWidgetTest {
         cardInputWidget.setCvcLabel("123")
         assertThat(cardInputWidget.cvcEditText.hint)
             .isEqualTo("123")
+    }
+
+    @Test
+    fun `Verify on postal code focus change listeners trigger the callback`() {
+        cardInputWidget.postalCodeEditText.getParentOnFocusChangeListener().onFocusChange(cardInputWidget.postalCodeEditText, true)
+
+        assertThat(cardInputListener.focusedFields)
+            .contains(CardInputListener.FocusField.PostalCode)
+    }
+
+    @Test
+    fun `Verify on cvc focus change listeners trigger the callback`() {
+        cardInputWidget.cvcEditText.getParentOnFocusChangeListener().onFocusChange(cardInputWidget.cvcEditText, true)
+
+        assertThat(cardInputListener.focusedFields)
+            .contains(CardInputListener.FocusField.Cvc)
+    }
+
+    @Test
+    fun `Verify on expiration date focus change listeners trigger the callback`() {
+        cardInputWidget.expiryDateEditText.getParentOnFocusChangeListener().onFocusChange(cardInputWidget.expiryDateEditText, true)
+
+        assertThat(cardInputListener.focusedFields)
+            .contains(CardInputListener.FocusField.ExpiryDate)
+    }
+
+    @Test
+    fun `Verify on card number focus change listeners trigger the callback`() {
+        cardInputWidget.cardNumberEditText.getParentOnFocusChangeListener().onFocusChange(cardInputWidget.cardNumberEditText, true)
+
+        assertThat(cardInputListener.focusedFields)
+            .contains(CardInputListener.FocusField.CardNumber)
     }
 
     private fun updateCardNumberAndIdle(cardNumber: String) {


### PR DESCRIPTION
# Summary
When the focus on postal code is entered the card input widget focus listener callback should be called.   The CardInputListener.FocusField already included PostalCode as a field that could change, but the callback was never being called.  Care was taken to make sure that this didn't impact the postal code validation on the field.

# Motivation
Requested by a user of the card input widget.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

