### PR TITLE
Add fields to bancontact: save for future use and mandate

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.specifications
 
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
+import com.stripe.android.paymentsheet.LocalFieldTextStyle
 
 internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
     "type" to "bancontact",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.specifications
 
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
-import com.stripe.android.paymentsheet.LocalFieldTextStyle
 
 internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
     "type" to "bancontact",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.specifications
 
+import androidx.compose.ui.graphics.Color
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
 
 internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
@@ -11,6 +13,11 @@ internal val bancontactNameSection =
     FormItemSpec.SectionSpec(IdentifierSpec("name"), SectionFieldSpec.Name)
 internal val bancontactEmailSection =
     FormItemSpec.SectionSpec(IdentifierSpec("email"), SectionFieldSpec.Email)
+internal val bancontactMandate = FormItemSpec.MandateTextSpec(
+    IdentifierSpec("mandate"),
+    R.string.sofort_mandate,
+    Color.Gray
+)
 val bancontact = FormSpec(
     LayoutSpec(
         listOf(
@@ -18,7 +25,7 @@ val bancontact = FormSpec(
             bancontactEmailSection,
             SaveForFutureUseSpec(
                 listOf(
-                    bancontactEmailSection
+                    bancontactEmailSection, bancontactMandate
                 )
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -1,28 +1,25 @@
 package com.stripe.android.paymentsheet.specifications
 
-import androidx.compose.ui.graphics.Color
-import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
 
 internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
     "type" to "bancontact",
     "billing_details" to billingParams
 )
 
+internal val bancontactNameSection =
+    FormItemSpec.SectionSpec(IdentifierSpec("name"), SectionFieldSpec.Name)
+internal val bancontactEmailSection =
+    FormItemSpec.SectionSpec(IdentifierSpec("email"), SectionFieldSpec.Email)
 val bancontact = FormSpec(
     LayoutSpec(
         listOf(
-            FormItemSpec.SectionSpec(
-                IdentifierSpec("name"),
-                SectionFieldSpec.Name
-            ),
-            FormItemSpec.SectionSpec(
-                IdentifierSpec("email"),
-                SectionFieldSpec.Email
-            ),
-            FormItemSpec.MandateTextSpec(
-                IdentifierSpec("mandate"),
-                R.string.sofort_mandate,
-                Color.Gray
+            bancontactNameSection,
+            bancontactEmailSection,
+            SaveForFutureUseSpec(
+                listOf(
+                    bancontactEmailSection
+                )
             )
         )
     ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -23,6 +23,7 @@ val bancontact = FormSpec(
         listOf(
             bancontactNameSection,
             bancontactEmailSection,
+            bancontactMandate,
             SaveForFutureUseSpec(
                 listOf(
                     bancontactEmailSection, bancontactMandate


### PR DESCRIPTION
# Summary
The Bancontact form requires the save for future use checkbox and the mandate.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![image](https://user-images.githubusercontent.com/77996191/124006045-a3b40700-d98e-11eb-9769-c96ea82e16bd.png)

