### PR TITLE
Upgrade Robolectric to 4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
 
     androidTestVersion = '1.4.0'
     junitVersion = '4.13.2'
-    robolectricVersion = '4.5.1'
+    robolectricVersion = '4.6'
 
     group_name = GROUP
     version_name = VERSION_NAME

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:3.11.2"
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.robolectric:robolectric:4.6'
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation 'org.json:json:20210307'
     testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"

--- a/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
@@ -1,14 +1,20 @@
 package com.stripe.android.view
 
+import android.os.Build
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CountryCode
 import com.stripe.android.model.getCountryCode
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.util.Locale
 import kotlin.test.Test
 
 /**
  * Test class for [CountryUtils]
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
 class CountryUtilsTest {
 
     @Test

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:3.11.2"
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.robolectric:robolectric:4.6'
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation 'org.json:json:20210307'
     testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"

--- a/stripe-test-e2e/build.gradle
+++ b/stripe-test-e2e/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.robolectric:robolectric:4.6'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.3'
     testImplementation "androidx.arch.core:core-testing:2.1.0"


### PR DESCRIPTION
https://github.com/robolectric/robolectric/releases/tag/robolectric-4.6

```
More details forthcoming, but the highlights are:

- Uses preinstrumented jars by default, significantly decreasing startup time.
- Massive fidelity improvements for Bitmap and BitmapFactory.
- Tons of bug fixes and fidelity improvements.
```