### PR TITLE
Add support for hiding form fields when SetupIntent

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -50,21 +50,6 @@ public abstract interface class com/stripe/android/paymentsheet/elements/common/
 	public abstract fun onValueChange (Ljava/lang/String;)V
 }
 
-public final class com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController : com/stripe/android/paymentsheet/elements/common/Controller, com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getErrorMessage ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getLabel ()I
-	public fun getOptionalIdentifiers ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getSaveForFutureUse ()Lkotlinx/coroutines/flow/Flow;
-	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
-	public fun onValueChange (Ljava/lang/String;)V
-	public final fun onValueChange (Z)V
-}
-
 public final class com/stripe/android/paymentsheet/forms/FormFieldValues {
 	public static final field $stable I
 	public fun <init> (Ljava/util/Map;ZZ)V
@@ -117,7 +102,6 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/Compose
 	public static final field Companion Lcom/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment$Companion;
 	public static final field EXTRA_PAYMENT_METHOD Ljava/lang/String;
 	public fun <init> ()V
-	public final fun enableSetupIntent (Z)V
 	public final fun getFormSpec ()Lcom/stripe/android/paymentsheet/specifications/FormSpec;
 	public final fun getFormViewModel ()Lcom/stripe/android/paymentsheet/forms/FormViewModel;
 	public fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -50,7 +50,7 @@ public abstract interface class com/stripe/android/paymentsheet/elements/common/
 	public abstract fun onValueChange (Ljava/lang/String;)V
 }
 
-public final class com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController : com/stripe/android/paymentsheet/elements/common/Controller {
+public final class com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController : com/stripe/android/paymentsheet/elements/common/Controller, com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController {
 	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;)V
@@ -58,7 +58,7 @@ public final class com/stripe/android/paymentsheet/elements/common/SaveForFuture
 	public fun getErrorMessage ()Lkotlinx/coroutines/flow/Flow;
 	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
 	public fun getLabel ()I
-	public final fun getOptionalIdentifiers ()Lkotlinx/coroutines/flow/Flow;
+	public fun getOptionalIdentifiers ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getSaveForFutureUse ()Lkotlinx/coroutines/flow/Flow;
 	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
 	public fun onValueChange (Ljava/lang/String;)V
@@ -77,6 +77,7 @@ public final class com/stripe/android/paymentsheet/forms/FormFieldValues {
 public final class com/stripe/android/paymentsheet/forms/FormViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/specifications/LayoutSpec;Ljava/lang/String;)V
+	public final fun enableSetupIntent (Z)V
 	public final fun getCompleteFormValues ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getCountFocusableFields ()I
 	public final fun getOptionalIdentifiers ()Lkotlinx/coroutines/flow/Flow;
@@ -116,6 +117,7 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/Compose
 	public static final field Companion Lcom/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment$Companion;
 	public static final field EXTRA_PAYMENT_METHOD Ljava/lang/String;
 	public fun <init> ()V
+	public final fun enableSetupIntent (Z)V
 	public final fun getFormSpec ()Lcom/stripe/android/paymentsheet/specifications/FormSpec;
 	public final fun getFormViewModel ()Lcom/stripe/android/paymentsheet/forms/FormViewModel;
 	public fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
@@ -172,6 +174,19 @@ public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$S
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getField ()Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec;
 	public fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SetupIntentHiddenFields : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$SetupIntentHiddenFields;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$SetupIntentHiddenFields;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/specifications/FormItemSpec$SetupIntentHiddenFields;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
+	public final fun getIdentifierSetupIntentHiddenFields ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -3,7 +3,9 @@ package com.stripe.android.paymentsheet
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.elements.common.Controller
 import com.stripe.android.paymentsheet.elements.common.DropdownFieldController
+import com.stripe.android.paymentsheet.elements.common.OptionalIdentifierListElement
 import com.stripe.android.paymentsheet.elements.common.SaveForFutureUseController
+import com.stripe.android.paymentsheet.elements.common.SetupIntentHiddenFieldController
 import com.stripe.android.paymentsheet.elements.common.TextFieldController
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
 
@@ -71,7 +73,16 @@ internal sealed class FormElement {
         override val identifier: IdentifierSpec,
         override val controller: SaveForFutureUseController,
         val merchantName: String?
-    ) : FormElement()
+    ) : FormElement(), OptionalIdentifierListElement
+
+    /**
+     * This is an element that will make elements (as specified by identifier) hidden
+     * when SetupIntent is used in the form
+     */
+    data class SetupIntentHiddenFieldsElement(
+        override val identifier: IdentifierSpec,
+        override val controller: SetupIntentHiddenFieldController,
+    ) : FormElement(), OptionalIdentifierListElement
 
     data class SectionElement(
         override val identifier: IdentifierSpec,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController.kt
@@ -2,7 +2,27 @@ package com.stripe.android.paymentsheet.elements.common
 
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 
-internal interface OptionalIdentifierListController {
-    val optionalIdentifiers: Flow<Set<IdentifierSpec>>
+internal sealed class OptionalIdentifierListController(
+    identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
+) : Controller {
+    protected val _enableHiding = MutableStateFlow(false)
+    val enableHiding: Flow<Boolean> = _enableHiding
+    override val fieldValue: Flow<String> = enableHiding.map { it.toString() }
+    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
+    override val isComplete: Flow<Boolean> = MutableStateFlow(true)
+
+    val optionalIdentifiers: Flow<Set<IdentifierSpec>> =
+        enableHiding.map { enableHiding ->
+            identifiersRequiredForFutureUse
+                .takeIf { enableHiding }
+                ?.toSet()
+                ?: emptySet()
+        }
+
+    abstract fun onValueChange(disableHiding: Boolean)
+
+    abstract override fun onValueChange(disableHiding: String)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListController.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentsheet.elements.common
+
+import com.stripe.android.paymentsheet.specifications.IdentifierSpec
+import kotlinx.coroutines.flow.Flow
+
+internal interface OptionalIdentifierListController {
+    val optionalIdentifiers: Flow<Set<IdentifierSpec>>
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/OptionalIdentifierListElement.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.paymentsheet.elements.common
+
+internal interface OptionalIdentifierListElement {
+    val controller: OptionalIdentifierListController
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController.kt
@@ -8,8 +8,7 @@ import kotlinx.coroutines.flow.map
 
 class SaveForFutureUseController(
     identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
-) :
-    Controller {
+) : Controller, OptionalIdentifierListController {
     override val label: Int = R.string.save_for_future_use
     private val _saveForFutureUse = MutableStateFlow(true)
     val saveForFutureUse: Flow<Boolean> = _saveForFutureUse
@@ -17,9 +16,12 @@ class SaveForFutureUseController(
     override val errorMessage: Flow<Int?> = MutableStateFlow(null)
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
 
-    val optionalIdentifiers: Flow<List<IdentifierSpec>> =
+    override val optionalIdentifiers: Flow<Set<IdentifierSpec>> =
         saveForFutureUse.map { saveFutureUseInstance ->
-            identifiersRequiredForFutureUse.takeUnless { saveFutureUseInstance } ?: emptyList()
+            identifiersRequiredForFutureUse
+                .takeUnless { saveFutureUseInstance }
+                ?.toSet()
+                ?: emptySet()
         }
 
     fun onValueChange(saveForFutureUse: Boolean) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseController.kt
@@ -2,33 +2,19 @@ package com.stripe.android.paymentsheet.elements.common
 
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 
-class SaveForFutureUseController(
+internal class SaveForFutureUseController(
     identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
-) : Controller, OptionalIdentifierListController {
+) : OptionalIdentifierListController(identifiersRequiredForFutureUse) {
     override val label: Int = R.string.save_for_future_use
-    private val _saveForFutureUse = MutableStateFlow(true)
-    val saveForFutureUse: Flow<Boolean> = _saveForFutureUse
-    override val fieldValue: Flow<String> = saveForFutureUse.map { it.toString() }
-    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
-    override val isComplete: Flow<Boolean> = MutableStateFlow(true)
+    val saveForFutureUse = enableHiding.map { !it }
 
-    override val optionalIdentifiers: Flow<Set<IdentifierSpec>> =
-        saveForFutureUse.map { saveFutureUseInstance ->
-            identifiersRequiredForFutureUse
-                .takeUnless { saveFutureUseInstance }
-                ?.toSet()
-                ?: emptySet()
-        }
-
-    fun onValueChange(saveForFutureUse: Boolean) {
-        _saveForFutureUse.value = saveForFutureUse
+    override fun onValueChange(saveForFutureUse: Boolean) {
+        _enableHiding.value = !saveForFutureUse
     }
 
-    override fun onValueChange(saveForFutureUseValue: String) {
-        _saveForFutureUse.value = saveForFutureUseValue.toBooleanStrictOrNull() ?: true
+    override fun onValueChange(saveForFutureUse: String) {
+        _enableHiding.value = !(saveForFutureUse.toBooleanStrictOrNull() ?: true)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SetupIntentHiddenFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SetupIntentHiddenFieldController.kt
@@ -2,30 +2,17 @@ package com.stripe.android.paymentsheet.elements.common
 
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 
 internal class SetupIntentHiddenFieldController(
-    identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
-) : Controller, OptionalIdentifierListController {
+    identifiersHiddenOnSetupIntent: List<IdentifierSpec> = emptyList()
+) : OptionalIdentifierListController(identifiersHiddenOnSetupIntent) {
     override val label: Int = R.string.invalid
-    private val _setupIntentInUse = MutableStateFlow(false)
-    val setupIntentInUse: Flow<Boolean> = _setupIntentInUse
-    override val fieldValue: Flow<String> = setupIntentInUse.map { it.toString() }
-    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
-    override val isComplete: Flow<Boolean> = MutableStateFlow(true)
 
-    override val optionalIdentifiers: Flow<Set<IdentifierSpec>> =
-        setupIntentInUse.map { setupIntentInUse ->
-            identifiersRequiredForFutureUse.takeIf { setupIntentInUse }?.toSet() ?: emptySet()
-        }
-
-    fun onValueChange(setupIntentInUse: Boolean) {
-        _setupIntentInUse.value = setupIntentInUse
+    override fun onValueChange(setupIntentInUse: Boolean) {
+        _enableHiding.value = setupIntentInUse
     }
 
     override fun onValueChange(setupIntentInUse: String) {
-        _setupIntentInUse.value = setupIntentInUse.toBooleanStrictOrNull() ?: true
+        _enableHiding.value = setupIntentInUse.toBooleanStrictOrNull() ?: true
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SetupIntentHiddenFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/common/SetupIntentHiddenFieldController.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.paymentsheet.elements.common
+
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.specifications.IdentifierSpec
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+internal class SetupIntentHiddenFieldController(
+    identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
+) : Controller, OptionalIdentifierListController {
+    override val label: Int = R.string.invalid
+    private val _setupIntentInUse = MutableStateFlow(false)
+    val setupIntentInUse: Flow<Boolean> = _setupIntentInUse
+    override val fieldValue: Flow<String> = setupIntentInUse.map { it.toString() }
+    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
+    override val isComplete: Flow<Boolean> = MutableStateFlow(true)
+
+    override val optionalIdentifiers: Flow<Set<IdentifierSpec>> =
+        setupIntentInUse.map { setupIntentInUse ->
+            identifiersRequiredForFutureUse.takeIf { setupIntentInUse }?.toSet() ?: emptySet()
+        }
+
+    fun onValueChange(setupIntentInUse: Boolean) {
+        _setupIntentInUse.value = setupIntentInUse
+    }
+
+    override fun onValueChange(setupIntentInUse: String) {
+        _setupIntentInUse.value = setupIntentInUse.toBooleanStrictOrNull() ?: true
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.combine
  */
 internal class TransformElementToFormFieldValueFlow(
     val elements: List<FormElement>,
-    val optionalIdentifiers: Flow<List<IdentifierSpec>>,
+    val optionalIdentifiers: Flow<Set<IdentifierSpec>>,
     val showingMandate: Flow<Boolean>,
     val saveForFutureUse: Flow<Boolean>
 ) {
@@ -44,7 +44,7 @@ internal class TransformElementToFormFieldValueFlow(
 
     private fun transform(
         idFieldSnapshotMap: Map<IdentifierSpec, FieldSnapshot>,
-        optionalIdentifiers: List<IdentifierSpec>,
+        optionalIdentifiers: Set<IdentifierSpec>,
         showingMandate: Boolean,
         saveForFutureUse: Boolean
     ): FormFieldValues? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.elements.IdealBankConfig
 import com.stripe.android.paymentsheet.elements.NameConfig
 import com.stripe.android.paymentsheet.elements.common.DropdownFieldController
 import com.stripe.android.paymentsheet.elements.common.SaveForFutureUseController
+import com.stripe.android.paymentsheet.elements.common.SetupIntentHiddenFieldController
 import com.stripe.android.paymentsheet.elements.common.TextFieldController
 import com.stripe.android.paymentsheet.elements.country.CountryConfig
 import com.stripe.android.paymentsheet.specifications.FormItemSpec
@@ -30,6 +31,7 @@ internal class TransformSpecToElement {
                 is FormItemSpec.SaveForFutureUseSpec -> transform(it, merchantName)
                 is FormItemSpec.SectionSpec -> transform(it, focusRequesterCount)
                 is FormItemSpec.MandateTextSpec -> transform(it, merchantName)
+                is FormItemSpec.SetupIntentHiddenFields -> transform(it)
             }
         }
 
@@ -115,5 +117,15 @@ internal class TransformSpecToElement {
                 }
             ),
             merchantName
+        )
+
+    private fun transform(spec: FormItemSpec.SetupIntentHiddenFields): FormElement =
+        FormElement.SetupIntentHiddenFieldsElement(
+            spec.identifier,
+            SetupIntentHiddenFieldController(
+                spec.identifierSetupIntentHiddenFields.map { element ->
+                    element.identifier
+                }
+            )
         )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.specifications
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.SetupIntentHiddenFields
 
 internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
     "type" to "bancontact",
@@ -18,15 +19,22 @@ internal val bancontactMandate = FormItemSpec.MandateTextSpec(
     R.string.sofort_mandate,
     Color.Gray
 )
+internal val bancontactSaveForFutureUse = SaveForFutureUseSpec(
+    listOf(
+        bancontactEmailSection, bancontactMandate
+    )
+)
+
 val bancontact = FormSpec(
     LayoutSpec(
         listOf(
             bancontactNameSection,
             bancontactEmailSection,
             bancontactMandate,
-            SaveForFutureUseSpec(
-                listOf(
-                    bancontactEmailSection, bancontactMandate
+            bancontactSaveForFutureUse,
+            SetupIntentHiddenFields(
+                bancontactSaveForFutureUse.identifierRequiredForFutureUse.plus(
+                    bancontactSaveForFutureUse
                 )
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/IdealSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/IdealSpec.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentsheet.specifications
 
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.MandateTextSpec
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SectionSpec
-import com.stripe.android.paymentsheet.specifications.FormItemSpec.MandateTextSpec
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Email
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.IdealBank
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Name
@@ -27,6 +27,7 @@ internal val idealMandate = MandateTextSpec(
     R.string.sofort_mandate,
     Color.Gray
 )
+internal val idealSaveForFutureUse = SaveForFutureUseSpec(listOf(idealEmailSection, idealMandate))
 val ideal = FormSpec(
     LayoutSpec(
         listOf(
@@ -34,7 +35,12 @@ val ideal = FormSpec(
             idealEmailSection,
             idealBankSection,
             idealMandate,
-            SaveForFutureUseSpec(listOf(idealEmailSection, idealMandate))
+            idealSaveForFutureUse,
+            FormItemSpec.SetupIntentHiddenFields(
+                idealSaveForFutureUse.identifierRequiredForFutureUse.plus(
+                    idealSaveForFutureUse
+                )
+            )
         )
     ),
     idealParamKey,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
@@ -2,9 +2,10 @@ package com.stripe.android.paymentsheet.specifications
 
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.MandateTextSpec
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.specifications.FormItemSpec.SectionSpec
-import com.stripe.android.paymentsheet.specifications.FormItemSpec.MandateTextSpec
+import com.stripe.android.paymentsheet.specifications.FormItemSpec.SetupIntentHiddenFields
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Country
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Email
 import com.stripe.android.paymentsheet.specifications.SectionFieldSpec.Name
@@ -27,6 +28,8 @@ internal val sofortMandate = MandateTextSpec(
     R.string.sofort_mandate,
     Color.Gray
 )
+internal val sofortSaveForFutureUse =
+    SaveForFutureUseSpec(listOf(sofortNameSection, sofortEmailSection, sofortMandate))
 val sofort = FormSpec(
     LayoutSpec(
         listOf(
@@ -34,7 +37,12 @@ val sofort = FormSpec(
             sofortEmailSection,
             sofortCountrySection,
             sofortMandate,
-            SaveForFutureUseSpec(listOf(sofortNameSection, sofortEmailSection, sofortMandate))
+            sofortSaveForFutureUse,
+            SetupIntentHiddenFields(
+                sofortSaveForFutureUse.identifierRequiredForFutureUse.plus(
+                    sofortSaveForFutureUse
+                )
+            )
         )
     ),
     sofortParamKey,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
@@ -56,6 +56,12 @@ sealed class FormItemSpec {
     ) : FormItemSpec(), OptionalItemSpec {
         override val identifier = IdentifierSpec("save_for_future_use")
     }
+
+    data class SetupIntentHiddenFields(
+        val identifierSetupIntentHiddenFields: List<OptionalItemSpec>
+    ) : FormItemSpec(), OptionalItemSpec {
+        override val identifier = IdentifierSpec("setup_intent_hidden")
+    }
 }
 
 /**

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/common/SaveForFutureUseControllerTest.kt
@@ -7,10 +7,10 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class SaveForFutureUseControllerTest {
-    val mandateIdentifier = IdentifierSpec("mandate")
-    val nameSectionIdentifier = IdentifierSpec("name")
-    val optionalIdentifiers = listOf(nameSectionIdentifier, mandateIdentifier)
-    val saveForFutureUseController = SaveForFutureUseController(optionalIdentifiers)
+    private val mandateIdentifier = IdentifierSpec("mandate")
+    private val nameSectionIdentifier = IdentifierSpec("name")
+    private val optionalIdentifiers = listOf(nameSectionIdentifier, mandateIdentifier)
+    private val saveForFutureUseController = SaveForFutureUseController(optionalIdentifiers)
 
     @Test
     fun `Save for future use is initialized as true and no optional items`() =
@@ -25,7 +25,7 @@ class SaveForFutureUseControllerTest {
             saveForFutureUseController.onValueChange(false)
             assertThat(saveForFutureUseController.saveForFutureUse.first()).isFalse()
             assertThat(saveForFutureUseController.optionalIdentifiers.first()).isEqualTo(
-                optionalIdentifiers
+                optionalIdentifiers.toSet()
             )
         }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
@@ -36,7 +36,7 @@ class TransformElementToFormViewValueFlowTest {
         countryController
     )
 
-    private val optionalIdentifersFlow = MutableStateFlow<List<IdentifierSpec>>(emptyList())
+    private val optionalIdentifersFlow = MutableStateFlow<Set<IdentifierSpec>>(emptySet())
 
     private val transformElementToFormFieldValueFlow = TransformElementToFormFieldValueFlow(
         listOf(countrySection, emailSection),
@@ -71,7 +71,7 @@ class TransformElementToFormViewValueFlowTest {
     fun `If an optional field is incomplete field pairs have the non-optional values`() {
         runBlocking {
             emailController.onValueChange("email is invalid")
-            optionalIdentifersFlow.value = listOf(emailSection.identifier)
+            optionalIdentifersFlow.value = setOf(emailSection.identifier)
 
             val formFieldValue = transformElementToFormFieldValueFlow.transformFlow().first()
 
@@ -87,7 +87,7 @@ class TransformElementToFormViewValueFlowTest {
     fun `If an optional field is complete field pairs contain only the non-optional values`() {
         runBlocking {
             emailController.onValueChange("email@valid.com")
-            optionalIdentifersFlow.value = listOf(emailSection.identifier)
+            optionalIdentifersFlow.value = setOf(emailSection.identifier)
 
             val formFieldValue = transformElementToFormFieldValueFlow.transformFlow().first()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -205,7 +205,42 @@ class TransformSpecToElementTest {
             saveForFutureUseController.onValueChange(false)
             assertThat(saveForFutureUseController.optionalIdentifiers.first())
                 .isEqualTo(
-                    optionalIdentifiers.map { it.identifier }
+                    optionalIdentifiers.map { it.identifier }.toSet()
+                )
+        }
+
+    @Test
+    fun `Add a setup intent element that hides fields correctly`() =
+        runBlocking {
+            val mandate = FormItemSpec.MandateTextSpec(
+                IdentifierSpec("mandate"),
+                R.string.sofort_mandate,
+                Color.Gray
+            )
+            val optionalIdentifiers = listOf(nameSection, mandate)
+            val setupIntentHiddenFieldSpec =
+                FormItemSpec.SetupIntentHiddenFields(optionalIdentifiers)
+            val formElement = transformSpecToElement.transform(
+                LayoutSpec(
+                    listOf(setupIntentHiddenFieldSpec)
+                ),
+                "Example, Inc.",
+                FocusRequesterCount()
+            )
+
+            val setupIntentHiddenFieldsElement =
+                formElement.first() as FormElement.SetupIntentHiddenFieldsElement
+            val setupIntentHiddenFieldsController = setupIntentHiddenFieldsElement.controller
+
+            assertThat(setupIntentHiddenFieldsElement.identifier)
+                .isEqualTo(setupIntentHiddenFieldSpec.identifier)
+
+            assertThat(setupIntentHiddenFieldsController.optionalIdentifiers.first()).isEmpty()
+
+            setupIntentHiddenFieldsController.onValueChange(true)
+            assertThat(setupIntentHiddenFieldsController.optionalIdentifiers.first())
+                .isEqualTo(
+                    optionalIdentifiers.map { it.identifier }.toSet()
                 )
         }
 }


### PR DESCRIPTION
# Summary
Add the ability to specify an element in the spec that will indicate which fields should be hidden when the intent is a setup intent.   This is for the case where the save for future usage should be hidden when it is a SetupIntent.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

