### PR TITLE
[CardFormView bug bash] preserve country state when configuration changes

### DIFF
--- a/stripe/src/main/java/com/stripe/android/model/CountryCode.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CountryCode.kt
@@ -1,12 +1,15 @@
 package com.stripe.android.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 internal fun Locale.getCountryCode(): CountryCode = CountryCode.create(this.country)
 
+@Parcelize
 internal data class CountryCode private constructor(
     val value: String,
-) {
+) : Parcelable {
     companion object {
         val US = CountryCode("US")
         val CA = CountryCode("CA")

--- a/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
@@ -42,6 +42,10 @@ internal class CountryAdapter(
         return suggestions[i]
     }
 
+    override fun getPosition(item: Country?): Int {
+        return suggestions.indexOf(item)
+    }
+
     override fun getItemId(i: Int): Long {
         return getItem(i).hashCode().toLong()
     }

--- a/stripe/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -169,6 +169,7 @@ internal class CountryTextInputLayout @JvmOverloads constructor(
         }
     }
 
+    @VisibleForTesting
     internal fun restoreSelectedCountry(state: SelectedCountryState) {
         super.onRestoreInstanceState(state.superState)
         state.countryCode.let { countryCode ->

--- a/stripe/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -31,7 +31,7 @@ import kotlin.properties.Delegates
  * [R.styleable.StripeCountryAutoCompleteTextInputLayout_countryItemLayout], note this layout must
  * be a [TextView].
  */
-internal open class CountryTextInputLayout @JvmOverloads constructor(
+internal class CountryTextInputLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = com.google.android.material.R.attr.textInputStyle
@@ -152,8 +152,8 @@ internal open class CountryTextInputLayout @JvmOverloads constructor(
 
     override fun onSaveInstanceState(): Parcelable? {
         selectedCountry?.let {
-            return CountryTextInputLayoutState(
-                it.code.value,
+            return SelectedCountryState(
+                it.code,
                 super.onSaveInstanceState()
             )
         } ?: run {
@@ -162,23 +162,21 @@ internal open class CountryTextInputLayout @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        if (state is CountryTextInputLayoutState) {
-            super.onRestoreInstanceState(state.superState)
-            CountryCode.create(state.countryCode).let { countryCode ->
-                updatedSelectedCountryCode(countryCode)
-                updateUiForCountryEntered(countryCode)
-                requestLayout()
-            }
+        if (state is SelectedCountryState) {
+            restoreSelectedCountry(state)
         } else {
             super.onRestoreInstanceState(state)
         }
     }
 
-    @Parcelize
-    data class CountryTextInputLayoutState(
-        val countryCode: String,
-        val superState: Parcelable?
-    ) : Parcelable
+    internal fun restoreSelectedCountry(state: SelectedCountryState) {
+        super.onRestoreInstanceState(state.superState)
+        state.countryCode.let { countryCode ->
+            updatedSelectedCountryCode(countryCode)
+            updateUiForCountryEntered(countryCode)
+            requestLayout()
+        }
+    }
 
     /**
      * Initialize the encapsulated [AutoCompleteTextView] with [countryAutoCompleteStyleRes] style
@@ -270,4 +268,10 @@ internal open class CountryTextInputLayout @JvmOverloads constructor(
         const val INVALID_COUNTRY_AUTO_COMPLETE_STYLE = 0
         val DEFAULT_ITEM_LAYOUT = R.layout.country_text_view
     }
+
+    @Parcelize
+    data class SelectedCountryState(
+        val countryCode: CountryCode,
+        val superState: Parcelable?
+    ) : Parcelable
 }

--- a/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.app.Application
 import android.content.Context
-import android.os.Parcelable
 import android.widget.AutoCompleteTextView
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
@@ -139,13 +138,6 @@ class CountryTextInputLayoutTest {
         )
     }
 
-    // Test class to expose #onRestoreInstanceState, use this to mimic configuration change.
-    private class TestCountryTextInputLayout(context: Context) : CountryTextInputLayout(context) {
-        fun restoreState(state: Parcelable?) {
-            onRestoreInstanceState(state)
-        }
-    }
-
     @Test
     fun `when screen rotates then selected country should carry over`() {
         val application = ApplicationProvider.getApplicationContext<Application>()
@@ -169,11 +161,13 @@ class CountryTextInputLayoutTest {
         // a new instance's onRestoreInstanceState.
         // activityScenario.recreate() won't trigger onRestoreInstanceState
         val oldState = oldCountryTextInputLayout.onSaveInstanceState()
-        val newCountryTextInputLayout = TestCountryTextInputLayout(
+        val newCountryTextInputLayout = CountryTextInputLayout(
             application
         )
         idleLooper()
-        newCountryTextInputLayout.restoreState(oldState)
+
+        // newCountryTextInputLayout.onResolvePointerIcon() is triggered during configuration change
+        newCountryTextInputLayout.restoreSelectedCountry(oldState as CountryTextInputLayout.SelectedCountryState)
 
         assertEquals(CountryCode.CA, oldCountryTextInputLayout.selectedCountryCode)
         assertEquals("Canada", oldCountryTextInputLayout.countryAutocomplete.text.toString())

--- a/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.view
 
-import android.app.Application
 import android.content.Context
 import android.widget.AutoCompleteTextView
 import androidx.test.core.app.ApplicationProvider

--- a/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -162,7 +162,6 @@ class CountryTextInputLayoutTest {
         oldCountryTextInputLayout.updatedSelectedCountryCode(CountryCode.CA)
         oldCountryTextInputLayout.updateUiForCountryEntered(CountryCode.CA)
 
-
         assertEquals(CountryCode.CA, oldCountryTextInputLayout.selectedCountryCode)
         assertEquals("Canada", oldCountryTextInputLayout.countryAutocomplete.text.toString())
 
@@ -178,7 +177,6 @@ class CountryTextInputLayoutTest {
 
         assertEquals(CountryCode.CA, oldCountryTextInputLayout.selectedCountryCode)
         assertEquals("Canada", oldCountryTextInputLayout.countryAutocomplete.text.toString())
-
     }
 
     @AfterTest

--- a/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -140,11 +140,9 @@ class CountryTextInputLayoutTest {
 
     @Test
     fun `when screen rotates then selected country should carry over`() {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        application.setTheme(R.style.StripePaymentSheetDefaultTheme)
-        val oldCountryTextInputLayout = CountryTextInputLayout(
-            application
-        )
+        val oldCountryTextInputLayout = activityScenarioFactory.createView { activity ->
+            CountryTextInputLayout(activity)
+        }
 
         idleLooper()
 
@@ -161,12 +159,14 @@ class CountryTextInputLayoutTest {
         // a new instance's onRestoreInstanceState.
         // activityScenario.recreate() won't trigger onRestoreInstanceState
         val oldState = oldCountryTextInputLayout.onSaveInstanceState()
-        val newCountryTextInputLayout = CountryTextInputLayout(
-            application
-        )
+
+        val newCountryTextInputLayout = activityScenarioFactory.createView { activity ->
+            CountryTextInputLayout(activity)
+        }
+
         idleLooper()
 
-        // newCountryTextInputLayout.onResolvePointerIcon() is triggered during configuration change
+        // newCountryTextInputLayout.onRestoreInstanceState() is triggered during configuration change
         newCountryTextInputLayout.restoreSelectedCountry(oldState as CountryTextInputLayout.SelectedCountryState)
 
         assertEquals(CountryCode.CA, oldCountryTextInputLayout.selectedCountryCode)


### PR DESCRIPTION
# Summary
Save state when configuration changes

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[CardFormView bug bash](https://paper.dropbox.com/doc/bug-bash-for-CardFormView--BJpcMF_NwlzfAcgFhBU65azvAg-prmyfTdTeknhHCsZxhzj2)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![countryBefore](https://user-images.githubusercontent.com/79880926/116769619-3fa6ae00-a9f2-11eb-9ec9-6437bac57ddc.gif)  | ![countryAfter](https://user-images.githubusercontent.com/79880926/116769616-3c132700-a9f2-11eb-8244-44fe3901d7fb.gif) |
