### PR TITLE
Modernize PaymentAuthWebViewClient

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -57,8 +57,8 @@ internal class PaymentAuthWebViewClient(
         view: WebView,
         request: WebResourceRequest
     ): Boolean {
-        val uri = request.url
         logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $request")
+        val uri = request.url
         updateCompletionUrl(uri)
 
         return if (isReturnUrl(uri)) {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.view
 
-import android.annotation.TargetApi
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.webkit.URLUtil
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -55,9 +53,12 @@ internal class PaymentAuthWebViewClient(
         isPageLoaded.value = true
     }
 
-    override fun shouldOverrideUrlLoading(view: WebView, urlString: String): Boolean {
-        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - $urlString")
-        val uri = Uri.parse(urlString)
+    override fun shouldOverrideUrlLoading(
+        view: WebView,
+        request: WebResourceRequest
+    ): Boolean {
+        val uri = request.url
+        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $request")
         updateCompletionUrl(uri)
 
         return if (isReturnUrl(uri)) {
@@ -76,7 +77,7 @@ internal class PaymentAuthWebViewClient(
             )
             true
         } else {
-            super.shouldOverrideUrlLoading(view, urlString)
+            super.shouldOverrideUrlLoading(view, request)
         }
     }
 
@@ -130,15 +131,6 @@ internal class PaymentAuthWebViewClient(
         if (!returnUrlParam.isNullOrBlank()) {
             completionUrlParam = returnUrlParam
         }
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    override fun shouldOverrideUrlLoading(
-        view: WebView,
-        request: WebResourceRequest
-    ): Boolean {
-        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(WebResourceRequest)")
-        return shouldOverrideUrlLoading(view, request.url.toString())
     }
 
     private fun isReturnUrl(uri: Uri): Boolean {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -57,23 +57,23 @@ internal class PaymentAuthWebViewClient(
         view: WebView,
         request: WebResourceRequest
     ): Boolean {
-        val uri = request.url
-        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $uri")
-        updateCompletionUrl(uri)
+        val url = request.url
+        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $url")
+        updateCompletionUrl(url)
 
-        return if (isReturnUrl(uri)) {
+        return if (isReturnUrl(url)) {
             logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - handle return URL")
-            onAuthCompleted(uri)
+            onAuthCompleted(url)
             true
-        } else if ("intent".equals(uri.scheme, ignoreCase = true)) {
-            openIntentScheme(uri)
+        } else if ("intent".equals(url.scheme, ignoreCase = true)) {
+            openIntentScheme(url)
             true
-        } else if (!URLUtil.isNetworkUrl(uri.toString())) {
+        } else if (!URLUtil.isNetworkUrl(url.toString())) {
             // Non-network URLs are likely deep-links into banking apps. If the deep-link can be
             // opened via an Intent, start it. Otherwise, stop the authentication attempt.
             openIntent(
-                uri,
-                Intent(Intent.ACTION_VIEW, uri)
+                url,
+                Intent(Intent.ACTION_VIEW, url)
             )
             true
         } else {

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -57,8 +57,8 @@ internal class PaymentAuthWebViewClient(
         view: WebView,
         request: WebResourceRequest
     ): Boolean {
-        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $request")
         val uri = request.url
+        logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading(): $uri")
         updateCompletionUrl(uri)
 
         return if (isReturnUrl(uri)) {

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.view
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ApplicationProvider
@@ -32,7 +33,10 @@ class PaymentAuthWebViewClientTest {
             "pi_123_secret_456",
             returnUrl = "stripe://payment_intent_return"
         )
-        val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(webView, url)
+        val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
+            webView,
+            FakeWebResourceRequest(url)
+        )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
@@ -55,7 +59,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            url
+            FakeWebResourceRequest(url)
         )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
@@ -76,7 +80,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            url
+            FakeWebResourceRequest(url)
         )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
@@ -97,7 +101,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            url
+            FakeWebResourceRequest(url)
         )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
@@ -116,7 +120,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            "https://example.com"
+            FakeWebResourceRequest("https://example.com")
         )
         assertThat(shouldOverrideUrlLoading)
             .isFalse()
@@ -134,7 +138,10 @@ class PaymentAuthWebViewClientTest {
         val url = "stripejs://use_stripe_sdk/return_url"
 
         val shouldOverrideUrlLoading = createWebViewClient("pi_123_secret_456")
-            .shouldOverrideUrlLoading(webView, url)
+            .shouldOverrideUrlLoading(
+                webView,
+                FakeWebResourceRequest(url)
+            )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
@@ -182,8 +189,10 @@ class PaymentAuthWebViewClientTest {
             "mailto:patrick@example.com?payment_intent=pi_123&payment_intent_client_secret=pi_123_secret_456&source_type=card"
         val webViewClient = createWebViewClient("pi_123_secret_456")
 
-        val shouldOverrideUrlLoading =
-            webViewClient.shouldOverrideUrlLoading(webView, url)
+        val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
+            webView,
+            FakeWebResourceRequest(url)
+        )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
@@ -201,8 +210,10 @@ class PaymentAuthWebViewClientTest {
             activityStarter = { throw ActivityNotFoundException() }
         )
 
-        val shouldOverrideUrlLoading =
-            webViewClient.shouldOverrideUrlLoading(webView, url)
+        val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
+            webView,
+            FakeWebResourceRequest(url)
+        )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
@@ -219,8 +230,10 @@ class PaymentAuthWebViewClientTest {
         val url = "alipays://link"
         val webViewClient = createWebViewClient("pi_123_secret_456")
 
-        val shouldOverrideUrlLoading =
-            webViewClient.shouldOverrideUrlLoading(webView, url)
+        val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
+            webView,
+            FakeWebResourceRequest(url)
+        )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
@@ -248,7 +261,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            deepLink
+            FakeWebResourceRequest(deepLink)
         )
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
@@ -273,7 +286,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            url
+            FakeWebResourceRequest(url)
         )
         assertThat(shouldOverrideUrlLoading)
             .isFalse()
@@ -295,7 +308,7 @@ class PaymentAuthWebViewClientTest {
 
         val shouldOverrideUrlLoading = webViewClient.shouldOverrideUrlLoading(
             webView,
-            url
+            FakeWebResourceRequest(url)
         )
         assertThat(shouldOverrideUrlLoading)
             .isFalse()
@@ -382,5 +395,16 @@ class PaymentAuthWebViewClientTest {
             error?.let(onAuthCompletedErrors::add)
             activityFinished = true
         }
+    }
+
+    private class FakeWebResourceRequest(
+        private val url: String
+    ) : WebResourceRequest {
+        override fun getUrl(): Uri = Uri.parse(url)
+        override fun isForMainFrame(): Boolean = false
+        override fun isRedirect(): Boolean = false
+        override fun hasGesture(): Boolean = false
+        override fun getMethod(): String = "GET"
+        override fun getRequestHeaders(): Map<String, String> = emptyMap()
     }
 }


### PR DESCRIPTION


# Summary
Remove usage of deprecated version of `shouldOverrideUrlLoading`.

# Motivation
Simplify `PaymentAuthWebViewClient`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified


