### PR TITLE
Remove the required billing option for now

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/BasePaymentSheetActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/BasePaymentSheetActivity.kt
@@ -30,14 +30,6 @@ internal abstract class BasePaymentSheetActivity : AppCompatActivity() {
     protected val isCustomerEnabled: Boolean
         get() = prefsManager.getBoolean("enable_customer", true)
 
-    protected val billingAddressCollection: PaymentSheet.BillingAddressCollectionLevel
-        get() {
-            return when (prefsManager.getBoolean("require_billing_address", false)) {
-                true -> PaymentSheet.BillingAddressCollectionLevel.Required
-                false -> PaymentSheet.BillingAddressCollectionLevel.Automatic
-            }
-        }
-
     protected val googlePayConfig: PaymentSheet.GooglePayConfiguration?
         get() {
             return when (prefsManager.getBoolean("enable_googlepay", true)) {

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -5230,34 +5230,23 @@ public class com/stripe/android/paymentsheet/PaymentResult$Failed$Creator : andr
 public final class com/stripe/android/paymentsheet/PaymentSheet {
 }
 
-public final class com/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel : java/lang/Enum {
-	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
-	public static final field Required Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
-	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
-}
-
 public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
-	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBillingAddressCollection ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;
 	public final fun getCustomer ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun getGooglePay ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun getMerchantDisplayName ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun setBillingAddressCollection (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingAddressCollectionLevel;)V
 	public final fun setCustomer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)V
 	public final fun setGooglePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
 	public final fun setMerchantDisplayName (Ljava/lang/String;)V

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -103,8 +103,7 @@ internal abstract class BaseAddCardFragment(
         saveCardCheckbox = viewBinding.saveCardCheckbox
         addCardHeader = viewBinding.addCardHeader
 
-        billingAddressView.level = sheetViewModel.config?.billingAddressCollection
-            ?: PaymentSheet.BillingAddressCollectionLevel.Automatic
+        billingAddressView.level = BillingAddressView.BillingAddressCollectionLevel.Automatic
 
         // This must be done prior to setting up the card widget or the save card checkbox won't
         // populate correctly.

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -103,8 +103,6 @@ internal abstract class BaseAddCardFragment(
         saveCardCheckbox = viewBinding.saveCardCheckbox
         addCardHeader = viewBinding.addCardHeader
 
-        billingAddressView.level = BillingAddressView.BillingAddressCollectionLevel.Automatic
-
         // This must be done prior to setting up the card widget or the save card checkbox won't
         // populate correctly.
         populateFieldsFromNewCard()

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -71,25 +71,7 @@ class PaymentSheet internal constructor(
          */
         var googlePay: GooglePayConfiguration? = null,
 
-        /**
-         * The amount of billing address details to collect.
-         *
-         * See [BillingAddressCollectionLevel]
-         */
-        var billingAddressCollection: BillingAddressCollectionLevel = BillingAddressCollectionLevel.Automatic
     ) : Parcelable
-
-    enum class BillingAddressCollectionLevel {
-        /**
-         * (Default) PaymentSheet will only collect the necessary billing address information.
-         */
-        Automatic,
-
-        /**
-         * PaymentSheet will always collect full billing address details.
-         */
-        Required
-    }
 
     @Parcelize
     data class CustomerConfiguration(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.MutableLiveData
 import com.stripe.android.R
 import com.stripe.android.databinding.StripeBillingAddressLayoutBinding
 import com.stripe.android.model.Address
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.view.Country
 import com.stripe.android.view.CountryUtils
 import com.stripe.android.view.PostalCodeValidator
@@ -42,8 +41,8 @@ internal class BillingAddressView @JvmOverloads constructor(
     }
 
     @VisibleForTesting
-    internal var level: PaymentSheet.BillingAddressCollectionLevel by Delegates.observable(
-        PaymentSheet.BillingAddressCollectionLevel.Automatic
+    internal var level: BillingAddressCollectionLevel by Delegates.observable(
+        BillingAddressCollectionLevel.Automatic
     ) { _, oldLevel, newLevel ->
         if (oldLevel != newLevel) {
             configureForLevel()
@@ -209,13 +208,13 @@ internal class BillingAddressView @JvmOverloads constructor(
             )
             if (isPostalCodeValid) {
                 when (level) {
-                    PaymentSheet.BillingAddressCollectionLevel.Automatic -> {
+                    BillingAddressCollectionLevel.Automatic -> {
                         Address(
                             country = countryCode,
                             postalCode = postalCode
                         )
                     }
-                    PaymentSheet.BillingAddressCollectionLevel.Required -> {
+                    BillingAddressCollectionLevel.Required -> {
                         createRequiredAddress(countryCode, postalCode)
                     }
                 }
@@ -285,7 +284,7 @@ internal class BillingAddressView @JvmOverloads constructor(
         postalCodeLayout.isVisible = shouldShowPostalCode
 
         val shouldShowPostalCodeContainer =
-            level == PaymentSheet.BillingAddressCollectionLevel.Required || shouldShowPostalCode
+            level == BillingAddressCollectionLevel.Required || shouldShowPostalCode
         viewBinding.cityPostalDivider.isVisible = shouldShowPostalCodeContainer
         viewBinding.cityPostalContainer.isVisible = shouldShowPostalCodeContainer
 
@@ -321,10 +320,10 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     private fun configureForLevel() {
         when (level) {
-            PaymentSheet.BillingAddressCollectionLevel.Automatic -> {
+            BillingAddressCollectionLevel.Automatic -> {
                 requiredViews.forEach { it.isVisible = false }
             }
-            PaymentSheet.BillingAddressCollectionLevel.Required -> {
+            BillingAddressCollectionLevel.Required -> {
                 requiredViews.forEach { it.isVisible = true }
             }
         }
@@ -333,10 +332,10 @@ internal class BillingAddressView @JvmOverloads constructor(
 
     fun focusFirstField() {
         when (level) {
-            PaymentSheet.BillingAddressCollectionLevel.Automatic -> {
+            BillingAddressCollectionLevel.Automatic -> {
                 postalCodeLayout.requestFocus()
             }
-            PaymentSheet.BillingAddressCollectionLevel.Required -> {
+            BillingAddressCollectionLevel.Required -> {
                 viewBinding.address1Layout.requestFocus()
             }
         }
@@ -387,5 +386,17 @@ internal class BillingAddressView @JvmOverloads constructor(
                 return TextKeyListener.getInstance()
             }
         }
+    }
+
+    internal enum class BillingAddressCollectionLevel {
+        /**
+         * (Default) PaymentSheet will only collect the necessary billing address information.
+         */
+        Automatic,
+
+        /**
+         * PaymentSheet will always collect full billing address details.
+         */
+        Required
     }
 }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
+import com.stripe.android.databinding.StripeBillingAddressLayoutBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -40,6 +41,27 @@ class PaymentSheetAddCardFragmentTest {
             context,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
+    }
+
+    @Test
+    fun `required billing fields should not be visible`() {
+        createFragment { _, viewBinding ->
+            val billingBinding = StripeBillingAddressLayoutBinding.bind(viewBinding.billingAddress)
+            assertThat(billingBinding.address1Divider.isVisible).isFalse()
+            assertThat(billingBinding.address1Layout.isVisible).isFalse()
+            assertThat(viewBinding.billingAddress.address1View.isVisible).isFalse()
+
+            assertThat(billingBinding.address2Divider.isVisible).isFalse()
+            assertThat(billingBinding.address2Layout.isVisible).isFalse()
+            assertThat(viewBinding.billingAddress.address2View.isVisible).isFalse()
+
+            assertThat(billingBinding.cityLayout.isVisible).isFalse()
+            assertThat(viewBinding.billingAddress.cityView.isVisible).isFalse()
+
+            assertThat(billingBinding.stateDivider.isVisible).isFalse()
+            assertThat(billingBinding.stateLayout.isVisible).isFalse()
+            assertThat(viewBinding.billingAddress.stateView.isVisible).isFalse()
+        }
     }
 
     @Test
@@ -356,10 +378,11 @@ class PaymentSheetAddCardFragmentTest {
 
             viewBinding.billingAddress.countryLayout.selectedCountry = USA
             viewBinding.billingAddress.postalCodeView.setText("123")
-            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!.onFocusChange(
-                viewBinding.billingAddress.postalCodeView,
-                false
-            )
+            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!
+                .onFocusChange(
+                    viewBinding.billingAddress.postalCodeView,
+                    false
+                )
             idleLooper()
 
             assertThat(viewBinding.billingErrors.text.toString())
@@ -377,10 +400,11 @@ class PaymentSheetAddCardFragmentTest {
 
             viewBinding.billingAddress.countryLayout.selectedCountry = USA
             viewBinding.billingAddress.postalCodeView.setText("94107")
-            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!.onFocusChange(
-                viewBinding.billingAddress.postalCodeView,
-                false
-            )
+            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!
+                .onFocusChange(
+                    viewBinding.billingAddress.postalCodeView,
+                    false
+                )
             idleLooper()
 
             assertThat(viewBinding.billingErrors.text.toString()).isEmpty()
@@ -397,10 +421,11 @@ class PaymentSheetAddCardFragmentTest {
 
             viewBinding.billingAddress.countryLayout.selectedCountry = CANADA
             viewBinding.billingAddress.postalCodeView.setText("!@#")
-            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!.onFocusChange(
-                viewBinding.billingAddress.postalCodeView,
-                false
-            )
+            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!
+                .onFocusChange(
+                    viewBinding.billingAddress.postalCodeView,
+                    false
+                )
             idleLooper()
 
             assertThat(viewBinding.billingErrors.text.toString())
@@ -418,10 +443,11 @@ class PaymentSheetAddCardFragmentTest {
 
             viewBinding.billingAddress.countryLayout.selectedCountry = CANADA
             viewBinding.billingAddress.postalCodeView.setText("A1G9Z9")
-            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!.onFocusChange(
-                viewBinding.billingAddress.postalCodeView,
-                false
-            )
+            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!
+                .onFocusChange(
+                    viewBinding.billingAddress.postalCodeView,
+                    false
+                )
             idleLooper()
 
             assertThat(viewBinding.billingErrors.text.toString()).isEmpty()
@@ -438,10 +464,11 @@ class PaymentSheetAddCardFragmentTest {
 
             viewBinding.billingAddress.countryLayout.selectedCountry = USA
             viewBinding.billingAddress.postalCodeView.setText("")
-            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!.onFocusChange(
-                viewBinding.billingAddress.postalCodeView,
-                false
-            )
+            viewBinding.billingAddress.postalCodeView.getParentOnFocusChangeListener()!!
+                .onFocusChange(
+                    viewBinding.billingAddress.postalCodeView,
+                    false
+                )
             idleLooper()
 
             assertThat(viewBinding.billingErrors.text.toString()).isEmpty()

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.Address
 import com.stripe.android.model.AddressFixtures
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
 import com.stripe.android.view.Country
@@ -57,7 +56,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `changing selectedCountry to country without postal code when level=Required should hide postal code view but show city view`() {
-        billingAddressView.level = PaymentSheet.BillingAddressCollectionLevel.Required
+        billingAddressView.level = BillingAddressView.BillingAddressCollectionLevel.Required
         billingAddressView.countryLayout.selectedCountry = ZIMBABWE
         idleLooper()
         assertThat(billingAddressView.postalCodeLayout.isVisible)
@@ -255,7 +254,7 @@ class BillingAddressViewTest {
         billingAddressView.cityView.setText("San Francisco")
         billingAddressView.stateView.setText("California")
 
-        billingAddressView.level = PaymentSheet.BillingAddressCollectionLevel.Required
+        billingAddressView.level = BillingAddressView.BillingAddressCollectionLevel.Required
         assertThat(billingAddressView.address.value)
             .isEqualTo(
                 Address(
@@ -268,7 +267,7 @@ class BillingAddressViewTest {
                 )
             )
 
-        billingAddressView.level = PaymentSheet.BillingAddressCollectionLevel.Automatic
+        billingAddressView.level = BillingAddressView.BillingAddressCollectionLevel.Automatic
         assertThat(billingAddressView.address.value)
             .isEqualTo(
                 Address(


### PR DESCRIPTION
# Summary
Users are not allowed to specify if the billing code is required, for now.  This will need to be added back in before too long.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
