### PR TITLE
Restore selected payment method from ViewModel when recreating Fragment.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -62,9 +62,7 @@ internal abstract class BasePaymentMethodsListFragment(
             viewBinding.recycler.adapter = it
         }
 
-        adapter.update(
-            config
-        )
+        adapter.update(config, sheetViewModel.selection.value)
 
         eventReporter.onShowExistingPaymentOptions()
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -39,7 +39,8 @@ internal class PaymentOptionsAdapter(
     }
 
     fun update(
-        config: FragmentConfig
+        config: FragmentConfig,
+        paymentSelection: PaymentSelection? = null
     ) {
         val items = listOfNotNull(
             Item.AddCard,
@@ -51,7 +52,8 @@ internal class PaymentOptionsAdapter(
         this.items = items
 
         onItemSelected(
-            position = findInitialSelectedPosition(config.savedSelection),
+            position = findSelectedPosition(paymentSelection).takeIf { it != -1 }
+                ?: findInitialSelectedPosition(config.savedSelection),
             isClick = false
         )
 
@@ -91,6 +93,26 @@ internal class PaymentOptionsAdapter(
             // the first payment method
             items.indexOfFirst { it is Item.ExistingPaymentMethod }.takeIf { it != -1 }
         ).firstOrNull() ?: NO_POSITION
+    }
+
+    /**
+     * Find the index of [paymentSelection] in the current items. Return -1 if not found.
+     */
+    private fun findSelectedPosition(paymentSelection: PaymentSelection?): Int {
+        return items.indexOfFirst { item ->
+            when (paymentSelection) {
+                PaymentSelection.GooglePay -> item is Item.GooglePay
+                is PaymentSelection.Saved -> {
+                    when (item) {
+                        is Item.ExistingPaymentMethod -> {
+                            paymentSelection.paymentMethod.id == item.paymentMethod.id
+                        }
+                        else -> false
+                    }
+                }
+                else -> false
+            }
+        }
     }
 
     @VisibleForTesting

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -52,7 +52,7 @@ internal class PaymentOptionsAdapter(
         this.items = items
 
         onItemSelected(
-            position = findSelectedPosition(paymentSelection).takeIf { it != -1 }
+            position = paymentSelection?.let { findSelectedPosition(it) }.takeIf { it != -1 }
                 ?: findInitialSelectedPosition(config.savedSelection),
             isClick = false
         )
@@ -98,7 +98,7 @@ internal class PaymentOptionsAdapter(
     /**
      * Find the index of [paymentSelection] in the current items. Return -1 if not found.
      */
-    private fun findSelectedPosition(paymentSelection: PaymentSelection?): Int {
+    private fun findSelectedPosition(paymentSelection: PaymentSelection): Int {
         return items.indexOfFirst { item ->
             when (paymentSelection) {
                 PaymentSelection.GooglePay -> item is Item.GooglePay

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -167,6 +167,64 @@ class PaymentOptionsAdapterTest {
     }
 
     @Test
+    fun `initial selected item should reflect SavedSelection`() {
+        val savedPaymentMethod = CONFIG.paymentMethods[3]
+        val adapter = createAdapter().also {
+            it.update(
+                CONFIG.copy(
+                    isGooglePayReady = true,
+                    savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
+                )
+            )
+        }
+
+        assertThat(adapter.selectedItem)
+            .isInstanceOf(PaymentOptionsAdapter.Item.ExistingPaymentMethod::class.java)
+        assertThat((adapter.selectedItem as PaymentOptionsAdapter.Item.ExistingPaymentMethod).paymentMethod)
+            .isEqualTo(savedPaymentMethod)
+    }
+
+    @Test
+    fun `initial selected item should reflect PaymentSelection`() {
+        val savedPaymentMethod = CONFIG.paymentMethods[2]
+        val selectedPaymentMethod = CONFIG.paymentMethods[3]
+        val adapter = createAdapter().also {
+            it.update(
+                CONFIG.copy(
+                    isGooglePayReady = true,
+                    savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
+                ),
+                PaymentSelection.Saved(selectedPaymentMethod)
+            )
+        }
+
+        assertThat(adapter.selectedItem)
+            .isInstanceOf(PaymentOptionsAdapter.Item.ExistingPaymentMethod::class.java)
+        assertThat((adapter.selectedItem as PaymentOptionsAdapter.Item.ExistingPaymentMethod).paymentMethod)
+            .isEqualTo(selectedPaymentMethod)
+    }
+
+    @Test
+    fun `initial selected item should fallback to config when invalid PaymentSelection`() {
+        val savedPaymentMethod = CONFIG.paymentMethods[2]
+        val selectedPaymentMethod = PaymentMethodFixtures.createCards(1).first()
+        val adapter = createAdapter().also {
+            it.update(
+                CONFIG.copy(
+                    isGooglePayReady = true,
+                    savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
+                ),
+                PaymentSelection.Saved(selectedPaymentMethod)
+            )
+        }
+
+        assertThat(adapter.selectedItem)
+            .isInstanceOf(PaymentOptionsAdapter.Item.ExistingPaymentMethod::class.java)
+        assertThat((adapter.selectedItem as PaymentOptionsAdapter.Item.ExistingPaymentMethod).paymentMethod)
+            .isEqualTo(savedPaymentMethod)
+    }
+
+    @Test
     fun `initial selected item should be null when the only item is AddCard`() {
         val adapter = createConfiguredAdapter(
             CONFIG.copy(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
On configuration change, restore selected payment method with higher precedence over saved selection.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Previously it would return to the saved selection.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
