### PR TITLE
add provider for publishableKey for `FlowController`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSession.kt
@@ -473,7 +473,7 @@ class CustomerSession @VisibleForTesting internal constructor(
 
             instance = CustomerSession(
                 context,
-                StripeApiRepository(context, config.publishableKey, appInfo),
+                StripeApiRepository(context, { config.publishableKey }, appInfo),
                 config.publishableKey,
                 config.stripeAccountId,
                 createCoroutineDispatcher(),

--- a/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -370,7 +370,7 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
         ): IssuingCardPinService {
             return IssuingCardPinService(
                 keyProvider,
-                StripeApiRepository(context, publishableKey, appInfo),
+                StripeApiRepository(context, { publishableKey }, appInfo),
                 StripeOperationIdFactory(),
                 stripeAccountId = stripeAccountId
             )

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -95,7 +95,7 @@ class Stripe internal constructor(
         context.applicationContext,
         StripeApiRepository(
             context.applicationContext,
-            publishableKey,
+            { publishableKey },
             appInfo,
             Logger.getInstance(enableLogging),
             betas = betas
@@ -115,7 +115,7 @@ class Stripe internal constructor(
         stripeRepository,
         StripePaymentController(
             context.applicationContext,
-            publishableKey,
+            { publishableKey },
             stripeRepository,
             enableLogging
         ),

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -66,7 +66,7 @@ internal class StripePaymentController internal constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor =
         AnalyticsRequestExecutor.Default(Logger.getInstance(enableLogging)),
     private val analyticsRequestFactory: AnalyticsRequestFactory =
-        AnalyticsRequestFactory(context.applicationContext) { publishableKeyProvider.get() },
+        AnalyticsRequestFactory(context.applicationContext, publishableKeyProvider),
     challengeProgressActivityStarter: ChallengeProgressActivityStarter =
         ChallengeProgressActivityStarter.Default(),
     private val alipayRepository: AlipayRepository = DefaultAlipayRepository(stripeRepository),

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -44,6 +44,7 @@ import com.stripe.android.view.AuthActivityStarter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -53,7 +54,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal class StripePaymentController internal constructor(
     context: Context,
-    private val publishableKey: String,
+    private val publishableKeyProvider: Provider<String>,
     private val stripeRepository: StripeRepository,
     private val enableLogging: Boolean = false,
     messageVersionRegistry: MessageVersionRegistry =
@@ -65,7 +66,7 @@ internal class StripePaymentController internal constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor =
         AnalyticsRequestExecutor.Default(Logger.getInstance(enableLogging)),
     private val analyticsRequestFactory: AnalyticsRequestFactory =
-        AnalyticsRequestFactory(context.applicationContext, publishableKey),
+        AnalyticsRequestFactory(context.applicationContext) { publishableKeyProvider.get() },
     challengeProgressActivityStarter: ChallengeProgressActivityStarter =
         ChallengeProgressActivityStarter.Default(),
     private val alipayRepository: AlipayRepository = DefaultAlipayRepository(stripeRepository),
@@ -78,14 +79,14 @@ internal class StripePaymentController internal constructor(
     private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
     private val paymentIntentFlowResultProcessor = PaymentIntentFlowResultProcessor(
         context,
-        publishableKey,
+        publishableKeyProvider,
         stripeRepository,
         enableLogging,
         workContext
     )
     private val setupIntentFlowResultProcessor = SetupIntentFlowResultProcessor(
         context,
-        publishableKey,
+        publishableKeyProvider,
         stripeRepository,
         enableLogging,
         workContext
@@ -468,7 +469,7 @@ internal class StripePaymentController internal constructor(
         val clientSecret = result.clientSecret.orEmpty()
 
         val requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
+            apiKey = publishableKeyProvider.get(),
             stripeAccount = result.stripeAccountId
         )
 
@@ -647,7 +648,7 @@ internal class StripePaymentController internal constructor(
         ): PaymentController {
             return StripePaymentController(
                 context.applicationContext,
-                publishableKey,
+                { publishableKey },
                 stripeRepository,
                 enableLogging
             )

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -58,7 +58,7 @@ internal class DefaultCardAccountRangeRepositoryFactory(
                 RemoteCardAccountRangeSource(
                     StripeApiRepository(
                         appContext,
-                        publishableKey
+                        { publishableKey }
                     ),
                     ApiRequest.Options(
                         publishableKey

--- a/payments-core/src/main/java/com/stripe/android/googlepaysheet/StripeGooglePayViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaysheet/StripeGooglePayViewModel.kt
@@ -102,7 +102,7 @@ internal class StripeGooglePayViewModel(
                 publishableKey,
                 stripeAccountId,
                 args,
-                StripeApiRepository(application, publishableKey),
+                StripeApiRepository(application, { publishableKey }),
                 appName,
                 Dispatchers.IO
             ) as T

--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.analytics.DeviceId
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.analytics.SessionId
 import com.stripe.android.utils.ContextUtils.packageInfo
+import javax.inject.Provider
 
 /**
  * Factory for [AnalyticsRequest] objects.
@@ -21,7 +22,7 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     private val packageManager: PackageManager?,
     private val packageInfo: PackageInfo?,
     private val packageName: String,
-    private val publishableKeySupplier: () -> String
+    private val publishableKeyProvider: Provider<String>
 ) {
     internal constructor(
         context: Context,
@@ -33,12 +34,12 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
 
     internal constructor(
         context: Context,
-        publishableKeySupplier: () -> String
+        publishableKeyProvider: Provider<String>
     ) : this(
         context.applicationContext.packageManager,
         context.applicationContext.packageInfo,
         context.applicationContext.packageName.orEmpty(),
-        publishableKeySupplier
+        publishableKeyProvider
     )
 
     @JvmSynthetic
@@ -237,7 +238,7 @@ internal class AnalyticsRequestFactory @VisibleForTesting internal constructor(
             FIELD_ANALYTICS_UA to ANALYTICS_UA,
             FIELD_EVENT to event,
             FIELD_PUBLISHABLE_KEY to runCatching {
-                publishableKeySupplier()
+                publishableKeyProvider.get()
             }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY),
             FIELD_OS_NAME to Build.VERSION.CODENAME,
             FIELD_OS_RELEASE to Build.VERSION.RELEASE,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -62,6 +62,7 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.security.Security
 import java.util.Locale
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -69,7 +70,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal class StripeApiRepository @JvmOverloads internal constructor(
     context: Context,
-    private val publishableKey: String,
+    publishableKeyProvider: Provider<String>,
     private val appInfo: AppInfo? = null,
     private val logger: Logger = Logger.noop(),
     private val workContext: CoroutineContext = Dispatchers.IO,
@@ -82,7 +83,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(context, workContext),
     private val analyticsRequestFactory: AnalyticsRequestFactory =
-        AnalyticsRequestFactory(context, publishableKey),
+        AnalyticsRequestFactory(context) { publishableKeyProvider.get() },
     private val fraudDetectionDataParamsUtils: FraudDetectionDataParamsUtils = FraudDetectionDataParamsUtils(),
     betas: Set<StripeApiBeta> = emptySet(),
     apiVersion: String = ApiVersion(betas = betas).code,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -83,7 +83,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(context, workContext),
     private val analyticsRequestFactory: AnalyticsRequestFactory =
-        AnalyticsRequestFactory(context) { publishableKeyProvider.get() },
+        AnalyticsRequestFactory(context, publishableKeyProvider),
     private val fraudDetectionDataParamsUtils: FraudDetectionDataParamsUtils = FraudDetectionDataParamsUtils(),
     betas: Set<StripeApiBeta> = emptySet(),
     apiVersion: String = ApiVersion(betas = betas).code,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -13,6 +13,7 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -20,7 +21,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
     context: Context,
-    private val publishableKey: String,
+    private val publishableKeyProvider: Provider<String>,
     protected val stripeRepository: StripeRepository,
     enableLogging: Boolean,
     private val workContext: CoroutineContext = Dispatchers.IO
@@ -34,7 +35,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         val result = unvalidatedResult.validate()
 
         val requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
+            apiKey = publishableKeyProvider.get(),
             stripeAccount = result.stripeAccountId
         )
 
@@ -109,12 +110,12 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
  */
 internal class PaymentIntentFlowResultProcessor(
     context: Context,
-    publishableKey: String,
+    publishableKeyProvider: Provider<String>,
     stripeRepository: StripeRepository,
     enableLogging: Boolean,
     workContext: CoroutineContext = Dispatchers.IO
 ) : PaymentFlowResultProcessor<PaymentIntent, PaymentIntentResult>(
-    context, publishableKey, stripeRepository, enableLogging, workContext
+    context, publishableKeyProvider, stripeRepository, enableLogging, workContext
 ) {
     override suspend fun retrieveStripeIntent(
         clientSecret: String,
@@ -155,12 +156,12 @@ internal class PaymentIntentFlowResultProcessor(
  */
 internal class SetupIntentFlowResultProcessor(
     context: Context,
-    publishableKey: String,
+    publishableKeyProvider: Provider<String>,
     stripeRepository: StripeRepository,
     enableLogging: Boolean,
     workContext: CoroutineContext = Dispatchers.IO
 ) : PaymentFlowResultProcessor<SetupIntent, SetupIntentResult>(
-    context, publishableKey, stripeRepository, enableLogging, workContext
+    context, publishableKeyProvider, stripeRepository, enableLogging, workContext
 ) {
     override suspend fun retrieveStripeIntent(
         clientSecret: String,

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -139,10 +139,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
         paymentController = StripePaymentController(
             application,
-            paymentConfig.publishableKey,
+            { paymentConfig.publishableKey },
             StripeApiRepository(
                 application,
-                paymentConfig.publishableKey
+                { paymentConfig.publishableKey }
             ),
             true,
             paymentRelayLauncher = paymentRelayLauncher,

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -426,7 +426,7 @@ internal class PaymentSheetViewModel internal constructor(
             val stripeAccountId = config.stripeAccountId
             val stripeRepository = StripeApiRepository(
                 application,
-                publishableKey
+                { publishableKey }
             )
 
             val starterArgs = starterArgsSupplier()
@@ -465,14 +465,14 @@ internal class PaymentSheetViewModel internal constructor(
                 when (starterArgs.clientSecret) {
                     is PaymentIntentClientSecret -> PaymentIntentFlowResultProcessor(
                         application,
-                        publishableKey,
+                        { publishableKey },
                         stripeRepository,
                         enableLogging = true,
                         Dispatchers.IO
                     )
                     is SetupIntentClientSecret -> SetupIntentFlowResultProcessor(
                         application,
-                        publishableKey,
+                        { publishableKey },
                         stripeRepository,
                         enableLogging = true,
                         Dispatchers.IO

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -110,7 +110,6 @@ internal class DefaultFlowController internal constructor(
     // configureWithSetupIntent.
     // TODO(ccen) inject paymentConfigurationProvider
     private val paymentConfigurationProvider = Provider {
-        PaymentConfiguration.clearInstance()
         PaymentConfiguration.getInstance(appContext)
     }
 

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.google.android.gms.common.api.Status
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.PaymentController
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -48,6 +47,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import javax.inject.Provider
 
 internal class DefaultFlowController internal constructor(
     private val appContext: Context,
@@ -60,7 +60,7 @@ internal class DefaultFlowController internal constructor(
     private val flowControllerInitializer: FlowControllerInitializer,
     paymentControllerFactory: PaymentControllerFactory,
     paymentFlowResultProcessorFactory:
-        (ClientSecret, String, StripeApiRepository) ->
+        (ClientSecret, Provider<String>, StripeApiRepository) ->
         PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>,
     private val eventReporter: EventReporter,
     private val sessionId: SessionId,
@@ -104,38 +104,40 @@ internal class DefaultFlowController internal constructor(
     private val viewModel =
         ViewModelProvider(viewModelStoreOwner)[FlowControllerViewModel::class.java]
 
-    // The properties below are lazily initialized to allow the developer to set the publishableKey
-    // and stripeAccountId in PaymentConfiguration any time before configuring the FlowController
-    // through configureWithPaymentIntent or configureWithSetupIntent.
-
-    private val paymentConfiguration: PaymentConfiguration by lazy {
+    // The provider below always refreshes the PaymentConfiguration instance to allow the developer
+    // to set the publishableKey and stripeAccountId in PaymentConfiguration any time before
+    // configuring the FlowController through configureWithPaymentIntent or
+    // configureWithSetupIntent.
+    // TODO(ccen) inject paymentConfigurationProvider
+    private val paymentConfigurationProvider = Provider {
+        PaymentConfiguration.clearInstance()
         PaymentConfiguration.getInstance(appContext)
     }
 
-    private val stripeApiRepository: StripeApiRepository by lazy {
+    private val stripeApiRepository =
         StripeApiRepository(
             appContext,
-            paymentConfiguration.publishableKey
+            { paymentConfigurationProvider.get().publishableKey }
         )
-    }
 
+    // paymentFlowResultProcessor needs to still be lazy as it needs viewModel.initData.clientSecret
+    // to be set, which is done by configureWithPaymentIntent or configureWithSetupIntent
     private val paymentFlowResultProcessor by lazy {
         paymentFlowResultProcessorFactory(
             viewModel.initData.clientSecret,
-            paymentConfiguration.publishableKey,
+            { paymentConfigurationProvider.get().publishableKey },
             stripeApiRepository
         )
     }
 
-    private val paymentController: PaymentController by lazy {
+    private val paymentController =
         paymentControllerFactory.create(
-            paymentConfiguration.publishableKey,
+            { paymentConfigurationProvider.get().publishableKey },
             stripeApiRepository,
             paymentRelayLauncher = paymentRelayLauncher,
             paymentBrowserAuthLauncher = paymentBrowserAuthLauncher,
             stripe3ds2ChallengeLauncher = stripe3ds2ChallengeLauncher
         )
-    }
 
     override fun configureWithPaymentIntent(
         paymentIntentClientSecret: String,
@@ -172,15 +174,15 @@ internal class DefaultFlowController internal constructor(
                 StripeIntentRepository.Api(
                     stripeRepository = stripeApiRepository,
                     requestOptions = ApiRequest.Options(
-                        paymentConfiguration.publishableKey,
-                        paymentConfiguration.stripeAccountId
+                        paymentConfigurationProvider.get().publishableKey,
+                        paymentConfigurationProvider.get().stripeAccountId
                     ),
                     workContext = Dispatchers.IO
                 ),
                 PaymentMethodsApiRepository(
                     stripeRepository = stripeApiRepository,
-                    publishableKey = paymentConfiguration.publishableKey,
-                    stripeAccountId = paymentConfiguration.stripeAccountId,
+                    publishableKey = paymentConfigurationProvider.get().publishableKey,
+                    stripeAccountId = paymentConfigurationProvider.get().stripeAccountId,
                     workContext = Dispatchers.IO
                 ),
                 configuration
@@ -285,8 +287,8 @@ internal class DefaultFlowController internal constructor(
                     authHostSupplier(),
                     confirmParams,
                     ApiRequest.Options(
-                        apiKey = paymentConfiguration.publishableKey,
-                        stripeAccount = paymentConfiguration.stripeAccountId
+                        apiKey = paymentConfigurationProvider.get().publishableKey,
+                        stripeAccount = paymentConfigurationProvider.get().stripeAccountId
                     )
                 )
             }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -73,12 +73,12 @@ internal class FlowControllerFactory(
         val sessionId = SessionId()
 
         val paymentControllerFactory =
-            PaymentControllerFactory { publishableKey, stripeRepository, paymentRelayLauncher,
+            PaymentControllerFactory { publishableKeyProvider, stripeRepository, paymentRelayLauncher,
                 paymentBrowserAuthLauncher, stripe3ds2ChallengeLauncher ->
 
                 StripePaymentController(
                     appContext,
-                    publishableKey,
+                    publishableKeyProvider,
                     stripeRepository,
                     enableLogging = true,
                     paymentRelayLauncher = paymentRelayLauncher,
@@ -121,18 +121,18 @@ internal class FlowControllerFactory(
                 workContext = Dispatchers.IO
             ),
             paymentControllerFactory = paymentControllerFactory,
-            paymentFlowResultProcessorFactory = { clientSecret, publishableKey, stripeApiRepository ->
+            paymentFlowResultProcessorFactory = { clientSecret, publishableKeyProvider, stripeApiRepository ->
                 when (clientSecret) {
                     is PaymentIntentClientSecret -> PaymentIntentFlowResultProcessor(
                         appContext,
-                        publishableKey,
+                        publishableKeyProvider,
                         stripeApiRepository,
                         enableLogging = false,
                         Dispatchers.IO
                     )
                     is SetupIntentClientSecret -> SetupIntentFlowResultProcessor(
                         appContext,
-                        publishableKey,
+                        publishableKeyProvider,
                         stripeApiRepository,
                         enableLogging = false,
                         Dispatchers.IO

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentControllerFactory.kt
@@ -6,10 +6,11 @@ import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
+import javax.inject.Provider
 
 internal fun interface PaymentControllerFactory {
     fun create(
-        publishableKey: String,
+        publishableKeyProvider: Provider<String>,
         stripeRepository: StripeRepository,
         paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>,
         paymentBrowserAuthLauncher: ActivityResultLauncher<PaymentBrowserAuthContract.Args>,

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -74,7 +74,7 @@ class CardNumberEditText internal constructor(
         AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             context,
-            publishableKeySupplier = publishableKeySupplier
+            publishableKeyProvider = publishableKeySupplier
         )
     )
 

--- a/payments-core/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -34,7 +34,7 @@ internal class FpxViewModel internal constructor(
             val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
             val stripeRepository = StripeApiRepository(
                 application,
-                publishableKey
+                { publishableKey }
             )
 
             return FpxViewModel(application, publishableKey, stripeRepository) as T

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -228,7 +228,7 @@ internal class PaymentMethodEndToEndTest {
     fun createPaymentMethod_withGrabPay_shouldCreateObject() = testDispatcher.runBlockingTest {
         val repository = StripeApiRepository(
             context,
-            ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY,
+            { ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY },
             workContext = testDispatcher
         )
 
@@ -245,7 +245,7 @@ internal class PaymentMethodEndToEndTest {
     fun `createPaymentMethod() with PayPal PaymentMethod should create expected object`() = testDispatcher.runBlockingTest {
         val paymentMethod = StripeApiRepository(
             context,
-            ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY,
+            { ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY },
             workContext = testDispatcher
         ).createPaymentMethod(
             PaymentMethodCreateParams.createPayPal(),

--- a/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -230,7 +230,7 @@ internal class StripeEndToEndTest {
     ): Stripe {
         val stripeRepository = StripeApiRepository(
             context,
-            publishableKey,
+            { publishableKey },
             workContext = testDispatcher
         )
         return Stripe(

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -272,7 +272,7 @@ internal class StripePaymentAuthTest {
         return Stripe(
             StripeApiRepository(
                 context,
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
                 stripeApiRequestExecutor = DefaultApiRequestExecutor(
                     workContext = testDispatcher
                 ),

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -262,7 +262,7 @@ internal class StripePaymentControllerTest {
     ): StripePaymentController {
         return StripePaymentController(
             context,
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
             stripeRepository,
             false,
             MessageVersionRegistry(),

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -46,6 +46,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import javax.inject.Provider;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1365,7 +1367,7 @@ public class StripeTest {
     ) {
         return new StripeApiRepository(
                 context,
-                publishableKey,
+                () -> publishableKey,
                 null,
                 new FakeLogger(),
                 workDispatcher,

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -213,7 +213,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
     ): CardAccountRangeSource {
         val stripeRepository = StripeApiRepository(
             application,
-            publishableKey
+            { publishableKey }
         )
         return RemoteCardAccountRangeSource(
             stripeRepository,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -67,7 +67,7 @@ internal class StripeApiRepositoryTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val stripeApiRepository = StripeApiRepository(
         context,
-        DEFAULT_OPTIONS.apiKey,
+        { DEFAULT_OPTIONS.apiKey },
         workContext = testDispatcher
     )
     private val fileFactory = FileFactory(context)
@@ -470,7 +470,7 @@ internal class StripeApiRepositoryTest {
     fun createSource_createsObjectAndLogs() = testDispatcher.runBlockingTest {
         val stripeApiRepository = StripeApiRepository(
             context,
-            DEFAULT_OPTIONS.apiKey,
+            { DEFAULT_OPTIONS.apiKey },
             workContext = testDispatcher,
             stripeApiRequestExecutor = DefaultApiRequestExecutor(
                 workContext = testDispatcher
@@ -828,7 +828,7 @@ internal class StripeApiRepositoryTest {
 
             val stripeRepository = StripeApiRepository(
                 context,
-                DEFAULT_OPTIONS.apiKey,
+                { DEFAULT_OPTIONS.apiKey },
                 workContext = testDispatcher,
                 sdkVersion = "AndroidBindings/13.0.0"
             )
@@ -852,7 +852,7 @@ internal class StripeApiRepositoryTest {
 
             val stripeRepository = StripeApiRepository(
                 context,
-                DEFAULT_OPTIONS.apiKey,
+                { DEFAULT_OPTIONS.apiKey },
                 workContext = testDispatcher,
                 sdkVersion = "AndroidBindings/14.0.0"
             )
@@ -959,7 +959,7 @@ internal class StripeApiRepositoryTest {
     fun `createRadarSession() with FraudDetectionData should return expected value`() = testDispatcher.runBlockingTest {
         val stripeRepository = StripeApiRepository(
             context,
-            DEFAULT_OPTIONS.apiKey,
+            { DEFAULT_OPTIONS.apiKey },
             analyticsRequestExecutor = analyticsRequestExecutor,
             fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
                 FraudDetectionData(
@@ -983,7 +983,7 @@ internal class StripeApiRepositoryTest {
     fun `createRadarSession() with null FraudDetectionData should throw an exception`() = testDispatcher.runBlockingTest {
         val stripeRepository = StripeApiRepository(
             context,
-            DEFAULT_OPTIONS.apiKey,
+            { DEFAULT_OPTIONS.apiKey },
             fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
                 null
             ),
@@ -1043,7 +1043,7 @@ internal class StripeApiRepositoryTest {
     private fun create(): StripeApiRepository {
         return StripeApiRepository(
             context,
-            DEFAULT_OPTIONS.apiKey,
+            { DEFAULT_OPTIONS.apiKey },
             workContext = testDispatcher,
             stripeApiRequestExecutor = stripeApiRequestExecutor,
             analyticsRequestExecutor = analyticsRequestExecutor,

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -23,7 +23,7 @@ internal class PaymentIntentFlowResultProcessorTest {
 
     private val processor = PaymentIntentFlowResultProcessor(
         ApplicationProvider.getApplicationContext(),
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
         FakeStripeRepository(),
         false,
         testDispatcher

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -23,7 +23,7 @@ internal class SetupIntentFlowResultProcessorTest {
 
     private val processor = SetupIntentFlowResultProcessor(
         ApplicationProvider.getApplicationContext(),
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
         FakeStripeRepository(),
         false,
         testDispatcher


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This could avoid the `lazy` delegations which dependes on the publishablekey to be set after the instance is created. Making them injectable.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
