### PR TITLE
Fix StripeBrowserLauncherActivity

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -24,7 +24,10 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  */
 internal class StripeBrowserLauncherActivity : AppCompatActivity() {
     private val viewModel: StripeBrowserLauncherViewModel by viewModels {
-        StripeBrowserLauncherViewModel.Factory(application)
+        StripeBrowserLauncherViewModel.Factory(
+            application,
+            this
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,14 +45,20 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
             viewModel.getResultIntent(args)
         )
 
-        val launcher = registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult(),
-            ::onResult
-        )
+        if (viewModel.hasLaunched) {
+            finish()
+        } else {
+            val launcher = registerForActivityResult(
+                ActivityResultContracts.StartActivityForResult(),
+                ::onResult
+            )
 
-        launcher.launch(
-            viewModel.createLaunchIntent(args)
-        )
+            launcher.launch(
+                viewModel.createLaunchIntent(args)
+            )
+
+            viewModel.hasLaunched = true
+        }
     }
 
     private fun onResult(activityResult: ActivityResult) {

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -5,21 +5,31 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
+import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import kotlin.properties.Delegates
 
 internal class StripeBrowserLauncherViewModel(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val browserCapabilities: BrowserCapabilities,
-    private val intentChooserTitle: String
+    private val intentChooserTitle: String,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    var hasLaunched: Boolean by Delegates.observable(
+        savedStateHandle.contains(KEY_HAS_LAUNCHED)
+    ) { _, _, newValue ->
+        savedStateHandle.set(KEY_HAS_LAUNCHED, true)
+    }
 
     fun createLaunchIntent(
         args: PaymentBrowserAuthContract.Args
@@ -85,9 +95,16 @@ internal class StripeBrowserLauncherViewModel(
     }
 
     class Factory(
-        private val application: Application
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        private val application: Application,
+        owner: SavedStateRegistryOwner
+    ) : AbstractSavedStateViewModelFactory(owner, null) {
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel?> create(
+            key: String,
+            modelClass: Class<T>,
+            handle: SavedStateHandle
+        ): T {
             val config = PaymentConfiguration.getInstance(application)
             val browserCapabilitiesSupplier = BrowserCapabilitiesSupplier(application)
 
@@ -98,8 +115,13 @@ internal class StripeBrowserLauncherViewModel(
                     config.publishableKey
                 ),
                 browserCapabilitiesSupplier.get(),
-                application.getString(R.string.stripe_verify_your_payment)
+                application.getString(R.string.stripe_verify_your_payment),
+                handle
             ) as T
         }
+    }
+
+    internal companion object {
+        const val KEY_HAS_LAUNCHED = "has_launched"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -26,11 +27,14 @@ class StripeBrowserLauncherViewModelTest {
         ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
     )
 
+    private val savedStateHandle = SavedStateHandle()
+
     private val viewModel = StripeBrowserLauncherViewModel(
         analyticsRequestExecutor,
         analyticsRequestFactory,
         BrowserCapabilities.CustomTabs,
-        "Verify your payment"
+        "Verify your payment",
+        savedStateHandle
     )
 
     @Test
@@ -87,6 +91,19 @@ class StripeBrowserLauncherViewModelTest {
                     sourceId = ""
                 )
             )
+    }
+
+    @Test
+    fun `hasLaunched should set entry on savedStateHandle`() {
+        assertThat(
+            savedStateHandle.contains(StripeBrowserLauncherViewModel.KEY_HAS_LAUNCHED)
+        ).isFalse()
+
+        viewModel.hasLaunched = true
+
+        assertThat(
+            savedStateHandle.contains(StripeBrowserLauncherViewModel.KEY_HAS_LAUNCHED)
+        ).isTrue()
     }
 
     private companion object {


### PR DESCRIPTION


# Summary
Fix `StripeBrowserLauncherActivity`'s behavior when
"Don't keep activities" is enabled.

Previously, when `StripeBrowserLauncherActivity` was recreated, it
would always re-invoke its `launcher`. Fix this by tracking when
the launcher was invoked.

Add `StripeBrowserLauncherViewModel#hasLaunched` property that is
backed by `SavedStateHandle` to survive process death.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
