### PR TITLE
Deprecate return_url in ConfirmSetupIntentParams

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesFragment.kt
@@ -219,8 +219,7 @@ class FragmentExamplesFragment : Fragment() {
             this,
             ConfirmPaymentIntentParams.createWithPaymentMethodId(
                 PAYMENT_METHOD_3DS2_REQUIRED,
-                paymentIntentClientSecret,
-                RETURN_URL
+                paymentIntentClientSecret
             )
         )
     }
@@ -231,8 +230,7 @@ class FragmentExamplesFragment : Fragment() {
             this,
             ConfirmSetupIntentParams.create(
                 PAYMENT_METHOD_3DS2_REQUIRED,
-                setupIntentClientSecret,
-                RETURN_URL
+                setupIntentClientSecret
             )
         )
     }
@@ -294,6 +292,5 @@ class FragmentExamplesFragment : Fragment() {
 
     private companion object {
         private const val PAYMENT_METHOD_3DS2_REQUIRED = "pm_card_threeDSecure2Required"
-        private const val RETURN_URL = "stripe://payment_auth"
     }
 }

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -1962,10 +1962,14 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : android/o
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -1991,18 +1995,23 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : android/o
 
 public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun createWithoutPaymentMethod (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun createWithoutPaymentMethod (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun createWithoutPaymentMethod$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 }
 
 public class com/stripe/android/model/ConfirmSetupIntentParams$Creator : android/os/Parcelable$Creator {

--- a/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import com.stripe.android.Stripe
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
@@ -112,6 +113,26 @@ data class ConfirmSetupIntentParams internal constructor(
          * to the SetupIntent.
          *
          * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+         *
+         * @return params that can be use to confirm a SetupIntent
+         */
+        @JvmStatic
+        fun createWithoutPaymentMethod(
+            clientSecret: String
+        ): ConfirmSetupIntentParams {
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret
+            )
+        }
+
+        /**
+         * Create the parameters necessary for confirming a SetupIntent, without specifying a payment method
+         * to attach to the SetupIntent. Only use this if a payment method has already been attached
+         * to the SetupIntent.
+         *
+         * @deprecated See [Stripe.confirmSetupIntent] for more details on `return_url`.
+         *
+         * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
          * @param returnUrl The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
          * If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
          * This parameter is only used for cards and other redirect-based payment methods.
@@ -119,10 +140,14 @@ data class ConfirmSetupIntentParams internal constructor(
          * @return params that can be use to confirm a SetupIntent
          */
         @JvmStatic
-        @JvmOverloads
+        @Deprecated(
+            "return_url is deprecated. The SDK correctly manages dispatching " +
+                "results after 3DS1 authentication without a custom return_url.",
+            ReplaceWith("createWithoutPaymentMethod(clientSecret)")
+        )
         fun createWithoutPaymentMethod(
             clientSecret: String,
-            returnUrl: String? = null
+            returnUrl: String?
         ): ConfirmSetupIntentParams {
             return ConfirmSetupIntentParams(
                 clientSecret = clientSecret,
@@ -137,6 +162,36 @@ data class ConfirmSetupIntentParams internal constructor(
          * @param paymentMethodId ID of the payment method (a PaymentMethod, Card, BankAccount, or
          * saved Source object) to attach to this SetupIntent.
          * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+         * @param mandateData optional details about the Mandate to create.
+         * @param mandateId optional ID of the Mandate to be used for this payment.
+         *
+         * @return params that can be use to confirm a SetupIntent
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun create(
+            paymentMethodId: String,
+            clientSecret: String,
+            mandateData: MandateDataParams? = null,
+            mandateId: String? = null
+        ): ConfirmSetupIntentParams {
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodId = paymentMethodId,
+                mandateId = mandateId,
+                mandateData = mandateData
+            )
+        }
+
+        /**
+         * Create the parameters necessary for confirming a SetupIntent while attaching a
+         * PaymentMethod that already exits.
+         *
+         * @deprecated See [Stripe.confirmSetupIntent] for more details on `return_url`.
+         *
+         * @param paymentMethodId ID of the payment method (a PaymentMethod, Card, BankAccount, or
+         * saved Source object) to attach to this SetupIntent.
+         * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
          * @param returnUrl The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
          * If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
          * This parameter is only used for cards and other redirect-based payment methods.
@@ -147,10 +202,14 @@ data class ConfirmSetupIntentParams internal constructor(
          */
         @JvmStatic
         @JvmOverloads
+        @Deprecated(
+            "return_url is deprecated. The SDK correctly manages dispatching " +
+                "results after 3DS1 authentication without a custom return_url."
+        )
         fun create(
             paymentMethodId: String,
             clientSecret: String,
-            returnUrl: String? = null,
+            returnUrl: String?,
             mandateId: String? = null,
             mandateData: MandateDataParams? = null
         ): ConfirmSetupIntentParams {
@@ -169,6 +228,35 @@ data class ConfirmSetupIntentParams internal constructor(
          * @param paymentMethodCreateParams the params to create a new PaymentMethod that will be
          * attached to the SetupIntent being confirmed
          * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+         * @param mandateData optional details about the Mandate to create.
+         * @param mandateId optional ID of the Mandate to be used for this payment.
+         *
+         * @return params that can be use to confirm a SetupIntent
+         */
+        @JvmOverloads
+        @JvmStatic
+        fun create(
+            paymentMethodCreateParams: PaymentMethodCreateParams,
+            clientSecret: String,
+            mandateData: MandateDataParams? = null,
+            mandateId: String? = null
+        ): ConfirmSetupIntentParams {
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                mandateId = mandateId,
+                mandateData = mandateData
+            )
+        }
+
+        /**
+         * Create the parameters necessary for confirming a SetupIntent with a new PaymentMethod
+         *
+         * @deprecated See [Stripe.confirmSetupIntent] for more details on `return_url`.
+         *
+         * @param paymentMethodCreateParams the params to create a new PaymentMethod that will be
+         * attached to the SetupIntent being confirmed
+         * @param clientSecret The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
          * @param returnUrl The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
          * If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
          * This parameter is only used for cards and other redirect-based payment methods.
@@ -179,10 +267,14 @@ data class ConfirmSetupIntentParams internal constructor(
          */
         @JvmOverloads
         @JvmStatic
+        @Deprecated(
+            "return_url is deprecated. The SDK correctly manages dispatching " +
+                "results after 3DS1 authentication without a custom return_url."
+        )
         fun create(
             paymentMethodCreateParams: PaymentMethodCreateParams,
             clientSecret: String,
-            returnUrl: String? = null,
+            returnUrl: String?,
             mandateId: String? = null,
             mandateData: MandateDataParams? = null
         ): ConfirmSetupIntentParams {

--- a/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -71,8 +71,7 @@ internal class StripePaymentAuthTest {
         val stripe = createStripe()
         val confirmSetupIntentParams = ConfirmSetupIntentParams.create(
             "pm_card_threeDSecure2Required",
-            "client_secret",
-            "yourapp://post-authentication-return-url"
+            "client_secret"
         )
         stripe.confirmSetupIntent(activity, confirmSetupIntentParams)
         verify(paymentController).startConfirmAndAuth(


### PR DESCRIPTION
The SDK correctly manages dispatching results after 3DS1
authentication. Setting a custom `return_url` prevents using
Custom Tabs and will trigger a WebView fallback.