### PR TITLE
Replace jcenter() with mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.dokkaVersion = '1.4.30'
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -26,7 +26,7 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
# Motivation
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

> After this date JCenter repository will still resolve artifacts, but
> end users should migrate to the canonical repo (e.g. Java packages
> should be retrieved from Maven Central). On Feb 1st, 2022 JCenter
> will only resolve artifacts for Artifactory clients.
