### PR TITLE
Set payment selection even when it's null.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -314,7 +314,7 @@ internal class DefaultFlowController internal constructor(
                 }
             }
             else -> null
-        }?.let {
+        }.let {
             viewModel.paymentSelection = it
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
On PaymentSheet custom flow, if the `FlowController` is configured again after it's created, it currently will not clear the selected payment method in case the new configuration is for a customer without any payment methods. It should still update the selected payment method, to `null` in this case.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug fix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
