### PR TITLE
Use card-shaped icons on card forms

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -22,7 +22,6 @@ import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.databinding.StripeHorizontalDividerBinding
 import com.stripe.android.databinding.StripeVerticalDividerBinding
-import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CountryCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -231,22 +230,6 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
         }
 
         cardMultilineWidget.setCvcIcon(R.drawable.stripe_ic_paymentsheet_cvc)
-
-        cardMultilineWidget.cardBrandIconSupplier =
-            CardMultilineWidget.CardBrandIconSupplier { cardBrand ->
-                CardMultilineWidget.CardBrandIcon(
-                    when (cardBrand) {
-                        CardBrand.Visa -> R.drawable.stripe_ic_paymentsheet_card_visa
-                        CardBrand.AmericanExpress -> R.drawable.stripe_ic_paymentsheet_card_amex
-                        CardBrand.Discover -> R.drawable.stripe_ic_paymentsheet_card_discover
-                        CardBrand.JCB -> R.drawable.stripe_ic_paymentsheet_card_jcb
-                        CardBrand.DinersClub -> R.drawable.stripe_ic_paymentsheet_card_dinersclub
-                        CardBrand.MasterCard -> R.drawable.stripe_ic_paymentsheet_card_mastercard
-                        CardBrand.UnionPay -> R.drawable.stripe_ic_paymentsheet_card_unionpay
-                        CardBrand.Unknown -> R.drawable.stripe_ic_paymentsheet_card_unknown
-                    }
-                )
-            }
 
         cardMultilineWidget.cardNumberErrorListener =
             StripeEditText.ErrorMessageListener { errorMessage ->

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -22,7 +22,6 @@ import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.databinding.StripeHorizontalDividerBinding
 import com.stripe.android.databinding.StripeVerticalDividerBinding
 import com.stripe.android.model.Address
-import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.CountryCode
 import com.stripe.android.view.CardFormView.Style
@@ -304,22 +303,6 @@ class CardFormView @JvmOverloads constructor(
         }
 
         cardMultilineWidget.setCvcIcon(R.drawable.stripe_ic_paymentsheet_cvc)
-
-        cardMultilineWidget.cardBrandIconSupplier =
-            CardMultilineWidget.CardBrandIconSupplier { cardBrand ->
-                CardMultilineWidget.CardBrandIcon(
-                    when (cardBrand) {
-                        CardBrand.Visa -> R.drawable.stripe_ic_paymentsheet_card_visa
-                        CardBrand.AmericanExpress -> R.drawable.stripe_ic_paymentsheet_card_amex
-                        CardBrand.Discover -> R.drawable.stripe_ic_paymentsheet_card_discover
-                        CardBrand.JCB -> R.drawable.stripe_ic_paymentsheet_card_jcb
-                        CardBrand.DinersClub -> R.drawable.stripe_ic_paymentsheet_card_dinersclub
-                        CardBrand.MasterCard -> R.drawable.stripe_ic_paymentsheet_card_mastercard
-                        CardBrand.UnionPay -> R.drawable.stripe_ic_paymentsheet_card_unionpay
-                        CardBrand.Unknown -> R.drawable.stripe_ic_paymentsheet_card_unknown
-                    }
-                )
-            }
 
         cardMultilineWidget.cardNumberErrorListener =
             StripeEditText.ErrorMessageListener { errorMessage ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use the default card-shaped icons on card forms.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The `stripe_ic_paymentsheet_card_*` icons should be used only to represent saved payment methods.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![image](https://user-images.githubusercontent.com/77990083/125395953-b18b6400-e360-11eb-8d43-b70be408e240.png)
