### PR TITLE
Show error message when authentication fails for Setup Intent

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -179,7 +179,7 @@ data class SetupIntent internal constructor(
         }
 
         internal companion object {
-            internal const val CODE_AUTHENTICATION_ERROR = "payment_intent_authentication_failure"
+            internal const val CODE_AUTHENTICATION_ERROR = "setup_intent_authentication_failure"
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -46,7 +46,7 @@ internal object SetupIntentFixtures {
             "created": 1561677666,
             "description": "a description",
             "last_setup_error": {
-                "code": "payment_intent_authentication_failure",
+                "code": "setup_intent_authentication_failure",
                 "doc_url": "https://stripe.com/docs/error-codes/payment-intent-authentication-failure",
                 "message": "The provided PaymentMethod has failed authentication. You can provide payment_method_data or a new PaymentMethod to attempt to fulfill this PaymentIntent again.",
                 "payment_method": {

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
@@ -52,7 +52,7 @@ class SetupIntentTest {
         assertNotNull(lastSetupError)
         assertNotNull(lastSetupError.paymentMethod)
         assertEquals("pm_1F7J1bCRMbs6FrXfQKsYwO3U", lastSetupError.paymentMethod?.id)
-        assertEquals("payment_intent_authentication_failure", lastSetupError.code)
+        assertEquals("setup_intent_authentication_failure", lastSetupError.code)
         assertEquals(SetupIntent.Error.Type.InvalidRequestError, lastSetupError.type)
         assertEquals(
             "https://stripe.com/docs/error-codes/payment-intent-authentication-failure",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show error message when authentication fails for Setup Intent.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We were checking for incorrect error code.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified