### PR TITLE
apply dokka to payments-core and paymentsheet module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,12 @@ nexusPublishing {
 }
 
 apply plugin: 'binary-compatibility-validator'
+apply plugin: 'org.jetbrains.dokka'
+
+
+tasks.dokkaHtmlMultiModule.configure {
+    outputDirectory = new File("${project.rootDir}/docs")
+}
 
 apiValidation {
     ignoredPackages += ["com.stripe.android.databinding"]

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -65,7 +65,6 @@ dependencies {
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 
-    dokkaHtmlPlugin("org.jetbrains.dokka:dokka-base:$dokkaVersion")
 }
 
 android {
@@ -117,7 +116,7 @@ android {
     }
 
     dokkaHtml {
-        outputDirectory = new File("${project.rootDir}/docs/")
+        outputDirectory = new File("${project.rootDir}/docs/$project.name")
     }
 
     buildFeatures {

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
+    id 'org.jetbrains.dokka'
     id "org.jetbrains.kotlin.plugin.parcelize"
 }
 
@@ -43,6 +44,10 @@ android {
 
     lintOptions {
         disable "UnrememberedMutableState"
+    }
+
+    dokkaHtml {
+        outputDirectory = new File("${project.rootDir}/docs/$project.name")
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use the newly introduced [dokkaHtmlMultiModule](https://kotlin.github.io/dokka/1.4.0/user_guide/gradle/usage/#multi-module-projects) task to generate an index page for all modules with `dokkaHtml` defined.

Note: instead of running `./gradlew dokkaHtml`, we will need to run `./gradlew dokkaHtmlMultiModule` to generate the docs for all modules

will generate the actual docs in a follow

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Docs for multimodule

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
