### PR TITLE
Fix coroutine usage in Stripe3DS2Authenticator

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
@@ -24,9 +24,7 @@ import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.Stripe3ds2ActivityStarterHost
 import com.stripe.android.stripe3ds2.transaction.Transaction
 import com.stripe.android.view.AuthActivityStarter
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.security.cert.CertificateException
 import kotlin.coroutines.CoroutineContext
@@ -135,7 +133,7 @@ internal class Stripe3DS2Authenticator(
             transaction.sdkTransactionId
         )
 
-        CoroutineScope(workContext).launch {
+        withContext(workContext) {
             val areqParams = transaction.createAuthenticationRequestParameters()
 
             val timeout = stripe3ds2Config.timeout


### PR DESCRIPTION
Switch context instead of launching a new coroutine