### PR TITLE
Make SourceParams a data class

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4571,6 +4571,11 @@ public class com/stripe/android/model/SourceOrderParams$Shipping$Creator : andro
 
 public final class com/stripe/android/model/SourceParams : com/stripe/android/model/StripeParamsModel {
 	public static final field Companion Lcom/stripe/android/model/SourceParams$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/stripe/android/model/SourceParams$Flow;
+	public final fun component8 ()Lcom/stripe/android/model/SourceOrderParams;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$OwnerParams;Lcom/stripe/android/model/Source$Usage;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$Flow;Lcom/stripe/android/model/SourceOrderParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$WeChatParams;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;)Lcom/stripe/android/model/SourceParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$OwnerParams;Lcom/stripe/android/model/Source$Usage;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$Flow;Lcom/stripe/android/model/SourceOrderParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams$WeChatParams;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams;
 	public static final fun createAlipayReusableParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
 	public static final fun createAlipaySingleUseParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
 	public static final fun createBancontactParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
@@ -4618,6 +4623,7 @@ public final class com/stripe/android/model/SourceParams : com/stripe/android/mo
 	public final fun setToken (Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
 	public final fun setUsage (Lcom/stripe/android/model/Source$Usage;)Lcom/stripe/android/model/SourceParams;
 	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/model/SourceParams$Companion {


### PR DESCRIPTION


# Summary
Move mutable properties to constructor
Remove custom implementations of `equals` and `hashCode`

# Motivation
Eventually we will make `SourceParams` implement `Parcelable`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

