### PR TITLE
[SDK modularization] Introduce `IntentAuthenticatorRegistry` and dagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
     espressoVersion = '3.3.0'
     ktlintVersion = '0.41.0'
     materialVersion = '1.3.0'
+    daggerVersion = '2.36'
 
     androidTestVersion = '1.3.0'
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5366,6 +5366,58 @@ public class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet$Creator 
 public abstract class com/stripe/android/payments/PaymentFlowResult {
 }
 
+public final class com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
+}
+
+public final class com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectNoOpIntentAuthenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)V
+	public static fun injectStripe3DS2Authenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;)V
+	public static fun injectWebIntentAuthenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;)V
+}
+
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideNoOpAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideNoOpAuthenticator$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideNoOpAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;
+}
+
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripe3DSAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;
+}
+
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideWebAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideWebAuthenticator$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideWebAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+}
+
+public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
+	public static fun builder ()Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
+	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
+}
+
+public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder {
+	public fun authenticationModule (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
+	public fun build ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent;
+}
+
 public abstract interface class com/stripe/android/paymentsheet/GooglePayRepository {
 	public abstract fun isReady ()Lkotlinx/coroutines/flow/Flow;
 }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5408,9 +5408,6 @@ public final class com/stripe/android/payments/core/injection/AuthenticationModu
 	public static fun provideWebAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
-public abstract interface annotation class com/stripe/android/payments/core/injection/AuthenticationScope : java/lang/annotation/Annotation {
-}
-
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5408,6 +5408,9 @@ public final class com/stripe/android/payments/core/injection/AuthenticationModu
 	public static fun provideWebAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
+public abstract interface annotation class com/stripe/android/payments/core/injection/AuthenticationScope : java/lang/annotation/Annotation {
+}
+
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'kotlin-kapt'
     id 'checkstyle'
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.parcelize'
@@ -28,6 +29,8 @@ dependencies {
     implementation libraries.androidx.activity.ktx
     implementation 'com.google.android.gms:play-services-wallet:18.1.3'
     implementation "com.google.android.material:material:$materialVersion"
+    implementation 'com.google.dagger:dagger:2.34.1'
+    kapt 'com.google.dagger:dagger-compiler:2.34.1'
 
     // For instructions on replacing the BouncyCastle dependency used by the 3DS2 SDK, see
     // https://github.com/stripe/stripe-android/issues/3173#issuecomment-785176608

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation libraries.androidx.activity.ktx
     implementation 'com.google.android.gms:play-services-wallet:18.1.3'
     implementation "com.google.android.material:material:$materialVersion"
-    implementation 'com.google.dagger:dagger:2.34.1'
-    kapt 'com.google.dagger:dagger-compiler:2.34.1'
+    implementation "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
     // For instructions on replacing the BouncyCastle dependency used by the 3DS2 SDK, see
     // https://github.com/stripe/stripe-android/issues/3173#issuecomment-785176608

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -115,7 +115,7 @@ internal class StripePaymentController internal constructor(
     }
 
     private val authenticatorRegistry: IntentAuthenticatorRegistry =
-        DefaultIntentAuthenticatorRegistry.getInstance(
+        DefaultIntentAuthenticatorRegistry.createInstance(
             stripeRepository,
             paymentRelayStarterFactory,
             paymentBrowserAuthStarterFactory,
@@ -537,7 +537,7 @@ internal class StripePaymentController internal constructor(
         returnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
-        authenticatorRegistry.lookUp(stripeIntent).authenticate(
+        authenticatorRegistry.getAuthenticator(stripeIntent).authenticate(
             host,
             stripeIntent,
             returnUrl,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -1,0 +1,116 @@
+package com.stripe.android.payments.core.authentication
+
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.Logger
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripePaymentController
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.injection.AuthenticationModule
+import com.stripe.android.payments.core.injection.DaggerAuthenticationComponent
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.view.AuthActivityStarter
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Default registry to provide look ups for [IntentAuthenticator].
+ * Should be only accessed through [DefaultIntentAuthenticatorRegistry.getInstance].
+ */
+internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor() :
+    IntentAuthenticatorRegistry {
+
+    // default authenticators always packaged with the SDK
+    @Inject
+    lateinit var webIntentAuthenticator: WebIntentAuthenticator
+
+    @Inject
+    lateinit var noOpIntentAuthenticator: NoOpIntentAuthenticator
+
+    // authenticators requiring a 3p SDK
+    // TODO(ccen) move them to a dedicated module
+    @Inject
+    lateinit var stripe3DS2Authenticator: Stripe3DS2Authenticator
+
+    override fun lookUp(stripeIntent: StripeIntent): IntentAuthenticator {
+        if (!stripeIntent.requiresAction()) {
+            return noOpIntentAuthenticator
+        }
+
+        when (val nextActionData = stripeIntent.nextActionData) {
+            is StripeIntent.NextActionData.SdkData.Use3DS2 -> {
+                return stripe3DS2Authenticator
+            }
+            is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
+                // can only triggered when `use_stripe_sdk=true`
+                return webIntentAuthenticator
+            }
+            is StripeIntent.NextActionData.RedirectToUrl -> {
+                // can only triggered when `use_stripe_sdk=false`
+                return webIntentAuthenticator
+            }
+            is StripeIntent.NextActionData.AlipayRedirect -> {
+                return webIntentAuthenticator
+            }
+            is StripeIntent.NextActionData.DisplayOxxoDetails -> {
+                return webIntentAuthenticator.takeIf { nextActionData.hostedVoucherUrl != null }
+                    ?: noOpIntentAuthenticator
+            }
+            else -> return noOpIntentAuthenticator
+        }
+    }
+
+    companion object {
+        // Holding this single instance would in turn holds DaggerAuthenticationComponent instance,
+        // which keeps dagger injection graph live.
+        private var instance: IntentAuthenticatorRegistry? = null
+
+        /**
+         * Return the singleton instance of [IntentAuthenticatorRegistry].
+         */
+        fun getInstance(
+            stripeRepository: StripeRepository,
+            paymentRelayStarterFactory: (AuthActivityStarter.Host) -> PaymentRelayStarter,
+            paymentBrowserAuthStarterFactory: (AuthActivityStarter.Host) -> PaymentBrowserAuthStarter,
+            analyticsRequestExecutor: AnalyticsRequestExecutor,
+            analyticsRequestFactory: AnalyticsRequestFactory,
+            logger: Logger,
+            enableLogging: Boolean,
+            workContext: CoroutineContext,
+            uiContext: CoroutineContext,
+            threeDs2Service: StripeThreeDs2Service,
+            messageVersionRegistry: MessageVersionRegistry,
+            challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
+            stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
+            stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?
+        ): IntentAuthenticatorRegistry {
+            if (instance == null) {
+                instance = DaggerAuthenticationComponent.builder().authenticationModule(
+                    AuthenticationModule(
+                        stripeRepository,
+                        paymentRelayStarterFactory,
+                        paymentBrowserAuthStarterFactory,
+                        analyticsRequestExecutor,
+                        analyticsRequestFactory,
+                        logger,
+                        enableLogging,
+                        workContext,
+                        uiContext,
+                        threeDs2Service,
+                        messageVersionRegistry,
+                        challengeProgressActivityStarter,
+                        stripe3ds2Config,
+                        stripe3ds2ChallengeLauncher
+                    )
+                ).build().registry
+            }
+            return instance!!
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -125,26 +125,23 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor()
             challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
             stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
             stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?
-        ): IntentAuthenticatorRegistry {
-            INSTANCE = DaggerAuthenticationComponent.builder().authenticationModule(
-                AuthenticationModule(
-                    stripeRepository,
-                    paymentRelayStarterFactory,
-                    paymentBrowserAuthStarterFactory,
-                    analyticsRequestExecutor,
-                    analyticsRequestFactory,
-                    logger,
-                    enableLogging,
-                    workContext,
-                    uiContext,
-                    threeDs2Service,
-                    messageVersionRegistry,
-                    challengeProgressActivityStarter,
-                    stripe3ds2Config,
-                    stripe3ds2ChallengeLauncher
-                )
-            ).build().registry
-            return INSTANCE as DefaultIntentAuthenticatorRegistry
-        }
+        ) = DaggerAuthenticationComponent.builder().authenticationModule(
+            AuthenticationModule(
+                stripeRepository,
+                paymentRelayStarterFactory,
+                paymentBrowserAuthStarterFactory,
+                analyticsRequestExecutor,
+                analyticsRequestFactory,
+                logger,
+                enableLogging,
+                workContext,
+                uiContext,
+                threeDs2Service,
+                messageVersionRegistry,
+                challengeProgressActivityStarter,
+                stripe3ds2Config,
+                stripe3ds2ChallengeLauncher
+            )
+        ).build().registry
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticator.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.payments.core.authentication
+
+import android.app.Activity
+import androidx.fragment.app.Fragment
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarter
+
+/**
+ * A unit to authenticate a [StripeIntent] base on its next_action.
+ */
+internal interface IntentAuthenticator {
+
+    /**
+     * Authenticates an [StripeIntent] based on its next_action
+     *
+     * @param host the host([Activity] or [Fragment]) where client is calling from, used to redirect back to client.
+     * @param stripeIntent the intent to authenticate
+     * @param threeDs1ReturnUrl a dedicated deeplink URL to return to only for 3ds1 web authentication. TODO(ccen): move it to [WebIntentAuthenticator]
+     * @param requestOptions configurations for the API request which triggers the authentication
+     */
+    suspend fun authenticate(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.payments.core.authentication
+
+import com.stripe.android.model.StripeIntent
+
+/**
+ * Registry to map [StripeIntent] to the corresponding [IntentAuthenticator] to handle its next_action
+ */
+internal interface IntentAuthenticatorRegistry {
+
+    /**
+     * Returns the correct [IntentAuthenticator] to handle the [StripeIntent].
+     */
+    fun lookUp(stripeIntent: StripeIntent): IntentAuthenticator
+
+    // TODO(ccen): Add registration API
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
@@ -10,7 +10,7 @@ internal interface IntentAuthenticatorRegistry {
     /**
      * Returns the correct [IntentAuthenticator] to handle the [StripeIntent].
      */
-    fun lookUp(stripeIntent: StripeIntent): IntentAuthenticator
+    fun getAuthenticator(stripeIntent: StripeIntent): IntentAuthenticator
 
     // TODO(ccen): Add registration API
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.payments.core.authentication
+
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarter
+
+/**
+ * [IntentAuthenticator] implementation to perform no-op, just return to client's host.
+ */
+internal class NoOpIntentAuthenticator(
+    private val paymentRelayStarterFactory: (AuthActivityStarter.Host) -> PaymentRelayStarter,
+) : IntentAuthenticator {
+
+    override suspend fun authenticate(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    ) {
+        paymentRelayStarterFactory(host)
+            .start(
+                PaymentRelayStarter.Args.create(stripeIntent, requestOptions.stripeAccount)
+            )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
@@ -1,0 +1,360 @@
+package com.stripe.android.payments.core.authentication
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripePaymentController
+import com.stripe.android.exception.StripeException
+import com.stripe.android.model.Stripe3ds2AuthParams
+import com.stripe.android.model.Stripe3ds2AuthResult
+import com.stripe.android.model.Stripe3ds2Fingerprint
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.DefaultStripeChallengeStatusReceiver
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.Stripe3ds2CompletionStarter
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.transaction.ChallengeParameters
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.stripe3ds2.transaction.Stripe3ds2ActivityStarterHost
+import com.stripe.android.stripe3ds2.transaction.Transaction
+import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.security.cert.CertificateException
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * [IntentAuthenticator] implementation to authenticate through Stripe's 3ds2 SDK.
+ *
+ * TODO(ccen): Move this to a standalone gradle module.
+ */
+internal class Stripe3DS2Authenticator(
+    private val stripeRepository: StripeRepository,
+    private val webIntentAuthenticator: WebIntentAuthenticator,
+    private val paymentRelayStarterFactory: (AuthActivityStarter.Host) -> PaymentRelayStarter,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    private val threeDs2Service: StripeThreeDs2Service,
+    private val messageVersionRegistry: MessageVersionRegistry,
+    private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
+    private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
+    private val stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?,
+    private val workContext: CoroutineContext,
+    private val uiContext: CoroutineContext
+) : IntentAuthenticator {
+    private val stripe3ds2CompletionStarterFactory =
+        { host: AuthActivityStarter.Host, requestCode: Int ->
+            stripe3ds2ChallengeLauncher?.let {
+                Stripe3ds2CompletionStarter.Modern(it)
+            } ?: Stripe3ds2CompletionStarter.Legacy(host, requestCode)
+        }
+
+    override suspend fun authenticate(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    ) {
+        handle3ds2Auth(
+            host,
+            stripeIntent,
+            requestOptions,
+            stripeIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
+        )
+    }
+
+    private suspend fun handle3ds2Auth(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        requestOptions: ApiRequest.Options,
+        nextActionData: StripeIntent.NextActionData.SdkData.Use3DS2
+    ) {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Fingerprint)
+        )
+        try {
+            begin3ds2Auth(
+                host,
+                stripeIntent,
+                Stripe3ds2Fingerprint(nextActionData),
+                requestOptions
+            )
+        } catch (e: CertificateException) {
+            handleError(
+                host,
+                StripePaymentController.getRequestCode(stripeIntent),
+                e
+            )
+        }
+    }
+
+    private suspend fun handleError(
+        host: AuthActivityStarter.Host,
+        requestCode: Int,
+        throwable: Throwable
+    ) = withContext(uiContext) {
+        paymentRelayStarterFactory(host)
+            .start(
+                PaymentRelayStarter.Args.ErrorArgs(
+                    StripeException.create(throwable),
+                    requestCode
+                )
+            )
+    }
+
+    private suspend fun begin3ds2Auth(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        stripe3ds2Fingerprint: Stripe3ds2Fingerprint,
+        requestOptions: ApiRequest.Options
+    ) {
+        val activity = host.activity ?: return
+
+        val transaction = threeDs2Service.createTransaction(
+            stripe3ds2Fingerprint.directoryServerEncryption.directoryServerId,
+            messageVersionRegistry.current, stripeIntent.isLiveMode,
+            stripe3ds2Fingerprint.directoryServerName,
+            stripe3ds2Fingerprint.directoryServerEncryption.rootCerts,
+            stripe3ds2Fingerprint.directoryServerEncryption.directoryServerPublicKey,
+            stripe3ds2Fingerprint.directoryServerEncryption.keyId
+        )
+
+        challengeProgressActivityStarter.start(
+            activity,
+            stripe3ds2Fingerprint.directoryServerName,
+            false,
+            stripe3ds2Config.uiCustomization.uiCustomization,
+            transaction.sdkTransactionId
+        )
+
+        CoroutineScope(workContext).launch {
+            val areqParams = transaction.createAuthenticationRequestParameters()
+
+            val timeout = stripe3ds2Config.timeout
+            val authParams = Stripe3ds2AuthParams(
+                stripe3ds2Fingerprint.source,
+                areqParams.sdkAppId,
+                areqParams.sdkReferenceNumber,
+                areqParams.sdkTransactionId.value,
+                areqParams.deviceData,
+                areqParams.sdkEphemeralPublicKey,
+                areqParams.messageVersion,
+                timeout,
+                // We do not currently have a fallback url
+                // TODO(smaskell-stripe): Investigate more robust error handling
+                returnUrl = null
+            )
+
+            val start3ds2AuthResult = runCatching {
+                requireNotNull(
+                    stripeRepository.start3ds2Auth(
+                        authParams,
+                        requestOptions
+                    )
+                )
+            }
+
+            val paymentRelayStarter = paymentRelayStarterFactory(host)
+            start3ds2AuthResult.fold(
+                onSuccess = { authResult ->
+                    on3ds2AuthSuccess(
+                        authResult,
+                        transaction,
+                        stripe3ds2Fingerprint.source,
+                        timeout,
+                        paymentRelayStarter,
+                        StripePaymentController.getRequestCode(stripeIntent),
+                        host,
+                        stripeIntent,
+                        requestOptions
+                    )
+                },
+                onFailure = { throwable ->
+                    on3ds2AuthFailure(
+                        throwable,
+                        StripePaymentController.getRequestCode(stripeIntent),
+                        paymentRelayStarter
+                    )
+                }
+            )
+        }
+    }
+
+    @VisibleForTesting
+    internal suspend fun on3ds2AuthSuccess(
+        result: Stripe3ds2AuthResult,
+        transaction: Transaction,
+        sourceId: String,
+        timeout: Int,
+        paymentRelayStarter: PaymentRelayStarter,
+        requestCode: Int,
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        requestOptions: ApiRequest.Options
+    ) {
+        val ares = result.ares
+        if (ares != null) {
+            if (ares.isChallenge) {
+                startChallengeFlow(
+                    ares,
+                    transaction,
+                    sourceId,
+                    timeout,
+                    paymentRelayStarter,
+                    host,
+                    stripeIntent,
+                    requestOptions
+                )
+            } else {
+                startFrictionlessFlow(
+                    paymentRelayStarter,
+                    stripeIntent
+                )
+            }
+        } else if (result.fallbackRedirectUrl != null) {
+            on3ds2AuthFallback(
+                result.fallbackRedirectUrl,
+                host,
+                stripeIntent,
+                requestOptions
+            )
+        } else {
+            val errorMessage = result.error?.let { error ->
+                listOf(
+                    "Code: ${error.errorCode}",
+                    "Detail: ${error.errorDetail}",
+                    "Description: ${error.errorDescription}",
+                    "Component: ${error.errorComponent}"
+                ).joinToString(separator = ", ")
+            } ?: "Invalid 3DS2 authentication response"
+
+            on3ds2AuthFailure(
+                RuntimeException(
+                    "Error encountered during 3DS2 authentication request. $errorMessage"
+                ),
+                requestCode,
+                paymentRelayStarter
+            )
+        }
+    }
+
+    /**
+     * Used when standard 3DS2 authentication mechanisms are unavailable.
+     */
+    private suspend fun on3ds2AuthFallback(
+        fallbackRedirectUrl: String,
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        requestOptions: ApiRequest.Options
+    ) {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Fallback)
+        )
+
+        webIntentAuthenticator.beginWebAuth(
+            host,
+            stripeIntent,
+            StripePaymentController.getRequestCode(stripeIntent),
+            stripeIntent.clientSecret.orEmpty(),
+            fallbackRedirectUrl,
+            requestOptions.stripeAccount,
+            // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
+            shouldCancelSource = true
+        )
+    }
+
+    private suspend fun on3ds2AuthFailure(
+        throwable: Throwable,
+        requestCode: Int,
+        paymentRelayStarter: PaymentRelayStarter
+    ) = withContext(uiContext) {
+        paymentRelayStarter.start(
+            PaymentRelayStarter.Args.ErrorArgs(
+                StripeException.create(throwable),
+                requestCode
+            )
+        )
+    }
+
+    private suspend fun startFrictionlessFlow(
+        paymentRelayStarter: PaymentRelayStarter,
+        stripeIntent: StripeIntent
+    ) = withContext(uiContext) {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2Frictionless)
+        )
+        paymentRelayStarter.start(
+            PaymentRelayStarter.Args.create(stripeIntent)
+        )
+    }
+
+    @VisibleForTesting
+    internal suspend fun startChallengeFlow(
+        ares: Stripe3ds2AuthResult.Ares,
+        transaction: Transaction,
+        sourceId: String,
+        maxTimeout: Int,
+        paymentRelayStarter: PaymentRelayStarter,
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        requestOptions: ApiRequest.Options
+    ) = withContext(workContext) {
+        runCatching {
+            requireNotNull(
+                host.fragment?.let { fragment ->
+                    Stripe3ds2ActivityStarterHost(fragment)
+                } ?: host.activity?.let { activity ->
+                    Stripe3ds2ActivityStarterHost(activity)
+                }
+            ) {
+                "Error while attempting to start 3DS2 challenge flow."
+            }
+        }.fold(
+            onSuccess = { stripe3ds2Host ->
+                delay(StripePaymentController.CHALLENGE_DELAY)
+
+                transaction.doChallenge(
+                    stripe3ds2Host,
+                    ChallengeParameters(
+                        acsSignedContent = ares.acsSignedContent,
+                        threeDsServerTransactionId = ares.threeDSServerTransId,
+                        acsTransactionId = ares.acsTransId
+                    ),
+                    DefaultStripeChallengeStatusReceiver(
+                        stripe3ds2CompletionStarterFactory(
+                            host,
+                            StripePaymentController.getRequestCode(stripeIntent)
+                        ),
+                        stripeRepository,
+                        stripeIntent,
+                        sourceId,
+                        requestOptions,
+                        analyticsRequestExecutor,
+                        analyticsRequestFactory,
+                        transaction,
+                        {
+                            transaction.close()
+                        },
+                        workContext = workContext
+                    ),
+                    maxTimeout
+                )
+            },
+            onFailure = {
+                on3ds2AuthFailure(
+                    it,
+                    StripePaymentController.getRequestCode(stripeIntent),
+                    paymentRelayStarter
+                )
+            }
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -1,0 +1,118 @@
+package com.stripe.android.payments.core.authentication
+
+import com.stripe.android.Logger
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.StripePaymentController
+import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * [IntentAuthenticator] implementation to redirect to a URL through [PaymentBrowserAuthStarter].
+ */
+internal class WebIntentAuthenticator(
+    private val paymentBrowserAuthStarterFactory: (AuthActivityStarter.Host) -> PaymentBrowserAuthStarter,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    private val logger: Logger,
+    private val enableLogging: Boolean,
+    private val uiContext: CoroutineContext
+) : IntentAuthenticator {
+
+    override suspend fun authenticate(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    ) {
+        val authUrl: String
+        val returnUrl: String?
+        var shouldCancelSource = false
+        var shouldCancelIntentOnUserNavigation = true
+
+        when (val nextActionData = stripeIntent.nextActionData) {
+            // can only triggered when `use_stripe_sdk=true`
+            is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
+                authUrl = nextActionData.url
+                returnUrl = threeDs1ReturnUrl
+                // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
+                shouldCancelSource = true
+                analyticsRequestExecutor.executeAsync(
+                    analyticsRequestFactory.createRequest(
+                        AnalyticsEvent.Auth3ds1Sdk
+                    )
+                )
+            }
+            // can only triggered when `use_stripe_sdk=false`
+            is StripeIntent.NextActionData.RedirectToUrl -> {
+                analyticsRequestExecutor.executeAsync(
+                    analyticsRequestFactory.createRequest(AnalyticsEvent.AuthRedirect)
+                )
+                authUrl = nextActionData.url.toString()
+                returnUrl = nextActionData.returnUrl
+            }
+            is StripeIntent.NextActionData.AlipayRedirect -> {
+                analyticsRequestExecutor.executeAsync(
+                    analyticsRequestFactory.createRequest(AnalyticsEvent.AuthRedirect)
+                )
+                authUrl = nextActionData.webViewUrl.toString()
+                returnUrl = nextActionData.returnUrl
+            }
+            is StripeIntent.NextActionData.DisplayOxxoDetails -> {
+                // nextActionData.hostedVoucherUrl will never be null as AuthenticatorRegistry won't direct it here
+                authUrl = nextActionData.hostedVoucherUrl.takeIf { it!!.isNotEmpty() }
+                    ?: throw IllegalArgumentException("null hostedVoucherUrl for DisplayOxxoDetails")
+                returnUrl = null
+                shouldCancelIntentOnUserNavigation = false
+            }
+            else ->
+                throw IllegalArgumentException("WebAuthenticator can't process nextActionData: $nextActionData")
+        }
+
+        beginWebAuth(
+            host,
+            stripeIntent,
+            StripePaymentController.getRequestCode(stripeIntent),
+            stripeIntent.clientSecret.orEmpty(),
+            authUrl,
+            requestOptions.stripeAccount,
+            returnUrl = returnUrl,
+            shouldCancelSource = shouldCancelSource,
+            shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
+        )
+    }
+
+    internal suspend fun beginWebAuth(
+        host: AuthActivityStarter.Host,
+        stripeIntent: StripeIntent,
+        requestCode: Int,
+        clientSecret: String,
+        authUrl: String,
+        stripeAccount: String?,
+        returnUrl: String? = null,
+        shouldCancelSource: Boolean = false,
+        shouldCancelIntentOnUserNavigation: Boolean = true
+    ) = withContext(uiContext) {
+        val paymentBrowserWebStarter = paymentBrowserAuthStarterFactory(host)
+        logger.debug("PaymentBrowserAuthStarter#start()")
+        paymentBrowserWebStarter.start(
+            PaymentBrowserAuthContract.Args(
+                objectId = stripeIntent.id.orEmpty(),
+                requestCode,
+                clientSecret,
+                authUrl,
+                returnUrl,
+                enableLogging,
+                stripeAccountId = stripeAccount,
+                shouldCancelSource = shouldCancelSource,
+                shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
+            )
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.payments.core.injection
+
+import com.stripe.android.payments.core.authentication.DefaultIntentAuthenticatorRegistry
+import dagger.Component
+import javax.inject.Singleton
+
+/**
+ * [Component] for com.stripe.android.payments.core.authentication.
+ *
+ * It holds the dagger graph for [DefaultIntentAuthenticatorRegistry], with
+ * more dependencies daggerized and a higher level [Component]s created, this class will be merged
+ * into it.
+ */
+@Singleton
+@Component(modules = [AuthenticationModule::class])
+internal interface AuthenticationComponent {
+    val registry: DefaultIntentAuthenticatorRegistry
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -2,7 +2,14 @@ package com.stripe.android.payments.core.injection
 
 import com.stripe.android.payments.core.authentication.DefaultIntentAuthenticatorRegistry
 import dagger.Component
-import javax.inject.Singleton
+import javax.inject.Scope
+
+/**
+ * Scope for for intent authentication.
+ */
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthenticationScope
 
 /**
  * [Component] for com.stripe.android.payments.core.authentication.
@@ -11,7 +18,7 @@ import javax.inject.Singleton
  * more dependencies daggerized and a higher level [Component]s created, this class will be merged
  * into it.
  */
-@Singleton
+@AuthenticationScope
 @Component(modules = [AuthenticationModule::class])
 internal interface AuthenticationComponent {
     val registry: DefaultIntentAuthenticatorRegistry

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -2,14 +2,7 @@ package com.stripe.android.payments.core.injection
 
 import com.stripe.android.payments.core.authentication.DefaultIntentAuthenticatorRegistry
 import dagger.Component
-import javax.inject.Scope
-
-/**
- * Scope for for intent authentication.
- */
-@Scope
-@Retention(AnnotationRetention.RUNTIME)
-annotation class AuthenticationScope
+import javax.inject.Singleton
 
 /**
  * [Component] for com.stripe.android.payments.core.authentication.
@@ -18,7 +11,7 @@ annotation class AuthenticationScope
  * more dependencies daggerized and a higher level [Component]s created, this class will be merged
  * into it.
  */
-@AuthenticationScope
+@Singleton
 @Component(modules = [AuthenticationModule::class])
 internal interface AuthenticationComponent {
     val registry: DefaultIntentAuthenticatorRegistry

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -1,0 +1,86 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.Logger
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripePaymentController
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.authentication.NoOpIntentAuthenticator
+import com.stripe.android.payments.core.authentication.Stripe3DS2Authenticator
+import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.view.AuthActivityStarter
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * [Module] for com.stripe.android.payments.core.authentication.
+ *
+ * All non-daggerized dependencies are passed in as constructor parameters for now, a parameter
+ * will be removed when it's daggerized and introduced to the dagger graph.
+ */
+@Module
+internal class AuthenticationModule(
+    private val stripeRepository: StripeRepository,
+    private val paymentRelayStarterFactory: (AuthActivityStarter.Host) -> PaymentRelayStarter,
+    private val paymentBrowserAuthStarterFactory: (AuthActivityStarter.Host) -> PaymentBrowserAuthStarter,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    private val logger: Logger,
+    private val enableLogging: Boolean,
+    private val workContext: CoroutineContext,
+    private val uiContext: CoroutineContext,
+    private val threeDs2Service: StripeThreeDs2Service,
+    private val messageVersionRegistry: MessageVersionRegistry,
+    private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
+    private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
+    private val stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?,
+) {
+    @Singleton
+    @Provides
+    internal fun provideNoOpAuthenticator(): NoOpIntentAuthenticator {
+        return NoOpIntentAuthenticator(paymentRelayStarterFactory)
+    }
+
+    @Singleton
+    @Provides
+    internal fun provideWebAuthenticator(): WebIntentAuthenticator {
+        return WebIntentAuthenticator(
+            paymentBrowserAuthStarterFactory,
+            analyticsRequestExecutor,
+            analyticsRequestFactory,
+            logger,
+            enableLogging,
+            uiContext,
+        )
+    }
+
+    @Singleton
+    @Provides
+    internal fun provideStripe3DSAuthenticator(
+        webIntentAuthenticator: WebIntentAuthenticator
+    ): Stripe3DS2Authenticator {
+        return Stripe3DS2Authenticator(
+            stripeRepository,
+            webIntentAuthenticator,
+            paymentRelayStarterFactory,
+            analyticsRequestExecutor,
+            analyticsRequestFactory,
+            threeDs2Service,
+            messageVersionRegistry,
+            challengeProgressActivityStarter,
+            stripe3ds2Config,
+            stripe3ds2ChallengeLauncher,
+            workContext,
+            uiContext
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -18,6 +18,7 @@ import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.view.AuthActivityStarter
 import dagger.Module
 import dagger.Provides
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -43,13 +44,13 @@ internal class AuthenticationModule(
     private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
     private val stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?,
 ) {
-    @AuthenticationScope
+    @Singleton
     @Provides
     internal fun provideNoOpAuthenticator(): NoOpIntentAuthenticator {
         return NoOpIntentAuthenticator(paymentRelayStarterFactory)
     }
 
-    @AuthenticationScope
+    @Singleton
     @Provides
     internal fun provideWebAuthenticator(): WebIntentAuthenticator {
         return WebIntentAuthenticator(
@@ -62,7 +63,7 @@ internal class AuthenticationModule(
         )
     }
 
-    @AuthenticationScope
+    @Singleton
     @Provides
     internal fun provideStripe3DSAuthenticator(
         webIntentAuthenticator: WebIntentAuthenticator

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -18,7 +18,6 @@ import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.view.AuthActivityStarter
 import dagger.Module
 import dagger.Provides
-import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -44,13 +43,13 @@ internal class AuthenticationModule(
     private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
     private val stripe3ds2ChallengeLauncher: ActivityResultLauncher<PaymentFlowResult.Unvalidated>?,
 ) {
-    @Singleton
+    @AuthenticationScope
     @Provides
     internal fun provideNoOpAuthenticator(): NoOpIntentAuthenticator {
         return NoOpIntentAuthenticator(paymentRelayStarterFactory)
     }
 
-    @Singleton
+    @AuthenticationScope
     @Provides
     internal fun provideWebAuthenticator(): WebIntentAuthenticator {
         return WebIntentAuthenticator(
@@ -63,7 +62,7 @@ internal class AuthenticationModule(
         )
     }
 
-    @Singleton
+    @AuthenticationScope
     @Provides
     internal fun provideStripe3DSAuthenticator(
         webIntentAuthenticator: WebIntentAuthenticator

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -1,0 +1,110 @@
+package com.stripe.android.payments.core.authentication
+
+import android.os.Bundle
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.FakeActivityResultLauncher
+import com.stripe.android.PaymentRelayContract
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripePaymentController.Companion.PAYMENT_REQUEST_CODE
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.view.AuthActivityStarter
+import com.stripe.android.view.PaymentRelayActivity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class NoOpIntentAuthenticatorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val host = mock<AuthActivityStarter.Host>()
+
+    private val paymentRelayStarterFactory =
+        mock<(AuthActivityStarter.Host) -> PaymentRelayStarter>()
+
+    private val authenticator = NoOpIntentAuthenticator(
+        paymentRelayStarterFactory
+    )
+
+    @Test
+    fun verifyModernPaymentRelayStarter() =
+        testDispatcher.runBlockingTest {
+
+            val launcher = FakeActivityResultLauncher(PaymentRelayContract())
+
+            whenever(paymentRelayStarterFactory(any())).thenReturn(
+                PaymentRelayStarter.Modern(
+                    launcher
+                )
+            )
+            authenticator.authenticate(
+                host,
+                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+                null,
+                REQUEST_OPTIONS
+            )
+
+            assertThat(launcher.launchArgs)
+                .containsExactly(
+                    PaymentRelayStarter.Args.PaymentIntentArgs(
+                        PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR
+                    )
+                )
+        }
+
+    @Test
+    fun verifyLegacyPaymentRelayStarter() =
+        testDispatcher.runBlockingTest {
+            val classArgumentCaptor: KArgumentCaptor<Class<*>> = argumentCaptor()
+            val bundleArgumentCaptor: KArgumentCaptor<Bundle> = argumentCaptor()
+            val requestCodeArgumentCaptor: KArgumentCaptor<Int> = argumentCaptor()
+            whenever(paymentRelayStarterFactory(any())).thenReturn(
+                PaymentRelayStarter.Legacy(
+                    host
+                )
+            )
+            authenticator.authenticate(
+                host,
+                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+                null,
+                REQUEST_OPTIONS
+            )
+
+            verify(host).startActivityForResult(
+                classArgumentCaptor.capture(),
+                bundleArgumentCaptor.capture(),
+                requestCodeArgumentCaptor.capture()
+            )
+
+            assertThat(classArgumentCaptor.firstValue).isEqualTo(PaymentRelayActivity::class.java)
+
+            assertThat(bundleArgumentCaptor.firstValue.get("extra_args")).isInstanceOf(
+                PaymentFlowResult.Unvalidated::class.java
+            )
+            val result =
+                bundleArgumentCaptor.firstValue.get("extra_args") as PaymentFlowResult.Unvalidated
+            assertThat(result.stripeAccountId).isNull()
+            assertThat(result.clientSecret).isEqualTo("pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s")
+
+            assertThat(requestCodeArgumentCaptor.firstValue).isEqualTo(PAYMENT_REQUEST_CODE)
+        }
+
+    private companion object {
+        private val REQUEST_OPTIONS = ApiRequest.Options(
+            apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -1,0 +1,399 @@
+package com.stripe.android.payments.core.authentication
+
+import android.app.Activity
+import android.content.Context
+import androidx.activity.result.ActivityResultLauncher
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argWhere
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.StripePaymentController
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.Stripe3ds2AuthResultFixtures
+import com.stripe.android.model.Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW
+import com.stripe.android.model.Stripe3ds2Fingerprint
+import com.stripe.android.model.Stripe3ds2FingerprintTest
+import com.stripe.android.model.Stripe3ds2Fixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequest
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.transaction.ChallengeParameters
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
+import com.stripe.android.stripe3ds2.transaction.Stripe3ds2ActivityStarterHost
+import com.stripe.android.stripe3ds2.transaction.Transaction
+import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class Stripe3DS2AuthenticatorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val activity: Activity = mock()
+    private val host = AuthActivityStarter.Host.create(activity)
+
+    private val sdkTransactionId = mock<SdkTransactionId>().also {
+        whenever(it.value).thenReturn(UUID.randomUUID().toString())
+    }
+    private val stripeRepository = mock<StripeRepository>()
+    private val webIntentAuthenticator = mock<WebIntentAuthenticator>()
+    private val paymentRelayStarterFactory =
+        mock<(AuthActivityStarter.Host) -> PaymentRelayStarter>()
+    private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val analyticsRequestFactory = AnalyticsRequestFactory(
+        context,
+        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+    )
+    private val threeDs2Service = mock<StripeThreeDs2Service>()
+    private val messageVersionRegistry = MessageVersionRegistry()
+    private val challengeProgressActivityStarter =
+        mock<StripePaymentController.ChallengeProgressActivityStarter>()
+    private val stripe3ds2Config = PaymentAuthConfig.Stripe3ds2Config.Builder()
+        .setTimeout(5)
+        .build()
+    private val stripe3ds2ChallengeLauncher =
+        mock<ActivityResultLauncher<PaymentFlowResult.Unvalidated>>()
+
+    private val paymentRelayStarter = mock<PaymentRelayStarter>()
+    private val relayStarterArgsArgumentCaptor: KArgumentCaptor<PaymentRelayStarter.Args> =
+        argumentCaptor()
+    private val analyticsRequestArgumentCaptor: KArgumentCaptor<AnalyticsRequest> = argumentCaptor()
+
+    private val transaction = mock<Transaction>()
+
+    private val authenticator = Stripe3DS2Authenticator(
+        stripeRepository,
+        webIntentAuthenticator,
+        paymentRelayStarterFactory,
+        analyticsRequestExecutor,
+        analyticsRequestFactory,
+        threeDs2Service,
+        messageVersionRegistry,
+        challengeProgressActivityStarter,
+        stripe3ds2Config,
+        stripe3ds2ChallengeLauncher,
+        testDispatcher,
+        testDispatcher
+    )
+
+    @Before
+    fun setUp() {
+        whenever(transaction.sdkTransactionId)
+            .thenReturn(sdkTransactionId)
+        runBlocking {
+            whenever(transaction.createAuthenticationRequestParameters())
+                .thenReturn(Stripe3ds2Fixtures.createAreqParams(sdkTransactionId))
+            whenever(
+                stripeRepository.start3ds2Auth(
+                    any(),
+                    any()
+                )
+            ).thenReturn(
+                ARES_CHALLENGE_FLOW
+            )
+        }
+    }
+
+    @Test
+    fun `on3ds2AuthSuccess() with challenge flow should not start relay activity`() {
+        testDispatcher.runBlockingTest {
+            authenticator.on3ds2AuthSuccess(
+                Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                StripePaymentController.PAYMENT_REQUEST_CODE,
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+            verify(paymentRelayStarter, never())
+                .start(anyOrNull())
+        }
+    }
+
+    @Test
+    fun `on3ds2AuthSuccess() with frictionless flow should start relay activity with PaymentIntent`() =
+        testDispatcher.runBlockingTest {
+            authenticator.on3ds2AuthSuccess(
+                Stripe3ds2AuthResultFixtures.ARES_FRICTIONLESS_FLOW,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                StripePaymentController.PAYMENT_REQUEST_CODE,
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+            verify(paymentRelayStarter)
+                .start(relayStarterArgsArgumentCaptor.capture())
+            val args =
+                relayStarterArgsArgumentCaptor.firstValue as? PaymentRelayStarter.Args.PaymentIntentArgs
+            assertThat(args?.paymentIntent)
+                .isEqualTo(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
+
+            verify(analyticsRequestExecutor)
+                .executeAsync(analyticsRequestArgumentCaptor.capture())
+            val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
+            val analyticsParams = requireNotNull(analyticsRequest.params)
+            assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_EVENT])
+                .isEqualTo(AnalyticsEvent.Auth3ds2Frictionless.toString())
+        }
+
+    @Test
+    fun `on3ds2AuthSuccess() with fallback redirect URL should send analyticsRequest invoke webAuthenticator`() =
+        testDispatcher.runBlockingTest {
+            authenticator.on3ds2AuthSuccess(
+                Stripe3ds2AuthResultFixtures.FALLBACK_REDIRECT_URL,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                StripePaymentController.PAYMENT_REQUEST_CODE,
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+
+            verify(analyticsRequestExecutor)
+                .executeAsync(analyticsRequestArgumentCaptor.capture())
+            val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
+            Truth.assertThat(
+                requireNotNull(analyticsRequest.params)[AnalyticsRequestFactory.FIELD_EVENT]
+            ).isEqualTo(AnalyticsEvent.Auth3ds2Fallback.toString())
+
+            verify(webIntentAuthenticator).beginWebAuth(
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                StripePaymentController.getRequestCode(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2),
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.clientSecret.orEmpty(),
+                Stripe3ds2AuthResultFixtures.FALLBACK_REDIRECT_URL.fallbackRedirectUrl!!,
+                REQUEST_OPTIONS.stripeAccount,
+                shouldCancelSource = true
+            )
+        }
+
+    @Test
+    fun `on3ds2AuthSuccess() with AReq error should start relay activity with exception`() =
+        testDispatcher.runBlockingTest {
+            authenticator.on3ds2AuthSuccess(
+                Stripe3ds2AuthResultFixtures.ERROR,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                StripePaymentController.PAYMENT_REQUEST_CODE,
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+
+            verify(paymentRelayStarter)
+                .start(relayStarterArgsArgumentCaptor.capture())
+
+            val args =
+                relayStarterArgsArgumentCaptor.firstValue as? PaymentRelayStarter.Args.ErrorArgs
+            Truth.assertThat(args?.exception?.message).isEqualTo(
+                "Error encountered during 3DS2 authentication request. " +
+                    "Code: 302, Detail: null, " +
+                    "Description: Data could not be decrypted by the receiving system due to " +
+                    "technical or other reason., Component: D"
+            )
+        }
+
+    @Test
+    fun `startChallengeFlow() when successful should call doChallenge()`() =
+        testDispatcher.runBlockingTest {
+            val ares = requireNotNull(Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW.ares)
+            authenticator.startChallengeFlow(
+                ares,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+
+            testDispatcher.advanceTimeBy(StripePaymentController.CHALLENGE_DELAY)
+
+            verify(transaction).doChallenge(
+                any<Stripe3ds2ActivityStarterHost>(),
+                eq(
+                    ChallengeParameters(
+                        acsSignedContent = null,
+                        threeDsServerTransactionId = ares.threeDSServerTransId,
+                        acsTransactionId = ares.acsTransId
+                    )
+                ),
+                any(),
+                eq(MAX_TIMEOUT)
+            )
+        }
+
+    @Test
+    fun `startChallengeFlow() when failure should start relay activity with exception()`() =
+        testDispatcher.runBlockingTest {
+            val failingHost = mock<AuthActivityStarter.Host>()
+            val ares = requireNotNull(Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW.ares)
+            authenticator.startChallengeFlow(
+                ares,
+                transaction,
+                SOURCE_ID,
+                MAX_TIMEOUT,
+                paymentRelayStarter,
+                failingHost,
+                PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                REQUEST_OPTIONS
+            )
+
+            verify(paymentRelayStarter).start(
+                argWhere<PaymentRelayStarter.Args.ErrorArgs> {
+                    it.exception.message == "Error while attempting to start 3DS2 challenge flow."
+                }
+            )
+        }
+
+    @Test
+    fun authenticate_withMastercardAnd3ds2_shouldStart3ds2ChallengeFlow() =
+        testDispatcher.runBlockingTest {
+            val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
+            val dsPublicKey =
+                Stripe3ds2Fingerprint(paymentIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2)
+                    .directoryServerEncryption
+                    .directoryServerPublicKey
+            whenever(
+                threeDs2Service.createTransaction(
+                    eq(MASTERCARD_DS_ID),
+                    eq(MESSAGE_VERSION),
+                    eq(paymentIntent.isLiveMode),
+                    eq("mastercard"),
+                    any(),
+                    eq(dsPublicKey),
+                    eq("7c4debe3f4af7f9d1569a2ffea4343c2566826ee")
+                )
+            ).thenReturn(transaction)
+
+            authenticator.authenticate(
+                host,
+                paymentIntent,
+                null,
+                REQUEST_OPTIONS
+            )
+            testDispatcher.advanceTimeBy(StripePaymentController.CHALLENGE_DELAY)
+
+            verify(threeDs2Service).createTransaction(
+                eq(MASTERCARD_DS_ID),
+                eq(MESSAGE_VERSION),
+                eq(paymentIntent.isLiveMode),
+                eq("mastercard"),
+                any(),
+                eq(dsPublicKey),
+                eq("7c4debe3f4af7f9d1569a2ffea4343c2566826ee")
+            )
+            verify(transaction)
+                .doChallenge(any<Stripe3ds2ActivityStarterHost>(), any(), any(), any())
+
+            verify(challengeProgressActivityStarter).start(
+                eq(activity),
+                eq("mastercard"),
+                eq(false),
+                any(),
+                eq(sdkTransactionId)
+            )
+
+            verify(analyticsRequestExecutor)
+                .executeAsync(analyticsRequestArgumentCaptor.capture())
+            val analyticsParams = requireNotNull(analyticsRequestArgumentCaptor.firstValue.params)
+            assertThat(analyticsParams[AnalyticsRequestFactory.FIELD_EVENT])
+                .isEqualTo(AnalyticsEvent.Auth3ds2Fingerprint.toString())
+        }
+
+    @Test
+    fun authenticate_withAmexAnd3ds2_shouldStart3ds2ChallengeFlow() =
+        testDispatcher.runBlockingTest {
+            whenever(
+                threeDs2Service.createTransaction(
+                    eq(AMEX_DS_ID),
+                    eq(MESSAGE_VERSION),
+                    eq(PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2.isLiveMode),
+                    eq("american_express"),
+                    any(),
+                    eq(Stripe3ds2FingerprintTest.DS_RSA_PUBLIC_KEY),
+                    eq(PaymentIntentFixtures.KEY_ID)
+                )
+            ).thenReturn(transaction)
+
+            authenticator.authenticate(
+                host,
+                PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2,
+                null,
+                REQUEST_OPTIONS
+            )
+            testDispatcher.advanceTimeBy(StripePaymentController.CHALLENGE_DELAY)
+
+            verify(threeDs2Service).createTransaction(
+                eq(AMEX_DS_ID),
+                eq(MESSAGE_VERSION),
+                eq(PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2.isLiveMode),
+                eq("american_express"),
+                any(),
+                eq(Stripe3ds2FingerprintTest.DS_RSA_PUBLIC_KEY),
+                eq(PaymentIntentFixtures.KEY_ID)
+            )
+            verify(transaction)
+                .doChallenge(any<Stripe3ds2ActivityStarterHost>(), any(), any(), any())
+
+            verify(challengeProgressActivityStarter).start(
+                eq(activity),
+                eq("american_express"),
+                eq(false),
+                any(),
+                eq(sdkTransactionId)
+            )
+        }
+
+    private companion object {
+        private const val ACCOUNT_ID = "acct_123"
+        private const val SOURCE_ID = "src_123"
+        private const val MAX_TIMEOUT = 5
+        private val REQUEST_OPTIONS = ApiRequest.Options(
+            apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            stripeAccount = ACCOUNT_ID
+        )
+
+        private const val MESSAGE_VERSION = Stripe3ds2Fixtures.MESSAGE_VERSION
+        private const val MASTERCARD_DS_ID = "A000000004"
+        private const val AMEX_DS_ID = "A000000025"
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -49,7 +49,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
@@ -57,10 +56,7 @@ class Stripe3DS2AuthenticatorTest {
     private val testDispatcher = TestCoroutineDispatcher()
     private val activity: Activity = mock()
     private val host = AuthActivityStarter.Host.create(activity)
-
-    private val sdkTransactionId = mock<SdkTransactionId>().also {
-        whenever(it.value).thenReturn(UUID.randomUUID().toString())
-    }
+    private val sdkTransactionId = SdkTransactionId.create()
     private val stripeRepository = mock<StripeRepository>()
     private val webIntentAuthenticator = mock<WebIntentAuthenticator>()
     private val paymentRelayStarterFactory =

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -1,0 +1,180 @@
+package com.stripe.android.payments.core.authentication
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.Logger
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.StripePaymentController.Companion.PAYMENT_REQUEST_CODE
+import com.stripe.android.StripePaymentController.Companion.SETUP_REQUEST_CODE
+import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequest
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class WebIntentAuthenticatorTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val paymentBrowserAuthStarterFactory =
+        mock<(AuthActivityStarter.Host) -> PaymentBrowserAuthStarter>()
+    private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
+    private val analyticsRequestFactory = AnalyticsRequestFactory(
+        context,
+        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+    )
+    private val logger = mock<Logger>()
+
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val host = mock<AuthActivityStarter.Host>()
+
+    private val paymentBrowserWebStarter = mock<PaymentBrowserAuthStarter>()
+
+    private val browserAuthContractArgumentCaptor: KArgumentCaptor<PaymentBrowserAuthContract.Args> =
+        argumentCaptor()
+    private val analyticsRequestArgumentCaptor: KArgumentCaptor<AnalyticsRequest> = argumentCaptor()
+
+    private val authenticator = WebIntentAuthenticator(
+        paymentBrowserAuthStarterFactory,
+        analyticsRequestExecutor,
+        analyticsRequestFactory,
+        logger,
+        enableLogging = false,
+        testDispatcher
+    )
+
+    @Before
+    fun setUp() {
+        whenever(paymentBrowserAuthStarterFactory(any())).thenReturn(paymentBrowserWebStarter)
+    }
+
+    @Test
+    fun authenticate_whenSdk3ds1() {
+        verifyAuthenticate(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_3DS1,
+            expectedUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW",
+            expectedReturnUrl = null,
+            expectedRequestCode = PAYMENT_REQUEST_CODE,
+            expectedAnalyticsEvent = AnalyticsEvent.Auth3ds1Sdk
+        )
+    }
+
+    @Test
+    fun authenticate_whenSdk3ds1_withReturnUrl() {
+        verifyAuthenticate(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_3DS1,
+            threeDs1ReturnUrl = RETURN_URL_FOR_3DS1,
+            expectedUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW",
+            expectedReturnUrl = RETURN_URL_FOR_3DS1,
+            expectedRequestCode = PAYMENT_REQUEST_CODE,
+            expectedAnalyticsEvent = AnalyticsEvent.Auth3ds1Sdk
+        )
+    }
+
+    @Test
+    fun authenticate_whenRedirectToUrl() {
+        verifyAuthenticate(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_REDIRECT,
+            expectedUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecaz6CRMbs6FrXfuYKBRSUG/src_client_secret_F6octeOshkgxT47dr0ZxSZiv",
+            expectedReturnUrl = "stripe://deeplink",
+            expectedRequestCode = PAYMENT_REQUEST_CODE,
+            expectedAnalyticsEvent = AnalyticsEvent.AuthRedirect
+        )
+    }
+
+    @Test
+    fun authenticate_whenRedirectToUrlWithSetupIntent() {
+        verifyAuthenticate(
+            stripeIntent = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
+            expectedUrl = "https://hooks.stripe.com/redirect/authenticate/src_1EqTStGMT9dGPIDGJGPkqE6B?client_secret=src_client_secret_FL9m741mmxtHykDlRTC5aQ02",
+            expectedReturnUrl = "stripe://setup_intent_return",
+            expectedRequestCode = SETUP_REQUEST_CODE,
+            expectedAnalyticsEvent = AnalyticsEvent.AuthRedirect
+        )
+    }
+
+    @Test
+    fun authenticate_whenDisplayOxxoDetails() {
+        verifyAuthenticate(
+            stripeIntent = PaymentIntentFixtures.OXXO_REQUIES_ACTION,
+            expectedUrl = "https://payments.stripe.com/oxxo/voucher/test_YWNjdF8xSWN1c1VMMzJLbFJvdDAxLF9KRlBtckVBMERWM0lBZEUyb",
+            expectedReturnUrl = null,
+            expectedRequestCode = PAYMENT_REQUEST_CODE,
+            expectedAnalyticsEvent = null,
+            expectedShouldCancelIntentOnUserNavigation = false,
+        )
+    }
+
+    private fun verifyAuthenticate(
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String? = null,
+        expectedUrl: String,
+        expectedReturnUrl: String?,
+        expectedRequestCode: Int,
+        expectedShouldCancelIntentOnUserNavigation: Boolean = true,
+        expectedAnalyticsEvent: AnalyticsEvent?
+    ) = testDispatcher.runBlockingTest {
+        authenticator.authenticate(
+            host,
+            stripeIntent,
+            threeDs1ReturnUrl,
+            REQUEST_OPTIONS
+        )
+        verify(paymentBrowserWebStarter).start(
+            browserAuthContractArgumentCaptor.capture()
+        )
+        val args = requireNotNull(
+            browserAuthContractArgumentCaptor.firstValue
+        )
+
+        assertThat(args.requestCode).isEqualTo(expectedRequestCode)
+        assertThat(args.url).isEqualTo(expectedUrl)
+        assertThat(args.returnUrl).isEqualTo(expectedReturnUrl)
+        assertThat(args.shouldCancelIntentOnUserNavigation).isEqualTo(
+            expectedShouldCancelIntentOnUserNavigation
+        )
+
+        expectedAnalyticsEvent?.let {
+            verifyAnalytics(it)
+        }
+    }
+
+    private fun verifyAnalytics(event: AnalyticsEvent) {
+        verify(analyticsRequestExecutor)
+            .executeAsync(analyticsRequestArgumentCaptor.capture())
+        val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
+        assertThat(
+            analyticsRequest.compactParams?.get(AnalyticsRequestFactory.FIELD_EVENT)
+        ).isEqualTo(event.toString())
+    }
+
+    private companion object {
+        private const val ACCOUNT_ID = "acct_123"
+
+        private const val RETURN_URL_FOR_3DS1 = "stripesdk://payment_return_url"
+        private val REQUEST_OPTIONS = ApiRequest.Options(
+            apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            stripeAccount = ACCOUNT_ID
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Adds abstraction layer to the logic to handle intent's next_action, ready ourselves to reach [milestone 3.1](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BLi4n4vib9d2xeEyYPBq~ENkAg-M9mrrTib7RFBVN7VimeGx#:h2=Milestone-3.1---0.5-week-per-m)

Please refer to design details [here](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BLi4n4vib9d2xeEyYPBq~ENkAg-M9mrrTib7RFBVN7VimeGx#:uid=589287508011797552037558&h2=Interfaces-design)


# Motivation
Please follow [this](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BK_huBjQWgZvAn8b4MiygyTMAg-M9mrrTib7RFBVN7VimeGx) for overall modularization progress

## Changes in this PR
As a follow up to #3743, there are two major changes involved:

- Abstract `StripePaymentController.handleNextAction` into three different `IntentAuthenticator`s. 
  - `NoOpIntentAuthenticator` - encapsulate `StripePaymentController.bypassAuth`, handling `next_action` with no-op
  - `WebIntentAuthenticator` - encapsulate `PaymentBrowserAuthStarter`, handling `next_action` which requires a web redirect
  - `Stripe3DS2Authenticator` - encapsulate the logic to invoke 3ds2 SDK.
    -  Note: this authenticator will be moved into a dedicate gradle module with dependency on 3ds2 SDK. Should we need any other modules that requires a 3p SDK in [milestone 3.1](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BLi4n4vib9d2xeEyYPBq~ENkAg-M9mrrTib7RFBVN7VimeGx#:h2=Milestone-3.1---0.5-week-per-m), we can create one following the same pattern.

- Use dagger to initialize `IntentAuthenticatorRegistry`
  - Please refer to [this](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BLdrVGS~YaEFRpYLLPAHYFUpAg-Y8OUkag2eU9iPwUhUaVKU) internal doc on details

## Follow up changes
- Now the 3 authenticators are "hardcoded" into the registry, add the API to register new authenticators
- Move `Stripe3DS2Authenticator` into its own module, reaching [milestone 3.1](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BLi4n4vib9d2xeEyYPBq~ENkAg-M9mrrTib7RFBVN7VimeGx#:h2=Milestone-3.1---0.5-week-per-m)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Some tests in `StripePaymentControllerTest` are moved into dedicate unittests for the three `IntentAuthenticator` instances with slightly name change:
- "handleNextAction" keyword in the test names replaced with "authenticate`
- in `NoOpIntentAuthenticatorTest`
  - Added tests to verify relaying back to host with both `Modern` and `Legacy` `PaymentRelayStarter`
- in `Stripe3ds2AuthenticatorTest`
  - the test `on3ds2AuthFallback() with ActivityResultLauncher should use ActivityResultLauncher` is removed, the logic is covered in `WebAuthenticatorTest`
  - the test `on3ds2AuthSuccess() with fallback redirect URL should start auth webview activity` is renamed to `renamed to on3ds2AuthSuccess() with fallback redirect URL should invoke webAuthenticator`, the logic to start webview is covered in `WebAuthenticatorTest`
- in `WebAuthenticatorTest`
  - the tests for verifying nextActionData=SdkData.Use3DS1 names will have "Sdk3ds1" keyword
  - some tests for verifying 3ds has nextActionData=RedirectToUrl, removed "3ds" from these tests names, only keep "redictToUrl" for readability


