### PR TITLE
Upgrade Android Gradle Plugin to 4.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0"

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -7,9 +7,6 @@ plugins {
 
     id 'signing'
     id 'maven-publish'
-
-    // make sure this line comes *after* you apply the Android plugin
-    id 'com.getkeepsafe.dexcount'
 }
 
 assemble.dependsOn('lint')

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceFactoryTest.kt
@@ -16,7 +16,7 @@ class BecsDebitMandateAcceptanceFactoryTest {
     @Test
     fun testCreate() {
         Locale.setDefault(Locale.US)
-        assertThat(factory.create("Rocketship Inc.").toString())
+        assertThat(factory.create("Rocketship Inc.").toString().trim())
             .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
@@ -20,7 +20,7 @@ class BecsDebitMandateAcceptanceTextViewTest {
 
         textView.companyName = "Rocketship Inc."
 
-        assertThat(textView.text.toString())
+        assertThat(textView.text.toString().trim())
             .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
@@ -156,7 +156,7 @@ internal class BecsDebitWidgetTest {
 
     @Test
     fun companyName_shouldUpdateMandateAcceptanceTextView() {
-        assertThat(becsDebitWidget.viewBinding.mandateAcceptanceTextView.text.toString())
+        assertThat(becsDebitWidget.viewBinding.mandateAcceptanceTextView.text.toString().trim())
             .isEqualTo(
                 """
                 By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.


### PR DESCRIPTION


# Summary
Release notes: https://developer.android.com/studio/releases/gradle-plugin#4-2-0

- Remove `dexcount-gradle-plugin` because it is incompatible with 4.2.0.
  This plugin hasn't had a release since October 2020, so it's likely that
  it will be some time before the plugin is made compatible.
  We don't rely on this plugin so it's safe to remove.

- Fix tests that are failing due to new changes in how string resources
  are processed. String resources that are defined with the closing
  tag on a new line line now include a whitespace character at the end
  of the string.

  ```xml
  <!--
  Resolves to "Some text" in AGP 4.1.2
  Resolves to "Some text " in AGP 4.2.0
  -->
  <string name="my_string">
  Some text
  </string>
  ```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

