### PR TITLE
Upgrade Kotlin to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.time.Duration
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlinVersion = '1.4.32'
+    ext.kotlinVersion = '1.5.0'
     ext.dokkaVersion = '1.4.30'
 
     repositories {

--- a/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SofortPaymentMethodActivity.kt
@@ -7,7 +7,6 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.example.databinding.SofortActivityBinding
-import java.util.Locale
 
 class SofortPaymentMethodActivity : StripeIntentActivity() {
     private val viewBinding: SofortActivityBinding by lazy {
@@ -27,7 +26,7 @@ class SofortPaymentMethodActivity : StripeIntentActivity() {
         viewBinding.submit.setOnClickListener {
             keyboardController.hide()
 
-            val country = viewBinding.country.text.toString().toLowerCase(Locale.ROOT)
+            val country = viewBinding.country.text.toString().lowercase()
             createAndConfirmPaymentIntent(
                 country,
                 PaymentMethodCreateParams.create(

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -31,7 +31,7 @@ public final class com/stripe/android/AppInfo$Companion {
 	public static synthetic fun create$default (Lcom/stripe/android/AppInfo$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/AppInfo;
 }
 
-public class com/stripe/android/AppInfo$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/AppInfo$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/AppInfo;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -117,7 +117,7 @@ public final class com/stripe/android/EphemeralKey : com/stripe/android/model/St
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/EphemeralKey$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/EphemeralKey$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralKey;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -132,6 +132,94 @@ public abstract interface class com/stripe/android/EphemeralKeyProvider {
 public abstract interface class com/stripe/android/EphemeralKeyUpdateListener {
 	public abstract fun onKeyUpdate (Ljava/lang/String;)V
 	public abstract fun onKeyUpdateFailure (ILjava/lang/String;)V
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$AddSource$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$AddSource;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$AddSource;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$AttachPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$AttachPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$AttachPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$DeleteSource$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$DeleteSource;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$DeleteSource;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$DetachPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$DetachPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$DetachPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$GetPaymentMethods$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$GetPaymentMethods;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$GetPaymentMethods;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$UpdateDefaultSource$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$UpdateDefaultSource;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$UpdateDefaultSource;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Customer$UpdateShipping$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Customer$UpdateShipping;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Customer$UpdateShipping;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Issuing$RetrievePin$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Issuing$RetrievePin;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Issuing$RetrievePin;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$Issuing$UpdatePin$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$Issuing$UpdatePin;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$Issuing$UpdatePin;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/EphemeralOperation$RetrieveKey$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/EphemeralOperation$RetrieveKey;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/EphemeralOperation$RetrieveKey;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/FingerprintData$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/FingerprintData;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/FingerprintData;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/GooglePayConfig {
@@ -177,7 +265,7 @@ public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParamet
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -206,7 +294,7 @@ public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo : androi
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/GooglePayJsonFactory$MerchantInfo$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -230,7 +318,7 @@ public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParame
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/GooglePayJsonFactory$ShippingAddressParameters$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParameters$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -263,7 +351,7 @@ public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Check
 	public static fun values ()[Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;
 }
 
-public class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -504,7 +592,7 @@ public final class com/stripe/android/PaymentConfiguration$Companion {
 	public static synthetic fun init$default (Lcom/stripe/android/PaymentConfiguration$Companion;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
-public class com/stripe/android/PaymentConfiguration$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/PaymentConfiguration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentConfiguration;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -528,11 +616,43 @@ public final class com/stripe/android/PaymentIntentResult : com/stripe/android/S
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/PaymentIntentResult$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/PaymentIntentResult$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentIntentResult;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/PaymentIntentResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentRelayStarter$Args$ErrorArgs$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentRelayStarter$Args$ErrorArgs;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentRelayStarter$Args$ErrorArgs;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentRelayStarter$Args$PaymentIntentArgs$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentRelayStarter$Args$PaymentIntentArgs;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentRelayStarter$Args$PaymentIntentArgs;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentRelayStarter$Args$SetupIntentArgs$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentRelayStarter$Args$SetupIntentArgs;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentRelayStarter$Args$SetupIntentArgs;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/PaymentRelayStarter$Args$SourceArgs$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentRelayStarter$Args$SourceArgs;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/PaymentRelayStarter$Args$SourceArgs;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -614,7 +734,7 @@ public final class com/stripe/android/PaymentSessionConfig$Builder : com/stripe/
 	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/PaymentSessionConfig$Builder;
 }
 
-public class com/stripe/android/PaymentSessionConfig$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/PaymentSessionConfig$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentSessionConfig;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -655,7 +775,7 @@ public final class com/stripe/android/PaymentSessionData : android/os/Parcelable
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/PaymentSessionData$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/PaymentSessionData$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/PaymentSessionData;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -679,7 +799,7 @@ public final class com/stripe/android/SetupIntentResult : com/stripe/android/Str
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/SetupIntentResult$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/SetupIntentResult$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/SetupIntentResult;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -907,7 +1027,7 @@ public final class com/stripe/android/StripeError : com/stripe/android/model/Str
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/StripeError$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/StripeError$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/StripeError;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -980,6 +1100,22 @@ public final class com/stripe/android/StripeTextUtils {
 	public static final fun removeSpacesAndHyphens (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class com/stripe/android/auth/PaymentBrowserAuthContract$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/auth/PaymentBrowserAuthContract$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/auth/PaymentBrowserAuthContract$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/cards/Bin$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/cards/Bin;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/cards/Bin;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/exception/APIConnectionException : com/stripe/android/exception/StripeException {
 	public static final field Companion Lcom/stripe/android/exception/APIConnectionException$Companion;
 	public fun <init> ()V
@@ -1033,6 +1169,54 @@ public abstract class com/stripe/android/exception/StripeException : java/lang/E
 	public final fun getStripeError ()Lcom/stripe/android/StripeError;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$GooglePayConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$GooglePayConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$GooglePayConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$Result$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$Result$Error$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Error;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Error;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$Result$PaymentData$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$PaymentData;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$PaymentData;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepay/StripeGooglePayContract$Result$Unavailable$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Unavailable;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepay/StripeGooglePayContract$Result$Unavailable;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/model/AccountParams : com/stripe/android/model/TokenParams {
@@ -1143,7 +1327,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder;
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1167,7 +1351,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1193,7 +1377,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1294,7 +1478,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public final fun setVerification (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder;
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1318,7 +1502,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1348,7 +1532,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1363,11 +1547,19 @@ public final class com/stripe/android/model/AccountParams$Companion {
 	public final fun create (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;)Lcom/stripe/android/model/AccountParams;
 }
 
-public class com/stripe/android/model/AccountParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AccountParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/AccountParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AccountRange$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AccountRange;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AccountRange;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -1414,7 +1606,7 @@ public final class com/stripe/android/model/Address$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
 }
 
-public class com/stripe/android/model/Address$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Address$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Address;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1464,11 +1656,19 @@ public final class com/stripe/android/model/AddressJapanParams$Builder : com/str
 	public final fun setTown (Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams$Builder;
 }
 
-public class com/stripe/android/model/AddressJapanParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/AddressJapanParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AddressJapanParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/AddressJapanParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/AlipayAuthResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AlipayAuthResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AlipayAuthResult;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -1504,7 +1704,7 @@ public final class com/stripe/android/model/BankAccount : com/stripe/android/mod
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/BankAccount$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/BankAccount$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BankAccount;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1550,7 +1750,7 @@ public final class com/stripe/android/model/BankAccountTokenParams : com/stripe/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/BankAccountTokenParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/BankAccountTokenParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BankAccountTokenParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1569,6 +1769,22 @@ public final class com/stripe/android/model/BankAccountTokenParams$Type : java/l
 public final class com/stripe/android/model/BankAccountTokenParamsFixtures {
 	public static final field DEFAULT Lcom/stripe/android/model/BankAccountTokenParams;
 	public static final field INSTANCE Lcom/stripe/android/model/BankAccountTokenParamsFixtures;
+}
+
+public final class com/stripe/android/model/BankStatuses$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BankStatuses;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/BankStatuses;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/BinRange$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/BinRange;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/BinRange;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/model/Card : com/stripe/android/model/TokenParams, com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
@@ -1679,7 +1895,7 @@ public final class com/stripe/android/model/Card$Companion {
 	public final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Card;
 }
 
-public class com/stripe/android/model/Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Card$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1735,6 +1951,14 @@ public final class com/stripe/android/model/CardFunding : java/lang/Enum {
 	public static fun values ()[Lcom/stripe/android/model/CardFunding;
 }
 
+public final class com/stripe/android/model/CardMetadata$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CardMetadata;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/CardMetadata;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/CardParams : com/stripe/android/model/TokenParams {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;II)V
@@ -1769,7 +1993,7 @@ public final class com/stripe/android/model/CardParams : com/stripe/android/mode
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/CardParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/CardParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CardParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -1993,7 +2217,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2063,7 +2287,7 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
 	public final fun createWithoutPaymentMethod (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 }
 
-public class com/stripe/android/model/ConfirmSetupIntentParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ConfirmSetupIntentParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2081,6 +2305,14 @@ public abstract interface class com/stripe/android/model/ConfirmStripeIntentPara
 }
 
 public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion {
+}
+
+public final class com/stripe/android/model/CountryCode$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CountryCode;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/CountryCode;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/model/Customer : com/stripe/android/model/StripeModel {
@@ -2123,7 +2355,7 @@ public final class com/stripe/android/model/Customer$Companion {
 	public final fun fromString (Ljava/lang/String;)Lcom/stripe/android/model/Customer;
 }
 
-public class com/stripe/android/model/Customer$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Customer$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Customer;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2147,7 +2379,7 @@ public final class com/stripe/android/model/CustomerSource : com/stripe/android/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/CustomerSource$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/CustomerSource$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CustomerSource;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2168,7 +2400,7 @@ public final class com/stripe/android/model/CvcTokenParams : com/stripe/android/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/CvcTokenParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/CvcTokenParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/CvcTokenParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2195,7 +2427,7 @@ public final class com/stripe/android/model/DateOfBirth : android/os/Parcelable,
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/DateOfBirth$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/DateOfBirth$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/DateOfBirth;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2249,7 +2481,7 @@ public final class com/stripe/android/model/GooglePayResult$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/GooglePayResult;
 }
 
-public class com/stripe/android/model/GooglePayResult$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/GooglePayResult$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/GooglePayResult;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2271,7 +2503,7 @@ public final class com/stripe/android/model/IssuingCardPin : com/stripe/android/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/IssuingCardPin$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/IssuingCardPin$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/IssuingCardPin;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2321,7 +2553,7 @@ public final class com/stripe/android/model/KlarnaSourceParams : android/os/Parc
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/KlarnaSourceParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/KlarnaSourceParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2358,7 +2590,7 @@ public final class com/stripe/android/model/KlarnaSourceParams$LineItem : androi
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/KlarnaSourceParams$LineItem$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/KlarnaSourceParams$LineItem$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2397,7 +2629,7 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2418,6 +2650,14 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
 }
 
+public final class com/stripe/android/model/ListPaymentMethodsParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ListPaymentMethodsParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ListPaymentMethodsParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/MandateDataParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/MandateDataParams$Type;)V
@@ -2431,7 +2671,7 @@ public final class com/stripe/android/model/MandateDataParams : android/os/Parce
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/MandateDataParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/MandateDataParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MandateDataParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2458,7 +2698,7 @@ public final class com/stripe/android/model/MandateDataParams$Type$Online : com/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/MandateDataParams$Type$Online$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/MandateDataParams$Type$Online$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MandateDataParams$Type$Online;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2556,7 +2796,7 @@ public final class com/stripe/android/model/PaymentIntent$ConfirmationMethod : j
 	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
 }
 
-public class com/stripe/android/model/PaymentIntent$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentIntent$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2592,7 +2832,7 @@ public final class com/stripe/android/model/PaymentIntent$Error : com/stripe/and
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentIntent$Error$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentIntent$Error$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent$Error;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2637,7 +2877,7 @@ public final class com/stripe/android/model/PaymentIntent$Shipping : com/stripe/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentIntent$Shipping$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentIntent$Shipping$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentIntent$Shipping;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2709,7 +2949,7 @@ public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stri
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$AuBecsDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$AuBecsDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2734,7 +2974,7 @@ public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$BacsDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$BacsDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2780,7 +3020,7 @@ public final class com/stripe/android/model/PaymentMethod$BillingDetails$Builder
 	public final fun setPhone (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
 }
 
-public class com/stripe/android/model/PaymentMethod$BillingDetails$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$BillingDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2876,7 +3116,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stri
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Card$Checks$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Card$Checks$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2884,7 +3124,7 @@ public class com/stripe/android/model/PaymentMethod$Card$Checks$Creator : androi
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public class com/stripe/android/model/PaymentMethod$Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Card$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2912,7 +3152,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$Networks : com/st
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Card$Networks$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Card$Networks$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2933,7 +3173,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2954,7 +3194,7 @@ public final class com/stripe/android/model/PaymentMethod$CardPresent : com/stri
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$CardPresent$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$CardPresent$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$CardPresent;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2966,7 +3206,7 @@ public final class com/stripe/android/model/PaymentMethod$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
 }
 
-public class com/stripe/android/model/PaymentMethod$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -2989,7 +3229,7 @@ public final class com/stripe/android/model/PaymentMethod$Fpx : com/stripe/andro
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Fpx$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Fpx$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Fpx;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3012,7 +3252,7 @@ public final class com/stripe/android/model/PaymentMethod$Ideal : com/stripe/and
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Ideal$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Ideal$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Ideal;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3033,7 +3273,7 @@ public final class com/stripe/android/model/PaymentMethod$Netbanking : com/strip
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Netbanking$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Netbanking$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Netbanking;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3062,7 +3302,7 @@ public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$SepaDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$SepaDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3083,7 +3323,7 @@ public final class com/stripe/android/model/PaymentMethod$Sofort : com/stripe/an
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Sofort$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Sofort$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Sofort;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3127,7 +3367,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 public final class com/stripe/android/model/PaymentMethod$Type$Companion {
 }
 
-public class com/stripe/android/model/PaymentMethod$Type$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Type$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Type;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3148,7 +3388,7 @@ public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/andro
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethod$Upi$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethod$Upi$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Upi;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3250,7 +3490,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebi
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3277,7 +3517,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3314,7 +3554,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Compa
 	public final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3397,7 +3637,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public static synthetic fun createWeChatPay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3428,7 +3668,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx$Builde
 	public final fun setBank (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx$Builder;
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Fpx$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3459,7 +3699,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal$Buil
 	public final fun setBank (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal$Builder;
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Ideal$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3480,7 +3720,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Netbanking$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3511,7 +3751,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit$
 	public final fun setIban (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Builder;
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3532,7 +3772,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : a
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Sofort$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3553,7 +3793,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : andr
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodCreateParams$Upi$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodCreateParams$Upi$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3584,7 +3824,7 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3612,7 +3852,7 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodOptionsParams$Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Card$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3638,11 +3878,19 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$WeChatPay;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$WeChatPay;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodsList$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodsList;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodsList;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -3724,7 +3972,7 @@ public final class com/stripe/android/model/PersonTokenParams$Builder : com/stri
 	public final fun setVerification (Lcom/stripe/android/model/PersonTokenParams$Verification;)Lcom/stripe/android/model/PersonTokenParams$Builder;
 }
 
-public class com/stripe/android/model/PersonTokenParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PersonTokenParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3752,7 +4000,7 @@ public final class com/stripe/android/model/PersonTokenParams$Document : android
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PersonTokenParams$Document$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PersonTokenParams$Document$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Document;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3799,7 +4047,7 @@ public final class com/stripe/android/model/PersonTokenParams$Relationship$Build
 	public final fun setTitle (Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Relationship$Builder;
 }
 
-public class com/stripe/android/model/PersonTokenParams$Relationship$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PersonTokenParams$Relationship$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3827,11 +4075,19 @@ public final class com/stripe/android/model/PersonTokenParams$Verification : and
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/PersonTokenParams$Verification$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/PersonTokenParams$Verification$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PersonTokenParams$Verification;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PersonTokenParams$Verification;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PiiTokenParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PiiTokenParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PiiTokenParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -3891,7 +4147,7 @@ public final class com/stripe/android/model/SetupIntent$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;
 }
 
-public class com/stripe/android/model/SetupIntent$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SetupIntent$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SetupIntent;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3925,7 +4181,7 @@ public final class com/stripe/android/model/SetupIntent$Error : com/stripe/andro
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SetupIntent$Error$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SetupIntent$Error$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SetupIntent$Error;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -3972,7 +4228,7 @@ public final class com/stripe/android/model/ShippingInformation : com/stripe/and
 public final class com/stripe/android/model/ShippingInformation$Companion {
 }
 
-public class com/stripe/android/model/ShippingInformation$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ShippingInformation$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ShippingInformation;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4007,7 +4263,7 @@ public final class com/stripe/android/model/ShippingMethod : com/stripe/android/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/ShippingMethod$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ShippingMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ShippingMethod;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4086,7 +4342,7 @@ public final class com/stripe/android/model/Source$CodeVerification : com/stripe
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/Source$CodeVerification$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$CodeVerification$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$CodeVerification;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4109,7 +4365,7 @@ public final class com/stripe/android/model/Source$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Source;
 }
 
-public class com/stripe/android/model/Source$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4176,7 +4432,7 @@ public final class com/stripe/android/model/Source$Klarna : com/stripe/android/m
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/Source$Klarna$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$Klarna$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Klarna;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4211,7 +4467,7 @@ public final class com/stripe/android/model/Source$Owner : com/stripe/android/mo
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/Source$Owner$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$Owner$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Owner;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4238,7 +4494,7 @@ public final class com/stripe/android/model/Source$Receiver : com/stripe/android
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/Source$Receiver$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$Receiver$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Receiver;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4264,7 +4520,7 @@ public final class com/stripe/android/model/Source$Redirect : com/stripe/android
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/Source$Redirect$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Source$Redirect$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Source$Redirect;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4361,7 +4617,7 @@ public final class com/stripe/android/model/SourceOrder : com/stripe/android/mod
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrder$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrder$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4390,7 +4646,7 @@ public final class com/stripe/android/model/SourceOrder$Item : com/stripe/androi
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrder$Item$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrder$Item$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder$Item;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4429,7 +4685,7 @@ public final class com/stripe/android/model/SourceOrder$Shipping : com/stripe/an
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrder$Shipping$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrder$Shipping$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrder$Shipping;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4457,7 +4713,7 @@ public final class com/stripe/android/model/SourceOrderParams : android/os/Parce
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrderParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrderParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4492,7 +4748,7 @@ public final class com/stripe/android/model/SourceOrderParams$Item : android/os/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrderParams$Item$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrderParams$Item$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams$Item;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4532,7 +4788,7 @@ public final class com/stripe/android/model/SourceOrderParams$Shipping : android
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceOrderParams$Shipping$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceOrderParams$Shipping$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4639,11 +4895,19 @@ public final class com/stripe/android/model/SourceParams$OwnerParams : android/o
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceParams$OwnerParams$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceParams$OwnerParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceParams$OwnerParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/SourceParams$OwnerParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/SourceParams$WeChatParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceParams$WeChatParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SourceParams$WeChatParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -4685,7 +4949,7 @@ public final class com/stripe/android/model/SourceTypeModel$Card : com/stripe/an
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceTypeModel$Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceTypeModel$Card$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceTypeModel$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4730,11 +4994,51 @@ public final class com/stripe/android/model/SourceTypeModel$SepaDebit : com/stri
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/SourceTypeModel$SepaDebit$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/SourceTypeModel$SepaDebit$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/SourceTypeModel$SepaDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Stripe3ds2AuthParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Stripe3ds2AuthParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Stripe3ds2AuthParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Stripe3ds2AuthResult$Ares$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Stripe3ds2AuthResult$Ares;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Stripe3ds2AuthResult$Ares;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Stripe3ds2AuthResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Stripe3ds2AuthResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Stripe3ds2AuthResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Stripe3ds2AuthResult$MessageExtension$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Stripe3ds2AuthResult$MessageExtension;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Stripe3ds2AuthResult$MessageExtension;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/Stripe3ds2AuthResult$ThreeDS2Error$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Stripe3ds2AuthResult$ThreeDS2Error;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/Stripe3ds2AuthResult$ThreeDS2Error;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -4766,7 +5070,7 @@ public final class com/stripe/android/model/StripeFile : com/stripe/android/mode
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeFile$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeFile$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeFile;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4799,7 +5103,7 @@ public final class com/stripe/android/model/StripeFileParams$FileLink : android/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeFileParams$FileLink$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeFileParams$FileLink$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeFileParams$FileLink;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4840,6 +5144,14 @@ public abstract interface class com/stripe/android/model/StripeIntent : com/stri
 public abstract class com/stripe/android/model/StripeIntent$NextActionData : com/stripe/android/model/StripeModel {
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$AlipayRedirect$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$AlipayRedirect;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$AlipayRedirect;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize : com/stripe/android/model/StripeIntent$NextActionData {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
@@ -4849,7 +5161,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuth
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4877,7 +5189,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayO
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4901,7 +5213,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$Redirect
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4926,7 +5238,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4954,7 +5266,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -4982,11 +5294,19 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -5074,7 +5394,7 @@ public final class com/stripe/android/model/Token$Companion {
 	public final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Token;
 }
 
-public class com/stripe/android/model/Token$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/Token$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/Token;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5140,7 +5460,7 @@ public final class com/stripe/android/model/WeChat : com/stripe/android/model/St
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/WeChat$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/WeChat$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/WeChat;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5163,7 +5483,7 @@ public final class com/stripe/android/model/WeChatPayNextAction : com/stripe/and
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/WeChatPayNextAction$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/WeChatPayNextAction$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/WeChatPayNextAction;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5188,7 +5508,7 @@ public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWa
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5209,7 +5529,7 @@ public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet : com/
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$ApplePayWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5230,7 +5550,7 @@ public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$GooglePayWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5257,7 +5577,7 @@ public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$MasterpassWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$MasterpassWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5278,7 +5598,7 @@ public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$SamsungPayWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5307,7 +5627,7 @@ public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet : 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/wallets/Wallet$VisaCheckoutWallet;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5315,7 +5635,23 @@ public class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet$Creator 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/networking/ApiRequest$Options$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/networking/ApiRequest$Options;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/networking/ApiRequest$Options;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract class com/stripe/android/payments/PaymentFlowResult {
+}
+
+public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract interface class com/stripe/android/paymentsheet/GooglePayRepository {
@@ -5329,6 +5665,38 @@ public final class com/stripe/android/paymentsheet/GooglePayRepository$Disabled 
 
 public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentOptionContract$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentOptionContract$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentOptionContract$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentOptionResult$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentOptionResult$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentOptionResult$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentOptionResult$Failed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentOptionResult$Failed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentOptionResult$Failed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentOptionResult$Succeeded$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentOptionResult$Succeeded;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentOptionResult$Succeeded;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet {
@@ -5364,7 +5732,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5388,7 +5756,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfigur
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5412,7 +5780,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5427,6 +5795,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheetContract$Result$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Result;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheetContract$Result;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract class com/stripe/android/paymentsheet/PaymentSheetResult : android/os/Parcelable {
 }
 
@@ -5437,7 +5821,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetResult$Canceled :
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheetResult$Canceled$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheetResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetResult$Canceled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5452,7 +5836,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetResult$Completed 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheetResult$Completed$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheetResult$Completed$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetResult$Completed;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5474,7 +5858,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetResult$Failed : c
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/paymentsheet/PaymentSheetResult$Failed$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentSheetResult$Failed$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetResult$Failed;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5484,6 +5868,46 @@ public class com/stripe/android/paymentsheet/PaymentSheetResult$Failed$Creator :
 
 public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResultCallback {
 	public abstract fun onPaymentSheetResult (Lcom/stripe/android/paymentsheet/PaymentSheetResult;)V
+}
+
+public final class com/stripe/android/paymentsheet/analytics/SessionId$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/analytics/SessionId;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/analytics/SessionId;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/flowcontroller/InitData$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/flowcontroller/InitData;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/flowcontroller/InitData;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/FragmentConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/FragmentConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/FragmentConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentIntentClientSecret$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentIntentClientSecret;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentIntentClientSecret;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentOption {
@@ -5497,6 +5921,62 @@ public final class com/stripe/android/paymentsheet/model/PaymentOption {
 	public final fun getLabel ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentSelection$GooglePay$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$GooglePay;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentSelection$GooglePay;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentSelection$New$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$New$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentSelection$New$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/PaymentSelection$Saved$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$Saved;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentSelection$Saved;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/SavedSelection$GooglePay$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/SavedSelection$GooglePay;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/SavedSelection$GooglePay;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/SavedSelection$None$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/SavedSelection$None;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/SavedSelection$None;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/SavedSelection$PaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/SavedSelection$PaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/SavedSelection$PaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/model/SetupIntentClientSecret$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/SetupIntentClientSecret;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/SetupIntentClientSecret;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract class com/stripe/android/view/ActivityStarter {
@@ -5554,7 +6034,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$
 	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
 }
 
-public class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5578,7 +6058,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5603,7 +6083,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5624,11 +6104,19 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/BecsDebitBanks$Bank$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/BecsDebitBanks$Bank;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/BecsDebitBanks$Bank;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -5780,6 +6268,14 @@ public final class com/stripe/android/view/CardValidCallback$Fields : java/lang/
 	public static fun values ()[Lcom/stripe/android/view/CardValidCallback$Fields;
 }
 
+public final class com/stripe/android/view/CountryTextInputLayout$SelectedCountryState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/CountryTextInputLayout$SelectedCountryState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/CountryTextInputLayout$SelectedCountryState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/view/CvcEditText : com/stripe/android/view/StripeEditText {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
@@ -5846,7 +6342,7 @@ public final class com/stripe/android/view/PaymentFlowActivityStarter$Args$Compa
 	public final fun create (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
 }
 
-public class com/stripe/android/view/PaymentFlowActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/PaymentFlowActivityStarter$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5912,7 +6408,7 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Bu
 	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder;
 }
 
-public class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -5946,7 +6442,7 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result$
 	public final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
 }
 
-public class com/stripe/android/view/PaymentMethodsActivityStarter$Result$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;

--- a/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -136,11 +136,11 @@ class GooglePayJsonFactory constructor(
         transactionInfo: TransactionInfo
     ): JSONObject {
         return JSONObject()
-            .put("currencyCode", transactionInfo.currencyCode.toUpperCase(Locale.ROOT))
+            .put("currencyCode", transactionInfo.currencyCode.uppercase())
             .put("totalPriceStatus", transactionInfo.totalPriceStatus.code)
             .apply {
                 transactionInfo.countryCode?.let {
-                    put("countryCode", it.toUpperCase(Locale.ROOT))
+                    put("countryCode", it.uppercase())
                 }
 
                 transactionInfo.transactionId?.let {
@@ -153,7 +153,7 @@ class GooglePayJsonFactory constructor(
                         PayWithGoogleUtils.getPriceString(
                             it,
                             Currency.getInstance(
-                                transactionInfo.currencyCode.toUpperCase(Locale.ROOT)
+                                transactionInfo.currencyCode.uppercase()
                             )
                         )
                     )
@@ -370,7 +370,7 @@ class GooglePayJsonFactory constructor(
         internal val normalizedAllowedCountryCodes: Set<String>
             get() {
                 return allowedCountryCodes.map {
-                    it.toUpperCase(Locale.ROOT)
+                    it.uppercase()
                 }.toSet()
             }
 

--- a/stripe/src/main/java/com/stripe/android/model/Address.kt
+++ b/stripe/src/main/java/com/stripe/android/model/Address.kt
@@ -4,7 +4,6 @@ import com.stripe.android.ObjectBuilder
 import com.stripe.android.model.parsers.AddressJsonParser
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
-import java.util.Locale
 
 /**
  * Model for an owner [address](https://stripe.com/docs/api#source_object-owner-address)
@@ -46,7 +45,7 @@ data class Address internal constructor(
         }
 
         fun setCountry(country: String?): Builder = apply {
-            this.country = country?.toUpperCase(Locale.ROOT)
+            this.country = country?.uppercase()
         }
 
         internal fun setCountryCode(countryCode: CountryCode?): Builder = apply {

--- a/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/AddressJapanParams.kt
@@ -3,7 +3,6 @@ package com.stripe.android.model
 import android.os.Parcelable
 import com.stripe.android.ObjectBuilder
 import kotlinx.parcelize.Parcelize
-import java.util.Locale
 
 @Parcelize
 data class AddressJapanParams(
@@ -78,7 +77,7 @@ data class AddressJapanParams(
          * @param country Two-letter country code (ISO 3166-1 alpha-2).
          */
         fun setCountry(country: String?): Builder = apply {
-            this.country = country?.toUpperCase(Locale.ROOT)
+            this.country = country?.uppercase()
         }
 
         /**

--- a/stripe/src/main/java/com/stripe/android/model/CountryCode.kt
+++ b/stripe/src/main/java/com/stripe/android/model/CountryCode.kt
@@ -18,6 +18,6 @@ internal data class CountryCode private constructor(
         fun isCA(countryCode: CountryCode?) = countryCode == CA
         fun isGB(countryCode: CountryCode?) = countryCode == GB
 
-        fun create(value: String) = CountryCode(value.toUpperCase(Locale.ROOT))
+        fun create(value: String) = CountryCode(value.uppercase())
     }
 }

--- a/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/stripe/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -7,7 +7,6 @@ import com.stripe.android.Stripe
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.Locale
 
 /**
  * Model for PaymentMethod creation parameters.
@@ -439,7 +438,7 @@ data class PaymentMethodCreateParams internal constructor(
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
             return mapOf(
-                PARAM_COUNTRY to country.toUpperCase(Locale.ROOT)
+                PARAM_COUNTRY to country.uppercase()
             )
         }
 
@@ -454,7 +453,7 @@ data class PaymentMethodCreateParams internal constructor(
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
             return mapOf(
-                PARAM_BANK to bank.toLowerCase(Locale.ROOT)
+                PARAM_BANK to bank.lowercase()
             )
         }
 

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/CurrencyFormatter.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/CurrencyFormatter.kt
@@ -14,7 +14,7 @@ internal class CurrencyFormatter {
         targetLocale: Locale = Locale.getDefault()
     ) = format(
         amount,
-        Currency.getInstance(amountCurrencyCode.toUpperCase(Locale.ROOT)),
+        Currency.getInstance(amountCurrencyCode.uppercase()),
         targetLocale
     )
 
@@ -70,7 +70,7 @@ internal class CurrencyFormatter {
          */
         return SERVER_DECIMAL_DIGITS
             .filter { entry ->
-                entry.key.contains(currency.currencyCode.toUpperCase(Locale.ROOT))
+                entry.key.contains(currency.currencyCode.uppercase())
             }.map {
                 it.value
             }.firstOrNull() ?: currency.defaultFractionDigits

--- a/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryAdapter.kt
@@ -10,7 +10,6 @@ import android.widget.Filter
 import android.widget.TextView
 import com.stripe.android.R
 import java.lang.ref.WeakReference
-import java.util.Locale
 
 /**
  * Adapter that populates a list of countries for a spinner.
@@ -128,8 +127,8 @@ internal class CountryAdapter(
         private fun getSuggestedCountries(constraint: CharSequence?): List<Country> {
             return unfilteredCountries
                 .filter {
-                    it.name.toLowerCase(Locale.ROOT).startsWith(
-                        constraint.toString().toLowerCase(Locale.ROOT)
+                    it.name.lowercase().startsWith(
+                        constraint.toString().lowercase()
                     )
                 }
         }

--- a/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -46,7 +46,7 @@ internal object CountryUtils {
         return listOfNotNull(getCountryByCode(currentLocale.getCountryCode(), currentLocale))
             .plus(
                 localizedCountries(currentLocale)
-                    .sortedBy { it.name.toLowerCase(Locale.ROOT) }
+                    .sortedBy { it.name.lowercase() }
                     .filterNot { it.code == currentLocale.getCountryCode() }
             )
     }
@@ -60,7 +60,7 @@ internal object CountryUtils {
     )
     @JvmSynthetic
     internal fun doesCountryUsePostalCode(countryCode: String): Boolean {
-        return !NO_POSTAL_CODE_COUNTRIES.contains(countryCode.toUpperCase(Locale.ROOT))
+        return !NO_POSTAL_CODE_COUNTRIES.contains(countryCode.uppercase())
     }
 
     @JvmSynthetic


### PR DESCRIPTION
# Summary
- `toLowerCase()` is deprecated and replaced by `lowercase()`. `lowercase()` defaults to `Locale.ROOT`.
- `toUpperCase()` is deprecated and replaced by `uppercase()`. `uppercase()` defaults to `Locale.ROOT`.

# Motivation
[Kotlin Plugin v1.5.0](https://plugins.jetbrains.com/plugin/6954-kotlin) is now available, so we can proceed with the upgrade.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
