### PR TITLE
Apply performance recommendations for JDK 11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ POM_DEVELOPER_ID=stripe
 POM_DEVELOPER_NAME=Stripe
 POM_DEVELOPER_EMAIL=support+android@stripe.com
 
-org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M
+org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M -XX:+UseParallelGC
 android.useAndroidX=true
 android.enableJetifier=false


### PR DESCRIPTION
Android Gradle Plugin 4.2.0 recommends using the parallel garbage
collector with JDK 11 [0]. This is done by setting a value
for `org.gradle.jvmargs`.
```
org.gradle.jvmargs=-XX:+UseParallelGC
```

The change was profiled [1] using the following command:
```
./gradlew --profile --offline --rerun-tasks :stripe:assembleDebug
```

| Without change | With change |
| -------------- | ----------- |
| ~50s           | ~40s        |

[0] https://developer.android.com/studio/releases/gradle-plugin#optimize-gc-jdk-11
[1] https://developer.android.com/studio/build/profile-your-build#using-the-gradle---profile-option