### PR TITLE
Notify failure endpoint when E2E tests fail

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -25,3 +25,16 @@ jobs:
         with:
           name: unit-test-report
           path: stripe-test-e2e/build/reports/tests/testDebugUnitTest/
+      - name: Notify failure endpoint
+        id: notifyFailureEndpoint
+        uses: fjogeleit/http-request-action@master
+        if: failure()
+        with:
+          url: ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }}
+          method: 'POST'
+          data: |
+            {
+              "project": "RUN_MOBILESDK",
+              "summary": "stripe-android E2E test failed",
+              "description": "Please ACK this ticket and investigate the failure. See https://github.com/stripe/stripe-android/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
# Summary
Report end-to-end test failures to notification endpoint

# Motivation
Track test failures

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

