### PR TITLE
Remove hardcoded SDK versions in tests

### DIFF
--- a/stripe/src/test/java/com/stripe/android/networking/StripeClientUserAgentHeaderFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeClientUserAgentHeaderFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.networking
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.Stripe
 import org.json.JSONObject
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,7 +23,7 @@ class StripeClientUserAgentHeaderFactoryTest {
                 {
                     "os.name": "android",
                     "os.version": "30",
-                    "bindings.version": "16.4.1",
+                    "bindings.version": "${Stripe.VERSION_NAME}",
                     "lang": "Java",
                     "publisher": "Stripe",
                     "http.agent": "example_value"

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.Stripe
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -36,6 +37,6 @@ class PaymentAuthWebViewTest {
         assertThat(userAgent)
             .contains("AppleWebkit")
         assertThat(userAgent)
-            .endsWith(" [Stripe/v1 AndroidBindings/16.4.1]")
+            .endsWith(" [Stripe/v1 AndroidBindings/${Stripe.VERSION_NAME}]")
     }
 }


### PR DESCRIPTION
# Summary
Unbreak tests by using `VERSION_NAME` constant.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
