### PR TITLE
Add initial version catalogs

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -51,14 +51,14 @@ private def getValue(key) {
 
 dependencies {
     implementation project(':payments')
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0'
+    implementation libraries.androidx.appcompat
+    implementation libraries.androidx.recyclerview
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation libraries.androidx.constraintlayout
+    implementation libraries.androidx.preferencektx
 
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
 

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -1,0 +1,31 @@
+[libraries.androidx-activityktx]
+version = "1.2.3"
+module = "androidx.activity:activity-ktx"
+
+[libraries.androidx-annotation]
+version = "1.2.0"
+module = "androidx.annotation:annotation"
+
+[libraries.androidx-appcompat]
+version = "1.3.0"
+module = "androidx.appcompat:appcompat"
+
+[libraries.androidx-browser]
+version = "1.3.0"
+module = "androidx.browser:browser"
+
+[libraries.androidx-constraintlayout]
+version = "2.0.4"
+module = "androidx.constraintlayout:constraintlayout"
+
+[libraries.androidx-corektx]
+version = "1.5.0"
+module = "androidx.core:core-ktx"
+
+[libraries.androidx-preferencektx]
+version = "1.1.1"
+module = "androidx.preference:preference-ktx"
+
+[libraries.androidx-recyclerview]
+version = "1.2.0"
+module = "androidx.recyclerview:recyclerview"

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -15,17 +15,17 @@ configurations {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.browser:browser:1.3.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0'
+    implementation libraries.androidx.annotation
+    implementation libraries.androidx.appcompat
+    implementation libraries.androidx.browser
+    implementation libraries.androidx.recyclerview
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidLifecycleVersion"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "androidx.activity:activity-ktx:1.2.3"
+    implementation libraries.androidx.constraintlayout
+    implementation libraries.androidx.activityktx
     implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     implementation "com.google.android.material:material:$materialVersion"
 
@@ -37,8 +37,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
-    javadocDeps 'androidx.annotation:annotation:1.2.0'
-    javadocDeps 'androidx.appcompat:appcompat:1.2.0'
+    javadocDeps libraries.androidx.annotation
+    javadocDeps libraries.androidx.appcompat
     javadocDeps "com.google.android.material:material:$materialVersion"
 
     testImplementation 'junit:junit:4.13.2'

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -34,13 +34,13 @@ dependencies {
 
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidLifecycleVersion"
-    implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'androidx.core:core-ktx:1.5.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation libraries.androidx.preferencektx
+    implementation libraries.androidx.corektx
+    implementation libraries.androidx.appcompat
+    implementation libraries.androidx.constraintlayout
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
-    implementation "androidx.activity:activity-ktx:1.2.3"
+    implementation libraries.androidx.activityktx
     implementation 'com.google.android.material:material:1.3.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,18 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
 include ':paymentsheet-example'
 include ':stripe-test-e2e'
 include ':example'
 include ':payments-core'
 include ':payments'
 include ':paymentsheet'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libraries") {
+            from(files(
+                    "gradle/androidx.versions.toml"
+            ))
+        }
+    }
+}


### PR DESCRIPTION




# Summary
Enable version catalogs and migrate some AndroidX dependencies
to version catalogs.

# Motivation
About version catalogs:

https://docs.gradle.org/7.0/release-notes.html#centralized-dependency-versions

```
A version catalog enables build authors to centralize the dependency
coordinates (group, artifact, version) of their third party dependencies
in a conventional configuration file and declare the actual dependencies
in a type-safe way.
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
