### PR TITLE
[CardFormView bug bash] fix divider padding in borderless mode

### DIFF
--- a/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -436,8 +436,7 @@ internal class CardFormView @JvmOverloads constructor(
                 layoutInflater,
                 countryLayout,
                 false
-            ).root,
-            1
+            ).root
         )
         countryPostalDivider.isVisible = false
 

--- a/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -430,14 +430,14 @@ internal class CardFormView @JvmOverloads constructor(
             1
         )
 
-        // add horizontal divider above postalCodeContainer and hide countryPostalDivider
-        postalCodeContainer.addView(
+        // add horizontal divider below countryLayout and hide countryPostalDivider
+        countryLayout.addView(
             StripeHorizontalDividerBinding.inflate(
                 layoutInflater,
                 countryLayout,
                 false
             ).root,
-            0
+            1
         )
         countryPostalDivider.isVisible = false
 

--- a/stripe/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -273,8 +273,8 @@ class CardFormViewTest {
             // 1 horizontal divider added below tl_cvc, now it has 2 child views
             assertThat(it.cardMultilineWidget.cvcInputLayout.childCount).isEqualTo(2)
 
-            // 1 horizontal divider added above postalCodeContainer, now it has 2 child views
-            assertThat(it.postalCodeContainer.childCount).isEqualTo(2)
+            // 1 horizontal divider added below countryLayout, now it has 2 child views
+            assertThat(it.countryLayout.childCount).isEqualTo(2)
 
             // divider with width=match_parent is invisible
             assertThat(it.countryPostalDivider.isVisible).isFalse()


### PR DESCRIPTION
# Summary
`TextInputLayout` applies a top padding to the top of child view added, which cause the divider added a couple of pixels below it's desired location.

Instead of adding the divider as the first child of Zip, adding it as the last child of country resolves this issue, as there's no bottom padding applied to the last child


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[CardFormView bug bash](https://paper.dropbox.com/doc/bug-bash-for-CardFormView--BJpcMF_NwlzfAcgFhBU65azvAg-prmyfTdTeknhHCsZxhzj2)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![paddingBefore](https://user-images.githubusercontent.com/79880926/116951941-3742b300-ac3e-11eb-989d-1ec58ebbf204.png)  | ![paddingAfter](https://user-images.githubusercontent.com/79880926/116951940-3578ef80-ac3e-11eb-8b35-c7182f85bcde.png) |
