### PR TITLE
[CardFormView bug bash] save error state on StripeEditText upon configuration change

### DIFF
--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -6546,24 +6546,6 @@ public abstract interface class com/stripe/android/view/StripeEditText$ErrorMess
 	public abstract fun displayErrorMessage (Ljava/lang/String;)V
 }
 
-public final class com/stripe/android/view/StripeEditText$StripeEditTextState : android/os/Parcelable {
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Landroid/os/Parcelable;Ljava/lang/String;Z)V
-	public final fun component1 ()Landroid/os/Parcelable;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Z
-	public final fun copy (Landroid/os/Parcelable;Ljava/lang/String;Z)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
-	public static synthetic fun copy$default (Lcom/stripe/android/view/StripeEditText$StripeEditTextState;Landroid/os/Parcelable;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getErrorMessage ()Ljava/lang/String;
-	public final fun getShouldShowError ()Z
-	public final fun getSuperState ()Landroid/os/Parcelable;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/view/StripeEditText$StripeEditTextState$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -6548,12 +6548,12 @@ public abstract interface class com/stripe/android/view/StripeEditText$ErrorMess
 
 public final class com/stripe/android/view/StripeEditText$StripeEditTextState : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;ZLandroid/os/Parcelable;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Landroid/os/Parcelable;
-	public final fun copy (Ljava/lang/String;ZLandroid/os/Parcelable;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
-	public static synthetic fun copy$default (Lcom/stripe/android/view/StripeEditText$StripeEditTextState;Ljava/lang/String;ZLandroid/os/Parcelable;ILjava/lang/Object;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public fun <init> (Landroid/os/Parcelable;Ljava/lang/String;Z)V
+	public final fun component1 ()Landroid/os/Parcelable;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Landroid/os/Parcelable;Ljava/lang/String;Z)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/StripeEditText$StripeEditTextState;Landroid/os/Parcelable;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getErrorMessage ()Ljava/lang/String;

--- a/stripe/api/stripe.api
+++ b/stripe/api/stripe.api
@@ -6519,6 +6519,8 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	protected final fun isLastKeyDelete ()Z
 	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
 	public fun onInitializeAccessibilityNodeInfo (Landroid/view/accessibility/AccessibilityNodeInfo;)V
+	public fun onRestoreInstanceState (Landroid/os/Parcelable;)V
+	public fun onSaveInstanceState ()Landroid/os/Parcelable;
 	public fun removeTextChangedListener (Landroid/text/TextWatcher;)V
 	public final fun setAfterTextChangedListener (Lcom/stripe/android/view/StripeEditText$AfterTextChangedListener;)V
 	public final fun setDeleteEmptyListener (Lcom/stripe/android/view/StripeEditText$DeleteEmptyListener;)V
@@ -6542,6 +6544,32 @@ public abstract interface class com/stripe/android/view/StripeEditText$DeleteEmp
 
 public abstract interface class com/stripe/android/view/StripeEditText$ErrorMessageListener {
 	public abstract fun displayErrorMessage (Ljava/lang/String;)V
+}
+
+public final class com/stripe/android/view/StripeEditText$StripeEditTextState : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;ZLandroid/os/Parcelable;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Landroid/os/Parcelable;
+	public final fun copy (Ljava/lang/String;ZLandroid/os/Parcelable;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public static synthetic fun copy$default (Lcom/stripe/android/view/StripeEditText$StripeEditTextState;Ljava/lang/String;ZLandroid/os/Parcelable;ILjava/lang/Object;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getShouldShowError ()Z
+	public final fun getSuperState ()Landroid/os/Parcelable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/view/StripeEditText$StripeEditTextState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/StripeEditText$StripeEditTextState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract interface class com/stripe/android/view/i18n/ErrorMessageTranslator {

--- a/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/stripe/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -181,11 +181,7 @@ internal class CardFormView @JvmOverloads constructor(
 
     private fun setupCountryAndPostal() {
         // wire up postal code and country
-        postalCodeView.config = if (CountryCode.isUS(countryLayout.selectedCountryCode)) {
-            PostalCodeEditText.Config.US
-        } else {
-            PostalCodeEditText.Config.Global
-        }
+        updatePostalCodeViewLocale(countryLayout.selectedCountryCode)
 
         // color in sync with CardMultilineWidget
         postalCodeView.setErrorColor(
@@ -209,15 +205,28 @@ internal class CardFormView @JvmOverloads constructor(
             onFieldError(Fields.Postal, null)
         }
 
+        postalCodeView.setErrorMessageListener { errorMessage ->
+            onFieldError(
+                Fields.Postal,
+                errorMessage
+            )
+        }
+
         countryLayout.countryCodeChangeCallback = { countryCode ->
-            postalCodeView.config = if (CountryCode.isUS(countryCode)) {
-                PostalCodeEditText.Config.US
-            } else {
-                PostalCodeEditText.Config.Global
-            }
+            updatePostalCodeViewLocale(countryCode)
             postalCodeContainer.isVisible = CountryUtils.doesCountryUsePostalCode(countryCode)
             postalCodeView.shouldShowError = false
             postalCodeView.text = null
+        }
+    }
+
+    private fun updatePostalCodeViewLocale(countryCode: CountryCode?) {
+        if (CountryCode.isUS(countryCode)) {
+            postalCodeView.config = PostalCodeEditText.Config.US
+            postalCodeView.setErrorMessage(resources.getString(R.string.address_zip_invalid))
+        } else {
+            postalCodeView.config = PostalCodeEditText.Config.Global
+            postalCodeView.setErrorMessage(resources.getString(R.string.address_postal_code_invalid))
         }
     }
 
@@ -232,11 +241,7 @@ internal class CardFormView @JvmOverloads constructor(
     private fun showPostalError() {
         onFieldError(
             Fields.Postal,
-            if (countryLayout.selectedCountryCode == null || CountryCode.isUS(countryLayout.selectedCountryCode!!)) {
-                resources.getString(R.string.address_zip_invalid)
-            } else {
-                resources.getString(R.string.address_postal_code_invalid)
-            }
+            postalCodeView.errorMessage
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -222,9 +222,9 @@ open class StripeEditText @JvmOverloads constructor(
 
     override fun onSaveInstanceState(): Parcelable {
         return StripeEditTextState(
+            super.onSaveInstanceState(),
             errorMessage,
-            shouldShowError,
-            super.onSaveInstanceState()
+            shouldShowError
         )
     }
 
@@ -296,8 +296,8 @@ open class StripeEditText @JvmOverloads constructor(
 
     @Parcelize
     data class StripeEditTextState(
+        val superState: Parcelable?,
         val errorMessage: String?,
-        val shouldShowError: Boolean,
-        val superState: Parcelable?
+        val shouldShowError: Boolean
     ) : Parcelable
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -2,6 +2,8 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.os.Bundle
+import android.os.Parcelable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.KeyEvent
@@ -12,6 +14,7 @@ import android.view.inputmethod.InputConnectionWrapper
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputEditText
 import com.stripe.android.R
@@ -218,6 +221,24 @@ open class StripeEditText @JvmOverloads constructor(
         fun displayErrorMessage(message: String?)
     }
 
+    override fun onSaveInstanceState(): Parcelable {
+        return bundleOf(
+            STATE_SUPER_STATE to super.onSaveInstanceState(),
+            STATE_ERROR_MESSAGE to errorMessage,
+            STATE_SHOULD_SHOW_ERROR to shouldShowError
+        )
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        if (state is Bundle) {
+            super.onRestoreInstanceState(state.getParcelable(STATE_SUPER_STATE))
+            errorMessage = state.getString(STATE_ERROR_MESSAGE)
+            shouldShowError = state.getBoolean(STATE_SHOULD_SHOW_ERROR)
+        } else {
+            super.onRestoreInstanceState(state)
+        }
+    }
+
     private class SoftDeleteInputConnection constructor(
         target: InputConnection,
         mutable: Boolean,
@@ -274,5 +295,11 @@ open class StripeEditText @JvmOverloads constructor(
         textWatchers.forEach {
             super.addTextChangedListener(it)
         }
+    }
+
+    companion object {
+        const val STATE_SUPER_STATE = "state_super_state"
+        const val STATE_SHOULD_SHOW_ERROR = "state_should_show_error"
+        const val STATE_ERROR_MESSAGE = "state_error_message"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -295,7 +295,7 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     @Parcelize
-    data class StripeEditTextState(
+    internal data class StripeEditTextState(
         val superState: Parcelable?,
         val errorMessage: String?,
         val shouldShowError: Boolean

--- a/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/stripe/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.content.res.ColorStateList
-import android.os.Bundle
 import android.os.Parcelable
 import android.text.TextWatcher
 import android.util.AttributeSet
@@ -14,10 +13,10 @@ import android.view.inputmethod.InputConnectionWrapper
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
-import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputEditText
 import com.stripe.android.R
+import kotlinx.parcelize.Parcelize
 
 /**
  * Extension of [TextInputEditText] that listens for users pressing the delete key when
@@ -222,20 +221,18 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     override fun onSaveInstanceState(): Parcelable {
-        return bundleOf(
-            STATE_SUPER_STATE to super.onSaveInstanceState(),
-            STATE_ERROR_MESSAGE to errorMessage,
-            STATE_SHOULD_SHOW_ERROR to shouldShowError
+        return StripeEditTextState(
+            errorMessage,
+            shouldShowError,
+            super.onSaveInstanceState()
         )
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        if (state is Bundle) {
-            super.onRestoreInstanceState(state.getParcelable(STATE_SUPER_STATE))
-            errorMessage = state.getString(STATE_ERROR_MESSAGE)
-            shouldShowError = state.getBoolean(STATE_SHOULD_SHOW_ERROR)
-        } else {
-            super.onRestoreInstanceState(state)
+        (state as StripeEditTextState).let {
+            super.onRestoreInstanceState(it.superState)
+            errorMessage = it.errorMessage
+            shouldShowError = it.shouldShowError
         }
     }
 
@@ -297,9 +294,10 @@ open class StripeEditText @JvmOverloads constructor(
         }
     }
 
-    companion object {
-        const val STATE_SUPER_STATE = "state_super_state"
-        const val STATE_SHOULD_SHOW_ERROR = "state_should_show_error"
-        const val STATE_ERROR_MESSAGE = "state_error_message"
-    }
+    @Parcelize
+    data class StripeEditTextState(
+        val errorMessage: String?,
+        val shouldShowError: Boolean,
+        val superState: Parcelable?
+    ) : Parcelable
 }


### PR DESCRIPTION
# Summary
save error state so that when configuration changes, the error listeners is correctly triggered

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[CardFormView bug bash](https://paper.dropbox.com/doc/bug-bash-for-CardFormView--BJpcMF_NwlzfAcgFhBU65azvAg-prmyfTdTeknhHCsZxhzj2)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![errorMsgBefore](https://user-images.githubusercontent.com/79880926/117237985-f040f300-ade0-11eb-9d8b-aa688c582753.gif)   | ![errorMsgAfter](https://user-images.githubusercontent.com/79880926/117237978-ed460280-ade0-11eb-99b4-4e0b2e302028.gif)|
