### PR TITLE
Locale independent totalPrice

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.Currency
+import java.util.Locale
 import kotlin.math.pow
 
 /**
@@ -27,7 +28,7 @@ object PayWithGoogleUtils {
             for (i in 0 until totalLength) {
                 builder.append('#')
             }
-            val noDecimalCurrencyFormat = DecimalFormat(builder.toString())
+            val noDecimalCurrencyFormat = DecimalFormat(builder.toString(), DecimalFormatSymbols.getInstance(Locale.ROOT))
             noDecimalCurrencyFormat.currency = currency
             noDecimalCurrencyFormat.isGroupingUsed = false
             return noDecimalCurrencyFormat.format(price)
@@ -49,9 +50,8 @@ object PayWithGoogleUtils {
         val modBreak = 10.0.pow(fractionDigits.toDouble())
         val decimalPrice = price / modBreak
 
-        // No matter the Locale, Android Pay requires a dot for the decimal separator.
-        val symbolOverride = DecimalFormatSymbols()
-        symbolOverride.decimalSeparator = '.'
+        // No matter the Locale, Android Pay requires a dot for the decimal separator, and Arabic numbers.
+        val symbolOverride = DecimalFormatSymbols.getInstance(Locale.ROOT)
         val decimalFormat = DecimalFormat(builder.toString(), symbolOverride)
         decimalFormat.currency = currency
         decimalFormat.isGroupingUsed = false

--- a/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
@@ -28,7 +28,8 @@ object PayWithGoogleUtils {
             for (i in 0 until totalLength) {
                 builder.append('#')
             }
-            val noDecimalCurrencyFormat = DecimalFormat(builder.toString(), DecimalFormatSymbols.getInstance(Locale.ROOT))
+            val noDecimalCurrencyFormat =
+                DecimalFormat(builder.toString(), DecimalFormatSymbols.getInstance(Locale.ROOT))
             noDecimalCurrencyFormat.currency = currency
             noDecimalCurrencyFormat.isGroupingUsed = false
             return noDecimalCurrencyFormat.format(price)
@@ -50,7 +51,8 @@ object PayWithGoogleUtils {
         val modBreak = 10.0.pow(fractionDigits.toDouble())
         val decimalPrice = price / modBreak
 
-        // No matter the Locale, Android Pay requires a dot for the decimal separator, and Arabic numbers.
+        // No matter the Locale, Android Pay requires a dot for the decimal separator, and Arabic
+        // numbers.
         val symbolOverride = DecimalFormatSymbols.getInstance(Locale.ROOT)
         val decimalFormat = DecimalFormat(builder.toString(), symbolOverride)
         decimalFormat.currency = currency

--- a/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
@@ -53,4 +53,17 @@ class PayWithGoogleUtilsTest {
         val littlePrice = getPriceString(7, Currency.getInstance("CLP"))
         assertThat(littlePrice).isEqualTo("7")
     }
+
+    @Test
+    fun getPriceString_whenLocaleWithArabicNumerals_returnsExpectedValue() {
+        Locale.setDefault(Locale.Builder().setLanguage("ar").setRegion("AE").build())
+        val priceString = getPriceString(100, Currency.getInstance("USD"))
+        assertThat(priceString).isEqualTo("1.00")
+
+        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
+        assertThat(littlePrice).isEqualTo("0.08")
+
+        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
+        assertThat(bigPrice).isEqualTo("200000.00")
+    }
 }


### PR DESCRIPTION
# Summary
Fixes a **major issue** with Google Pay returning code 10, developer error, because `totalPrice` is being displayed in Eastern Arabic numerals when the locale is set to Arabic. This caused payment attempts to fail on multiple real devices.

# Motivation
The Google Pay API only supports Arabic numerals 0-9, not Eastern Arabic numerals ٠-٩.

Use case:
**Given** my locale is set to ar_AE,
**When** I use Stripe's `GooglePayJsonFactory.createPaymentDataRequest`,
**And** send the JSON body to the Google Pay SDK via `PaymentsClient.loadPaymentData(PaymentDataRequest.fromJson(...)`,
**Then** it should accept it without issues.
**However**, the Google Pay SDK call currently fails with error code 10, "developer error".

Example JSON that's sent to Google Pay currently and fails as per above:
```
{"apiVersion":2,"apiVersionMinor":0,"allowedPaymentMethods":[{"type":"CARD","parameters":{"allowedAuthMethods":["PAN_ONLY","CRYPTOGRAM_3DS"],"allowedCardNetworks":["AMEX","DISCOVER","MASTERCARD","VISA","JCB"]},"tokenizationSpecification":{"type":"PAYMENT_GATEWAY","parameters":{"gateway":"stripe","stripe:version":"2020-03-02","stripe:publishableKey":"..."}}}],"transactionInfo":{"currencyCode":"USD","totalPriceStatus":"FINAL","totalPrice":"٥.٠٠","checkoutOption":"COMPLETE_IMMEDIATE_PURCHASE"},"emailRequired":false,"merchantInfo":{"merchantName":"..."}}
```

# Testing
Added test: PayWithGoogleUtilsTest.getPriceString_whenLocaleWithArabicNumerals_returnsExpectedValue

Without applying the bug fix, the test will fail as below:
```
value of: getPriceString(...)
expected: 1.00
but was : ١.٠٠
Expected :1.00
Actual   :١.٠٠

at com.stripe.android.PayWithGoogleUtilsTest.getPriceString_whenLocaleWithArabicNumerals_returnsExpectedValue(PayWithGoogleUtilsTest.kt:61)
```