### PR TITLE
Set canCancelSource=true in StripeBrowserLauncherViewModel result

### DIFF
--- a/stripe/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/stripe/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -70,7 +70,12 @@ internal class PaymentBrowserAuthContract(
         val enableLogging: Boolean = false,
         val toolbarCustomization: StripeToolbarCustomization? = null,
         val stripeAccountId: String? = null,
+
+        /**
+         * TODO(mshafrir-stripe): we should probably rename this to `canCancelSource`
+         */
         val shouldCancelSource: Boolean = false,
+
         /**
          * For most payment methods, if the user navigates away from the webview
          * (e.g. by pressing the back button or tapping "close" in the menu bar),

--- a/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -65,7 +65,8 @@ internal class StripeBrowserLauncherViewModel(
             PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
                 sourceId = url.lastPathSegment.orEmpty(),
-                stripeAccountId = args.stripeAccountId
+                stripeAccountId = args.stripeAccountId,
+                canCancelSource = args.shouldCancelSource
             ).toBundle()
         )
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -120,7 +120,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
                         .copy(
                             exception = StripeException.create(error),
                             flowOutcome = StripeIntentResult.Outcome.FAILED,
-                            shouldCancelSource = true
+                            canCancelSource = true
                         )
                 )
             )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -62,7 +62,7 @@ internal class PaymentAuthWebViewActivityViewModel(
                     } else {
                         StripeIntentResult.Outcome.SUCCEEDED
                     },
-                    shouldCancelSource = args.shouldCancelSource
+                    canCancelSource = args.shouldCancelSource
                 ).toBundle()
             )
         }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -536,7 +536,7 @@ internal class StripePaymentControllerTest {
                 PaymentFlowResult.Unvalidated(
                     clientSecret = clientSecret,
                     sourceId = sourceId,
-                    shouldCancelSource = true,
+                    canCancelSource = true,
                     stripeAccountId = ACCOUNT_ID
                 ).toBundle()
             )
@@ -602,7 +602,7 @@ internal class StripePaymentControllerTest {
             source = SourceFixtures.CARD,
             sourceId = SourceFixtures.CARD.id,
             flowOutcome = StripeIntentResult.Outcome.SUCCEEDED,
-            shouldCancelSource = true
+            canCancelSource = true
         )
         val resultBundle = ParcelUtils.copy(
             expectedResult.toBundle(),

--- a/stripe/src/test/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/DefaultPaymentFlowResultProcessorTest.kt
@@ -42,7 +42,7 @@ internal class DefaultPaymentFlowResultProcessorTest {
             PaymentFlowResult.Unvalidated(
                 clientSecret = "client_secret",
                 flowOutcome = StripeIntentResult.Outcome.CANCELED,
-                shouldCancelSource = true
+                canCancelSource = true
             )
         )
 
@@ -61,7 +61,7 @@ internal class DefaultPaymentFlowResultProcessorTest {
             PaymentFlowResult.Unvalidated(
                 clientSecret = "client_secret",
                 flowOutcome = StripeIntentResult.Outcome.CANCELED,
-                shouldCancelSource = true
+                canCancelSource = true
             )
         )
 

--- a/stripe/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -35,14 +35,7 @@ class StripeBrowserLauncherViewModelTest {
 
     @Test
     fun `createLaunchIntent() should create an intent and wrap in a Chooser Intent`() {
-        val launchIntent = viewModel.createLaunchIntent(
-            PaymentBrowserAuthContract.Args(
-                objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
-                requestCode = 50000,
-                clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
-                url = "https://bank.com"
-            )
-        )
+        val launchIntent = viewModel.createLaunchIntent(ARGS)
 
         val browserIntent =
             requireNotNull(launchIntent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT))
@@ -78,5 +71,30 @@ class StripeBrowserLauncherViewModelTest {
 
         assertThat(analyticsRequests.first().params["event"])
             .isEqualTo("stripe_android.auth_with_defaultbrowser")
+    }
+
+    @Test
+    fun `getResultIntent() with shouldCancelSource=true should include expected PaymentFlowResult`() {
+        val intent = viewModel.getResultIntent(
+            ARGS.copy(shouldCancelSource = true)
+        )
+        val result = intent.getParcelableExtra<PaymentFlowResult.Unvalidated>("extra_args")
+        assertThat(result)
+            .isEqualTo(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+                    canCancelSource = true,
+                    sourceId = ""
+                )
+            )
+    }
+
+    private companion object {
+        private val ARGS = PaymentBrowserAuthContract.Args(
+            objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
+            requestCode = 50000,
+            clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+            url = "https://bank.com"
+        )
     }
 }

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -73,7 +73,7 @@ internal class PaymentAuthWebViewActivityTest {
                         clientSecret = CLIENT_SECRET,
                         exception = StripeException.create(ActivityNotFoundException()),
                         flowOutcome = StripeIntentResult.Outcome.FAILED,
-                        shouldCancelSource = true,
+                        canCancelSource = true,
                         sourceId = ""
                     )
                 )

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -37,7 +37,7 @@ class PaymentAuthWebViewActivityViewModelTest {
         val resultIntent = PaymentFlowResult.Unvalidated.fromIntent(intent)
         assertThat(resultIntent.flowOutcome)
             .isEqualTo(StripeIntentResult.Outcome.CANCELED)
-        assertThat(resultIntent.shouldCancelSource)
+        assertThat(resultIntent.canCancelSource)
             .isTrue()
     }
 
@@ -54,7 +54,7 @@ class PaymentAuthWebViewActivityViewModelTest {
         val resultIntent = PaymentFlowResult.Unvalidated.fromIntent(intent)
         assertThat(resultIntent.flowOutcome)
             .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
-        assertThat(resultIntent.shouldCancelSource)
+        assertThat(resultIntent.canCancelSource)
             .isTrue()
     }
 


### PR DESCRIPTION


# Summary
In `PaymentAuthWebViewActivityViewModel#cancellationResult` we set
`canCancelSource=true` and conditionally set
`shouldCancelIntentOnUserNavigation`.

In `StripeBrowserLauncherViewModel`, we have no way to tell what
action the customer took during 3DS1, whether cancel, succeed, or fail.
That means the source is always cancellable.

# Motivation
Ensure PaymentIntent and SetupIntent objects are correctly cancelled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

