### PR TITLE
Use StripeBrowserLauncherActivity when Chrome is available

### DIFF
--- a/stripe/AndroidManifest.xml
+++ b/stripe/AndroidManifest.xml
@@ -59,4 +59,14 @@
             android:theme="@style/StripeGooglePayDefaultTheme" />
     </application>
 
+    <!--
+    See https://developer.android.com/training/package-visibility/declaring for more details.
+    -->
+    <queries>
+        <!--
+        Added to check if Chrome is installed for browser-based payment authentication (e.g. 3DS1).
+        -->
+        <package android:name="com.android.chrome" />
+    </queries>
+
 </manifest>

--- a/stripe/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/stripe/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -15,7 +15,7 @@ internal interface PaymentBrowserAuthStarter :
     AuthActivityStarter<PaymentBrowserAuthContract.Args> {
     class Legacy(
         private val host: AuthActivityStarter.Host,
-        private val isCustomTabsSupported: Boolean,
+        private val hasCompatibleBrowser: Boolean,
         private val defaultReturnUrl: DefaultReturnUrl
     ) : PaymentBrowserAuthStarter {
         override fun start(args: PaymentBrowserAuthContract.Args) {
@@ -23,12 +23,11 @@ internal interface PaymentBrowserAuthStarter :
                 .copy(statusBarColor = host.statusBarColor)
                 .toBundle()
 
-            val shouldUseCustomTabs = args.shouldUseCustomTabs(
-                isCustomTabsSupported,
-                defaultReturnUrl
-            )
+            val shouldUseBrowser =
+                hasCompatibleBrowser && args.hasDefaultReturnUrl(defaultReturnUrl)
+
             host.startActivityForResult(
-                when (shouldUseCustomTabs) {
+                when (shouldUseBrowser) {
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },

--- a/stripe/src/main/java/com/stripe/android/Stripe.kt
+++ b/stripe/src/main/java/com/stripe/android/Stripe.kt
@@ -143,19 +143,21 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [PaymentIntent].
      * Used for [automatic confirmation](https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow) flow.
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
@@ -186,19 +188,21 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [PaymentIntent].
      * Used for [automatic confirmation](https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow) flow.
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
@@ -299,19 +303,21 @@ class Stripe internal constructor(
      * Confirm and, if necessary, authenticate a [PaymentIntent].
      * Used for [automatic confirmation](https://stripe.com/docs/payments/payment-intents/quickstart#automatic-confirmation-flow) flow.
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the [PaymentIntent]
@@ -640,19 +646,21 @@ class Stripe internal constructor(
     /**
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param stripeAccountId Optional, the Connect account to associate with this request.
@@ -679,19 +687,21 @@ class Stripe internal constructor(
     /**
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param activity the `Activity` that is launching the payment authentication flow
      * @param stripeAccountId Optional, the Connect account to associate with this request.
@@ -722,19 +732,21 @@ class Stripe internal constructor(
     /**
      * Confirm and, if necessary, authenticate a [SetupIntent].
      *
-     * For confirmation attempts that require 3DS1 authentication,
-     * [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) will be used
-     * to render the 3DS1 page if both of the following are true:
-     * - Custom Tabs are supported on the device
-     * - The [return_url](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-return_url)
-     *   in the confirmation request is not set (i.e. set to `null`)
+     * For confirmation attempts that require 3DS1 authentication, if the
+     * [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url)
+     * in the confirmation request is not set (i.e. set to `null`), then the following logic will
+     * be used:
+     * - Use [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/overview/) if they
+     *   are supported on the device.
+     * - If Custom Tabs are not supported, use Chrome if it is available on the device.
+     * - Otherwise, use a WebView.
      *
-     * Otherwise, a WebView will be used.
+     * If a custom `return_url` value is set, a WebView will always be used.
      *
-     * |                   | Custom Tabs available? | Custom Tabs unavailable? |
-     * |-------------------|------------------------|--------------------------|
-     * | No return_url     | Custom Tabs            | WebView                  |
-     * | Custom return_url | WebView                | WebView                  |
+     * |                   | Custom Tabs available? | Chrome available? | Fallback |
+     * |-------------------|------------------------|-------------------|----------|
+     * | No return_url     | Custom Tabs            | Chrome            | WebView  |
+     * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
      * @param stripeAccountId Optional, the Connect account to associate with this request.

--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -27,7 +27,8 @@ import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.CustomTabsCapabilities
+import com.stripe.android.payments.BrowserCapabilities
+import com.stripe.android.payments.BrowserCapabilitiesSupplier
 import com.stripe.android.payments.DefaultPaymentFlowResultProcessor
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.DefaultStripeChallengeStatusReceiver
@@ -100,8 +101,8 @@ internal class StripePaymentController internal constructor(
         } ?: PaymentRelayStarter.Legacy(host)
     }
 
-    private val isCustomTabsSupported: Boolean by lazy {
-        CustomTabsCapabilities(context).isSupported()
+    private val hasCompatibleBrowser: Boolean by lazy {
+        BrowserCapabilitiesSupplier(context).get() != BrowserCapabilities.Unknown
     }
 
     private val paymentBrowserAuthStarterFactory = { host: AuthActivityStarter.Host ->
@@ -109,7 +110,7 @@ internal class StripePaymentController internal constructor(
             PaymentBrowserAuthStarter.Modern(it)
         } ?: PaymentBrowserAuthStarter.Legacy(
             host,
-            isCustomTabsSupported,
+            hasCompatibleBrowser,
             defaultReturnUrl
         )
     }

--- a/stripe/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.payments
+
+/**
+ * Representation of the device's browser capabilities. Used for determining how to handle
+ * browser-based payment authentication.
+ */
+internal enum class BrowserCapabilities {
+    CustomTabs,
+    Chrome,
+    Unknown
+}

--- a/stripe/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
@@ -6,20 +6,36 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 
 /**
- * A class to check if the device supports Custom Tabs.
+ * Supply the device's [BrowserCapabilities].
  *
- * See https://developer.chrome.com/docs/android/custom-tabs/integration-guide/ for more details.
+ * See https://developer.chrome.com/docs/android/custom-tabs/integration-guide/ for more details
+ * on Custom Tabs.
  */
-internal class CustomTabsCapabilities(
+internal class BrowserCapabilitiesSupplier(
     private val context: Context
 ) {
-    fun isSupported(): Boolean {
+    fun get(): BrowserCapabilities {
+        return when {
+            isCustomTabsSupported() -> BrowserCapabilities.CustomTabs
+            isChromeInstalled() -> BrowserCapabilities.Chrome
+            else -> BrowserCapabilities.Unknown
+        }
+    }
+
+    private fun isCustomTabsSupported(): Boolean {
         return runCatching {
             CustomTabsClient.bindCustomTabsService(
                 context,
                 CHROME_PACKAGE,
                 NoopCustomTabsServiceConnection()
             )
+        }.getOrDefault(false)
+    }
+
+    private fun isChromeInstalled(): Boolean {
+        return runCatching {
+            context.packageManager.getPackageInfo(CHROME_PACKAGE, 0)
+            true
         }.getOrDefault(false)
     }
 

--- a/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -19,16 +19,19 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  *
  * The eventual replacement for [PaymentAuthWebViewActivity].
  *
- * [StripeBrowserLauncherActivity] will only be used if Custom Tabs are enabled. See
- * [PaymentBrowserAuthContract.Args.shouldUseCustomTabs].
+ * [StripeBrowserLauncherActivity] will only be used when the following are true:
+ * - Custom Tabs are available or Chrome is installed
+ * - the confirmation request's `return_url` is set to [DefaultReturnUrl.value]
+ *
+ * See [BrowserCapabilities] and [PaymentBrowserAuthContract.Args.hasDefaultReturnUrl].
  */
 internal class StripeBrowserLauncherActivity : AppCompatActivity() {
     private val viewModel: StripeBrowserLauncherViewModel by viewModels {
         StripeBrowserLauncherViewModel.Factory(application)
     }
 
-    private val customTabsCapabilities: CustomTabsCapabilities by lazy {
-        CustomTabsCapabilities(this)
+    private val browserCapabilities: BrowserCapabilities by lazy {
+        BrowserCapabilitiesSupplier(this).get()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,7 +56,7 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
             ::onResult
         )
 
-        val shouldUseCustomTabs = customTabsCapabilities.isSupported()
+        val shouldUseCustomTabs = browserCapabilities == BrowserCapabilities.CustomTabs
         viewModel.logCapabilities(shouldUseCustomTabs)
 
         if (shouldUseCustomTabs) {

--- a/stripe/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/stripe/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -35,7 +35,7 @@ class PaymentBrowserAuthStarterTest {
 
     private val legacyStarter = PaymentBrowserAuthStarter.Legacy(
         AuthActivityStarter.Host.create(activity),
-        isCustomTabsSupported = true,
+        hasCompatibleBrowser = true,
         defaultReturnUrl
     )
 
@@ -81,7 +81,7 @@ class PaymentBrowserAuthStarterTest {
                 fragment = null,
                 statusBarColor = Color.RED
             ),
-            isCustomTabsSupported = true,
+            hasCompatibleBrowser = true,
             defaultReturnUrl
         )
         legacyStarter.start(DATA)

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -100,7 +100,7 @@ internal class StripePaymentControllerTest {
     private val defaultReturnUrl = DefaultReturnUrl.create(context)
     private val paymentBrowserAuthContract = PaymentBrowserAuthContract(
         defaultReturnUrl,
-        isCustomTabsSupported = { true }
+        hasCompatibleBrowser = { true }
     )
     private val controller = createController()
 

--- a/stripe/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/stripe/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -38,10 +38,10 @@ class PaymentBrowserAuthContractTest {
     }
 
     @Test
-    fun `createIntent() when custom tabs supported and custom return_url should use PaymentAuthWebViewActivity`() {
+    fun `createIntent() when has compatible browser and custom return_url should use PaymentAuthWebViewActivity`() {
         val intent = PaymentBrowserAuthContract(
             defaultReturnUrl,
-            isCustomTabsSupported = { true }
+            hasCompatibleBrowser = { true }
         ).createIntent(
             activity,
             ARGS.copy(
@@ -54,10 +54,10 @@ class PaymentBrowserAuthContractTest {
     }
 
     @Test
-    fun `createIntent() when custom tabs supported and default return_url should use StripeBrowserLauncherActivity`() {
+    fun `createIntent() when has compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
         val intent = PaymentBrowserAuthContract(
             defaultReturnUrl,
-            isCustomTabsSupported = { true }
+            hasCompatibleBrowser = { true }
         ).createIntent(
             activity,
             ARGS.copy(
@@ -70,10 +70,10 @@ class PaymentBrowserAuthContractTest {
     }
 
     @Test
-    fun `createIntent() when custom tabs not supported and default return_url should use StripeBrowserLauncherActivity`() {
+    fun `createIntent() when no compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
         val intent = PaymentBrowserAuthContract(
             defaultReturnUrl,
-            isCustomTabsSupported = { false }
+            hasCompatibleBrowser = { false }
         ).createIntent(
             activity,
             ARGS.copy(
@@ -89,7 +89,7 @@ class PaymentBrowserAuthContractTest {
     fun `createIntent() should set statusBarColor from activity`() {
         val intent = PaymentBrowserAuthContract(
             defaultReturnUrl,
-            isCustomTabsSupported = { false }
+            hasCompatibleBrowser = { false }
         ).createIntent(
             activity,
             ARGS

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -21,14 +21,14 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
-class PaymentAuthWebViewActivityTest {
+internal class PaymentAuthWebViewActivityTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val contract = PaymentBrowserAuthContract(
         DefaultReturnUrl.create(context),
-        isCustomTabsSupported = { true }
+        hasCompatibleBrowser = { true }
     )
 
     @BeforeTest


### PR DESCRIPTION
# Summary
Previously, `StripeBrowserLauncherActivity` was only used when
the device had Custom Tabs support. Expand support to include
devices that don't have Custom Tabs but do have Chrome installed.

Rename `CustomTabsCapabilities` to `BrowserCapabilitiesSupplier`.

This PR adds a `<queries />` entry for the Chrome package. This is
required by Android 11.

# Motivation
Continue migration away from WebViews for browser-based authentication.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
Demonstration of behavior when Custom Tabs are not available and Chrome is installed:

| Success  | Failure | Cancel |
| - | - | - |
| ![success](https://user-images.githubusercontent.com/45020849/116708641-e90f8480-a99d-11eb-872c-f871769cff6f.gif) | ![fail](https://user-images.githubusercontent.com/45020849/116708772-09d7da00-a99e-11eb-8ee2-3fd8bc46e020.gif) | ![cancel](https://user-images.githubusercontent.com/45020849/116708933-31c73d80-a99e-11eb-8f32-766379a1c275.gif) |



