### PR TITLE
Only use StripeBrowserLauncherActivity when Custom Tabs are supported

### DIFF
--- a/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentAuthWebViewStarter.kt
@@ -16,11 +16,16 @@ internal interface PaymentAuthWebViewStarter :
     AuthActivityStarter<PaymentAuthWebViewContract.Args> {
     class Legacy(
         private val host: AuthActivityStarter.Host,
+        private val isCustomTabsSupported: Boolean,
         private val defaultReturnUrl: DefaultReturnUrl
     ) : PaymentAuthWebViewStarter {
         override fun start(args: PaymentAuthWebViewContract.Args) {
+            val shouldUseCustomTabs = args.shouldUseCustomTabs(
+                isCustomTabsSupported,
+                defaultReturnUrl
+            )
             host.startActivityForResult(
-                when (args.shouldUseBrowser(defaultReturnUrl)) {
+                when (shouldUseCustomTabs) {
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -27,6 +27,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.CustomTabsCapabilities
 import com.stripe.android.payments.DefaultPaymentFlowResultProcessor
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.DefaultStripeChallengeStatusReceiver
@@ -99,11 +100,16 @@ internal class StripePaymentController internal constructor(
         } ?: PaymentRelayStarter.Legacy(host)
     }
 
+    private val isCustomTabsSupported: Boolean by lazy {
+        CustomTabsCapabilities(context).isSupported()
+    }
+
     private val paymentAuthWebViewStarterFactory = { host: AuthActivityStarter.Host ->
         paymentAuthWebViewLauncher?.let {
             PaymentAuthWebViewStarter.Modern(it)
         } ?: PaymentAuthWebViewStarter.Legacy(
             host,
+            isCustomTabsSupported,
             defaultReturnUrl
         )
     }

--- a/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentAuthWebViewContract.kt
@@ -18,14 +18,10 @@ import kotlinx.parcelize.Parcelize
  */
 internal class PaymentAuthWebViewContract(
     private val defaultReturnUrl: DefaultReturnUrl,
-    private val isCustomTabsSupported: (Context) -> Boolean
+    private val isCustomTabsSupported: (Context) -> Boolean = { context ->
+        CustomTabsCapabilities(context).isSupported()
+    }
 ) : ActivityResultContract<PaymentAuthWebViewContract.Args, PaymentFlowResult.Unvalidated>() {
-    constructor(
-        defaultReturnUrl: DefaultReturnUrl
-    ) : this(
-        defaultReturnUrl,
-        { context -> CustomTabsCapabilities(context).isSupported() }
-    )
 
     override fun createIntent(
         context: Context,

--- a/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -17,6 +17,9 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  * Custom Tabs (if available) or a browser.
  *
  * The eventual replacement for [PaymentAuthWebViewActivity].
+ *
+ * [StripeBrowserLauncherActivity] will only be used if Custom Tabs are enabled. See
+ * [PaymentAuthWebViewContract.Args.shouldUseCustomTabs].
  */
 internal class StripeBrowserLauncherActivity : AppCompatActivity() {
     private val viewModel: StripeBrowserLauncherViewModel by viewModels()

--- a/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentAuthWebViewStarterTest.kt
@@ -32,6 +32,7 @@ class PaymentAuthWebViewStarterTest {
     private val host = AuthActivityStarter.Host.create(activity)
     private val legacyStarter = PaymentAuthWebViewStarter.Legacy(
         host,
+        isCustomTabsSupported = true,
         defaultReturnUrl
     )
 

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -98,7 +98,10 @@ internal class StripePaymentControllerTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val defaultReturnUrl = DefaultReturnUrl.create(context)
-    private val paymentAuthWebViewContract = PaymentAuthWebViewContract(defaultReturnUrl)
+    private val paymentAuthWebViewContract = PaymentAuthWebViewContract(
+        defaultReturnUrl,
+        isCustomTabsSupported = { true }
+    )
     private val controller = createController()
 
     @BeforeTest

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -27,7 +27,8 @@ class PaymentAuthWebViewActivityTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val contract = PaymentAuthWebViewContract(
-        DefaultReturnUrl.create(context)
+        DefaultReturnUrl.create(context),
+        isCustomTabsSupported = { true }
     )
 
     @BeforeTest


### PR DESCRIPTION


# Summary
Update logic in `PaymentAuthWebViewContract` to only use
`StripeBrowserLauncherActivity` if Custom Tabs are supported on the
device.

While testing on emulators with older API versions (e.g. API 21)
that didn't have Chrome installed, it was discovered that return URL
handling wasn't working as expected.

# Motivation
This PR reduces the scope of #3596 until we can verify behavior
on non-Chrome devices or add a check for the availability of Chrome.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
