### PR TITLE
[CardFormView bug bash] Don't notify focus change error if expiry is empty

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -244,7 +244,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
         }
 
         internalFocusChangeListeners.add { _, hasFocus ->
-            if (!hasFocus && !isDateValid) {
+            if (!hasFocus && !text.isNullOrEmpty() && !isDateValid) {
                 shouldShowError = true
             }
         }

--- a/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.stripe.android.R
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.testharness.ViewTestUtils
@@ -409,5 +410,45 @@ class ExpiryDateEditTextTest {
         idleLooper()
 
         verify(textChangeListener, times(1)).afterTextChanged(any())
+    }
+
+    @Test
+    fun `when losing focus and has invalid date then error message listener should trigger`() {
+        val errorMessageListener = mock<StripeEditText.ErrorMessageListener>()
+        expiryDateEditText.requestFocus()
+        expiryDateEditText.append("1")
+        expiryDateEditText.setErrorMessageListener(errorMessageListener)
+        expiryDateEditText.clearFocus()
+
+        idleLooper()
+
+        verify(errorMessageListener).displayErrorMessage(context.getString(R.string.incomplete_expiry_date))
+    }
+
+    @Test
+    fun `when losing focus and has valid date then error message listener should not trigger`() {
+        val errorMessageListener = mock<StripeEditText.ErrorMessageListener>()
+        expiryDateEditText.requestFocus()
+        expiryDateEditText.append("12/50")
+        expiryDateEditText.setErrorMessageListener(errorMessageListener)
+        expiryDateEditText.clearFocus()
+
+        idleLooper()
+
+        verifyNoMoreInteractions(errorMessageListener)
+    }
+
+    @Test
+    fun `when losing focus and has empty text then error message listener should not trigger`() {
+        val errorMessageListener = mock<StripeEditText.ErrorMessageListener>()
+        expiryDateEditText.requestFocus()
+        expiryDateEditText.append("1")
+        expiryDateEditText.setText("")
+        expiryDateEditText.setErrorMessageListener(errorMessageListener)
+        expiryDateEditText.clearFocus()
+
+        idleLooper()
+
+        verifyNoMoreInteractions(errorMessageListener)
     }
 }


### PR DESCRIPTION
# Summary
This prevents the error message showing up when there expiry text is empy

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[CardFormView bug bash](https://paper.dropbox.com/doc/bug-bash-for-CardFormView--BJpcMF_NwlzfAcgFhBU65azvAg-prmyfTdTeknhHCsZxhzj2)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![expBefore](https://user-images.githubusercontent.com/79880926/116753864-a4dfac80-a9bc-11eb-993c-d142b48ccde9.gif)  | ![expAfter](https://user-images.githubusercontent.com/79880926/116753875-a9a46080-a9bc-11eb-9b19-d29d060a7a8a.gif) |
