### PR TITLE
Add init analytics events for GooglePayLauncher

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -256,6 +256,6 @@ class GooglePayLauncher internal constructor(
     }
 
     internal companion object {
-        const val PRODUCT_USAGE = "GooglePayLauncher"
+        internal const val PRODUCT_USAGE = "GooglePayLauncher"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -5,8 +5,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -21,7 +25,9 @@ class GooglePayLauncher internal constructor(
     private val config: Config,
     private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
     private val readyCallback: ReadyCallback,
-    private val activityResultLauncher: ActivityResultLauncher<GooglePayLauncherContract.Args>
+    private val activityResultLauncher: ActivityResultLauncher<GooglePayLauncherContract.Args>,
+    analyticsRequestExecutor: AnalyticsRequestExecutor,
+    analyticsRequestFactory: AnalyticsRequestFactory
 ) {
     private var isReady = false
 
@@ -55,7 +61,12 @@ class GooglePayLauncher internal constructor(
             GooglePayLauncherContract()
         ) {
             resultCallback.onResult(it)
-        }
+        },
+        AnalyticsRequestExecutor.Default(),
+        AnalyticsRequestFactory(
+            activity,
+            PaymentConfiguration.getInstance(activity).publishableKey
+        )
     )
 
     /**
@@ -88,10 +99,20 @@ class GooglePayLauncher internal constructor(
             GooglePayLauncherContract()
         ) {
             resultCallback.onResult(it)
-        }
+        },
+        AnalyticsRequestExecutor.Default(),
+        AnalyticsRequestFactory(
+            fragment.requireContext(),
+            PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,
+            setOf(PRODUCT_USAGE)
+        )
     )
 
     init {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.createRequest(AnalyticsEvent.GooglePayLauncherInit)
+        )
+
         lifecycleScope.launch {
             val repository = googlePayRepositoryFactory(config.environment)
             readyCallback.onReady(
@@ -232,5 +253,9 @@ class GooglePayLauncher internal constructor(
 
     fun interface ResultCallback {
         fun onResult(result: Result)
+    }
+
+    internal companion object {
+        const val PRODUCT_USAGE = "GooglePayLauncher"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -26,8 +26,8 @@ class GooglePayLauncher internal constructor(
     private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
     private val readyCallback: ReadyCallback,
     private val activityResultLauncher: ActivityResultLauncher<GooglePayLauncherContract.Args>,
-    analyticsRequestExecutor: AnalyticsRequestExecutor,
-    analyticsRequestFactory: AnalyticsRequestFactory
+    analyticsRequestFactory: AnalyticsRequestFactory,
+    analyticsRequestExecutor: AnalyticsRequestExecutor = AnalyticsRequestExecutor.Default()
 ) {
     private var isReady = false
 
@@ -62,7 +62,6 @@ class GooglePayLauncher internal constructor(
         ) {
             resultCallback.onResult(it)
         },
-        AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             activity,
             PaymentConfiguration.getInstance(activity).publishableKey
@@ -100,7 +99,6 @@ class GooglePayLauncher internal constructor(
         ) {
             resultCallback.onResult(it)
         },
-        AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             fragment.requireContext(),
             PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -215,7 +215,7 @@ internal class GooglePayLauncherViewModel(
             val analyticsRequestFactory = AnalyticsRequestFactory(
                 application,
                 publishableKey,
-                setOf(PRODUCT_USAGE)
+                setOf(GooglePayLauncher.PRODUCT_USAGE)
             )
 
             val stripeRepository = StripeApiRepository(
@@ -268,9 +268,5 @@ internal class GooglePayLauncherViewModel(
                 googlePayRepository
             ) as T
         }
-    }
-
-    private companion object {
-        private const val PRODUCT_USAGE = "GooglePayLauncher"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -258,6 +258,6 @@ class GooglePayPaymentMethodLauncher internal constructor(
     }
 
     internal companion object {
-        const val PRODUCT_USAGE = "GooglePayPaymentMethodLauncher"
+        internal const val PRODUCT_USAGE = "GooglePayPaymentMethodLauncher"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -28,8 +28,8 @@ class GooglePayPaymentMethodLauncher internal constructor(
     private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
     private val readyCallback: ReadyCallback,
     private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
-    analyticsRequestExecutor: AnalyticsRequestExecutor,
-    analyticsRequestFactory: AnalyticsRequestFactory
+    analyticsRequestFactory: AnalyticsRequestFactory,
+    analyticsRequestExecutor: AnalyticsRequestExecutor = AnalyticsRequestExecutor.Default()
 ) {
     private var isReady = false
 
@@ -64,7 +64,6 @@ class GooglePayPaymentMethodLauncher internal constructor(
         ) {
             resultCallback.onResult(it)
         },
-        AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             activity,
             PaymentConfiguration.getInstance(activity).publishableKey
@@ -102,7 +101,6 @@ class GooglePayPaymentMethodLauncher internal constructor(
         ) {
             resultCallback.onResult(it)
         },
-        AnalyticsRequestExecutor.Default(),
         AnalyticsRequestFactory(
             fragment.requireContext(),
             PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -128,7 +128,7 @@ internal class GooglePayPaymentMethodLauncherViewModel(
             val analyticsRequestFactory = AnalyticsRequestFactory(
                 application,
                 publishableKey,
-                setOf(PRODUCT_USAGE)
+                setOf(GooglePayPaymentMethodLauncher.PRODUCT_USAGE)
             )
 
             val stripeRepository = StripeApiRepository(
@@ -174,9 +174,5 @@ internal class GooglePayPaymentMethodLauncherViewModel(
                 googlePayRepository
             ) as T
         }
-    }
-
-    private companion object {
-        private const val PRODUCT_USAGE = "GooglePayPaymentMethodLauncher"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsEvent.kt
@@ -81,6 +81,9 @@ internal enum class AnalyticsEvent(internal val code: String) {
 
     RadarSessionCreate("radar_session_create"),
 
+    GooglePayLauncherInit("googlepaylauncher_init"),
+    GooglePayPaymentMethodLauncherInit("googlepaypaymentmethodlauncher_init"),
+
     CardMetadataPublishableKeyAvailable("card_metadata_pk_available"),
     CardMetadataPublishableKeyUnavailable("card_metadata_pk_unavailable"),
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -70,8 +70,8 @@ class GooglePayLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 
@@ -99,8 +99,8 @@ class GooglePayLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
 
             assertThat(firedEvents)
@@ -122,8 +122,8 @@ class GooglePayLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -11,7 +11,11 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -37,6 +41,15 @@ class GooglePayLauncherTest {
     private val readyCallback = GooglePayLauncher.ReadyCallback(readyCallbackInvocations::add)
     private val resultCallback = GooglePayLauncher.ResultCallback(results::add)
 
+    private val analyticsRequestFactory = AnalyticsRequestFactory(
+        ApplicationProvider.getApplicationContext(),
+        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+    )
+    private val firedEvents = mutableListOf<String>()
+    private val analyticsRequestExecutor = AnalyticsRequestExecutor {
+        firedEvents.add(it.params["event"].toString())
+    }
+
     @AfterTest
     fun cleanup() {
         testDispatcher.cleanupTestCoroutines()
@@ -56,7 +69,9 @@ class GooglePayLauncherTest {
                     FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
                 ) {
                     resultCallback.onResult(it)
-                }
+                },
+                analyticsRequestExecutor,
+                analyticsRequestFactory
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 
@@ -67,6 +82,29 @@ class GooglePayLauncherTest {
 
             assertThat(results)
                 .containsExactly(GooglePayLauncher.Result.Completed)
+        }
+    }
+
+    @Test
+    fun `init should fire expected event`() {
+        scenario.onFragment { fragment ->
+            GooglePayLauncher(
+                testScope,
+                CONFIG,
+                { FakeGooglePayRepository(true) },
+                readyCallback,
+                fragment.registerForActivityResult(
+                    GooglePayLauncherContract(),
+                    FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
+                ) {
+                    resultCallback.onResult(it)
+                },
+                analyticsRequestExecutor,
+                analyticsRequestFactory
+            )
+
+            assertThat(firedEvents)
+                .containsExactly("stripe_android.googlepaylauncher_init")
         }
     }
 
@@ -83,7 +121,9 @@ class GooglePayLauncherTest {
                     FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
                 ) {
                     resultCallback.onResult(it)
-                }
+                },
+                analyticsRequestExecutor,
+                analyticsRequestFactory
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -75,8 +75,8 @@ class GooglePayPaymentMethodLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 
@@ -109,8 +109,8 @@ class GooglePayPaymentMethodLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
 
             assertThat(firedEvents)
@@ -136,8 +136,8 @@ class GooglePayPaymentMethodLauncherTest {
                 ) {
                     resultCallback.onResult(it)
                 },
-                analyticsRequestExecutor,
-                analyticsRequestFactory
+                analyticsRequestFactory,
+                analyticsRequestExecutor
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
 


### PR DESCRIPTION
# Summary
- Fire `googlepaylauncher_init` when `GooglePayLauncher` is instantiated
- Fire `googlepaypaymentmethodlauncher_init` when
  `GooglePayPaymentMethodLauncher` is instantiated

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
