### PR TITLE
Introduce suspend fun for Stripe Android SDK - part2

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -821,8 +821,8 @@ public final class com/stripe/android/Stripe {
 	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun isAuthenticateSourceResult (ILandroid/content/Intent;)Z
-	public final fun isForPaymentIntentResult (ILandroid/content/Intent;)Z
-	public final fun isForSetupIntentResult (ILandroid/content/Intent;)Z
+	public final fun isPaymentResult (ILandroid/content/Intent;)Z
+	public final fun isSetupResult (ILandroid/content/Intent;)Z
 	public final fun onAuthenticateSourceResult (Landroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun onPaymentResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
 	public final fun onSetupResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -821,6 +821,8 @@ public final class com/stripe/android/Stripe {
 	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun handleNextActionForSetupIntent$default (Lcom/stripe/android/Stripe;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun isAuthenticateSourceResult (ILandroid/content/Intent;)Z
+	public final fun isForPaymentIntentResult (ILandroid/content/Intent;)Z
+	public final fun isForSetupIntentResult (ILandroid/content/Intent;)Z
 	public final fun onAuthenticateSourceResult (Landroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun onPaymentResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
 	public final fun onSetupResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
@@ -932,6 +934,9 @@ public final class com/stripe/android/StripeKtxKt {
 	public static synthetic fun createPiiToken$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createSource (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createSource$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun getAuthenticateSourceResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getPaymentIntentResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getSetupIntentResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retrievePaymentIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retrieveSetupIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -151,7 +151,7 @@ internal interface PaymentController {
         APIException::class,
         IllegalArgumentException::class
     )
-    suspend fun getSource(data: Intent): Source
+    suspend fun getAuthenticateSourceResult(data: Intent): Source
 
     /**
      * Determine which authentication mechanism should be used, or bypass authentication

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -55,20 +55,6 @@ internal interface PaymentController {
     fun shouldHandleSourceResult(requestCode: Int, data: Intent?): Boolean
 
     /**
-     * If payment authentication triggered an exception, get the exception object and pass to
-     * [ApiResultCallback.onError].
-     *
-     * Otherwise, get the PaymentIntent's client_secret from {@param data} and use to retrieve
-     * the PaymentIntent object with updated status.
-     *
-     * @param data the result Intent
-     */
-    fun handlePaymentResult(
-        data: Intent,
-        callback: ApiResultCallback<PaymentIntentResult>
-    )
-
-    /**
      * Get the PaymentIntent's client_secret from {@param data} and use to retrieve
      * the PaymentIntent object with updated status.
      *
@@ -91,20 +77,6 @@ internal interface PaymentController {
     suspend fun getPaymentIntentResult(data: Intent): PaymentIntentResult
 
     /**
-     * If setup authentication triggered an exception, get the exception object and pass to
-     * [ApiResultCallback.onError].
-     *
-     * Otherwise, get the SetupIntent's client_secret from {@param data} and use to retrieve the
-     * SetupIntent object with updated status.
-     *
-     * @param data the result Intent
-     */
-    fun handleSetupResult(
-        data: Intent,
-        callback: ApiResultCallback<SetupIntentResult>
-    )
-
-    /**
      * Get the SetupIntent's client_secret from {@param data} and use to retrieve
      * the SetupIntent object with updated status.
      *
@@ -125,11 +97,6 @@ internal interface PaymentController {
         IllegalArgumentException::class
     )
     suspend fun getSetupIntentResult(data: Intent): SetupIntentResult
-
-    fun handleSourceResult(
-        data: Intent,
-        callback: ApiResultCallback<Source>
-    )
 
     /**
      * Get the Source's client_secret from {@param data} and use to retrieve

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -43,19 +43,22 @@ internal interface PaymentController {
     )
 
     /**
-     * Decide whether [handlePaymentResult] should be called.
+     * Decide whether [getPaymentIntentResult] should be called.
      */
     fun shouldHandlePaymentResult(requestCode: Int, data: Intent?): Boolean
 
     /**
-     * Decide whether [handleSetupResult] should be called.
+     * Decide whether [getSetupIntentResult] should be called.
      */
     fun shouldHandleSetupResult(requestCode: Int, data: Intent?): Boolean
 
+    /**
+     * Decide whether [getAuthenticateSourceResult] should be called.
+     */
     fun shouldHandleSourceResult(requestCode: Int, data: Intent?): Boolean
 
     /**
-     * Get the PaymentIntent's client_secret from {@param data} and use to retrieve
+     * Get the PaymentIntent's client_secret from [data] and use to retrieve
      * the PaymentIntent object with updated status.
      *
      * @param data the result Intent
@@ -77,7 +80,7 @@ internal interface PaymentController {
     suspend fun getPaymentIntentResult(data: Intent): PaymentIntentResult
 
     /**
-     * Get the SetupIntent's client_secret from {@param data} and use to retrieve
+     * Get the SetupIntent's client_secret from [data] and use to retrieve
      * the SetupIntent object with updated status.
      *
      * @param data the result Intent
@@ -99,7 +102,7 @@ internal interface PaymentController {
     suspend fun getSetupIntentResult(data: Intent): SetupIntentResult
 
     /**
-     * Get the Source's client_secret from {@param data} and use to retrieve
+     * Get the Source's client_secret from [data] and use to retrieve
      * the Source object with updated status.
      *
      * @param data the result Intent

--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -1,6 +1,10 @@
 package com.stripe.android
 
 import android.content.Intent
+import com.stripe.android.exception.APIConnectionException
+import com.stripe.android.exception.APIException
+import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.Source
@@ -65,6 +69,28 @@ internal interface PaymentController {
     )
 
     /**
+     * Get the PaymentIntent's client_secret from {@param data} and use to retrieve
+     * the PaymentIntent object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [PaymentIntentResult] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the PaymentIntent response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    suspend fun getPaymentIntentResult(data: Intent): PaymentIntentResult
+
+    /**
      * If setup authentication triggered an exception, get the exception object and pass to
      * [ApiResultCallback.onError].
      *
@@ -78,10 +104,54 @@ internal interface PaymentController {
         callback: ApiResultCallback<SetupIntentResult>
     )
 
+    /**
+     * Get the SetupIntent's client_secret from {@param data} and use to retrieve
+     * the SetupIntent object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [SetupIntentResult] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the SetupIntent response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    suspend fun getSetupIntentResult(data: Intent): SetupIntentResult
+
     fun handleSourceResult(
         data: Intent,
         callback: ApiResultCallback<Source>
     )
+
+    /**
+     * Get the Source's client_secret from {@param data} and use to retrieve
+     * the Source object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [Source] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the Source response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    suspend fun getSource(data: Intent): Source
 
     /**
      * Determine which authentication mechanism should be used, or bypass authentication

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -347,7 +347,7 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
-        return if (isPaymentResult(requestCode, data) && data != null) {
+        return if (data != null && isPaymentResult(requestCode, data)) {
             executeAsync(callback) {
                 paymentController.getPaymentIntentResult(data)
             }
@@ -637,7 +637,7 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
-        return if (isSetupResult(requestCode, data) && data != null) {
+        return if (data != null && isSetupResult(requestCode, data)) {
             executeAsync(callback) {
                 paymentController.getSetupIntentResult(data)
             }

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -324,7 +324,7 @@ class Stripe internal constructor(
 
     /**
      * Check if the requestCode and [Intent] is for [PaymentIntentResult].
-     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * The [Intent] should be retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
      * by [Activity] started with [confirmPayment] or [handleNextActionForPayment].
      *
      * @return whether the requestCode and intent is for [PaymentIntentResult].
@@ -615,7 +615,7 @@ class Stripe internal constructor(
 
     /**
      * Check if the requestCode and [Intent] is for [SetupIntentResult].
-     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * The [Intent] should be retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
      * by [Activity] started with [confirmSetupIntent].
      *
      * @return whether the requestCode and intent is for [SetupIntentResult].
@@ -883,7 +883,7 @@ class Stripe internal constructor(
 
     /**
      * Check if the requestCode and [Intent] is for [Source] authentication.
-     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * The [Intent] should be retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
      * by [Activity] started with [authenticateSource].
      *
      * @return whether the requestCode and intent is for [Source] authentication

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -329,7 +329,7 @@ class Stripe internal constructor(
      *
      * @return whether the requestCode and intent is for [PaymentIntentResult].
      */
-    fun isForPaymentIntentResult(
+    fun isPaymentResult(
         requestCode: Int,
         data: Intent?
     ): Boolean {
@@ -347,8 +347,8 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
-        return if (isForPaymentIntentResult(requestCode, data)) {
-            paymentController.handlePaymentResult(data!!, callback)
+        return if (isPaymentResult(requestCode, data) && data != null) {
+            paymentController.handlePaymentResult(data, callback)
             true
         } else {
             false
@@ -618,7 +618,7 @@ class Stripe internal constructor(
      *
      * @return whether the requestCode and intent is for [SetupIntentResult].
      */
-    fun isForSetupIntentResult(
+    fun isSetupResult(
         requestCode: Int,
         data: Intent?
     ): Boolean {
@@ -635,8 +635,8 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
-        return if (isForSetupIntentResult(requestCode, data)) {
-            paymentController.handleSetupResult(data!!, callback)
+        return if (isSetupResult(requestCode, data) && data != null) {
+            paymentController.handleSetupResult(data, callback)
             true
         } else {
             false

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -323,9 +323,9 @@ class Stripe internal constructor(
     }
 
     /**
-     * Check if the requestCode and intent is for [PaymentIntentResult].
-     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
-     * by activity started with [confirmPayment] or [handleNextActionForPayment].
+     * Check if the requestCode and [Intent] is for [PaymentIntentResult].
+     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by [Activity] started with [confirmPayment] or [handleNextActionForPayment].
      *
      * @return whether the requestCode and intent is for [PaymentIntentResult].
      */
@@ -614,9 +614,9 @@ class Stripe internal constructor(
     }
 
     /**
-     * Check if the requestCode and intent is for [SetupIntentResult].
-     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
-     * by activity started with [confirmSetupIntent].
+     * Check if the requestCode and [Intent] is for [SetupIntentResult].
+     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by [Activity] started with [confirmSetupIntent].
      *
      * @return whether the requestCode and intent is for [SetupIntentResult].
      */
@@ -882,9 +882,9 @@ class Stripe internal constructor(
     }
 
     /**
-     * Check if the requestCode and intent is for [Source] authentication.
-     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
-     * by activity started with [authenticateSource].
+     * Check if the requestCode and [Intent] is for [Source] authentication.
+     * The [Intent] should the retrieved from the result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by [Activity] started with [authenticateSource].
      *
      * @return whether the requestCode and intent is for [Source] authentication
      */

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -348,7 +348,9 @@ class Stripe internal constructor(
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
         return if (isPaymentResult(requestCode, data) && data != null) {
-            paymentController.handlePaymentResult(data, callback)
+            executeAsync(callback) {
+                paymentController.getPaymentIntentResult(data)
+            }
             true
         } else {
             false
@@ -636,7 +638,9 @@ class Stripe internal constructor(
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
         return if (isSetupResult(requestCode, data) && data != null) {
-            paymentController.handleSetupResult(data, callback)
+            executeAsync(callback) {
+                paymentController.getSetupIntentResult(data)
+            }
             true
         } else {
             false
@@ -900,10 +904,9 @@ class Stripe internal constructor(
         data: Intent,
         callback: ApiResultCallback<Source>
     ) {
-        paymentController.handleSourceResult(
-            data,
-            callback
-        )
+        executeAsync(callback) {
+            paymentController.getAuthenticateSourceResult(data)
+        }
     }
 
     /**

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -323,6 +323,20 @@ class Stripe internal constructor(
     }
 
     /**
+     * Check if the requestCode and intent is for [PaymentIntentResult].
+     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by activity started with [confirmPayment] or [handleNextActionForPayment].
+     *
+     * @return whether the requestCode and intent is for [PaymentIntentResult].
+     */
+    fun isForPaymentIntentResult(
+        requestCode: Int,
+        data: Intent?
+    ): Boolean {
+        return data != null && paymentController.shouldHandlePaymentResult(requestCode, data)
+    }
+
+    /**
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a PaymentIntent automatic confirmation (see [confirmPayment]) or
      * manual confirmation (see [handleNextActionForPayment]})
@@ -333,8 +347,8 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
-        return if (data != null && paymentController.shouldHandlePaymentResult(requestCode, data)) {
-            paymentController.handlePaymentResult(data, callback)
+        return if (isForPaymentIntentResult(requestCode, data)) {
+            paymentController.handlePaymentResult(data!!, callback)
             true
         } else {
             false
@@ -598,6 +612,20 @@ class Stripe internal constructor(
     }
 
     /**
+     * Check if the requestCode and intent is for [SetupIntentResult].
+     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by activity started with [confirmSetupIntent].
+     *
+     * @return whether the requestCode and intent is for [SetupIntentResult].
+     */
+    fun isForSetupIntentResult(
+        requestCode: Int,
+        data: Intent?
+    ): Boolean {
+        return data != null && paymentController.shouldHandleSetupResult(requestCode, data)
+    }
+
+    /**
      * Should be called via `Activity#onActivityResult(int, int, Intent)}}` to handle the
      * result of a SetupIntent confirmation (see [confirmSetupIntent]).
      */
@@ -607,8 +635,8 @@ class Stripe internal constructor(
         data: Intent?,
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
-        return if (data != null && paymentController.shouldHandleSetupResult(requestCode, data)) {
-            paymentController.handleSetupResult(data, callback)
+        return if (isForSetupIntentResult(requestCode, data)) {
+            paymentController.handleSetupResult(data!!, callback)
             true
         } else {
             false
@@ -850,7 +878,11 @@ class Stripe internal constructor(
     }
 
     /**
-     * Should be called in `onActivityResult()` to determine if the result is for Source authentication
+     * Check if the requestCode and intent is for [Source] authentication.
+     * The Intent should the retrieved from result from `Activity#onActivityResult(int, int, Intent)}}`
+     * by activity started with [authenticateSource].
+     *
+     * @return whether the requestCode and intent is for [Source] authentication
      */
     fun isAuthenticateSourceResult(
         requestCode: Int,

--- a/stripe/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeKtx.kt
@@ -56,7 +56,7 @@ suspend fun Stripe.createPaymentMethod(
     paymentMethodCreateParams: PaymentMethodCreateParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): PaymentMethod = runApiRequestCaptureEmptyResult {
+): PaymentMethod = runApiRequest {
     stripeRepository.createPaymentMethod(
         paymentMethodCreateParams,
         ApiRequest.Options(
@@ -95,7 +95,7 @@ suspend fun Stripe.createSource(
     sourceParams: SourceParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Source = runApiRequestCaptureEmptyResult {
+): Source = runApiRequest {
     stripeRepository.createSource(
         sourceParams,
         ApiRequest.Options(
@@ -134,7 +134,7 @@ suspend fun Stripe.createAccountToken(
     accountParams: AccountParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         accountParams,
         ApiRequest.Options(
@@ -173,7 +173,7 @@ suspend fun Stripe.createBankAccountToken(
     bankAccountTokenParams: BankAccountTokenParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         bankAccountTokenParams,
         ApiRequest.Options(
@@ -212,7 +212,7 @@ suspend fun Stripe.createPiiToken(
     personalId: String,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         PiiTokenParams(personalId),
         ApiRequest.Options(
@@ -253,7 +253,7 @@ suspend fun Stripe.createCardToken(
     cardParams: CardParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         cardParams,
         ApiRequest.Options(
@@ -291,7 +291,7 @@ suspend fun Stripe.createCvcUpdateToken(
     @Size(min = 3, max = 4) cvc: String,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         CvcTokenParams(cvc),
         ApiRequest.Options(
@@ -331,7 +331,7 @@ suspend fun Stripe.createPersonToken(
     params: PersonTokenParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequestCaptureEmptyResult {
+): Token = runApiRequest {
     stripeRepository.createToken(
         params,
         ApiRequest.Options(
@@ -372,7 +372,7 @@ suspend fun Stripe.createFile(
     fileParams: StripeFileParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId,
-): StripeFile = runApiRequestCaptureEmptyResult {
+): StripeFile = runApiRequest {
     stripeRepository.createFile(
         fileParams,
         ApiRequest.Options(
@@ -409,7 +409,7 @@ suspend fun Stripe.createFile(
 suspend fun Stripe.retrievePaymentIntent(
     clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId
-): PaymentIntent = runApiRequestCaptureEmptyResult {
+): PaymentIntent = runApiRequest {
     stripeRepository.retrievePaymentIntent(
         clientSecret,
         ApiRequest.Options(
@@ -445,7 +445,7 @@ suspend fun Stripe.retrievePaymentIntent(
 suspend fun Stripe.retrieveSetupIntent(
     clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId
-): SetupIntent = runApiRequestCaptureEmptyResult {
+): SetupIntent = runApiRequest {
     stripeRepository.retrieveSetupIntent(
         clientSecret,
         ApiRequest.Options(
@@ -483,7 +483,7 @@ suspend fun Stripe.retrieveSource(
     @Size(min = 1) sourceId: String,
     @Size(min = 1) clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId
-): Source = runApiRequestCaptureEmptyResult {
+): Source = runApiRequest {
     stripeRepository.retrieveSource(
         sourceId,
         clientSecret,
@@ -519,7 +519,7 @@ suspend fun Stripe.retrieveSource(
 suspend fun Stripe.confirmSetupIntent(
     confirmSetupIntentParams: ConfirmSetupIntentParams,
     idempotencyKey: String? = null
-): SetupIntent = runApiRequestCaptureEmptyResult {
+): SetupIntent = runApiRequest {
     stripeRepository.confirmSetupIntent(
         confirmSetupIntentParams,
         ApiRequest.Options(
@@ -555,7 +555,7 @@ suspend fun Stripe.confirmSetupIntent(
 suspend fun Stripe.confirmPaymentIntent(
     confirmPaymentIntentParams: ConfirmPaymentIntentParams,
     idempotencyKey: String? = null
-): PaymentIntent = runApiRequestCaptureEmptyResult {
+): PaymentIntent = runApiRequest {
     stripeRepository.confirmPaymentIntent(
         confirmPaymentIntentParams,
         ApiRequest.Options(
@@ -571,12 +571,12 @@ suspend fun Stripe.confirmPaymentIntent(
  *
  * @return the result if the API result and JSON parsing are successful; otherwise, throw an exception.
  */
-private inline fun <reified APIObject : StripeModel> runApiRequestCaptureEmptyResult(
-    block: () -> APIObject?
-): APIObject =
+private inline fun <reified ApiObject : StripeModel> runApiRequest(
+    block: () -> ApiObject?
+): ApiObject =
     runCatching {
         requireNotNull(block()) {
-            "Failed to parse ${APIObject::class.java.simpleName}."
+            "Failed to parse ${ApiObject::class.java.simpleName}."
         }
     }.getOrElse { throw StripeException.create(it) }
 
@@ -601,14 +601,14 @@ private inline fun <reified APIObject : StripeModel> runApiRequestCaptureEmptyRe
 )
 suspend fun Stripe.getPaymentIntentResult(
     requestCode: Int,
-    data: Intent?,
+    data: Intent,
 ): PaymentIntentResult {
-    return runApiRequestCaptureIllegalArgumentException(
-        isForPaymentIntentResult(
+    return runApiRequest(
+        isPaymentResult(
             requestCode,
             data
         )
-    ) { paymentController.getPaymentIntentResult(data!!) }
+    ) { paymentController.getPaymentIntentResult(data) }
 }
 
 /**
@@ -633,14 +633,14 @@ suspend fun Stripe.getPaymentIntentResult(
 )
 suspend fun Stripe.getSetupIntentResult(
     requestCode: Int,
-    data: Intent?,
+    data: Intent,
 ): SetupIntentResult {
-    return runApiRequestCaptureIllegalArgumentException(
-        isForSetupIntentResult(
+    return runApiRequest(
+        isSetupResult(
             requestCode,
             data
         )
-    ) { paymentController.getSetupIntentResult(data!!) }
+    ) { paymentController.getSetupIntentResult(data) }
 }
 
 /**
@@ -664,14 +664,14 @@ suspend fun Stripe.getSetupIntentResult(
 )
 suspend fun Stripe.getAuthenticateSourceResult(
     requestCode: Int,
-    data: Intent?,
+    data: Intent,
 ): Source {
-    return runApiRequestCaptureIllegalArgumentException(
+    return runApiRequest(
         isAuthenticateSourceResult(
             requestCode,
             data
         )
-    ) { paymentController.getSource(data!!) }
+    ) { paymentController.getAuthenticateSourceResult(data) }
 }
 
 /**
@@ -680,13 +680,13 @@ suspend fun Stripe.getAuthenticateSourceResult(
  *
  * @return the result if the API result and JSON parsing are successful; otherwise, throw an exception.
  */
-internal inline fun <reified APIObject : StripeModel> runApiRequestCaptureIllegalArgumentException(
+internal inline fun <reified ApiObject : StripeModel> runApiRequest(
     isValidParam: Boolean,
-    block: () -> APIObject
-): APIObject =
+    block: () -> ApiObject
+): ApiObject =
     runCatching {
         require(isValidParam) {
-            "Incorrect requestCode and data for ${APIObject::class.java.simpleName}."
+            "Incorrect requestCode and data for ${ApiObject::class.java.simpleName}."
         }
         block()
     }.getOrElse { throw StripeException.create(it) }

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -542,7 +542,7 @@ internal class StripePaymentController internal constructor(
         APIException::class,
         IllegalArgumentException::class
     )
-    override suspend fun getSource(data: Intent): Source {
+    override suspend fun getAuthenticateSourceResult(data: Intent): Source {
         val result = PaymentFlowResult.Unvalidated.fromIntent(data)
         val sourceId = result.sourceId.orEmpty()
         val clientSecret = result.clientSecret.orEmpty()

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -5,6 +5,10 @@ import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.auth.PaymentAuthWebViewContract
+import com.stripe.android.exception.APIConnectionException
+import com.stripe.android.exception.APIException
+import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.exception.StripeException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -400,6 +404,31 @@ internal class StripePaymentController internal constructor(
     }
 
     /**
+     * Get the PaymentIntent's client_secret from {@param data} and use to retrieve
+     * the PaymentIntent object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [PaymentIntentResult] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    override suspend fun getPaymentIntentResult(data: Intent) =
+        paymentFlowResultProcessor.processPaymentIntent(
+            PaymentFlowResult.Unvalidated.fromIntent(data)
+        )
+
+    /**
      * If setup authentication triggered an exception, get the exception object and pass to
      * [ApiResultCallback.onError].
      *
@@ -427,6 +456,31 @@ internal class StripePaymentController internal constructor(
             )
         }
     }
+
+    /**
+     * Get the SetupIntent's client_secret from {@param data} and use to retrieve
+     * the PaymentIntent object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [SetupIntentResult] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    override suspend fun getSetupIntentResult(data: Intent) =
+        paymentFlowResultProcessor.processSetupIntent(
+            PaymentFlowResult.Unvalidated.fromIntent(data)
+        )
 
     override fun handleSourceResult(
         data: Intent,
@@ -466,6 +520,53 @@ internal class StripePaymentController internal constructor(
                 )
             }
         }
+    }
+
+    /**
+     * Get the Source's client_secret from {@param data} and use to retrieve
+     * the Source object with updated status.
+     *
+     * @param data the result Intent
+     * @return the [Source] object
+     *
+     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+     * @throws InvalidRequestException your request has invalid parameters
+     * @throws APIConnectionException failure to connect to Stripe's API
+     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+     * @throws IllegalArgumentException if the Source response's JsonParser returns null
+     */
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class,
+        IllegalArgumentException::class
+    )
+    override suspend fun getSource(data: Intent): Source {
+        val result = PaymentFlowResult.Unvalidated.fromIntent(data)
+        val sourceId = result.sourceId.orEmpty()
+        val clientSecret = result.clientSecret.orEmpty()
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = result.stripeAccountId
+        )
+
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.create(
+                analyticsDataFactory.createAuthSourceParams(
+                    AnalyticsEvent.AuthSourceResult,
+                    sourceId
+                )
+            )
+        )
+        return requireNotNull(
+            stripeRepository.retrieveSource(
+                sourceId,
+                clientSecret,
+                requestOptions
+            )
+        )
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -375,35 +375,6 @@ internal class StripePaymentController internal constructor(
     }
 
     /**
-     * If payment authentication triggered an exception, get the exception object and pass to
-     * [ApiResultCallback.onError].
-     *
-     * Otherwise, get the PaymentIntent's client_secret from {@param data} and use to retrieve
-     * the PaymentIntent object with updated status.
-     *
-     * @param data the result Intent
-     */
-    override fun handlePaymentResult(
-        data: Intent,
-        callback: ApiResultCallback<PaymentIntentResult>
-    ) {
-        CoroutineScope(workContext).launch {
-            runCatching {
-                paymentFlowResultProcessor.processPaymentIntent(
-                    PaymentFlowResult.Unvalidated.fromIntent(data)
-                )
-            }.fold(
-                onSuccess = {
-                    dispatchPaymentIntentResult(it, callback)
-                },
-                onFailure = {
-                    dispatchError(it, callback)
-                }
-            )
-        }
-    }
-
-    /**
      * Get the PaymentIntent's client_secret from {@param data} and use to retrieve
      * the PaymentIntent object with updated status.
      *
@@ -429,35 +400,6 @@ internal class StripePaymentController internal constructor(
         )
 
     /**
-     * If setup authentication triggered an exception, get the exception object and pass to
-     * [ApiResultCallback.onError].
-     *
-     * Otherwise, get the SetupIntent's client_secret from {@param data} and use to retrieve the
-     * SetupIntent object with updated status.
-     *
-     * @param data the result Intent
-     */
-    override fun handleSetupResult(
-        data: Intent,
-        callback: ApiResultCallback<SetupIntentResult>
-    ) {
-        CoroutineScope(workContext).launch {
-            runCatching {
-                paymentFlowResultProcessor.processSetupIntent(
-                    PaymentFlowResult.Unvalidated.fromIntent(data)
-                )
-            }.fold(
-                onSuccess = {
-                    dispatchSetupIntentResult(it, callback)
-                },
-                onFailure = {
-                    dispatchError(it, callback)
-                }
-            )
-        }
-    }
-
-    /**
      * Get the SetupIntent's client_secret from {@param data} and use to retrieve
      * the PaymentIntent object with updated status.
      *
@@ -481,46 +423,6 @@ internal class StripePaymentController internal constructor(
         paymentFlowResultProcessor.processSetupIntent(
             PaymentFlowResult.Unvalidated.fromIntent(data)
         )
-
-    override fun handleSourceResult(
-        data: Intent,
-        callback: ApiResultCallback<Source>
-    ) {
-        val result = PaymentFlowResult.Unvalidated.fromIntent(data)
-        val sourceId = result.sourceId.orEmpty()
-        val clientSecret = result.clientSecret.orEmpty()
-
-        val requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = result.stripeAccountId
-        )
-
-        analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.create(
-                analyticsDataFactory.createAuthSourceParams(
-                    AnalyticsEvent.AuthSourceResult,
-                    sourceId
-                )
-            )
-        )
-
-        CoroutineScope(workContext).launch {
-            val sourceResult = runCatching {
-                requireNotNull(
-                    stripeRepository.retrieveSource(sourceId, clientSecret, requestOptions)
-                )
-            }
-
-            withContext(Dispatchers.Main) {
-                sourceResult.fold(
-                    onSuccess = callback::onSuccess,
-                    onFailure = {
-                        dispatchError(it, callback)
-                    }
-                )
-            }
-        }
-    }
 
     /**
      * Get the Source's client_secret from {@param data} and use to retrieve

--- a/stripe/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android
 
+import android.content.Intent
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -64,8 +65,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createPaymentMethod should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createPaymentMethod should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createPaymentMethod,
             stripe::createPaymentMethod
         )
@@ -85,8 +86,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createSource should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createSource should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createSource,
             stripe::createSource
         )
@@ -106,8 +107,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createAccountToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createAccountToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createAccountToken
         )
@@ -127,8 +128,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createBankAccountToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createBankAccountToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createBankAccountToken
         )
@@ -148,8 +149,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createPiiToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI with String param then throws APIException`(
+    fun `When repository returns null then createPiiToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createPiiToken
         )
@@ -169,8 +170,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createCardToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createCardToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createCardToken
         )
@@ -190,8 +191,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createCvcUpdateToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI with String param then throws APIException`(
+    fun `When repository returns null then createCvcUpdateToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createCvcUpdateToken
         )
@@ -211,8 +212,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createPersonToken should throw APIException`(): Unit =
-        `Given repository returns null when calling createAPI then throws APIException`(
+    fun `When repository returns null then createPersonToken should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createPersonToken
         )
@@ -236,7 +237,7 @@ internal class StripeKtxTest {
         }
 
     @Test
-    fun `When repository returns null then createFile should throw APIException`(): Unit =
+    fun `When repository returns null then createFile should throw InvalidRequestException`(): Unit =
         testDispatcher.runBlockingTest {
             whenever(
                 mockApiRepository.createFile(any(), any())
@@ -266,8 +267,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then retrievePaymentIntent should throw APIException`(): Unit =
-        `Given repository returns null when calling retrieveAPI with String param then throws APIException`(
+    fun `When repository returns null then retrievePaymentIntent should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling retrieveAPI with String param then throws InvalidRequestException`(
             mockApiRepository::retrievePaymentIntent,
             stripe::retrievePaymentIntent
         )
@@ -287,8 +288,8 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then retrieveSetupIntent should throw APIException`(): Unit =
-        `Given repository returns null when calling retrieveAPI with String param then throws APIException`(
+    fun `When repository returns null then retrieveSetupIntent should throw InvalidRequestException`(): Unit =
+        `Given repository returns null when calling retrieveAPI with String param then throws InvalidRequestException`(
             mockApiRepository::retrieveSetupIntent,
             stripe::retrieveSetupIntent
         )
@@ -325,7 +326,7 @@ internal class StripeKtxTest {
         }
 
     @Test
-    fun `When repository returns null then retrieveSource should throw APIException`(): Unit =
+    fun `When repository returns null then retrieveSource should throw InvalidRequestException`(): Unit =
         testDispatcher.runBlockingTest {
             whenever(
                 mockApiRepository.retrieveSource(any(), any(), any())
@@ -365,7 +366,7 @@ internal class StripeKtxTest {
         }
 
     @Test
-    fun `When repository returns null then confirmSetupIntentSuspend should throw APIException`(): Unit =
+    fun `When repository returns null then confirmSetupIntentSuspend should throw InvalidRequestException`(): Unit =
         testDispatcher.runBlockingTest {
             whenever(
                 mockApiRepository.confirmSetupIntent(any(), any(), any())
@@ -401,7 +402,7 @@ internal class StripeKtxTest {
         }
 
     @Test
-    fun `When repository returns null then confirmPaymentIntentSuspend should throw APIException`(): Unit =
+    fun `When repository returns null then confirmPaymentIntentSuspend should throw InvalidRequestException`(): Unit =
         testDispatcher.runBlockingTest {
             whenever(
                 mockApiRepository.confirmPaymentIntent(any(), any(), any())
@@ -411,6 +412,75 @@ internal class StripeKtxTest {
                 stripe.confirmPaymentIntent(mock())
             }
         }
+
+    @Test
+    fun `When controller returns correct value then getPaymentIntentResult should succeed`(): Unit =
+        `Given controller returns non-empty value when calling getAPI then returns correct result`(
+            mockPaymentController::shouldHandlePaymentResult,
+            mockPaymentController::getPaymentIntentResult,
+            stripe::getPaymentIntentResult
+        )
+
+    @Test
+    fun `When controller throws exception then getPaymentIntentResult should throw same exception`(): Unit =
+        `Given controller returns exception when calling getAPI then throws same exception`(
+            mockPaymentController::shouldHandlePaymentResult,
+            mockPaymentController::getPaymentIntentResult,
+            stripe::getPaymentIntentResult
+        )
+
+    @Test
+    fun `When isNotForSetupIntent then getPaymentIntentResult should throw InvalidRequestException`(): Unit =
+        `Given controller check fails when calling getAPI then throws InvalidRequestException`(
+            mockPaymentController::shouldHandlePaymentResult,
+            stripe::getPaymentIntentResult
+        )
+
+    @Test
+    fun `When controller returns correct value then getSetupIntentResult should succeed`(): Unit =
+        `Given controller returns non-empty value when calling getAPI then returns correct result`(
+            mockPaymentController::shouldHandleSetupResult,
+            mockPaymentController::getSetupIntentResult,
+            stripe::getSetupIntentResult
+        )
+
+    @Test
+    fun `When controller throws exception then getSetupIntentResult should throw same exception`(): Unit =
+        `Given controller returns exception when calling getAPI then throws same exception`(
+            mockPaymentController::shouldHandleSetupResult,
+            mockPaymentController::getSetupIntentResult,
+            stripe::getSetupIntentResult
+        )
+
+    @Test
+    fun `When isNotForSetupIntent then getSetupIntentResult should throw InvalidRequestException`(): Unit =
+        `Given controller check fails when calling getAPI then throws InvalidRequestException`(
+            mockPaymentController::shouldHandleSetupResult,
+            stripe::getSetupIntentResult
+        )
+
+    @Test
+    fun `When controller returns correct value then getAuthenticateSourceResult should succeed`(): Unit =
+        `Given controller returns non-empty value when calling getAPI then returns correct result`(
+            mockPaymentController::shouldHandleSourceResult,
+            mockPaymentController::getSource,
+            stripe::getAuthenticateSourceResult
+        )
+
+    @Test
+    fun `When controller throws exception then getAuthenticateSourceResult should throw same exception`(): Unit =
+        `Given controller returns exception when calling getAPI then throws same exception`(
+            mockPaymentController::shouldHandleSourceResult,
+            mockPaymentController::getSource,
+            stripe::getAuthenticateSourceResult
+        )
+
+    @Test
+    fun `When isNotForSetupIntent then getAuthenticateSourceResult should throw InvalidRequestException`(): Unit =
+        `Given controller check fails when calling getAPI then throws InvalidRequestException`(
+            mockPaymentController::shouldHandleSourceResult,
+            stripe::getAuthenticateSourceResult
+        )
 
     private inline fun <reified APIObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI then returns correct result`(
@@ -451,7 +521,7 @@ internal class StripeKtxTest {
     }
 
     private inline fun <reified APIObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
-    `Given repository returns null when calling createAPI then throws APIException`(
+    `Given repository returns null when calling createAPI then throws InvalidRequestException`(
         crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
         crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> APIObject
     ): Unit = testDispatcher.runBlockingTest {
@@ -507,7 +577,7 @@ internal class StripeKtxTest {
     }
 
     private inline fun <reified APIObject : StripeModel, reified RepositoryParam : Any>
-    `Given repository returns null when calling createAPI with String param then throws APIException`(
+    `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
         crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
         crossinline createApiInvocationBlock: suspend (String, String?, String?) -> APIObject
     ): Unit = testDispatcher.runBlockingTest {
@@ -561,7 +631,7 @@ internal class StripeKtxTest {
     }
 
     private inline fun <reified APIObject : StripeModel>
-    `Given repository returns null when calling retrieveAPI with String param then throws APIException`(
+    `Given repository returns null when calling retrieveAPI with String param then throws InvalidRequestException`(
         crossinline repositoryBlock: suspend (String, ApiRequest.Options, List<String>) -> APIObject?,
         crossinline retrieveApiInvocationBlock: suspend (String, String?) -> APIObject
     ): Unit = testDispatcher.runBlockingTest {
@@ -577,6 +647,69 @@ internal class StripeKtxTest {
         }
     }
 
+    private inline fun <reified APIObject : StripeModel>
+    `Given controller returns non-empty value when calling getAPI then returns correct result`(
+        crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
+        crossinline controllerInvocationBlock: suspend (Intent) -> APIObject,
+        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+    ) = testDispatcher.runBlockingTest {
+        val expectedApiObj = mock<APIObject>()
+
+        whenever(
+            controllerCheckBlock(any(), any())
+        ).thenReturn(true)
+
+        whenever(
+            controllerInvocationBlock(any())
+        ).thenReturn(expectedApiObj)
+
+        val actualObj = getAPIInvocationBlock(
+            TEST_REQUEST_CODE,
+            mock()
+        )
+
+        assertSame(expectedApiObj, actualObj)
+    }
+
+    private inline fun <APIObject : StripeModel>
+    `Given controller returns exception when calling getAPI then throws same exception`(
+        crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
+        crossinline controllerInvocationBlock: suspend (Intent) -> APIObject,
+        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+    ): Unit = testDispatcher.runBlockingTest {
+        whenever(
+            controllerCheckBlock(any(), any())
+        ).thenReturn(true)
+
+        whenever(
+            controllerInvocationBlock(any())
+        ).thenThrow(mock<AuthenticationException>())
+
+        assertFailsWith<AuthenticationException> {
+            getAPIInvocationBlock(
+                TEST_REQUEST_CODE,
+                mock()
+            )
+        }
+    }
+
+    private inline fun <reified APIObject : StripeModel>
+    `Given controller check fails when calling getAPI then throws InvalidRequestException`(
+        crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
+        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+    ): Unit = testDispatcher.runBlockingTest {
+        whenever(
+            controllerCheckBlock(any(), any())
+        ).thenReturn(false)
+
+        assertFailsWith<InvalidRequestException>("Incorrect requestCode and data for ${APIObject::class.java.simpleName}.") {
+            getAPIInvocationBlock(
+                TEST_REQUEST_CODE,
+                mock()
+            )
+        }
+    }
+
     private inline fun <reified T : Throwable> assertFailsWithMessage(
         throwableMsg: String,
         block: () -> Unit
@@ -586,6 +719,7 @@ internal class StripeKtxTest {
     }
 
     private companion object {
+        const val TEST_REQUEST_CODE = 1
         const val TEST_IDEMPOTENCY_KEY = "test_idempotenc_key"
         const val TEST_STRIPE_ACCOUNT_ID = "test_account_id"
     }

--- a/stripe/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -463,7 +463,7 @@ internal class StripeKtxTest {
     fun `When controller returns correct value then getAuthenticateSourceResult should succeed`(): Unit =
         `Given controller returns non-empty value when calling getAPI then returns correct result`(
             mockPaymentController::shouldHandleSourceResult,
-            mockPaymentController::getSource,
+            mockPaymentController::getAuthenticateSourceResult,
             stripe::getAuthenticateSourceResult
         )
 
@@ -471,7 +471,7 @@ internal class StripeKtxTest {
     fun `When controller throws exception then getAuthenticateSourceResult should throw same exception`(): Unit =
         `Given controller returns exception when calling getAPI then throws same exception`(
             mockPaymentController::shouldHandleSourceResult,
-            mockPaymentController::getSource,
+            mockPaymentController::getAuthenticateSourceResult,
             stripe::getAuthenticateSourceResult
         )
 
@@ -482,12 +482,12 @@ internal class StripeKtxTest {
             stripe::getAuthenticateSourceResult
         )
 
-    private inline fun <reified APIObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
+    private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI then returns correct result`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
-        crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> APIObject
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> ApiObject
     ) = testDispatcher.runBlockingTest {
-        val expectedApiObj = mock<APIObject>()
+        val expectedApiObj = mock<ApiObject>()
 
         whenever(
             repositoryBlock(any(), any())
@@ -520,16 +520,16 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
+    private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns null when calling createAPI then throws InvalidRequestException`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
-        crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> APIObject
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
         whenever(
             repositoryBlock(any(), any())
         ).thenReturn(null)
 
-        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${APIObject::class.java.simpleName}.") {
+        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${ApiObject::class.java.simpleName}.") {
             createApiInvocationBlock(
                 mock(),
                 TEST_IDEMPOTENCY_KEY,
@@ -538,12 +538,12 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel, reified RepositoryParam : StripeParamsModel>
+    private inline fun <reified ApiObject : StripeModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI with String param then returns correct result`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
-        crossinline createApiInvocationBlock: suspend (String, String?, String?) -> APIObject
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline createApiInvocationBlock: suspend (String, String?, String?) -> ApiObject
     ) = testDispatcher.runBlockingTest {
-        val expectedApiObj = mock<APIObject>()
+        val expectedApiObj = mock<ApiObject>()
 
         whenever(
             repositoryBlock(any(), any())
@@ -576,16 +576,16 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel, reified RepositoryParam : Any>
+    private inline fun <reified ApiObject : StripeModel, reified RepositoryParam : Any>
     `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> APIObject?,
-        crossinline createApiInvocationBlock: suspend (String, String?, String?) -> APIObject
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline createApiInvocationBlock: suspend (String, String?, String?) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
         whenever(
             repositoryBlock(any(), any())
         ).thenReturn(null)
 
-        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${APIObject::class.java.simpleName}.") {
+        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${ApiObject::class.java.simpleName}.") {
             createApiInvocationBlock(
                 "param1",
                 TEST_IDEMPOTENCY_KEY,
@@ -594,12 +594,12 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel>
+    private inline fun <reified ApiObject : StripeModel>
     `Given repository returns non-empty value when calling retrieveAPI with String param then returns correct result`(
-        crossinline repositoryBlock: suspend (String, ApiRequest.Options, List<String>) -> APIObject?,
-        crossinline retrieveApiInvocationBlock: suspend (String, String?) -> APIObject
+        crossinline repositoryBlock: suspend (String, ApiRequest.Options, List<String>) -> ApiObject?,
+        crossinline retrieveApiInvocationBlock: suspend (String, String?) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
-        val expectedApiObj = mock<APIObject>()
+        val expectedApiObj = mock<ApiObject>()
 
         whenever(
             repositoryBlock(any(), any(), any())
@@ -630,16 +630,16 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel>
+    private inline fun <reified ApiObject : StripeModel>
     `Given repository returns null when calling retrieveAPI with String param then throws InvalidRequestException`(
-        crossinline repositoryBlock: suspend (String, ApiRequest.Options, List<String>) -> APIObject?,
-        crossinline retrieveApiInvocationBlock: suspend (String, String?) -> APIObject
+        crossinline repositoryBlock: suspend (String, ApiRequest.Options, List<String>) -> ApiObject?,
+        crossinline retrieveApiInvocationBlock: suspend (String, String?) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
         whenever(
             repositoryBlock(any(), any(), any())
         ).thenReturn(null)
 
-        assertFailsWith<InvalidRequestException>("Failed to parse ${APIObject::class.java.simpleName}.") {
+        assertFailsWith<InvalidRequestException>("Failed to parse ${ApiObject::class.java.simpleName}.") {
             retrieveApiInvocationBlock(
                 "param1",
                 TEST_STRIPE_ACCOUNT_ID
@@ -647,13 +647,13 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel>
+    private inline fun <reified ApiObject : StripeModel>
     `Given controller returns non-empty value when calling getAPI then returns correct result`(
         crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
-        crossinline controllerInvocationBlock: suspend (Intent) -> APIObject,
-        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+        crossinline controllerInvocationBlock: suspend (Intent) -> ApiObject,
+        crossinline getAPIInvocationBlock: suspend (Int, Intent) -> ApiObject
     ) = testDispatcher.runBlockingTest {
-        val expectedApiObj = mock<APIObject>()
+        val expectedApiObj = mock<ApiObject>()
 
         whenever(
             controllerCheckBlock(any(), any())
@@ -671,11 +671,11 @@ internal class StripeKtxTest {
         assertSame(expectedApiObj, actualObj)
     }
 
-    private inline fun <APIObject : StripeModel>
+    private inline fun <ApiObject : StripeModel>
     `Given controller returns exception when calling getAPI then throws same exception`(
         crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
-        crossinline controllerInvocationBlock: suspend (Intent) -> APIObject,
-        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+        crossinline controllerInvocationBlock: suspend (Intent) -> ApiObject,
+        crossinline getAPIInvocationBlock: suspend (Int, Intent) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
         whenever(
             controllerCheckBlock(any(), any())
@@ -693,16 +693,16 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified APIObject : StripeModel>
+    private inline fun <reified ApiObject : StripeModel>
     `Given controller check fails when calling getAPI then throws InvalidRequestException`(
         crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
-        crossinline getAPIInvocationBlock: suspend (Int, Intent?) -> APIObject
+        crossinline getAPIInvocationBlock: suspend (Int, Intent) -> ApiObject
     ): Unit = testDispatcher.runBlockingTest {
         whenever(
             controllerCheckBlock(any(), any())
         ).thenReturn(false)
 
-        assertFailsWith<InvalidRequestException>("Incorrect requestCode and data for ${APIObject::class.java.simpleName}.") {
+        assertFailsWith<InvalidRequestException>("Incorrect requestCode and data for ${ApiObject::class.java.simpleName}.") {
             getAPIInvocationBlock(
                 TEST_REQUEST_CODE,
                 mock()

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -198,7 +198,6 @@ class StripePaymentAuthTest {
             verify(setupCallback).onSuccess(result)
         }
 
-
     @Test
     fun onSetupResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
         testDispatcher.runBlockingTest {

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -145,7 +145,7 @@ class StripePaymentAuthTest {
     @Test
     fun onPaymentResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
         testDispatcher.runBlockingTest {
-            val data = mock<Intent>()
+            val data = Intent()
             whenever(
                 paymentController.shouldHandlePaymentResult(
                     StripePaymentController.PAYMENT_REQUEST_CODE,
@@ -201,7 +201,7 @@ class StripePaymentAuthTest {
     @Test
     fun onSetupResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
         testDispatcher.runBlockingTest {
-            val data = mock<Intent>()
+            val data = Intent()
             whenever(
                 paymentController.shouldHandleSetupResult(
                     StripePaymentController.SETUP_REQUEST_CODE,
@@ -230,7 +230,7 @@ class StripePaymentAuthTest {
     fun onAuthenticateSourceResult_whenControllerReturnsCorrectResult_shouldGetCorrectResult() =
         testDispatcher.runBlockingTest {
             val result = mock<Source>()
-            val data = mock<Intent>()
+            val data = Intent()
             whenever(
                 paymentController.getAuthenticateSourceResult(
                     data
@@ -251,7 +251,7 @@ class StripePaymentAuthTest {
     @Test
     fun onAuthenticateSourceResult_whenControllerReturnsNull_shouldThrowException() =
         testDispatcher.runBlockingTest {
-            val data = mock<Intent>()
+            val data = Intent()
             whenever(
                 paymentController.getAuthenticateSourceResult(
                     data

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -7,21 +7,27 @@ import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.Source
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultApiRequestExecutor
 import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -35,7 +41,13 @@ class StripePaymentAuthTest {
     private val paymentController: PaymentController = mock()
     private val paymentCallback: ApiResultCallback<PaymentIntentResult> = mock()
     private val setupCallback: ApiResultCallback<SetupIntentResult> = mock()
+    private val sourceCallback: ApiResultCallback<Source> = mock()
     private val hostArgumentCaptor: KArgumentCaptor<AuthActivityStarter.Host> = argumentCaptor()
+
+    @AfterTest
+    fun cleanup() {
+        testDispatcher.cleanupTestCoroutines()
+    }
 
     @Test
     fun confirmPayment_shouldConfirmAndAuth() {
@@ -102,44 +114,161 @@ class StripePaymentAuthTest {
     }
 
     @Test
-    fun onPaymentResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
-        val data = Intent()
-        whenever(
-            paymentController.shouldHandlePaymentResult(
+    fun onPaymentResult_whenShouldHandleResultAndControllerReturnsCorrectResult_shouldGetCorrectResult() =
+        testDispatcher.runBlockingTest {
+            val data = Intent()
+            val result = mock<PaymentIntentResult>()
+            whenever(
+                paymentController.shouldHandlePaymentResult(
+                    StripePaymentController.PAYMENT_REQUEST_CODE,
+                    data
+                )
+            ).thenReturn(true)
+            whenever(
+                paymentController.getPaymentIntentResult(
+                    data
+                )
+            ).thenReturn(result)
+
+            val stripe = createStripe()
+            stripe.onPaymentResult(
                 StripePaymentController.PAYMENT_REQUEST_CODE,
-                data
+                data,
+                callback = paymentCallback
             )
-        ).thenReturn(true)
 
-        val stripe = createStripe()
-        stripe.onPaymentResult(
-            StripePaymentController.PAYMENT_REQUEST_CODE,
-            data,
-            callback = paymentCallback
-        )
+            idleLooper()
 
-        verify(paymentController).handlePaymentResult(data, paymentCallback)
-    }
+            verify(paymentCallback).onSuccess(result)
+        }
 
     @Test
-    fun onSetupResult_whenShouldHandleResultIsTrue_shouldCallHandleResult() {
-        val data = Intent()
-        whenever(
-            paymentController.shouldHandleSetupResult(
-                StripePaymentController.SETUP_REQUEST_CODE,
-                data
+    fun onPaymentResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
+        testDispatcher.runBlockingTest {
+            val data = mock<Intent>()
+            whenever(
+                paymentController.shouldHandlePaymentResult(
+                    StripePaymentController.PAYMENT_REQUEST_CODE,
+                    data
+                )
+            ).thenReturn(true)
+            whenever(
+                paymentController.getPaymentIntentResult(
+                    data
+                )
+            ).thenReturn(null)
+
+            val stripe = createStripe()
+            stripe.onPaymentResult(
+                StripePaymentController.PAYMENT_REQUEST_CODE,
+                data,
+                callback = paymentCallback
             )
-        ).thenReturn(true)
 
-        val stripe = createStripe()
-        stripe.onSetupResult(
-            StripePaymentController.SETUP_REQUEST_CODE,
-            data,
-            callback = setupCallback
-        )
+            idleLooper()
 
-        verify(paymentController).handleSetupResult(data, setupCallback)
-    }
+            verify(paymentCallback).onError(isA<InvalidRequestException>())
+        }
+
+    @Test
+    fun onSetupResult_whenShouldHandleResultAndControllerReturnsCorrectResult_shouldGetCorrectResult() =
+        testDispatcher.runBlockingTest {
+            val data = Intent()
+            val result = mock<SetupIntentResult>()
+            whenever(
+                paymentController.shouldHandleSetupResult(
+                    StripePaymentController.SETUP_REQUEST_CODE,
+                    data
+                )
+            ).thenReturn(true)
+            whenever(
+                paymentController.getSetupIntentResult(
+                    data
+                )
+            ).thenReturn(result)
+
+            val stripe = createStripe()
+            stripe.onSetupResult(
+                StripePaymentController.SETUP_REQUEST_CODE,
+                data,
+                callback = setupCallback
+            )
+
+            idleLooper()
+            verify(setupCallback).onSuccess(result)
+        }
+
+
+    @Test
+    fun onSetupResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
+        testDispatcher.runBlockingTest {
+            val data = mock<Intent>()
+            whenever(
+                paymentController.shouldHandleSetupResult(
+                    StripePaymentController.SETUP_REQUEST_CODE,
+                    data
+                )
+            ).thenReturn(true)
+            whenever(
+                paymentController.getSetupIntentResult(
+                    data
+                )
+            ).thenReturn(null)
+
+            val stripe = createStripe()
+            stripe.onSetupResult(
+                StripePaymentController.SETUP_REQUEST_CODE,
+                data,
+                callback = setupCallback
+            )
+
+            idleLooper()
+
+            verify(setupCallback).onError(isA<InvalidRequestException>())
+        }
+
+    @Test
+    fun onAuthenticateSourceResult_whenControllerReturnsCorrectResult_shouldGetCorrectResult() =
+        testDispatcher.runBlockingTest {
+            val result = mock<Source>()
+            val data = mock<Intent>()
+            whenever(
+                paymentController.getAuthenticateSourceResult(
+                    data
+                )
+            ).thenReturn(result)
+
+            val stripe = createStripe()
+            stripe.onAuthenticateSourceResult(
+                data,
+                callback = sourceCallback
+            )
+
+            idleLooper()
+
+            verify(sourceCallback).onSuccess(result)
+        }
+
+    @Test
+    fun onAuthenticateSourceResult_whenControllerReturnsNull_shouldThrowException() =
+        testDispatcher.runBlockingTest {
+            val data = mock<Intent>()
+            whenever(
+                paymentController.getAuthenticateSourceResult(
+                    data
+                )
+            ).thenReturn(null)
+
+            val stripe = createStripe()
+            stripe.onAuthenticateSourceResult(
+                data,
+                callback = sourceCallback
+            )
+
+            idleLooper()
+
+            verify(sourceCallback).onError(isA<InvalidRequestException>())
+        }
 
     private fun createStripe(): Stripe {
         return Stripe(
@@ -153,7 +282,8 @@ class StripePaymentAuthTest {
             ),
             paymentController,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            null
+            null,
+            testDispatcher
         )
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -19,7 +19,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.auth.PaymentAuthWebViewContract
-import com.stripe.android.exception.APIException
 import com.stripe.android.exception.InvalidRequestException
 import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.ConfirmPaymentIntentParams


### PR DESCRIPTION
# Summary
Introduce `suspend fun` for all existing Stripe APIs.

**Note: the doc linked to in this PR is internal only**

This is a follow up change on #3557, for the changes in ['get' APIs](https://paper.dropbox.com/doc/suspend-fun-FTW--BIJ_K2mkl96vRq0gPwLgorV9Ag), the following changes are made:

- expose `isForPaymentintentResult`, `isForSetupIntentResult` in `Stripe.kt`, checking if `resultCode` and `Intent` is for required `StripeModel`
- expose `getPaymentIntentResult`, `getSetupIntentResult` and `getSource` in `PaymentController`
- expose `getPaymentIntentResult`, `getSetupIntentResult` and `getSource` in `StripeKtx.kt` by invoking the functions above, retrieving `StripeModel` from `resultCode` and `Intent` on activity result

Will add these to the example app in a follow up PR.

# Motivation
For details, please refer to this [doc](https://paper.dropbox.com/doc/suspend-fun-FTW--BIJ_K2mkl96vRq0gPwLgorV9Ag-GR5U3bvtiLUozGIup8lxw) 

Fixes #2642

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

