### PR TITLE
Analyze impact on library size for each PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Diffuse output
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: peter-evans/create-or-update-comment@v1
         if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,12 +9,12 @@ jobs:
         with:
           ref: master
       - name: Build in master
-        run: ./gradlew :payments-core:assembleDebug && mv payments-core/build/outputs/aar/payments-core-debug.aar payments-core/build/outputs/aar/payments-core-debug-master.aar
+        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core/build/outputs/aar/payments-core-release-master.aar
       - name: Upload AAR
         uses: actions/upload-artifact@v1
         with:
           name: aar
-          path: payments-core/build/outputs/aar/payments-core-debug-master.aar
+          path: payments-core/build/outputs/aar/payments-core-release-master.aar
 
   # Checkout PR branch and build the APK
   build-pr:
@@ -22,12 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build from PR
-        run: ./gradlew :payments-core:assembleDebug && mv payments-core/build/outputs/aar/payments-core-debug.aar payments-core/build/outputs/aar/payments-core-debug-pr.aar
+        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core/build/outputs/aar/payments-core-release-pr.aar
       - name: Upload AAR
         uses: actions/upload-artifact@v1
         with:
           name: aar
-          path: payments-core/build/outputs/aar/payments-core-debug-pr.aar
+          path: payments-core/build/outputs/aar/payments-core-release-pr.aar
   # Execute Diffuse only when the two AARs are built successfully
   diffuse:
     needs: [build-master, build-pr]
@@ -42,8 +42,8 @@ jobs:
         id: diffuse
         uses: usefulness/diffuse-action@v1
         with:
-          old-file-path: aar/payments-core-debug-master.aar
-          new-file-path: aar/payments-core-debug-pr.aar
+          old-file-path: aar/payments-core-release-master.aar
+          new-file-path: aar/payments-core-release-pr.aar
 
       # Post comment with output
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,71 +1,73 @@
-name: Binary size diff
+name: paymentsheet-example size diff
 on: [pull_request]
-params:
-  - name: payments-core-release
-    build-target: :payments-core:assembleRelease
-    build-output: payments-core/build/outputs/aar/payments-core-release.aar
-    format: aar
 jobs:
   # Checkout master branch and build the APK
   build-master:
     runs-on: ubuntu-latest
     steps:
-      - ${{ each parameter in params }}:
-        - uses: actions/checkout@v1
-          with:
-            ref: master
-        - name: Build in master
-          run: ./gradlew ${{ parameter.build-target }} && mv ${{ parameter.build-output }} ${{ parameter.name }}-master.${{ parameter.format }}
-        - name: Upload AAR
-          uses: actions/upload-artifact@v1
-          with:
-            name: aar
-            path: ${{ parameter.name }}-master.${{ parameter.format }}
+      - uses: actions/checkout@v1
+        with:
+          ref: master
+      - name: Build in master
+        run: ./gradlew :paymentsheet-example:assembleRelease && mv paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-unsigned.apk paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-master.apk
+      - name: Upload APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: apk
+          path: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-master.apk
 
   # Checkout PR branch and build the APK
-#  build-pr:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - name: Build from PR
-#        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core-release-pr.aar
-#      - name: Upload AAR
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: aar
-#          path: payments-core-release-pr.aar
-#
-#  # Execute Diffuse only when the two AARs are built successfully
-#  diffuse:
-#    needs: [build-master, build-pr]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - name: Download AARs
-#        uses: actions/download-artifact@v1
-#        with:
-#          name: aar
-#      - name: diffuse
-#        id: diffuse
-#        uses: usefulness/diffuse-action@v1
-#        with:
-#          old-file-path: aar/payments-core-release-master.aar
-#          new-file-path: aar/payments-core-release-pr.aar
-#      # Post comment with output
-#      - uses: peter-evans/find-comment@v1
-#        id: find_comment
-#        with:
-#          issue-number: ${{ github.event.pull_request.number }}
-#          body-includes: Diffuse output
-#
-#      - uses: peter-evans/create-or-update-comment@v1
-#        if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
-#        with:
-#          body: |
-#            Diffuse output:
-#
-#            ${{ steps.diffuse.outputs.diff-gh-comment }}
-#          edit-mode: replace
-#          comment-id: ${{ steps.find_comment.outputs.comment-id }}
-#          issue-number: ${{ github.event.pull_request.number }}
-#          token: ${{ secrets.GITHUB_TOKEN }}
+  build-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build from PR
+        run: ./gradlew :paymentsheet-example:assembleRelease && mv paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-unsigned.apk paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-pr.apk
+      - name: Upload APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: apk
+          path: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-pr.apk
+
+  # Execute Diffuse only when the two APKs are built successfully
+  diffuse:
+    needs: [build-master, build-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download APKs
+        uses: actions/download-artifact@v1
+        with:
+          name: apk
+      - name: diffuse
+        id: diffuse
+        uses: usefulness/diffuse-action@v1
+        with:
+          old-file-path: apk/paymentsheet-example-release-master.apk
+          new-file-path: apk/paymentsheet-example-release-pr.apk
+
+      # Post comment with output
+
+      - uses: peter-evans/find-comment@v1
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Diffuse output
+
+      - uses: peter-evans/create-or-update-comment@v1
+        if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
+        with:
+          body: |
+            Diffuse output:
+
+            ${{ steps.diffuse.outputs.diff-gh-comment }}
+          edit-mode: replace
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload diffuse output
+        uses: actions/upload-artifact@v2
+        with:
+          name: diffuse-output
+          path: ${{ steps.diffuse.outputs.diff-file }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,5 +38,8 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: aar
-      - name: Execute Diffuse
-        run: ./diffuse diff --aar aar/payments-core-debug-master.aar aar/payments-core-debug-pr.aar
+      - name: diffuse
+        uses: usefulness/diffuse-action@v1
+        with:
+          old-file-path: aar/payments-core-debug-master.aar
+          new-file-path: aar/payments-core-debug-pr.aar

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: aar
       - name: diffuse
+        id: diffuse
         uses: usefulness/diffuse-action@v1
         with:
           old-file-path: aar/payments-core-debug-master.aar
@@ -51,7 +52,6 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Diffuse output
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: peter-evans/create-or-update-comment@v1
         if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,3 +43,23 @@ jobs:
         with:
           old-file-path: aar/payments-core-debug-master.aar
           new-file-path: aar/payments-core-debug-pr.aar
+
+      # Post comment with output
+
+      - uses: peter-evans/find-comment@v1
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Diffuse output
+
+      - uses: peter-evans/create-or-update-comment@v1
+        if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
+        with:
+          body: |
+            Diffuse output:
+
+            ${{ steps.diffuse.outputs.diff-gh-comment }}
+          edit-mode: replace
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,66 +1,71 @@
-name: payments-core size diff
+name: Binary size diff
 on: [pull_request]
+params:
+  - name: payments-core-release
+    build-target: :payments-core:assembleRelease
+    build-output: payments-core/build/outputs/aar/payments-core-release.aar
+    format: aar
 jobs:
   # Checkout master branch and build the APK
   build-master:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-        with:
-          ref: master
-      - name: Build in master
-        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core/build/outputs/aar/payments-core-release-master.aar
-      - name: Upload AAR
-        uses: actions/upload-artifact@v1
-        with:
-          name: aar
-          path: payments-core/build/outputs/aar/payments-core-release-master.aar
+      - ${{ each parameter in params }}:
+        - uses: actions/checkout@v1
+          with:
+            ref: master
+        - name: Build in master
+          run: ./gradlew ${{ parameter.build-target }} && mv ${{ parameter.build-output }} ${{ parameter.name }}-master.${{ parameter.format }}
+        - name: Upload AAR
+          uses: actions/upload-artifact@v1
+          with:
+            name: aar
+            path: ${{ parameter.name }}-master.${{ parameter.format }}
 
   # Checkout PR branch and build the APK
-  build-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Build from PR
-        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core/build/outputs/aar/payments-core-release-pr.aar
-      - name: Upload AAR
-        uses: actions/upload-artifact@v1
-        with:
-          name: aar
-          path: payments-core/build/outputs/aar/payments-core-release-pr.aar
-  # Execute Diffuse only when the two AARs are built successfully
-  diffuse:
-    needs: [build-master, build-pr]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Download AARs
-        uses: actions/download-artifact@v1
-        with:
-          name: aar
-      - name: diffuse
-        id: diffuse
-        uses: usefulness/diffuse-action@v1
-        with:
-          old-file-path: aar/payments-core-release-master.aar
-          new-file-path: aar/payments-core-release-pr.aar
-
-      # Post comment with output
-
-      - uses: peter-evans/find-comment@v1
-        id: find_comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: Diffuse output
-
-      - uses: peter-evans/create-or-update-comment@v1
-        if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
-        with:
-          body: |
-            Diffuse output:
-
-            ${{ steps.diffuse.outputs.diff-gh-comment }}
-          edit-mode: replace
-          comment-id: ${{ steps.find_comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+#  build-pr:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Build from PR
+#        run: ./gradlew :payments-core:assembleRelease && mv payments-core/build/outputs/aar/payments-core-release.aar payments-core-release-pr.aar
+#      - name: Upload AAR
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: aar
+#          path: payments-core-release-pr.aar
+#
+#  # Execute Diffuse only when the two AARs are built successfully
+#  diffuse:
+#    needs: [build-master, build-pr]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Download AARs
+#        uses: actions/download-artifact@v1
+#        with:
+#          name: aar
+#      - name: diffuse
+#        id: diffuse
+#        uses: usefulness/diffuse-action@v1
+#        with:
+#          old-file-path: aar/payments-core-release-master.aar
+#          new-file-path: aar/payments-core-release-pr.aar
+#      # Post comment with output
+#      - uses: peter-evans/find-comment@v1
+#        id: find_comment
+#        with:
+#          issue-number: ${{ github.event.pull_request.number }}
+#          body-includes: Diffuse output
+#
+#      - uses: peter-evans/create-or-update-comment@v1
+#        if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
+#        with:
+#          body: |
+#            Diffuse output:
+#
+#            ${{ steps.diffuse.outputs.diff-gh-comment }}
+#          edit-mode: replace
+#          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+#          issue-number: ${{ github.event.pull_request.number }}
+#          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,42 @@
+name: payments-core size diff
+on: [pull_request]
+jobs:
+  # Checkout master branch and build the APK
+  build-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: master
+      - name: Build in master
+        run: ./gradlew :payments-core:assembleDebug && mv payments-core/build/outputs/aar/payments-core-debug.aar payments-core/build/outputs/aar/payments-core-debug-master.aar
+      - name: Upload AAR
+        uses: actions/upload-artifact@v1
+        with:
+          name: aar
+          path: payments-core/build/outputs/aar/payments-core-debug-master.aar
+
+  # Checkout PR branch and build the APK
+  build-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build from PR
+        run: ./gradlew :payments-core:assembleDebug && mv payments-core/build/outputs/aar/payments-core-debug.aar payments-core/build/outputs/aar/payments-core-debug-pr.aar
+      - name: Upload AAR
+        uses: actions/upload-artifact@v1
+        with:
+          name: aar
+          path: payments-core/build/outputs/aar/payments-core-debug-pr.aar
+  # Execute Diffuse only when the two AARs are built successfully
+  diffuse:
+    needs: [build-master, build-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download AARs
+        uses: actions/download-artifact@v1
+        with:
+          name: aar
+      - name: Execute Diffuse
+        run: ./diffuse diff --aar aar/payments-core-debug-master.aar aar/payments-core-debug-pr.aar


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add GitHub Action that analyzes change to library size for each PR.
Use the `paymentsheet-example` target because it bundles `payments-core` and `paymentsheet`. In the future we can diff each of the modules separately.
- https://levelup.gitconnected.com/diffusing-your-apk-ea9d044d4c0d
- https://github.com/usefulness/diffuse-action

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Have visibility on impact of PRs to library size.
Verify impact of PR #3840