### PR TITLE
Add SDK user agent to PaymentAuthWebView's user agent

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.webkit.WebView
+import com.stripe.android.networking.RequestHeadersFactory
 import com.stripe.android.view.PaymentAuthWebViewClient.Companion.BLANK_PAGE
 
 /**
@@ -39,6 +40,8 @@ internal class PaymentAuthWebView @JvmOverloads constructor(
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun configureSettings() {
+        val sdkUserAgent = RequestHeadersFactory.getUserAgent()
+        settings.userAgentString = "${settings.userAgentString.orEmpty()} [$sdkUserAgent]"
         settings.javaScriptEnabled = true
         settings.allowContentAccess = false
         settings.domStorageEnabled = true

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.view
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentAuthWebViewTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    private val webView: PaymentAuthWebView by lazy {
+        activityScenarioFactory.createView {
+            PaymentAuthWebView(it)
+        }
+    }
+
+    @BeforeTest
+    fun setup() {
+        PaymentConfiguration.init(
+            context,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        )
+    }
+
+    @Test
+    fun `userAgentString should add SDK user agent suffix`() {
+        val userAgent = webView.settings.userAgentString
+        assertThat(userAgent)
+            .contains("AppleWebkit")
+        assertThat(userAgent)
+            .endsWith(" [Stripe/v1 AndroidBindings/16.4.1]")
+    }
+}


### PR DESCRIPTION


# Summary
If the original user agent is:
```
Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
```

The modified user agent would be:
```
Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 [Stripe/v1 AndroidBindings/16.4.1]
```

# Motivation
Help identify what the SDK version that is triggering the
WebView request.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

