### PR TITLE
Migrate Nexus publishing Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlinVersion = '1.4.32'
@@ -18,7 +20,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.codearte.nexus-staging' version '0.30.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 }
 
 allprojects {
@@ -66,10 +68,23 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
-nexusStaging {
-    username = project.hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-    password = project.hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+nexusPublishing {
     packageGroup = GROUP
+
+    repositories {
+        sonatype {
+            username = project.findProperty('NEXUS_USERNAME') ?: ""
+            password = project.findProperty('NEXUS_PASSWORD') ?: ""
+        }
+    }
+
+    clientTimeout = Duration.ofMinutes(5)
+    connectTimeout = Duration.ofMinutes(1)
+
+    transitionCheckOptions {
+        maxRetries.set(40)
+        delayBetween.set(Duration.ofSeconds(10))
+    }
 }
 
 apply plugin: 'binary-compatibility-validator'


### PR DESCRIPTION
# Summary
`io.codearte.nexus-staging` is deprecated and has been replaced with
`io.github.gradle-nexus.publish-plugin`

See the [migration guide](https://github.com/gradle-nexus/publish-plugin/wiki/Migration-from-gradle_nexus_staging-plugin---nexus_publish-plugin-duo) for more details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
