### PR TITLE
Simple refactor: move returnUrl to `WebIntentAuthenticator` and clean up `IntentAuthenticator` interface

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4623,7 +4623,7 @@ public final class com/stripe/android/payments/core/authentication/WebIntentAuth
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4586,7 +4586,7 @@ public final class com/stripe/android/payments/core/authentication/DefaultIntent
 }
 
 public abstract interface class com/stripe/android/payments/core/authentication/IntentAuthenticator : com/stripe/android/payments/core/ActivityResultLauncherHost {
-	public abstract fun authenticate (Lcom/stripe/android/view/AuthActivityStarterHost;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun authenticate (Lcom/stripe/android/view/AuthActivityStarterHost;Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/payments/core/authentication/IntentAuthenticator$DefaultImpls {
@@ -4619,11 +4619,11 @@ public final class com/stripe/android/payments/core/authentication/UnsupportedAu
 }
 
 public final class com/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {

--- a/payments-core/src/main/java/com/stripe/android/PaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentController.kt
@@ -186,7 +186,6 @@ internal interface PaymentController {
     suspend fun handleNextAction(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        returnUrl: String?,
         requestOptions: ApiRequest.Options
     )
 

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -541,11 +541,6 @@ internal class StripePaymentController internal constructor(
     /**
      * Determine which authentication mechanism should be used, or bypass authentication
      * if it is not needed.
-     *
-     * @param returnUrl in some cases, the return URL is not provided in
-     * [StripeIntent.NextActionData]. Specifically, it is not available in
-     * [StripeIntent.NextActionData.SdkData.Use3DS1]. Wire it through so that we can correctly
-     * determine how we should handle authentication.
      */
     @VisibleForTesting
     override suspend fun handleNextAction(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -69,7 +69,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
-            intentReturnUrlMap: MutableMap<String, String>
+            threeDs1IntentReturnUrlMap: MutableMap<String, String>
         ) = DaggerAuthenticationComponent.builder()
             .context(context)
             .stripeRepository(stripeRepository)
@@ -80,7 +80,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             .enableLogging(enableLogging)
             .workContext(workContext)
             .uiContext(uiContext)
-            .intentReturnUrlMap(intentReturnUrlMap)
+            .threeDs1IntentReturnUrlMap(threeDs1IntentReturnUrlMap)
             .build()
             .registry
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -69,6 +69,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
+            returnUrlSupplier: () -> String?
         ) = DaggerAuthenticationComponent.builder()
             .context(context)
             .stripeRepository(stripeRepository)
@@ -79,6 +80,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             .enableLogging(enableLogging)
             .workContext(workContext)
             .uiContext(uiContext)
+            .returnUrlSupplier(returnUrlSupplier)
             .build()
             .registry
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultIntentAuthenticatorRegistry.kt
@@ -69,7 +69,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
-            returnUrlSupplier: () -> String?
+            intentReturnUrlMap: MutableMap<String, String>
         ) = DaggerAuthenticationComponent.builder()
             .context(context)
             .stripeRepository(stripeRepository)
@@ -80,7 +80,7 @@ internal class DefaultIntentAuthenticatorRegistry @Inject internal constructor(
             .enableLogging(enableLogging)
             .workContext(workContext)
             .uiContext(uiContext)
-            .returnUrlSupplier(returnUrlSupplier)
+            .intentReturnUrlMap(intentReturnUrlMap)
             .build()
             .registry
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/IntentAuthenticator.kt
@@ -19,13 +19,11 @@ interface IntentAuthenticator : ActivityResultLauncherHost {
      *
      * @param host the host([Activity] or [Fragment]) where client is calling from, used to redirect back to client.
      * @param stripeIntent the intent to authenticate
-     * @param threeDs1ReturnUrl a dedicated deeplink URL to return to only for 3ds1 web authentication. TODO(ccen): move it to [WebIntentAuthenticator]
      * @param requestOptions configurations for the API request which triggers the authentication
      */
     suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     )
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -18,7 +18,6 @@ internal class NoOpIntentAuthenticator @Inject constructor(
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         paymentRelayStarterFactory(host)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
@@ -20,7 +20,6 @@ internal class OxxoAuthenticator @Inject constructor(
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         (stripeIntent.nextActionData as NextActionData.DisplayOxxoDetails).let { oxxoDetailsData ->
@@ -28,14 +27,12 @@ internal class OxxoAuthenticator @Inject constructor(
                 noOpIntentAuthenticator.authenticate(
                     host,
                     stripeIntent,
-                    threeDs1ReturnUrl,
                     requestOptions
                 )
             } else {
                 webIntentAuthenticator.authenticate(
                     host,
                     stripeIntent,
-                    threeDs1ReturnUrl,
                     requestOptions
                 )
             }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -21,7 +21,6 @@ internal class UnsupportedAuthenticator @Inject constructor(
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         val exception = stripeIntent.nextActionData?.let {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -27,13 +27,13 @@ internal class WebIntentAuthenticator @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
-    @UIContext private val uiContext: CoroutineContext
+    @UIContext private val uiContext: CoroutineContext,
+    private val returnUrlSupplier: () -> String?
 ) : IntentAuthenticator {
 
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         val authUrl: String
@@ -45,7 +45,7 @@ internal class WebIntentAuthenticator @Inject constructor(
             // can only triggered when `use_stripe_sdk=true`
             is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
                 authUrl = nextActionData.url
-                returnUrl = threeDs1ReturnUrl
+                returnUrl = returnUrlSupplier()
                 // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
                 shouldCancelSource = true
                 analyticsRequestExecutor.executeAsync(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -28,7 +28,7 @@ internal class WebIntentAuthenticator @Inject constructor(
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
-    private val intentReturnUrlMap: MutableMap<String, String>,
+    private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
 ) : IntentAuthenticator {
 
     override suspend fun authenticate(
@@ -46,7 +46,7 @@ internal class WebIntentAuthenticator @Inject constructor(
             is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
                 authUrl = nextActionData.url
                 returnUrl = stripeIntent.id?.let {
-                    intentReturnUrlMap.remove(it)
+                    threeDs1IntentReturnUrlMap.remove(it)
                 }
                 // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
                 shouldCancelSource = true

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -28,7 +28,7 @@ internal class WebIntentAuthenticator @Inject constructor(
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
-    private val returnUrlSupplier: () -> String?
+    private val intentReturnUrlMap: MutableMap<String, String>,
 ) : IntentAuthenticator {
 
     override suspend fun authenticate(
@@ -45,7 +45,9 @@ internal class WebIntentAuthenticator @Inject constructor(
             // can only triggered when `use_stripe_sdk=true`
             is StripeIntent.NextActionData.SdkData.Use3DS1 -> {
                 authUrl = nextActionData.url
-                returnUrl = returnUrlSupplier()
+                returnUrl = stripeIntent.id?.let {
+                    intentReturnUrlMap.remove(it)
+                }
                 // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
                 shouldCancelSource = true
                 analyticsRequestExecutor.executeAsync(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
@@ -74,7 +74,6 @@ internal class Stripe3DS2Authenticator(
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         handle3ds2Auth(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -65,7 +65,9 @@ internal interface AuthenticationComponent {
         fun uiContext(@UIContext uiContext: CoroutineContext): Builder
 
         @BindsInstance
-        fun intentReturnUrlMap(intentReturnUrlMap: MutableMap<String, String>): Builder
+        fun threeDs1IntentReturnUrlMap(
+            threeDs1IntentReturnUrlMap: MutableMap<String, String>
+        ): Builder
 
         fun build(): AuthenticationComponent
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -65,7 +65,7 @@ internal interface AuthenticationComponent {
         fun uiContext(@UIContext uiContext: CoroutineContext): Builder
 
         @BindsInstance
-        fun returnUrlSupplier(supplier: () -> String?): Builder
+        fun intentReturnUrlMap(intentReturnUrlMap: MutableMap<String, String>): Builder
 
         fun build(): AuthenticationComponent
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -64,6 +64,9 @@ internal interface AuthenticationComponent {
         @BindsInstance
         fun uiContext(@UIContext uiContext: CoroutineContext): Builder
 
+        @BindsInstance
+        fun returnUrlSupplier(supplier: () -> String?): Builder
+
         fun build(): AuthenticationComponent
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
@@ -81,7 +81,6 @@ internal abstract class AbsPaymentController : PaymentController {
     override suspend fun handleNextAction(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        returnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
     }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -53,7 +53,6 @@ class NoOpIntentAuthenticatorTest {
             authenticator.authenticate(
                 host,
                 PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-                null,
                 REQUEST_OPTIONS
             )
 
@@ -79,7 +78,6 @@ class NoOpIntentAuthenticatorTest {
             authenticator.authenticate(
                 host,
                 PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-                null,
                 REQUEST_OPTIONS
             )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -276,7 +276,6 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.authenticate(
                 host,
                 paymentIntent,
-                null,
                 REQUEST_OPTIONS
             )
             testDispatcher.advanceTimeBy(StripePaymentController.CHALLENGE_DELAY)
@@ -326,7 +325,6 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.authenticate(
                 host,
                 PaymentIntentFixtures.PI_REQUIRES_AMEX_3DS2,
-                null,
                 REQUEST_OPTIONS
             )
             testDispatcher.advanceTimeBy(StripePaymentController.CHALLENGE_DELAY)

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -52,7 +52,6 @@ class UnsupportedAuthenticatorTest {
         authenticator.authenticate(
             mock(),
             PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
-            null,
             REQUEST_OPTIONS
         )
 
@@ -77,7 +76,6 @@ class UnsupportedAuthenticatorTest {
         authenticator.authenticate(
             mock(),
             PI_SUCCEEDED,
-            null,
             REQUEST_OPTIONS
         )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -52,7 +52,7 @@ class WebIntentAuthenticatorTest {
         argumentCaptor()
     private val analyticsRequestArgumentCaptor: KArgumentCaptor<AnalyticsRequest> = argumentCaptor()
 
-    private var returnUrlFor3ds1: String? = RETURN_URL_FOR_3DS1
+    private var threeDs1IntentReturnUrlMap = mutableMapOf<String, String>()
 
     private val authenticator = WebIntentAuthenticator(
         paymentBrowserAuthStarterFactory,
@@ -60,18 +60,18 @@ class WebIntentAuthenticatorTest {
         analyticsRequestFactory,
         enableLogging = false,
         testDispatcher,
-        { returnUrlFor3ds1 }
+        threeDs1IntentReturnUrlMap
     )
 
     @Before
     fun setUp() {
-        returnUrlFor3ds1 = RETURN_URL_FOR_3DS1
+        threeDs1IntentReturnUrlMap[PAYMENT_INTENT_ID_FOR_3DS1] = RETURN_URL_FOR_3DS1
         whenever(paymentBrowserAuthStarterFactory(any())).thenReturn(paymentBrowserWebStarter)
     }
 
     @Test
     fun authenticate_whenSdk3ds1() {
-        returnUrlFor3ds1 = null
+        threeDs1IntentReturnUrlMap.remove(PAYMENT_INTENT_ID_FOR_3DS1)
         verifyAuthenticate(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_3DS1,
             expectedUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW",
@@ -90,6 +90,7 @@ class WebIntentAuthenticatorTest {
             expectedRequestCode = PAYMENT_REQUEST_CODE,
             expectedAnalyticsEvent = AnalyticsEvent.Auth3ds1Sdk
         )
+        assertThat(threeDs1IntentReturnUrlMap).doesNotContainKey(PAYMENT_INTENT_ID_FOR_3DS1)
     }
 
     @Test
@@ -170,6 +171,7 @@ class WebIntentAuthenticatorTest {
     private companion object {
         private const val ACCOUNT_ID = "acct_123"
 
+        private const val PAYMENT_INTENT_ID_FOR_3DS1 = "pi_1EceMnCRMbs6FrXfCXdF8dnx"
         private const val RETURN_URL_FOR_3DS1 = "stripesdk://payment_return_url"
         private val REQUEST_OPTIONS = ApiRequest.Options(
             apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,

--- a/wechatpay/api/wechatpay.api
+++ b/wechatpay/api/wechatpay.api
@@ -7,7 +7,7 @@ public final class com/stripe/android/payments/wechatpay/BuildConfig {
 
 public final class com/stripe/android/payments/wechatpay/WeChatPayAuthenticator : com/stripe/android/payments/core/authentication/IntentAuthenticator {
 	public fun <init> ()V
-	public fun authenticate (Lcom/stripe/android/view/AuthActivityStarterHost;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun authenticate (Lcom/stripe/android/view/AuthActivityStarterHost;Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onLauncherInvalidated ()V
 	public fun onNewActivityResultCaller (Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
 }

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
@@ -44,7 +44,6 @@ class WeChatPayAuthenticator : IntentAuthenticator {
     override suspend fun authenticate(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
-        threeDs1ReturnUrl: String?,
         requestOptions: ApiRequest.Options
     ) {
         val weChatPayRedirect =


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`IntentAuthenticator.authenticate()` has a returnUrl parameter that's only used in `WebIntentAuthenticator` when next action type is 3ds1, instead of passing it as a param, create a provider and inject it. This way we can remove the param from the interface.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This param was left there when we initially introduced the `IntentAuthenticator`s in order to minimize the PR size. Now that we have a cleaner structure, it should be removed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified - verified in example app

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
