### PR TITLE
Remove foo appended to the source id.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -915,7 +915,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             apiRequestFactory.createPost(
                 getApiUrl("3ds2/challenge_complete"),
                 requestOptions,
-                mapOf("source" to sourceId + "foo")
+                mapOf("source" to sourceId)
             ),
             Stripe3ds2AuthResultJsonParser()
         ) {


### PR DESCRIPTION
# Summary
Remove the addition of the word "foo" to the source id.

# Motivation
When running through the test case with card ****3238 I was finding that if success, fail, or cancel there were requests being made to complete_callback that were always failing.  In some cases this resulted in taking a really long time for the callbacks to complete.  In looking into the source ID I found that foo was being appended to the end of it.  This change was made in b626db1 when adding the retry logic.  It might have been added to force the testing of the retry.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

