### PR TITLE
Fix definition of successful payment on custom flow

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -433,15 +433,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     fun onPaymentFlowResult(paymentFlowResult: PaymentFlowResult.Unvalidated) {
         viewModelScope.launch {
-            val result = runCatching {
+            runCatching {
                 withContext(workContext) {
                     paymentFlowResultProcessorProvider.get().processResult(
                         paymentFlowResult
                     )
                 }
-            }
-
-            result.fold(
+            }.fold(
                 onSuccess = {
                     onStripeIntentResult(it)
                 },

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -422,29 +422,21 @@ internal class DefaultFlowController @Inject internal constructor(
 
     private fun createPaymentSheetResult(
         stripeIntentResult: StripeIntentResult<StripeIntent>
-    ): PaymentSheetResult {
-        val stripeIntent = stripeIntentResult.intent
-        return when {
-            stripeIntent.status == StripeIntent.Status.Succeeded ||
-                stripeIntent.status == StripeIntent.Status.RequiresCapture -> {
-                PaymentSheetResult.Completed
-            }
-            stripeIntentResult.outcome == StripeIntentResult.Outcome.CANCELED -> {
-                PaymentSheetResult.Canceled
-            }
-            stripeIntent.lastErrorMessage != null -> {
-                PaymentSheetResult.Failed(
-                    error = IllegalArgumentException(
-                        "Failed to confirm ${stripeIntent.javaClass.simpleName}: " +
-                            stripeIntent.lastErrorMessage
+    ) = when (stripeIntentResult.outcome) {
+        StripeIntentResult.Outcome.SUCCEEDED -> {
+            PaymentSheetResult.Completed
+        }
+        StripeIntentResult.Outcome.CANCELED -> {
+            PaymentSheetResult.Canceled
+        }
+        else -> {
+            PaymentSheetResult.Failed(
+                error = stripeIntentResult.intent.lastErrorMessage?.let {
+                    IllegalArgumentException(
+                        "Failed to confirm ${stripeIntentResult.intent.javaClass.simpleName}: $it"
                     )
-                )
-            }
-            else -> {
-                PaymentSheetResult.Failed(
-                    error = RuntimeException("Failed to complete payment.")
-                )
-            }
+                } ?: RuntimeException("Failed to complete payment.")
+            )
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
@@ -40,6 +40,26 @@ class PaymentIntentResultTest {
     }
 
     @Test
+    fun outcome_whenCardAndProcessing_shouldReturnUnknown() {
+        val paymentIntent = PaymentIntent(
+            created = 500L,
+            amount = 1000L,
+            clientSecret = "secret",
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            isLiveMode = false,
+            id = "pi_12345",
+            currency = "usd",
+            paymentMethodTypes = listOf("card"),
+            status = StripeIntent.Status.Processing
+        )
+        val result = PaymentIntentResult(
+            intent = paymentIntent
+        )
+        assertThat(result.outcome)
+            .isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
+    }
+
+    @Test
     fun `should parcelize correctly`() {
         ParcelUtils.verifyParcelRoundtrip(
             PaymentIntentResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Payment Sheet custom flow behaves differently from the complete flow when processing the result of a PI/SI confirmation. Now both use [`StripeIntentResult.determineOutcome`](https://github.com/stripe/stripe-android/blob/e0367eb48bc63928947095223ee175c92b09c799/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt#L26-L57) to define when a `StripeIntentResult` is successful or not:
- `StripeIntent.Status.RequiresConfirmation` was previously considered failure in the custom flow, but success in the complete flow. Now it is considered success in both.
- `StripeIntent.Status.Processing` for payment methods `SepaDebit, BacsDebit, AuBecsDebit, Sofort` was previously considered failure in the custom flow, but success in the complete flow. Now it is considered success in both.
- Other `StripeIntent.Status` remain unchanged.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Inconsistent results when reusing a `SepaDebit` payment method in the custom and complete flows.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Added redundant test to `PaymentSheetViewModelTest` and `DefaultFlowControllerTest`, but I think it's important to make sure they're in sync.