### PR TITLE
Use LiveData<Event<x>> in consumable events.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -117,7 +117,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         setupAddButton(viewBinding.addButton)
 
-        viewModel.transition.observe(this) { transitionTarget ->
+        viewModel.transition.observe(this) { event ->
+            val transitionTarget = event.getContentIfNotHandled()
             if (transitionTarget != null) {
                 onTransitionTarget(
                     transitionTarget,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -164,7 +164,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
         ) {
             viewModel.onGooglePayResult(it)
         }
-        viewModel.launchGooglePay.observe(this) { args ->
+        viewModel.launchGooglePay.observe(this) { event ->
+            val args = event.getContentIfNotHandled()
             if (args != null) {
                 googlePayLauncher.launch(args)
             }
@@ -194,7 +195,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
 
         setupBuyButton()
 
-        viewModel.transition.observe(this) { transitionTarget ->
+        viewModel.transition.observe(this) { event ->
+            val transitionTarget = event.getContentIfNotHandled()
             if (transitionTarget != null) {
                 onTransitionTarget(
                     transitionTarget,
@@ -212,7 +214,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
             fetchConfig()
         }
 
-        viewModel.startConfirm.observe(this) { confirmParams ->
+        viewModel.startConfirm.observe(this) { event ->
+            val confirmParams = event.getContentIfNotHandled()
             if (confirmParams != null) {
                 paymentController.startConfirmAndAuth(
                     AuthActivityStarter.Host.create(this),

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
@@ -64,7 +63,7 @@ internal class PaymentSheetViewModel internal constructor(
     )
 
     private val _startConfirm = MutableLiveData<Event<ConfirmPaymentIntentParams>>()
-    internal val startConfirm = _startConfirm.map { it.getContentIfNotHandled() }
+    internal val startConfirm: LiveData<Event<ConfirmPaymentIntentParams>> = _startConfirm
 
     @VisibleForTesting
     internal val _viewState = MutableLiveData<ViewState.PaymentSheet>(null)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.R
@@ -27,6 +26,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.TestOnly
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -48,7 +48,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     internal val isGooglePayReady: LiveData<Boolean> = _isGooglePayReady.distinctUntilChanged()
 
     protected val _launchGooglePay = MutableLiveData<Event<StripeGooglePayContract.Args>>()
-    internal val launchGooglePay = _launchGooglePay.map { it.getContentIfNotHandled() }
+    internal val launchGooglePay: LiveData<Event<StripeGooglePayContract.Args>> = _launchGooglePay
 
     protected val _paymentIntent = MutableLiveData<PaymentIntent?>()
     internal val paymentIntent: LiveData<PaymentIntent?> = _paymentIntent
@@ -66,7 +66,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     private val savedSelection: LiveData<SavedSelection> = _savedSelection
 
     private val _transition = MutableLiveData<Event<TransitionTargetType?>>(Event(null))
-    internal val transition = _transition.map { it.getContentIfNotHandled() }
+    internal val transition: LiveData<Event<TransitionTargetType?>> = _transition
 
     /**
      * On [BaseAddCardFragment] this is set every time the details in the add
@@ -215,5 +215,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
                 content
             }
         }
+        /**
+         * Returns the content, even if it's already been handled.
+         */
+        @TestOnly
+        fun peekContent(): T = content
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.ViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -212,7 +213,7 @@ class PaymentOptionsActivityTest {
         val viewModel = createViewModel(
             PAYMENT_OPTIONS_CONTRACT_ARGS.copy(isGooglePayReady = true)
         )
-        val transitionTarget = mutableListOf<TransitionTarget?>()
+        val transitionTarget = mutableListOf<BaseSheetViewModel.Event<TransitionTarget?>>()
         viewModel.transition.observeForever {
             transitionTarget.add(it)
         }
@@ -221,7 +222,7 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             idleLooper()
-            assertThat(transitionTarget[1])
+            assertThat(transitionTarget[1].peekContent())
                 .isInstanceOf(TransitionTarget.SelectSavedPaymentMethod::class.java)
         }
     }
@@ -234,7 +235,7 @@ class PaymentOptionsActivityTest {
         )
 
         val viewModel = createViewModel(args)
-        val transitionTarget = mutableListOf<TransitionTarget?>()
+        val transitionTarget = mutableListOf<BaseSheetViewModel.Event<TransitionTarget?>>()
         viewModel.transition.observeForever {
             transitionTarget.add(it)
         }
@@ -244,7 +245,7 @@ class PaymentOptionsActivityTest {
             createIntent(args)
         ).use {
             idleLooper()
-            assertThat(transitionTarget[1])
+            assertThat(transitionTarget[1].peekContent())
                 .isInstanceOf(TransitionTarget.SelectSavedPaymentMethod::class.java)
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -208,7 +208,7 @@ class PaymentOptionsViewModelTest {
             application = ApplicationProvider.getApplicationContext()
         )
 
-        var transitionTarget: TransitionTarget? = null
+        var transitionTarget: BaseSheetViewModel.Event<TransitionTarget?>? = null
         viewModel.transition.observeForever {
             transitionTarget = it
         }
@@ -217,7 +217,7 @@ class PaymentOptionsViewModelTest {
         val fragmentConfig = FragmentConfigFixtures.DEFAULT
         viewModel.resolveTransitionTarget(fragmentConfig)
 
-        assertThat(transitionTarget).isNull()
+        assertThat(transitionTarget!!.peekContent()).isNull()
     }
 
     @Test
@@ -235,7 +235,7 @@ class PaymentOptionsViewModelTest {
             application = ApplicationProvider.getApplicationContext()
         )
 
-        val transitionTarget: MutableList<TransitionTarget?> = mutableListOf()
+        val transitionTarget = mutableListOf<BaseSheetViewModel.Event<TransitionTarget?>>()
         viewModel.transition.observeForever {
             transitionTarget.add(it)
         }
@@ -243,7 +243,8 @@ class PaymentOptionsViewModelTest {
         val fragmentConfig = FragmentConfigFixtures.DEFAULT
         viewModel.resolveTransitionTarget(fragmentConfig)
 
-        assertThat(transitionTarget).containsExactly(null)
+        assertThat(transitionTarget).hasSize(1)
+        assertThat(transitionTarget[0].peekContent()).isNull()
     }
 
     @Test
@@ -261,7 +262,7 @@ class PaymentOptionsViewModelTest {
             application = ApplicationProvider.getApplicationContext()
         )
 
-        val transitionTarget: MutableList<TransitionTarget?> = mutableListOf()
+        val transitionTarget = mutableListOf<BaseSheetViewModel.Event<TransitionTarget?>>()
         viewModel.transition.observeForever {
             transitionTarget.add(it)
         }
@@ -269,7 +270,7 @@ class PaymentOptionsViewModelTest {
         val fragmentConfig = FragmentConfigFixtures.DEFAULT
         viewModel.resolveTransitionTarget(fragmentConfig)
         assertThat(transitionTarget).hasSize(2)
-        assertThat(transitionTarget[1])
+        assertThat(transitionTarget[1].peekContent())
             .isInstanceOf(TransitionTarget.AddPaymentMethodFull::class.java)
 
         viewModel.resolveTransitionTarget(fragmentConfig)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -314,7 +314,7 @@ internal class PaymentSheetActivityTest {
                 assertThat(activity.viewBinding.buyButton.isEnabled)
                     .isFalse()
 
-                assertThat(viewModel.startConfirm.value)
+                assertThat(viewModel.startConfirm.value?.peekContent())
                     .isEqualTo(
                         ConfirmPaymentIntentParams(
                             clientSecret = "client_secret",

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -104,14 +104,9 @@ class PaymentSheetListFragmentTest {
     fun `posts transition when add card clicked`() {
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)
-            assertThat(activityViewModel.transition.value).isNull()
+            assertThat(activityViewModel.transition.value?.peekContent()).isNull()
 
             idleLooper()
-
-            val transitionTarget = mutableListOf<PaymentSheetViewModel.TransitionTarget?>()
-            activityViewModel.transition.observeForever { target ->
-                transitionTarget.add(target)
-            }
 
             val recycler = recyclerView(it)
             assertThat(recycler.adapter).isInstanceOf(PaymentOptionsAdapter::class.java)
@@ -119,7 +114,7 @@ class PaymentSheetListFragmentTest {
             adapter.addCardClickListener.onClick(it.requireView())
             idleLooper()
 
-            assertThat(transitionTarget.lastOrNull())
+            assertThat(activityViewModel.transition.value?.peekContent())
                 .isEqualTo(
                     PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(
                         FragmentConfigFixtures.DEFAULT.copy(

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -114,7 +114,7 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should confirm saved payment methods`() = testDispatcher.runBlockingTest {
-        val confirmParams = mutableListOf<ConfirmPaymentIntentParams?>()
+        val confirmParams = mutableListOf<BaseSheetViewModel.Event<ConfirmPaymentIntentParams>>()
         viewModel.startConfirm.observeForever {
             confirmParams.add(it)
         }
@@ -123,8 +123,9 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        assertThat(confirmParams)
-            .containsExactly(
+        assertThat(confirmParams).hasSize(1)
+        assertThat(confirmParams[0].peekContent())
+            .isEqualTo(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     requireNotNull(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id),
                     CLIENT_SECRET,
@@ -135,7 +136,7 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `checkout() should confirm new payment methods`() = testDispatcher.runBlockingTest {
-        val confirmParams = mutableListOf<ConfirmPaymentIntentParams?>()
+        val confirmParams = mutableListOf<BaseSheetViewModel.Event<ConfirmPaymentIntentParams>>()
         viewModel.startConfirm.observeForever {
             confirmParams.add(it)
         }
@@ -148,8 +149,9 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        assertThat(confirmParams)
-            .containsExactly(
+        assertThat(confirmParams).hasSize(1)
+        assertThat(confirmParams[0].peekContent())
+            .isEqualTo(
                 ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                     PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     CLIENT_SECRET,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow-up to PR#3569. Using `map { it.getContentIfNotHandled() }` will keep the value as active, instead of consuming it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Events should become `null` after being fetched for the first time.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
