### PR TITLE
Update display of errors on custom save workflow.

### DIFF
--- a/stripe/res/layout/stripe_activity_payment_options.xml
+++ b/stripe/res/layout/stripe_activity_payment_options.xml
@@ -51,7 +51,7 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone"
                     android:layout_marginVertical="2dp"
-                    android:layout_marginHorizontal="10dp" />
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
 
                 <com.stripe.android.paymentsheet.ui.PrimaryButton
                     android:id="@+id/add_button"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -115,9 +115,8 @@ internal class PaymentOptionsViewModel(
                     }
                 },
                 onFailure = {
-                    _processing.value = false
+                    onApiError(it.localizedMessage)
                     _viewState.value = ViewState.PaymentOptions.Ready
-                    // TODO(michelleb-stripe): Handle failure cases
                 }
             )
         }


### PR DESCRIPTION
# Summary
How we display the errors when saving a custom card was updated.  If the save fails we stay on the add card view, and show the error message.   The layout was also updated so it lines up with the Add button.

# Motivation
WIthout adding the error message the user is on the add page, but does not know the cause or if things succeeded or failed.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

