### PR TITLE
Add disabling of the form when processing.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -45,19 +45,6 @@ public final class com/stripe/android/paymentsheet/forms/FormViewModel : android
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/specifications/LayoutSpec;ZZLjava/lang/String;)V
 	public final fun getCompleteFormValues ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getCountFocusableFields ()I
-	public final fun getOptionalIdentifiers ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getSaveForFutureUse ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getShowingMandate ()Lkotlinx/coroutines/flow/Flow;
-	public final fun populateFormViewValues (Lcom/stripe/android/paymentsheet/forms/FormFieldValues;)V
-	public final fun setSaveForFutureUse (Z)V
-	public final fun setSaveForFutureUseVisibility (Z)V
-}
-
-public final class com/stripe/android/paymentsheet/forms/FormViewModel$Factory : androidx/lifecycle/ViewModelProvider$Factory {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/paymentsheet/specifications/LayoutSpec;ZZLjava/lang/String;)V
-	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/model/SupportedPaymentMethod : java/lang/Enum {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/StripeTheme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/StripeTheme.kt
@@ -29,6 +29,8 @@ private val TealLight = Color(0xFF56c8d8)
 private val Purple = Color(0xFF4a148c)
 private val PurpleLight = Color(0xFF7c43bd)
 
+internal val GrayLight = Color(0xFFF8F8F8)
+
 private val StripeDarkPalette = darkColors(
     primary = Blue200,
     primaryVariant = Green400,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownField.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.elements
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -29,6 +31,12 @@ internal fun DropDown(
     val selectedIndex by controller.selectedIndex.asLiveData().observeAsState(0)
     val items = controller.displayItems
     var expanded by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val currentTextColor = if (enabled) {
+        Color.Unspecified
+    } else {
+        TextFieldDefaults.textFieldColors().indicatorColor(enabled, false, interactionSource).value
+    }
 
     Box(
         modifier = Modifier
@@ -43,7 +51,8 @@ internal fun DropDown(
                     enabled = enabled,
                     onClick = { expanded = true }
                 )
-                .padding(16.dp)
+                .padding(16.dp),
+            color = currentTextColor
         )
         DropdownMenu(
             expanded = expanded,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownField.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.asLiveData
 @Composable
 internal fun DropDown(
     controller: DropdownFieldController,
+    enabled: Boolean,
 ) {
     val selectedIndex by controller.selectedIndex.asLiveData().observeAsState(0)
     val items = controller.displayItems
@@ -38,7 +39,10 @@ internal fun DropDown(
             items[selectedIndex],
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = { expanded = true })
+                .clickable(
+                    enabled = enabled,
+                    onClick = { expanded = true }
+                )
                 .padding(16.dp)
         )
         DropdownMenu(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/Section.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/Section.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentsheet.GrayLight
 
 internal data class CardStyle(
     val cardBorderColor: Color = Color(0x14000000),
@@ -26,12 +27,17 @@ internal data class CardStyle(
  */
 @ExperimentalAnimationApi
 @Composable
-internal fun Section(error: String?, content: @Composable () -> Unit) {
+internal fun Section(error: String?, enabled: Boolean, content: @Composable () -> Unit) {
     val cardStyle = CardStyle()
     Column(modifier = Modifier.padding(top = 8.dp)) {
         Card(
             border = BorderStroke(cardStyle.cardBorderWidth, cardStyle.cardBorderColor),
-            elevation = cardStyle.cardElevation
+            elevation = cardStyle.cardElevation,
+            backgroundColor = if (enabled) {
+                MaterialTheme.colors.surface
+            } else {
+                GrayLight
+            }
         ) {
             content()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextField.kt
@@ -48,6 +48,7 @@ internal fun TextField(
     myFocus: FocusRequester,
     nextFocus: FocusRequester?,
     modifier: Modifier = Modifier,
+    enabled: Boolean,
 ) {
     Log.d("Construct", "SimpleTextFieldElement ${textFieldController.debugLabel}")
 
@@ -99,6 +100,7 @@ internal fun TextField(
         keyboardOptions = KeyboardOptions(imeAction = imeAction(nextFocus)),
         colors = colors,
         maxLines = 1,
-        singleLine = true
+        singleLine = true,
+        enabled = enabled
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextField.kt
@@ -33,7 +33,8 @@ internal data class TextFieldColors(
     val placeholderColor: Color = Color(0x14000000),
     val backgroundColor: Color = Color.Transparent,
     val focusedIndicatorColor: Color = Color.Transparent, // primary color by default
-    val unfocusedIndicatorColor: Color = Color.Transparent
+    val unfocusedIndicatorColor: Color = Color.Transparent,
+    val disabledIndicatorColor: Color = Color.Transparent
 )
 
 /**
@@ -68,6 +69,7 @@ internal fun TextField(
         placeholderColor = textFieldColors.placeholderColor,
         backgroundColor = textFieldColors.backgroundColor,
         focusedIndicatorColor = textFieldColors.focusedIndicatorColor,
+        disabledIndicatorColor = textFieldColors.disabledIndicatorColor,
         unfocusedIndicatorColor = textFieldColors.unfocusedIndicatorColor
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -47,6 +47,7 @@ internal fun Form(
     val optionalIdentifiers by formViewModel.optionalIdentifiers.asLiveData().observeAsState(
         null
     )
+    val enabled by formViewModel.enabled.asLiveData().observeAsState(true)
 
     Column(
         modifier = Modifier
@@ -68,9 +69,15 @@ internal fun Form(
                         ) {
                             val controller = element.controller
 
-                            val error by controller.errorMessage.asLiveData().observeAsState(null)
+                            val error by controller.errorMessage.asLiveData()
+                                .observeAsState(null)
                             val sectionErrorString =
-                                error?.let { stringResource(it, stringResource(controller.label)) }
+                                error?.let {
+                                    stringResource(
+                                        it,
+                                        stringResource(controller.label)
+                                    )
+                                }
 
                             Section(sectionErrorString) {
                                 when (element.field) {
@@ -81,16 +88,21 @@ internal fun Form(
                                             myFocus = focusRequesters[focusRequesterIndex],
                                             nextFocus = focusRequesters.getOrNull(
                                                 focusRequesterIndex + 1
-                                            )
+                                            ),
+                                            enabled = enabled
                                         )
                                     }
                                     is DropdownFieldElement -> {
-                                        DropDown(element.field.controller)
+                                        DropDown(
+                                            element.field.controller,
+                                            enabled
+                                        )
                                     }
                                 }
                             }
                         }
                     }
+
                     is MandateTextElement -> {
                         Text(
                             stringResource(element.stringResId, element.merchantName ?: ""),
@@ -106,7 +118,8 @@ internal fun Form(
                         Row(modifier = Modifier.padding(vertical = 8.dp)) {
                             Checkbox(
                                 checked = checked,
-                                onCheckedChange = { controller.onValueChange(it) }
+                                onCheckedChange = { controller.onValueChange(it) },
+                                enabled = enabled
                             )
                             Text(stringResource(controller.label, element.merchantName ?: ""))
                         }
@@ -149,7 +162,12 @@ class FormViewModel(
         }
     }
 
-    private var focusIndex = FocusRequesterCount()
+    val enabled = MutableStateFlow(true)
+    fun setEnabled(enabled: Boolean) {
+        this.enabled.value = enabled
+    }
+
+    internal var focusIndex = FocusRequesterCount()
     fun getCountFocusableFields() = focusIndex.get()
 
     private val specToFormTransform = TransformSpecToElement()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -79,7 +79,7 @@ internal fun Form(
                                     )
                                 }
 
-                            Section(sectionErrorString) {
+                            Section(sectionErrorString, enabled) {
                                 when (element.field) {
                                     is TextFieldElement -> {
                                         val focusRequesterIndex = element.field.focusIndexOrder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -145,7 +145,7 @@ class FormViewModel(
     saveForFutureUseInitialVisibility: Boolean,
     merchantName: String,
 ) : ViewModel() {
-    class Factory(
+    internal class Factory(
         private val layout: LayoutSpec,
         private val saveForFutureUseValue: Boolean,
         private val saveForFutureUseVisibility: Boolean,
@@ -162,13 +162,13 @@ class FormViewModel(
         }
     }
 
-    val enabled = MutableStateFlow(true)
-    fun setEnabled(enabled: Boolean) {
+    internal val enabled = MutableStateFlow(true)
+    internal fun setEnabled(enabled: Boolean) {
         this.enabled.value = enabled
     }
 
     internal var focusIndex = FocusRequesterCount()
-    fun getCountFocusableFields() = focusIndex.get()
+    internal fun getCountFocusableFields() = focusIndex.get()
 
     private val specToFormTransform = TransformSpecToElement()
     internal val elements = specToFormTransform.transform(
@@ -179,11 +179,11 @@ class FormViewModel(
 
     private val saveForFutureUseVisible = MutableStateFlow(saveForFutureUseInitialVisibility)
 
-    fun setSaveForFutureUseVisibility(isVisible: Boolean) {
+    internal fun setSaveForFutureUseVisibility(isVisible: Boolean) {
         saveForFutureUseVisible.value = isVisible
     }
 
-    fun setSaveForFutureUse(value: Boolean) {
+    internal fun setSaveForFutureUse(value: Boolean) {
         elements
             .filterIsInstance<SaveForFutureUseElement>()
             .firstOrNull()?.controller?.onValueChange(value)
@@ -197,10 +197,10 @@ class FormViewModel(
         .filterIsInstance<SaveForFutureUseElement>()
         .firstOrNull()
 
-    val saveForFutureUse = saveForFutureUseElement?.controller?.saveForFutureUse
+    internal val saveForFutureUse = saveForFutureUseElement?.controller?.saveForFutureUse
         ?: MutableStateFlow(saveForFutureUseInitialValue)
 
-    val optionalIdentifiers =
+    internal val optionalIdentifiers =
         combine(
             saveForFutureUseVisible,
             saveForFutureUseElement?.controller?.optionalIdentifiers
@@ -216,7 +216,7 @@ class FormViewModel(
         }
 
     // Mandate is showing if it is an element of the form and it isn't optional
-    val showingMandate = optionalIdentifiers.map {
+    internal val showingMandate = optionalIdentifiers.map {
         elements
             .filterIsInstance<MandateTextElement>()
             .firstOrNull()?.let { mandate ->
@@ -229,7 +229,7 @@ class FormViewModel(
     ).transformFlow()
 
     internal val populateFormFromFormFieldValues = PopulateFormFromFormFieldValues(elements)
-    fun populateFormViewValues(formFieldValues: FormFieldValues) {
+    internal fun populateFormViewValues(formFieldValues: FormFieldValues) {
         populateFormFromFormFieldValues.populateWith(formFieldValues)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
@@ -69,7 +69,7 @@ class ComposeFormDataCollectionFragment : Fragment() {
      * should show its UI as enabled or disabled.
      */
     fun setProcessing(processing: Boolean) {
-        // TODO: Enable or disable views accordingly
+        formViewModel.setEnabled(!processing)
     }
 
     companion object {


### PR DESCRIPTION
# Summary
When processing the formViewModel should be called to set the state to disabled.  This should then disable all clickable fields in the form.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
