### PR TITLE
Remove unused SDK analytics params

### DIFF
--- a/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/stripe/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -302,10 +302,7 @@ internal class StripePaymentController internal constructor(
         requestOptions: ApiRequest.Options
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuthSource(
-                AnalyticsEvent.AuthSourceStart,
-                source.id
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.AuthSourceStart)
         )
 
         runCatching {
@@ -352,10 +349,7 @@ internal class StripePaymentController internal constructor(
         requestOptions: ApiRequest.Options
     ) = withContext(uiContext) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuthSource(
-                AnalyticsEvent.AuthSourceRedirect,
-                source.id
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.AuthSourceRedirect)
         )
 
         paymentBrowserAuthStarter.start(
@@ -470,10 +464,7 @@ internal class StripePaymentController internal constructor(
         )
 
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuthSource(
-                AnalyticsEvent.AuthSourceResult,
-                sourceId
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.AuthSourceResult)
         )
 
         return requireNotNull(
@@ -597,10 +588,7 @@ internal class StripePaymentController internal constructor(
         nextActionData: StripeIntent.NextActionData.SdkData.Use3DS2
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds2Fingerprint,
-                stripeIntent.id.orEmpty()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Fingerprint)
         )
         try {
             begin3ds2Auth(
@@ -626,9 +614,8 @@ internal class StripePaymentController internal constructor(
         returnUrl: String?
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds1Sdk,
-                stripeIntent.id.orEmpty()
+            analyticsRequestFactory.createRequest(
+                AnalyticsEvent.Auth3ds1Sdk
             )
         )
         beginWebAuth(
@@ -651,10 +638,7 @@ internal class StripePaymentController internal constructor(
         nextActionData: StripeIntent.NextActionData.RedirectToUrl
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.AuthRedirect,
-                stripeIntent.id.orEmpty()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.AuthRedirect)
         )
 
         beginWebAuth(
@@ -681,10 +665,7 @@ internal class StripePaymentController internal constructor(
         nextActionData: StripeIntent.NextActionData.AlipayRedirect
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.AuthRedirect,
-                stripeIntent.id.orEmpty()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.AuthRedirect)
         )
 
         beginWebAuth(
@@ -791,7 +772,6 @@ internal class StripePaymentController internal constructor(
                 requireNotNull(
                     stripeRepository.start3ds2Auth(
                         authParams,
-                        stripeIntent.id.orEmpty(),
                         requestOptions
                     )
                 )
@@ -891,10 +871,7 @@ internal class StripePaymentController internal constructor(
         requestOptions: ApiRequest.Options
     ) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds2Fallback,
-                stripeIntent.id.orEmpty()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Fallback)
         )
         beginWebAuth(
             paymentBrowserAuthStarterFactory(host),
@@ -913,10 +890,7 @@ internal class StripePaymentController internal constructor(
         stripeIntent: StripeIntent
     ) = withContext(uiContext) {
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds2Frictionless,
-                stripeIntent.id.orEmpty()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Frictionless)
         )
         paymentRelayStarter.start(
             PaymentRelayStarter.Args.create(stripeIntent)

--- a/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
@@ -12,8 +12,6 @@ import com.stripe.android.model.Token
 import com.stripe.android.paymentsheet.analytics.DeviceId
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.analytics.SessionId
-import com.stripe.android.stripe3ds2.transaction.ProtocolErrorEvent
-import com.stripe.android.stripe3ds2.transaction.RuntimeErrorEvent
 import com.stripe.android.utils.ContextUtils.packageInfo
 
 /**
@@ -44,89 +42,13 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     )
 
     @JvmSynthetic
-    internal fun createAuth(
-        event: AnalyticsEvent,
-        intentId: String,
-        requestId: RequestId? = null,
-        extraParams: Map<String, Any> = emptyMap()
-    ): AnalyticsRequest {
-        return createRequest(
-            event,
-            requestId = requestId,
-            extraParams = extraParams.plus(
-                createIntentParam(intentId)
-            )
-        )
-    }
-
-    @JvmSynthetic
-    internal fun createAuthSource(
-        event: AnalyticsEvent,
-        sourceId: String?
-    ): AnalyticsRequest {
-        return createRequest(
-            event,
-            requestId = null,
-            extraParams = sourceId?.let { mapOf(FIELD_SOURCE_ID to it) }
-        )
-    }
-
-    @JvmSynthetic
     internal fun create3ds2Challenge(
         event: AnalyticsEvent,
-        intentId: String,
         uiTypeCode: String
     ): AnalyticsRequest {
         return createRequest(
             event,
-            requestId = null,
-            extraParams = createIntentParam(intentId)
-                .plus(
-                    FIELD_3DS2_UI_TYPE to
-                        ThreeDS2UiType.fromUiTypeCode(uiTypeCode).toString()
-                )
-        )
-    }
-
-    @JvmSynthetic
-    internal fun create3ds2ChallengeError(
-        intentId: String,
-        runtimeErrorEvent: RuntimeErrorEvent
-    ): AnalyticsRequest {
-        return createRequest(
-            AnalyticsEvent.Auth3ds2ChallengeErrored,
-            requestId = null,
-            extraParams = createIntentParam(intentId)
-                .plus(
-                    FIELD_ERROR_DATA to mapOf(
-                        "type" to "runtime_error_event",
-                        "error_code" to runtimeErrorEvent.errorCode,
-                        "error_message" to runtimeErrorEvent.errorMessage
-                    )
-                )
-        )
-    }
-
-    @JvmSynthetic
-    internal fun create3ds2ChallengeErrorParams(
-        intentId: String,
-        protocolErrorEvent: ProtocolErrorEvent
-    ): AnalyticsRequest {
-        val errorMessage = protocolErrorEvent.errorMessage
-        val errorData = mapOf(
-            "type" to "protocol_error_event",
-            "sdk_trans_id" to protocolErrorEvent.sdkTransactionId?.value,
-            "error_code" to errorMessage.errorCode,
-            "error_description" to errorMessage.errorDescription,
-            "error_details" to errorMessage.errorDetails,
-            "trans_id" to errorMessage.transactionId
-        )
-
-        return createRequest(
-            AnalyticsEvent.Auth3ds2ChallengeErrored,
-            requestId = null,
-            extraParams = createIntentParam(intentId)
-                .plus(FIELD_ERROR_DATA to errorData)
+            threeDS2UiType = ThreeDS2UiType.fromUiTypeCode(uiTypeCode)
         )
     }
 
@@ -134,11 +56,9 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     internal fun createTokenCreation(
         productUsageTokens: Set<String>?,
         tokenType: Token.Type,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.TokenCreate,
-            requestId = requestId,
             productUsageTokens = productUsageTokens,
             tokenType = tokenType
         )
@@ -148,11 +68,9 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     internal fun createPaymentMethodCreation(
         paymentMethodType: PaymentMethodCreateParams.Type?,
         productUsageTokens: Set<String>?,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.PaymentMethodCreate,
-            requestId = requestId,
             sourceType = paymentMethodType?.code,
             productUsageTokens = productUsageTokens
         )
@@ -162,25 +80,11 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     internal fun createSourceCreation(
         @Source.SourceType sourceType: String,
         productUsageTokens: Set<String>? = null,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.SourceCreate,
-            requestId = requestId,
             productUsageTokens = productUsageTokens,
             sourceType = sourceType
-        )
-    }
-
-    @JvmSynthetic
-    internal fun createSourceRetrieve(
-        sourceId: String,
-        requestId: RequestId?
-    ): AnalyticsRequest {
-        return createRequest(
-            AnalyticsEvent.SourceRetrieve,
-            requestId = requestId,
-            extraParams = mapOf(FIELD_SOURCE_ID to sourceId)
         )
     }
 
@@ -188,11 +92,9 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     internal fun createAddSource(
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String,
-        requestId: RequestId?,
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.CustomerAddSource,
-            requestId = requestId,
             productUsageTokens = productUsageTokens,
             sourceType = sourceType
         )
@@ -201,11 +103,9 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createDeleteSource(
         productUsageTokens: Set<String>?,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.CustomerDeleteSource,
-            requestId = requestId,
             productUsageTokens = productUsageTokens
         )
     }
@@ -213,23 +113,19 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createAttachPaymentMethod(
         productUsageTokens: Set<String>?,
-        requestId: RequestId?,
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.CustomerAttachPaymentMethod,
-            requestId = requestId,
             productUsageTokens = productUsageTokens
         )
     }
 
     @JvmSynthetic
     internal fun createDetachPaymentMethod(
-        productUsageTokens: Set<String>?,
-        requestId: RequestId?,
+        productUsageTokens: Set<String>?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.CustomerDetachPaymentMethod,
-            requestId = requestId,
             productUsageTokens = productUsageTokens
         )
     }
@@ -237,60 +133,22 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createPaymentIntentConfirmation(
         paymentMethodType: String? = null,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.PaymentIntentConfirm,
-            requestId = requestId,
             sourceType = paymentMethodType
-        )
-    }
-
-    @JvmSynthetic
-    internal fun createPaymentIntentRetrieve(
-        intentId: String,
-        requestId: RequestId?
-    ): AnalyticsRequest {
-        return createRequest(
-            AnalyticsEvent.PaymentIntentRetrieve,
-            requestId = requestId,
-            extraParams = createIntentParam(intentId)
         )
     }
 
     @JvmSynthetic
     internal fun createSetupIntentConfirmation(
         paymentMethodType: String?,
-        intentId: String,
-        requestId: RequestId?
     ): AnalyticsRequest {
         return createRequest(
             AnalyticsEvent.SetupIntentConfirm,
-            requestId = requestId,
-            sourceType = paymentMethodType,
-            extraParams = createIntentParam(intentId)
+            sourceType = paymentMethodType
         )
     }
-
-    @JvmSynthetic
-    internal fun createSetupIntentRetrieveParams(
-        intentId: String,
-        requestId: RequestId?
-    ): AnalyticsRequest {
-        return createRequest(
-            AnalyticsEvent.SetupIntentRetrieve,
-            requestId = requestId,
-            extraParams = createIntentParam(intentId)
-        )
-    }
-
-    @JvmSynthetic
-    internal fun createRequest(
-        event: AnalyticsEvent
-    ) = createRequest(
-        event,
-        requestId = null
-    )
 
     @JvmSynthetic
     internal fun createRequest(
@@ -300,8 +158,7 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     ): AnalyticsRequest {
         return AnalyticsRequest(
             createParams(
-                event.toString(),
-                requestId = null
+                event.toString()
             ).plus(
                 FIELD_DEVICE_ID to deviceId.value
             ).plus(
@@ -315,31 +172,28 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     @JvmSynthetic
     internal fun createRequest(
         event: AnalyticsEvent,
-        requestId: RequestId? = null,
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String? = null,
         tokenType: Token.Type? = null,
-        extraParams: Map<String, Any>? = null
+        threeDS2UiType: ThreeDS2UiType? = null
     ): AnalyticsRequest {
         return AnalyticsRequest(
             createParams(
                 event.toString(),
-                requestId,
                 productUsageTokens,
                 sourceType,
                 tokenType,
-                extraParams
+                threeDS2UiType
             )
         )
     }
 
     private fun createParams(
         event: String,
-        requestId: RequestId?,
         productUsageTokens: Set<String>? = null,
         @Source.SourceType sourceType: String? = null,
         tokenType: Token.Type? = null,
-        extraParams: Map<String, Any>? = null
+        threeDS2UiType: ThreeDS2UiType? = null
     ): Map<String, Any> {
         return createStandardParams(event)
             .plus(createAppDataParams())
@@ -351,11 +205,12 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
             .plus(sourceType?.let { mapOf(FIELD_SOURCE_TYPE to it) }.orEmpty())
             .plus(createTokenTypeParam(sourceType, tokenType))
             .plus(
-                requestId?.let {
-                    mapOf(FIELD_REQUEST_ID to it.value)
+                threeDS2UiType?.let {
+                    mapOf(
+                        FIELD_3DS2_UI_TYPE to it.toString()
+                    )
                 }.orEmpty()
             )
-            .plus(extraParams.orEmpty())
     }
 
     private fun createTokenTypeParam(
@@ -413,7 +268,7 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
         } ?: packageName
     }
 
-    private enum class ThreeDS2UiType(
+    internal enum class ThreeDS2UiType(
         private val code: String?,
         private val typeName: String
     ) {
@@ -442,15 +297,11 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
         internal const val FIELD_DEVICE_ID = "device_id"
         internal const val FIELD_DEVICE_TYPE = "device_type"
         internal const val FIELD_EVENT = "event"
-        internal const val FIELD_ERROR_DATA = "error"
-        internal const val FIELD_INTENT_ID = "intent_id"
         internal const val FIELD_OS_NAME = "os_name"
         internal const val FIELD_OS_RELEASE = "os_release"
         internal const val FIELD_OS_VERSION = "os_version"
         internal const val FIELD_PUBLISHABLE_KEY = "publishable_key"
-        internal const val FIELD_REQUEST_ID = "request_id"
         internal const val FIELD_SESSION_ID = "session_id"
-        internal const val FIELD_SOURCE_ID = "source_id"
         internal const val FIELD_SOURCE_TYPE = "source_type"
         internal const val FIELD_3DS2_UI_TYPE = "3ds2_ui_type"
         internal const val FIELD_TOKEN_TYPE = "token_type"
@@ -459,8 +310,7 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
         internal val VALID_PARAM_FIELDS: Set<String> = setOf(
             FIELD_ANALYTICS_UA, FIELD_APP_NAME, FIELD_APP_VERSION, FIELD_BINDINGS_VERSION,
             FIELD_DEVICE_TYPE, FIELD_EVENT, FIELD_OS_VERSION, FIELD_OS_NAME, FIELD_OS_RELEASE,
-            FIELD_PRODUCT_USAGE, FIELD_PUBLISHABLE_KEY, FIELD_REQUEST_ID,
-            FIELD_SOURCE_TYPE, FIELD_TOKEN_TYPE
+            FIELD_PRODUCT_USAGE, FIELD_PUBLISHABLE_KEY, FIELD_SOURCE_TYPE, FIELD_TOKEN_TYPE
         )
 
         private const val ANALYTICS_PREFIX = "analytics"
@@ -470,11 +320,5 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
         private val DEVICE_TYPE: String = "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}"
 
         internal const val ANALYTICS_UA = "$ANALYTICS_PREFIX.$ANALYTICS_NAME-$ANALYTICS_VERSION"
-
-        private fun createIntentParam(intentId: String): Map<String, String> {
-            return mapOf(
-                FIELD_INTENT_ID to intentId
-            )
-        }
     }
 }

--- a/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -132,14 +132,13 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         return fetchStripeModel(
             apiRequestFactory.createPost(apiUrl, options, params),
             PaymentIntentJsonParser()
-        ) { requestId ->
+        ) {
             val paymentMethodType =
                 confirmPaymentIntentParams.paymentMethodCreateParams?.typeCode
                     ?: confirmPaymentIntentParams.sourceParams?.type
             fireAnalyticsRequest(
                 analyticsRequestFactory.createPaymentIntentConfirmation(
-                    paymentMethodType,
-                    requestId = requestId
+                    paymentMethodType
                 )
             )
         }
@@ -174,12 +173,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 createClientSecretParam(clientSecret, expandFields)
             ),
             PaymentIntentJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
-                analyticsRequestFactory.createPaymentIntentRetrieve(
-                    paymentIntentId,
-                    requestId = requestId
-                )
+                analyticsRequestFactory.createRequest(AnalyticsEvent.PaymentIntentRetrieve)
             )
         }
     }
@@ -207,11 +203,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("source" to sourceId)
             ),
             PaymentIntentJsonParser()
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.PaymentIntentCancelSource,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.PaymentIntentCancelSource)
         }
     }
 
@@ -251,12 +244,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 )
             ),
             SetupIntentJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createSetupIntentConfirmation(
-                    confirmSetupIntentParams.paymentMethodCreateParams?.typeCode,
-                    setupIntentId,
-                    requestId = requestId
+                    confirmSetupIntentParams.paymentMethodCreateParams?.typeCode
                 )
             )
         }
@@ -291,12 +282,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 createClientSecretParam(clientSecret, expandFields)
             ),
             SetupIntentJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
-                analyticsRequestFactory.createSetupIntentRetrieveParams(
-                    setupIntentId,
-                    requestId = requestId
-                )
+                analyticsRequestFactory.createRequest(AnalyticsEvent.SetupIntentRetrieve)
             )
         }
     }
@@ -322,11 +310,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("source" to sourceId)
             ),
             SetupIntentJsonParser()
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.SetupIntentCancelSource,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.SetupIntentCancelSource)
         }
     }
 
@@ -359,12 +344,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     .plus(fingerprintData?.params.orEmpty())
             ),
             SourceJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createSourceCreation(
                     sourceParams.type,
-                    sourceParams.attribution,
-                    requestId = requestId
+                    sourceParams.attribution
                 )
             )
         }
@@ -396,12 +380,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 SourceParams.createRetrieveSourceParams(clientSecret)
             ),
             SourceJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
-                analyticsRequestFactory.createSourceRetrieve(
-                    sourceId,
-                    requestId
-                )
+                analyticsRequestFactory.createRequest(AnalyticsEvent.SourceRetrieve)
             )
         }
     }
@@ -429,12 +410,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     .plus(fingerprintData?.params.orEmpty())
             ),
             PaymentMethodJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createPaymentMethodCreation(
                     paymentMethodCreateParams.type,
-                    productUsageTokens = paymentMethodCreateParams.attribution,
-                    requestId = requestId
+                    productUsageTokens = paymentMethodCreateParams.attribution
                 )
             )
         }
@@ -472,12 +452,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     .plus(fingerprintData?.params.orEmpty())
             ),
             TokenJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createTokenCreation(
                     productUsageTokens = tokenParams.attribution,
-                    tokenType = tokenParams.tokenType,
-                    requestId = requestId
+                    tokenType = tokenParams.tokenType
                 )
             )
         }
@@ -508,12 +487,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("source" to sourceId)
             ),
             SourceJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createAddSource(
                     productUsageTokens,
-                    sourceType,
-                    requestId = requestId
+                    sourceType
                 )
             )
         }
@@ -542,11 +520,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 requestOptions
             ),
             SourceJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createDeleteSource(
-                    productUsageTokens,
-                    requestId = requestId
+                    productUsageTokens
                 )
             )
         }
@@ -578,12 +555,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("customer" to customerId)
             ),
             PaymentMethodJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory
                     .createAttachPaymentMethod(
-                        productUsageTokens,
-                        requestId = requestId
+                        productUsageTokens
                     )
             )
         }
@@ -611,12 +587,11 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 requestOptions
             ),
             PaymentMethodJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory
                     .createDetachPaymentMethod(
-                        productUsageTokens,
-                        requestId = requestId
+                        productUsageTokens
                     )
             )
         }
@@ -647,11 +622,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 listPaymentMethodsParams.toParamMap()
             ),
             PaymentMethodsListJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createRequest(
                     AnalyticsEvent.CustomerRetrievePaymentMethods,
-                    requestId = requestId,
                     productUsageTokens = productUsageTokens
                 )
             )
@@ -685,11 +659,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("default_source" to sourceId)
             ),
             CustomerJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createRequest(
                     event = AnalyticsEvent.CustomerSetDefaultSource,
-                    requestId = requestId,
                     productUsageTokens = productUsageTokens,
                     sourceType = sourceType
                 )
@@ -721,11 +694,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 mapOf("shipping" to shippingInformation.toParamMap())
             ),
             CustomerJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createRequest(
                     AnalyticsEvent.CustomerSetShippingInfo,
-                    requestId = requestId,
                     productUsageTokens = productUsageTokens
                 )
             )
@@ -753,11 +725,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 requestOptions
             ),
             CustomerJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
                 analyticsRequestFactory.createRequest(
                     AnalyticsEvent.CustomerRetrieve,
-                    requestId = requestId,
                     productUsageTokens = productUsageTokens
                 )
             )
@@ -785,14 +756,13 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             apiRequestFactory.createGet(
                 getIssuingCardPinUrl(cardId),
                 requestOptions,
-                mapOf("verification" to createVerificationParam(verificationId, userOneTimeCode))
+                mapOf(
+                    "verification" to createVerificationParam(verificationId, userOneTimeCode)
+                )
             ),
             IssuingCardPinJsonParser()
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.IssuingRetrievePin,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.IssuingRetrievePin)
         }
 
         return issuingCardPin?.pin
@@ -824,11 +794,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     "pin" to newPin
                 )
             )
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.IssuingUpdatePin,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.IssuingUpdatePin)
         }
     }
 
@@ -846,11 +813,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     mapOf("account_holder_type" to "individual")
                 ),
                 FpxBankStatusesJsonParser()
-            ) { requestId ->
-                fireAnalyticsRequest(
-                    AnalyticsEvent.FpxBankStatusesRetrieve,
-                    requestId
-                )
+            ) {
+                fireAnalyticsRequest(AnalyticsEvent.FpxBankStatusesRetrieve)
             }
 
             requireNotNull(fpxBankStatuses)
@@ -873,10 +837,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 // no-op
             }
         }.onFailure {
-            fireAnalyticsRequest(
-                AnalyticsEvent.CardMetadataLoadFailure,
-                null
-            )
+            fireAnalyticsRequest(AnalyticsEvent.CardMetadataLoadFailure)
         }.getOrNull()
     }
 
@@ -886,7 +847,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     @VisibleForTesting
     override suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
-        stripeIntentId: String,
         requestOptions: ApiRequest.Options
     ): Stripe3ds2AuthResult? {
         return fetchStripeModel(
@@ -896,13 +856,9 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 authParams.toParamMap()
             ),
             Stripe3ds2AuthResultJsonParser()
-        ) { requestId ->
+        ) {
             fireAnalyticsRequest(
-                analyticsRequestFactory.createAuth(
-                    AnalyticsEvent.Auth3ds2Start,
-                    stripeIntentId,
-                    requestId
-                )
+                analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Start)
             )
         }
     }
@@ -932,11 +888,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     ): StripeFile {
         val response = makeFileUploadRequest(
             FileUploadRequest(fileParams, requestOptions, appInfo)
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.FileCreate,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.FileCreate)
         }
         return StripeFileJsonParser().parse(response.responseJson)
     }
@@ -961,11 +914,8 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 url,
                 requestOptions
             )
-        ) { requestId ->
-            fireAnalyticsRequest(
-                AnalyticsEvent.StripeUrlRetrieve,
-                requestId
-            )
+        ) {
+            fireAnalyticsRequest(AnalyticsEvent.StripeUrlRetrieve)
         }
 
         return response.responseJson
@@ -1018,7 +968,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     private suspend fun <ModelType : StripeModel> fetchStripeModel(
         apiRequest: ApiRequest,
         jsonParser: ModelJsonParser<ModelType>,
-        onResponse: (RequestId?) -> Unit
+        onResponse: () -> Unit
     ): ModelType? {
         return jsonParser.parse(makeApiRequest(apiRequest, onResponse).responseJson)
     }
@@ -1033,14 +983,14 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     )
     internal suspend fun makeApiRequest(
         apiRequest: ApiRequest,
-        onResponse: (RequestId?) -> Unit
+        onResponse: () -> Unit
     ): StripeResponse {
         val dnsCacheData = disableDnsCache()
 
         val response = runCatching {
             stripeApiRequestExecutor.execute(apiRequest)
         }.also {
-            onResponse(it.getOrNull()?.requestId)
+            onResponse()
         }.getOrElse {
             throw when (it) {
                 is IOException -> APIConnectionException.create(it, apiRequest.baseUrl)
@@ -1118,14 +1068,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     private fun fireAnalyticsRequest(
-        event: AnalyticsEvent,
-        requestId: RequestId?
+        event: AnalyticsEvent
     ) {
         fireAnalyticsRequest(
-            analyticsRequestFactory.createRequest(
-                event,
-                requestId
-            )
+            analyticsRequestFactory.createRequest(event)
         )
     }
 

--- a/stripe/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/stripe/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -305,7 +305,6 @@ internal interface StripeRepository {
 
     suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
-        stripeIntentId: String,
         requestOptions: ApiRequest.Options
     ): Stripe3ds2AuthResult?
 

--- a/stripe/src/main/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiver.kt
+++ b/stripe/src/main/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiver.kt
@@ -54,7 +54,6 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create3ds2Challenge(
                 AnalyticsEvent.Auth3ds2ChallengeCompleted,
-                stripeIntent.id.orEmpty(),
                 uiTypeCode
             )
         )
@@ -70,7 +69,6 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create3ds2Challenge(
                 AnalyticsEvent.Auth3ds2ChallengeCanceled,
-                stripeIntent.id.orEmpty(),
                 uiTypeCode
             )
         )
@@ -86,7 +84,6 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create3ds2Challenge(
                 AnalyticsEvent.Auth3ds2ChallengeTimedOut,
-                stripeIntent.id.orEmpty(),
                 uiTypeCode
             )
         )
@@ -100,10 +97,7 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
     ) {
         super.protocolError(protocolErrorEvent)
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.create3ds2ChallengeErrorParams(
-                stripeIntent.id.orEmpty(),
-                protocolErrorEvent
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2ChallengeErrored)
         )
         log3ds2ChallengePresented()
 
@@ -115,10 +109,7 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
     ) {
         super.runtimeError(runtimeErrorEvent)
         analyticsRequestExecutor.executeAsync(
-            analyticsRequestFactory.create3ds2ChallengeError(
-                stripeIntent.id.orEmpty(),
-                runtimeErrorEvent
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2ChallengeErrored)
         )
         log3ds2ChallengePresented()
 
@@ -129,7 +120,6 @@ internal class DefaultStripeChallengeStatusReceiver internal constructor(
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.create3ds2Challenge(
                 AnalyticsEvent.Auth3ds2ChallengePresented,
-                stripeIntent.id.orEmpty(),
                 transaction.initialChallengeUiType.orEmpty()
             )
         )

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -3,7 +3,6 @@ package com.stripe.android.view
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -97,9 +96,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         viewBinding.webView.webViewClient = webViewClient
         viewBinding.webView.webChromeClient = PaymentAuthWebChromeClient(this, logger)
 
-        viewModel.logStart(
-            runCatching { Uri.parse(args.url) }.getOrNull()
-        )
+        viewModel.logStart()
         viewBinding.webView.loadUrl(
             args.url,
             viewModel.extraHeaders
@@ -108,11 +105,10 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
 
     @VisibleForTesting
     internal fun onAuthComplete(
-        uri: Uri?,
         error: Throwable?
     ) {
         if (error != null) {
-            viewModel.logError(uri, error)
+            viewModel.logError()
             setResult(
                 Activity.RESULT_OK,
                 createResultIntent(
@@ -125,7 +121,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
                 )
             )
         } else {
-            viewModel.logComplete(uri)
+            viewModel.logComplete()
         }
         finish()
     }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -70,19 +70,14 @@ internal class PaymentAuthWebViewActivityViewModel(
     /**
      * Log that 3DS1 challenge started.
      */
-    fun logStart(uri: Uri?) {
+    fun logStart() {
         fireAnalytics(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds1ChallengeStart,
-                args.objectId,
-                extraParams = uri.createAnalyticsChallengeUri()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds1ChallengeStart)
         )
 
         fireAnalytics(
             analyticsRequestFactory.createRequest(
-                AnalyticsEvent.AuthWithWebView,
-                extraParams = uri.createAnalyticsChallengeUri()
+                AnalyticsEvent.AuthWithWebView
             )
         )
     }
@@ -90,34 +85,18 @@ internal class PaymentAuthWebViewActivityViewModel(
     /**
      * Log that 3DS1 challenge completed with an error.
      */
-    fun logError(
-        uri: Uri?,
-        error: Throwable
-    ) {
+    fun logError() {
         fireAnalytics(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds1ChallengeError,
-                args.objectId,
-                extraParams = mapOf(
-                    FIELD_ERROR_MESSAGE to error.message.orEmpty(),
-                    FIELD_ERROR_STACKTRACE to error.stackTraceToString()
-                ).plus(
-                    uri.createAnalyticsChallengeUri()
-                )
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds1ChallengeError)
         )
     }
 
     /**
      * Log that 3DS1 challenge completed without an error.
      */
-    fun logComplete(uri: Uri?) {
+    fun logComplete() {
         fireAnalytics(
-            analyticsRequestFactory.createAuth(
-                AnalyticsEvent.Auth3ds1ChallengeComplete,
-                args.objectId,
-                extraParams = uri.createAnalyticsChallengeUri()
-            )
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds1ChallengeComplete)
         )
     }
 
@@ -125,15 +104,6 @@ internal class PaymentAuthWebViewActivityViewModel(
         request: AnalyticsRequest
     ) {
         analyticsRequestExecutor.executeAsync(request)
-    }
-
-    private fun Uri?.createAnalyticsChallengeUri(): Map<String, String> {
-        val sanitizedUri = if (this != null) {
-            "${this.scheme}://${this.host}"
-        } else {
-            ""
-        }
-        return mapOf(FIELD_CHALLENGE_URI to sanitizedUri)
     }
 
     internal data class ToolbarTitleData(
@@ -155,11 +125,5 @@ internal class PaymentAuthWebViewActivityViewModel(
                 AnalyticsRequestFactory(application, publishableKey)
             ) as T
         }
-    }
-
-    private companion object {
-        private const val FIELD_CHALLENGE_URI = "challenge_uri"
-        private const val FIELD_ERROR_MESSAGE = "error_message"
-        private const val FIELD_ERROR_STACKTRACE = "error_stacktrace"
     }
 }

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -38,12 +38,7 @@ internal class PaymentAuthWebViewClient(
 
         if (url != null && isCompletionUrl(url)) {
             logger.debug("$url is a completion URL")
-
-            onAuthCompleted(
-                runCatching {
-                    Uri.parse(url)
-                }.exceptionOrNull()
-            )
+            onAuthCompleted()
         }
     }
 

--- a/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/stripe/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -16,7 +16,7 @@ internal class PaymentAuthWebViewClient(
     private val clientSecret: String,
     returnUrl: String?,
     private val activityStarter: (Intent) -> Unit,
-    private val activityFinisher: (Uri?, Throwable?) -> Unit
+    private val activityFinisher: (Throwable?) -> Unit
 ) : WebViewClient() {
     // user-specified return URL
     private val userReturnUri: Uri? = returnUrl?.let { Uri.parse(it) }
@@ -42,7 +42,7 @@ internal class PaymentAuthWebViewClient(
             onAuthCompleted(
                 runCatching {
                     Uri.parse(url)
-                }.getOrNull()
+                }.exceptionOrNull()
             )
         }
     }
@@ -63,7 +63,7 @@ internal class PaymentAuthWebViewClient(
 
         return if (isReturnUrl(url)) {
             logger.debug("PaymentAuthWebViewClient#shouldOverrideUrlLoading() - handle return URL")
-            onAuthCompleted(url)
+            onAuthCompleted()
             true
         } else if ("intent".equals(url.scheme, ignoreCase = true)) {
             openIntentScheme(url)
@@ -72,7 +72,6 @@ internal class PaymentAuthWebViewClient(
             // Non-network URLs are likely deep-links into banking apps. If the deep-link can be
             // opened via an Intent, start it. Otherwise, stop the authentication attempt.
             openIntent(
-                url,
                 Intent(Intent.ACTION_VIEW, url)
             )
             true
@@ -85,12 +84,11 @@ internal class PaymentAuthWebViewClient(
         logger.debug("PaymentAuthWebViewClient#openIntentScheme()")
         runCatching {
             openIntent(
-                uri,
                 Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME)
             )
         }.onFailure { error ->
             logger.error("Failed to start Intent.", error)
-            onAuthCompleted(uri, error)
+            onAuthCompleted(error)
         }
     }
 
@@ -99,7 +97,6 @@ internal class PaymentAuthWebViewClient(
      * for more details on app-to-app interaction.
      */
     private fun openIntent(
-        uri: Uri,
         intent: Intent
     ) {
         logger.debug("PaymentAuthWebViewClient#openIntent()")
@@ -115,7 +112,7 @@ internal class PaymentAuthWebViewClient(
                 // irrespective of whether or not the app is installed.
                 // If this intent fails to resolve, we should still let the user
                 // continue on the mobile site.
-                onAuthCompleted(uri, error)
+                onAuthCompleted(error)
             }
         }
     }
@@ -176,11 +173,10 @@ internal class PaymentAuthWebViewClient(
      * Invoked when authentication flow has completed, whether succeeded or failed.
      */
     private fun onAuthCompleted(
-        uri: Uri?,
         error: Throwable? = null
     ) {
         logger.debug("PaymentAuthWebViewClient#onAuthCompleted()")
-        activityFinisher(uri, error)
+        activityFinisher(error)
     }
 
     internal companion object {

--- a/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/AnalyticsRequestFactoryTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.model.Token
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.RequestId
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -41,8 +40,7 @@ class AnalyticsRequestFactoryTest {
 
         val params = analyticsRequestFactory.createTokenCreation(
             ATTRIBUTION,
-            Token.Type.Pii,
-            REQUEST_ID
+            Token.Type.Pii
         ).params
 
         // Size is SIZE-1 because tokens don't have a source_type field
@@ -62,8 +60,7 @@ class AnalyticsRequestFactoryTest {
 
         val params = analyticsRequestFactory.createTokenCreation(
             ATTRIBUTION,
-            Token.Type.CvcUpdate,
-            REQUEST_ID
+            Token.Type.CvcUpdate
         ).params
 
         // Size is SIZE-1 because tokens don't have a source_type field
@@ -77,8 +74,7 @@ class AnalyticsRequestFactoryTest {
     fun getSourceCreationParams_withValidInput_createsCorrectMap() {
         val loggingParams = analyticsRequestFactory.createSourceCreation(
             Source.SourceType.SEPA_DEBIT,
-            ATTRIBUTION,
-            REQUEST_ID
+            ATTRIBUTION
         ).params
 
         // Size is SIZE-1 because tokens don't have a token_type field
@@ -106,8 +102,7 @@ class AnalyticsRequestFactoryTest {
             analyticsRequestFactory
                 .createPaymentMethodCreation(
                     PaymentMethodCreateParams.Type.Card,
-                    ATTRIBUTION,
-                    REQUEST_ID
+                    ATTRIBUTION
                 ).params
         ).isEqualTo(
             mapOf(
@@ -122,8 +117,7 @@ class AnalyticsRequestFactoryTest {
                 "app_name" to "com.stripe.android.test",
                 "app_version" to 0,
                 "product_usage" to ATTRIBUTION.toList(),
-                "source_type" to "card",
-                "request_id" to "req_123"
+                "source_type" to "card"
             )
         )
     }
@@ -132,8 +126,7 @@ class AnalyticsRequestFactoryTest {
     fun createPaymentIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val loggingParams =
             analyticsRequestFactory.createPaymentIntentConfirmation(
-                PaymentMethod.Type.Card.code,
-                REQUEST_ID
+                PaymentMethod.Type.Card.code
             ).params
 
         assertThat(loggingParams)
@@ -149,8 +142,7 @@ class AnalyticsRequestFactoryTest {
     @Test
     fun getPaymentIntentRetrieveParams_withValidInput_createsCorrectMap() {
         val loggingParams = analyticsRequestFactory.createRequest(
-            AnalyticsEvent.PaymentIntentRetrieve,
-            REQUEST_ID
+            AnalyticsEvent.PaymentIntentRetrieve
         ).params
 
         assertThat(loggingParams)
@@ -170,8 +162,6 @@ class AnalyticsRequestFactoryTest {
     fun getSetupIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val params = analyticsRequestFactory.createSetupIntentConfirmation(
             PaymentMethod.Type.Card.code,
-            "seti_12345",
-            REQUEST_ID
         ).params
 
         assertThat(params[AnalyticsRequestFactory.FIELD_SOURCE_TYPE])
@@ -195,8 +185,7 @@ class AnalyticsRequestFactoryTest {
             AnalyticsRequestFactory(packageManager, packageInfo, packageName) { API_KEY }
                 .createTokenCreation(
                     ATTRIBUTION,
-                    Token.Type.Card,
-                    REQUEST_ID
+                    Token.Type.Card
                 ).params
         assertThat(params)
             .hasSize(AnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 1)
@@ -207,7 +196,8 @@ class AnalyticsRequestFactoryTest {
         assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_RELEASE])
         assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_NAME])
         assertEquals(versionCode, params[AnalyticsRequestFactory.FIELD_APP_VERSION])
-        assertEquals(BuildConfig.LIBRARY_PACKAGE_NAME, params[AnalyticsRequestFactory.FIELD_APP_NAME])
+        assertThat(params[AnalyticsRequestFactory.FIELD_APP_NAME])
+            .isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
 
         assertEquals(Stripe.VERSION_NAME, params[AnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
         assertEquals(expectedEventName, params[AnalyticsRequestFactory.FIELD_EVENT])
@@ -226,8 +216,7 @@ class AnalyticsRequestFactoryTest {
         val expectedUaName = AnalyticsRequestFactory.ANALYTICS_UA
 
         val params = analyticsRequestFactory.createSourceCreation(
-            Source.SourceType.SEPA_DEBIT,
-            requestId = REQUEST_ID
+            Source.SourceType.SEPA_DEBIT
         ).params
 
         assertThat(params)
@@ -286,7 +275,6 @@ class AnalyticsRequestFactoryTest {
         assertThat(
             analyticsRequestFactory.create3ds2Challenge(
                 AnalyticsEvent.Auth3ds2ChallengeCompleted,
-                "pi_123",
                 "01"
             ).params
         ).containsEntry("3ds2_ui_type", "text")
@@ -296,7 +284,6 @@ class AnalyticsRequestFactoryTest {
     fun `create3ds2ChallengeParams with uiTypeCode '99' should create params with expected 3ds2_ui_type`() {
         val params = analyticsRequestFactory.create3ds2Challenge(
             AnalyticsEvent.Auth3ds2ChallengeCompleted,
-            "pi_123",
             "99"
         ).params
 
@@ -306,14 +293,12 @@ class AnalyticsRequestFactoryTest {
 
     @Test
     fun `when publishable key is unavailable, create params with undefined key`() {
-        val params = AnalyticsRequestFactory(
+        val factory = AnalyticsRequestFactory(
             context
         ) {
             throw RuntimeException()
-        }.createSourceRetrieve(
-            "src_123",
-            requestId = REQUEST_ID
-        ).params
+        }
+        val params = factory.createRequest(AnalyticsEvent.SourceRetrieve).params
 
         assertThat(params["publishable_key"])
             .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
@@ -324,8 +309,7 @@ class AnalyticsRequestFactoryTest {
         val sdkVersion = Stripe.VERSION_NAME
         val analyticsRequest = analyticsRequestFactory.createPaymentMethodCreation(
             PaymentMethodCreateParams.Type.Card,
-            emptySet(),
-            REQUEST_ID
+            emptySet()
         )
         assertThat(analyticsRequest.headers)
             .isEqualTo(
@@ -335,12 +319,11 @@ class AnalyticsRequestFactoryTest {
                 )
             )
         assertThat(analyticsRequest.url)
-            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&event=stripe_android.payment_method_creation&request_id=req_123")
+            .isEqualTo("https://q.stripe.com?app_name=com.stripe.android.test&publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&analytics_ua=analytics.stripe_android-1.0&os_name=REL&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&event=stripe_android.payment_method_creation")
     }
 
     private companion object {
         private const val API_KEY = "pk_abc123"
         private val ATTRIBUTION = setOf("CardInputView")
-        private val REQUEST_ID = RequestId("req_123")
     }
 }

--- a/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/stripe/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -175,8 +175,6 @@ internal class StripePaymentControllerTest {
             val analyticsParams = requireNotNull(analyticsRequestArgumentCaptor.firstValue.params)
             assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_EVENT])
                 .isEqualTo(AnalyticsEvent.Auth3ds2Fingerprint.toString())
-            assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_INTENT_ID])
-                .isEqualTo(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.id)
         }
 
     @Test
@@ -292,8 +290,6 @@ internal class StripePaymentControllerTest {
         val analyticsParams = requireNotNull(analyticsRequestArgumentCaptor.firstValue.params)
         assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(AnalyticsEvent.AuthRedirect.toString())
-        assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_INTENT_ID])
-            .isEqualTo("pi_1EZlvVCRMbs6FrXfKpq2xMmy")
     }
 
     @Test
@@ -350,8 +346,7 @@ internal class StripePaymentControllerTest {
             StripePaymentController.getRequestCode(
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     "pm_123",
-                    "client_secret",
-                    ""
+                    "client_secret"
                 )
             )
         ).isEqualTo(StripePaymentController.PAYMENT_REQUEST_CODE)
@@ -402,7 +397,6 @@ internal class StripePaymentControllerTest {
             val analyticsParams = requireNotNull(analyticsRequest.params)
             assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_EVENT])
                 .isEqualTo(AnalyticsEvent.Auth3ds2Frictionless.toString())
-            assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_INTENT_ID]).isEqualTo("pi_1ExkUeAWhjPjYwPiXph9ouXa")
         }
 
     @Test
@@ -630,7 +624,6 @@ internal class StripePaymentControllerTest {
                 ConfirmPaymentIntentParams.createWithPaymentMethodId(
                     "pm_123",
                     "client_secret",
-                    ""
                 ),
                 mock(),
                 REQUEST_OPTIONS

--- a/stripe/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -217,7 +217,6 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
 
     override suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
-        stripeIntentId: String,
         requestOptions: ApiRequest.Options
     ) = Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW
 

--- a/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
@@ -30,8 +30,7 @@ class AnalyticsRequestExecutorTest {
         AnalyticsRequestFactory(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
             .createPaymentMethodCreation(
                 PaymentMethodCreateParams.Type.Card,
-                emptySet(),
-                RequestId("req_123")
+                emptySet()
             )
 
     @Test

--- a/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/stripe/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -75,7 +75,8 @@ internal class StripeApiRepositoryTest {
     private val fingerprintDataRepository: FingerprintDataRepository = mock()
 
     private val apiRequestArgumentCaptor: KArgumentCaptor<ApiRequest> = argumentCaptor()
-    private val fileUploadRequestArgumentCaptor: KArgumentCaptor<FileUploadRequest> = argumentCaptor()
+    private val fileUploadRequestArgumentCaptor: KArgumentCaptor<FileUploadRequest> =
+        argumentCaptor()
     private val analyticsRequestArgumentCaptor: KArgumentCaptor<AnalyticsRequest> = argumentCaptor()
 
     @BeforeTest
@@ -211,48 +212,50 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun createCardSource_withAttribution_shouldPopulateProductUsage() = testDispatcher.runBlockingTest {
-        val stripeResponse = StripeResponse(
-            200,
-            SourceFixtures.SOURCE_CARD_JSON.toString(),
-            emptyMap()
-        )
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-            .thenReturn(stripeResponse)
-        create().createSource(
-            SourceParams.createCardParams(CardParamsFixtures.WITH_ATTRIBUTION),
-            DEFAULT_OPTIONS
-        )
+    fun createCardSource_withAttribution_shouldPopulateProductUsage() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                SourceFixtures.SOURCE_CARD_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+            create().createSource(
+                SourceParams.createCardParams(CardParamsFixtures.WITH_ATTRIBUTION),
+                DEFAULT_OPTIONS
+            )
 
-        verifyFingerprintAndAnalyticsRequests(
-            AnalyticsEvent.SourceCreate,
-            productUsage = listOf("CardInputView")
-        )
-    }
+            verifyFingerprintAndAnalyticsRequests(
+                AnalyticsEvent.SourceCreate,
+                productUsage = listOf("CardInputView")
+            )
+        }
 
     @Test
-    fun createAlipaySource_withAttribution_shouldPopulateProductUsage() = testDispatcher.runBlockingTest {
-        val stripeResponse = StripeResponse(
-            200,
-            SourceFixtures.ALIPAY_JSON.toString(),
-            emptyMap()
-        )
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-            .thenReturn(stripeResponse)
-        create().createSource(
-            SourceParams.createMultibancoParams(
-                100,
-                "return_url",
-                "jenny@example.com"
-            ),
-            DEFAULT_OPTIONS
-        )
+    fun createAlipaySource_withAttribution_shouldPopulateProductUsage() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                SourceFixtures.ALIPAY_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+            create().createSource(
+                SourceParams.createMultibancoParams(
+                    100,
+                    "return_url",
+                    "jenny@example.com"
+                ),
+                DEFAULT_OPTIONS
+            )
 
-        verifyFingerprintAndAnalyticsRequests(
-            AnalyticsEvent.SourceCreate,
-            productUsage = null
-        )
-    }
+            verifyFingerprintAndAnalyticsRequests(
+                AnalyticsEvent.SourceCreate,
+                productUsage = null
+            )
+        }
 
     @Test
     fun createSource_withConnectAccount_keepsHeaderInAccount() = testDispatcher.runBlockingTest {
@@ -293,14 +296,15 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun start3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException() = testDispatcher.runBlockingTest {
-        val authParams = Stripe3ds2AuthParams(
-            "src_invalid",
-            "1.0.0",
-            "3DS_LOA_SDK_STIN_12345",
-            UUID.randomUUID().toString(),
-            "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew",
-            """
+    fun start3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException() =
+        testDispatcher.runBlockingTest {
+            val authParams = Stripe3ds2AuthParams(
+                "src_invalid",
+                "1.0.0",
+                "3DS_LOA_SDK_STIN_12345",
+                UUID.randomUUID().toString(),
+                "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.nid2Q-Ii21cSPHBaszR5KSXz866yX9I7AthLKpfWZoc7RIfz11UJ1EHuvIRDIyqqJ8txNUKKoL4keqMTqK5Yc5TqsxMn0nML8pZaPn40nXsJm_HFv3zMeOtRR7UTewsDWIgf5J-A6bhowIOmvKPCJRxspn_Cmja-YpgFWTp08uoJvqgntgg1lHmI1kh1UV6DuseYFUfuQlICTqC3TspAzah2CALWZORF_QtSeHc_RuqK02wOQMs-7079jRuSdBXvI6dQnL5ESH25wHHosfjHMZ9vtdUFNJo9J35UI1sdWFDzzj8k7bt0BupZhyeU0PSM9EHP-yv01-MQ9eslPTVNbFJ9YOHtq8WamvlKDr1sKxz6Ac_gUM8NgEcPP9SafPVxDd4H1Fwb5-4NYu2AD4xoAgMWE-YtzvfIFXZcU46NDoi6Xum3cHJqTH0UaOhBoqJJft9XZXYW80fjts-v28TkA76-QPF7CTDM6KbupvBkSoRq218eJLEywySXgCwf-Q95fsBtnnyhKcvfRaByq5kT7PH3DYD1rCQLexJ76A79kurre9pDjTKAv85G9DNkOFuVUYnNB3QGFReCcF9wzkGnZXdfkgN2BkB6n94bbkEyjbRb5r37XH6oRagx2fWLVj7kC5baeIwUPVb5kV_x4Kle7C-FPY1Obz4U7s6SVRnLGXY.IP9OcQx5uZxBRluOpn1m6Q.w-Ko5Qg6r-KCmKnprXEbKA7wV-SdLNDAKqjtuku6hda_0crOPRCPU4nn26Yxj7EG.p01pl8CKukuXzjLeY3a_Ew",
+                """
             {
                 "kty": "EC",
                 "use": "sig",
@@ -309,38 +313,38 @@ internal class StripeApiRepositoryTest {
                 "x": "hSwyaaAp3ppSGkpt7d9G8wnp3aIXelsZVo05EPpqetg",
                 "y": "OUVOv9xPh5RYWapla0oz3vCJWRRXlDmppy5BGNeSl-A"
             }
-            """.trimIndent(),
-            Stripe3ds2Fixtures.MESSAGE_VERSION,
-            10,
-            "stripe://payment-auth-return"
-        )
+                """.trimIndent(),
+                Stripe3ds2Fixtures.MESSAGE_VERSION,
+                10,
+                "stripe://payment-auth-return"
+            )
 
-        val invalidRequestException =
-            assertFailsWith<InvalidRequestException> {
-                stripeApiRepository.start3ds2Auth(
-                    authParams,
-                    "pi_12345",
-                    DEFAULT_OPTIONS
-                )
-            }
+            val invalidRequestException =
+                assertFailsWith<InvalidRequestException> {
+                    stripeApiRepository.start3ds2Auth(
+                        authParams,
+                        DEFAULT_OPTIONS
+                    )
+                }
 
-        assertEquals("source", invalidRequestException.stripeError?.param)
-        assertEquals("resource_missing", invalidRequestException.stripeError?.code)
-    }
+            assertEquals("source", invalidRequestException.stripeError?.param)
+            assertEquals("resource_missing", invalidRequestException.stripeError?.code)
+        }
 
     @Test
-    fun complete3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException() = testDispatcher.runBlockingTest {
-        val invalidRequestException =
-            assertFailsWith<InvalidRequestException> {
-                stripeApiRepository.complete3ds2Auth(
-                    "src_123",
-                    DEFAULT_OPTIONS
-                )
-            }
-        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, invalidRequestException.statusCode)
-        assertEquals("source", invalidRequestException.stripeError?.param)
-        assertEquals("resource_missing", invalidRequestException.stripeError?.code)
-    }
+    fun complete3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException() =
+        testDispatcher.runBlockingTest {
+            val invalidRequestException =
+                assertFailsWith<InvalidRequestException> {
+                    stripeApiRepository.complete3ds2Auth(
+                        "src_123",
+                        DEFAULT_OPTIONS
+                    )
+                }
+            assertEquals(HttpURLConnection.HTTP_NOT_FOUND, invalidRequestException.statusCode)
+            assertEquals("source", invalidRequestException.stripeError?.param)
+            assertEquals("resource_missing", invalidRequestException.stripeError?.code)
+        }
 
     @Test
     fun fireAnalyticsRequest_shouldReturnSuccessful() {
@@ -352,104 +356,104 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun requestData_withConnectAccount_shouldReturnCorrectResponseHeaders() = testDispatcher.runBlockingTest {
-        val connectAccountId = "acct_1Acj2PBUgO3KuWzz"
-        var requestId: RequestId? = null
-        val response = stripeApiRepository.makeApiRequest(
-            DEFAULT_API_REQUEST_FACTORY.createPost(
-                StripeApiRepository.sourcesUrl,
-                ApiRequest.Options(
-                    ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY,
-                    connectAccountId
-                ),
-                SourceParams.createCardParams(CARD_PARAMS).toParamMap()
-            )
-        ) {
-            requestId = it
-        }
-        assertNotNull(response)
-        assertThat(requestId)
-            .isNotNull()
+    fun requestData_withConnectAccount_shouldReturnCorrectResponseHeaders() =
+        testDispatcher.runBlockingTest {
+            val connectAccountId = "acct_1Acj2PBUgO3KuWzz"
+            val response = stripeApiRepository.makeApiRequest(
+                DEFAULT_API_REQUEST_FACTORY.createPost(
+                    StripeApiRepository.sourcesUrl,
+                    ApiRequest.Options(
+                        ApiKeyFixtures.CONNECTED_ACCOUNT_PUBLISHABLE_KEY,
+                        connectAccountId
+                    ),
+                    SourceParams.createCardParams(CARD_PARAMS).toParamMap()
+                )
+            ) {
+            }
+            assertNotNull(response)
 
-        val accountsHeader = requireNotNull(
-            response.getHeaderValue(STRIPE_ACCOUNT_RESPONSE_HEADER)
-        ) {
-            "Stripe API response should contain 'Stripe-Account' header"
+            val accountsHeader = requireNotNull(
+                response.getHeaderValue(STRIPE_ACCOUNT_RESPONSE_HEADER)
+            ) {
+                "Stripe API response should contain 'Stripe-Account' header"
+            }
+            assertThat(accountsHeader)
+                .containsExactly(connectAccountId)
         }
-        assertThat(accountsHeader)
-            .containsExactly(connectAccountId)
-    }
 
     @Test
-    fun confirmPaymentIntent_withSourceData_canSuccessfulConfirm() = testDispatcher.runBlockingTest {
-        // put a private key here to simulate the backend
-        val clientSecret = "pi_12345_secret_fake"
+    fun confirmPaymentIntent_withSourceData_canSuccessfulConfirm() =
+        testDispatcher.runBlockingTest {
+            // put a private key here to simulate the backend
+            val clientSecret = "pi_12345_secret_fake"
 
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-            .thenReturn(
-                StripeResponse(
-                    200,
-                    PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
-                    emptyMap()
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(
+                    StripeResponse(
+                        200,
+                        PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
+                        emptyMap()
+                    )
+                )
+
+            val confirmPaymentIntentParams =
+                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    clientSecret,
+                    "yourapp://post-authentication-return-url"
+                )
+            val paymentIntent = requireNotNull(
+                create().confirmPaymentIntent(
+                    confirmPaymentIntentParams,
+                    ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
                 )
             )
 
-        val confirmPaymentIntentParams =
-            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            verify(stripeApiRequestExecutor).execute(apiRequestArgumentCaptor.capture())
+            val apiRequest = apiRequestArgumentCaptor.firstValue
+            val paymentMethodDataParams =
+                apiRequest.params?.get("payment_method_data") as Map<String, *>
+            assertTrue(paymentMethodDataParams["muid"] is String)
+            assertTrue(paymentMethodDataParams["guid"] is String)
+            assertEquals("card", paymentMethodDataParams["type"])
+
+            verifyFingerprintAndAnalyticsRequests(AnalyticsEvent.PaymentIntentConfirm)
+
+            val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
+            assertEquals(PaymentMethod.Type.Card.code, analyticsRequest.params["source_type"])
+        }
+
+    @Ignore("requires a secret key")
+    fun disabled_confirmPaymentIntent_withSourceId_canSuccessfulConfirm() =
+        testDispatcher.runBlockingTest {
+            val clientSecret = "temporarily put a private key here simulate the backend"
+            val publishableKey = "put a public key that matches the private key here"
+            val sourceId = "id of the source created on the backend"
+
+            val confirmPaymentIntentParams = ConfirmPaymentIntentParams.createWithSourceId(
+                sourceId,
                 clientSecret,
                 "yourapp://post-authentication-return-url"
             )
-        val paymentIntent = create().confirmPaymentIntent(
-            confirmPaymentIntentParams,
-            ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
-        )
-
-        assertNotNull(paymentIntent)
-
-        verify(stripeApiRequestExecutor).execute(apiRequestArgumentCaptor.capture())
-        val apiRequest = apiRequestArgumentCaptor.firstValue
-        val paymentMethodDataParams =
-            apiRequest.params?.get("payment_method_data") as Map<String, *>
-        assertTrue(paymentMethodDataParams["muid"] is String)
-        assertTrue(paymentMethodDataParams["guid"] is String)
-        assertEquals("card", paymentMethodDataParams["type"])
-
-        verifyFingerprintAndAnalyticsRequests(AnalyticsEvent.PaymentIntentConfirm)
-
-        val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
-        assertEquals(PaymentMethod.Type.Card.code, analyticsRequest.params["source_type"])
-    }
+            val paymentIntent = stripeApiRepository.confirmPaymentIntent(
+                confirmPaymentIntentParams,
+                ApiRequest.Options(publishableKey)
+            )
+            assertNotNull(paymentIntent)
+        }
 
     @Ignore("requires a secret key")
-    fun disabled_confirmPaymentIntent_withSourceId_canSuccessfulConfirm() = testDispatcher.runBlockingTest {
-        val clientSecret = "temporarily put a private key here simulate the backend"
-        val publishableKey = "put a public key that matches the private key here"
-        val sourceId = "id of the source created on the backend"
+    fun disabled_confirmRetrieve_withSourceId_canSuccessfulRetrieve() =
+        testDispatcher.runBlockingTest {
+            val clientSecret = "temporarily put a private key here simulate the backend"
+            val publishableKey = "put a public key that matches the private key here"
 
-        val confirmPaymentIntentParams = ConfirmPaymentIntentParams.createWithSourceId(
-            sourceId,
-            clientSecret,
-            "yourapp://post-authentication-return-url"
-        )
-        val paymentIntent = stripeApiRepository.confirmPaymentIntent(
-            confirmPaymentIntentParams,
-            ApiRequest.Options(publishableKey)
-        )
-        assertNotNull(paymentIntent)
-    }
-
-    @Ignore("requires a secret key")
-    fun disabled_confirmRetrieve_withSourceId_canSuccessfulRetrieve() = testDispatcher.runBlockingTest {
-        val clientSecret = "temporarily put a private key here simulate the backend"
-        val publishableKey = "put a public key that matches the private key here"
-
-        val paymentIntent = stripeApiRepository.retrievePaymentIntent(
-            clientSecret,
-            ApiRequest.Options(publishableKey)
-        )
-        assertNotNull(paymentIntent)
-    }
+            val paymentIntent = stripeApiRepository.retrievePaymentIntent(
+                clientSecret,
+                ApiRequest.Options(publishableKey)
+            )
+            assertNotNull(paymentIntent)
+        }
 
     @Test
     fun createSource_createsObjectAndLogs() = testDispatcher.runBlockingTest {
@@ -745,33 +749,35 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() = testDispatcher.runBlockingTest {
-        val exception = assertFailsWith<InvalidRequestException> {
-            stripeApiRepository.cancelPaymentIntentSource(
-                "pi_1FejpSH8dsfnfKo38L276wr6",
-                "src_1FejpbH8dsfnfKo3KR7EqCzJ",
-                ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY)
+    fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() =
+        testDispatcher.runBlockingTest {
+            val exception = assertFailsWith<InvalidRequestException> {
+                stripeApiRepository.cancelPaymentIntentSource(
+                    "pi_1FejpSH8dsfnfKo38L276wr6",
+                    "src_1FejpbH8dsfnfKo3KR7EqCzJ",
+                    ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY)
+                )
+            }
+            assertEquals(
+                "This PaymentIntent could be not be fulfilled via this session because a different payment method was attached to it. Another session could be attempting to fulfill this PaymentIntent. Please complete that session or try again.",
+                exception.message
             )
+            assertEquals("payment_intent_unexpected_state", exception.stripeError?.code)
         }
-        assertEquals(
-            "This PaymentIntent could be not be fulfilled via this session because a different payment method was attached to it. Another session could be attempting to fulfill this PaymentIntent. Please complete that session or try again.",
-            exception.message
-        )
-        assertEquals("payment_intent_unexpected_state", exception.stripeError?.code)
-    }
 
     @Test
-    fun createSource_whenUnknownHostExceptionThrown_convertsToAPIConnectionException() = testDispatcher.runBlockingTest {
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-            .thenAnswer { throw UnknownHostException() }
+    fun createSource_whenUnknownHostExceptionThrown_convertsToAPIConnectionException() =
+        testDispatcher.runBlockingTest {
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenAnswer { throw UnknownHostException() }
 
-        assertFailsWith<APIConnectionException> {
-            create().createSource(
-                SourceParams.createCardParams(CARD_PARAMS),
-                DEFAULT_OPTIONS
-            )
+            assertFailsWith<APIConnectionException> {
+                create().createSource(
+                    SourceParams.createCardParams(CARD_PARAMS),
+                    DEFAULT_OPTIONS
+                )
+            }
         }
-    }
 
     @Test
     fun createFile_shouldFireExpectedRequests() = testDispatcher.runBlockingTest {
@@ -803,69 +809,72 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun apiRequest_withErrorResponse_onUnsupportedSdkVersion_shouldNotBeTranslated() = testDispatcher.runBlockingTest {
-        Locale.setDefault(Locale.JAPAN)
+    fun apiRequest_withErrorResponse_onUnsupportedSdkVersion_shouldNotBeTranslated() =
+        testDispatcher.runBlockingTest {
+            Locale.setDefault(Locale.JAPAN)
 
-        val stripeRepository = StripeApiRepository(
-            context,
-            DEFAULT_OPTIONS.apiKey,
-            workContext = testDispatcher,
-            sdkVersion = "AndroidBindings/13.0.0"
-        )
+            val stripeRepository = StripeApiRepository(
+                context,
+                DEFAULT_OPTIONS.apiKey,
+                workContext = testDispatcher,
+                sdkVersion = "AndroidBindings/13.0.0"
+            )
 
-        val ex = assertFailsWith<InvalidRequestException> {
-            stripeRepository.retrieveSetupIntent(
-                "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
-                DEFAULT_OPTIONS
+            val ex = assertFailsWith<InvalidRequestException> {
+                stripeRepository.retrieveSetupIntent(
+                    "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
+                    DEFAULT_OPTIONS
+                )
+            }
+            assertEquals(
+                "No such setupintent: 'seti_1CkiBMLENEVhOs7YMtUehLau'",
+                ex.stripeError?.message
             )
         }
-        assertEquals(
-            "No such setupintent: 'seti_1CkiBMLENEVhOs7YMtUehLau'",
-            ex.stripeError?.message
-        )
-    }
 
     @Test
-    fun apiRequest_withErrorResponse_onSupportedSdkVersion_shouldBeTranslated() = testDispatcher.runBlockingTest {
-        Locale.setDefault(Locale.JAPAN)
+    fun apiRequest_withErrorResponse_onSupportedSdkVersion_shouldBeTranslated() =
+        testDispatcher.runBlockingTest {
+            Locale.setDefault(Locale.JAPAN)
 
-        val stripeRepository = StripeApiRepository(
-            context,
-            DEFAULT_OPTIONS.apiKey,
-            workContext = testDispatcher,
-            sdkVersion = "AndroidBindings/14.0.0"
-        )
+            val stripeRepository = StripeApiRepository(
+                context,
+                DEFAULT_OPTIONS.apiKey,
+                workContext = testDispatcher,
+                sdkVersion = "AndroidBindings/14.0.0"
+            )
 
-        val ex = assertFailsWith<InvalidRequestException> {
-            stripeRepository.retrieveSetupIntent(
-                "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
-                DEFAULT_OPTIONS
+            val ex = assertFailsWith<InvalidRequestException> {
+                stripeRepository.retrieveSetupIntent(
+                    "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
+                    DEFAULT_OPTIONS
+                )
+            }
+            assertEquals(
+                "そのような setupintent はありません : 'seti_1CkiBMLENEVhOs7YMtUehLau' ",
+                ex.stripeError?.message
             )
         }
-        assertEquals(
-            "そのような setupintent はありません : 'seti_1CkiBMLENEVhOs7YMtUehLau' ",
-            ex.stripeError?.message
-        )
-    }
 
     @Test
-    fun createCardToken_withAttribution_shouldPopulateProductUsage() = testDispatcher.runBlockingTest {
-        val stripeResponse = StripeResponse(
-            200,
-            TokenFixtures.CARD_TOKEN_JSON.toString(),
-            emptyMap()
-        )
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>())).thenReturn(stripeResponse)
-        create().createToken(
-            CardParamsFixtures.WITH_ATTRIBUTION,
-            DEFAULT_OPTIONS
-        )
+    fun createCardToken_withAttribution_shouldPopulateProductUsage() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                TokenFixtures.CARD_TOKEN_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>())).thenReturn(stripeResponse)
+            create().createToken(
+                CardParamsFixtures.WITH_ATTRIBUTION,
+                DEFAULT_OPTIONS
+            )
 
-        verifyFingerprintAndAnalyticsRequests(
-            AnalyticsEvent.TokenCreate,
-            listOf("CardInputView")
-        )
-    }
+            verifyFingerprintAndAnalyticsRequests(
+                AnalyticsEvent.TokenCreate,
+                listOf("CardInputView")
+            )
+        }
 
     @Test
     fun createBankToken_shouldNotPopulateProductUsage() = testDispatcher.runBlockingTest {
@@ -887,49 +896,51 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun createCardPaymentMethod_withAttribution_shouldPopulateProductUsage() = testDispatcher.runBlockingTest {
-        val stripeResponse = StripeResponse(
-            200,
-            PaymentMethodFixtures.CARD_JSON.toString(),
-            emptyMap()
-        )
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
-            .thenReturn(stripeResponse)
+    fun createCardPaymentMethod_withAttribution_shouldPopulateProductUsage() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                PaymentMethodFixtures.CARD_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
 
-        create().createPaymentMethod(
-            PaymentMethodCreateParams.create(
-                PaymentMethodCreateParamsFixtures.CARD
-                    .copy(attribution = setOf("CardInputView"))
-            ),
-            DEFAULT_OPTIONS
-        )
+            create().createPaymentMethod(
+                PaymentMethodCreateParams.create(
+                    PaymentMethodCreateParamsFixtures.CARD
+                        .copy(attribution = setOf("CardInputView"))
+                ),
+                DEFAULT_OPTIONS
+            )
 
-        verifyFingerprintAndAnalyticsRequests(
-            AnalyticsEvent.PaymentMethodCreate,
-            productUsage = listOf("CardInputView")
-        )
-    }
+            verifyFingerprintAndAnalyticsRequests(
+                AnalyticsEvent.PaymentMethodCreate,
+                productUsage = listOf("CardInputView")
+            )
+        }
 
     @Test
-    fun createSepaDebitPaymentMethod_shouldNotPopulateProductUsage() = testDispatcher.runBlockingTest {
-        val stripeResponse = StripeResponse(
-            200,
-            PaymentMethodFixtures.SEPA_DEBIT_JSON.toString(),
-            emptyMap()
-        )
-        whenever(stripeApiRequestExecutor.execute(any<ApiRequest>())).thenReturn(stripeResponse)
-        create().createPaymentMethod(
-            PaymentMethodCreateParams.create(
-                PaymentMethodCreateParams.SepaDebit("my_iban")
-            ),
-            DEFAULT_OPTIONS
-        )
+    fun createSepaDebitPaymentMethod_shouldNotPopulateProductUsage() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                PaymentMethodFixtures.SEPA_DEBIT_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>())).thenReturn(stripeResponse)
+            create().createPaymentMethod(
+                PaymentMethodCreateParams.create(
+                    PaymentMethodCreateParams.SepaDebit("my_iban")
+                ),
+                DEFAULT_OPTIONS
+            )
 
-        verifyFingerprintAndAnalyticsRequests(
-            AnalyticsEvent.PaymentMethodCreate,
-            productUsage = null
-        )
-    }
+            verifyFingerprintAndAnalyticsRequests(
+                AnalyticsEvent.PaymentMethodCreate,
+                productUsage = null
+            )
+        }
 
     private fun verifyFingerprintAndAnalyticsRequests(
         event: AnalyticsEvent,

--- a/stripe/src/test/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiverTest.kt
+++ b/stripe/src/test/java/com/stripe/android/payments/DefaultStripeChallengeStatusReceiverTest.kt
@@ -240,15 +240,6 @@ class DefaultStripeChallengeStatusReceiverTest {
         assertThat(analyticsParamsFirst[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(AnalyticsEvent.Auth3ds2ChallengeErrored.toString())
 
-        assertThat(analyticsParamsFirst[AnalyticsRequestFactory.FIELD_ERROR_DATA])
-            .isEqualTo(
-                mapOf(
-                    "type" to "runtime_error_event",
-                    "error_code" to "404",
-                    "error_message" to "Resource not found"
-                )
-            )
-
         assertThat(requireNotNull(analyticsRequests[1].params)[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(AnalyticsEvent.Auth3ds2ChallengePresented.toString())
     }
@@ -290,18 +281,6 @@ class DefaultStripeChallengeStatusReceiverTest {
         val analyticsParamsFirst = requireNotNull(analyticsRequests[0].params)
         assertThat(analyticsParamsFirst[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(AnalyticsEvent.Auth3ds2ChallengeErrored.toString())
-
-        assertThat(analyticsParamsFirst[AnalyticsRequestFactory.FIELD_ERROR_DATA])
-            .isEqualTo(
-                mapOf(
-                    "type" to "protocol_error_event",
-                    "error_code" to "201",
-                    "sdk_trans_id" to sdkTransactionId.value,
-                    "error_description" to "Required element missing",
-                    "error_details" to "eci",
-                    "trans_id" to "047f76a6-d1d4-48a2-aa65-786abb6f7f46"
-                )
-            )
 
         assertThat(requireNotNull(analyticsRequests[1].params)[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(AnalyticsEvent.Auth3ds2ChallengePresented.toString())

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.content.ActivityNotFoundException
 import android.content.Context
-import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -61,7 +60,6 @@ internal class PaymentAuthWebViewActivityTest {
         runOnActivityScenario { activityScenario ->
             activityScenario.onActivity {
                 it.onAuthComplete(
-                    Uri.parse("https://example.com"),
                     ActivityNotFoundException()
                 )
                 it.finish()

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -111,12 +111,6 @@ class PaymentAuthWebViewActivityViewModelTest {
         val params = analyticsRequests.first().params
         assertThat(params["event"])
             .isEqualTo("stripe_android.3ds1_challenge_error")
-        assertThat(params["error_message"])
-            .isEqualTo("Failed to find activity")
-        assertThat(params["error_stacktrace"].toString())
-            .startsWith("android.content.ActivityNotFoundException: Failed to find activity\n")
-        assertThat(params["challenge_uri"])
-            .isEqualTo("https://example.com")
     }
 
     @Test
@@ -128,8 +122,6 @@ class PaymentAuthWebViewActivityViewModelTest {
         val params = analyticsRequests.first().params
         assertThat(params["event"])
             .isEqualTo("stripe_android.3ds1_challenge_complete")
-        assertThat(params["challenge_uri"])
-            .isEqualTo("https://example.com")
     }
 
     @Test
@@ -141,8 +133,6 @@ class PaymentAuthWebViewActivityViewModelTest {
         val params = analyticsRequests.first().params
         assertThat(params["event"])
             .isEqualTo("stripe_android.3ds1_challenge_complete")
-        assertThat(params["challenge_uri"])
-            .isEqualTo("")
     }
 
     private fun createViewModel(

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.view
 
-import android.content.ActivityNotFoundException
-import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -108,10 +106,7 @@ class PaymentAuthWebViewActivityViewModelTest {
     fun `logError() should fire expected event`() {
         val viewModel = createViewModel(ARGS)
 
-        viewModel.logError(
-            Uri.parse("https://example.com/path?secret=password"),
-            ActivityNotFoundException("Failed to find activity")
-        )
+        viewModel.logError()
 
         val params = analyticsRequests.first().params
         assertThat(params["event"])
@@ -128,9 +123,7 @@ class PaymentAuthWebViewActivityViewModelTest {
     fun `logComplete() should fire expected event`() {
         val viewModel = createViewModel(ARGS)
 
-        viewModel.logComplete(
-            Uri.parse("https://example.com/path?secret=password")
-        )
+        viewModel.logComplete()
 
         val params = analyticsRequests.first().params
         assertThat(params["event"])
@@ -143,9 +136,7 @@ class PaymentAuthWebViewActivityViewModelTest {
     fun `logComplete() with uri=null should fire expected event`() {
         val viewModel = createViewModel(ARGS)
 
-        viewModel.logComplete(
-            uri = null
-        )
+        viewModel.logComplete()
 
         val params = analyticsRequests.first().params
         assertThat(params["event"])

--- a/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
+++ b/stripe/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
@@ -19,7 +19,6 @@ class PaymentAuthWebViewClientTest {
     private val isPageLoaded = MutableLiveData(false)
 
     private val onAuthCompletedErrors = mutableListOf<Throwable>()
-    private val onAuthCompleteUris = mutableListOf<Uri>()
     private var activityFinished = false
 
     private val webView = WebView(ApplicationProvider.getApplicationContext())
@@ -40,8 +39,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -64,8 +61,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -85,8 +80,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -106,8 +99,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -125,8 +116,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isFalse()
 
-        assertThat(onAuthCompleteUris)
-            .isEmpty()
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -145,8 +134,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -161,8 +148,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(isPageLoaded.value)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -175,8 +160,6 @@ class PaymentAuthWebViewClientTest {
         createWebViewClient("pi_123_secret_456")
             .onPageFinished(webView, url)
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -196,8 +179,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .isEmpty()
         assertThat(onAuthCompletedErrors)
             .isEmpty()
     }
@@ -217,8 +198,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(url))
         assertThat(onAuthCompletedErrors)
             .hasSize(1)
         assertThat(activityFinished)
@@ -237,8 +216,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(shouldOverrideUrlLoading)
             .isTrue()
 
-        assertThat(onAuthCompleteUris)
-            .isEmpty()
         assertThat(onAuthCompletedErrors)
             .isEmpty()
         assertThat(activityFinished)
@@ -270,8 +247,6 @@ class PaymentAuthWebViewClientTest {
         assertThat(intent.dataString)
             .isEqualTo("https://example.com/")
 
-        assertThat(onAuthCompleteUris)
-            .containsExactly(Uri.parse(deepLink))
         assertThat(onAuthCompletedErrors)
             .hasSize(1)
         assertThat(activityFinished)
@@ -295,9 +270,6 @@ class PaymentAuthWebViewClientTest {
             .isEqualTo(
                 "https://hooks.stripe.com/redirect/complete/src_X9Y8Z7?client_secret=src_client_secret_abc123"
             )
-
-        assertThat(onAuthCompleteUris)
-            .isEmpty()
     }
 
     @Test
@@ -315,9 +287,6 @@ class PaymentAuthWebViewClientTest {
 
         assertThat(webViewClient.completionUrlParam)
             .isNull()
-
-        assertThat(onAuthCompleteUris)
-            .isEmpty()
     }
 
     @Test
@@ -390,8 +359,7 @@ class PaymentAuthWebViewClientTest {
             clientSecret,
             returnUrl,
             activityStarter,
-        ) { uri, error ->
-            uri?.let(onAuthCompleteUris::add)
+        ) { error ->
             error?.let(onAuthCompletedErrors::add)
             activityFinished = true
         }


### PR DESCRIPTION

# Summary
Params that have been removed:
- `error`
- `intent_id`
- `request_id`
- `source_id`
- `challenge_uri`
- `error_message`
- `error_stacktrace`

Remove `extraParams` parameter from `AnalyticsRequestFactory` methods
so that arbitrary parameters can't be added to the analytics request.

# Motivation
MOBILESDK-250

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
