### PR TITLE
Custom flow should confirm all New PaymentSelection types.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -262,7 +262,6 @@ internal class DefaultFlowController @Inject internal constructor(
                         paymentSelection
                     )
                 }
-
             }
             else -> null
         }?.let { confirmParams ->

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -256,12 +256,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 confirmParamsFactory.create(paymentSelection)
             }
             is PaymentSelection.New -> {
-                when (paymentSelection) {
-                    is PaymentSelection.New.Card -> confirmParamsFactory.create(paymentSelection)
-                    is PaymentSelection.New.GenericPaymentMethod -> confirmParamsFactory.create(
-                        paymentSelection
-                    )
-                }
+                confirmParamsFactory.create(paymentSelection)
             }
             else -> null
         }?.let { confirmParams ->

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -242,7 +243,8 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    private fun confirmPaymentSelection(
+    @VisibleForTesting
+    fun confirmPaymentSelection(
         paymentSelection: PaymentSelection?,
         initData: InitData
     ) {
@@ -253,8 +255,14 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentSelection.Saved -> {
                 confirmParamsFactory.create(paymentSelection)
             }
-            is PaymentSelection.New.Card -> {
-                confirmParamsFactory.create(paymentSelection)
+            is PaymentSelection.New -> {
+                when (paymentSelection) {
+                    is PaymentSelection.New.Card -> confirmParamsFactory.create(paymentSelection)
+                    is PaymentSelection.New.GenericPaymentMethod -> confirmParamsFactory.create(
+                        paymentSelection
+                    )
+                }
+
             }
             else -> null
         }?.let { confirmParams ->

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -432,9 +432,7 @@ internal class DefaultFlowControllerTest {
                 any(),
                 any()
             )
-
         }
-
 
     @Test
     fun `confirmPayment() with GooglePay should start StripeGooglePayLauncher`() {
@@ -714,6 +712,5 @@ internal class DefaultFlowControllerTest {
         )
         private val PAYMENT_METHODS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD) + PaymentMethodFixtures.createCards(5)
-
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -58,6 +59,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -427,10 +429,25 @@ internal class DefaultFlowControllerTest {
                 )
             )
 
+            val confirmPaymentIntentParams = ConfirmPaymentIntentParams(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                setupFutureUsage = null,
+                shipping = null,
+                savePaymentMethod = null,
+                paymentMethodOptions = null,
+                mandateId = null,
+                mandateData = null,
+            )
+            val apiOptions = ApiRequest.Options(
+                apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                stripeAccount = null
+            )
+
             verify(paymentController).startConfirmAndAuth(
                 any(),
-                any(),
-                any()
+                eq(confirmPaymentIntentParams),
+                eq(apiOptions)
             )
         }
 

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -410,6 +410,33 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
+    fun `confirmPaymentSelection() with generic payment method should start paymentController`() =
+        runBlockingTest {
+            flowController.confirmPaymentSelection(
+                NEW_CARD_PAYMENT_SELECTION,
+                InitData(
+                    PaymentSheetFixtures.CONFIG_CUSTOMER,
+                    PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                    PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                    listOf(PaymentMethod.Type.Card),
+                    PAYMENT_METHODS,
+                    SavedSelection.PaymentMethod(
+                        id = "pm_123456789"
+                    ),
+                    isGooglePayReady = false
+                )
+            )
+
+            verify(paymentController).startConfirmAndAuth(
+                any(),
+                any(),
+                any()
+            )
+
+        }
+
+
+    @Test
     fun `confirmPayment() with GooglePay should start StripeGooglePayLauncher`() {
         flowController.configureWithPaymentIntent(
             PaymentSheetFixtures.CLIENT_SECRET,
@@ -670,6 +697,11 @@ internal class DefaultFlowControllerTest {
     }
 
     private companion object {
+        private val NEW_CARD_PAYMENT_SELECTION = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            CardBrand.Discover,
+            false
+        )
         private val VISA_PAYMENT_OPTION = PaymentOption(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,
             label = "····4242"
@@ -680,5 +712,8 @@ internal class DefaultFlowControllerTest {
             CardBrand.Visa,
             shouldSavePaymentMethod = true
         )
+        private val PAYMENT_METHODS =
+            listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD) + PaymentMethodFixtures.createCards(5)
+
     }
 }


### PR DESCRIPTION
# Summary
This fixes a bug where the new GenericPaymentSelection type was not included in the confirm when statement.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
