### PR TITLE
Add the ideal bank selector specification

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -213,6 +213,11 @@ public final class com/stripe/android/paymentsheet/specifications/SectionFieldSp
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec$Email;
 }
 
+public final class com/stripe/android/paymentsheet/specifications/SectionFieldSpec$IdealBank : com/stripe/android/paymentsheet/specifications/SectionFieldSpec {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec$IdealBank;
+}
+
 public final class com/stripe/android/paymentsheet/specifications/SectionFieldSpec$Name : com/stripe/android/paymentsheet/specifications/SectionFieldSpec {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec$Name;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -103,4 +103,9 @@ internal sealed class SectionFieldElement {
         override val identifier: IdentifierSpec,
         override val controller: DropdownFieldController
     ) : SectionFieldElement(), SectionFieldElementType.DropdownFieldElement
+
+    class IdealBank internal constructor(
+        override val identifier: IdentifierSpec,
+        override val controller: DropdownFieldController
+    ) : SectionFieldElement(), SectionFieldElementType.DropdownFieldElement
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -104,7 +104,7 @@ internal sealed class SectionFieldElement {
         override val controller: DropdownFieldController
     ) : SectionFieldElement(), SectionFieldElementType.DropdownFieldElement
 
-    class IdealBank internal constructor(
+    data class IdealBank internal constructor(
         override val identifier: IdentifierSpec,
         override val controller: DropdownFieldController
     ) : SectionFieldElement(), SectionFieldElementType.DropdownFieldElement

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethod.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentsheet.forms
 
+import com.stripe.android.paymentsheet.elements.IdealBankConfig
 import com.stripe.android.paymentsheet.elements.country.CountryUtils
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Country
+import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.IdealBank
 import java.util.Locale
 
 /**
@@ -26,18 +28,33 @@ class TransformFormToPaymentMethod {
         // Need to convert Country Fields to a country code to put it in the parameter map
         val formKeyValueMap = formFieldValues.fieldValuePairs
             .mapValues { entry ->
-                if (entry.key == Country.identifier) {
-                    entry.value?.let {
-                        CountryUtils.getCountryCodeByName(it, Locale.getDefault())?.value
+                when (entry.key) {
+                    Country.identifier -> {
+                        transformCountry(entry.value)
                     }
-                } else {
-                    entry.value
+                    IdealBank.identifier -> {
+                        val test = transformIdealBank(entry.value)
+                        test
+                    }
+                    else -> {
+                        entry.value
+                    }
                 }
             }
             .mapKeys { it.key.value }
 
         createMap(mapStructure, destMap, formKeyValueMap)
         return destMap
+    }
+
+    private fun transformCountry(countryDisplayName: String?) = countryDisplayName?.let {
+        CountryUtils.getCountryCodeByName(it, Locale.getDefault())?.value
+    }
+
+    private fun transformIdealBank(bankDisplayName: String?) = bankDisplayName?.let {
+        IdealBankConfig.DISPLAY_TO_PARAM
+            .firstOrNull { it.displayName == bankDisplayName }
+            ?.paymentMethodParamFieldValue
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethod.kt
@@ -33,8 +33,7 @@ class TransformFormToPaymentMethod {
                         transformCountry(entry.value)
                     }
                     IdealBank.identifier -> {
-                        val test = transformIdealBank(entry.value)
-                        test
+                        transformIdealBank(entry.value)
                     }
                     else -> {
                         entry.value
@@ -92,18 +91,22 @@ class TransformFormToPaymentMethod {
             formFieldKeyValues: Map<String, String?>
         ) {
             mapStructure.keys.forEach { key ->
-                if (mapStructure[key] == null) {
-                    dest[key] = formFieldKeyValues[key]
-                } else if (mapStructure[key] is MutableMap<*, *>) {
-                    val newDestMap = mutableMapOf<String, Any?>()
-                    dest[key] = newDestMap
-                    createMap(
-                        mapStructure[key] as MutableMap<String, Any?>,
-                        newDestMap,
-                        formFieldKeyValues
-                    )
-                } else {
-                    dest[key] = mapStructure[key]
+                when {
+                    mapStructure[key] == null -> {
+                        dest[key] = formFieldKeyValues[key]
+                    }
+                    mapStructure[key] is MutableMap<*, *> -> {
+                        val newDestMap = mutableMapOf<String, Any?>()
+                        dest[key] = newDestMap
+                        createMap(
+                            mapStructure[key] as MutableMap<String, Any?>,
+                            newDestMap,
+                            formFieldKeyValues
+                        )
+                    }
+                    else -> {
+                        dest[key] = mapStructure[key]
+                    }
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
@@ -4,6 +4,7 @@ import com.stripe.android.paymentsheet.FocusRequesterCount
 import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.SectionFieldElement
 import com.stripe.android.paymentsheet.elements.EmailConfig
+import com.stripe.android.paymentsheet.elements.IdealBankConfig
 import com.stripe.android.paymentsheet.elements.NameConfig
 import com.stripe.android.paymentsheet.elements.common.DropdownFieldController
 import com.stripe.android.paymentsheet.elements.common.SaveForFutureUseController
@@ -48,6 +49,9 @@ internal class TransformSpecToElement {
             )
             SectionFieldSpec.Country -> transform(
                 spec.field as SectionFieldSpec.Country
+            )
+            SectionFieldSpec.IdealBank -> transform(
+                spec.field as SectionFieldSpec.IdealBank
             )
         }
 
@@ -94,6 +98,12 @@ internal class TransformSpecToElement {
         SectionFieldElement.Country(
             spec.identifier,
             DropdownFieldController(CountryConfig())
+        )
+
+    private fun transform(spec: SectionFieldSpec.IdealBank) =
+        SectionFieldElement.IdealBank(
+            spec.identifier,
+            DropdownFieldController(IdealBankConfig())
         )
 
     private fun transform(spec: FormItemSpec.SaveForFutureUseSpec, merchantName: String) =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
@@ -67,4 +67,6 @@ sealed class SectionFieldSpec(val identifier: IdentifierSpec) {
     object Email : SectionFieldSpec(IdentifierSpec("email"))
 
     object Country : SectionFieldSpec(IdentifierSpec("country"))
+
+    object IdealBank : SectionFieldSpec(IdentifierSpec("bank"))
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethodTest.kt
@@ -14,7 +14,7 @@ class TransformFormToPaymentMethodTest {
     @Test
     fun `transform to payment method with bank`() {
         val paymentMethodParams = TransformFormToPaymentMethod().transform(
-            mutableMapOf(
+            mapOf(
                 "type" to "ideal",
                 "billing_details" to billingParams,
                 "ideal" to mapOf("bank" to null)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformFormToPaymentMethodTest.kt
@@ -1,13 +1,38 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.specifications.SectionFieldSpec
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Country
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Email
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Name
+import com.stripe.android.paymentsheet.specifications.billingParams
 import com.stripe.android.paymentsheet.specifications.sofortParamKey
 import org.junit.Test
 
 class TransformFormToPaymentMethodTest {
+
+    @Test
+    fun `transform to payment method with bank`() {
+        val paymentMethodParams = TransformFormToPaymentMethod().transform(
+            mutableMapOf(
+                "type" to "ideal",
+                "billing_details" to billingParams,
+                "ideal" to mapOf("bank" to null)
+            ),
+            FormFieldValues(
+                mapOf(
+                    SectionFieldSpec.IdealBank.identifier to "ABN AMRO"
+                )
+            )
+        )
+
+        assertThat(paymentMethodParams.toString().replace("\\s".toRegex(), ""))
+            .isEqualTo(
+                """
+                    {type=ideal,billing_details={address={city=null,country=null,line1=null,line2=null,postal_code=null,state=null},name=null,email=null,phone=null},ideal={bank=abn_amro}}
+                """.trimIndent()
+            )
+    }
 
     @Test
     fun `transform to payment method params`() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -7,10 +7,12 @@ import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.FormElement.MandateTextElement
 import com.stripe.android.paymentsheet.FormElement.SectionElement
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.SectionFieldElement
 import com.stripe.android.paymentsheet.SectionFieldElement.Country
 import com.stripe.android.paymentsheet.SectionFieldElement.Email
 import com.stripe.android.paymentsheet.SectionFieldElement.Name
 import com.stripe.android.paymentsheet.elements.EmailConfig
+import com.stripe.android.paymentsheet.elements.IdealBankConfig
 import com.stripe.android.paymentsheet.elements.NameConfig
 import com.stripe.android.paymentsheet.elements.country.CountryConfig
 import com.stripe.android.paymentsheet.specifications.FormItemSpec
@@ -62,6 +64,35 @@ class TransformSpecToElementTest {
         assertThat(countrySectionElement.identifier.value).isEqualTo("countrySection")
 
         assertThat(countryElement.identifier.value).isEqualTo("country")
+    }
+
+    @Test
+    fun `Adding a ideal bank section sets up the section and country elements correctly`() {
+        val idealSection = FormItemSpec.SectionSpec(
+            IdentifierSpec("idealSection"),
+            SectionFieldSpec.IdealBank
+        )
+        val formElement = transformSpecToElement.transform(
+            LayoutSpec(
+                listOf(idealSection)
+            ),
+            "Example, Inc.",
+            FocusRequesterCount()
+        )
+
+        val idealSectionElement = formElement.first() as SectionElement
+        val idealElement = idealSectionElement.field as SectionFieldElement.IdealBank
+
+        // With only a single field in a section the section controller is just a pass through
+        // of the section field controller
+        assertThat(idealSectionElement.controller).isEqualTo(idealElement.controller)
+
+        // Verify the correct config is setup for the controller
+        assertThat(idealElement.controller.label).isEqualTo(IdealBankConfig().label)
+
+        assertThat(idealSectionElement.identifier.value).isEqualTo("idealSection")
+
+        assertThat(idealElement.identifier.value).isEqualTo("bank")
     }
 
     @Test


### PR DESCRIPTION
# Summary
There is a new type of form field that can be added that contains a list of banks for the iDEAL payment method.  This adds the new spec type so it can be added to the forms.  It is also a nice example of the code required to add a new field type.  The next PR will add this spec to the ideal form.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
