### PR TITLE
Add gradlePluginPortal() to repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        gradlePluginPortal()
     }
 
     dependencies {
@@ -27,8 +28,9 @@ allprojects {
     group = GROUP
 
     repositories {
-        google()
         mavenCentral()
+        google()
+        gradlePluginPortal()
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION


# Summary
This is required for Dokka

See https://github.com/Kotlin/dokka

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
Verified by running `./gradlew :stripe:dokkaHtml`

