### PR TITLE
[SDK daggerization] `PaymentSheetViewModel`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4467,6 +4467,14 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResu
 	public abstract fun onPaymentSheetResult (Lcom/stripe/android/paymentsheet/PaymentSheetResult;)V
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel_Factory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/repositories/PaymentMethodsRepository;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/GooglePayRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/PaymentController;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+}
+
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
@@ -4478,6 +4486,11 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 public final class com/stripe/android/paymentsheet/injection/DaggerFlowControllerComponent : com/stripe/android/paymentsheet/injection/FlowControllerComponent {
 	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/FlowControllerComponent$Builder;
 	public fun getFlowController ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+}
+
+public final class com/stripe/android/paymentsheet/injection/DaggerPaymentSheetViewModelComponent : com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent {
+	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent$Builder;
+	public fun getViewModel ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_ProvideEventReporterFactory : dagger/internal/Factory {
@@ -4542,6 +4555,94 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideViewModel (Lcom/stripe/android/paymentsheet/injection/FlowControllerModule;Landroidx/lifecycle/ViewModelStoreOwner;)Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideApiRequestOptionsFactory;
+	public fun get ()Lcom/stripe/android/networking/ApiRequest$Options;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideApiRequestOptions (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ldagger/Lazy;)Lcom/stripe/android/networking/ApiRequest$Options;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideGooglePayRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideGooglePayRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/GooglePayRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideGooglePayRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;)Lcom/stripe/android/paymentsheet/GooglePayRepository;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideLoggerFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideLoggerFactory;
+	public fun get ()Lcom/stripe/android/Logger;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideLogger (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lcom/stripe/android/Logger;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentConfigurationFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentConfigurationFactory;
+	public fun get ()Lcom/stripe/android/PaymentConfiguration;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentConfiguration (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;)Lcom/stripe/android/PaymentConfiguration;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentFlowResultProcessorFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentFlowResultProcessorFactory;
+	public fun get ()Lcom/stripe/android/payments/PaymentFlowResultProcessor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentFlowResultProcessor (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Ldagger/Lazy;Lcom/stripe/android/networking/StripeApiRepository;)Lcom/stripe/android/payments/PaymentFlowResultProcessor;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentMethodsApiRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePaymentMethodsApiRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/repositories/PaymentMethodsRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentMethodsApiRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;)Lcom/stripe/android/paymentsheet/repositories/PaymentMethodsRepository;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePrefsRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePrefsRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PrefsRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePrefsRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/GooglePayRepository;)Lcom/stripe/android/paymentsheet/PrefsRepository;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripeApiRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripeApiRepositoryFactory;
+	public fun get ()Lcom/stripe/android/networking/StripeApiRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeApiRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;Ldagger/Lazy;)Lcom/stripe/android/networking/StripeApiRepository;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripeIntentRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripeIntentRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeIntentRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;)Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripePaymentControllerFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideStripePaymentControllerFactory;
+	public fun get ()Lcom/stripe/android/PaymentController;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripePaymentController (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/app/Application;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;)Lcom/stripe/android/PaymentController;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideWorkContextFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideWorkContextFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/coroutines/CoroutineContext;
+	public static fun provideWorkContext (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lkotlin/coroutines/CoroutineContext;
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentOption {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4557,6 +4557,9 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public static fun provideViewModel (Lcom/stripe/android/paymentsheet/injection/FlowControllerModule;Landroidx/lifecycle/ViewModelStoreOwner;)Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
 }
 
+public abstract interface annotation class com/stripe/android/paymentsheet/injection/IOContext : java/lang/annotation/Annotation {
+}
+
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)V
 	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideApiRequestOptionsFactory;

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -32,7 +32,7 @@ import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetViewModelComponent
-import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
+import com.stripe.android.paymentsheet.injection.IOContext
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -48,7 +48,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -81,7 +80,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private val googlePayRepository: GooglePayRepository,
     prefsRepository: PrefsRepository,
     private val logger: Logger,
-    @Named(PaymentSheetViewModelModule.WORK_CONTEXT) workContext: CoroutineContext,
+    @IOContext workContext: CoroutineContext,
     private val paymentController: PaymentController
 ) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     application = application,

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import android.app.Application
+import androidx.activity.result.ActivityResultCaller
 import androidx.annotation.IntegerRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
@@ -11,7 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.Logger
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.PaymentController
 import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIConnectionException
@@ -26,29 +27,29 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentFlowResultProcessor
-import com.stripe.android.payments.PaymentIntentFlowResultProcessor
-import com.stripe.android.payments.SetupIntentFlowResultProcessor
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetViewModelComponent
+import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.repositories.PaymentMethodsApiRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import kotlinx.coroutines.Dispatchers
+import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -66,17 +67,22 @@ internal fun PaymentSheetViewState.convert(): PrimaryButton.State {
     }
 }
 
-internal class PaymentSheetViewModel internal constructor(
+@Singleton
+internal class PaymentSheetViewModel @Inject internal constructor(
+    // Properties provided through PaymentSheetViewModelComponent.Builder
+    application: Application,
+    internal val args: PaymentSheetContract.Args,
+    private val eventReporter: EventReporter,
+    // Properties provided through injection
+    private val apiRequestOptions: ApiRequest.Options,
     private val stripeIntentRepository: StripeIntentRepository,
     private val paymentMethodsRepository: PaymentMethodsRepository,
-    private val paymentFlowResultProcessor: PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>,
+    private val paymentFlowResultProcessor: dagger.Lazy<PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>>,
     private val googlePayRepository: GooglePayRepository,
     prefsRepository: PrefsRepository,
-    private val eventReporter: EventReporter,
-    internal val args: PaymentSheetContract.Args,
-    private val logger: Logger = Logger.noop(),
-    workContext: CoroutineContext,
-    application: Application
+    private val logger: Logger,
+    @Named(PaymentSheetViewModelModule.WORK_CONTEXT) workContext: CoroutineContext,
+    private val paymentController: PaymentController
 ) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     application = application,
     config = args.config,
@@ -281,6 +287,28 @@ internal class PaymentSheetViewModel internal constructor(
         }
     }
 
+    suspend fun confirmStripeIntent(
+        authActivityStarterHost: AuthActivityStarterHost,
+        confirmStripeIntentParams: ConfirmStripeIntentParams
+    ) {
+        paymentController.startConfirmAndAuth(
+            authActivityStarterHost,
+            confirmStripeIntentParams,
+            apiRequestOptions
+        )
+    }
+
+    fun registerFromActivity(activityResultCaller: ActivityResultCaller) {
+        paymentController.registerLaunchersWithActivityResultCaller(
+            activityResultCaller,
+            ::onPaymentFlowResult
+        )
+    }
+
+    fun unregisterFromActivity() {
+        paymentController.unregisterLaunchers()
+    }
+
     private fun confirmPaymentSelection(paymentSelection: PaymentSelection?) {
         when (paymentSelection) {
             is PaymentSelection.Saved -> {
@@ -366,7 +394,7 @@ internal class PaymentSheetViewModel internal constructor(
         viewModelScope.launch {
             val result = runCatching {
                 withContext(workContext) {
-                    paymentFlowResultProcessor.processResult(
+                    paymentFlowResultProcessor.get().processResult(
                         paymentFlowResult
                     )
                 }
@@ -418,83 +446,25 @@ internal class PaymentSheetViewModel internal constructor(
     internal class Factory(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> PaymentSheetContract.Args,
+        private val eventReporterSupplier: (() -> EventReporter)? = null
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            val application = applicationSupplier()
-            val config = PaymentConfiguration.getInstance(application)
-            val publishableKey = config.publishableKey
-            val stripeAccountId = config.stripeAccountId
-            val stripeRepository = StripeApiRepository(
-                application,
-                { publishableKey }
-            )
-
-            val starterArgs = starterArgsSupplier()
-
-            val googlePayRepository =
-                starterArgs.config?.googlePay?.environment?.let { environment ->
-                    DefaultGooglePayRepository(
-                        application,
-                        environment
-                    )
-                } ?: GooglePayRepository.Disabled
-
-            val prefsRepository = starterArgs.config?.customer?.let { (id) ->
-                DefaultPrefsRepository(
-                    application,
-                    customerId = id,
-                    isGooglePayReady = { googlePayRepository.isReady().first() },
-                    workContext = Dispatchers.IO
+            return DaggerPaymentSheetViewModelComponent.builder()
+                .application(applicationSupplier())
+                .starterArgs(starterArgsSupplier())
+                .eventReporter(
+                    eventReporterSupplier?.let {
+                        it()
+                    } ?: run {
+                        DefaultEventReporter(
+                            mode = EventReporter.Mode.Complete,
+                            starterArgsSupplier().sessionId,
+                            applicationSupplier()
+                        )
+                    }
                 )
-            } ?: PrefsRepository.Noop()
-
-            val stripeIntentRepository = StripeIntentRepository.Api(
-                stripeRepository = stripeRepository,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
-                workContext = Dispatchers.IO
-            )
-
-            val paymentMethodsRepository = PaymentMethodsApiRepository(
-                stripeRepository = stripeRepository,
-                publishableKey = publishableKey,
-                stripeAccountId = stripeAccountId,
-                workContext = Dispatchers.IO
-            )
-
-            val paymentFlowResultProcessor =
-                when (starterArgs.clientSecret) {
-                    is PaymentIntentClientSecret -> PaymentIntentFlowResultProcessor(
-                        application,
-                        { publishableKey },
-                        stripeRepository,
-                        enableLogging = true,
-                        Dispatchers.IO
-                    )
-                    is SetupIntentClientSecret -> SetupIntentFlowResultProcessor(
-                        application,
-                        { publishableKey },
-                        stripeRepository,
-                        enableLogging = true,
-                        Dispatchers.IO
-                    )
-                }
-
-            return PaymentSheetViewModel(
-                stripeIntentRepository,
-                paymentMethodsRepository,
-                paymentFlowResultProcessor,
-                googlePayRepository,
-                prefsRepository,
-                DefaultEventReporter(
-                    mode = EventReporter.Mode.Complete,
-                    starterArgs.sessionId,
-                    application
-                ),
-                starterArgs,
-                logger = Logger.noop(),
-                workContext = Dispatchers.IO,
-                application = application
-            ) as T
+                .build()
+                .viewModel as T
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import com.stripe.android.paymentsheet.PaymentSheetContract
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(modules = [PaymentSheetViewModelModule::class])
+internal interface PaymentSheetViewModelComponent {
+    val viewModel: PaymentSheetViewModel
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun starterArgs(starterArgs: PaymentSheetContract.Args): Builder
+
+        @BindsInstance
+        fun eventReporter(eventReporter: EventReporter): Builder
+
+        fun build(): PaymentSheetViewModelComponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Singleton
@@ -27,3 +28,9 @@ internal interface PaymentSheetViewModelComponent {
         fun build(): PaymentSheetViewModelComponent
     }
 }
+
+/**
+ * [Qualifier] for coroutine context used for IO.
+ */
+@Qualifier
+annotation class IOContext

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -1,0 +1,187 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import com.stripe.android.Logger
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.PaymentController
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.StripePaymentController
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.payments.PaymentFlowResultProcessor
+import com.stripe.android.payments.PaymentIntentFlowResultProcessor
+import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.paymentsheet.DefaultGooglePayRepository
+import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.GooglePayRepository
+import com.stripe.android.paymentsheet.PaymentSheetContract
+import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
+import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsApiRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodsRepository
+import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import javax.inject.Named
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal class PaymentSheetViewModelModule {
+    /**
+     * Provides a non-singleton PaymentConfiguration.
+     *
+     * Needs to be recalculated whenever needed to allow client to set the publishableKey and
+     * stripeAccountId in PaymentConfiguration any time before configuring the FlowController
+     * through configureWithPaymentIntent or configureWithSetupIntent.
+     *
+     * Should always be injected with [Lazy] or [Provider].
+     */
+    @Provides
+    fun providePaymentConfiguration(application: Application): PaymentConfiguration {
+        return PaymentConfiguration.getInstance(application)
+    }
+
+    // Below are all Singleton instance to be injected into PaymentSheetViewModel
+
+    @Provides
+    @Singleton
+    fun provideApiRequestOptions(
+        lazyPaymentConfiguration: Lazy<PaymentConfiguration>
+    ) = ApiRequest.Options(
+        apiKey = lazyPaymentConfiguration.get().publishableKey,
+        stripeAccount = lazyPaymentConfiguration.get().stripeAccountId
+    )
+
+    @Provides
+    @Singleton
+    fun provideStripeApiRepository(
+        application: Application,
+        lazyPaymentConfiguration: Lazy<PaymentConfiguration>
+    ) = StripeApiRepository(
+        application,
+        { lazyPaymentConfiguration.get().publishableKey }
+    )
+
+    @Provides
+    @Singleton
+    fun provideStripeIntentRepository(
+        stripeApiRepository: StripeApiRepository,
+        lazyPaymentConfig: Lazy<PaymentConfiguration>
+    ): StripeIntentRepository {
+        return StripeIntentRepository.Api(
+            stripeRepository = stripeApiRepository,
+            requestOptions = ApiRequest.Options(
+                lazyPaymentConfig.get().publishableKey,
+                lazyPaymentConfig.get().stripeAccountId
+            ),
+            workContext = Dispatchers.IO
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun providePaymentMethodsApiRepository(
+        stripeApiRepository: StripeApiRepository,
+        lazyPaymentConfig: Lazy<PaymentConfiguration>
+    ): PaymentMethodsRepository {
+        return PaymentMethodsApiRepository(
+            stripeRepository = stripeApiRepository,
+            publishableKey = lazyPaymentConfig.get().publishableKey,
+            stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+            workContext = Dispatchers.IO
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun providePaymentFlowResultProcessor(
+        application: Application,
+        starterArgs: PaymentSheetContract.Args,
+        lazyPaymentConfig: Lazy<PaymentConfiguration>,
+        stripeApiRepository: StripeApiRepository,
+    ): PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>> {
+        return when (starterArgs.clientSecret) {
+            is PaymentIntentClientSecret -> PaymentIntentFlowResultProcessor(
+                application,
+                { lazyPaymentConfig.get().publishableKey },
+                stripeApiRepository,
+                enableLogging = true,
+                Dispatchers.IO
+            )
+            is SetupIntentClientSecret -> SetupIntentFlowResultProcessor(
+                application,
+                { lazyPaymentConfig.get().publishableKey },
+                stripeApiRepository,
+                enableLogging = true,
+                Dispatchers.IO
+            )
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideGooglePayRepository(
+        application: Application,
+        starterArgs: PaymentSheetContract.Args
+    ): GooglePayRepository {
+        return starterArgs.config?.googlePay?.environment?.let { environment ->
+            DefaultGooglePayRepository(
+                application,
+                environment
+            )
+        } ?: GooglePayRepository.Disabled
+    }
+
+    @Provides
+    @Singleton
+    fun providePrefsRepository(
+        application: Application,
+        starterArgs: PaymentSheetContract.Args,
+        googlePayRepository: GooglePayRepository
+    ): PrefsRepository {
+        return starterArgs.config?.customer?.let { (id) ->
+            DefaultPrefsRepository(
+                application,
+                customerId = id,
+                isGooglePayReady = { googlePayRepository.isReady().first() },
+                workContext = Dispatchers.IO
+            )
+        } ?: PrefsRepository.Noop()
+    }
+
+    // TODO: Replace with an actual logger
+    @Provides
+    @Singleton
+    fun provideLogger() = Logger.noop()
+
+    @Provides
+    @Singleton
+    @Named(WORK_CONTEXT)
+    fun provideWorkContext(): CoroutineContext = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    fun provideStripePaymentController(
+        application: Application,
+        stripeApiRepository: StripeApiRepository,
+        lazyPaymentConfiguration: Lazy<PaymentConfiguration>,
+    ): PaymentController {
+        return StripePaymentController(
+            application,
+            { lazyPaymentConfiguration.get().publishableKey },
+            stripeApiRepository,
+            enableLogging = true
+        )
+    }
+
+    companion object {
+        const val WORK_CONTEXT = "WORK_CONTEXT"
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -27,7 +27,6 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
@@ -162,8 +161,7 @@ internal class PaymentSheetViewModelModule {
     fun provideLogger() = Logger.noop()
 
     @Provides
-    @Singleton
-    @Named(WORK_CONTEXT)
+    @IOContext
     fun provideWorkContext(): CoroutineContext = Dispatchers.IO
 
     @Provides
@@ -179,9 +177,5 @@ internal class PaymentSheetViewModelModule {
             stripeApiRepository,
             enableLogging = true
         )
-    }
-
-    companion object {
-        const val WORK_CONTEXT = "WORK_CONTEXT"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -9,10 +9,12 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.StripePaymentController
 import com.stripe.android.databinding.PrimaryButtonBinding
 import com.stripe.android.databinding.StripeGooglePayButtonBinding
 import com.stripe.android.googlepaylauncher.GooglePayLauncherResult
@@ -23,6 +25,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentFlowResultProcessor
@@ -685,15 +688,24 @@ internal class PaymentSheetActivityTest {
         whenever(paymentFlowResultProcessor.processResult(any())).thenReturn(paymentIntentResult)
 
         PaymentSheetViewModel(
-            stripeIntentRepository = StripeIntentRepository.Static(paymentIntent),
-            paymentMethodsRepository = FakePaymentMethodsRepository(paymentMethods),
-            paymentFlowResultProcessor = paymentFlowResultProcessor,
-            googlePayRepository = googlePayRepository,
-            prefsRepository = FakePrefsRepository(),
-            eventReporter = eventReporter,
-            args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
-            workContext = testDispatcher,
-            application = ApplicationProvider.getApplicationContext()
+            ApplicationProvider.getApplicationContext(),
+            PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
+            eventReporter,
+            ApiRequest.Options(
+                apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            StripeIntentRepository.Static(paymentIntent),
+            FakePaymentMethodsRepository(paymentMethods),
+            { paymentFlowResultProcessor },
+            googlePayRepository,
+            FakePrefsRepository(),
+            Logger.noop(),
+            testDispatcher,
+            StripePaymentController(
+                ApplicationProvider.getApplicationContext(),
+                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                mock()
+            )
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.common.api.Status
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.Logger
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.googlepaylauncher.GooglePayLauncherResult
@@ -653,15 +654,20 @@ internal class PaymentSheetViewModelTest {
         )
     ): PaymentSheetViewModel {
         return PaymentSheetViewModel(
-            stripeIntentRepository = stripeIntentRepository,
-            paymentMethodsRepository = paymentMethodsRepository,
-            paymentFlowResultProcessor,
+            application,
+            args,
+            eventReporter,
+            ApiRequest.Options(
+                apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            ),
+            stripeIntentRepository,
+            paymentMethodsRepository,
+            { paymentFlowResultProcessor },
             googlePayRepository,
             prefsRepository,
-            eventReporter,
-            args,
-            workContext = testDispatcher,
-            application = application
+            Logger.noop(),
+            testDispatcher,
+            mock()
         )
     }
 
@@ -676,7 +682,8 @@ internal class PaymentSheetViewModelTest {
 
     private companion object {
         private const val CLIENT_SECRET = PaymentSheetFixtures.CLIENT_SECRET
-        private val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
+        private val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP =
+            PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
         private val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
         private val ARGS_WITHOUT_CUSTOMER = PaymentSheetFixtures.ARGS_WITHOUT_CUSTOMER
 


### PR DESCRIPTION
# Summary
Move dependency creation from `PaymentSheetViewModel` into `PaymentSheetViewModelComponent`, provided through `PaymentSheetViewModelModule`

Cleaned up `PaymentSheetActivity` by moving all non-UI deps into `PaymentSheetViewModel`, updated `PaymentSheetViewModel.Factory` - instead of creating it through constructor, creates one with dagger.


# Motivation
This is part of the plan to fully daggerize Payment SDK and clean up unnecessary factory/instance creations, see details in [this](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BMGwAIZjjRIeyHfmUjNhz4UpAg-Y8OUkag2eU9iPwUhUaVKU) internal doc.

Specifically, this change is one of the steps to daggerize `StripePaymentController`, which is currently created from 
- [x] [FlowControllerFactory](https://github.com/stripe/stripe-android/blob/bcfcd70a5b1fd3972a94f914c25b4e3642baf377/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt#L75) - daggerized in #3809
- [ ] [Stripe](https://github.com/stripe/stripe-android/blob/bcfcd70a5b1fd3972a94f914c25b4e3642baf377/payments-core/src/main/java/com/stripe/android/Stripe.kt#L116)
- [x] [PaymentSheetActivity](https://github.com/stripe/stripe-android/blob/bcfcd70a5b1fd3972a94f914c25b4e3642baf377/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt#L140) - daggerized in this PR

All `StripePaymentController` dep initialization will be moved to a standalone `@Module` and be shared by the above three hosts.




# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified - verified with PaymentSheet example app