### PR TITLE
support beta header

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -857,6 +857,7 @@ public final class com/stripe/android/Stripe$Companion {
 }
 
 public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
+	public static final field AlipayV1 Lcom/stripe/android/StripeApiBeta;
 	public static final field WechatPayV1 Lcom/stripe/android/StripeApiBeta;
 	public final fun getCode ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/StripeApiBeta;

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -857,7 +857,6 @@ public final class com/stripe/android/Stripe$Companion {
 }
 
 public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
-	public static final field AlipayV1 Lcom/stripe/android/StripeApiBeta;
 	public static final field WechatPayV1 Lcom/stripe/android/StripeApiBeta;
 	public final fun getCode ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/StripeApiBeta;

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -694,7 +694,8 @@ public final class com/stripe/android/Stripe {
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun authenticatePayment (Landroid/app/Activity;Ljava/lang/String;)V
 	public final fun authenticatePayment (Landroidx/fragment/app/Fragment;Ljava/lang/String;)V
 	public final fun authenticateSetup (Landroid/app/Activity;Ljava/lang/String;)V
@@ -853,6 +854,13 @@ public final class com/stripe/android/Stripe$Companion {
 	public final fun getAppInfo ()Lcom/stripe/android/AppInfo;
 	public final fun setAdvancedFraudSignalsEnabled (Z)V
 	public final fun setAppInfo (Lcom/stripe/android/AppInfo;)V
+}
+
+public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
+	public static final field WechatPayV1 Lcom/stripe/android/StripeApiBeta;
+	public final fun getCode ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/StripeApiBeta;
+	public static fun values ()[Lcom/stripe/android/StripeApiBeta;
 }
 
 public final class com/stripe/android/StripeError : com/stripe/android/model/StripeModel, java/io/Serializable {

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -19,23 +19,13 @@ internal data class ApiVersion internal constructor(
 
     val code: String
         get() =
-            betas?.let {
+            betas?.let { betas ->
                 listOf(this.version)
                     .plus(
-                        betas!!.map { it.code }
+                        betas.map { it.code }
                     )
                     .joinToString(";")
             } ?: version
-
-    override fun toString(): String {
-        return betas?.let {
-            listOf(this.version)
-                .plus(
-                    betas!!.map { it.code }
-                )
-                .joinToString(";")
-        } ?: version
-    }
 
     internal companion object {
         const val API_VERSION_CODE: String = "2020-03-02"

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -9,19 +9,33 @@ package com.stripe.android
  * See [https://stripe.com/docs/upgrades](https://stripe.com/docs/upgrades) for latest
  * API changes.
  */
-internal data class ApiVersion internal constructor(internal val code: String) {
+internal data class ApiVersion internal constructor(
+    internal val version: String,
+    internal var betas: Set<StripeApiBeta>? = null
+) {
+    constructor(
+        betas: Set<StripeApiBeta>
+    ) : this(API_VERSION_CODE, betas)
+
+    val code: String
+        get() =
+            betas?.let {
+                listOf(this.version)
+                    .plus(
+                        betas!!.map { it.code }
+                    )
+                    .joinToString(";")
+            } ?: version
 
     override fun toString(): String {
-        return code
+        return betas?.let {
+            listOf(this.version)
+                .plus(
+                    betas!!.map { it.code }
+                )
+                .joinToString(";")
+        } ?: version
     }
-
-    fun withBetas(betas: Set<StripeApiBeta>): ApiVersion =
-        if (betas.isNullOrEmpty()) INSTANCE else
-            ApiVersion(
-                listOf(this.code)
-                    .plus(betas.map { it.code })
-                    .joinToString(";")
-            )
 
     internal companion object {
         const val API_VERSION_CODE: String = "2020-03-02"

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -15,8 +15,16 @@ internal data class ApiVersion internal constructor(internal val code: String) {
         return code
     }
 
+    fun withBetas(betas: Set<StripeApiBeta>): ApiVersion =
+        if (betas.isNullOrEmpty()) INSTANCE else
+            ApiVersion(
+                listOf(this.code)
+                    .plus(betas.map { it.code })
+                    .joinToString(";")
+            )
+
     internal companion object {
-        private const val API_VERSION_CODE: String = "2020-03-02"
+        const val API_VERSION_CODE: String = "2020-03-02"
 
         private val INSTANCE = ApiVersion(API_VERSION_CODE)
 

--- a/stripe/src/main/java/com/stripe/android/ApiVersion.kt
+++ b/stripe/src/main/java/com/stripe/android/ApiVersion.kt
@@ -11,7 +11,7 @@ package com.stripe.android
  */
 internal data class ApiVersion internal constructor(
     internal val version: String,
-    internal var betas: Set<StripeApiBeta>? = null
+    internal val betas: Set<StripeApiBeta> = emptySet()
 ) {
     constructor(
         betas: Set<StripeApiBeta>
@@ -19,13 +19,11 @@ internal data class ApiVersion internal constructor(
 
     val code: String
         get() =
-            betas?.let { betas ->
-                listOf(this.version)
-                    .plus(
-                        betas.map { it.code }
-                    )
-                    .joinToString(";")
-            } ?: version
+            listOf(this.version)
+                .plus(
+                    betas.map { it.code }
+                )
+                .joinToString(";")
 
     internal companion object {
         const val API_VERSION_CODE: String = "2020-03-02"

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -75,20 +75,25 @@ class Stripe internal constructor(
      * @param enableLogging enable logging in the Stripe and Stripe 3DS2 SDKs; disabled by default.
      * It is recommended to disable logging in production. Logs can be accessed from the command line using
      * `adb logcat -s StripeSdk`
+     * @param betas optional, set of beta flags to pass to the Stripe API. Setting this property is
+     * not sufficient to participate in a beta, and passing a beta you are not registered
+     * in will result in API errors.
      */
     @JvmOverloads
     constructor(
         context: Context,
         publishableKey: String,
         stripeAccountId: String? = null,
-        enableLogging: Boolean = false
+        enableLogging: Boolean = false,
+        betas: Set<StripeApiBeta> = emptySet()
     ) : this(
         context.applicationContext,
         StripeApiRepository(
             context.applicationContext,
             publishableKey,
             appInfo,
-            Logger.getInstance(enableLogging)
+            Logger.getInstance(enableLogging),
+            betas = betas
         ),
         ApiKeyValidator.get().requireValid(publishableKey),
         stripeAccountId,

--- a/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -4,5 +4,7 @@ package com.stripe.android
  * Enums of beta headers allowed to be override when initializing [Stripe].
  */
 enum class StripeApiBeta(val code: String) {
+    @Deprecated("alipay is public")
+    AlipayV1("alipay_beta=v1"),
     WechatPayV1("wechat_pay_beta=v1");
 }

--- a/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -1,12 +1,8 @@
 package com.stripe.android
 
+/**
+ * Enums of beta headers allowed to be override when initializing [Stripe].
+ */
 enum class StripeApiBeta(val code: String) {
-    AlipayV1("alipay_beta=v1"),
-    OxxoV1("oxxo_beta=v1");
-
-    internal companion object {
-        internal fun fromCode(code: String): StripeApiBeta? {
-            return values().firstOrNull { it.code == code }
-        }
-    }
+    WechatPayV1("wechat_pay_beta=v1");
 }

--- a/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -1,0 +1,12 @@
+package com.stripe.android
+
+enum class StripeApiBeta(val code: String) {
+    AlipayV1("alipay_beta=v1"),
+    OxxoV1("oxxo_beta=v1");
+
+    internal companion object {
+        internal fun fromCode(code: String): StripeApiBeta? {
+            return values().firstOrNull { it.code == code }
+        }
+    }
+}

--- a/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/stripe/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -4,7 +4,5 @@ package com.stripe.android
  * Enums of beta headers allowed to be override when initializing [Stripe].
  */
 enum class StripeApiBeta(val code: String) {
-    @Deprecated("alipay is public")
-    AlipayV1("alipay_beta=v1"),
     WechatPayV1("wechat_pay_beta=v1");
 }

--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -9,6 +9,7 @@ import com.stripe.android.FingerprintData
 import com.stripe.android.FingerprintDataRepository
 import com.stripe.android.Logger
 import com.stripe.android.Stripe
+import com.stripe.android.StripeApiBeta
 import com.stripe.android.cards.Bin
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.APIException
@@ -81,7 +82,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     private val analyticsDataFactory: AnalyticsDataFactory =
         AnalyticsDataFactory(context, publishableKey),
     private val fingerprintParamsUtils: FingerprintParamsUtils = FingerprintParamsUtils(),
-    apiVersion: String = ApiVersion.get().code,
+    betas: Set<StripeApiBeta> = emptySet(),
+    apiVersion: String = ApiVersion.get().withBetas(betas).code,
     sdkVersion: String = Stripe.VERSION
 ) : StripeRepository {
     private val analyticsRequestFactory = AnalyticsRequest.Factory(logger)

--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -83,7 +83,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         AnalyticsDataFactory(context, publishableKey),
     private val fingerprintParamsUtils: FingerprintParamsUtils = FingerprintParamsUtils(),
     betas: Set<StripeApiBeta> = emptySet(),
-    apiVersion: String = ApiVersion.get().withBetas(betas).code,
+    apiVersion: String = ApiVersion(betas = betas).code,
     sdkVersion: String = Stripe.VERSION
 ) : StripeRepository {
     private val analyticsRequestFactory = AnalyticsRequest.Factory(logger)

--- a/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
@@ -11,8 +11,14 @@ class ApiVersionTest {
     }
 
     @Test
-    fun `wechat pay beta should have correct code`() {
-        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.WechatPayV1)).code)
+    fun `single beta header should have correct code`() {
+        assertThat(ApiVersion(setOf(StripeApiBeta.WechatPayV1)).code)
             .isEqualTo("$API_VERSION_CODE;${StripeApiBeta.WechatPayV1.code}")
+    }
+
+    @Test
+    fun `multiple beta headers should have correct code`() {
+        assertThat(ApiVersion(setOf(StripeApiBeta.WechatPayV1, StripeApiBeta.AlipayV1)).code)
+            .isEqualTo("$API_VERSION_CODE;${StripeApiBeta.WechatPayV1.code};${StripeApiBeta.AlipayV1.code}")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
@@ -1,0 +1,29 @@
+package com.stripe.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ApiVersionTest {
+    @Test
+    fun `instance should instantiate correctly`() {
+        assertThat(ApiVersion.get().code).isEqualTo("2020-03-02")
+    }
+
+    @Test
+    fun `alipay beta should have correct code`() {
+        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.AlipayV1)).code)
+            .isEqualTo("2020-03-02;alipay_beta=v1")
+    }
+
+    @Test
+    fun `oxxo beta should have correct code`() {
+        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.OxxoV1)).code)
+            .isEqualTo("2020-03-02;oxxo_beta=v1")
+    }
+
+    @Test
+    fun `betas should combine correctly`() {
+        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.AlipayV1, StripeApiBeta.OxxoV1)).code)
+            .isEqualTo("2020-03-02;alipay_beta=v1;oxxo_beta=v1")
+    }
+}

--- a/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
@@ -1,29 +1,18 @@
 package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiVersion.Companion.API_VERSION_CODE
 import org.junit.Test
 
 class ApiVersionTest {
     @Test
     fun `instance should instantiate correctly`() {
-        assertThat(ApiVersion.get().code).isEqualTo("2020-03-02")
+        assertThat(ApiVersion.get().code).isEqualTo(API_VERSION_CODE)
     }
 
     @Test
-    fun `alipay beta should have correct code`() {
-        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.AlipayV1)).code)
-            .isEqualTo("2020-03-02;alipay_beta=v1")
-    }
-
-    @Test
-    fun `oxxo beta should have correct code`() {
-        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.OxxoV1)).code)
-            .isEqualTo("2020-03-02;oxxo_beta=v1")
-    }
-
-    @Test
-    fun `betas should combine correctly`() {
-        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.AlipayV1, StripeApiBeta.OxxoV1)).code)
-            .isEqualTo("2020-03-02;alipay_beta=v1;oxxo_beta=v1")
+    fun `wechat pay beta should have correct code`() {
+        assertThat(ApiVersion.get().withBetas(setOf(StripeApiBeta.WechatPayV1)).code)
+            .isEqualTo("$API_VERSION_CODE;${StripeApiBeta.WechatPayV1.code}")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
+++ b/stripe/src/test/java/com/stripe/android/ApiVersionTest.kt
@@ -15,10 +15,4 @@ class ApiVersionTest {
         assertThat(ApiVersion(setOf(StripeApiBeta.WechatPayV1)).code)
             .isEqualTo("$API_VERSION_CODE;${StripeApiBeta.WechatPayV1.code}")
     }
-
-    @Test
-    fun `multiple beta headers should have correct code`() {
-        assertThat(ApiVersion(setOf(StripeApiBeta.WechatPayV1, StripeApiBeta.AlipayV1)).code)
-            .isEqualTo("$API_VERSION_CODE;${StripeApiBeta.WechatPayV1.code};${StripeApiBeta.AlipayV1.code}")
-    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add support to add beta headers so that we can do 
`--header 'Stripe-Version: 2020-03-02;wechat_pay_beta=v1' `

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Some API bindings are only available in beta version, we would like to support beta APIs.

This is a simplified version of #2612 without changes to `PaymentConfiguration` and `CustomerSession`, as they're not used by Wechat Pay API. 
iOS has a similar approach, where a [set](https://github.com/stripe-ios/stripe-ios/blob/07a24494cb3f26e6c22d83f8dde36f5d88eca186/Stripe/STPAPIClient.swift#L69) is available override betas when initializing `STPAPIClient`

Wechat change incoming as a follow up PR.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
