### PR TITLE
Add extra headers to PaymentAuthWebViewActivity's loadUrl request

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -100,7 +100,10 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         viewModel.logStart(
             runCatching { Uri.parse(args.url) }.getOrNull()
         )
-        viewBinding.webView.loadUrl(args.url)
+        viewBinding.webView.loadUrl(
+            args.url,
+            viewModel.extraHeaders
+        )
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -8,11 +8,13 @@ import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.AnalyticsEvent
 import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.Stripe
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentAuthWebViewContract
 import com.stripe.android.networking.AnalyticsDataFactory
 import com.stripe.android.networking.AnalyticsRequest
 import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.StripeClientUserAgentHeaderFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 
@@ -22,6 +24,10 @@ internal class PaymentAuthWebViewActivityViewModel(
     private val analyticsRequestFactory: AnalyticsRequest.Factory,
     private val analyticsDataFactory: AnalyticsDataFactory
 ) : ViewModel() {
+    val extraHeaders: Map<String, String> by lazy {
+        StripeClientUserAgentHeaderFactory().create(Stripe.appInfo)
+    }
+
     @JvmSynthetic
     internal val buttonText = args.toolbarCustomization?.let { toolbarCustomization ->
         toolbarCustomization.buttonText.takeUnless { it.isNullOrBlank() }


### PR DESCRIPTION
## Summary
Pass the `X-Stripe-Client-User-Agent` in the initial `hooks.stripe.com` request to help identify the requesting SDK version.

## Screenshot
Verified using https://manytools.org/http-html-text/http-request-headers/

![Screenshot_1617310284](https://user-images.githubusercontent.com/45020849/113352859-d8baaa00-930a-11eb-93a9-e9a6037c14c6.png)
