### PR TITLE
Prevent layout animation when changing button visibility.

### DIFF
--- a/stripe/res/layout/stripe_activity_payment_options.xml
+++ b/stripe/res/layout/stripe_activity_payment_options.xml
@@ -57,17 +57,23 @@
                     android:layout_marginVertical="2dp"
                     android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
 
-                <com.stripe.android.paymentsheet.ui.PrimaryButton
-                    android:id="@+id/add_button"
-                    android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-                    android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
+                <!-- Needed to avoid animating layout changes when showing/hiding the button -->
+                <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/stripe_paymentsheet_add_button_label"
-                    android:visibility="gone"/>
+                    android:layout_height="wrap_content">
 
+                    <com.stripe.android.paymentsheet.ui.PrimaryButton
+                        android:id="@+id/add_button"
+                        android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
+                        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                        android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stripe_paymentsheet_add_button_label"
+                        android:visibility="gone" />
+
+                </FrameLayout>
             </LinearLayout>
         </ScrollView>
     </LinearLayout>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a `FrameLayout` around pay button in custom sheet, so that changing the button visibility doesn't trigger layout animation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
On API 21, this causes the sheet to jump during fragment transition.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
