### PR TITLE
Cleanup ChallengeProgressActivityStarter usage

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -4,7 +4,6 @@ import com.stripe.android.Logger
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.PaymentRelayStarter
-import com.stripe.android.StripePaymentController
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
@@ -82,7 +81,6 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor()
             uiContext: CoroutineContext,
             threeDs2Service: StripeThreeDs2Service,
             messageVersionRegistry: MessageVersionRegistry,
-            challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
             stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
             stripe3ds2ChallengeLauncherFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter
         ) = DaggerAuthenticationComponent.builder().authenticationModule(
@@ -98,7 +96,6 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor()
                 uiContext,
                 threeDs2Service,
                 messageVersionRegistry,
-                challengeProgressActivityStarter,
                 stripe3ds2Config,
                 stripe3ds2ChallengeLauncherFactory
             )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.payments.core.authentication
 
+import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.PaymentRelayStarter
@@ -16,11 +17,14 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.DefaultStripeChallengeStatusReceiver
 import com.stripe.android.payments.Stripe3ds2CompletionStarter
+import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
 import com.stripe.android.stripe3ds2.transaction.ChallengeParameters
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.stripe3ds2.transaction.Stripe3ds2ActivityStarterHost
 import com.stripe.android.stripe3ds2.transaction.Transaction
+import com.stripe.android.stripe3ds2.views.ChallengeProgressActivity
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -40,11 +44,11 @@ internal class Stripe3DS2Authenticator(
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val threeDs2Service: StripeThreeDs2Service,
     private val messageVersionRegistry: MessageVersionRegistry,
-    private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
     private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
     private val stripe3ds2CompletionStarterFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter,
     private val workContext: CoroutineContext,
-    private val uiContext: CoroutineContext
+    private val uiContext: CoroutineContext,
+    private val challengeProgressActivityStarter: ChallengeProgressActivityStarter = DefaultChallengeProgressActivityStarter()
 ) : IntentAuthenticator {
 
     override suspend fun authenticate(
@@ -341,6 +345,34 @@ internal class Stripe3DS2Authenticator(
                     workContext = workContext
                 ),
                 maxTimeout
+            )
+        }
+    }
+
+    internal fun interface ChallengeProgressActivityStarter {
+        fun start(
+            context: Context,
+            directoryServerName: String,
+            cancelable: Boolean,
+            uiCustomization: StripeUiCustomization,
+            sdkTransactionId: SdkTransactionId
+        )
+    }
+
+    internal class DefaultChallengeProgressActivityStarter : ChallengeProgressActivityStarter {
+        override fun start(
+            context: Context,
+            directoryServerName: String,
+            cancelable: Boolean,
+            uiCustomization: StripeUiCustomization,
+            sdkTransactionId: SdkTransactionId
+        ) {
+            ChallengeProgressActivity.show(
+                context,
+                directoryServerName,
+                cancelable,
+                uiCustomization,
+                sdkTransactionId
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -4,7 +4,6 @@ import com.stripe.android.Logger
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.PaymentRelayStarter
-import com.stripe.android.StripePaymentController
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
@@ -39,7 +38,6 @@ internal class AuthenticationModule(
     private val uiContext: CoroutineContext,
     private val threeDs2Service: StripeThreeDs2Service,
     private val messageVersionRegistry: MessageVersionRegistry,
-    private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter,
     private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
     private val stripe3ds2CompletionStarterFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter,
 ) {
@@ -75,7 +73,6 @@ internal class AuthenticationModule(
             analyticsRequestFactory,
             threeDs2Service,
             messageVersionRegistry,
-            challengeProgressActivityStarter,
             stripe3ds2Config,
             stripe3ds2CompletionStarterFactory,
             workContext,

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -65,8 +65,6 @@ internal class StripePaymentControllerTest {
             .thenReturn(sdkTransactionId)
     }
     private val analyticsRequestExecutor: AnalyticsRequestExecutor = mock()
-    private val challengeProgressActivityStarter: StripePaymentController.ChallengeProgressActivityStarter =
-        mock()
     private val alipayRepository = mock<AlipayRepository>()
     private val stripeRepository = FakeStripeRepository()
 
@@ -265,7 +263,6 @@ internal class StripePaymentControllerTest {
             threeDs2Service,
             analyticsRequestExecutor,
             analyticsRequestFactory,
-            challengeProgressActivityStarter,
             alipayRepository,
             workContext = testDispatcher,
             uiContext = testDispatcher

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -66,7 +66,7 @@ class Stripe3DS2AuthenticatorTest {
     private val threeDs2Service = mock<StripeThreeDs2Service>()
     private val messageVersionRegistry = MessageVersionRegistry()
     private val challengeProgressActivityStarter =
-        mock<StripePaymentController.ChallengeProgressActivityStarter>()
+        mock<Stripe3DS2Authenticator.ChallengeProgressActivityStarter>()
     private val stripe3ds2Config = PaymentAuthConfig.Stripe3ds2Config.Builder()
         .setTimeout(5)
         .build()
@@ -86,11 +86,11 @@ class Stripe3DS2AuthenticatorTest {
         analyticsRequestFactory,
         threeDs2Service,
         messageVersionRegistry,
-        challengeProgressActivityStarter,
         stripe3ds2Config,
         { _, _ -> mock() },
         testDispatcher,
-        testDispatcher
+        testDispatcher,
+        challengeProgressActivityStarter
     )
 
     @Before


### PR DESCRIPTION


# Summary
Move `ChallengeProgressActivityStarter` and implementation out of
`StripePaymentController` to `Stripe3DS2Authenticator`. It is only used
in `Stripe3DS2Authenticator`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

