### PR TITLE
Consolidate the close sheet code path

### DIFF
--- a/example/res/xml/payment_sheet_preferences.xml
+++ b/example/res/xml/payment_sheet_preferences.xml
@@ -9,6 +9,11 @@
         app:defaultValue="Widget Store" />
 
     <SwitchPreferenceCompat
+        app:key="setup_intent"
+        app:title="Use SetupIntent"
+        app:defaultValue="false" />
+
+    <SwitchPreferenceCompat
         app:key="enable_customer"
         app:title="Use Customer API"
         app:defaultValue="true" />

--- a/example/res/xml/payment_sheet_preferences.xml
+++ b/example/res/xml/payment_sheet_preferences.xml
@@ -9,11 +9,6 @@
         app:defaultValue="Widget Store" />
 
     <SwitchPreferenceCompat
-        app:key="setup_intent"
-        app:title="Use SetupIntent"
-        app:defaultValue="false" />
-
-    <SwitchPreferenceCompat
         app:key="enable_customer"
         app:title="Use Customer API"
         app:defaultValue="true" />

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -89,9 +89,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             is ViewState.PaymentOptions.FinishProcessing -> addButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
             )
-            is ViewState.PaymentOptions.ProcessResult -> processResult(
-                viewState.result
-            )
         }
     }
 
@@ -113,6 +110,10 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             closeSheet(
                 PaymentOptionResult.Failed(it)
             )
+        }
+
+        viewModel.paymentOptionResult.observe(this) {
+            closeSheet(it)
         }
 
         setupAddButton(viewBinding.addButton)

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -106,12 +106,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
         setContentView(viewBinding.root)
 
-        viewModel.fatal.observe(this) {
-            closeSheet(
-                PaymentOptionResult.Failed(it)
-            )
-        }
-
         viewModel.paymentOptionResult.observe(this) {
             closeSheet(it)
         }
@@ -228,20 +222,12 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
     }
 
-    private fun processResult(result: PaymentOptionResult) {
-        closeSheet(result)
-    }
-
     override fun setActivityResult(result: PaymentOptionResult) {
         setResult(
             result.resultCode,
             Intent()
                 .putExtras(result.toBundle())
         )
-    }
-
-    override fun onUserCancel() {
-        closeSheet(PaymentOptionResult.Canceled(mostRecentError = viewModel.fatal.value))
     }
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -34,6 +34,10 @@ internal class PaymentOptionsViewModel(
     )
     internal val viewState: LiveData<ViewState.PaymentOptions> = _viewState.distinctUntilChanged()
 
+    @VisibleForTesting
+    internal val _paymentOptionResult = MutableLiveData<PaymentOptionResult>()
+    internal val paymentOptionResult: LiveData<PaymentOptionResult> = _paymentOptionResult
+
     // Only used to determine if we should skip the list and go to the add card view.
     // and how to populate that view.
     override var newCard = args.newCard
@@ -71,17 +75,13 @@ internal class PaymentOptionsViewModel(
     private fun processExistingCard(paymentSelection: PaymentSelection) {
         _viewState.value = ViewState.PaymentOptions.Ready
         prefsRepository.savePaymentSelection(paymentSelection)
-        _viewState.value = ViewState.PaymentOptions.ProcessResult(
-            PaymentOptionResult.Succeeded(paymentSelection)
-        )
+        _paymentOptionResult.value = PaymentOptionResult.Succeeded(paymentSelection)
     }
 
     private fun processNewCard(paymentSelection: PaymentSelection) {
         _viewState.value = ViewState.PaymentOptions.Ready
         prefsRepository.savePaymentSelection(paymentSelection)
-        _viewState.value = ViewState.PaymentOptions.ProcessResult(
-            PaymentOptionResult.Succeeded(paymentSelection)
-        )
+        _paymentOptionResult.value = PaymentOptionResult.Succeeded(paymentSelection)
     }
 
     fun resolveTransitionTarget(config: FragmentConfig) {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -58,6 +58,16 @@ internal class PaymentOptionsViewModel(
         _processing.postValue(false)
     }
 
+    override fun onFatal(throwable: Throwable) {
+        _fatal.value = throwable
+        _paymentOptionResult.value = PaymentOptionResult.Failed(throwable)
+    }
+
+    override fun onUserCancel() {
+        _paymentOptionResult.value =
+            PaymentOptionResult.Canceled(mostRecentError = _fatal.value)
+    }
+
     fun onUserSelection() {
         selection.value?.let { paymentSelection ->
             // TODO(michelleb-stripe): Should the payment selection in the event be the saved or new item?

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -21,7 +21,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.R
-import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentAuthWebViewContract
 import com.stripe.android.databinding.ActivityPaymentSheetBinding
@@ -108,9 +107,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             )
             is ViewState.PaymentSheet.FinishProcessing -> viewBinding.buyButton.updateState(
                 PrimaryButton.State.FinishProcessing(viewState.onComplete)
-            )
-            is ViewState.PaymentSheet.ProcessResult<*> -> processResult(
-                viewState.result
             )
         }
     }
@@ -220,6 +216,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                 )
             }
         }
+
+        viewModel.paymentSheetResult.observe(this) {
+            closeSheet(it)
+        }
     }
 
     private fun fetchConfig() {
@@ -317,17 +317,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         viewModel.ctaEnabled.observe(this) { isEnabled ->
             viewBinding.buyButton.isEnabled = isEnabled
-        }
-    }
-
-    private fun processResult(stripeIntentResult: StripeIntentResult<*>) {
-        when (stripeIntentResult.outcome) {
-            StripeIntentResult.Outcome.SUCCEEDED -> {
-                closeSheet(PaymentSheetResult.Completed)
-            }
-            else -> {
-                // TODO(mshafrir-stripe): handle other outcomes
-            }
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -173,10 +173,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
         setContentView(viewBinding.root)
 
-        viewModel.fatal.observe(this) {
-            closeSheet(PaymentSheetResult.Failed(it))
-        }
-
         rootView.doOnNextLayout {
             // Show bottom sheet only after the Activity has been laid out so that it animates in
             bottomSheetController.expand()
@@ -326,10 +322,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             Intent()
                 .putExtras(PaymentSheetContract.Result(result).toBundle())
         )
-    }
-
-    override fun onUserCancel() {
-        closeSheet(PaymentSheetResult.Canceled)
     }
 
     internal companion object {

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -62,6 +62,10 @@ internal class PaymentSheetViewModel internal constructor(
         args.clientSecret
     )
 
+    @VisibleForTesting
+    internal val _paymentSheetResult = MutableLiveData<PaymentSheetResult>()
+    internal val paymentSheetResult: LiveData<PaymentSheetResult> = _paymentSheetResult
+
     private val _startConfirm = MutableLiveData<Event<ConfirmPaymentIntentParams>>()
     internal val startConfirm: LiveData<Event<ConfirmPaymentIntentParams>> = _startConfirm
 
@@ -146,7 +150,7 @@ internal class PaymentSheetViewModel internal constructor(
             """.trimIndent()
         )
         _viewState.value = ViewState.PaymentSheet.FinishProcessing {
-            _viewState.value = ViewState.PaymentSheet.ProcessResult(
+            processResult(
                 PaymentIntentResult(
                     paymentIntent,
                     StripeIntentResult.Outcome.SUCCEEDED
@@ -231,7 +235,7 @@ internal class PaymentSheetViewModel internal constructor(
                 }
 
                 _viewState.value = ViewState.PaymentSheet.FinishProcessing {
-                    _viewState.value = ViewState.PaymentSheet.ProcessResult(paymentIntentResult)
+                    processResult(paymentIntentResult)
                 }
             }
             else -> {
@@ -244,6 +248,17 @@ internal class PaymentSheetViewModel internal constructor(
                     onSuccess = ::resetViewState,
                     onFailure = ::onFatal
                 )
+            }
+        }
+    }
+
+    private fun processResult(stripeIntentResult: PaymentIntentResult) {
+        when (stripeIntentResult.outcome) {
+            StripeIntentResult.Outcome.SUCCEEDED -> {
+                _paymentSheetResult.value = PaymentSheetResult.Completed
+            }
+            else -> {
+                // TODO(mshafrir-stripe): handle other outcomes
             }
         }
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -144,7 +144,7 @@ internal class PaymentSheetViewModel internal constructor(
             runCatching {
                 stripeIntentRepository.get(args.clientSecret)
             }.fold(
-                onSuccess = ::onFetchPaymentIntentResponse,
+                onSuccess = ::onPaymentIntentResponse,
                 onFailure = {
                     _paymentIntent.value = null
                     onFatal(it)
@@ -153,9 +153,9 @@ internal class PaymentSheetViewModel internal constructor(
         }
     }
 
-    private fun onFetchPaymentIntentResponse(paymentIntent: PaymentIntent) {
+    private fun onPaymentIntentResponse(paymentIntent: PaymentIntent) {
         if (paymentIntent.isConfirmed) {
-            onFetchConfirmedPaymentIntent(paymentIntent)
+            onConfirmedPaymentIntent(paymentIntent)
         } else {
             runCatching {
                 paymentIntentValidator.requireValid(paymentIntent)
@@ -174,7 +174,7 @@ internal class PaymentSheetViewModel internal constructor(
      *
      * See [How intents work](https://stripe.com/docs/payments/intents) for more details.
      */
-    private fun onFetchConfirmedPaymentIntent(paymentIntent: PaymentIntent) {
+    private fun onConfirmedPaymentIntent(paymentIntent: PaymentIntent) {
         logger.info(
             """
             PaymentIntent with id=${paymentIntent.id}" has already been confirmed.

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/model/ViewState.kt
@@ -1,9 +1,5 @@
 package com.stripe.android.paymentsheet.model
 
-import com.stripe.android.StripeIntentResult
-import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.PaymentOptionResult
-
 internal sealed class ViewState {
     /**
      * The PaymentSheet view state is a little different from the PaymentOptions because the
@@ -21,10 +17,6 @@ internal sealed class ViewState {
         data class FinishProcessing(
             val onComplete: () -> Unit
         ) : PaymentSheet()
-
-        data class ProcessResult<T : StripeIntent>(
-            val result: StripeIntentResult<T>
-        ) : PaymentSheet()
     }
 
     /**
@@ -39,10 +31,6 @@ internal sealed class ViewState {
 
         data class FinishProcessing(
             val onComplete: () -> Unit
-        ) : PaymentOptions()
-
-        data class ProcessResult(
-            val result: PaymentOptionResult
         ) : PaymentOptions()
     }
 }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -33,7 +33,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val messageView: TextView
     abstract val fragmentContainerParent: ViewGroup
 
-    abstract fun onUserCancel()
     abstract fun setActivityResult(result: ResultType)
 
     private val keyboardController: KeyboardController by lazy {
@@ -86,7 +85,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         toolbar.setNavigationOnClickListener {
             if (toolbar.isEnabled) {
                 if (supportFragmentManager.backStackEntryCount == 0) {
-                    onUserCancel()
+                    viewModel.onUserCancel()
                 } else {
                     onUserBack()
                 }
@@ -110,13 +109,14 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
             viewModel.onBackPressed()
             super.onBackPressed()
         } else {
-            onUserCancel()
+            viewModel.onUserCancel()
         }
     }
 
     protected fun closeSheet(
         result: ResultType
     ) {
+        // TODO(mlb): Consider if this needs to be an abstract function
         setActivityResult(result)
         bottomSheetController.hide()
     }
@@ -142,7 +142,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         if (!isProcessing) {
             // Handle taps outside of bottom sheet
             rootView.setOnClickListener {
-                onUserCancel()
+                viewModel.onUserCancel()
             }
         } else {
             rootView.setOnClickListener(null)
@@ -150,7 +150,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         }
     }
 
-    protected fun onUserBack() {
+    private fun onUserBack() {
         keyboardController.hide()
         onBackPressed()
     }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -41,8 +41,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     internal val customerConfig = config?.customer
 
     // a fatal error
-    private val _fatal = MutableLiveData<Throwable>()
-    internal val fatal: LiveData<Throwable> = _fatal
+    protected val _fatal = MutableLiveData<Throwable>()
 
     protected val _isGooglePayReady = MutableLiveData<Boolean>()
     internal val isGooglePayReady: LiveData<Boolean> = _isGooglePayReady.distinctUntilChanged()
@@ -93,6 +92,8 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
      * described above, and when you have an unsaved card.
      */
     abstract var newCard: PaymentSelection.New.Card?
+
+    abstract fun onFatal(throwable: Throwable)
 
     val ctaEnabled: LiveData<Boolean> = processing.switchMap { isProcessing ->
         selection.switchMap { paymentSelection ->
@@ -145,10 +146,6 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         _transition.postValue(Event(target))
     }
 
-    fun onFatal(throwable: Throwable) {
-        _fatal.postValue(throwable)
-    }
-
     fun onApiError(errorMessage: String?) {
         _userMessage.value = errorMessage?.let { UserMessage.Error(it) }
         _processing.value = false
@@ -186,6 +183,8 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         }
     }
 
+    abstract fun onUserCancel()
+
     sealed class UserMessage {
         abstract val message: String
 
@@ -215,6 +214,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
                 content
             }
         }
+
         /**
          * Returns the content, even if it's already been handled.
          */

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -296,10 +296,8 @@ class PaymentOptionsActivityTest {
         ).use {
             it.onActivity { activity ->
                 val paymentSelectionMock: PaymentSelection = PaymentSelection.GooglePay
-                viewModel._viewState.value = ViewState.PaymentOptions.ProcessResult(
-                    PaymentOptionResult.Succeeded(
-                        paymentSelectionMock
-                    )
+                viewModel._paymentOptionResult.value = PaymentOptionResult.Succeeded(
+                    paymentSelectionMock
                 )
                 idleLooper()
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -64,31 +64,34 @@ class PaymentOptionsViewModelTest {
 
     @Test
     fun `onUserSelection() when selection has been made should set the view state to process result`() {
-        var viewState: ViewState? = null
-        viewModel.viewState.observeForever {
-            viewState = it
+        var paymentOptionResult: PaymentOptionResult? = null
+        viewModel.paymentOptionResult.observeForever {
+            paymentOptionResult = it
         }
         viewModel.updateSelection(SELECTION_SAVED_PAYMENT_METHOD)
 
         viewModel.onUserSelection()
 
-        assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
-            .isEqualTo(PaymentOptionResult.Succeeded(SELECTION_SAVED_PAYMENT_METHOD))
+        assertThat(paymentOptionResult).isEqualTo(
+            PaymentOptionResult.Succeeded(
+                SELECTION_SAVED_PAYMENT_METHOD
+            )
+        )
         verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
     }
 
     @Test
     fun `onUserSelection() when new card selection with no save should set the view state to process result`() =
         testDispatcher.runBlockingTest {
-            var viewState: ViewState? = null
-            viewModel.viewState.observeForever {
-                viewState = it
+            var paymentOptionResult: PaymentOptionResult? = null
+            viewModel.paymentOptionResult.observeForever {
+                paymentOptionResult = it
             }
             viewModel.updateSelection(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION)
 
             viewModel.onUserSelection()
 
-            assertThat((viewState as ViewState.PaymentOptions.ProcessResult).result)
+            assertThat(paymentOptionResult)
                 .isEqualTo(
                     PaymentOptionResult.Succeeded(
                         NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION
@@ -110,6 +113,11 @@ class PaymentOptionsViewModelTest {
                 viewState.add(it)
             }
 
+            var paymentOptionResult: PaymentOptionResult? = null
+            viewModel.paymentOptionResult.observeForever {
+                paymentOptionResult = it
+            }
+
             viewModel.updateSelection(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
 
             viewModel.onUserSelection()
@@ -118,8 +126,7 @@ class PaymentOptionsViewModelTest {
                 .isInstanceOf(ViewState.PaymentOptions.Ready::class.java)
 
             val paymentOptionResultSucceeded =
-                (viewState[1] as ViewState.PaymentOptions.ProcessResult)
-                    .result as PaymentOptionResult.Succeeded
+                paymentOptionResult as PaymentOptionResult.Succeeded
             assertThat((paymentOptionResultSucceeded).paymentSelection)
                 .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
             verify(eventReporter).onSelectPaymentOption(paymentOptionResultSucceeded.paymentSelection)

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -24,7 +24,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -23,7 +23,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.FakePaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -440,12 +439,7 @@ internal class PaymentSheetActivityTest {
                 // wait for bottom sheet to animate in
                 idleLooper()
 
-                viewModel._viewState.value = ViewState.PaymentSheet.ProcessResult(
-                    PaymentIntentResult(
-                        intent = PAYMENT_INTENT.copy(status = StripeIntent.Status.Succeeded),
-                        outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED
-                    )
-                )
+                viewModel._paymentSheetResult.value = PaymentSheetResult.Completed
 
                 idleLooper()
 

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddCardFragmentTest.kt
@@ -298,7 +298,7 @@ class PaymentSheetAddCardFragmentTest {
         createFragment(
             fragmentConfig = null
         ) { fragment, _ ->
-            assertThat(fragment.sheetViewModel.fatal.value?.message)
+            assertThat((fragment.sheetViewModel.paymentSheetResult.value as PaymentSheetResult.Failed).error.message)
                 .isEqualTo("Failed to start add payment option fragment.")
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -153,7 +153,7 @@ class PaymentSheetListFragmentTest {
         createScenario(
             fragmentConfig = null
         ).onFragment { fragment ->
-            assertThat(fragment.sheetViewModel.fatal.value?.message)
+            assertThat((fragment.sheetViewModel.paymentSheetResult.value as PaymentSheetResult.Failed).error.message)
                 .isEqualTo("Failed to start existing payment options fragment.")
         }
     }

--- a/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -350,12 +350,12 @@ internal class PaymentSheetViewModelTest {
                 workContext = testDispatcher
             )
         )
-        var error: Throwable? = null
-        viewModel.fatal.observeForever {
-            error = it
+        var result: PaymentSheetResult? = null
+        viewModel.paymentSheetResult.observeForever {
+            result = it
         }
         viewModel.fetchStripeIntent()
-        assertThat(error?.message)
+        assertThat((result as? PaymentSheetResult.Failed)?.error?.message)
             .isEqualTo("Could not parse PaymentIntent.")
     }
 
@@ -368,12 +368,12 @@ internal class PaymentSheetViewModelTest {
                 )
             )
         )
-        var error: Throwable? = null
-        viewModel.fatal.observeForever {
-            error = it
+        var result: PaymentSheetResult? = null
+        viewModel.paymentSheetResult.observeForever {
+            result = it
         }
         viewModel.fetchStripeIntent()
-        assertThat(error?.message)
+        assertThat((result as? PaymentSheetResult.Failed)?.error?.message)
             .isEqualTo(
                 "PaymentIntent with confirmation_method='automatic' is required.\n" +
                     "See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-confirmation_method."
@@ -387,12 +387,12 @@ internal class PaymentSheetViewModelTest {
                 PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
             )
         )
-        var error: Throwable? = null
-        viewModel.fatal.observeForever {
-            error = it
+        var result: PaymentSheetResult? = null
+        viewModel.paymentSheetResult.observeForever {
+            result = it
         }
         viewModel.fetchStripeIntent()
-        assertThat(error?.message)
+        assertThat((result as? PaymentSheetResult.Failed)?.error?.message)
             .isEqualTo(
                 "PaymentIntent with confirmation_method='automatic' is required.\n" +
                     "See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-confirmation_method."


### PR DESCRIPTION
# Summary
Remove the processResult from the view state and instead create variable in the viewModel that when set closes the sheet with the result value.   Converted all methods of closing the sheet to use this path.

# Motivation
The prevents some of the back and forth between the viewModel and the activity, it makes the closeSheet path consistent in that it always goes through the view model, and it moves more logic out of the activity.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
