### PR TITLE
Add a block list to not override default return URL

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -622,7 +622,7 @@ internal class StripePaymentController internal constructor(
                     EXPAND_PAYMENT_METHOD
                 ).paymentMethod?.type
             }
-        return RETURN_URL_OVERRIDE_ALLOWLIST.contains(paymentMethodType)
+        return !RETURN_URL_OVERRIDE_BLOCKLIST.contains(paymentMethodType)
     }
 
     internal companion object {
@@ -631,9 +631,9 @@ internal class StripePaymentController internal constructor(
         internal const val SOURCE_REQUEST_CODE = 50002
 
         /**
-         * List of payment methods to override the return_url to [DefaultReturnUrl]
+         * List of payment methods not to override the return_url to [DefaultReturnUrl]
          */
-        internal val RETURN_URL_OVERRIDE_ALLOWLIST = setOf(PaymentMethod.Type.Card)
+        internal val RETURN_URL_OVERRIDE_BLOCKLIST = setOf(PaymentMethod.Type.WeChatPay)
 
         /**
          * Get the appropriate request code for the given stripe intent type

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -622,7 +622,7 @@ internal class StripePaymentController internal constructor(
                     EXPAND_PAYMENT_METHOD
                 ).paymentMethod?.type
             }
-        return !RETURN_URL_OVERRIDE_BLOCKLIST.contains(paymentMethodType)
+        return RETURN_URL_OVERRIDE_ALLOWLIST.contains(paymentMethodType)
     }
 
     internal companion object {
@@ -631,9 +631,9 @@ internal class StripePaymentController internal constructor(
         internal const val SOURCE_REQUEST_CODE = 50002
 
         /**
-         * List of payment methods not to override the return_url to [DefaultReturnUrl]
+         * List of payment methods to override the return_url to [DefaultReturnUrl]
          */
-        internal val RETURN_URL_OVERRIDE_BLOCKLIST = setOf(PaymentMethod.Type.WeChatPay)
+        internal val RETURN_URL_OVERRIDE_ALLOWLIST = setOf(PaymentMethod.Type.Card)
 
         /**
          * Get the appropriate request code for the given stripe intent type

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -598,7 +598,7 @@ internal class StripePaymentController internal constructor(
     }
 
     /**
-     * Decide if a [StripeIntent] confirmation request's returnUrl should be overriden
+     * Decide whether a [StripeIntent] confirmation request's returnUrl should be overridden
      * to [DefaultReturnUrl] if client doesn't set any value.
      */
     private suspend fun shouldOverrideReturnUrl(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -195,7 +195,7 @@ data class PaymentMethodCreateParams internal constructor(
         }
 
     internal enum class Type(
-        private val paymentMethodType: PaymentMethod.Type,
+        internal val paymentMethodType: PaymentMethod.Type,
         val hasMandate: Boolean = false
     ) {
         Card(PaymentMethod.Type.Card),

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -253,13 +253,13 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is overridden when PM from confirmStripeIntentParams is not in the blocklist`() =
+    fun `returnUrl is overridden when PM from confirmStripeIntentParams is in the allowList`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
                 ConfirmPaymentIntentParams(
                     clientSecret = "clientSecret",
-                    paymentMethodCreateParams = PaymentMethodCreateParams.Companion.createBlik()
+                    paymentMethodCreateParams = PaymentMethodCreateParams.Companion.createCard(mock())
                 ),
                 REQUEST_OPTIONS
             )
@@ -269,7 +269,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is not overridden when PM from confirmStripeIntentParams is in the blocklist`() =
+    fun `returnUrl is not overridden when PM from confirmStripeIntentParams is not in the allowList`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
@@ -284,7 +284,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is overridden when fetched PM is not in the block list`() =
+    fun `returnUrl is overridden when fetched PM is in the allowList`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
@@ -299,7 +299,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is not overridden when fetched PM is in the block list`() =
+    fun `returnUrl is not overridden when fetched PM is not in the blockList`() =
         testDispatcher.runBlockingTest {
             stripeRepository.retrieveStripeIntentResponse =
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
@@ -329,7 +329,7 @@ internal class StripePaymentControllerTest {
     }
 
     private class FakeStripeRepository : AbsFakeStripeRepository() {
-        var retrieveStripeIntentResponse = PaymentIntentFixtures.PI_REQUIRES_REDIRECT
+        var retrieveStripeIntentResponse = PaymentIntentFixtures.PI_WITH_EXPANDED_PAYMENT_METHOD_JSON
         var retrievePaymentIntentResponse = PaymentIntentFixtures.PI_REQUIRES_REDIRECT
         var cancelPaymentIntentResponse = PaymentIntentFixtures.CANCELLED
         var confirmPaymentIntentResponse = PaymentIntentFixtures.PI_WITH_SHIPPING

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -253,13 +253,13 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is overridden when PM from confirmStripeIntentParams is in the allowList`() =
+    fun `returnUrl is overridden when PM from confirmStripeIntentParams is not in the blocklist`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
                 ConfirmPaymentIntentParams(
                     clientSecret = "clientSecret",
-                    paymentMethodCreateParams = PaymentMethodCreateParams.Companion.createCard(mock())
+                    paymentMethodCreateParams = PaymentMethodCreateParams.Companion.createBlik()
                 ),
                 REQUEST_OPTIONS
             )
@@ -269,7 +269,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is not overridden when PM from confirmStripeIntentParams is not in the allowList`() =
+    fun `returnUrl is not overridden when PM from confirmStripeIntentParams is in the blocklist`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
@@ -284,7 +284,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is overridden when fetched PM is in the allowList`() =
+    fun `returnUrl is overridden when fetched PM is not in the blockList`() =
         testDispatcher.runBlockingTest {
             controller.startConfirmAndAuth(
                 mock(),
@@ -299,7 +299,7 @@ internal class StripePaymentControllerTest {
         }
 
     @Test
-    fun `returnUrl is not overridden when fetched PM is not in the blockList`() =
+    fun `returnUrl is not overridden when fetched PM is in the blockList`() =
         testDispatcher.runBlockingTest {
             stripeRepository.retrieveStripeIntentResponse =
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
@@ -329,7 +329,7 @@ internal class StripePaymentControllerTest {
     }
 
     private class FakeStripeRepository : AbsFakeStripeRepository() {
-        var retrieveStripeIntentResponse = PaymentIntentFixtures.PI_WITH_EXPANDED_PAYMENT_METHOD_JSON
+        var retrieveStripeIntentResponse = PaymentIntentFixtures.PI_REQUIRES_REDIRECT
         var retrievePaymentIntentResponse = PaymentIntentFixtures.PI_REQUIRES_REDIRECT
         var cancelPaymentIntentResponse = PaymentIntentFixtures.CANCELLED
         var confirmPaymentIntentResponse = PaymentIntentFixtures.PI_WITH_SHIPPING

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -1004,7 +1004,28 @@ internal object PaymentIntentFixtures {
             }
           },
           "on_behalf_of": null,
-          "payment_method": "pm_1IlJH7BNJ02ErVOjxKQu1wfH",
+          "payment_method": {
+            "id": "pm_1J7sAgBNJ02ErVOjxd4BCQmH",
+            "object": "payment_method",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+            },
+            "created": 1625016298,
+            "customer": null,
+            "livemode": true,
+            "type": "wechat_pay",
+            "wechat_pay": {}
+          },
           "payment_method_options": {
             "wechat_pay": {
             }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -628,6 +628,8 @@ internal object PaymentIntentFixtures {
         """.trimIndent()
     )
 
+    val PI_WITH_EXPANDED_PAYMENT_METHOD_JSON = PARSER.parse(EXPANDED_PAYMENT_METHOD_JSON)!!
+
     val PI_WITH_SHIPPING_JSON = JSONObject(
         """
         {

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -628,8 +628,6 @@ internal object PaymentIntentFixtures {
         """.trimIndent()
     )
 
-    val PI_WITH_EXPANDED_PAYMENT_METHOD_JSON = PARSER.parse(EXPANDED_PAYMENT_METHOD_JSON)!!
-
     val PI_WITH_SHIPPING_JSON = JSONObject(
         """
         {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The block list is based on PaymentMethod type, we first check if it's available in `confirmStripeIntentParams`. If not then fetch the PI with expand to get its PaymentMethod type

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The default return url override is only supposed to apply to webview related payment flows, for other types of payment methods, overriding this field doesn't make sense, and some of them gets blocked by backend if it's incorrectly set.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
