### PR TITLE
Fix crash on Android 8 and 9 when opening the PaymentSheet

### DIFF
--- a/stripe/res/layout/fragment_paymentsheet_add_card.xml
+++ b/stripe/res/layout/fragment_paymentsheet_add_card.xml
@@ -74,6 +74,8 @@
             android:id="@+id/card_multiline_widget"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@android:color/white"
+            android:backgroundTint="@color/stripe_paymentsheet_elements_background_states"
             app:shouldShowPostalCode="false" />
     </com.google.android.material.card.MaterialCardView>
 

--- a/stripe/res/values/styles.xml
+++ b/stripe/res/values/styles.xml
@@ -133,7 +133,8 @@
         <item name="boxStrokeWidth">0dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
-        <item name="android:background">@color/stripe_paymentsheet_elements_background_states</item>
+        <item name="android:background">@android:color/white</item>
+        <item name="android:backgroundTint">@color/stripe_paymentsheet_elements_background_states</item>
         <item name="android:textColorHint">@color/stripe_paymentsheet_textinputlayout_hint</item>
     </style>
 
@@ -142,7 +143,8 @@
         <item name="boxStrokeWidth">0dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
-        <item name="android:background">@color/stripe_paymentsheet_elements_background_states</item>
+        <item name="android:background">@android:color/white</item>
+        <item name="android:backgroundTint">@color/stripe_paymentsheet_elements_background_states</item>
     </style>
 
     <style name="StripePaymentSheetTextInputEditText">

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -200,7 +200,19 @@ internal abstract class BaseAddCardFragment(
         cardMultilineWidget.setCvcPlaceholderText("")
 
         cardMultilineWidget.cvcEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
-        cardMultilineWidget.setBackgroundResource(R.color.stripe_paymentsheet_elements_background_states)
+
+        context?.let {
+            cardMultilineWidget.setBackgroundColor(
+                ContextCompat.getColor(
+                    it,
+                    android.R.color.white,
+                )
+            )
+            cardMultilineWidget.backgroundTintList = ContextCompat.getColorStateList(
+                it,
+                R.color.stripe_paymentsheet_elements_background_states
+            )
+        }
 
         // add vertical divider between expiry date and CVC
         cardMultilineWidget.secondRowLayout.addView(

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/BaseAddCardFragment.kt
@@ -201,19 +201,6 @@ internal abstract class BaseAddCardFragment(
 
         cardMultilineWidget.cvcEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
 
-        context?.let {
-            cardMultilineWidget.setBackgroundColor(
-                ContextCompat.getColor(
-                    it,
-                    android.R.color.white,
-                )
-            )
-            cardMultilineWidget.backgroundTintList = ContextCompat.getColorStateList(
-                it,
-                R.color.stripe_paymentsheet_elements_background_states
-            )
-        }
-
         // add vertical divider between expiry date and CVC
         cardMultilineWidget.secondRowLayout.addView(
             StripeVerticalDividerBinding.inflate(


### PR DESCRIPTION
# Summary
On Android 8 and 9 the background being set must be a drawable not a color or it will crash.   In order to set the background color use background tint.  I don't believe the background color is suppose to change when disabled in dark mode.

# Motivation
https://github.com/stripe/stripe-react-native/issues/212

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
Android 8
<img width="812" alt="Android8-enable-disable" src="https://user-images.githubusercontent.com/77996191/118166844-d56f0f80-b3da-11eb-92cb-4347ded2e94d.png">

Android 9
<img width="833" alt="Android-9-enable-disable" src="https://user-images.githubusercontent.com/77996191/118166872-def87780-b3da-11eb-8f14-ee5796d106e3.png">

Android 11
<img width="831" alt="Android11-enable-disable" src="https://user-images.githubusercontent.com/77996191/118166911-ecadfd00-b3da-11eb-830a-245a3a4d2e60.png">
