### PR TITLE
Refactor StripeGooglePayContract.Args to not take a PaymentIntent

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
@@ -81,9 +81,7 @@ internal class StripeGooglePayContract :
         internal var isEmailRequired: Boolean = false,
 
         /**
-         * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
-         * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant”
-         * message is displayed in the payment sheet.
+         * Merchant name encoded as UTF-8.
          */
         internal var merchantName: String? = null,
 

--- a/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayContract.kt
@@ -11,7 +11,6 @@ import androidx.core.os.bundleOf
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
 import com.stripe.android.R
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.ShippingInformation
 import com.stripe.android.view.ActivityStarter
@@ -42,7 +41,6 @@ internal class StripeGooglePayContract :
      */
     @Parcelize
     data class Args(
-        var paymentIntent: PaymentIntent,
         var config: GooglePayConfig,
         @ColorInt val statusBarColor: Int?
     ) : ActivityStarter.Args {
@@ -60,16 +58,41 @@ internal class StripeGooglePayContract :
         var environment: StripeGooglePayEnvironment,
 
         /**
+         * Total monetary value of the transaction.
+         *
+         * The value of this field is represented in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+         * For example, when [currencyCode] is `"USD"`, a value of `100` represents 100 cents ($1.00).
+         */
+        internal var amount: Int?,
+
+        /**
          * ISO 3166-1 alpha-2 country code where the transaction is processed.
          */
         internal var countryCode: String,
+
+        /**
+         * ISO 4217 alphabetic currency code.
+         */
+        internal var currencyCode: String,
 
         /**
          * Set to true to request an email address.
          */
         internal var isEmailRequired: Boolean = false,
 
-        internal var merchantName: String? = null
+        /**
+         * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
+         * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant”
+         * message is displayed in the payment sheet.
+         */
+        internal var merchantName: String? = null,
+
+        /**
+         * A unique ID that identifies a transaction attempt. Merchants may use an existing ID or
+         * generate a specific one for Google Pay transaction attempts. This field is required
+         * when you send callbacks to the Google Transaction Events API.
+         */
+        internal var transactionId: String? = null
     ) : Parcelable
 
     sealed class Result : ActivityStarter.Result {
@@ -100,7 +123,7 @@ internal class StripeGooglePayContract :
         }
 
         /**
-         * See [Args.PaymentData]
+         * See [Args]
          */
         @Parcelize
         data class PaymentData(

--- a/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepay/StripeGooglePayViewModel.kt
@@ -47,14 +47,13 @@ internal class StripeGooglePayViewModel(
     }
 
     fun createPaymentDataRequestForPaymentIntentArgs(): JSONObject {
-        val paymentIntent = args.paymentIntent
         return googlePayJsonFactory.createPaymentDataRequest(
             transactionInfo = GooglePayJsonFactory.TransactionInfo(
-                currencyCode = paymentIntent.currency.orEmpty(),
+                currencyCode = args.config.currencyCode,
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
                 countryCode = args.config.countryCode,
-                transactionId = paymentIntent.id,
-                totalPrice = paymentIntent.amount?.toInt(),
+                transactionId = args.config.transactionId,
+                totalPrice = args.config.amount,
                 checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
             ),
             merchantInfo = GooglePayJsonFactory.MerchantInfo(

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -257,7 +257,6 @@ internal class PaymentSheetViewModel internal constructor(
             (stripeIntent.value as? PaymentIntent)?.let { paymentIntent ->
                 _launchGooglePay.value = Event(
                     StripeGooglePayContract.Args(
-                        paymentIntent = paymentIntent,
                         config = StripeGooglePayContract.GooglePayConfig(
                             environment = when (args.config?.googlePay?.environment) {
                                 PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -265,8 +264,11 @@ internal class PaymentSheetViewModel internal constructor(
                                 else ->
                                     StripeGooglePayEnvironment.Test
                             },
+                            amount = paymentIntent.amount?.toInt(),
                             countryCode = args.googlePayConfig?.countryCode.orEmpty(),
-                            merchantName = args.config?.merchantDisplayName
+                            currencyCode = paymentIntent.currency.orEmpty(),
+                            merchantName = args.config?.merchantDisplayName,
+                            transactionId = paymentIntent.id
                         ),
                         statusBarColor = args.statusBarColor
                     )
@@ -291,7 +293,9 @@ internal class PaymentSheetViewModel internal constructor(
         }
     }
 
-    private fun onStripeIntentResult(stripeIntentResult: StripeIntentResult<out StripeIntent>) {
+    private fun onStripeIntentResult(
+        stripeIntentResult: StripeIntentResult<StripeIntent>
+    ) {
         when (stripeIntentResult.outcome) {
             StripeIntentResult.Outcome.SUCCEEDED -> {
                 eventReporter.onPaymentSuccess(selection.value)

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -247,7 +247,6 @@ internal class DefaultFlowController internal constructor(
             }
             googlePayLauncher(
                 StripeGooglePayContract.Args(
-                    paymentIntent = initData.stripeIntent,
                     config = StripeGooglePayContract.GooglePayConfig(
                         environment = when (config?.googlePay?.environment) {
                             PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -255,8 +254,11 @@ internal class DefaultFlowController internal constructor(
                             else ->
                                 StripeGooglePayEnvironment.Test
                         },
+                        amount = initData.stripeIntent.amount?.toInt(),
                         countryCode = config?.googlePay?.countryCode.orEmpty(),
-                        merchantName = config?.merchantDisplayName
+                        currencyCode = initData.stripeIntent.currency.orEmpty(),
+                        merchantName = config?.merchantDisplayName,
+                        transactionId = initData.stripeIntent.id
                     ),
                     statusBarColor = statusBarColor()
                 )

--- a/payments-core/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepay/StripeGooglePayActivityTest.kt
@@ -9,8 +9,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentIntentFixtures
 import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -102,16 +100,14 @@ class StripeGooglePayActivityTest {
     private companion object {
         private val CONFIG = StripeGooglePayContract.GooglePayConfig(
             environment = StripeGooglePayEnvironment.Test,
+            amount = 1000,
             countryCode = "US",
-            isEmailRequired = true
-        )
-
-        private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
-            confirmationMethod = PaymentIntent.ConfirmationMethod.Automatic
+            currencyCode = "usd",
+            isEmailRequired = true,
+            transactionId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6"
         )
 
         private val ARGS = StripeGooglePayContract.Args(
-            paymentIntent = PAYMENT_INTENT,
             config = CONFIG,
             statusBarColor = Color.RED
         )

--- a/payments-core/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepay/StripeGooglePayViewModelTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeJsonUtils
@@ -211,12 +210,14 @@ class StripeGooglePayViewModelTest {
     private companion object {
         private val CONFIG = StripeGooglePayContract.GooglePayConfig(
             environment = StripeGooglePayEnvironment.Test,
+            amount = 2000,
             countryCode = "US",
-            isEmailRequired = true
+            currencyCode = "usd",
+            isEmailRequired = true,
+            transactionId = "pi_1ExkUeAWhjPjYwPiXph9ouXa"
         )
 
         private val ARGS = StripeGooglePayContract.Args(
-            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             config = CONFIG,
             statusBarColor = Color.RED
         )

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -403,11 +403,13 @@ internal class DefaultFlowControllerTest {
         assertThat(launchArgs)
             .isEqualTo(
                 StripeGooglePayContract.Args(
-                    paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     config = StripeGooglePayContract.GooglePayConfig(
                         environment = StripeGooglePayEnvironment.Test,
+                        amount = 1099,
                         countryCode = "US",
-                        merchantName = "Widget Store"
+                        currencyCode = "usd",
+                        merchantName = "Widget Store",
+                        transactionId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6"
                     ),
                     statusBarColor = ContextCompat.getColor(
                         activity,


### PR DESCRIPTION


# Summary
Make `StripeGooglePayContract` more flexible by not depending on an
actual fetched `PaymentIntent`.

# Motivation
Reuse `StripeGooglePayContract` for more scenarios.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

