### PR TITLE
Fix Google Pay support for Connect accounts

### DIFF
--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayActivity.kt
@@ -33,10 +33,14 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
     private val publishableKey: String by lazy {
         PaymentConfiguration.getInstance(this).publishableKey
     }
+    private val stripeAccountId: String? by lazy {
+        PaymentConfiguration.getInstance(this).stripeAccountId
+    }
     private val viewModel: StripeGooglePayViewModel by viewModels {
         StripeGooglePayViewModel.Factory(
             application,
             publishableKey,
+            stripeAccountId,
             args
         )
     }

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
@@ -131,12 +131,13 @@ internal class StripeGooglePayContract :
     }
 }
 
-internal fun Status.getErrorResourceID(): Int? {
-    return when (this) {
+internal fun StripeGooglePayContract.Result.Error.getErrorResourceID(): Int? {
+    return when (googlePayStatus) {
         Status.RESULT_SUCCESS -> null
-        Status.RESULT_INTERNAL_ERROR, Status.RESULT_CANCELED, Status.RESULT_DEAD_CLIENT -> R.string.stripe_google_pay_error_internal
+        Status.RESULT_INTERNAL_ERROR, Status.RESULT_CANCELED, Status.RESULT_DEAD_CLIENT, null ->
+            R.string.stripe_google_pay_error_internal
         else -> {
-            when (this.statusCode) {
+            when (googlePayStatus.statusCode) {
                 CommonStatusCodes.API_NOT_CONNECTED, // "The client attempted to call a method from an API that failed to connect."
                 CommonStatusCodes.CANCELED, // -> "The result was canceled either due to client disconnect or PendingResult.cancel()."
                 CommonStatusCodes.DEVELOPER_ERROR, // -> "The application is misconfigured."

--- a/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
@@ -22,6 +22,7 @@ import kotlin.coroutines.CoroutineContext
 internal class StripeGooglePayViewModel(
     application: Application,
     private val publishableKey: String,
+    private val stripeAccountId: String? = null,
     private val args: StripeGooglePayContract.Args,
     private val stripeRepository: StripeRepository,
     private val appName: String,
@@ -77,7 +78,10 @@ internal class StripeGooglePayViewModel(
                     requireNotNull(
                         stripeRepository.createPaymentMethod(
                             params,
-                            ApiRequest.Options(publishableKey)
+                            ApiRequest.Options(
+                                publishableKey,
+                                stripeAccountId
+                            )
                         )
                     )
                 }
@@ -88,13 +92,16 @@ internal class StripeGooglePayViewModel(
     internal class Factory(
         private val application: Application,
         private val publishableKey: String,
+        private val stripeAccountId: String? = null,
         private val args: StripeGooglePayContract.Args
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            val appName = application.applicationInfo.loadLabel(application.packageManager).toString()
+            val appName =
+                application.applicationInfo.loadLabel(application.packageManager).toString()
             return StripeGooglePayViewModel(
                 application,
                 publishableKey,
+                stripeAccountId,
                 args,
                 StripeApiRepository(application, publishableKey),
                 appName,

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -334,11 +334,13 @@ internal class PaymentSheetViewModel internal constructor(
                 confirmPaymentSelection(paymentSelection)
             }
             is StripeGooglePayContract.Result.Error -> {
+                logger.error("Error processing Google Pay payment", googlePayResult.exception)
                 eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
                 paymentIntent.value?.let { it ->
                     resetViewState(
                         it,
                         googlePayResult.googlePayStatus?.getErrorResourceID()
+                            ?: R.string.stripe_google_pay_error_internal
                     )
                 }
             }

--- a/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/stripe/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -339,8 +339,7 @@ internal class PaymentSheetViewModel internal constructor(
                 paymentIntent.value?.let { it ->
                     resetViewState(
                         it,
-                        googlePayResult.googlePayStatus?.getErrorResourceID()
-                            ?: R.string.stripe_google_pay_error_internal
+                        googlePayResult.getErrorResourceID()
                     )
                 }
             }

--- a/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/stripe/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.googlepay
 
 import android.graphics.Color
-import androidx.arch.core.executor.testing.CountingTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -16,10 +15,8 @@ import com.stripe.android.networking.ApiRequest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.json.JSONObject
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -30,10 +27,6 @@ class StripeGooglePayViewModelTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val viewModel: StripeGooglePayViewModel by lazy { createViewModel() }
-
-    @Rule
-    @JvmField
-    val countingTaskExecutorRule = CountingTaskExecutorRule()
 
     @BeforeTest
     fun setup() {
@@ -169,7 +162,7 @@ class StripeGooglePayViewModelTest {
 
     @Test
     fun `createPaymentMethod() with stripeAccount should include stripeAccount in request`() {
-        val stripeAccout = "account_id"
+        val stripeAccount = "account_id"
         var requestOptions: ApiRequest.Options? = null
         val stripeRepository = object : AbsFakeStripeRepository() {
             override suspend fun createPaymentMethod(
@@ -183,7 +176,7 @@ class StripeGooglePayViewModelTest {
         val viewModel = StripeGooglePayViewModel(
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            stripeAccout,
+            stripeAccount,
             ARGS,
             stripeRepository,
             "App Name",
@@ -195,10 +188,8 @@ class StripeGooglePayViewModelTest {
         )
 
         viewModel.createPaymentMethod(params).observeForever {
-            assertThat(requestOptions?.stripeAccount).isEqualTo(stripeAccout)
+            assertThat(requestOptions?.stripeAccount).isEqualTo(stripeAccount)
         }
-
-        countingTaskExecutorRule.drainTasks(3, TimeUnit.SECONDS)
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Include `stripeAccountId` in request to create PaymentMethod from Google Pay token.
Log error and show default error message if Google Pay processing failed without a `googlePayStatus`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Account id was not added in request, so payment would fail because the PaymentMethod was not assigned to the Connect account.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
