### PR TITLE
Upgrade Gradle to 7.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.parcelize'
 
-    id 'maven'
     id 'signing'
     id 'maven-publish'
 


### PR DESCRIPTION
# Motivation
From https://docs.gradle.org/7.0/release-notes.html

> This release enables file system watching by default to make your incremental builds faster, expands support for building projects with Java 16, and adds support for building on Macs using Apple Silicon processors (such as M1).
>
> This release also introduces a feature preview for centralized dependency versions, enables build validation errors to make your builds more reliable, and makes it easier to create convention plugins for settings files. Many incubating features have been promoted to stable.

# Testing
Verified by build the example app successfully.

