### PR TITLE
Make sure CVC, Date, and card number are always LTR regardless of the language

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -50,6 +50,9 @@ import kotlin.properties.Delegates
  *
  * The individual `EditText` views of this widget can be styled by defining a style
  * `Stripe.CardInputWidget.EditText` that extends `Stripe.Base.CardInputWidget.EditText`.
+ *
+ * The card number, cvc, and expiry date will always be left to right regardless of locale.  Postal
+ * code layout direction will be set according to the locale.
  */
 class CardInputWidget @JvmOverloads constructor(
     context: Context,

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -40,6 +40,9 @@ import kotlin.properties.Delegates
  *
  * To enable 19-digit card support, [PaymentConfiguration.init] must be called before
  * [CardMultilineWidget] is instantiated.
+ *
+ * The card number, cvc, and expiry date will always be left to right regardless of locale.  Postal
+ * code layout direction will be set according to the locale.
  */
 class CardMultilineWidget @JvmOverloads constructor(
     context: Context,

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -177,6 +177,8 @@ class CardNumberEditText internal constructor(
         }
 
         updateLengthFilter()
+
+        this.layoutDirection = LAYOUT_DIRECTION_LTR
     }
 
     override fun onAttachedToWindow() {

--- a/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -71,6 +71,8 @@ class CvcEditText @JvmOverloads constructor(
                 shouldShowError = true
             }
         }
+
+        layoutDirection = LAYOUT_DIRECTION_LTR
     }
 
     override val accessibilityText: String?

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -262,6 +262,8 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 shouldShowError = true
             }
         }
+
+        layoutDirection = LAYOUT_DIRECTION_LTR
     }
 
     /**


### PR DESCRIPTION
# Summary
When entering credit card numbers, month, date, and cvc in countries that use rtl formatting, the text view should still be ltr.

# Motivation
https://github.com/stripe/stripe-android/issues/3515

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
