### PR TITLE
Simplify the adding of new SupportedPaymentMethods.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
@@ -33,6 +33,6 @@ class AddPaymentMethodsAdapterTest {
     }
 
     private fun createAdapter() = AddPaymentMethodsAdapter(
-        listOf(SupportedPaymentMethod.Card, SupportedPaymentMethod.Bancontact)
+        listOf<SupportedPaymentMethod>().plus(SupportedPaymentMethod.values())
     ) { }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
@@ -33,6 +33,6 @@ class AddPaymentMethodsAdapterTest {
     }
 
     private fun createAdapter() = AddPaymentMethodsAdapter(
-        listOf<SupportedPaymentMethod>().plus(SupportedPaymentMethod.values())
+        listOf(*SupportedPaymentMethod.values())
     ) { }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -3,38 +3,39 @@ package com.stripe.android.paymentsheet.model
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.specifications.FormSpec
 import com.stripe.android.paymentsheet.specifications.bancontact
 import com.stripe.android.paymentsheet.specifications.sofort
 
 /**
  * Enum defining all payment methods supported in Payment Sheet.
+ *
+ * FormSpec is optionally null only because Card is not converted to the compose model.
  */
 enum class SupportedPaymentMethod(
     val code: String,
     @StringRes val displayNameResource: Int,
-    @DrawableRes val iconResource: Int
+    @DrawableRes val iconResource: Int,
+    val formSpec: FormSpec?
 ) {
     Card(
         "card",
         R.string.stripe_paymentsheet_payment_method_card,
-        R.drawable.stripe_ic_paymentsheet_pm_card
+        R.drawable.stripe_ic_paymentsheet_pm_card,
+        null
     ),
     Bancontact(
         "bancontact",
         R.string.stripe_paymentsheet_payment_method_bancontact,
-        R.drawable.stripe_ic_paymentsheet_pm_bancontact
+        R.drawable.stripe_ic_paymentsheet_pm_bancontact,
+        bancontact
     ),
     Sofort(
         "sofort",
         R.string.stripe_paymentsheet_payment_method_sofort,
-        R.drawable.stripe_ic_paymentsheet_pm_sofort
+        R.drawable.stripe_ic_paymentsheet_pm_sofort,
+        sofort
     );
-
-    fun getFormSpec() = when (this) {
-        Bancontact -> bancontact
-        Sofort -> sofort
-        else -> null
-    }
 
     override fun toString(): String {
         return code

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
@@ -28,7 +28,7 @@ class ComposeFormDataCollectionFragment : Fragment() {
     val formSpec by lazy {
         requireNotNull(
             requireArguments().getString(EXTRA_PAYMENT_METHOD)?.let {
-                SupportedPaymentMethod.valueOf(it).getFormSpec()
+                SupportedPaymentMethod.valueOf(it).formSpec
             }
         )
     }


### PR DESCRIPTION
# Summary
Taking advantage the SupportedPaymentMethod enum to populate the list of all supported payment methods.  Then combined the getFormSpec into the SupportedPaymentMethod type.

# Motivation
This leaves just one place for specifying the supported payment methods.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
