### PR TITLE
Upgrade androidx.recyclerview:recyclerview to 1.2.0

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -52,7 +52,7 @@ private def getValue(key) {
 dependencies {
     implementation project(':stripe')
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"
     implementation "com.google.android.material:material:$materialVersion"

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidLifecycleVersion"

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -136,12 +136,12 @@ internal class PaymentOptionsAdapter(
             }
             ViewType.GooglePay -> GooglePayViewHolder(parent).apply {
                 itemView.setOnClickListener {
-                    onItemSelected(adapterPosition, isClick = true)
+                    onItemSelected(bindingAdapterPosition, isClick = true)
                 }
             }
             ViewType.Card -> CardViewHolder(parent).apply {
                 itemView.setOnClickListener {
-                    onItemSelected(adapterPosition, isClick = true)
+                    onItemSelected(bindingAdapterPosition, isClick = true)
                 }
             }
         }

--- a/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodListAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AddPaymentMethodListAdapter.kt
@@ -58,7 +58,7 @@ internal class AddPaymentMethodListAdapter(
         val item = items[position]
 
         holder.itemView.setOnClickListener {
-            selectedPosition = holder.adapterPosition
+            selectedPosition = holder.bindingAdapterPosition
         }
 
         val bankViewHolder = holder as BankViewHolder

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodSwipeCallback.kt
@@ -43,7 +43,7 @@ internal class PaymentMethodSwipeCallback(
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        val paymentMethod = adapter.getPaymentMethodAtPosition(viewHolder.adapterPosition)
+        val paymentMethod = adapter.getPaymentMethodAtPosition(viewHolder.bindingAdapterPosition)
         listener.onSwiped(paymentMethod)
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -132,7 +132,7 @@ internal class PaymentMethodsAdapter constructor(
                 holder.setPaymentMethod(paymentMethod)
                 holder.setSelected(paymentMethod.id == selectedPaymentMethodId)
                 holder.itemView.setOnClickListener {
-                    onPositionClicked(holder.adapterPosition)
+                    onPositionClicked(holder.bindingAdapterPosition)
                 }
             }
             is ViewHolder.GooglePayViewHolder -> {
@@ -211,7 +211,7 @@ internal class PaymentMethodsAdapter constructor(
                 parent.context.getString(R.string.delete_payment_method)
             ) { _, _ ->
                 listener?.onDeletePaymentMethodAction(
-                    paymentMethod = getPaymentMethodAtPosition(viewHolder.adapterPosition)
+                    paymentMethod = getPaymentMethodAtPosition(viewHolder.bindingAdapterPosition)
                 )
                 true
             }

--- a/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ShippingMethodAdapter.kt
@@ -55,7 +55,7 @@ internal class ShippingMethodAdapter :
         holder.setShippingMethod(shippingMethods[i])
         holder.setSelected(i == selectedIndex)
         holder.shippingMethodView.setOnClickListener {
-            selectedIndex = holder.adapterPosition
+            selectedIndex = holder.bindingAdapterPosition
         }
     }
 


### PR DESCRIPTION


# Summary
https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.2.0

Replace deprecated `ViewHolder.getAdapterPosition` with
`ViewHolder.getBindingAdapterPosition`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
