### PR TITLE
fix text listener double trigger in CardNumberEditText and ExpiryDateEditText

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5861,6 +5861,7 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addTextChangedListener (Landroid/text/TextWatcher;)V
 	protected fun getAccessibilityText ()Ljava/lang/String;
 	public final fun getCachedColorStateList ()Landroid/content/res/ColorStateList;
 	public final fun getDefaultErrorColorInt ()I
@@ -5869,6 +5870,7 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	protected final fun isLastKeyDelete ()Z
 	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
 	public fun onInitializeAccessibilityNodeInfo (Landroid/view/accessibility/AccessibilityNodeInfo;)V
+	public fun removeTextChangedListener (Landroid/text/TextWatcher;)V
 	public final fun setAfterTextChangedListener (Lcom/stripe/android/view/StripeEditText$AfterTextChangedListener;)V
 	public final fun setDeleteEmptyListener (Lcom/stripe/android/view/StripeEditText$DeleteEmptyListener;)V
 	public final fun setErrorColor (I)V

--- a/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -306,7 +306,6 @@ class CardNumberEditText internal constructor(
     }
 
     private inner class CardNumberTextWatcher : StripeTextWatcher() {
-        private var ignoreChanges = false
         private var latestChangeStart: Int = 0
         private var latestInsertionSize: Int = 0
 
@@ -318,20 +317,14 @@ class CardNumberEditText internal constructor(
         private var isPastedPan = false
 
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-            if (!ignoreChanges) {
-                isPastedPan = false
-                beforeCardNumber = unvalidatedCardNumber
+            isPastedPan = false
+            beforeCardNumber = unvalidatedCardNumber
 
-                latestChangeStart = start
-                latestInsertionSize = after
-            }
+            latestChangeStart = start
+            latestInsertionSize = after
         }
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            if (ignoreChanges) {
-                return
-            }
-
             val cardNumber = CardNumber.Unvalidated(s?.toString().orEmpty())
             val staticAccountRange = staticCardAccountRanges.filter(cardNumber)
                 .let { accountRanges ->
@@ -372,14 +365,8 @@ class CardNumberEditText internal constructor(
         }
 
         override fun afterTextChanged(s: Editable?) {
-            if (ignoreChanges) {
-                return
-            }
-
-            ignoreChanges = true
-
             if (shouldUpdateAfterChange) {
-                setText(formattedNumber)
+                setTextSilent(formattedNumber)
                 newCursorPosition?.let {
                     setSelection(it.coerceIn(0, fieldText.length))
                 }
@@ -387,8 +374,6 @@ class CardNumberEditText internal constructor(
 
             formattedNumber = null
             newCursorPosition = null
-
-            ignoreChanges = false
 
             if (unvalidatedCardNumber.length == panLength) {
                 val wasCardNumberValid = isCardNumberValid

--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -100,7 +100,6 @@ class ExpiryDateEditText @JvmOverloads constructor(
     private fun listenForTextChanges() {
         addTextChangedListener(
             object : StripeTextWatcher() {
-                private var ignoreChanges = false
                 private var latestChangeStart: Int = 0
                 private var latestInsertionSize: Int = 0
                 private var expirationDate = ExpirationDate.Unvalidated.EMPTY
@@ -114,18 +113,11 @@ class ExpiryDateEditText @JvmOverloads constructor(
                     count: Int,
                     after: Int
                 ) {
-                    if (ignoreChanges) {
-                        return
-                    }
                     latestChangeStart = start
                     latestInsertionSize = after
                 }
 
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                    if (ignoreChanges) {
-                        return
-                    }
-
                     var inErrorState = false
 
                     val inputText = s?.toString().orEmpty()
@@ -186,19 +178,12 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 }
 
                 override fun afterTextChanged(s: Editable?) {
-                    if (ignoreChanges) {
-                        return
-                    }
-
-                    ignoreChanges = true
                     if (!isLastKeyDelete && formattedDate != null) {
-                        setText(formattedDate)
+                        setTextSilent(formattedDate)
                         newCursorPosition?.let {
                             setSelection(it.coerceIn(0, fieldText.length))
                         }
                     }
-
-                    ignoreChanges = false
 
                     // Note: we want to show an error state if the month is invalid or the
                     // final, complete date is in the past. We don't want to show an error state for

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -48,7 +48,6 @@ open class StripeEditText @JvmOverloads constructor(
     @ColorInt
     private var externalErrorColor: Int? = null
 
-
     private val textWatchers by lazy {
         mutableListOf<TextWatcher>()
     }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.accessibility.AccessibilityNodeInfo
@@ -46,6 +47,11 @@ open class StripeEditText @JvmOverloads constructor(
 
     @ColorInt
     private var externalErrorColor: Int? = null
+
+
+    private val textWatchers by lazy {
+        mutableListOf<TextWatcher>()
+    }
 
     /**
      * Gets whether or not the text should be displayed in error mode.
@@ -95,6 +101,7 @@ open class StripeEditText @JvmOverloads constructor(
 
     init {
         maxLines = 1
+
         listenForTextChanges()
         listenForDeleteEmpty()
         defaultColorStateList = textColors
@@ -244,4 +251,31 @@ open class StripeEditText @JvmOverloads constructor(
 
     @VisibleForTesting
     internal fun getParentOnFocusChangeListener() = super.getOnFocusChangeListener()
+
+    override fun addTextChangedListener(watcher: TextWatcher?) {
+        super.addTextChangedListener(watcher)
+        watcher?.let {
+            textWatchers.add(it)
+        }
+    }
+
+    override fun removeTextChangedListener(watcher: TextWatcher?) {
+        super.removeTextChangedListener(watcher)
+        watcher?.let {
+            textWatchers.remove(it)
+        }
+    }
+
+    /**
+     * Set text without notifying its corresponding text watchers.
+     */
+    internal fun setTextSilent(text: CharSequence?) {
+        textWatchers.forEach {
+            super.removeTextChangedListener(it)
+        }
+        setText(text)
+        textWatchers.forEach {
+            super.addTextChangedListener(it)
+        }
+    }
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -48,9 +48,7 @@ open class StripeEditText @JvmOverloads constructor(
     @ColorInt
     private var externalErrorColor: Int? = null
 
-    private val textWatchers by lazy {
-        mutableListOf<TextWatcher>()
-    }
+    private val textWatchers = mutableListOf<TextWatcher>()
 
     /**
      * Gets whether or not the text should be displayed in error mode.

--- a/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -1,9 +1,14 @@
 package com.stripe.android.view
 
+import android.text.TextWatcher
 import android.view.ViewGroup
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardNumberFixtures
 import com.stripe.android.CardNumberFixtures.AMEX_BIN
@@ -903,6 +908,17 @@ internal class CardNumberEditTextTest {
             .hasSize(1)
         assertThat(analyticsRequests.first().params["event"])
             .isEqualTo("stripe_android.card_metadata_loaded_too_slow")
+    }
+
+    @Test
+    fun verifyAdditionalTextChangeListenerGetTriggeredOnlyOnce() {
+        val textChangeListener = mock<TextWatcher>()
+        cardNumberEditText.addTextChangedListener(textChangeListener)
+        cardNumberEditText.setText("1")
+
+        idleLooper()
+
+        verify(textChangeListener, times(1)).afterTextChanged(any())
     }
 
     private fun verifyCardBrandBin(

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -12,7 +12,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.R
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.testharness.ViewTestUtils
-import com.stripe.android.utils.TestUtils
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -1,12 +1,19 @@
 package com.stripe.android.view
 
 import android.content.Context
+import android.text.TextWatcher
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.R
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.utils.TestUtils
+import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
@@ -392,5 +399,16 @@ class ExpiryDateEditTextTest {
         expiryDateEditText.setText(3, 4)
         assertThat(expiryDateEditText.fieldText)
             .isEqualTo("03/04")
+    }
+
+    @Test
+    fun verifyAdditionalTextChangeListenerGetTriggeredOnlyOnce() {
+        val textChangeListener = mock<TextWatcher>()
+        expiryDateEditText.addTextChangedListener(textChangeListener)
+        expiryDateEditText.setText("1")
+
+        idleLooper()
+
+        verify(textChangeListener, times(1)).afterTextChanged(any())
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -217,6 +217,5 @@ internal class StripeEditTextTest {
         verify(watcher, times(count)).beforeTextChanged(any(), any(), any(), any())
         verify(watcher, times(count)).onTextChanged(any(), any(), any(), any())
         verify(watcher, times(count)).afterTextChanged(any())
-
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -2,17 +2,22 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.text.TextWatcher
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.R
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.runner.RunWith
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -164,5 +169,54 @@ internal class StripeEditTextTest {
         editText.shouldShowError = false
         assertThat(editText.currentTextColor)
             .isEqualTo(-570425344)
+    }
+
+    @Test
+    fun setTextSilent_shouldNotNotifyTextWatchers() {
+        val textWatcher = mock<TextWatcher>()
+        editText.addTextChangedListener(textWatcher)
+        editText.setText("1")
+
+        verifyTextWatcherIsTriggered(textWatcher, 1)
+
+        editText.setTextSilent("1")
+
+        verifyNoMoreInteractions(textWatcher)
+    }
+
+    @Test
+    fun setTextSilent_shouldNotChangeSuperClassTextWatchers() {
+        val textWatcher1 = mock<TextWatcher>()
+        val textWatcher2 = mock<TextWatcher>()
+        editText.addTextChangedListener(textWatcher1)
+        editText.addTextChangedListener(textWatcher2)
+        editText.setText("1")
+        idleLooper()
+
+        verifyTextWatcherIsTriggered(textWatcher1, 1)
+        verifyTextWatcherIsTriggered(textWatcher2, 1)
+
+        reset(textWatcher1)
+        reset(textWatcher2)
+
+        editText.removeTextChangedListener(textWatcher2)
+        editText.setText("1")
+
+        verifyTextWatcherIsTriggered(textWatcher1, 1)
+        verifyTextWatcherIsTriggered(textWatcher2, 0)
+
+        editText.removeTextChangedListener(textWatcher1)
+        editText.setText("1")
+        idleLooper()
+
+        verifyNoMoreInteractions(textWatcher1)
+        verifyNoMoreInteractions(textWatcher2)
+    }
+
+    private fun verifyTextWatcherIsTriggered(watcher: TextWatcher, count: Int) {
+        verify(watcher, times(count)).beforeTextChanged(any(), any(), any(), any())
+        verify(watcher, times(count)).onTextChanged(any(), any(), any(), any())
+        verify(watcher, times(count)).afterTextChanged(any())
+
     }
 }


### PR DESCRIPTION
# Summary
Fix the bug when additional `TextWatcher`s are added to `CardNumberEditText` and `ExpiryDateEditText`, they are triggered twice on all text callbacks.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To format card number(add spaces in between) and expiry date(add / in between), the two views validate the input and call `setText` in `afterTextChanged`. They used a boolean `ignoreChanges` to make sure `setText` doesn't trigger `afterTextChanged` again, but it doesn't prevent other listeners added getting triggered.

The fix is to remember all listeners added/removed, and expose a dedicated `setTextSilent` function to remove/addback them while calling the regular `setText`


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
