### PR TITLE
reimplement wechatpay module with reflection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ ext {
     androidTestVersion = '1.4.0'
     junitVersion = '4.13.2'
     robolectricVersion = '4.6'
+    mockitoCoreVersion = '3.11.2'
+    mockitoKotlinVersion = '3.2.0'
 
     group_name = GROUP
     version_name = VERSION_NAME

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4418,6 +4418,8 @@ public final class com/stripe/android/model/TokenizationMethod : java/lang/Enum 
 
 public final class com/stripe/android/model/WeChat : com/stripe/android/model/StripeModel {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -4458,6 +4460,12 @@ public final class com/stripe/android/model/WeChatPayNextAction : com/stripe/and
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/parsers/PaymentIntentJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
+	public fun <init> ()V
+	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
+	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/StripeModel;
 }
 
 public abstract class com/stripe/android/model/wallets/Wallet : com/stripe/android/model/StripeModel {
@@ -4584,6 +4592,8 @@ public final class com/stripe/android/networking/ApiRequest$Options : android/os
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/networking/ApiRequest$Options$Companion;
 	public static final field UNDEFINED_PUBLISHABLE_KEY Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/ApiRequest$Options;
 	public static synthetic fun copy$default (Lcom/stripe/android/networking/ApiRequest$Options;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/networking/ApiRequest$Options;
 	public fun describeContents ()I
@@ -4621,10 +4631,16 @@ public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : a
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;ILcom/stripe/android/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILcom/stripe/android/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lcom/stripe/android/exception/StripeException;
 	public final fun copy (Ljava/lang/String;ILcom/stripe/android/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
 	public static synthetic fun copy$default (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Ljava/lang/String;ILcom/stripe/android/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getException ()Lcom/stripe/android/exception/StripeException;
+	public final fun getFlowOutcome ()I
 	public fun hashCode ()I
 	public final synthetic fun toBundle ()Landroid/os/Bundle;
 	public fun toString ()Ljava/lang/String;
@@ -4784,6 +4800,14 @@ public final class com/stripe/android/payments/core/injection/Stripe3DSAuthentic
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {
+}
+
+public final class com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule_ProvideWeChatAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule_ProvideWeChatAuthenticator$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideWeChatAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Lcom/stripe/android/payments/core/authentication/UnsupportedAuthenticator;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;
 }
 
 public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -44,12 +44,12 @@ dependencies {
     javadocDeps libraries.androidx.appcompat
     javadocDeps "com.google.android.material:material:$materialVersion"
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.mockito:mockito-core:3.11.2"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation 'org.json:json:20210307'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"

--- a/payments-core/src/main/java/com/stripe/android/model/WeChat.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/WeChat.kt
@@ -4,9 +4,11 @@ import kotlinx.parcelize.Parcelize
 
 /**
  * [WeChat Pay Payments with Sources](https://stripe.com/docs/sources/wechat-pay)
+ *
+ * [WeChat Pay Payments with PaymentIntents](https://stripe.com/docs/payments/wechat-pay/accept-a-payment?platform=android)
  */
 @Parcelize
-data class WeChat internal constructor(
+data class WeChat constructor(
     val statementDescriptor: String? = null,
     val appId: String?,
     val nonce: String?,

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
@@ -7,7 +8,8 @@ import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
-internal class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
     override fun parse(json: JSONObject): PaymentIntent? {
         val objectType = optString(json, FIELD_OBJECT)
         if (OBJECT_TYPE != objectType) {

--- a/payments-core/src/main/java/com/stripe/android/networking/ApiRequest.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/ApiRequest.kt
@@ -48,7 +48,7 @@ data class ApiRequest internal constructor(
      * Data class representing options for a Stripe API request.
      */
     @Parcelize
-    data class Options internal constructor(
+    data class Options constructor(
         internal val apiKey: String,
         internal val stripeAccount: String? = null,
         internal val idempotencyKey: String? = null

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
@@ -24,9 +24,9 @@ import kotlinx.parcelize.Parcelize
 sealed class PaymentFlowResult {
     @Parcelize
     data class Unvalidated constructor(
-        internal val clientSecret: String? = null,
-        @StripeIntentResult.Outcome internal val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
-        internal val exception: StripeException? = null,
+        val clientSecret: String? = null,
+        @StripeIntentResult.Outcome val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
+        val exception: StripeException? = null,
         internal val canCancelSource: Boolean = false,
         internal val sourceId: String? = null,
         internal val source: Source? = null,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -25,7 +25,8 @@ import kotlin.coroutines.CoroutineContext
 @Component(
     modules = [
         AuthenticationModule::class,
-        Stripe3DSAuthenticatorModule::class
+        Stripe3DSAuthenticatorModule::class,
+        WeChatPayAuthenticatorModule::class
     ]
 )
 internal interface AuthenticationComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.payments.core.injection
+
+import com.stripe.android.Stripe
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.UnsupportedAuthenticator
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+
+/**
+ * Provides [PaymentAuthenticator] for [NextActionData.WeChatPayRedirect] through reflection,
+ * requires "com.stripe:stripe-wechatpay:[Stripe.VERSION_NAME]" dependency.
+ * Will register a [UnsupportedAuthenticator] if the dependency is not added.
+ */
+@Module
+internal class WeChatPayAuthenticatorModule {
+    @IntentAuthenticatorMap
+    @Provides
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.WeChatPayRedirect::class)
+    internal fun provideWeChatAuthenticator(
+        unsupportedAuthenticator: UnsupportedAuthenticator
+    ): PaymentAuthenticator<StripeIntent> {
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            Class.forName(
+                "com.stripe.android.payments.wechatpay.WeChatPayAuthenticator"
+            ).getConstructor()
+                .newInstance() as PaymentAuthenticator<StripeIntent>
+        } catch (e: ClassNotFoundException) {
+            unsupportedAuthenticator
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
@@ -29,9 +29,6 @@ internal class WeChatPayAuthenticatorModule {
                 "com.stripe.android.payments.wechatpay.WeChatPayAuthenticator"
             ).getConstructor()
                 .newInstance() as PaymentAuthenticator<StripeIntent>
-        }.fold(
-            onSuccess = { it },
-            onFailure = { unsupportedAuthenticator }
-        )
+        }.getOrDefault(unsupportedAuthenticator)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
@@ -23,14 +23,15 @@ internal class WeChatPayAuthenticatorModule {
     internal fun provideWeChatAuthenticator(
         unsupportedAuthenticator: UnsupportedAuthenticator
     ): PaymentAuthenticator<StripeIntent> {
-        return try {
+        return runCatching {
             @Suppress("UNCHECKED_CAST")
             Class.forName(
                 "com.stripe.android.payments.wechatpay.WeChatPayAuthenticator"
             ).getConstructor()
                 .newInstance() as PaymentAuthenticator<StripeIntent>
-        } catch (e: ClassNotFoundException) {
-            unsupportedAuthenticator
-        }
+        }.fold(
+            onSuccess = { it },
+            onFailure = { unsupportedAuthenticator }
+        )
     }
 }

--- a/wechatpay/api/wechatpay.api
+++ b/wechatpay/api/wechatpay.api
@@ -13,3 +13,32 @@ public final class com/stripe/android/payments/wechatpay/WeChatPayAuthenticator 
 	public fun onNewActivityResultCaller (Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
 }
 
+public final class com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper : com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper {
+	public fun <init> ()V
+	public fun createIWXAPIEventHandler (Ljava/lang/reflect/InvocationHandler;)Ljava/lang/Object;
+	public fun createPayReq (Lcom/stripe/android/model/WeChat;)Ljava/lang/Object;
+	public fun createWXAPI (Landroid/content/Context;)Ljava/lang/Object;
+	public fun getRespErrorCode (Ljava/lang/Object;)I
+	public fun handleIntent (Ljava/lang/Object;Landroid/content/Intent;Ljava/lang/Object;)Z
+	public fun isWeChatPayAvailable ()Z
+	public fun registerApp (Ljava/lang/Object;Ljava/lang/String;)Z
+	public fun sendReq (Ljava/lang/Object;Ljava/lang/Object;)Z
+}
+
+public abstract interface class com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper {
+	public static final field Companion Lcom/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper$Companion;
+	public static final field WECHAT_PAY_GRADLE_DEP Ljava/lang/String;
+	public abstract fun createIWXAPIEventHandler (Ljava/lang/reflect/InvocationHandler;)Ljava/lang/Object;
+	public abstract fun createPayReq (Lcom/stripe/android/model/WeChat;)Ljava/lang/Object;
+	public abstract fun createWXAPI (Landroid/content/Context;)Ljava/lang/Object;
+	public abstract fun getRespErrorCode (Ljava/lang/Object;)I
+	public abstract fun handleIntent (Ljava/lang/Object;Landroid/content/Intent;Ljava/lang/Object;)Z
+	public abstract fun isWeChatPayAvailable ()Z
+	public abstract fun registerApp (Ljava/lang/Object;Ljava/lang/String;)Z
+	public abstract fun sendReq (Ljava/lang/Object;Ljava/lang/Object;)Z
+}
+
+public final class com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper$Companion {
+	public static final field WECHAT_PAY_GRADLE_DEP Ljava/lang/String;
+}
+

--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -76,10 +76,11 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     args "-F", "src/**/*.kt"
 }
 
-ext {
-    artifactId = "stripe-wechatpay"
-    artifactName = "stripe-wechatpay"
-    artifactDescrption = "The wechatpay module of Stripe Payment Android SDK"
-}
-
-apply from: "${rootDir}/deploy/deploy.gradle"
+// TODO(ccen) release this when WeChatPay backend API allows Android SDK sending returnUrls.
+//ext {
+//    artifactId = "stripe-wechatpay"
+//    artifactName = "stripe-wechatpay"
+//    artifactDescrption = "The wechatpay module of Stripe Payment Android SDK"
+//}
+//
+//apply from: "${rootDir}/deploy/deploy.gradle"

--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -15,11 +15,20 @@ configurations {
 dependencies {
     implementation project(':payments-core')
 
+    implementation libraries.androidx.appcompat
+    implementation 'androidx.core:core-ktx:1.5.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    ktlint "com.pinterest:ktlint:$ktlintVersion"
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
 
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
+    testImplementation "androidx.test:core-ktx:$androidTestVersion"
+
+    ktlint "com.pinterest:ktlint:$ktlintVersion"
 }
 
 android {
@@ -31,6 +40,13 @@ android {
         targetSdkVersion rootProject.ext.compileSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    testOptions {
+        unitTests {
+            // Note: without this, all Robolectric tests using BuildConfig will fail.
+            includeAndroidResources = true
+        }
     }
 
     compileOptions {
@@ -60,11 +76,10 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     args "-F", "src/**/*.kt"
 }
 
-// TODO(ccen): Uncomment this once the module is ready to be released
-//ext {
-//    artifactId = "stripe-wechatpay"
-//    artifactName = "stripe-wechatpay"
-//    artifactDescrption = "The wechatpay module of Stripe Payment Android SDK"
-//}
-//
-//apply from: "${rootDir}/deploy/deploy.gradle"
+ext {
+    artifactId = "stripe-wechatpay"
+    artifactName = "stripe-wechatpay"
+    artifactDescrption = "The wechatpay module of Stripe Payment Android SDK"
+}
+
+apply from: "${rootDir}/deploy/deploy.gradle"

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthActivity.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthActivity.kt
@@ -3,41 +3,125 @@ package com.stripe.android.payments.wechatpay
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.StripeException
 import com.stripe.android.model.WeChat
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.wechatpay.reflection.DefaultWeChatPayReflectionHelper
+import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
 
-internal class WeChatPayAuthActivity : AppCompatActivity() {
+internal class WeChatPayAuthActivity : AppCompatActivity(), InvocationHandler {
+    // TODO(ccen): inject reflectionHelper as a singleton
+    @VisibleForTesting
+    internal var reflectionHelperProvider: () -> WeChatPayReflectionHelper =
+        { DefaultWeChatPayReflectionHelper() }
+    private val reflectionHelper by lazy { reflectionHelperProvider() }
+    private val weChatApi by lazy { reflectionHelper.createWXAPI(this) }
+    private val iWXAPIEventHandler by lazy { reflectionHelper.createIWXAPIEventHandler(this) }
+    private var clientSecret: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         runCatching {
-            launchWeChat(
-                requireNotNull(WeChatPayAuthContract.Args.fromIntent(intent)).weChat
-            )
-        }.onFailure {
-            finishWithResult(
-                PaymentFlowResult.Unvalidated(
-                    flowOutcome = StripeIntentResult.Outcome.FAILED,
-                    exception = StripeException.create(it)
+            requireNotNull(
+                WeChatPayAuthContract.Args.fromIntent(intent),
+                { NULL_ARG_MSG }
+            ).let {
+                clientSecret = it.clientSecret
+                launchWeChat(
+                    it.weChat
                 )
+            }
+        }.onFailure {
+            Log.d(TAG, "incorrect Intent")
+            finishWithResult(StripeIntentResult.Outcome.FAILED, it)
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        reflectionHelper.handleIntent(weChatApi, intent, iWXAPIEventHandler)
+        Log.d(TAG, "onNewIntent - callback from IWXAPI")
+    }
+
+    override fun invoke(proxy: Any?, method: Method?, args: Array<out Any>?): Any? {
+        // IWXAPIEventHandler.onReq(BaseReq var1)
+        if (method?.name == "onReq") {
+            // no-op
+        }
+        // IWXAPIEventHandler.onResp(BaseResp var1)
+        else if (method?.name == "onResp") {
+            val resp = args?.get(0)
+            resp?.let {
+                val errorCode = reflectionHelper.getRespErrorCode(resp)
+                Log.d(TAG, "onResp with errCode: $errorCode")
+                when (errorCode) {
+                    WECHAT_PAY_ERR_OK -> {
+                        finishWithResult(StripeIntentResult.Outcome.SUCCEEDED)
+                    }
+                    WECHAT_PAY_ERR_USER_CANCEL -> {
+                        finishWithResult(StripeIntentResult.Outcome.CANCELED)
+                    }
+                    else -> {
+                        finishWithResult(
+                            StripeIntentResult.Outcome.FAILED,
+                            IllegalStateException("$FAILS_WITH_CODE $errorCode")
+                        )
+                    }
+                }
+            } ?: run {
+                finishWithResult(
+                    StripeIntentResult.Outcome.FAILED,
+                    IllegalStateException(NULL_RESP)
+                )
+            }
+        }
+        return null
+    }
+
+    private fun launchWeChat(weChat: WeChat) {
+        if (reflectionHelper.registerApp(weChatApi, weChat.appId)) {
+            Log.d(TAG, "registerApp success")
+            reflectionHelper.sendReq(weChatApi, reflectionHelper.createPayReq(weChat))
+        } else {
+            Log.d(TAG, "registerApp failure")
+            finishWithResult(
+                StripeIntentResult.Outcome.FAILED,
+                IllegalStateException(REGISTRATION_FAIL)
             )
         }
     }
 
-    private fun launchWeChat(weChat: WeChat) {
-        // TODO: invoke WeChat SDK
-    }
-
     private fun finishWithResult(
-        paymentFlowResult: PaymentFlowResult.Unvalidated
+        @StripeIntentResult.Outcome flowOutcome: Int,
+        exception: Throwable? = null
     ) {
+        Log.d(TAG, "finishWithResult with flowOutcome: $flowOutcome")
+        val paymentFlowResult = PaymentFlowResult.Unvalidated(
+            clientSecret = clientSecret,
+            flowOutcome = flowOutcome,
+            exception = exception?.let { StripeException.create(exception) }
+        )
         setResult(
             Activity.RESULT_OK,
             Intent()
                 .putExtras(paymentFlowResult.toBundle())
         )
         finish()
+    }
+
+    companion object {
+        const val TAG = "WeChatPayAuthActivity"
+        const val NULL_ARG_MSG = "WeChatPayAuthContract.Args is null"
+        const val FAILS_WITH_CODE = "WeChatPay fails with errorCode:"
+        const val NULL_RESP = "WeChatPay BaseResp is PayResp"
+        const val REGISTRATION_FAIL = "WeChatPay registerApp fails"
+        const val WECHAT_PAY_ERR_OK = 0 // BaseResp.ErrCode.ERR_OK
+        const val WECHAT_PAY_ERR_USER_CANCEL = -2 // BaseResp.ErrCode.ERR_USER_CANCEL
     }
 }

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthContract.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthContract.kt
@@ -21,7 +21,8 @@ internal class WeChatPayAuthContract :
 
     @Parcelize
     internal data class Args(
-        val weChat: WeChat
+        val weChat: WeChat,
+        val clientSecret: String
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper.kt
@@ -1,0 +1,118 @@
+package com.stripe.android.payments.wechatpay.reflection
+
+import android.content.Context
+import android.content.Intent
+import com.stripe.android.model.WeChat
+import com.stripe.android.payments.wechatpay.WeChatPayAuthActivity
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
+
+class DefaultWeChatPayReflectionHelper : WeChatPayReflectionHelper {
+    override fun isWeChatPayAvailable(): Boolean {
+        return try {
+            Class.forName("com.tencent.mm.opensdk.openapi.IWXAPIEventHandler")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
+    /**
+     * Calls "WXAPIFactory.createWXAPI(Context var0, String var1): IWXAPI"
+     */
+    override fun createWXAPI(context: Context): Any {
+        val wxApiFactoryClassCreateMethod =
+            Class.forName("com.tencent.mm.opensdk.openapi.WXAPIFactory")
+                .getMethod("createWXAPI", Context::class.java, String::class.java)
+        return wxApiFactoryClassCreateMethod.invoke(null, context, null)!!
+    }
+
+    /**
+     * Calls "IWXAPI.registerApp(String var1): Boolean"
+     */
+    override fun registerApp(iWxApi: Any, appId: String?): Boolean {
+        val iWxApiRegisterAppMethod = Class.forName("com.tencent.mm.opensdk.openapi.IWXAPI")
+            .getMethod("registerApp", String::class.java)
+        return iWxApiRegisterAppMethod.invoke(iWxApi, appId) as Boolean
+    }
+
+    /**
+     * Calls "IWXAPI.sendReq(BaseReq var1): Boolean"
+     */
+    override fun sendReq(iWxApi: Any, baseReq: Any): Boolean {
+        val iWxApiSendReqMethod = Class.forName("com.tencent.mm.opensdk.openapi.IWXAPI")
+            .getMethod("sendReq", Class.forName("com.tencent.mm.opensdk.modelbase.BaseReq"))
+        return iWxApiSendReqMethod.invoke(iWxApi, baseReq) as Boolean
+    }
+
+    /**
+     * Creates "com.tencent.mm.opensdk.modelpay.PayReq" with a [WeChat] object
+     * and have "PayReq.Options.callbackClassName" set as [WeChatPayAuthActivity]'s name
+     */
+    override fun createPayReq(weChat: WeChat): Any {
+        val payReqClass = Class.forName("com.tencent.mm.opensdk.modelpay.PayReq")
+
+        val payReqAppId = payReqClass.getField("appId")
+        val payReqPartnerId = payReqClass.getField("partnerId")
+        val payReqPrepayId = payReqClass.getField("prepayId")
+        val payReqPackageValue = payReqClass.getField("packageValue")
+        val payReqNonceStr = payReqClass.getField("nonceStr")
+        val payReqTimeStamp = payReqClass.getField("timeStamp")
+        val payReqSign = payReqClass.getField("sign")
+        val payReqOptions = payReqClass.getField("options")
+
+        val payReqOptionsClass = Class.forName("com.tencent.mm.opensdk.modelpay.PayReq\$Options")
+        val payReqOptionsCallbackClassName = payReqOptionsClass.getField("callbackClassName")
+
+        val payReqOptionsInstance = payReqOptionsClass.getConstructor().newInstance().also {
+            payReqOptionsCallbackClassName.set(it, WeChatPayAuthActivity::class.java.name)
+        }
+
+        return payReqClass.getConstructor().newInstance().also {
+            payReqAppId.set(it, weChat.appId)
+            payReqPartnerId.set(it, weChat.partnerId)
+            payReqPrepayId.set(it, weChat.prepayId)
+            payReqPackageValue.set(it, weChat.packageValue)
+            payReqNonceStr.set(it, weChat.nonce)
+            payReqTimeStamp.set(it, weChat.timestamp)
+            payReqSign.set(it, weChat.sign)
+            payReqOptions.set(it, payReqOptionsInstance)
+        }
+    }
+
+    override fun createIWXAPIEventHandler(handler: InvocationHandler): Any {
+        val iWXAPIEventHandlerClass = Class.forName(
+            "com.tencent.mm.opensdk.openapi.IWXAPIEventHandler"
+        )
+        return Proxy.newProxyInstance(
+            iWXAPIEventHandlerClass.classLoader,
+            arrayOf(iWXAPIEventHandlerClass),
+            handler
+        )
+    }
+
+    /**
+     * Calls "IWXAPI.handleIntent(Intent var1, IWXAPIEventHandler var2): Boolean"
+     */
+    override fun handleIntent(weChatApi: Any, intent: Intent?, iWXAPIEventHandler: Any): Boolean {
+        val handleIntentMethod = Class.forName("com.tencent.mm.opensdk.openapi.IWXAPI")
+            .getMethod(
+                "handleIntent",
+                Intent::class.java,
+                Class.forName(
+                    "com.tencent.mm.opensdk.openapi.IWXAPIEventHandler"
+                )
+            )
+
+        return handleIntentMethod(weChatApi, intent, iWXAPIEventHandler) as Boolean
+    }
+
+    /**
+     * Calls "com.tencent.mm.opensdk.modelpay.PayResp.PayResp#errorCode"
+     */
+    override fun getRespErrorCode(payResp: Any): Int {
+        val payRespErrorCode = Class.forName("com.tencent.mm.opensdk.modelpay.PayResp")
+            .getField("errCode")
+        return payRespErrorCode.get(payResp) as Int
+    }
+}

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.wechatpay.reflection
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.stripe.android.model.WeChat
 import com.stripe.android.payments.wechatpay.WeChatPayAuthActivity
 import java.lang.reflect.InvocationHandler
@@ -12,7 +13,8 @@ class DefaultWeChatPayReflectionHelper : WeChatPayReflectionHelper {
         return try {
             Class.forName("com.tencent.mm.opensdk.openapi.IWXAPIEventHandler")
             true
-        } catch (e: ClassNotFoundException) {
+        } catch (e: Exception) {
+            Log.e(TAG, "WeChatPay dependency not found")
             false
         }
     }
@@ -114,5 +116,9 @@ class DefaultWeChatPayReflectionHelper : WeChatPayReflectionHelper {
         val payRespErrorCode = Class.forName("com.tencent.mm.opensdk.modelpay.PayResp")
             .getField("errCode")
         return payRespErrorCode.get(payResp) as Int
+    }
+
+    private companion object {
+        val TAG = DefaultWeChatPayReflectionHelper::class.java.simpleName
     }
 }

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.payments.wechatpay.reflection
+
+import android.content.Context
+import android.content.Intent
+import com.stripe.android.model.WeChat
+import java.lang.reflect.InvocationHandler
+
+/**
+ * Interface to call WeChatPay SDK through reflection.
+ */
+interface WeChatPayReflectionHelper {
+    /**
+     * Checks if [WECHAT_PAY_GRADLE_DEP] dependency available.
+     */
+    fun isWeChatPayAvailable(): Boolean
+
+    /**
+     * Creates a "com.tencent.mm.opensdk.openapi.IWXAPI" instance.
+     */
+    fun createWXAPI(context: Context): Any
+
+    /**
+     * Registers the appId through a "com.tencent.mm.opensdk.openapi.IWXAPI" instance.
+     */
+    fun registerApp(iWxApi: Any, appId: String?): Boolean
+
+    /**
+     * Sends a "com.tencent.mm.opensdk.modelbase.BaseReq" through a
+     * "com.tencent.mm.opensdk.openapi.IWXAPI" instance.
+     */
+    fun sendReq(iWxApi: Any, baseReq: Any): Boolean
+
+    /**
+     * Creates a "com.tencent.mm.opensdk.modelpay.PayReq" object from [WeChat] object.
+     */
+    fun createPayReq(weChat: WeChat): Any
+
+    /**
+     * Handles a [Intent] through a "com.tencent.mm.opensdk.openapi.IWXAPIEventHandler" instance.
+     */
+    fun handleIntent(weChatApi: Any, intent: Intent?, iWXAPIEventHandler: Any): Boolean
+
+    /**
+     * Gets the errorCode from a "com.tencent.mm.opensdk.modelpay.PayResp" object.
+     */
+    fun getRespErrorCode(payResp: Any): Int
+
+    /**
+     * Creates a proxy object for "com.tencent.mm.opensdk.openapi.IWXAPIEventHandler".
+     */
+    fun createIWXAPIEventHandler(handler: InvocationHandler): Any
+
+    companion object {
+        // version number needs to match
+        const val WECHAT_PAY_GRADLE_DEP =
+            "com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.7.0"
+    }
+}

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/InjectableActivityScenario.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/InjectableActivityScenario.kt
@@ -1,0 +1,198 @@
+package com.stripe.android.payments.wechatpay
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.runner.lifecycle.ActivityLifecycleCallback
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import java.io.Closeable
+
+/**
+ * Creates an [InjectableActivityScenario] that uses the supplied injections.
+ *
+ * ```
+ * injectableActivityScenario<MyActivity> {
+ *   injectActivity { // this: MyActivity
+ *     dependency1 = myMockDependency1
+ *     dependency2 = myMockDependency2
+ *   }
+ *   injectFragment<MyFragment> { // this: MyFragment
+ *     dependency1 = myMockDependency1
+ *   }
+ * }
+ * ```
+ *
+ * Copied from payments-core/src/test/com/stripe/android/utils
+ * TODO(ccen): create a shared test module to host test utils
+ */
+inline fun <reified T : Activity> injectableActivityScenario(injector: InjectableActivityScenario<T>.() -> Unit) =
+    InjectableActivityScenario(T::class.java).apply {
+        this.injector()
+    }
+
+/**
+ * Adds an injector to the target [InjectableActivityScenario] for the given [Activity].
+ */
+inline fun <reified A : Activity> InjectableActivityScenario<*>.injectActivity(noinline injector: A.() -> Unit) {
+    injectActivity(A::class.java, injector)
+}
+
+/**
+ * Adds an injector to the target [InjectableActivityScenario] for the given [Fragment].
+ */
+inline fun <reified F : Fragment> InjectableActivityScenario<*>.injectFragment(noinline injector: F.() -> Unit) {
+    injectFragment(F::class.java, injector)
+}
+
+/**
+ * InjectableActivityScenario is an extension and wrapper of [ActivityScenario] which allows you to easily inject
+ * any [Activity]s and [Fragment]s that need to be loaded from the launch Activity.
+ *
+ * Based on https://gist.github.com/rharter/5939bb73207aeb6f24c8522ecf4c9d72
+ *
+ * ```
+ * val activityScenario = InjectableActivityScenario(MyActivity::class.java)
+ * activityScenario.injectActivity { // this: MyActivity
+ *   dependency1 = myMockDependency1
+ *   dependency2 = myMockDependency2
+ * }
+ * activityScenario.injectFragment(MyFragment::class.java) { // this: MyFragment
+ *   dependency1 = myMockDependency1
+ * }
+ * ```
+ */
+class InjectableActivityScenario<T : Activity>(private val activityClass: Class<T>) :
+    AutoCloseable, Closeable {
+
+    val state: Lifecycle.State?
+        get() = delegate?.state
+
+    private var delegate: ActivityScenario<T>? = null
+
+    private val activityInjectors = mutableListOf<ActivityInjector<out Activity>>()
+    private val fragmentInjectors = mutableListOf<FragmentInjector<out Fragment>>()
+
+    fun launch(startIntent: Intent? = null): InjectableActivityScenario<T> {
+        ActivityLifecycleMonitorRegistry.getInstance().addLifecycleCallback(activityLifecycleObserver)
+        delegate = if (startIntent != null) {
+            ActivityScenario.launch(startIntent)
+        } else {
+            ActivityScenario.launch(activityClass)
+        }
+        return this
+    }
+
+    override fun close() {
+        delegate?.close()
+        ActivityLifecycleMonitorRegistry.getInstance().removeLifecycleCallback(activityLifecycleObserver)
+    }
+
+    fun moveToState(newState: Lifecycle.State): InjectableActivityScenario<T> {
+        val d =
+            delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")
+        d.moveToState(newState)
+        return this
+    }
+
+    fun recreate(): InjectableActivityScenario<T> {
+        val d = delegate ?: throw IllegalStateException("Cannot recreate the activity since it hasn't been launched.")
+        d.recreate()
+        return this
+    }
+
+    fun onActivity(action: (T) -> Unit): InjectableActivityScenario<T> {
+        val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")
+        d.onActivity(action)
+        return this
+    }
+
+    fun getResult(): Instrumentation.ActivityResult =
+        delegate?.result ?: throw IllegalStateException("Cannot get result since activity hasn't been launched.")
+
+    /**
+     * Injects the target Activity using the supplied [injector].
+     *
+     */
+    fun injectActivity(injector: T.() -> Unit) {
+        activityInjectors.add(ActivityInjector(activityClass, injector))
+    }
+
+    fun <A : Activity> injectActivity(activityClass: Class<A>, injector: A.() -> Unit) {
+        activityInjectors.add(ActivityInjector(activityClass, injector))
+    }
+
+    fun <F : Fragment> injectFragment(fragmentClass: Class<F>, injector: F.() -> Unit) {
+        fragmentInjectors.add(FragmentInjector(fragmentClass, injector))
+    }
+
+    fun <F : Fragment> injectFragment(fragment: F, injector: F.() -> Unit) {
+        fragmentInjectors.add(
+            FragmentInjector(
+                fragment::class.java,
+                injector
+            )
+        )
+    }
+
+    private class ActivityInjector<A : Activity>(
+        private val activityClass: Class<A>,
+        private val injector: A.() -> Unit
+    ) {
+        fun inject(activity: Activity?): Boolean {
+            if (activityClass.isInstance(activity)) {
+                activityClass.cast(activity)!!.injector()
+                return true
+            }
+            return false
+        }
+    }
+
+    private class FragmentInjector<F : Fragment>(
+        private val fragmentClass: Class<F>,
+        private val injection: F.() -> Unit
+    ) {
+        fun inject(fragment: Fragment?): Boolean {
+            if (fragmentClass.isInstance(fragment)) {
+                fragmentClass.cast(fragment)!!.injection()
+                return true
+            }
+            return false
+        }
+    }
+
+    private val fragmentCallbacks = object : FragmentManager.FragmentLifecycleCallbacks() {
+        override fun onFragmentPreAttached(fm: FragmentManager, f: Fragment, context: Context) {
+            fragmentInjectors.forEach {
+                if (it.inject(f)) return
+            }
+        }
+    }
+
+    private val activityLifecycleObserver = object : ActivityLifecycleCallback {
+        override fun onActivityLifecycleChanged(activity: Activity?, stage: Stage?) {
+            when (stage) {
+                Stage.PRE_ON_CREATE -> {
+                    if (activity is FragmentActivity) {
+                        activity.supportFragmentManager.registerFragmentLifecycleCallbacks(fragmentCallbacks, true)
+                    }
+                    activityInjectors.forEach { if (it.inject(activity)) return }
+                }
+                Stage.DESTROYED -> {
+                    if (activity is FragmentActivity) {
+                        activity.supportFragmentManager.unregisterFragmentLifecycleCallbacks(fragmentCallbacks)
+                    }
+                }
+                else -> {
+                    // no op
+                }
+            }
+        }
+    }
+}

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/PaymentIntentFixtures.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/PaymentIntentFixtures.kt
@@ -1,0 +1,210 @@
+package com.stripe.android.payments.wechatpay
+
+import com.stripe.android.model.parsers.PaymentIntentJsonParser
+import org.json.JSONObject
+
+object PaymentIntentFixtures {
+    private val PARSER = PaymentIntentJsonParser()
+
+    private val PI_REQUIRES_BLIK_AUTHORIZE_JSON = JSONObject(
+        """
+        {
+          "id": "pi_1IVmwXFY0qyl6XeWwxGWA04D",
+          "object": "payment_intent",
+          "amount": 1099,
+          "amount_capturable": 0,
+          "amount_received": 0,
+          "amount_subtotal": 1099,
+          "application": null,
+          "application_fee_amount": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "charges": {
+            "object": "list",
+            "data": [
+        
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges?payment_intent=pi_1IVmwXFY0qyl6XeWwxGWA04D"
+          },
+          "client_secret": "pi_1IVmwXFY0qyl6XeWwxGWA04D_secret_4U8cSCdPefr8LHtPsKvA3mcQz",
+          "confirmation_method": "automatic",
+          "created": 1615939737,
+          "currency": "pln",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "next_action": {
+            "type": "blik_authorize"
+          },
+          "on_behalf_of": null,
+          "payment_method": "pm_1IVnI3FY0qyl6XeWxJFdBh2g",
+          "payment_method_options": {
+            "blik": {
+            }
+          },
+          "payment_method_types": [
+            "blik"
+          ],
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_action",
+          "total_details": {
+            "amount_discount": 0,
+            "amount_tax": 0
+          },
+          "transfer_data": null,
+          "transfer_group": null
+        }
+        """.trimIndent()
+    )
+
+    internal val PI_REQUIRES_BLIK_AUTHORIZE = PARSER.parse(PI_REQUIRES_BLIK_AUTHORIZE_JSON)!!
+
+    private val PI_REQUIRES_WECHAT_PAY_AUTHORIZE_JSON = JSONObject(
+        """
+        {
+          "id": "pi_1IlJH7BNJ02ErVOjm37T3OUt",
+          "object": "payment_intent",
+          "amount": 1099,
+          "amount_capturable": 0,
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "charges": {
+            "object": "list",
+            "data": [
+        
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges?payment_intent=pi_1IlJH7BNJ02ErVOjm37T3OUt"
+          },
+          "client_secret": "pi_1IlJH7BNJ02ErVOjm37T3OUt_secret_vgMExmjvESdtPqddHOSSSDip2",
+          "confirmation_method": "automatic",
+          "created": 1619638941,
+          "currency": "usd",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "next_action": {
+            "type": "wechat_pay_redirect_to_android_app",
+            "wechat_pay_redirect_to_android_app": {
+              "app_id": "wx65997d6307c3827d",
+              "nonce_str": "some_random_string",
+              "package": "Sign=WXPay",
+              "partner_id": "wx65997d6307c3827d",
+              "prepay_id": "test_transaction",
+              "sign": "8B26124BABC816D7140034DDDC7D3B2F1036CCB2D910E52592687F6A44790D5E",
+              "timestamp": "1619638941"
+            }
+          },
+          "on_behalf_of": null,
+          "payment_method": "pm_1IlJH7BNJ02ErVOjxKQu1wfH",
+          "payment_method_options": {
+            "wechat_pay": {
+            }
+          },
+          "payment_method_types": [
+            "wechat_pay"
+          ],
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_action",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+        """.trimIndent()
+    )
+
+    internal val PI_REQUIRES_WECHAT_PAY_AUTHORIZE =
+        PARSER.parse(PI_REQUIRES_WECHAT_PAY_AUTHORIZE_JSON)!!
+
+    private val PI_NO_NEXT_ACTION_DATA_JSON = JSONObject(
+        """
+        {
+          "id": "pi_1IVmwXFY0qyl6XeWwxGWA04D",
+          "object": "payment_intent",
+          "amount": 1099,
+          "amount_capturable": 0,
+          "amount_received": 0,
+          "amount_subtotal": 1099,
+          "application": null,
+          "application_fee_amount": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "charges": {
+            "object": "list",
+            "data": [
+        
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges?payment_intent=pi_1IVmwXFY0qyl6XeWwxGWA04D"
+          },
+          "client_secret": "pi_1IVmwXFY0qyl6XeWwxGWA04D_secret_4U8cSCdPefr8LHtPsKvA3mcQz",
+          "confirmation_method": "automatic",
+          "created": 1615939737,
+          "currency": "pln",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "next_action": {
+          },
+          "on_behalf_of": null,
+          "payment_method": "pm_1IVnI3FY0qyl6XeWxJFdBh2g",
+          "payment_method_options": {
+            "blik": {
+            }
+          },
+          "payment_method_types": [
+            "blik"
+          ],
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_action",
+          "total_details": {
+            "amount_discount": 0,
+            "amount_tax": 0
+          },
+          "transfer_data": null,
+          "transfer_group": null
+        }
+        """.trimIndent()
+    )
+
+    internal val PI_NO_NEXT_ACTION_DATA = PARSER.parse(PI_NO_NEXT_ACTION_DATA_JSON)!!
+}

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthActivityTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthActivityTest.kt
@@ -1,0 +1,227 @@
+package com.stripe.android.payments.wechatpay
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.WeChat
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.wechatpay.WeChatPayAuthActivity.Companion.WECHAT_PAY_ERR_OK
+import com.stripe.android.payments.wechatpay.WeChatPayAuthActivity.Companion.WECHAT_PAY_ERR_USER_CANCEL
+import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import java.lang.reflect.Method
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+class WeChatPayAuthActivityTest {
+    private val mockWeChatApi = mock<Any>()
+    private val mockReflectionHelper: WeChatPayReflectionHelper = mock()
+    private val context = ApplicationProvider.getApplicationContext<Context>().also {
+        it.setTheme(R.style.Theme_AppCompat)
+    }
+    private val mockOnRespMethod = mock<Method>()
+    private val responseArg = Object()
+
+    @Before
+    fun setupMocks() {
+        whenever(mockReflectionHelper.registerApp(any(), any())).thenReturn(true)
+        whenever(mockReflectionHelper.createWXAPI(any())).thenReturn(mockWeChatApi)
+        whenever(mockOnRespMethod.name).thenReturn("onResp")
+    }
+
+    @Test
+    fun `when registration succeeds should sendReq to wechatApi`() {
+        val mockBaseReq = mock<Any>()
+        whenever(mockReflectionHelper.createPayReq(any())).thenReturn(mockBaseReq)
+        val weChatCaptor = argumentCaptor<WeChat>()
+
+        testActivityWithIntent(createIntent(isValid = true)) {
+            it.onActivity {
+                verify(mockReflectionHelper).createPayReq(weChatCaptor.capture())
+
+                val req = weChatCaptor.firstValue
+
+                assertEquals(req.partnerId, PARTNER_ID)
+                assertEquals(req.prepayId, PREPAY_ID)
+                assertEquals(req.packageValue, PACKAGE_VALUE)
+                assertEquals(req.nonce, NONCE)
+                assertEquals(req.timestamp, TIME_STAMP)
+                assertEquals(req.sign, SIGN)
+
+                verify(mockReflectionHelper).sendReq(same(mockWeChatApi), same(mockBaseReq))
+            }
+        }
+    }
+
+    @Test
+    fun `when registration fails should finish with exception`() {
+        whenever(mockReflectionHelper.registerApp(any(), any())).thenReturn(false)
+        testActivityWithIntent(createIntent(isValid = true)) {
+            assertResult(
+                it.getResult(),
+                StripeIntentResult.Outcome.FAILED,
+                WeChatPayAuthActivity.REGISTRATION_FAIL
+            )
+        }
+    }
+
+    @Test
+    fun `when started with invalid intent should finish with exception`() {
+        testActivityWithIntent(
+            createIntent(isValid = false)
+        ) {
+            assertResult(
+                it.getResult(),
+                StripeIntentResult.Outcome.FAILED,
+                WeChatPayAuthActivity.NULL_ARG_MSG
+            )
+        }
+    }
+
+    @Test
+    fun `when weChatApi succeeds should finish with success`() {
+        whenever(mockReflectionHelper.getRespErrorCode(eq(responseArg))).thenReturn(
+            WECHAT_PAY_ERR_OK
+        )
+
+        testActivityWithIntent(createIntent(isValid = true)) {
+            it.onActivity { activity ->
+                activity.invoke(mock(), mockOnRespMethod, arrayOf(responseArg))
+            }
+
+            assertResult(
+                it.getResult(),
+                StripeIntentResult.Outcome.SUCCEEDED,
+                exceptionMessage = null,
+                hasClientSecret = true
+            )
+        }
+    }
+
+    @Test
+    fun `when weChatApi canceled should finish with canceled`() {
+        whenever(mockReflectionHelper.getRespErrorCode(eq(responseArg))).thenReturn(
+            WECHAT_PAY_ERR_USER_CANCEL
+        )
+
+        testActivityWithIntent(createIntent(isValid = true)) {
+            it.onActivity { activity ->
+                activity.invoke(mock(), mockOnRespMethod, arrayOf(responseArg))
+            }
+
+            assertResult(
+                it.getResult(),
+                StripeIntentResult.Outcome.CANCELED,
+                exceptionMessage = null,
+                hasClientSecret = true
+            )
+        }
+    }
+
+    @Test
+    fun `when weChatApi returns unexpected code should finish with failed`() {
+        val unexpectedErrorCode =
+            12345 // any value other than WECHAT_PAY_ERR_OK or WECHAT_PAY_ERR_USER_CANCEL
+
+        whenever(mockReflectionHelper.getRespErrorCode(eq(responseArg))).thenReturn(
+            unexpectedErrorCode
+        )
+
+        testActivityWithIntent(createIntent(isValid = true)) {
+            it.onActivity { activity ->
+                activity.invoke(mock(), mockOnRespMethod, arrayOf(responseArg))
+            }
+
+            assertResult(
+                it.getResult(),
+                StripeIntentResult.Outcome.FAILED,
+                exceptionMessage = "${WeChatPayAuthActivity.FAILS_WITH_CODE} $unexpectedErrorCode",
+                hasClientSecret = true
+            )
+        }
+    }
+
+    /**
+     * Asserts the [Instrumentation.ActivityResult] when [WeChatPayAuthActivity] finishes.
+     * Only assert the result's exception message when [exceptionMessage] is not null.
+     * Only assert the result's clientSecret if [hasClientSecret] is true.
+     */
+    private fun assertResult(
+        activityResult: Instrumentation.ActivityResult,
+        flowOutcome: Int,
+        exceptionMessage: String? = null,
+        hasClientSecret: Boolean = false,
+    ) {
+        assertEquals(Activity.RESULT_OK, activityResult.resultCode)
+        val flowResult = PaymentFlowResult.Unvalidated.fromIntent(activityResult.resultData)
+        assertEquals(flowOutcome, flowResult.flowOutcome)
+        if (hasClientSecret) {
+            assertEquals(flowResult.clientSecret, CLIENT_SECRET)
+        }
+        exceptionMessage?.let {
+            assertEquals(flowResult.exception!!.message, it)
+        } ?: run {
+            assertNull(flowResult.exception)
+        }
+    }
+
+    private fun testActivityWithIntent(
+        intent: Intent?,
+        testBody: (InjectableActivityScenario<WeChatPayAuthActivity>) -> Unit
+    ) = injectableActivityScenario<WeChatPayAuthActivity> {
+        injectActivity {
+            reflectionHelperProvider = { mockReflectionHelper }
+        }
+    }.launch(intent).use {
+        testBody(it)
+    }
+
+    private fun createIntent(isValid: Boolean = false) =
+        if (isValid) {
+            WeChatPayAuthContract().createIntent(
+                context,
+                WeChatPayAuthContract.Args(
+                    WeChat(
+                        appId = APP_ID,
+                        partnerId = PARTNER_ID,
+                        prepayId = PREPAY_ID,
+                        packageValue = PACKAGE_VALUE,
+                        nonce = NONCE,
+                        timestamp = TIME_STAMP,
+                        sign = SIGN
+                    ),
+                    CLIENT_SECRET
+                )
+            )
+        } else {
+            Intent(
+                context,
+                WeChatPayAuthActivity::class.java
+            )
+        }
+
+    private companion object {
+        const val APP_ID = "appId"
+        const val PARTNER_ID = "partnerId"
+        const val PREPAY_ID = "prepayId"
+        const val PACKAGE_VALUE = "packageValue"
+        const val NONCE = "nonceStr"
+        const val TIME_STAMP = "timeStamp"
+        const val SIGN = "sign"
+        const val CLIENT_SECRET = "clientSecret"
+    }
+}

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -1,0 +1,129 @@
+package com.stripe.android.payments.wechatpay
+
+import com.stripe.android.model.WeChat
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class WeChatPayAuthenticatorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val mockWeChatAuthLauncherFactory: (AuthActivityStarterHost, Int) -> WeChatPayAuthStarter =
+        mock()
+    private val mockWeChatPayAuthStarter: WeChatPayAuthStarter = mock()
+    private val mockReflectionHelper: WeChatPayReflectionHelper = mock()
+    private val authenticator = WeChatPayAuthenticator().also {
+        it.weChatAuthLauncherFactory = mockWeChatAuthLauncherFactory
+        it.reflectionHelper = mockReflectionHelper
+    }
+
+    @Before
+    fun setUpMocks() {
+        whenever(mockWeChatAuthLauncherFactory(any(), any())).thenReturn(
+            mockWeChatPayAuthStarter
+        )
+
+        whenever(mockReflectionHelper.isWeChatPayAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun `authenticate should throw exception when weChatPay dependency is not available`() =
+        testDispatcher.runBlockingTest {
+            whenever(mockReflectionHelper.isWeChatPayAvailable()).thenReturn(false)
+
+            assertFailsWithMessage<IllegalArgumentException>(
+                "WeChatPay dependency is not found, add " +
+                    "${WeChatPayReflectionHelper.WECHAT_PAY_GRADLE_DEP} in app's build.gradle"
+            ) {
+                authenticator.authenticate(
+                    mock(),
+                    PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
+                    REQUEST_OPTIONS
+                )
+            }
+        }
+
+    @Test
+    fun `authenticate should throw exception when stripeIntent is not WeChatPay`() =
+        testDispatcher.runBlockingTest {
+            assertFailsWithMessage<IllegalArgumentException>(
+                "stripeIntent.nextActionData should be WeChatPayRedirect, " +
+                    "instead it is BlikAuthorize"
+            ) {
+                authenticator.authenticate(
+                    mock(),
+                    PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
+                    REQUEST_OPTIONS
+                )
+            }
+        }
+
+    @Test
+    fun `authenticate should throw exception when stripeIntent#nextActionData is null`() =
+        testDispatcher.runBlockingTest {
+            assertFailsWithMessage<IllegalArgumentException>(
+                "stripeIntent.nextActionData should be WeChatPayRedirect, " +
+                    "instead it is null"
+            ) {
+                authenticator.authenticate(
+                    mock(),
+                    PaymentIntentFixtures.PI_NO_NEXT_ACTION_DATA,
+                    REQUEST_OPTIONS
+                )
+            }
+        }
+
+    @Test
+    fun `wechatPayAuthStarter should start when stripeIntent is WeChatPay`() =
+        testDispatcher.runBlockingTest {
+            authenticator.authenticate(
+                mock(),
+                PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
+                REQUEST_OPTIONS
+            )
+            verify(mockWeChatPayAuthStarter).start(
+                argWhere {
+                    it.weChat == WeChat(
+                        appId = "wx65997d6307c3827d",
+                        nonce = "some_random_string",
+                        packageValue = "Sign=WXPay",
+                        partnerId = "wx65997d6307c3827d",
+                        prepayId = "test_transaction",
+                        sign = "8B26124BABC816D7140034DDDC7D3B2F1036CCB2D910E52592687F6A44790D5E",
+                        timestamp = "1619638941"
+                    ) &&
+                        it.clientSecret == "pi_1IlJH7BNJ02ErVOjm37T3OUt_secret_vgMExmjvESdtPqddHOSSSDip2"
+                }
+            )
+        }
+
+    private inline fun <reified T : Throwable> assertFailsWithMessage(
+        throwableMsg: String,
+        block: () -> Unit
+    ) {
+        val throwable = assertFailsWith<T> { block() }
+        assertEquals(throwableMsg, throwable.message)
+    }
+
+    private companion object {
+        private val REQUEST_OPTIONS = ApiRequest.Options(
+            apiKey = "TestKey",
+            stripeAccount = "TestAccountId"
+        )
+    }
+}

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -3,14 +3,12 @@ package com.stripe.android.payments.wechatpay
 import com.stripe.android.model.WeChat
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
-import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -23,21 +21,15 @@ import kotlin.test.assertFailsWith
 @ExperimentalCoroutinesApi
 class WeChatPayAuthenticatorTest {
     private val testDispatcher = TestCoroutineDispatcher()
-    private val mockWeChatAuthLauncherFactory: (AuthActivityStarterHost, Int) -> WeChatPayAuthStarter =
-        mock()
     private val mockWeChatPayAuthStarter: WeChatPayAuthStarter = mock()
     private val mockReflectionHelper: WeChatPayReflectionHelper = mock()
     private val authenticator = WeChatPayAuthenticator().also {
-        it.weChatAuthLauncherFactory = mockWeChatAuthLauncherFactory
+        it.weChatAuthLauncherFactory = { _, _ -> mockWeChatPayAuthStarter }
         it.reflectionHelper = mockReflectionHelper
     }
 
     @Before
     fun setUpMocks() {
-        whenever(mockWeChatAuthLauncherFactory(any(), any())).thenReturn(
-            mockWeChatPayAuthStarter
-        )
-
         whenever(mockReflectionHelper.isWeChatPayAvailable()).thenReturn(true)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Reimplement wechat pay module with reflection(see original PR at #3909)

Instead of including `com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.7.0` directly from the module, the client will need to declare dependency on  in their app's build.gradle. 

* Will add a README on how to use this module in a follow up.
* Please refer to [this](https://paper.dropbox.com/doc/Daggerize-Android-Mobile-SDK--BHYN_GRJ3hyOqFbLhaBqsIBUAg-M9mrrTib7RFBVN7VimeGx) internal doc for modularization details

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
by including `com.stripe:stripe-wechatpay:x.y.z` and `com.tencent.mm.opensdk:wechat-sdk-android-without-mta:x.y.z` on top of `com.stripe:stripe-android:x.y.z`, the client can access wechatPay through `Stripe.confirmPayment` without adding any logic.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

