### PR TITLE
Set the default payment method on the custom workflow

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -136,17 +136,19 @@ internal class DefaultFlowControllerInitializer(
         paymentMethods: List<PaymentMethod>
     ) {
         if (prefsRepository.getSavedSelection() == SavedSelection.None) {
-            paymentMethods.firstOrNull()?.let { paymentMethod ->
-                prefsRepository.savePaymentSelection(
-                    PaymentSelection.Saved(paymentMethod)
-                )
+            when {
+                paymentMethods.isNotEmpty() -> {
+                    PaymentSelection.Saved(paymentMethods.first())
+                }
+                isGooglePayReady -> {
+                    PaymentSelection.GooglePay
+                }
+                else -> {
+                    null
+                }
+            }?.let {
+                prefsRepository.savePaymentSelection(it)
             }
-        }
-
-        if (isGooglePayReady &&
-            prefsRepository.getSavedSelection() == SavedSelection.None
-        ) {
-            prefsRepository.savePaymentSelection(PaymentSelection.GooglePay)
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -72,13 +72,8 @@ internal class DefaultFlowControllerInitializer(
                     types = paymentMethodTypes,
                     customerConfig
                 ).let { paymentMethods ->
-                    if (prefsRepository.getSavedSelection() == SavedSelection.None) {
-                        paymentMethods.firstOrNull()?.let { paymentMethod ->
-                            prefsRepository.savePaymentSelection(
-                                PaymentSelection.Saved(paymentMethod)
-                            )
-                        }
-                    }
+
+                    setLastSavedPaymentMethod(prefsRepository, isGooglePayReady, paymentMethods)
 
                     FlowControllerInitializer.InitResult.Success(
                         InitData(
@@ -112,13 +107,19 @@ internal class DefaultFlowControllerInitializer(
                         PaymentMethod.Type.fromCode(it)
                     }
 
+                val savedSelection = if (isGooglePayReady) {
+                    SavedSelection.GooglePay
+                } else {
+                    SavedSelection.None
+                }
+
                 FlowControllerInitializer.InitResult.Success(
                     InitData(
                         config = config,
                         paymentIntent = paymentIntent,
                         paymentMethodTypes = paymentMethodTypes,
                         paymentMethods = emptyList(),
-                        savedSelection = SavedSelection.None,
+                        savedSelection = savedSelection,
                         isGooglePayReady = isGooglePayReady
                     )
                 )
@@ -127,6 +128,26 @@ internal class DefaultFlowControllerInitializer(
                 FlowControllerInitializer.InitResult.Failure(it)
             }
         )
+    }
+
+    private suspend fun setLastSavedPaymentMethod(
+        prefsRepository: PrefsRepository,
+        isGooglePayReady: Boolean,
+        paymentMethods: List<PaymentMethod>
+    ) {
+        if (prefsRepository.getSavedSelection() == SavedSelection.None) {
+            paymentMethods.firstOrNull()?.let { paymentMethod ->
+                prefsRepository.savePaymentSelection(
+                    PaymentSelection.Saved(paymentMethod)
+                )
+            }
+        }
+
+        if (isGooglePayReady &&
+            prefsRepository.getSavedSelection() == SavedSelection.None
+        ) {
+            prefsRepository.savePaymentSelection(PaymentSelection.GooglePay)
+        }
     }
 
     private suspend fun retrieveAllPaymentMethods(


### PR DESCRIPTION
# Summary
The changes here will make it so that if there is no customer, or a customer with no payment methods, and google pay is available that the default selection is google pay.  Simply pressing buy will purchase with this payment method.

# Motivation
It is always better to have a payment method available if possible, so the customer doesn't necessarily have to go in and select one.

# Testing
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

