### PR TITLE
Update PaymentBrowserAuthContract logic

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -16,7 +16,6 @@ internal interface PaymentBrowserAuthStarter :
     AuthActivityStarter<PaymentBrowserAuthContract.Args> {
     class Legacy(
         private val host: AuthActivityStarterHost,
-        private val hasCompatibleBrowser: Boolean,
         private val defaultReturnUrl: DefaultReturnUrl
     ) : PaymentBrowserAuthStarter {
         override fun start(args: PaymentBrowserAuthContract.Args) {
@@ -24,11 +23,8 @@ internal interface PaymentBrowserAuthStarter :
                 .copy(statusBarColor = host.statusBarColor)
                 .toBundle()
 
-            val shouldUseBrowser =
-                hasCompatibleBrowser && args.hasDefaultReturnUrl(defaultReturnUrl)
-
             host.startActivityForResult(
-                when (shouldUseBrowser) {
+                when (args.hasDefaultReturnUrl(defaultReturnUrl)) {
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -27,8 +27,6 @@ import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.BrowserCapabilities
-import com.stripe.android.payments.BrowserCapabilitiesSupplier
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowFailureMessageFactory
 import com.stripe.android.payments.PaymentFlowResult
@@ -80,10 +78,6 @@ internal class StripePaymentController internal constructor(
 
     private val defaultReturnUrl = DefaultReturnUrl.create(context)
 
-    private val hasCompatibleBrowser: Boolean by lazy {
-        BrowserCapabilitiesSupplier(context).get() != BrowserCapabilities.Unknown
-    }
-
     /**
      * [paymentRelayLauncher] is mutable and might be updated during
      * through [registerLaunchersWithActivityResultCaller]
@@ -106,7 +100,6 @@ internal class StripePaymentController internal constructor(
             PaymentBrowserAuthStarter.Modern(it)
         } ?: PaymentBrowserAuthStarter.Legacy(
             host,
-            hasCompatibleBrowser,
             defaultReturnUrl
         )
     }
@@ -133,7 +126,7 @@ internal class StripePaymentController internal constructor(
             activityResultCallback
         )
         paymentBrowserAuthLauncher = activityResultCaller.registerForActivityResult(
-            PaymentBrowserAuthContract(defaultReturnUrl),
+            PaymentBrowserAuthContract(),
             activityResultCallback
         )
         authenticatorRegistry.onNewActivityResultCaller(

--- a/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -6,8 +6,6 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
-import com.stripe.android.payments.BrowserCapabilities
-import com.stripe.android.payments.BrowserCapabilitiesSupplier
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.StripeBrowserLauncherActivity
@@ -19,19 +17,15 @@ import kotlinx.parcelize.Parcelize
  * An [ActivityResultContract] for completing payment authentication in a browser. This will
  * be handled in either [StripeBrowserLauncherActivity] or [PaymentAuthWebViewActivity].
  */
-internal class PaymentBrowserAuthContract(
-    private val defaultReturnUrl: DefaultReturnUrl,
-    private val hasCompatibleBrowser: (Context) -> Boolean = { context ->
-        BrowserCapabilitiesSupplier(context).get() != BrowserCapabilities.Unknown
-    }
-) : ActivityResultContract<PaymentBrowserAuthContract.Args, PaymentFlowResult.Unvalidated>() {
+internal class PaymentBrowserAuthContract :
+    ActivityResultContract<PaymentBrowserAuthContract.Args, PaymentFlowResult.Unvalidated>() {
 
     override fun createIntent(
         context: Context,
         input: Args
     ): Intent {
-        val shouldUseBrowser =
-            hasCompatibleBrowser(context) && input.hasDefaultReturnUrl(defaultReturnUrl)
+        val defaultReturnUrl = DefaultReturnUrl.create(context)
+        val shouldUseBrowser = input.hasDefaultReturnUrl(defaultReturnUrl)
 
         val statusBarColor = when (context) {
             is Activity -> context.window?.statusBarColor

--- a/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
@@ -6,6 +6,5 @@ package com.stripe.android.payments
  */
 internal enum class BrowserCapabilities {
     CustomTabs,
-    Chrome,
     Unknown
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
@@ -17,7 +17,6 @@ internal class BrowserCapabilitiesSupplier(
     fun get(): BrowserCapabilities {
         return when {
             isCustomTabsSupported() -> BrowserCapabilities.CustomTabs
-            isChromeInstalled() -> BrowserCapabilities.Chrome
             else -> BrowserCapabilities.Unknown
         }
     }
@@ -29,13 +28,6 @@ internal class BrowserCapabilitiesSupplier(
                 CHROME_PACKAGE,
                 NoopCustomTabsServiceConnection()
             )
-        }.getOrDefault(false)
-    }
-
-    private fun isChromeInstalled(): Boolean {
-        return runCatching {
-            context.packageManager.getPackageInfo(CHROME_PACKAGE, 0)
-            true
         }.getOrDefault(false)
     }
 

--- a/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -34,7 +34,6 @@ class PaymentBrowserAuthStarterTest {
 
     private val legacyStarter = PaymentBrowserAuthStarter.Legacy(
         AuthActivityStarterHost.create(activity),
-        hasCompatibleBrowser = true,
         defaultReturnUrl
     )
 
@@ -79,7 +78,6 @@ class PaymentBrowserAuthStarterTest {
                 activity,
                 statusBarColor = Color.RED
             ),
-            hasCompatibleBrowser = true,
             defaultReturnUrl
         )
         legacyStarter.start(DATA)

--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.Test
 class PaymentBrowserAuthContractTest {
 
     private val defaultReturnUrl = DefaultReturnUrl(
-        "com.example.app"
+        "com.stripe.android.test"
     )
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
@@ -39,10 +39,7 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when has compatible browser and custom return_url should use PaymentAuthWebViewActivity`() {
-        val intent = PaymentBrowserAuthContract(
-            defaultReturnUrl,
-            hasCompatibleBrowser = { true }
-        ).createIntent(
+        val intent = PaymentBrowserAuthContract().createIntent(
             activity,
             ARGS.copy(
                 returnUrl = "myapp://custom"
@@ -55,10 +52,7 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when has compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
-        val intent = PaymentBrowserAuthContract(
-            defaultReturnUrl,
-            hasCompatibleBrowser = { true }
-        ).createIntent(
+        val intent = PaymentBrowserAuthContract().createIntent(
             activity,
             ARGS.copy(
                 returnUrl = defaultReturnUrl.value
@@ -71,10 +65,7 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when no compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
-        val intent = PaymentBrowserAuthContract(
-            defaultReturnUrl,
-            hasCompatibleBrowser = { false }
-        ).createIntent(
+        val intent = PaymentBrowserAuthContract().createIntent(
             activity,
             ARGS.copy(
                 returnUrl = defaultReturnUrl.value
@@ -82,15 +73,12 @@ class PaymentBrowserAuthContractTest {
         )
 
         assertThat(intent.component?.className)
-            .isEqualTo(PaymentAuthWebViewActivity::class.java.name)
+            .isEqualTo(StripeBrowserLauncherActivity::class.java.name)
     }
 
     @Test
     fun `createIntent() should set statusBarColor from activity`() {
-        val intent = PaymentBrowserAuthContract(
-            defaultReturnUrl,
-            hasCompatibleBrowser = { false }
-        ).createIntent(
+        val intent = PaymentBrowserAuthContract().createIntent(
             activity,
             ARGS
         )

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -11,7 +11,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.exception.StripeException
-import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -25,10 +24,7 @@ internal class PaymentAuthWebViewActivityTest {
     val rule = InstantTaskExecutorRule()
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val contract = PaymentBrowserAuthContract(
-        DefaultReturnUrl.create(context),
-        hasCompatibleBrowser = { true }
-    )
+    private val contract = PaymentBrowserAuthContract()
 
     @BeforeTest
     fun before() {


### PR DESCRIPTION

# Summary
Remove the `hasCompatibleBrowser` requirement in
`PaymentBrowserAuthContract`. We can assume that any modern
device has a compatible browser. Previously, Chrome was the only
browser that would pass the `hasCompatibleBrowser` check.

This change will direct more usage to `StripeBrowserLauncherActivity`.

# Motivation
Reduce usage of `PaymentAuthWebViewActivity`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

