### PR TITLE
Create GooglePayPaymentMethodLauncher

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -30,19 +30,20 @@ internal class GooglePayPaymentMethodLauncher internal constructor(
 
     /**
      * Constructor to be used when launching [GooglePayPaymentMethodLauncher] from an Activity.
+     * This constructor must be called no later than `Activity#onCreate()`.
      *
      * @param activity the Activity that is launching the [GooglePayPaymentMethodLauncher]
      *
      * @param readyCallback called after determining whether Google Pay is available and ready on
      * the device. [present] may only be called if Google Pay is ready.
      *
-     * @param callback called with the result of the [GooglePayPaymentMethodLauncher] operation
+     * @param resultCallback called with the result of the [GooglePayPaymentMethodLauncher] operation
      */
     internal constructor(
         activity: ComponentActivity,
         config: Config,
         readyCallback: ReadyCallback,
-        callback: ResultCallback
+        resultCallback: ResultCallback
     ) : this(
         activity.lifecycleScope,
         config,
@@ -56,25 +57,26 @@ internal class GooglePayPaymentMethodLauncher internal constructor(
         activity.registerForActivityResult(
             GooglePayPaymentMethodLauncherContract()
         ) {
-            callback.onResult(it)
+            resultCallback.onResult(it)
         }
     )
 
     /**
      * Constructor to be used when launching [GooglePayPaymentMethodLauncher] from a Fragment.
+     * This constructor must be called no later than `Fragment#onViewCreated()`.
      *
      * @param fragment the Fragment that is launching the [GooglePayPaymentMethodLauncher]
      *
      * @param readyCallback called after determining whether Google Pay is available and ready on
      * the device. [present] may only be called if Google Pay is ready.
      *
-     * @param callback called with the result of the [GooglePayPaymentMethodLauncher] operation
+     * @param resultCallback called with the result of the [GooglePayPaymentMethodLauncher] operation
      */
     internal constructor(
         fragment: Fragment,
         config: Config,
         readyCallback: ReadyCallback,
-        callback: ResultCallback
+        resultCallback: ResultCallback
     ) : this(
         fragment.viewLifecycleOwner.lifecycleScope,
         config,
@@ -88,7 +90,7 @@ internal class GooglePayPaymentMethodLauncher internal constructor(
         fragment.registerForActivityResult(
             GooglePayPaymentMethodLauncherContract()
         ) {
-            callback.onResult(it)
+            resultCallback.onResult(it)
         }
     )
 
@@ -103,6 +105,11 @@ internal class GooglePayPaymentMethodLauncher internal constructor(
         }
     }
 
+    /**
+     * Present the Google Pay UI when the final amount of the transaction is not yet known.
+     *
+     * An [IllegalStateException] will be thrown if Google Pay is not available or ready for usage.
+     */
     fun present(currencyCode: String) {
         check(isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -117,6 +124,11 @@ internal class GooglePayPaymentMethodLauncher internal constructor(
         )
     }
 
+    /**
+     * Present the Google Pay UI when the final amount of the transaction is known.
+     *
+     * An [IllegalStateException] will be thrown if Google Pay is not available or ready for usage.
+     */
     fun present(
         currencyCode: String,
         amount: Int

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -1,0 +1,212 @@
+package com.stripe.android.googlepaylauncher
+
+import android.os.Parcelable
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.DefaultGooglePayRepository
+import com.stripe.android.paymentsheet.GooglePayRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+
+/**
+ * A drop-in class that presents a Google Pay sheet to collect a customer's payment.
+ *
+ * When successful, will return a [PaymentMethod] via [Result.Completed.paymentMethod].
+ */
+internal class GooglePayPaymentMethodLauncher internal constructor(
+    lifecycleScope: CoroutineScope,
+    private val config: Config,
+    private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
+    private val readyCallback: ReadyCallback,
+    private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>
+) {
+    private var isReady = false
+
+    /**
+     * Constructor to be used when launching [GooglePayPaymentMethodLauncher] from an Activity.
+     *
+     * @param activity the Activity that is launching the [GooglePayPaymentMethodLauncher]
+     *
+     * @param readyCallback called after determining whether Google Pay is available and ready on
+     * the device. [present] may only be called if Google Pay is ready.
+     *
+     * @param callback called with the result of the [GooglePayPaymentMethodLauncher] operation
+     */
+    internal constructor(
+        activity: ComponentActivity,
+        config: Config,
+        readyCallback: ReadyCallback,
+        callback: ResultCallback
+    ) : this(
+        activity.lifecycleScope,
+        config,
+        googlePayRepositoryFactory = {
+            DefaultGooglePayRepository(
+                activity.application,
+                it
+            )
+        },
+        readyCallback,
+        activity.registerForActivityResult(
+            GooglePayPaymentMethodLauncherContract()
+        ) {
+            callback.onResult(it)
+        }
+    )
+
+    /**
+     * Constructor to be used when launching [GooglePayPaymentMethodLauncher] from a Fragment.
+     *
+     * @param fragment the Fragment that is launching the [GooglePayPaymentMethodLauncher]
+     *
+     * @param readyCallback called after determining whether Google Pay is available and ready on
+     * the device. [present] may only be called if Google Pay is ready.
+     *
+     * @param callback called with the result of the [GooglePayPaymentMethodLauncher] operation
+     */
+    internal constructor(
+        fragment: Fragment,
+        config: Config,
+        readyCallback: ReadyCallback,
+        callback: ResultCallback
+    ) : this(
+        fragment.viewLifecycleOwner.lifecycleScope,
+        config,
+        googlePayRepositoryFactory = {
+            DefaultGooglePayRepository(
+                fragment.requireActivity().application,
+                it
+            )
+        },
+        readyCallback,
+        fragment.registerForActivityResult(
+            GooglePayPaymentMethodLauncherContract()
+        ) {
+            callback.onResult(it)
+        }
+    )
+
+    init {
+        lifecycleScope.launch {
+            val repository = googlePayRepositoryFactory(config.environment)
+            readyCallback.onReady(
+                repository.isReady().first().also {
+                    isReady = it
+                }
+            )
+        }
+    }
+
+    fun present(currencyCode: String) {
+        check(isReady) {
+            "present() may only be called when Google Pay is available on this device."
+        }
+
+        activityResultLauncher.launch(
+            GooglePayPaymentMethodLauncherContract.Args(
+                config = config,
+                currencyCode = currencyCode,
+                amount = null
+            )
+        )
+    }
+
+    fun present(
+        currencyCode: String,
+        amount: Int
+    ) {
+        check(isReady) {
+            "present() may only be called when Google Pay is available on this device."
+        }
+
+        activityResultLauncher.launch(
+            GooglePayPaymentMethodLauncherContract.Args(
+                config = config,
+                currencyCode = currencyCode,
+                amount = amount
+            )
+        )
+    }
+
+    @Parcelize
+    internal data class Config @JvmOverloads constructor(
+        val environment: GooglePayEnvironment,
+        val merchantCountryCode: String,
+        val merchantName: String,
+
+        /**
+         * Flag to indicate whether Google Pay collect the customer's email address. Default to `false`.
+         */
+        var isEmailRequired: Boolean = false,
+
+        /**
+         * Billing address collection configuration.
+         */
+        var billingAddressConfig: BillingAddressConfig = BillingAddressConfig(),
+
+        /**
+         * If `true`, Google Pay is considered ready if the customer's Google Pay wallet
+         * has existing payment methods.
+         */
+        var existingPaymentMethodRequired: Boolean = false
+    ) : Parcelable
+
+    @Parcelize
+    internal data class BillingAddressConfig @JvmOverloads constructor(
+        internal val isRequired: Boolean = false,
+
+        /**
+         * Billing address format required to complete the transaction.
+         */
+        internal val format: Format = Format.Min,
+
+        /**
+         * Set to true if a phone number is required to process the transaction.
+         */
+        internal val isPhoneNumberRequired: Boolean = false
+    ) : Parcelable {
+        /**
+         * Billing address format required to complete the transaction.
+         */
+        enum class Format(internal val code: String) {
+            /**
+             * Name, country code, and postal code (default).
+             */
+            Min("MIN"),
+
+            /**
+             * Name, street address, locality, region, country code, and postal code.
+             */
+            Full("FULL")
+        }
+    }
+
+    internal sealed class Result : Parcelable {
+        @Parcelize
+        data class Completed(
+            val paymentMethod: PaymentMethod
+        ) : Result()
+
+        @Parcelize
+        data class Failed(
+            val error: Throwable
+        ) : Result()
+
+        @Parcelize
+        object Canceled : Result()
+    }
+
+    internal fun interface ReadyCallback {
+        fun onReady(isReady: Boolean)
+    }
+
+    internal fun interface ResultCallback {
+        fun onResult(result: Result)
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.googlepaylauncher
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Parcelable
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.os.bundleOf
+import kotlinx.parcelize.Parcelize
+
+internal class GooglePayPaymentMethodLauncherContract :
+    ActivityResultContract<GooglePayPaymentMethodLauncherContract.Args, GooglePayPaymentMethodLauncher.Result>() {
+
+    override fun createIntent(context: Context, input: Args): Intent {
+        val statusBarColor = when (context) {
+            is Activity -> context.window?.statusBarColor
+            else -> null
+        }
+
+        val extras = input.toBundle().apply {
+            if (statusBarColor != null) {
+                putInt(EXTRA_STATUS_BAR_COLOR, statusBarColor)
+            }
+        }
+
+        // TODO(mshafrir-stripe): update target activity
+        return Intent(context, StripeGooglePayActivity::class.java)
+            .putExtras(extras)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?
+    ): GooglePayPaymentMethodLauncher.Result {
+        return intent?.getParcelableExtra(EXTRA_RESULT)
+            ?: GooglePayPaymentMethodLauncher.Result.Failed(
+                IllegalArgumentException("Could not parse a valid result.")
+            )
+    }
+
+    @Parcelize
+    data class Args(
+        internal val config: GooglePayPaymentMethodLauncher.Config,
+        internal val currencyCode: String,
+        internal val amount: Int?
+    ) : Parcelable {
+        fun toBundle() = bundleOf("" to this)
+
+        internal companion object {
+            private const val EXTRA_ARGS = "extra_args"
+
+            fun fromIntent(intent: Intent): Args? {
+                return intent.getParcelableExtra(EXTRA_ARGS)
+            }
+        }
+    }
+
+    internal companion object {
+        internal const val EXTRA_RESULT = "extra_result"
+        internal const val EXTRA_STATUS_BAR_COLOR = "extra_status_bar_color"
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractTest.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.googlepaylauncher
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import com.google.common.truth.Truth.assertThat
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class GooglePayPaymentMethodLauncherContractTest {
+    private val scenario = launchFragmentInContainer { TestFragment() }
+    private val contract = GooglePayPaymentMethodLauncherContract()
+
+    @Test
+    fun `createIntent() should only add statusBarColor extra if available`() {
+        scenario.onFragment {
+            val intent = contract.createIntent(
+                it.requireActivity(),
+                GooglePayPaymentMethodLauncherContract.Args(
+                    CONFIG,
+                    currencyCode = "usd",
+                    amount = 1000
+                )
+            )
+
+            assertThat(
+                intent.hasExtra(GooglePayPaymentMethodLauncherContract.EXTRA_STATUS_BAR_COLOR)
+            ).isTrue()
+        }
+    }
+
+    internal class TestFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View = FrameLayout(inflater.context)
+    }
+
+    private companion object {
+        val CONFIG = GooglePayPaymentMethodLauncher.Config(
+            GooglePayEnvironment.Test,
+            merchantCountryCode = "US",
+            merchantName = "Widget Store"
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -1,0 +1,152 @@
+package com.stripe.android.googlepaylauncher
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.GooglePayRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class GooglePayPaymentMethodLauncherTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val testScope = TestCoroutineScope(testDispatcher)
+
+    private val scenario = launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
+        TestFragment()
+    }
+
+    private val readyCallbackInvocations = mutableListOf<Boolean>()
+    private val results = mutableListOf<GooglePayPaymentMethodLauncher.Result>()
+
+    private val readyCallback =
+        GooglePayPaymentMethodLauncher.ReadyCallback(readyCallbackInvocations::add)
+    private val resultCallback = GooglePayPaymentMethodLauncher.ResultCallback(results::add)
+
+    @AfterTest
+    fun cleanup() {
+        testDispatcher.cleanupTestCoroutines()
+        testScope.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `present() should successfully return a result when Google Pay is available`() {
+        val result = GooglePayPaymentMethodLauncher.Result.Completed(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
+        scenario.onFragment { fragment ->
+            val launcher = GooglePayPaymentMethodLauncher(
+                testScope,
+                CONFIG,
+                { FakeGooglePayRepository(true) },
+                readyCallback,
+                fragment.registerForActivityResult(
+                    GooglePayPaymentMethodLauncherContract(),
+                    FakeActivityResultRegistry(result)
+                ) {
+                    resultCallback.onResult(it)
+                }
+            )
+            scenario.moveToState(Lifecycle.State.RESUMED)
+
+            assertThat(readyCallbackInvocations)
+                .containsExactly(true)
+
+            launcher.present(
+                currencyCode = "usd"
+            )
+
+            assertThat(results)
+                .containsExactly(result)
+        }
+    }
+
+    @Test
+    fun `present() should throw IllegalStateException when Google Pay is not available`() {
+        scenario.onFragment { fragment ->
+            val launcher = GooglePayPaymentMethodLauncher(
+                testScope,
+                CONFIG,
+                { FakeGooglePayRepository(false) },
+                readyCallback,
+                fragment.registerForActivityResult(
+                    GooglePayPaymentMethodLauncherContract(),
+                    FakeActivityResultRegistry(
+                        GooglePayPaymentMethodLauncher.Result.Completed(
+                            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        )
+                    )
+                ) {
+                    resultCallback.onResult(it)
+                }
+            )
+            scenario.moveToState(Lifecycle.State.RESUMED)
+
+            assertThat(readyCallbackInvocations)
+                .containsExactly(false)
+
+            assertFailsWith<IllegalStateException> {
+                launcher.present(
+                    currencyCode = "usd"
+                )
+            }
+        }
+    }
+
+    private class FakeGooglePayRepository(
+        private var isReady: Boolean
+    ) : GooglePayRepository {
+        override fun isReady(): Flow<Boolean> = flowOf(isReady)
+    }
+
+    private class FakeActivityResultRegistry(
+        private val result: GooglePayPaymentMethodLauncher.Result
+    ) : ActivityResultRegistry() {
+        override fun <I, O> onLaunch(
+            requestCode: Int,
+            contract: ActivityResultContract<I, O>,
+            input: I,
+            options: ActivityOptionsCompat?
+        ) {
+            dispatchResult(
+                requestCode,
+                result
+            )
+        }
+    }
+
+    internal class TestFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View = FrameLayout(inflater.context)
+    }
+
+    private companion object {
+        val CONFIG = GooglePayPaymentMethodLauncher.Config(
+            GooglePayEnvironment.Test,
+            merchantCountryCode = "US",
+            merchantName = "Widget Store"
+        )
+    }
+}


### PR DESCRIPTION


# Summary
As opposed to `GooglePayLauncher`, will be used for returning a
`PaymentMethod` instead of confirming a `PaymentIntent` or
`SetupIntent`.

# Motivation
Create complement to `GooglePayLauncher`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
