### PR TITLE
Use findProperty in Gradle scripts

### DIFF
--- a/stripe-test-e2e/build.gradle
+++ b/stripe-test-e2e/build.gradle
@@ -13,13 +13,7 @@ def getBackendUrl() {
 }
 
 private def readProperty(name) {
-    final String propValue
-    if (hasProperty(name)) {
-        propValue = property(name)
-    } else {
-        propValue = System.getenv(name)
-    }
-
+    final String propValue = findProperty(name) ?: System.getenv(name)
     return propValue?.trim() ? propValue : ""
 }
 

--- a/stripe/deploy.gradle
+++ b/stripe/deploy.gradle
@@ -11,21 +11,21 @@ def isReleaseBuild() {
 }
 
 def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    return findProperty('RELEASE_REPOSITORY_URL') ?:
+            "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
 
 def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
+    return findProperty('SNAPSHOT_REPOSITORY_URL') ?:
+            "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
 def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+    return findProperty('NEXUS_USERNAME') ?: ""
 }
 
 def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+    return findProperty('NEXUS_PASSWORD') ?: ""
 }
 
 task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION


# Summary
Use `findProperty` instead of `hasProperty` to get property values.

`findProperty` returns the value of the property if it exists, null
if not.

https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#findProperty-java.lang.String-

# Motivation
Simplify

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
