### PR TITLE
Add SetupIntent support in GooglePayLauncher

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -93,16 +93,6 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
         disableAnimations()
     }
 
-//    /**
-//     * Check that Google Pay is available and ready
-//     */
-//    private suspend fun onReadyToPay(paymentDataRequest: JSONObject): Task<PaymentData> {
-//        require(viewModel.isReadyToPay()) {
-//            "Google Pay is unavailable."
-//        }
-//        return viewModel.createLoadPaymentDataTask(paymentDataRequest)
-//    }
-
     private fun payWithGoogle(task: Task<PaymentData>) {
         AutoResolveHelper.resolveTask(
             task,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -98,8 +98,15 @@ internal class GooglePayLauncherViewModel(
                 )
             }
             is SetupIntent -> {
-                // TODO(mshafrir-stripe): add SetupIntent support
-                error("SetupIntents are not currently supported in GooglePayLauncher.")
+                GooglePayJsonFactory.TransactionInfo(
+                    // TODO(mshafrir-stripe): get currencyCode for SetupIntents
+                    currencyCode = "",
+                    totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.NotCurrentlyKnown,
+                    countryCode = args.config.merchantCountryCode,
+                    transactionId = stripeIntent.id,
+                    totalPrice = null,
+                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
+                )
             }
         }
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -115,14 +115,22 @@ class GooglePayLauncherViewModelTest {
     }
 
     @Test
-    fun `createTransactionInfo() with SetupIntent should throw expected exception`() {
-        val error = assertFailsWith<IllegalStateException> {
-            viewModel.createTransactionInfo(
-                SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
+    fun `createTransactionInfo() with SetupIntent should return expected TransactionInfo`() {
+        val transactionInfo = viewModel.createTransactionInfo(
+            SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
+        )
+        assertThat(transactionInfo)
+            .isEqualTo(
+                GooglePayJsonFactory.TransactionInfo(
+                    currencyCode = "",
+                    totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.NotCurrentlyKnown,
+                    countryCode = "us",
+                    transactionId = "seti_1GSmaFCRMbs",
+                    totalPrice = null,
+                    totalPriceLabel = null,
+                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
+                )
             )
-        }
-        assertThat(error.message)
-            .isEqualTo("SetupIntents are not currently supported in GooglePayLauncher.")
     }
 
     @Test


### PR DESCRIPTION


# Summary
`currencyCode` is required by Google Pay. `currencyCode` will be
configurable via `GooglePayLauncher.Config` in a follow-up PR.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

