### PR TITLE
Close the transaction when complete.

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -943,6 +943,9 @@ internal class StripePaymentController internal constructor(
                         analyticsRequestExecutor,
                         analyticsRequestFactory,
                         transaction,
+                        {
+                            transaction.close()
+                        },
                         workContext = workContext
                     ),
                     maxTimeout

--- a/stripe/src/main/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiver.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiver.kt
@@ -38,6 +38,7 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val transaction: Transaction,
+    private val endChallenge: () -> Unit,
     private val retryDelaySupplier: RetryDelaySupplier = RetryDelaySupplier(),
     enableLogging: Boolean = false,
     private val workContext: CoroutineContext
@@ -224,6 +225,8 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
     private suspend fun startCompletionActivity(
         flowOutcome: ChallengeFlowOutcome
     ) = withContext(Dispatchers.Main) {
+        endChallenge()
+
         stripe3ds2CompletionStarter.start(
             PaymentFlowResult.Unvalidated(
                 clientSecret = stripeIntent.clientSecret.orEmpty(),


### PR DESCRIPTION
# Summary
The`DefaultStripeChallengeStatusReceiver` will now call end when completion in any case (success/failure/timeout, etc).

# Motivation
A memory leak was occurring when completing the challenge flow successfully.
https://jira.corp.stripe.com/browse/MOBILESDK-217

# Testing
This has been tested inside the stripe-android example app with payment sheet.   Tested success, failure, and cancel to make sure no memory leak occurs.
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

