### PR TITLE
Allow PI status of RequiresAction

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2708,6 +2708,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public static final field WeChatPay Lcom/stripe/android/model/PaymentMethod$Type;
 	public final field code Ljava/lang/String;
 	public final field isReusable Z
+	public final field isVoucher Z
 	public fun describeContents ()I
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Type;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -112,29 +112,30 @@ data class PaymentMethod internal constructor(
     @Parcelize
     enum class Type constructor(
         @JvmField val code: String,
-        @JvmField val isReusable: Boolean
+        @JvmField val isReusable: Boolean,
+        @JvmField val isVoucher: Boolean
     ) : Parcelable {
-        Card("card", isReusable = true),
-        CardPresent("card_present", isReusable = false),
-        Fpx("fpx", isReusable = false),
-        Ideal("ideal", isReusable = false),
-        SepaDebit("sepa_debit", isReusable = false),
-        AuBecsDebit("au_becs_debit", isReusable = true),
-        BacsDebit("bacs_debit", isReusable = true),
-        Sofort("sofort", isReusable = false),
-        Upi("upi", isReusable = false),
-        P24("p24", isReusable = false),
-        Bancontact("bancontact", isReusable = false),
-        Giropay("giropay", isReusable = false),
-        Eps("eps", isReusable = false),
-        Oxxo("oxxo", isReusable = false),
-        Alipay("alipay", isReusable = false),
-        GrabPay("grabpay", isReusable = false),
-        PayPal("paypal", isReusable = false),
-        AfterpayClearpay("afterpay_clearpay", isReusable = false),
-        Netbanking("netbanking", isReusable = false),
-        Blik("blik", isReusable = false),
-        WeChatPay("wechat_pay", isReusable = false);
+        Card("card", isReusable = true, isVoucher = false),
+        CardPresent("card_present", isReusable = false, isVoucher = false),
+        Fpx("fpx", isReusable = false, isVoucher = false),
+        Ideal("ideal", isReusable = false, isVoucher = false),
+        SepaDebit("sepa_debit", isReusable = false, isVoucher = false),
+        AuBecsDebit("au_becs_debit", isReusable = true, isVoucher = false),
+        BacsDebit("bacs_debit", isReusable = true, isVoucher = false),
+        Sofort("sofort", isReusable = false, isVoucher = false),
+        Upi("upi", isReusable = false, isVoucher = false),
+        P24("p24", isReusable = false, isVoucher = false),
+        Bancontact("bancontact", isReusable = false, isVoucher = false),
+        Giropay("giropay", isReusable = false, isVoucher = false),
+        Eps("eps", isReusable = false, isVoucher = false),
+        Oxxo("oxxo", isReusable = false, isVoucher = true),
+        Alipay("alipay", isReusable = false, isVoucher = false),
+        GrabPay("grabpay", isReusable = false, isVoucher = false),
+        PayPal("paypal", isReusable = false, isVoucher = false),
+        AfterpayClearpay("afterpay_clearpay", isReusable = false, isVoucher = false),
+        Netbanking("netbanking", isReusable = false, isVoucher = false),
+        Blik("blik", isReusable = false, isVoucher = false),
+        WeChatPay("wechat_pay", isReusable = false, isVoucher = false);
 
         override fun toString(): String {
             return code

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -24,10 +24,13 @@ internal class StripeIntentValidator {
                 )
             }
             stripeIntent is PaymentIntent &&
-                stripeIntent.status != StripeIntent.Status.RequiresPaymentMethod -> {
+                (
+                    (stripeIntent.status != StripeIntent.Status.RequiresPaymentMethod) &&
+                        (stripeIntent.status != StripeIntent.Status.RequiresAction)
+                    ) -> {
                 error(
                     """
-                        A PaymentIntent with status='requires_payment_method' is required.
+                        A PaymentIntent with status='requires_payment_method' or 'requires_action` is required.
                         The current PaymentIntent has status ${stripeIntent.status}.
                         See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status.
                     """.trimIndent()

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -37,10 +37,13 @@ internal class StripeIntentValidator {
                 )
             }
             stripeIntent is SetupIntent &&
-                stripeIntent.status != StripeIntent.Status.RequiresPaymentMethod -> {
+                (
+                    (stripeIntent.status != StripeIntent.Status.RequiresPaymentMethod) &&
+                        (stripeIntent.status != StripeIntent.Status.RequiresAction)
+                    ) -> {
                 error(
                     """
-                        A SetupIntent with status='requires_payment_method' is required.
+                        A SetupIntent with status='requires_payment_method' or 'requires_action` is required.
                         The current SetupIntent has status ${stripeIntent.status}.
                         See https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status
                     """.trimIndent()

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -156,7 +156,13 @@ internal class StripePaymentControllerTest {
                     Triple(paymentIntent.id.orEmpty(), sourceId, REQUEST_OPTIONS)
                 )
 
-            assertThat(paymentIntentResult).isEqualTo(PaymentIntentResult(paymentIntent))
+            assertThat(paymentIntentResult).isEqualTo(
+                PaymentIntentResult(
+                    paymentIntent,
+                    0,
+                    "We are unable to authenticate your payment method. Please choose a different payment method and try again."
+                )
+            )
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.parsers.PaymentIntentJsonParser
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -16,6 +17,28 @@ class PaymentFlowFailureMessageFactoryTest {
     private val factory = PaymentFlowFailureMessageFactory(
         ApplicationProvider.getApplicationContext()
     )
+
+    @Test
+    fun `create() with PaymentIntent with requiresAction on a card`() {
+        assertThat(
+            factory.create(
+                PaymentIntentJsonParser().parse(PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD_JSON)!!,
+                StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "We are unable to authenticate your payment method. Please choose a different payment method and try again."
+        )
+    }
+
+    @Test
+    fun `create() with PaymentIntent with requiresAction on oxxo`() {
+        assertThat(
+            factory.create(
+                PaymentIntentJsonParser().parse(PaymentIntentFixtures.OXXO_REQUIRES_ACTION_JSON)!!,
+                StripeIntentResult.Outcome.FAILED
+            )
+        ).isNull()
+    }
 
     @Test
     fun `create() with PaymentIntent with lastPaymentError`() {

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.parsers.PaymentIntentJsonParser
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -32,7 +33,7 @@ class StripeIntentValidatorTest {
     }
 
     @Test
-    fun `requireValid() requires status = RequiresPaymentMethod`() {
+    fun `requireValid() processing is not valid`() {
         assertFails {
             validator.requireValid(
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -40,5 +41,19 @@ class StripeIntentValidatorTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `requireValid() allows status = RequiresPaymentMethod`() {
+        validator.requireValid(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        )
+    }
+
+    @Test
+    fun `requireValid() allows status = RequiresAction`() {
+        validator.requireValid(
+            PaymentIntentJsonParser().parse(PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD_JSON)!!,
+        )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
@@ -3,8 +3,10 @@ package com.stripe.android.paymentsheet.model
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
+import com.stripe.android.model.parsers.SetupIntentJsonParser
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -44,16 +46,32 @@ class StripeIntentValidatorTest {
     }
 
     @Test
-    fun `requireValid() allows status = RequiresPaymentMethod`() {
+    fun `PaymentIntent requireValid() allows status = RequiresPaymentMethod`() {
         validator.requireValid(
             PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
         )
     }
 
     @Test
-    fun `requireValid() allows status = RequiresAction`() {
+    fun `PaymentIntent requireValid() allows status = RequiresAction`() {
         validator.requireValid(
             PaymentIntentJsonParser().parse(PaymentIntentFixtures.EXPANDED_PAYMENT_METHOD_JSON)!!,
+        )
+    }
+
+    @Test
+    fun `SetupIntent requireValid() allows status = RequiresPaymentMethod`() {
+        validator.requireValid(
+            SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
+        )
+    }
+
+    @Test
+    fun `SetupIntent requireValid() allows status = RequiresAction`() {
+        validator.requireValid(
+            SetupIntentJsonParser().parse(
+                SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT_JSON
+            )!!
         )
     }
 }


### PR DESCRIPTION
# Summary
When Bancontact, Sofort, and iDEAL authentication is cancelled, the PI next status is requires_action, and canCancelSource is not set on the PI.  This means that the PaymentIntent is not cancelled and thus the PI will not have a status of require_payment_method (as is the case when a card like ****3184 is cancelled.   Requires_action is an acceptable final state for vouchers, but for all other PMs this indicates that the authorization was cancelled and requires authorization again.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
