### PR TITLE
[SDK daggerization] Register `IntentAuthenticator`s  with multibinding

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4253,55 +4253,61 @@ public abstract class com/stripe/android/payments/PaymentFlowResult {
 }
 
 public final class com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
+	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;Ljava/util/Map;)Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
 }
 
-public final class com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry_MembersInjector : dagger/MembersInjector {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
-	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;)V
-	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectNoOpIntentAuthenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)V
-	public static fun injectStripe3DS2Authenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;)V
-	public static fun injectWebIntentAuthenticator (Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;)V
-}
-
-public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideNoOpAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideNoOpAuthenticator$payments_core_releaseFactory;
+public final class com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideNoOpAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;)Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;
 }
 
-public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory;
-	public fun get ()Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;
+public final class com/stripe/android/payments/core/authentication/OxxoAuthenticator_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideStripe3DSAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/Stripe3DS2Authenticator;
+	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
 }
 
-public final class com/stripe/android/payments/core/injection/AuthenticationModule_ProvideWebAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_ProvideWebAuthenticator$payments_core_releaseFactory;
+public final class com/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideWebAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
-	public static fun builder ()Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
+	public static fun builder ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry;
 }
 
-public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder {
-	public fun authenticationModule (Lcom/stripe/android/payments/core/injection/AuthenticationModule;)Lcom/stripe/android/payments/core/injection/DaggerAuthenticationComponent$Builder;
-	public fun build ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent;
+public abstract interface annotation class com/stripe/android/payments/core/injection/IOContext : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/stripe/android/payments/core/injection/IntentAuthenticatorKey : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class com/stripe/android/payments/core/injection/IntentAuthenticatorMap : java/lang/annotation/Annotation {
+}
+
+public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/IntentAuthenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripe3DSAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;Landroid/content/Context;ZLcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/IntentAuthenticator;
+}
+
+public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {
 }
 
 public abstract interface class com/stripe/android/paymentsheet/GooglePayRepository {
@@ -4555,9 +4561,6 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideViewModel (Lcom/stripe/android/paymentsheet/injection/FlowControllerModule;Landroidx/lifecycle/ViewModelStoreOwner;)Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
-}
-
-public abstract interface annotation class com/stripe/android/paymentsheet/injection/IOContext : java/lang/annotation/Annotation {
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.payments.core.authentication
 
-import com.stripe.android.Logger
-import com.stripe.android.PaymentAuthConfig
+import android.content.Context
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.model.StripeIntent
@@ -9,10 +8,8 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.Stripe3ds2CompletionStarter
-import com.stripe.android.payments.core.injection.AuthenticationModule
 import com.stripe.android.payments.core.injection.DaggerAuthenticationComponent
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
-import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.payments.core.injection.IntentAuthenticatorMap
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -21,47 +18,23 @@ import kotlin.coroutines.CoroutineContext
  * Default registry to provide look ups for [IntentAuthenticator].
  * Should be only accessed through [DefaultIntentAuthenticatorRegistry.createInstance].
  */
-internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor() :
-    IntentAuthenticatorRegistry {
-
-    // default authenticators always packaged with the SDK
-    // TODO(ccen) register a singleton instance of each authenticator with registration API
-    @Inject
-    lateinit var webIntentAuthenticator: WebIntentAuthenticator
-
-    @Inject
-    lateinit var noOpIntentAuthenticator: NoOpIntentAuthenticator
-
-    // authenticators requiring a 3p SDK
-    // TODO(ccen) move them to a dedicated module
-    @Inject
-    lateinit var stripe3DS2Authenticator: Stripe3DS2Authenticator
+internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
+    private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
+    @IntentAuthenticatorMap
+    private val intentAuthenticatorMap:
+        Map<Class<out StripeIntent.NextActionData>, @JvmSuppressWildcards IntentAuthenticator>
+) : IntentAuthenticatorRegistry {
 
     override fun getAuthenticator(stripeIntent: StripeIntent): IntentAuthenticator {
         if (!stripeIntent.requiresAction()) {
             return noOpIntentAuthenticator
         }
 
-        when (val nextActionData = stripeIntent.nextActionData) {
-            is StripeIntent.NextActionData.SdkData.Use3DS2 -> {
-                return stripe3DS2Authenticator
-            }
-            is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
-                // can only triggered when `use_stripe_sdk=true`
-                return webIntentAuthenticator
-            }
-            is StripeIntent.NextActionData.RedirectToUrl -> {
-                // can only triggered when `use_stripe_sdk=false`
-                return webIntentAuthenticator
-            }
-            is StripeIntent.NextActionData.AlipayRedirect -> {
-                return webIntentAuthenticator
-            }
-            is StripeIntent.NextActionData.DisplayOxxoDetails -> {
-                return webIntentAuthenticator.takeIf { nextActionData.hostedVoucherUrl != null }
-                    ?: noOpIntentAuthenticator
-            }
-            else -> return noOpIntentAuthenticator
+        return stripeIntent.nextActionData?.let {
+            intentAuthenticatorMap
+                .getOrElse(it::class.java) { noOpIntentAuthenticator }
+        } ?: run {
+            noOpIntentAuthenticator
         }
     }
 
@@ -70,35 +43,28 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor()
          * Create an instance of [IntentAuthenticatorRegistry] with dagger.
          */
         fun createInstance(
+            context: Context,
             stripeRepository: StripeRepository,
             paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
             paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
+            stripe3ds2ChallengeLauncherFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter,
             analyticsRequestExecutor: AnalyticsRequestExecutor,
             analyticsRequestFactory: AnalyticsRequestFactory,
-            logger: Logger,
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
-            threeDs2Service: StripeThreeDs2Service,
-            messageVersionRegistry: MessageVersionRegistry,
-            stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
-            stripe3ds2ChallengeLauncherFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter
-        ) = DaggerAuthenticationComponent.builder().authenticationModule(
-            AuthenticationModule(
-                stripeRepository,
-                paymentRelayStarterFactory,
-                paymentBrowserAuthStarterFactory,
-                analyticsRequestExecutor,
-                analyticsRequestFactory,
-                logger,
-                enableLogging,
-                workContext,
-                uiContext,
-                threeDs2Service,
-                messageVersionRegistry,
-                stripe3ds2Config,
-                stripe3ds2ChallengeLauncherFactory
-            )
-        ).build().registry
+        ) = DaggerAuthenticationComponent.builder()
+            .context(context)
+            .stripeRepository(stripeRepository)
+            .paymentRelayStarterFactory(paymentRelayStarterFactory)
+            .paymentBrowserAuthStarterFactory(paymentBrowserAuthStarterFactory)
+            .stripe3ds2ChallengeLauncherFactory(stripe3ds2ChallengeLauncherFactory)
+            .analyticsRequestExecutor(analyticsRequestExecutor)
+            .analyticsRequestFactory(analyticsRequestFactory)
+            .enableLogging(enableLogging)
+            .workContext(workContext)
+            .uiContext(uiContext)
+            .build()
+            .registry
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticatorRegistry.kt
@@ -5,12 +5,10 @@ import com.stripe.android.model.StripeIntent
 /**
  * Registry to map [StripeIntent] to the corresponding [IntentAuthenticator] to handle its next_action
  */
-internal interface IntentAuthenticatorRegistry {
+internal fun interface IntentAuthenticatorRegistry {
 
     /**
      * Returns the correct [IntentAuthenticator] to handle the [StripeIntent].
      */
     fun getAuthenticator(stripeIntent: StripeIntent): IntentAuthenticator
-
-    // TODO(ccen): Add registration API
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -4,11 +4,14 @@ import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.view.AuthActivityStarterHost
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * [IntentAuthenticator] implementation to perform no-op, just return to client's host.
  */
-internal class NoOpIntentAuthenticator(
+@Singleton
+internal class NoOpIntentAuthenticator @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
 ) : IntentAuthenticator {
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.payments.core.authentication
+
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarterHost
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [IntentAuthenticator] for [NextActionData.DisplayOxxoDetails], redirects to
+ * [WebIntentAuthenticator] or [NoOpIntentAuthenticator] based on whether if there is a
+ * hostedVoucherUrl set.
+ */
+@Singleton
+internal class OxxoAuthenticator @Inject constructor(
+    private val webIntentAuthenticator: WebIntentAuthenticator,
+    private val noOpIntentAuthenticator: NoOpIntentAuthenticator
+) : IntentAuthenticator {
+    override suspend fun authenticate(
+        host: AuthActivityStarterHost,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    ) {
+        (stripeIntent.nextActionData as NextActionData.DisplayOxxoDetails).let { oxxoDetailsData ->
+            if (oxxoDetailsData.hostedVoucherUrl == null) {
+                noOpIntentAuthenticator.authenticate(
+                    host,
+                    stripeIntent,
+                    threeDs1ReturnUrl,
+                    requestOptions
+                )
+            } else {
+                webIntentAuthenticator.authenticate(
+                    host,
+                    stripeIntent,
+                    threeDs1ReturnUrl,
+                    requestOptions
+                )
+            }
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/Stripe3DS2Authenticator.kt
@@ -32,7 +32,7 @@ import java.security.cert.CertificateException
 import kotlin.coroutines.CoroutineContext
 
 /**
- * [IntentAuthenticator] authenticate through Stripe's 3ds2 SDK.
+ * [IntentAuthenticator] authenticating through Stripe's 3ds2 SDK.
  */
 internal class Stripe3DS2Authenticator(
     private val config: PaymentAuthConfig,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -9,20 +9,25 @@ import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.core.injection.AuthenticationComponent.Companion.ENABLE_LOGGING
+import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
  * [IntentAuthenticator] implementation to redirect to a URL through [PaymentBrowserAuthStarter].
  */
-internal class WebIntentAuthenticator(
+@Singleton
+internal class WebIntentAuthenticator @Inject constructor(
     private val paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
-    private val logger: Logger,
-    private val enableLogging: Boolean,
-    private val uiContext: CoroutineContext
+    @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
+    @UIContext private val uiContext: CoroutineContext
 ) : IntentAuthenticator {
 
     override suspend fun authenticate(
@@ -100,7 +105,7 @@ internal class WebIntentAuthenticator(
         shouldCancelIntentOnUserNavigation: Boolean = true
     ) = withContext(uiContext) {
         val paymentBrowserWebStarter = paymentBrowserAuthStarterFactory(host)
-        logger.debug("PaymentBrowserAuthStarter#start()")
+        Logger.getInstance(enableLogging).debug("PaymentBrowserAuthStarter#start()")
         paymentBrowserWebStarter.start(
             PaymentBrowserAuthContract.Args(
                 objectId = stripeIntent.id.orEmpty(),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationAnnotations.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationAnnotations.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.payments.core.injection
+
+import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.authentication.IntentAuthenticator
+import dagger.MapKey
+import javax.inject.Qualifier
+import kotlin.reflect.KClass
+
+/**
+ * [Qualifier] for the multibinding map between [NextActionData] and [IntentAuthenticator].
+ */
+@Qualifier
+annotation class IntentAuthenticatorMap
+
+/**
+ * [MapKey] for the [IntentAuthenticatorMap], encapsulating the [NextActionData] class type.
+ */
+@MapKey
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IntentAuthenticatorKey(val value: KClass<out NextActionData>)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -1,8 +1,19 @@
 package com.stripe.android.payments.core.injection
 
+import android.content.Context
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.Stripe3ds2CompletionStarter
 import com.stripe.android.payments.core.authentication.DefaultIntentAuthenticatorRegistry
+import com.stripe.android.view.AuthActivityStarterHost
+import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [Component] for com.stripe.android.payments.core.authentication.
@@ -12,7 +23,57 @@ import javax.inject.Singleton
  * into it.
  */
 @Singleton
-@Component(modules = [AuthenticationModule::class])
+@Component(
+    modules = [
+        AuthenticationModule::class,
+        Stripe3DSAuthenticatorModule::class
+    ]
+)
 internal interface AuthenticationComponent {
     val registry: DefaultIntentAuthenticatorRegistry
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        @BindsInstance
+        fun stripeRepository(stripeRepository: StripeRepository): Builder
+
+        @BindsInstance
+        fun paymentRelayStarterFactory(
+            paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
+        ): Builder
+
+        @BindsInstance
+        fun paymentBrowserAuthStarterFactory(
+            paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter
+        ): Builder
+
+        @BindsInstance
+        fun stripe3ds2ChallengeLauncherFactory(
+            stripe3ds2ChallengeLauncherFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter
+        ): Builder
+
+        @BindsInstance
+        fun analyticsRequestExecutor(analyticsRequestExecutor: AnalyticsRequestExecutor): Builder
+
+        @BindsInstance
+        fun analyticsRequestFactory(analyticsRequestFactory: AnalyticsRequestFactory): Builder
+
+        @BindsInstance
+        fun enableLogging(@Named(ENABLE_LOGGING) enableLogging: Boolean): Builder
+
+        @BindsInstance
+        fun workContext(@IOContext workContext: CoroutineContext): Builder
+
+        @BindsInstance
+        fun uiContext(@UIContext uiContext: CoroutineContext): Builder
+
+        fun build(): AuthenticationComponent
+    }
+
+    companion object {
+        const val ENABLE_LOGGING = "enableLogging"
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -1,82 +1,39 @@
 package com.stripe.android.payments.core.injection
 
-import com.stripe.android.Logger
-import com.stripe.android.PaymentAuthConfig
-import com.stripe.android.PaymentBrowserAuthStarter
-import com.stripe.android.PaymentRelayStarter
-import com.stripe.android.networking.AnalyticsRequestExecutor
-import com.stripe.android.networking.AnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.Stripe3ds2CompletionStarter
-import com.stripe.android.payments.core.authentication.NoOpIntentAuthenticator
-import com.stripe.android.payments.core.authentication.Stripe3DS2Authenticator
+import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.authentication.IntentAuthenticator
+import com.stripe.android.payments.core.authentication.OxxoAuthenticator
 import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
-import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
-import com.stripe.android.view.AuthActivityStarterHost
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
-import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
+import dagger.multibindings.IntoMap
 
 /**
- * [Module] for com.stripe.android.payments.core.authentication.
- *
- * All non-daggerized dependencies are passed in as constructor parameters for now, a parameter
- * will be removed when it's daggerized and introduced to the dagger graph.
+ * Provides mappings between [NextActionData] and [IntentAuthenticator] provided by payment SDK.
  */
 @Module
-internal class AuthenticationModule(
-    private val stripeRepository: StripeRepository,
-    private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
-    private val paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
-    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
-    private val analyticsRequestFactory: AnalyticsRequestFactory,
-    private val logger: Logger,
-    private val enableLogging: Boolean,
-    private val workContext: CoroutineContext,
-    private val uiContext: CoroutineContext,
-    private val threeDs2Service: StripeThreeDs2Service,
-    private val messageVersionRegistry: MessageVersionRegistry,
-    private val stripe3ds2Config: PaymentAuthConfig.Stripe3ds2Config,
-    private val stripe3ds2CompletionStarterFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter,
-) {
-    @Singleton
-    @Provides
-    internal fun provideNoOpAuthenticator(): NoOpIntentAuthenticator {
-        return NoOpIntentAuthenticator(paymentRelayStarterFactory)
-    }
+internal interface AuthenticationModule {
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS1::class)
+    fun binds3DS1Authenticator(webIntentAuthenticator: WebIntentAuthenticator): IntentAuthenticator
 
-    @Singleton
-    @Provides
-    internal fun provideWebAuthenticator(): WebIntentAuthenticator {
-        return WebIntentAuthenticator(
-            paymentBrowserAuthStarterFactory,
-            analyticsRequestExecutor,
-            analyticsRequestFactory,
-            logger,
-            enableLogging,
-            uiContext,
-        )
-    }
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.RedirectToUrl::class)
+    fun bindsRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): IntentAuthenticator
 
-    @Singleton
-    @Provides
-    internal fun provideStripe3DSAuthenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): Stripe3DS2Authenticator {
-        return Stripe3DS2Authenticator(
-            stripeRepository,
-            webIntentAuthenticator,
-            paymentRelayStarterFactory,
-            analyticsRequestExecutor,
-            analyticsRequestFactory,
-            threeDs2Service,
-            messageVersionRegistry,
-            stripe3ds2Config,
-            stripe3ds2CompletionStarterFactory,
-            workContext,
-            uiContext
-        )
-    }
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.AlipayRedirect::class)
+    fun bindsAlipayRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): IntentAuthenticator
+
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.DisplayOxxoDetails::class)
+    fun bindsOxxoAuthenticator(oxxoAuthenticator: OxxoAuthenticator): IntentAuthenticator
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/IOContext.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/IOContext.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.payments.core.injection
+
+import javax.inject.Qualifier
+
+/**
+ * [Qualifier] for coroutine context used for IO.
+ */
+@Qualifier
+annotation class IOContext

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.Stripe3ds2CompletionStarter
+import com.stripe.android.payments.core.authentication.IntentAuthenticator
+import com.stripe.android.payments.core.authentication.Stripe3DS2Authenticator
+import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import com.stripe.android.view.AuthActivityStarterHost
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provides [IntentAuthenticator] for [NextActionData.SdkData.Use3DS2].
+ * Requires 3ds2 SDK.
+ */
+@Module
+internal class Stripe3DSAuthenticatorModule {
+    @IntentAuthenticatorMap
+    @Provides
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS2::class)
+    internal fun provideStripe3DSAuthenticator(
+        context: Context,
+        @Named(AuthenticationComponent.ENABLE_LOGGING) enableLogging: Boolean,
+        stripeRepository: StripeRepository,
+        webIntentAuthenticator: WebIntentAuthenticator,
+        paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
+        analyticsRequestExecutor: AnalyticsRequestExecutor,
+        analyticsRequestFactory: AnalyticsRequestFactory,
+        stripe3ds2CompletionStarterFactory: (AuthActivityStarterHost, Int) -> Stripe3ds2CompletionStarter,
+        @IOContext workContext: CoroutineContext,
+        @UIContext uiContext: CoroutineContext
+    ): IntentAuthenticator {
+        return Stripe3DS2Authenticator(
+            PaymentAuthConfig.get(),
+            stripeRepository,
+            webIntentAuthenticator,
+            paymentRelayStarterFactory,
+            analyticsRequestExecutor,
+            analyticsRequestFactory,
+            stripe3ds2CompletionStarterFactory,
+            workContext,
+            uiContext,
+            StripeThreeDs2ServiceImpl(context, enableLogging),
+            MessageVersionRegistry(),
+            Stripe3DS2Authenticator.DefaultChallengeProgressActivityStarter()
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/UIContext.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/UIContext.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.payments.core.injection
+
+import javax.inject.Qualifier
+
+/**
+ * [Qualifier] for coroutine context used for UI.
+ */
+@Qualifier
+annotation class UIContext

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -29,10 +29,10 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentFlowResultProcessor
+import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetViewModelComponent
-import com.stripe.android.paymentsheet.injection.IOContext
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
@@ -6,7 +6,6 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import dagger.BindsInstance
 import dagger.Component
-import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Singleton
@@ -28,9 +27,3 @@ internal interface PaymentSheetViewModelComponent {
         fun build(): PaymentSheetViewModelComponent
     }
 }
-
-/**
- * [Qualifier] for coroutine context used for IO.
- */
-@Qualifier
-annotation class IOContext

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.paymentsheet.DefaultGooglePayRepository
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.GooglePayRepository

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -24,8 +24,6 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
-import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.stripe3ds2.transaction.Transaction
 import com.stripe.android.utils.ParcelUtils
@@ -56,7 +54,6 @@ import kotlin.test.Test
 @ExperimentalCoroutinesApi
 internal class StripePaymentControllerTest {
     private val activity: ComponentActivity = mock()
-    private val threeDs2Service: StripeThreeDs2Service = mock()
     private val sdkTransactionId = mock<SdkTransactionId>().also {
         whenever(it.value).thenReturn(UUID.randomUUID().toString())
     }
@@ -258,9 +255,6 @@ internal class StripePaymentControllerTest {
             { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
             stripeRepository,
             false,
-            MessageVersionRegistry(),
-            CONFIG,
-            threeDs2Service,
             analyticsRequestExecutor,
             analyticsRequestFactory,
             alipayRepository,
@@ -347,13 +341,5 @@ internal class StripePaymentControllerTest {
             apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             stripeAccount = ACCOUNT_ID
         )
-
-        private val CONFIG = PaymentAuthConfig.Builder()
-            .set3ds2Config(
-                PaymentAuthConfig.Stripe3ds2Config.Builder()
-                    .setTimeout(5)
-                    .build()
-            )
-            .build()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -67,9 +67,12 @@ class Stripe3DS2AuthenticatorTest {
     private val messageVersionRegistry = MessageVersionRegistry()
     private val challengeProgressActivityStarter =
         mock<Stripe3DS2Authenticator.ChallengeProgressActivityStarter>()
-    private val stripe3ds2Config = PaymentAuthConfig.Stripe3ds2Config.Builder()
-        .setTimeout(5)
-        .build()
+
+    private val paymentAuthConfig = PaymentAuthConfig.Builder().set3ds2Config(
+        PaymentAuthConfig.Stripe3ds2Config.Builder()
+            .setTimeout(5)
+            .build()
+    ).build()
 
     private val paymentRelayStarter = mock<PaymentRelayStarter>()
     private val relayStarterArgsArgumentCaptor: KArgumentCaptor<PaymentRelayStarter.Args> =
@@ -79,18 +82,18 @@ class Stripe3DS2AuthenticatorTest {
     private val transaction = mock<Transaction>()
 
     private val authenticator = Stripe3DS2Authenticator(
+        paymentAuthConfig,
         stripeRepository,
         webIntentAuthenticator,
         paymentRelayStarterFactory,
         analyticsRequestExecutor,
         analyticsRequestFactory,
-        threeDs2Service,
-        messageVersionRegistry,
-        stripe3ds2Config,
         { _, _ -> mock() },
         testDispatcher,
         testDispatcher,
-        challengeProgressActivityStarter
+        threeDs2Service,
+        messageVersionRegistry,
+        challengeProgressActivityStarter,
     )
 
     @Before

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.Logger
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.StripePaymentController.Companion.PAYMENT_REQUEST_CODE
 import com.stripe.android.StripePaymentController.Companion.SETUP_REQUEST_CODE
@@ -43,7 +42,6 @@ class WebIntentAuthenticatorTest {
         context,
         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
     )
-    private val logger = mock<Logger>()
 
     private val testDispatcher = TestCoroutineDispatcher()
     private val host = mock<AuthActivityStarterHost>()
@@ -58,7 +56,6 @@ class WebIntentAuthenticatorTest {
         paymentBrowserAuthStarterFactory,
         analyticsRequestExecutor,
         analyticsRequestFactory,
-        logger,
         enableLogging = false,
         testDispatcher
     )


### PR DESCRIPTION
# Summary
* Some refactor on `StripePaymentController`, it's now fully decoupled from 3ds2 deps, all 3ds2 deps lives within `Stripe3DS2Authentcator`

* Register (NextActionData, IntentAuthenticator) pairs using multibinding into `@IntentAuthenticatorMap`

* Separate the process of registering default authenticators(`WebIntentAuthenticator` and `NoOpIntentAuthenticator`) and 3p sdk authenticators(`Stripe3DS2Authenticator`)
  * Default authenticators that comes with main payment SDK are `@Inject`ed through constructor and `@Binds` into the map through `AuthenticationModule`
  * 3p sdk authenticators(currently only `Stripe3DS2Authenticator`) are `@Provided` into the map through through `Stripe3DSAuthenticatorModule`, the provides method might return a `UnsupportedAuthenticator` for later Authenticators that cannot be created through reflection


Please refer to [this](https://paper.dropbox.com/doc/diagram-Modularizing-Android-Mobile-SDK--BM1lOu1BZcqPNb3XeFFSwNhdAg-M9mrrTib7RFBVN7VimeGx#:uid=589287508011797552037558&h2=Interfaces-design) internal doc for the `IntentAuthenticator` framework design

Please refer to [this](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BLjYyeXplZZPDFGP2h74ToazAg-Y8OUkag2eU9iPwUhUaVKU) doc for daggerization details


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Complete the authenticator registry function, make it possible to create a separate `WechatPayAuthenticator`, which requires wechat pay SDK.

* Decouple `IntentAuthenticatorRegistry` from `StripePaymentController`, make it available to be plugged into `PaymentLauncher` later. (See [here](https://paper.dropbox.com/doc/2021-05-28-Android-SDK-PaymentLauncher-API-eWPQ4N7Qzb77yvqiO23j2) for `PaymentLauncher` design)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
