### PR TITLE
Don't save the payment method until confirm.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionResult.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.bundleOf
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -17,25 +16,9 @@ internal sealed class PaymentOptionResult(
         return bundleOf(EXTRA_RESULT to this)
     }
 
-    internal sealed class Succeeded : PaymentOptionResult(Activity.RESULT_OK) {
-        abstract val paymentSelection: PaymentSelection
-
-        @Parcelize
-        data class Unsaved(
-            override val paymentSelection: PaymentSelection,
-        ) : Succeeded()
-
-        @Parcelize
-        data class Existing(
-            override val paymentSelection: PaymentSelection,
-        ) : Succeeded()
-
-        @Parcelize
-        data class NewlySaved(
-            override val paymentSelection: PaymentSelection,
-            val newSavedPaymentMethod: PaymentMethod
-        ) : Succeeded()
-    }
+    @Parcelize
+    data class Succeeded(val paymentSelection: PaymentSelection) :
+        PaymentOptionResult(Activity.RESULT_OK)
 
     @Parcelize
     data class Failed(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -72,7 +72,7 @@ internal class PaymentOptionsViewModel(
         _viewState.value = ViewState.PaymentOptions.Ready
         prefsRepository.savePaymentSelection(paymentSelection)
         _viewState.value = ViewState.PaymentOptions.ProcessResult(
-            PaymentOptionResult.Succeeded.Existing(paymentSelection)
+            PaymentOptionResult.Succeeded(paymentSelection)
         )
     }
 
@@ -80,7 +80,7 @@ internal class PaymentOptionsViewModel(
         _viewState.value = ViewState.PaymentOptions.Ready
         prefsRepository.savePaymentSelection(paymentSelection)
         _viewState.value = ViewState.PaymentOptions.ProcessResult(
-            PaymentOptionResult.Succeeded.Unsaved(paymentSelection)
+            PaymentOptionResult.Succeeded(paymentSelection)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -148,7 +148,7 @@ internal class DefaultFlowController internal constructor(
         paymentOptionLauncher(
             PaymentOptionContract.Args(
                 paymentIntent = initData.paymentIntent,
-                paymentMethods = viewModel.newlySavedPaymentMethods.plus(initData.paymentMethods),
+                paymentMethods = initData.paymentMethods,
                 sessionId = sessionId,
                 config = initData.config,
                 isGooglePayReady = initData.isGooglePayReady,
@@ -321,10 +321,6 @@ internal class DefaultFlowController internal constructor(
             is PaymentOptionResult.Succeeded -> {
                 val paymentSelection = paymentOptionResult.paymentSelection
                 viewModel.paymentSelection = paymentSelection
-
-                (paymentOptionResult as? PaymentOptionResult.Succeeded.NewlySaved)?.let {
-                    viewModel.newlySavedPaymentMethods.add(it.newSavedPaymentMethod)
-                }
 
                 paymentOptionCallback.onPaymentOption(
                     paymentOptionFactory.create(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -1,14 +1,12 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.lifecycle.ViewModel
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class FlowControllerViewModel : ViewModel() {
     private var _initData: InitData? = null
 
     var paymentSelection: PaymentSelection? = null
-    val newlySavedPaymentMethods = mutableListOf<PaymentMethod>()
 
     fun setInitData(initData: InitData) {
         _initData = initData

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsApiRepository.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.repositories
 import com.stripe.android.Logger
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -48,49 +47,7 @@ internal class PaymentMethodsApiRepository(
         }.getOrDefault(emptyList())
     }
 
-    override suspend fun save(
-        customerConfig: PaymentSheet.CustomerConfiguration,
-        paymentMethodCreateParams: PaymentMethodCreateParams
-    ): PaymentMethod = withContext(workContext) {
-        runCatching {
-            val paymentMethod = requireNotNull(
-                stripeRepository.createPaymentMethod(
-                    paymentMethodCreateParams,
-                    ApiRequest.Options(
-                        publishableKey,
-                        stripeAccountId
-                    )
-                )
-            ) {
-                ERROR_MSG
-            }
-
-            requireNotNull(paymentMethod.id) {
-                ERROR_MSG
-            }
-
-            requireNotNull(
-                stripeRepository.attachPaymentMethod(
-                    customerConfig.id,
-                    publishableKey,
-                    PRODUCT_USAGE,
-                    paymentMethod.id,
-                    ApiRequest.Options(
-                        customerConfig.ephemeralKeySecret,
-                        stripeAccountId
-                    )
-                )
-            ) {
-                ERROR_MSG
-            }
-        }.onFailure {
-            logger.error("Failed to save ${customerConfig.id}'s payment methods.", it)
-            throw it
-        }.getOrThrow()
-    }
-
     private companion object {
         private val PRODUCT_USAGE = setOf("PaymentSheet")
-        private val ERROR_MSG = "Could not parse PaymentMethod."
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 
 internal interface PaymentMethodsRepository {
@@ -9,9 +8,4 @@ internal interface PaymentMethodsRepository {
         customerConfig: PaymentSheet.CustomerConfiguration,
         type: PaymentMethod.Type
     ): List<PaymentMethod>
-
-    suspend fun save(
-        customerConfig: PaymentSheet.CustomerConfiguration,
-        paymentMethodCreateParams: PaymentMethodCreateParams,
-    ): PaymentMethod
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/FakePaymentMethodsRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/FakePaymentMethodsRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 
 class FakePaymentMethodsRepository(
@@ -13,13 +12,4 @@ class FakePaymentMethodsRepository(
         customerConfig: PaymentSheet.CustomerConfiguration,
         type: PaymentMethod.Type
     ): List<PaymentMethod> = paymentMethods
-
-    override suspend fun save(
-        customerConfig: PaymentSheet.CustomerConfiguration,
-        paymentMethodCreateParams: PaymentMethodCreateParams
-    ): PaymentMethod {
-        return error?.let {
-            throw it
-        } ?: savedPaymentMethod
-    }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -297,7 +297,7 @@ class PaymentOptionsActivityTest {
             it.onActivity { activity ->
                 val paymentSelectionMock: PaymentSelection = PaymentSelection.GooglePay
                 viewModel._viewState.value = ViewState.PaymentOptions.ProcessResult(
-                    PaymentOptionResult.Succeeded.Unsaved(
+                    PaymentOptionResult.Succeeded(
                         paymentSelectionMock
                     )
                 )

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -336,7 +336,6 @@ class PaymentOptionsActivityTest {
         return PaymentOptionsViewModel(
             args = args,
             prefsRepository = FakePrefsRepository(),
-            paymentMethodsRepository = FakePaymentMethodsRepository(args.paymentMethods),
             eventReporter = eventReporter,
             workContext = testDispatcher,
             application = ApplicationProvider.getApplicationContext()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -46,7 +46,6 @@ class PaymentOptionsViewModelTest {
     private val viewModel = PaymentOptionsViewModel(
         args = PAYMENT_OPTION_CONTRACT_ARGS,
         prefsRepository = prefsRepository,
-        paymentMethodsRepository = paymentMethodRepository,
         eventReporter = eventReporter,
         workContext = testDispatcher,
         application = ApplicationProvider.getApplicationContext()
@@ -182,7 +181,6 @@ class PaymentOptionsViewModelTest {
         val viewModel = PaymentOptionsViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.copy(newCard = null),
             prefsRepository = FakePrefsRepository(),
-            paymentMethodsRepository = FakePaymentMethodsRepository(emptyList()),
             eventReporter = eventReporter,
             workContext = testDispatcher,
             application = ApplicationProvider.getApplicationContext()
@@ -209,7 +207,6 @@ class PaymentOptionsViewModelTest {
                 )
             ),
             prefsRepository = FakePrefsRepository(),
-            paymentMethodsRepository = FakePaymentMethodsRepository(emptyList()),
             eventReporter = eventReporter,
             workContext = testDispatcher,
             application = ApplicationProvider.getApplicationContext()
@@ -236,7 +233,6 @@ class PaymentOptionsViewModelTest {
                 )
             ),
             prefsRepository = FakePrefsRepository(),
-            paymentMethodsRepository = FakePaymentMethodsRepository(emptyList()),
             eventReporter = eventReporter,
             workContext = testDispatcher,
             application = ApplicationProvider.getApplicationContext()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -73,7 +73,7 @@ class PaymentOptionsViewModelTest {
         viewModel.onUserSelection()
 
         assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
-            .isEqualTo(PaymentOptionResult.Succeeded.Existing(SELECTION_SAVED_PAYMENT_METHOD))
+            .isEqualTo(PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD))
         verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
 
@@ -90,7 +90,7 @@ class PaymentOptionsViewModelTest {
 
             assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
                 .isEqualTo(
-                    PaymentOptionResult.Succeeded.Unsaved(
+                    PaymentOptionResult.Succeeded(
                         NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION
                     )
                 )
@@ -126,11 +126,9 @@ class PaymentOptionsViewModelTest {
 
             val paymentOptionResultSucceeded =
                 (viewState[3] as ViewState.PaymentOptions.ProcessResult)
-                    .result as PaymentOptionResult.Succeeded.NewlySaved
+                    .result as PaymentOptionResult.Succeeded
             assertThat((paymentOptionResultSucceeded).paymentSelection)
                 .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
-            assertThat((paymentOptionResultSucceeded).newSavedPaymentMethod)
-                .isEqualTo(paymentMethodRepository.savedPaymentMethod)
             verify(eventReporter).onSelectPaymentOption(paymentOptionResultSucceeded.paymentSelection)
 
             assertThat((prefsRepository.getSavedSelection() as SavedSelection.PaymentMethod).id)
@@ -169,7 +167,7 @@ class PaymentOptionsViewModelTest {
         viewModel.onUserSelection()
 
         verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
-        assertThat(viewStates.size).isEqualTo(3)
+        assertThat(viewStates.size).isEqualTo(2)
         assertThat(viewStates[0]).isInstanceOf(ViewState.PaymentOptions.Ready::class.java)
         assertThat(viewStates[1]).isInstanceOf(ViewState.PaymentOptions.StartProcessing::class.java)
         assertThat(viewStates[2]).isInstanceOf(ViewState.PaymentOptions.Ready::class.java)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -138,33 +138,6 @@ class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `onUserSelection() when save fails error is reported and in ready state`() {
-        val exceptionMessage = "Card not valid."
-        paymentMethodRepository.error = Exception(exceptionMessage)
-
-        val viewStates: MutableList<ViewState> = mutableListOf()
-        viewModel.viewState.observeForever {
-            viewStates.add(it)
-        }
-
-        var userMessage: BaseSheetViewModel.UserMessage? = null
-        viewModel.userMessage.observeForever {
-            userMessage = it
-        }
-
-        viewModel.updateSelection(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
-
-        viewModel.onUserSelection()
-
-        verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
-        assertThat(viewStates.size).isEqualTo(2)
-        assertThat(viewStates[0]).isInstanceOf(ViewState.PaymentOptions.Ready::class.java)
-        assertThat(viewStates[1]).isInstanceOf(ViewState.PaymentOptions.StartProcessing::class.java)
-        assertThat(viewStates[2]).isInstanceOf(ViewState.PaymentOptions.Ready::class.java)
-        assertThat(userMessage).isEqualTo(BaseSheetViewModel.UserMessage.Error(exceptionMessage))
-    }
-
-    @Test
     fun `resolveTransitionTarget no new card`() {
         val viewModel = PaymentOptionsViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.copy(newCard = null),

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -116,23 +116,13 @@ class PaymentOptionsViewModelTest {
 
             assertThat(viewState[0])
                 .isInstanceOf(ViewState.PaymentOptions.Ready::class.java)
-            assertThat(viewState[1])
-                .isInstanceOf(ViewState.PaymentOptions.StartProcessing::class.java)
-
-            assertThat(viewState[2])
-                .isInstanceOf(ViewState.PaymentOptions.FinishProcessing::class.java)
-
-            (viewState[2] as ViewState.PaymentOptions.FinishProcessing).onComplete()
 
             val paymentOptionResultSucceeded =
-                (viewState[3] as ViewState.PaymentOptions.ProcessResult)
+                (viewState[1] as ViewState.PaymentOptions.ProcessResult)
                     .result as PaymentOptionResult.Succeeded
             assertThat((paymentOptionResultSucceeded).paymentSelection)
                 .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
             verify(eventReporter).onSelectPaymentOption(paymentOptionResultSucceeded.paymentSelection)
-
-            assertThat((prefsRepository.getSavedSelection() as SavedSelection.PaymentMethod).id)
-                .isEqualTo(paymentMethodRepository.savedPaymentMethod.id!!)
         }
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -206,7 +206,7 @@ class DefaultFlowControllerTest {
         }
 
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded.Existing(
+            PaymentOptionResult.Succeeded(
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
         )
@@ -273,12 +273,7 @@ class DefaultFlowControllerTest {
         // Add a saved card payment method so that we can make sure it is added when we open
         // up the payment option launcher
         val newSavedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded.NewlySaved(
-                SAVE_NEW_CARD_SELECTION,
-                newSavedPaymentMethod
-            )
-        )
+        flowController.onPaymentOptionResult(PaymentOptionResult.Succeeded(SAVE_NEW_CARD_SELECTION))
 
         // Save off the actual launch arguments when paymentOptionLauncher is called
         var launchArgs: PaymentOptionContract.Args? = null
@@ -290,7 +285,7 @@ class DefaultFlowControllerTest {
 
         // Make sure that paymentMethods contains the new added payment methods and the initial payment methods.
         assertThat(launchArgs!!.paymentMethods)
-            .isEqualTo(listOf(newSavedPaymentMethod).plus(initialPaymentMethods))
+            .isEqualTo(initialPaymentMethods)
     }
 
     @Test
@@ -353,7 +348,7 @@ class DefaultFlowControllerTest {
         ) { _, _ ->
         }
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded.Existing(PaymentSelection.GooglePay)
+            PaymentOptionResult.Succeeded(PaymentSelection.GooglePay)
         )
         flowController.confirmPayment()
         assertThat(launchArgs)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/repositories/PaymentMethodsRepositoryTest.kt
@@ -5,12 +5,9 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.PaymentMethodCreateParamsFixtures
-import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
@@ -18,7 +15,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -56,46 +52,6 @@ internal class PaymentMethodsRepositoryTest {
             )
     }
 
-    @Test
-    fun `save should return a paymentMethod`() = testDispatcher.runBlockingTest {
-        stripeRepository.createPaymentMethod = CARD_PAYMENT_METHOD
-        stripeRepository.attachPaymentMethod = CARD_PAYMENT_METHOD
-
-        val paymentMethod = repository.save(
-            PaymentSheetFixtures.CONFIG_CUSTOMER.customer!!,
-            PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-        )
-
-        assertThat(paymentMethod)
-            .isEqualTo(stripeRepository.attachPaymentMethod)
-    }
-
-    @Test
-    fun `createMethod should throw an exception on null`() = testDispatcher.runBlockingTest {
-        val exception = assertFailsWith<Exception>(ERROR_MSG) {
-            repository.save(
-                PaymentSheetFixtures.CONFIG_CUSTOMER.customer!!,
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-            )
-        }
-        assertThat(exception.message)
-            .isEqualTo(ERROR_MSG)
-    }
-
-    @Test
-    fun `attachMethod should throw an exception on null`() = testDispatcher.runBlockingTest {
-        stripeRepository.createPaymentMethod = CARD_PAYMENT_METHOD
-
-        val exception = assertFailsWith<Exception>(ERROR_MSG) {
-            repository.save(
-                PaymentSheetFixtures.CONFIG_CUSTOMER.customer!!,
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-            )
-        }
-        assertThat(exception.message)
-            .isEqualTo(ERROR_MSG)
-    }
-
     private class FakeStripeRepository : AbsFakeStripeRepository() {
         var paymentMethods: List<PaymentMethod> = emptyList()
 
@@ -130,9 +86,5 @@ internal class PaymentMethodsRepositoryTest {
         ): PaymentMethod? {
             return attachPaymentMethod
         }
-    }
-
-    private companion object {
-        val ERROR_MSG = "Could not parse PaymentMethod."
     }
 }


### PR DESCRIPTION
# Summary
When save payment method is selected on the custom workflow the sheet should close immediately (the payment method should not be created and attached to the customer).  If the user presses select again it will open up the saved card (similar to how it works when the card is not saved).   The card will be saved with the payment method is confirmed.

Related to #3466 

- [x] Check if the PaymentOptionResult.NewlySaved is needed.
- [x] Do we still want to add it to the list of payment methods
- [x] PaymentOptionResult.Succeeded.Unsaved

# Motivation
#ir-peach-pamphlet

attach may trigger SCA authentication, so we'll stop doing that, and if we're not attaching the PM, there's no point creating one.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

