### PR TITLE
Make PaymentController.startConfirmAndAuth() suspending

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentController.kt
@@ -16,7 +16,7 @@ internal interface PaymentController {
     /**
      * Confirm the Stripe Intent and resolve any next actions
      */
-    fun startConfirmAndAuth(
+    suspend fun startConfirmAndAuth(
         host: AuthActivityStarter.Host,
         confirmStripeIntentParams: ConfirmStripeIntentParams,
         requestOptions: ApiRequest.Options

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -3,10 +3,12 @@ package com.stripe.android
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.annotation.Size
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.APIException
 import com.stripe.android.exception.AuthenticationException
@@ -147,14 +149,16 @@ class Stripe internal constructor(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
         stripeAccountId: String? = this.stripeAccountId
     ) {
-        paymentController.startConfirmAndAuth(
-            AuthActivityStarter.Host.create(activity),
-            confirmPaymentIntentParams,
-            ApiRequest.Options(
-                apiKey = publishableKey,
-                stripeAccount = stripeAccountId
+        getLifecycleScope(activity).launch {
+            paymentController.startConfirmAndAuth(
+                AuthActivityStarter.Host.create(activity),
+                confirmPaymentIntentParams,
+                ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
             )
-        )
+        }
     }
 
     /**
@@ -202,14 +206,16 @@ class Stripe internal constructor(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
         stripeAccountId: String? = this.stripeAccountId
     ) {
-        paymentController.startConfirmAndAuth(
-            AuthActivityStarter.Host.create(fragment),
-            confirmPaymentIntentParams,
-            ApiRequest.Options(
-                apiKey = publishableKey,
-                stripeAccount = stripeAccountId
+        fragment.lifecycleScope.launch {
+            paymentController.startConfirmAndAuth(
+                AuthActivityStarter.Host.create(fragment),
+                confirmPaymentIntentParams,
+                ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
             )
-        )
+        }
     }
 
     /**
@@ -475,14 +481,16 @@ class Stripe internal constructor(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
         stripeAccountId: String? = this.stripeAccountId
     ) {
-        paymentController.startConfirmAndAuth(
-            AuthActivityStarter.Host.create(activity),
-            confirmSetupIntentParams,
-            ApiRequest.Options(
-                apiKey = publishableKey,
-                stripeAccount = stripeAccountId
+        getLifecycleScope(activity).launch {
+            paymentController.startConfirmAndAuth(
+                AuthActivityStarter.Host.create(activity),
+                confirmSetupIntentParams,
+                ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
             )
-        )
+        }
     }
 
     /**
@@ -499,14 +507,16 @@ class Stripe internal constructor(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
         stripeAccountId: String? = this.stripeAccountId
     ) {
-        paymentController.startConfirmAndAuth(
-            AuthActivityStarter.Host.create(fragment),
-            confirmSetupIntentParams,
-            ApiRequest.Options(
-                apiKey = publishableKey,
-                stripeAccount = stripeAccountId
+        fragment.lifecycleScope.launch {
+            paymentController.startConfirmAndAuth(
+                AuthActivityStarter.Host.create(fragment),
+                confirmSetupIntentParams,
+                ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
             )
-        )
+        }
     }
 
     /**
@@ -1686,6 +1696,17 @@ class Stripe internal constructor(
                 callback.onError(StripeException.create(it))
             }
         )
+    }
+
+    /**
+     * Get a `LifecycleCoroutineScope` if available. Otherwise, default to a `CoroutineScope`
+     * using `Dispatchers.IO`.
+     */
+    private fun getLifecycleScope(
+        activity: Activity
+    ): CoroutineScope = when (activity) {
+        is ComponentActivity -> activity.lifecycleScope
+        else -> CoroutineScope(Dispatchers.IO)
     }
 
     companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -14,6 +14,7 @@ import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -38,6 +39,7 @@ import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.launch
 
 internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
     @VisibleForTesting
@@ -217,14 +219,16 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentResult>() {
         viewModel.startConfirm.observe(this) { event ->
             val confirmParams = event.getContentIfNotHandled()
             if (confirmParams != null) {
-                paymentController.startConfirmAndAuth(
-                    AuthActivityStarter.Host.create(this),
-                    confirmParams,
-                    ApiRequest.Options(
-                        apiKey = paymentConfig.publishableKey,
-                        stripeAccount = paymentConfig.stripeAccountId
+                lifecycleScope.launch {
+                    paymentController.startConfirmAndAuth(
+                        AuthActivityStarter.Host.create(this@PaymentSheetActivity),
+                        confirmParams,
+                        ApiRequest.Options(
+                            apiKey = paymentConfig.publishableKey,
+                            stripeAccount = paymentConfig.stripeAccountId
+                        )
                     )
-                )
+                }
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -207,14 +207,16 @@ internal class DefaultFlowController internal constructor(
             }
             else -> null
         }?.let { confirmParams ->
-            paymentController.startConfirmAndAuth(
-                authHostSupplier(),
-                confirmParams,
-                ApiRequest.Options(
-                    apiKey = publishableKey,
-                    stripeAccount = stripeAccountId
+            lifecycleScope.launch {
+                paymentController.startConfirmAndAuth(
+                    authHostSupplier(),
+                    confirmParams,
+                    ApiRequest.Options(
+                        apiKey = publishableKey,
+                        stripeAccount = stripeAccountId
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
-class StripePaymentAuthTest {
+internal class StripePaymentAuthTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -50,7 +50,7 @@ class StripePaymentAuthTest {
     }
 
     @Test
-    fun confirmPayment_shouldConfirmAndAuth() {
+    fun confirmPayment_shouldConfirmAndAuth() = testDispatcher.runBlockingTest {
         val stripe = createStripe()
         val confirmPaymentIntentParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
             "pm_card_threeDSecure2Required",
@@ -67,7 +67,7 @@ class StripePaymentAuthTest {
     }
 
     @Test
-    fun confirmSetupIntent_shouldConfirmAndAuth() {
+    fun confirmSetupIntent_shouldConfirmAndAuth() = testDispatcher.runBlockingTest {
         val stripe = createStripe()
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
             "pm_card_threeDSecure2Required",

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -75,7 +75,6 @@ internal class StripePaymentControllerTest {
         whenever(it.sdkTransactionId)
             .thenReturn(sdkTransactionId)
     }
-    private val setupIntentResultCallback: ApiResultCallback<SetupIntentResult> = mock()
     private val paymentRelayStarter: PaymentRelayStarter = mock()
     private val analyticsRequestExecutor: AnalyticsRequestExecutor = mock()
     private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter =
@@ -94,8 +93,6 @@ internal class StripePaymentControllerTest {
         argumentCaptor()
     private val intentArgumentCaptor: KArgumentCaptor<Intent> = argumentCaptor()
     private val analyticsRequestArgumentCaptor: KArgumentCaptor<AnalyticsRequest> = argumentCaptor()
-    private val setupIntentResultArgumentCaptor: KArgumentCaptor<SetupIntentResult> =
-        argumentCaptor()
 
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -606,50 +603,52 @@ internal class StripePaymentControllerTest {
     }
 
     @Test
-    fun `bypassAuth() with ActivityResultLauncher should use ActivityResultLauncher`() = testDispatcher.runBlockingTest {
-        verifyZeroInteractions(activity)
+    fun `bypassAuth() with ActivityResultLauncher should use ActivityResultLauncher`() =
+        testDispatcher.runBlockingTest {
+            verifyZeroInteractions(activity)
 
-        val launcher = FakeActivityResultLauncher(PaymentRelayContract())
-        createController(
-            paymentRelayLauncher = launcher
-        ).bypassAuth(
-            host,
-            PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-            null
-        )
-        assertThat(launcher.launchArgs)
-            .containsExactly(
-                PaymentRelayStarter.Args.PaymentIntentArgs(
-                    PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR
-                )
+            val launcher = FakeActivityResultLauncher(PaymentRelayContract())
+            createController(
+                paymentRelayLauncher = launcher
+            ).bypassAuth(
+                host,
+                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+                null
             )
-    }
+            assertThat(launcher.launchArgs)
+                .containsExactly(
+                    PaymentRelayStarter.Args.PaymentIntentArgs(
+                        PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR
+                    )
+                )
+        }
 
     @Test
-    fun `on3ds2AuthFallback() with ActivityResultLauncher should use ActivityResultLauncher`() = testDispatcher.runBlockingTest {
-        verifyZeroInteractions(activity)
+    fun `on3ds2AuthFallback() with ActivityResultLauncher should use ActivityResultLauncher`() =
+        testDispatcher.runBlockingTest {
+            verifyZeroInteractions(activity)
 
-        val launcher = FakeActivityResultLauncher(PaymentAuthWebViewContract())
-        createController(
-            paymentAuthWebViewLauncher = launcher
-        ).on3ds2AuthFallback(
-            "https://example.com",
-            host,
-            PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-            REQUEST_OPTIONS
-        )
-        assertThat(launcher.launchArgs)
-            .containsExactly(
-                PaymentAuthWebViewContract.Args(
-                    objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
-                    requestCode = 50000,
-                    clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
-                    stripeAccountId = ACCOUNT_ID,
-                    url = "https://example.com",
-                    shouldCancelSource = true
-                )
+            val launcher = FakeActivityResultLauncher(PaymentAuthWebViewContract())
+            createController(
+                paymentAuthWebViewLauncher = launcher
+            ).on3ds2AuthFallback(
+                "https://example.com",
+                host,
+                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+                REQUEST_OPTIONS
             )
-    }
+            assertThat(launcher.launchArgs)
+                .containsExactly(
+                    PaymentAuthWebViewContract.Args(
+                        objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
+                        requestCode = 50000,
+                        clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+                        stripeAccountId = ACCOUNT_ID,
+                        url = "https://example.com",
+                        shouldCancelSource = true
+                    )
+                )
+        }
 
     private fun createController(
         paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>? = null,


### PR DESCRIPTION

# Summary
Launch using a lifecycle-aware `CoroutineScope` where possible.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

