### PR TITLE
Populating BillingView should not result in bad zip code

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -344,6 +344,9 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     internal fun populate(address: Address?) {
         address?.let { it ->
+            // The postal code needs to be set prior to the country, because the
+            // country will trigger a validation of the postal code, which will be
+            // invalid if not set first.
             this.postalCodeView.setText(it.postalCode)
             it.country?.let { countryCode ->
                 countryLayout.selectedCountry = CountryUtils.getCountryByCode(countryCode)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -344,6 +344,7 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     internal fun populate(address: Address?) {
         address?.let { it ->
+            this.postalCodeView.setText(it.postalCode)
             it.country?.let { countryCode ->
                 countryLayout.selectedCountry = CountryUtils.getCountryByCode(countryCode)
                 this.countryView.setText(CountryUtils.getDisplayCountry(countryCode))
@@ -351,7 +352,6 @@ internal class BillingAddressView @JvmOverloads constructor(
             this.address1View.setText(it.line1)
             this.address2View.setText(it.line2)
             this.cityView.setText(it.city)
-            this.postalCodeView.setText(it.postalCode)
             this.stateView.setText(it.state)
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.Address
+import com.stripe.android.model.AddressFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
@@ -236,6 +237,12 @@ class BillingAddressViewTest {
         billingAddressView.countryLayout.selectedCountry = USA
         assertThat(billingAddressView.stateLayout.hint)
             .isEqualTo("State")
+    }
+
+    @Test
+    fun `Calling populate should not result in an erroneous zip code if it has a value`() {
+        billingAddressView.populate(AddressFixtures.ADDRESS)
+        assertThat(billingAddressView.postalCodeView.shouldShowError).isFalse()
     }
 
     @Test


### PR DESCRIPTION
# Summary
If the billing view is populated with data including a zip code the check zip code will fire, but this requires that the country be set first.

# Motivation
So the postal code does not appear invalid when populating the view.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

