### PR TITLE
Remove PaymentIntent.nextAction

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -26,6 +26,8 @@
      - `metadata` has been removed to reflect that it is no longer returned to clients using a
        publishable key
      - `PaymentMethod.Card.Builder` has been removed
+- Changes to `PaymentIntent`
+    - `nextAction` property has been removed. Use `nextActionData` instead.
 - Changes to `PaymentMethodCreateParams`
      - `Ideal.Builder`, `Fpx.Builder`, and `SepaDebit.Builder` have been removed
 - Changes to `Source`

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1992,15 +1992,14 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Z
-	public final fun component13 ()Ljava/util/Map;
-	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component13 ()Lcom/stripe/android/model/PaymentMethod;
+	public final fun component14 ()Ljava/lang/String;
 	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Lcom/stripe/android/model/StripeIntent$Status;
-	public final fun component19 ()Lcom/stripe/android/model/PaymentIntent$Error;
+	public final fun component16 ()Lcom/stripe/android/model/StripeIntent$Status;
+	public final fun component18 ()Lcom/stripe/android/model/PaymentIntent$Error;
+	public final fun component19 ()Lcom/stripe/android/model/PaymentIntent$Shipping;
 	public final fun component2 ()Ljava/util/List;
-	public final fun component20 ()Lcom/stripe/android/model/PaymentIntent$Shipping;
-	public final fun component21 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public final fun component20 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/stripe/android/model/PaymentIntent$CancellationReason;
@@ -2008,8 +2007,8 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
 	public final fun component9 ()J
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;)Lcom/stripe/android/model/PaymentIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/StripeIntent$NextActionData;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
@@ -2025,7 +2024,6 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public fun getId ()Ljava/lang/String;
 	public fun getLastErrorMessage ()Ljava/lang/String;
 	public final fun getLastPaymentError ()Lcom/stripe/android/model/PaymentIntent$Error;
-	public final fun getNextAction ()Ljava/util/Map;
 	public fun getNextActionData ()Lcom/stripe/android/model/StripeIntent$NextActionData;
 	public fun getNextActionType ()Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -1,8 +1,9 @@
 package com.stripe.android.model
 
+import com.stripe.android.model.PaymentIntent.CaptureMethod
+import com.stripe.android.model.PaymentIntent.ConfirmationMethod
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 import org.json.JSONObject
 import java.util.regex.Pattern
 
@@ -97,12 +98,6 @@ data class PaymentIntent internal constructor(
      * `false` if the object exists in test mode.
      */
     override val isLiveMode: Boolean,
-
-    /**
-     * If present, this property tells you what actions you need to take in order for your
-     * customer to fulfill a payment using the provided source.
-     */
-    val nextAction: Map<String, @RawValue Any?>? = null,
 
     override val paymentMethod: PaymentMethod? = null,
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -4,7 +4,6 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeJsonUtils
-import com.stripe.android.model.StripeJsonUtils.jsonArrayToList
 import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
@@ -50,7 +49,6 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         val setupFutureUsage = StripeIntent.Usage.fromCode(
             optString(json, FIELD_SETUP_FUTURE_USAGE)
         )
-        val nextAction = StripeJsonUtils.optMap(json, FIELD_NEXT_ACTION)
         val lastPaymentError =
             json.optJSONObject(FIELD_LAST_PAYMENT_ERROR)?.let {
                 ErrorJsonParser().parse(it)
@@ -76,7 +74,6 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
             currency = currency,
             description = description,
             isLiveMode = livemode,
-            nextAction = nextAction,
             paymentMethod = paymentMethod,
             paymentMethodId = paymentMethodId,
             receiptEmail = receiptEmail,
@@ -119,7 +116,7 @@ internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
     }
 
     internal class ShippingJsonParser : ModelJsonParser<PaymentIntent.Shipping> {
-        override fun parse(json: JSONObject): PaymentIntent.Shipping? {
+        override fun parse(json: JSONObject): PaymentIntent.Shipping {
             return PaymentIntent.Shipping(
                 address = json.optJSONObject(FIELD_ADDRESS)?.let {
                     AddressJsonParser().parse(it)

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -31,7 +31,7 @@ class PaymentIntentTest {
             .isEqualTo(PaymentIntent.CaptureMethod.Automatic)
         assertThat(paymentIntent.confirmationMethod)
             .isEqualTo(PaymentIntent.ConfirmationMethod.Manual)
-        assertThat(paymentIntent.nextAction)
+        assertThat(paymentIntent.nextActionData)
             .isNotNull()
         assertThat(paymentIntent.receiptEmail)
             .isEqualTo("jenny@example.com")


### PR DESCRIPTION


# Summary
`nextAction` is a raw map - it is not parcelizable.
Use `PaymentIntent.nextActionData` instead.

# Motivation
Fix `PaymentIntent` parcelization 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
