### PR TITLE
[SDK modularization] share deploy script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ ext {
     fragmentVersion = '1.3.3'
 
     androidTestVersion = '1.3.0'
+
+    group_name = GROUP
+    version_name = VERSION_NAME
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/deploy/deploy.gradle
+++ b/deploy/deploy.gradle
@@ -43,21 +43,21 @@ afterEvaluate { project ->
         publications {
             // Creates a Maven publication called "release".
             release(MavenPublication) {
-                // Applies the component for the release build variant.
-                from components.release
-
                 // Adds Javadocs and Sources as separate jars.
                 artifact androidJavadocsJar
                 artifact androidSourcesJar
+                artifact bundleReleaseAar
 
-                groupId = "com.stripe"
-                artifactId = "stripe-android"
+                groupId = GROUP
+                artifactId = project.artifactId
                 version = VERSION_NAME
 
+                logger.lifecycle("publishing $groupId:$artifactId:$version")
+
                 pom {
-                    name = "stripe-android"
+                    name = project.artifactName
                     packaging = "aar"
-                    description = "Stripe Android SDK"
+                    description = project.artifactDescrption
                     url = "https://github.com/stripe/stripe-android"
 
                     scm {
@@ -81,6 +81,43 @@ afterEvaluate { project ->
                         }
                     }
                 }
+
+                pom.withXml {
+                    final dependenciesNode = asNode().appendNode("dependencies")
+                    ext.addDependency = { dep, scope ->
+                        logger.lifecycle("updating dep $dep")
+                        if (dep.group == null || dep.version == null || dep.name == null || dep.name == "unspecified")
+                            return // invalid dependencies should be ignored
+
+                        final depGroup = dep.group
+                        final depName = dep.name
+                        final depVersion = dep.version != 'unspecified' ? dep.version : VERSION_NAME
+
+                        final dependencyNode = dependenciesNode.appendNode("dependency")
+                        dependencyNode.appendNode("groupId", depGroup)
+                        dependencyNode.appendNode("artifactId", depName)
+                        dependencyNode.appendNode("version", depVersion)
+                        dependencyNode.appendNode("scope", scope)
+
+                        if (!dep.transitive) {
+                            // In case of non transitive dependency, all its dependencies should be force excluded from them POM file
+                            final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
+                            exclusionNode.appendNode('groupId', '*')
+                            exclusionNode.appendNode('artifactId', '*')
+                        } else if (!dep.properties.excludeRules.empty) {
+                            // For transitive with exclusions, all exclude rules should be added to the POM file
+                            final exclusions = dependencyNode.appendNode('exclusions')
+                            dep.properties.excludeRules.each { ExcludeRule rule ->
+                                final exclusionNode = exclusions.appendNode('exclusion')
+                                exclusionNode.appendNode('groupId', rule.group ?: '*')
+                                exclusionNode.appendNode('artifactId', rule.module ?: '*')
+                            }
+                        }
+                    }
+                    configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }
+                    configurations.implementation.getDependencies().each { dep -> addDependency(dep, "runtime") }
+                }
+
             }
         }
         repositories {

--- a/deploy/deploy.gradle
+++ b/deploy/deploy.gradle
@@ -49,9 +49,9 @@ afterEvaluate { project ->
                 artifact androidSourcesJar
                 artifact bundleReleaseAar
 
-                groupId = "com.stripe"
+                groupId = rootProject.group_name
                 artifactId = project.artifactId
-                version = VERSION_NAME
+                version = rootProject.version_name
 
                 logger.lifecycle("publishing $groupId:$artifactId:$version")
 

--- a/deploy/deploy.gradle
+++ b/deploy/deploy.gradle
@@ -39,6 +39,7 @@ task androidSourcesJar(type: Jar) {
 afterEvaluate { project ->
     // See https://developer.android.com/studio/build/maven-publish-plugin
     // and https://docs.gradle.org/current/userguide/publishing_maven.html
+    // and https://proandroiddev.com/android-maven-publish-for-your-libraries-b76ad47677df
     publishing {
         publications {
             // Creates a Maven publication called "release".
@@ -48,7 +49,7 @@ afterEvaluate { project ->
                 artifact androidSourcesJar
                 artifact bundleReleaseAar
 
-                groupId = GROUP
+                groupId = "com.stripe"
                 artifactId = project.artifactId
                 version = VERSION_NAME
 
@@ -99,20 +100,6 @@ afterEvaluate { project ->
                         dependencyNode.appendNode("version", depVersion)
                         dependencyNode.appendNode("scope", scope)
 
-                        if (!dep.transitive) {
-                            // In case of non transitive dependency, all its dependencies should be force excluded from them POM file
-                            final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
-                            exclusionNode.appendNode('groupId', '*')
-                            exclusionNode.appendNode('artifactId', '*')
-                        } else if (!dep.properties.excludeRules.empty) {
-                            // For transitive with exclusions, all exclude rules should be added to the POM file
-                            final exclusions = dependencyNode.appendNode('exclusions')
-                            dep.properties.excludeRules.each { ExcludeRule rule ->
-                                final exclusionNode = exclusions.appendNode('exclusion')
-                                exclusionNode.appendNode('groupId', rule.group ?: '*')
-                                exclusionNode.appendNode('artifactId', rule.module ?: '*')
-                            }
-                        }
                     }
                     configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }
                     configurations.implementation.getDependencies().each { dep -> addDependency(dep, "runtime") }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ POM_DEVELOPER_EMAIL=support+android@stripe.com
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M -XX:+UseParallelGC
 android.useAndroidX=true
 android.enableJetifier=false
+
+# Update Stripe.VERSION_NAME when publishing a new release
+VERSION_NAME=16.8.2

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -146,4 +146,11 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     args "-F", "src/**/*.kt"
 }
 
-apply from: 'deploy.gradle'
+
+ext {
+    artifactId = "stripe-android"
+    artifactName = "stripe-android"
+    artifactDescrption = "Stripe Android SDK"
+}
+
+apply from: "${rootDir}/deploy/deploy.gradle"

--- a/stripe/gradle.properties
+++ b/stripe/gradle.properties
@@ -1,2 +1,0 @@
-# Update Stripe.VERSION_NAME when publishing a new release
-VERSION_NAME=16.8.2


### PR DESCRIPTION
# Summary
move `deploy.gradle` to root directory


Please follow modularization details in [this](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BK_huBjQWgZvAn8b4MiygyTMAg-M9mrrTib7RFBVN7VimeGx) internal doc

# Motivation

We'll need to publish multiple maven targets to modularize Android SDK. This change make it possible to reuse the deploy script across different modules.

**The following changes are made**:
* move `deploy.gradle` into a root dir
* when generating a release `deploy.gradle` no longer call `from component.release`, instead it 
  * explicitly creates a required aar through `artifact bundleReleaseAar` 
  * replaces module dependency version from `unspecified` with `VERSION_NAME`. Please see implemetation in `pom.withXml` and detail explanation in [this](https://proandroiddev.com/android-maven-publish-for-your-libraries-b76ad47677df) tutorial
* move the definition of `VERSION_NAME` into root `gradle.properties`, the same version will be used for all modules
* parameterize `artifactId`, `artifactName` and `artifactDescription` of a maven target, each module needs to define them in their `build.gradle`


**Follow up**:
Since we moved the `VERSION_NAME`, need to update release script

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified 
  - published a release with a test `VERSION_NAME` `99.1.1` to my local `~/.m2/repository` by executing `./gradlew :stripe:publishReleasePublicationToMavenLocal`
  - created a new Android app, add `mavenLocal()` and depdends on `implementation 'com.stripe:stripe-android:99.1.1'` - verified the app works fine


# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
