### PR TITLE
Use starting Activity's statusBarColor to theme Custom Tabs toolbar

### DIFF
--- a/example/res/values-night/colors.xml
+++ b/example/res/values-night/colors.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="blurple">#5851df</color>
+
     <color name="primary">#a3acb9</color>
     <color name="primaryDark">#000000</color>
     <color name="appPrimaryDark">#242424</color>

--- a/example/res/values/colors.xml
+++ b/example/res/values/colors.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="blurple">#635BFF</color>
+
     <color name="primary">#5F65D4</color>
     <color name="primaryDark">#392996</color>
-    <color name="appPrimaryDark">#887fc0</color>
+    <color name="appPrimaryDark">#1a1843</color>
     <color name="accent">#5469d4</color>
     <color name="title">#ffffff</color>
     <color name="textPrimary">#000000</color>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
-        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimary">@color/blurple</item>
         <item name="colorPrimaryDark">@color/appPrimaryDark</item>
         <item name="colorAccent">@color/accent</item>
         <item name="colorControlActivated">@color/accent</item>
@@ -11,7 +11,7 @@
 
     <style name="StripeDefaultTheme" parent="StripeBaseTheme">
         <!-- Applied to toolbar background -->
-        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimary">@color/blurple</item>
 
         <!-- Applied to status bar -->
         <item name="colorPrimaryDark">@color/primaryDark</item>
@@ -43,7 +43,7 @@
     <!-- Applied to 3DS2 Challenge Screen -->
     <style name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme">
         <!-- 3DS2 Challenge Screen toolbar background -->
-        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimary">@color/blurple</item>
         <!-- 3DS2 Challenge Screen status bar -->
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <!-- 3DS2 Challenge Screen toolbar text -->

--- a/stripe/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -19,6 +19,10 @@ internal interface PaymentBrowserAuthStarter :
         private val defaultReturnUrl: DefaultReturnUrl
     ) : PaymentBrowserAuthStarter {
         override fun start(args: PaymentBrowserAuthContract.Args) {
+            val extras = args
+                .copy(statusBarColor = host.statusBarColor)
+                .toBundle()
+
             val shouldUseCustomTabs = args.shouldUseCustomTabs(
                 isCustomTabsSupported,
                 defaultReturnUrl
@@ -28,7 +32,7 @@ internal interface PaymentBrowserAuthStarter :
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },
-                args.toBundle(),
+                extras,
                 args.requestCode
             )
         }

--- a/stripe/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.auth
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
@@ -33,6 +34,15 @@ internal class PaymentBrowserAuthContract(
             defaultReturnUrl
         )
 
+        val statusBarColor = when (context) {
+            is Activity -> context.window?.statusBarColor
+            else -> null
+        }
+
+        val extras = input
+            .copy(statusBarColor = statusBarColor)
+            .toBundle()
+
         return Intent(
             context,
             when (shouldUseCustomTabs) {
@@ -40,7 +50,7 @@ internal class PaymentBrowserAuthContract(
                 false -> PaymentAuthWebViewActivity::class.java
             }
         ).also { intent ->
-            intent.putExtras(input.toBundle())
+            intent.putExtras(extras)
         }
     }
 
@@ -71,7 +81,9 @@ internal class PaymentBrowserAuthContract(
          * Simply displaying the web view is all we need to do, and we expect the user to
          * navigate away after this.
          */
-        val shouldCancelIntentOnUserNavigation: Boolean = true
+        val shouldCancelIntentOnUserNavigation: Boolean = true,
+
+        val statusBarColor: Int? = null
     ) : Parcelable {
         /**
          * If true, use [StripeBrowserLauncherActivity].

--- a/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.view.PaymentAuthWebViewActivity
@@ -56,9 +57,20 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
         viewModel.logCapabilities(shouldUseCustomTabs)
 
         if (shouldUseCustomTabs) {
+            val customTabColorSchemeParams = args.statusBarColor?.let { statusBarColor ->
+                CustomTabColorSchemeParams.Builder()
+                    .setToolbarColor(statusBarColor)
+                    .build()
+            }
+
             // use Custom Tabs
             val customTabsIntent = CustomTabsIntent.Builder()
                 .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+                .also {
+                    if (customTabColorSchemeParams != null) {
+                        it.setDefaultColorSchemeParams(customTabColorSchemeParams)
+                    }
+                }
                 .build()
             customTabsIntent.intent.data = url
             launcher.launch(customTabsIntent.intent)

--- a/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/AuthActivityStarter.kt
@@ -12,7 +12,11 @@ internal interface AuthActivityStarter<ArgsType> {
     /**
      * A representation of an object (i.e. Activity or Fragment) that can start an activity.
      */
-    class Host private constructor(activity: Activity, fragment: Fragment?) {
+    class Host internal constructor(
+        activity: Activity,
+        fragment: Fragment?,
+        val statusBarColor: Int?
+    ) {
         private val activityRef: WeakReference<Activity> = WeakReference(activity)
         private val fragmentRef: WeakReference<Fragment>? = fragment?.let { WeakReference(it) }
 
@@ -22,7 +26,11 @@ internal interface AuthActivityStarter<ArgsType> {
         internal val fragment: Fragment?
             get() = fragmentRef?.get()
 
-        internal fun startActivityForResult(target: Class<*>, extras: Bundle, requestCode: Int) {
+        internal fun startActivityForResult(
+            target: Class<*>,
+            extras: Bundle,
+            requestCode: Int
+        ) {
             val activity = activityRef.get() ?: return
 
             val intent = Intent(activity, target).putExtras(extras)
@@ -39,13 +47,26 @@ internal interface AuthActivityStarter<ArgsType> {
 
         internal companion object {
             @JvmSynthetic
-            internal fun create(fragment: Fragment): Host {
-                return Host(fragment.requireActivity(), fragment)
+            internal fun create(
+                fragment: Fragment
+            ): Host {
+                val activity = fragment.requireActivity()
+                return Host(
+                    activity = activity,
+                    fragment = fragment,
+                    statusBarColor = activity.window?.statusBarColor
+                )
             }
 
             @JvmSynthetic
-            internal fun create(activity: Activity): Host {
-                return Host(activity, null)
+            internal fun create(
+                activity: Activity
+            ): Host {
+                return Host(
+                    activity = activity,
+                    fragment = null,
+                    statusBarColor = activity.window?.statusBarColor
+                )
             }
         }
     }

--- a/stripe/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -2,8 +2,11 @@ package com.stripe.android
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argWhere
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -29,9 +32,9 @@ class PaymentBrowserAuthStarterTest {
     private val defaultReturnUrl = DefaultReturnUrl.create(
         ApplicationProvider.getApplicationContext()
     )
-    private val host = AuthActivityStarter.Host.create(activity)
+
     private val legacyStarter = PaymentBrowserAuthStarter.Legacy(
-        host,
+        AuthActivityStarter.Host.create(activity),
         isCustomTabsSupported = true,
         defaultReturnUrl
     )
@@ -68,6 +71,29 @@ class PaymentBrowserAuthStarterTest {
         )
         assertNotNull(args.toolbarCustomization)
         assertEquals(DATA.clientSecret, args.clientSecret)
+    }
+
+    @Test
+    fun `intent extras should include statusBarColor when available`() {
+        val legacyStarter = PaymentBrowserAuthStarter.Legacy(
+            AuthActivityStarter.Host(
+                activity,
+                fragment = null,
+                statusBarColor = Color.RED
+            ),
+            isCustomTabsSupported = true,
+            defaultReturnUrl
+        )
+        legacyStarter.start(DATA)
+        verify(activity).startActivityForResult(
+            argWhere { intent ->
+                val args = requireNotNull(
+                    intent.getParcelableExtra<PaymentBrowserAuthContract.Args>("extra_args")
+                )
+                args.statusBarColor == Color.RED
+            },
+            any()
+        )
     }
 
     private companion object {

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -16,7 +16,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.android.StripePaymentController.Companion.EXPAND_PAYMENT_METHOD
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -651,7 +650,7 @@ internal class StripePaymentControllerTest {
     @Test
     fun `bypassAuth() with ActivityResultLauncher should use ActivityResultLauncher`() =
         testDispatcher.runBlockingTest {
-            verifyZeroInteractions(activity)
+            verify(activity).window
 
             val launcher = FakeActivityResultLauncher(PaymentRelayContract())
             createController(
@@ -672,7 +671,7 @@ internal class StripePaymentControllerTest {
     @Test
     fun `on3ds2AuthFallback() with ActivityResultLauncher should use ActivityResultLauncher`() =
         testDispatcher.runBlockingTest {
-            verifyZeroInteractions(activity)
+            verify(activity).window
 
             val launcher = FakeActivityResultLauncher(paymentBrowserAuthContract)
             createController(


### PR DESCRIPTION
# Summary
Include `statusBarColor` when starting `StripeBrowserLauncherActivity`.
Use this value to set Custom Tabs toolbar color.

Also update example app to use "blurple" for primary color.

# Motivation
Make Custom Tabs more consistent with merchant app.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
<img src="https://user-images.githubusercontent.com/45020849/116465963-ed239100-a83b-11eb-9f5d-945874c2127d.gif" width="388" height="799" />
