### PR TITLE
Use publishable key provider when creating AnalyticsRequestFactory

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -32,7 +32,7 @@ internal class DefaultEventReporter internal constructor(
         AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             context,
-            PaymentConfiguration.getInstance(context).publishableKey
+            { PaymentConfiguration.getInstance(context).publishableKey }
         ),
         workContext
     )

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.argWhere
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
@@ -106,6 +107,17 @@ class DefaultEventReporterTest {
                 val deviceIdValue = requireNotNull(req.compactParams?.get("device_id")).toString()
                 UUID.fromString(deviceIdValue) != null
             }
+        )
+    }
+
+    @Test
+    fun `constructor does not read from PaymentConfiguration`() {
+        PaymentConfiguration.clearInstance()
+        // Would crash if it tries to read from the uninitialized PaymentConfiguration
+        DefaultEventReporter(
+            EventReporter.Mode.Complete,
+            sessionId,
+            ApplicationProvider.getApplicationContext()
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of reading publishable key from `PaymentConfiguration` when `DefaultEventReporter` is initialized (which happens when `FlowController` is created, and could be before the publishable key is retrieved from the server), use a provider to read its value only when it's actually used.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes crash if the publishable key is not set before `FlowController` is instantiated.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified