### PR TITLE
Add `UnsupportedAuthenticator`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4390,6 +4390,14 @@ public final class com/stripe/android/payments/core/authentication/OxxoAuthentic
 	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
 }
 
+public final class com/stripe/android/payments/core/authentication/UnsupportedAuthenticator_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/UnsupportedAuthenticator_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/UnsupportedAuthenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;)Lcom/stripe/android/payments/core/authentication/UnsupportedAuthenticator;
+}
+
 public final class com/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.payments.core.authentication
+
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.Stripe
+import com.stripe.android.exception.StripeException
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.getRequestCode
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarterHost
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [IntentAuthenticator] to return if there is no available authenticators. Informs the correct
+ * dependency to include for that authenticator.
+ */
+@Singleton
+internal class UnsupportedAuthenticator @Inject constructor(
+    private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
+) : IntentAuthenticator {
+    override suspend fun authenticate(
+        host: AuthActivityStarterHost,
+        stripeIntent: StripeIntent,
+        threeDs1ReturnUrl: String?,
+        requestOptions: ApiRequest.Options
+    ) {
+        val exception = stripeIntent.nextActionData?.let {
+            val nextActionType = it::class.java
+            StripeException.create(
+                IllegalArgumentException(
+                    "${nextActionType.simpleName} type is not supported, add " +
+                        "${ACTION_DEPENDENCY_MAP[nextActionType]} in build.gradle to support it"
+                )
+            )
+        } ?: run {
+            StripeException.create(
+                IllegalArgumentException("stripeIntent.nextActionData is null")
+            )
+        }
+
+        paymentRelayStarterFactory(host)
+            .start(
+                PaymentRelayStarter.Args.ErrorArgs(
+                    exception = exception,
+                    requestCode = stripeIntent.getRequestCode()
+                )
+            )
+    }
+
+    internal companion object {
+        val ACTION_DEPENDENCY_MAP = mapOf<Class<out StripeIntent.NextActionData>, String>(
+            StripeIntent.NextActionData.WeChatPayRedirect::class.java
+                to "com.stripe:stripe-wechatpay:${Stripe.VERSION_NAME}"
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -1,0 +1,100 @@
+package com.stripe.android.payments.core.authentication
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.FakeActivityResultLauncher
+import com.stripe.android.PaymentRelayContract
+import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.Stripe
+import com.stripe.android.StripePaymentController
+import com.stripe.android.exception.StripeException
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentIntentFixtures.PI_SUCCEEDED
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class UnsupportedAuthenticatorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val paymentRelayStarterFactory =
+        mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()
+
+    private val authenticator = UnsupportedAuthenticator(
+        paymentRelayStarterFactory
+    )
+
+    private val launcher = FakeActivityResultLauncher(PaymentRelayContract())
+
+    @Before
+    fun setUpStarterFactory() {
+        whenever(paymentRelayStarterFactory(any())).thenReturn(
+            PaymentRelayStarter.Modern(
+                launcher
+            )
+        )
+    }
+
+    @Test
+    fun verifyWeChat() = testDispatcher.runBlockingTest {
+        authenticator.authenticate(
+            mock(),
+            PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
+            null,
+            REQUEST_OPTIONS
+        )
+
+        assertThat(launcher.launchArgs)
+            .containsExactly(
+                PaymentRelayStarter.Args.ErrorArgs(
+                    exception = StripeException.create(
+                        IllegalArgumentException(
+                            "${StripeIntent.NextActionData.WeChatPayRedirect::class.java.simpleName} " +
+                                "type is not supported, add " +
+                                "com.stripe:stripe-wechatpay:${Stripe.VERSION_NAME} in build.gradle " +
+                                "to support it"
+                        )
+                    ),
+                    requestCode = StripePaymentController.PAYMENT_REQUEST_CODE
+                )
+            )
+    }
+
+    @Test
+    fun verifyNullNextActionType() = testDispatcher.runBlockingTest {
+        authenticator.authenticate(
+            mock(),
+            PI_SUCCEEDED,
+            null,
+            REQUEST_OPTIONS
+        )
+
+        assertThat(launcher.launchArgs)
+            .containsExactly(
+                PaymentRelayStarter.Args.ErrorArgs(
+                    exception = StripeException.create(
+                        IllegalArgumentException("stripeIntent.nextActionData is null")
+                    ),
+                    requestCode = StripePaymentController.PAYMENT_REQUEST_CODE
+                )
+            )
+    }
+
+    private companion object {
+        private val REQUEST_OPTIONS = ApiRequest.Options(
+            apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This authenticator will be mapped to `NextActionType` that doesn't have a supported Authenticator implementation, which would happen if user doesn't include the required dependency.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prepare for WeChatPay authenticator module


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
