### PR TITLE
Fix StripeEditText crash on instantiation

### DIFF
--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -12,7 +12,7 @@ version = "1.2.0"
 module = "androidx.annotation:annotation"
 
 [libraries.androidx-appcompat]
-version = "1.3.0"
+version = "1.4.0-alpha02"
 module = "androidx.appcompat:appcompat"
 
 [libraries.androidx-browser]

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -12,7 +12,7 @@ version = "1.2.0"
 module = "androidx.annotation:annotation"
 
 [libraries.androidx-appcompat]
-version = "1.4.0-alpha02"
+version = "1.3.0"
 module = "androidx.appcompat:appcompat"
 
 [libraries.androidx-browser]

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -47,7 +47,7 @@ open class StripeEditText @JvmOverloads constructor(
     @ColorInt
     private var externalErrorColor: Int? = null
 
-    private val textWatchers = mutableListOf<TextWatcher>()
+    private var textWatchers: MutableList<TextWatcher>? = null
 
     /**
      * Gets whether or not the text should be displayed in error mode.
@@ -96,6 +96,7 @@ open class StripeEditText @JvmOverloads constructor(
         }
 
     init {
+        textWatchers = mutableListOf()
         maxLines = 1
 
         listenForTextChanges()
@@ -264,17 +265,22 @@ open class StripeEditText @JvmOverloads constructor(
     @VisibleForTesting
     internal fun getParentOnFocusChangeListener() = super.getOnFocusChangeListener()
 
+    /**
+     * Note: [addTextChangedListener] will potentially be called by a superclass constructor
+     */
     override fun addTextChangedListener(watcher: TextWatcher?) {
         super.addTextChangedListener(watcher)
+
         watcher?.let {
-            textWatchers.add(it)
+            textWatchers?.add(it)
         }
     }
 
     override fun removeTextChangedListener(watcher: TextWatcher?) {
         super.removeTextChangedListener(watcher)
+
         watcher?.let {
-            textWatchers.remove(it)
+            textWatchers?.remove(it)
         }
     }
 
@@ -282,11 +288,11 @@ open class StripeEditText @JvmOverloads constructor(
      * Set text without notifying its corresponding text watchers.
      */
     internal fun setTextSilent(text: CharSequence?) {
-        textWatchers.forEach {
+        textWatchers?.forEach {
             super.removeTextChangedListener(it)
         }
         setText(text)
-        textWatchers.forEach {
+        textWatchers?.forEach {
             super.addTextChangedListener(it)
         }
     }


### PR DESCRIPTION
In `androidx.appcompat:appcompat:1.4.0-alpha02`,
`addTextChangedListener()` is called by a `StripeEditText` superclass.

This was causing a crash because `textWatchers` was not instantiated
before it was accessed. Change `textWatchers` to nullable and
initialize it in `StripeEditText`'s `init` block.

Fixes #3770