### PR TITLE
Rename Static Text element/spec to Mandate element/spec

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -94,6 +94,22 @@ public abstract class com/stripe/android/paymentsheet/specifications/FormItemSpe
 	public static final field $stable I
 }
 
+public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+	public static final field $stable I
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
+	public final fun component2 ()I
+	public final fun component3-0d7_KjU ()J
+	public final fun copy-mxwnekA (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJ)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec;
+	public static synthetic fun copy-mxwnekA$default (Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec;Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJILjava/lang/Object;)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor-0d7_KjU ()J
+	public fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
+	public final fun getStringResId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SaveForFutureUseSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;)V
@@ -117,22 +133,6 @@ public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$S
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getField ()Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec;
 	public fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$StaticTextSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
-	public static final field $stable I
-	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
-	public final fun component2 ()I
-	public final fun component3-0d7_KjU ()J
-	public final fun copy-mxwnekA (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJ)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$StaticTextSpec;
-	public static synthetic fun copy-mxwnekA$default (Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$StaticTextSpec;Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJILjava/lang/Object;)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$StaticTextSpec;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getColor-0d7_KjU ()J
-	public fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
-	public final fun getStringResId ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -54,7 +54,7 @@ internal sealed class FormElement {
      * This is an element that has static text because it takes no user input, it is not
      * outputted from the list of form field values.
      */
-    internal data class StaticTextElement(
+    internal data class MandateTextElement(
         override val identifier: IdentifierSpec,
         val stringResId: Int,
         val color: Color,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.asLiveData
 import com.stripe.android.paymentsheet.FocusRequesterCount
 import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.FormElement.SectionElement
-import com.stripe.android.paymentsheet.FormElement.StaticTextElement
+import com.stripe.android.paymentsheet.FormElement.MandateTextElement
 import com.stripe.android.paymentsheet.SectionFieldElementType.DropdownFieldElement
 import com.stripe.android.paymentsheet.SectionFieldElementType.TextFieldElement
 import com.stripe.android.paymentsheet.elements.common.DropDown
@@ -78,7 +78,7 @@ internal fun Form(
                             }
                         }
                     }
-                    is StaticTextElement -> {
+                    is MandateTextElement -> {
                         Text(
                             stringResource(element.stringResId),
                             modifier = Modifier.padding(vertical = 8.dp),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
@@ -24,7 +24,7 @@ internal class TransformSpecToElement {
             when (it) {
                 is FormItemSpec.SaveForFutureUseSpec -> transform(it)
                 is FormItemSpec.SectionSpec -> transform(it, focusRequesterCount)
-                is FormItemSpec.StaticTextSpec -> transform(it)
+                is FormItemSpec.MandateTextSpec -> transform(it)
             }
         }
 
@@ -56,10 +56,10 @@ internal class TransformSpecToElement {
         )
     }
 
-    private fun transform(spec: FormItemSpec.StaticTextSpec) =
+    private fun transform(spec: FormItemSpec.MandateTextSpec) =
         // It could be argued that the static text should have a controller, but
         // since it doesn't provide a form field we leave it out for now
-        FormElement.StaticTextElement(
+        FormElement.MandateTextElement(
             spec.identifier,
             spec.stringResId,
             spec.color

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -19,7 +19,7 @@ val bancontact = FormSpec(
                 IdentifierSpec("email"),
                 SectionFieldSpec.Email
             ),
-            FormItemSpec.StaticTextSpec(
+            FormItemSpec.MandateTextSpec(
                 IdentifierSpec("mandate"),
                 R.string.sofort_mandate,
                 Color.Gray

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SectionSpec
-import com.stripe.android.paymentsheet.specifications.FormItemSpec.StaticTextSpec
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.MandateTextSpec
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Country
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Email
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Name
@@ -22,7 +22,7 @@ internal val sofortParamKey: MutableMap<String, Any?> = mutableMapOf(
 internal val sofortNameSection = SectionSpec(IdentifierSpec("name"), Name)
 internal val sofortEmailSection = SectionSpec(IdentifierSpec("email"), Email)
 internal val sofortCountrySection = SectionSpec(IdentifierSpec("country"), Country)
-internal val sofortMandate = StaticTextSpec(
+internal val sofortMandate = MandateTextSpec(
     IdentifierSpec("mandate"),
     R.string.sofort_mandate,
     Color.Gray

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
@@ -61,7 +61,7 @@ sealed class FormItemSpec {
     /**
      * This is for elements that do not receive user input
      */
-    data class StaticTextSpec(
+    data class MandateTextSpec(
         override val identifier: IdentifierSpec,
         @StringRes val stringResId: Int,
         val color: Color

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.FocusRequesterCount
 import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.FormElement.SectionElement
-import com.stripe.android.paymentsheet.FormElement.StaticTextElement
+import com.stripe.android.paymentsheet.FormElement.MandateTextElement
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.SectionFieldElement.Country
 import com.stripe.android.paymentsheet.SectionFieldElement.Email
@@ -120,7 +120,7 @@ class TransformSpecToElementTest {
 
     @Test
     fun `Add a mandate section spec setup of the mandate element correctly`() {
-        val mandate = FormItemSpec.StaticTextSpec(
+        val mandate = FormItemSpec.MandateTextSpec(
             IdentifierSpec("mandate"),
             R.string.sofort_mandate,
             Color.Gray
@@ -132,7 +132,7 @@ class TransformSpecToElementTest {
             FocusRequesterCount()
         )
 
-        val mandateElement = formElement.first() as StaticTextElement
+        val mandateElement = formElement.first() as MandateTextElement
 
         assertThat(mandateElement.controller).isNull()
         assertThat(mandateElement.color).isEqualTo(mandate.color)
@@ -143,7 +143,7 @@ class TransformSpecToElementTest {
     @Test
     fun `Add a save for future use section spec sets the mandate element correctly`() =
         runBlocking {
-            val mandate = FormItemSpec.StaticTextSpec(
+            val mandate = FormItemSpec.MandateTextSpec(
                 IdentifierSpec("mandate"),
                 R.string.sofort_mandate,
                 Color.Gray


### PR DESCRIPTION
# Summary
Rename static text element/spec to mandate text element/spec.

# Motivation
The mandate functionality is diverging from just a static text field, and more logic needs to be added in future PRs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

