### PR TITLE
Clean up CardMultilineWidget constructor

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodCardView.kt
@@ -67,10 +67,8 @@ internal class AddPaymentMethodCardView @JvmOverloads internal constructor(
             true
         )
         cardMultilineWidget = viewBinding.cardMultilineWidget
-        cardMultilineWidget.setShouldShowPostalCode(
+        cardMultilineWidget.shouldShowPostalCode =
             billingAddressFields == BillingAddressFields.PostalCode
-        )
-
         billingAddressWidget = viewBinding.billingAddressWidget
         if (billingAddressFields == BillingAddressFields.Full) {
             billingAddressWidget.visibility = View.VISIBLE

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -522,12 +522,6 @@ class CardMultilineWidget @JvmOverloads constructor(
         showCvcIconInCvcField = resId != null
     }
 
-
-//    fun setShouldShowPostalCode(shouldShowPostalCode: Boolean) {
-//        this.shouldShowPostalCode = shouldShowPostalCode
-//        adjustViewForPostalCodeAttribute(shouldShowPostalCode)
-//    }
-
     /**
      * Set the card number. Method does not change text field focus.
      *

--- a/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -47,8 +47,7 @@ import kotlin.properties.Delegates
 class CardMultilineWidget @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0,
-    private var shouldShowPostalCode: Boolean = CardWidget.DEFAULT_POSTAL_CODE_ENABLED
+    defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr), CardWidget {
     private val viewBinding = CardMultilineWidgetBinding.inflate(
         LayoutInflater.from(context),
@@ -107,6 +106,16 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     @ColorInt
     private val tintColorInt: Int
+
+    /**
+     * The postal code field is enabled by default. Disabling the postal code field may impact
+     * auth success rates, so it is discouraged to disable it unless you are collecting the postal
+     * code outside of this form.
+     */
+    internal var shouldShowPostalCode: Boolean
+        by Delegates.observable(CardWidget.DEFAULT_POSTAL_CODE_ENABLED) { _, _, newValue ->
+            adjustViewForPostalCodeAttribute(newValue)
+        }
 
     /**
      * If [shouldShowPostalCode] is true and [postalCodeRequired] is true, then postal code is a
@@ -513,15 +522,11 @@ class CardMultilineWidget @JvmOverloads constructor(
         showCvcIconInCvcField = resId != null
     }
 
-    /**
-     * The postal code field is enabled by default. Disabling the postal code field may impact
-     * auth success rates, so it is discouraged to disable it unless you are collecting the postal
-     * code outside of this form.
-     */
-    fun setShouldShowPostalCode(shouldShowPostalCode: Boolean) {
-        this.shouldShowPostalCode = shouldShowPostalCode
-        adjustViewForPostalCodeAttribute(shouldShowPostalCode)
-    }
+
+//    fun setShouldShowPostalCode(shouldShowPostalCode: Boolean) {
+//        this.shouldShowPostalCode = shouldShowPostalCode
+//        adjustViewForPostalCodeAttribute(shouldShowPostalCode)
+//    }
 
     /**
      * Set the card number. Method does not change text field focus.

--- a/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -109,9 +109,9 @@ internal class CardMultilineWidgetTest {
         shouldShowPostalCode: Boolean
     ): CardMultilineWidget {
         return CardMultilineWidget(
-            activity,
-            shouldShowPostalCode = shouldShowPostalCode
+            activity
         ).also {
+            it.shouldShowPostalCode = shouldShowPostalCode
             it.cardNumberEditText.workContext = testDispatcher
         }
     }
@@ -361,7 +361,7 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsBlank_returnsNull() {
-        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.shouldShowPostalCode = true
         cardMultilineWidget.postalCodeRequired = true
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
@@ -375,7 +375,7 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsNotBlank_returnsNotNull() {
-        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.shouldShowPostalCode = true
         cardMultilineWidget.postalCodeRequired = false
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
@@ -389,7 +389,7 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsNotRequiredAndValueIsBlank_returnsNotNull() {
-        cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.shouldShowPostalCode = true
         cardMultilineWidget.postalCodeRequired = false
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
@@ -559,7 +559,7 @@ internal class CardMultilineWidgetTest {
     fun initView_whenZipRequiredThenSetToHidden_secondRowLosesPostalCodeAndAdjustsMargin() {
         assertThat(fullGroup.postalCodeInputLayout.visibility)
             .isEqualTo(View.VISIBLE)
-        cardMultilineWidget.setShouldShowPostalCode(false)
+        cardMultilineWidget.shouldShowPostalCode = false
         assertThat(fullGroup.postalCodeInputLayout.visibility)
             .isEqualTo(View.GONE)
 
@@ -584,7 +584,7 @@ internal class CardMultilineWidgetTest {
     fun initView_whenZipHiddenThenSetToRequired_secondRowAddsPostalCodeAndAdjustsMargin() {
         assertThat(noZipGroup.postalCodeInputLayout.visibility)
             .isEqualTo(View.GONE)
-        noZipCardMultilineWidget.setShouldShowPostalCode(true)
+        noZipCardMultilineWidget.shouldShowPostalCode = true
         assertThat(noZipGroup.postalCodeInputLayout.visibility)
             .isEqualTo(View.VISIBLE)
 


### PR DESCRIPTION
# Summary
Clean up CardMultilineWidget constructor

# Motivation
The value passed through View constructor will not be picked up in xml

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
