### PR TITLE
inject `Stripe3ds2TransactionViewModel`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4824,24 +4824,24 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Stri
 	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZI)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
 }
 
-public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_MembersInjector : dagger/MembersInjector {
+public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory_MembersInjector : dagger/MembersInjector {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
-	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/AnalyticsRequestExecutor;)V
-	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
-	public static fun injectChallengeResultProcessor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;)V
-	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;)V
+	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;)V
+	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
+	public static fun injectChallengeResultProcessor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;)V
+	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectMessageVersionRegistry (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;)V
-	public static fun injectStripeRepository (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/StripeRepository;)V
-	public static fun injectThreeDs2Service (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;)V
-	public static fun injectWorkContext (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lkotlin/coroutines/CoroutineContext;)V
+	public static fun injectMessageVersionRegistry (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;)V
+	public static fun injectStripeRepository (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/StripeRepository;)V
+	public static fun injectThreeDs2Service (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;)V
+	public static fun injectWorkContext (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lkotlin/coroutines/CoroutineContext;)V
 }
 
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry;
-	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;)V
+	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/IOContext : java/lang/annotation/Annotation {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4808,9 +4808,40 @@ public final class com/stripe/android/payments/core/authentication/WebIntentAuth
 	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
+public final class com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/RetryDelaySupplier;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor;
+}
+
+public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZI)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
+}
+
+public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/AnalyticsRequestExecutor;)V
+	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
+	public static fun injectChallengeResultProcessor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;)V
+	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectMessageVersionRegistry (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;)V
+	public static fun injectStripeRepository (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/networking/StripeRepository;)V
+	public static fun injectThreeDs2Service (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;)V
+	public static fun injectWorkContext (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;Lkotlin/coroutines/CoroutineContext;)V
+}
+
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry;
+	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;)V
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/IOContext : java/lang/annotation/Annotation {
@@ -4878,12 +4909,28 @@ public final class com/stripe/android/payments/core/injection/PaymentCommonModul
 	public static fun provideStripePaymentController (Landroid/content/Context;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;)Lcom/stripe/android/PaymentController;
 }
 
-public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_ProvideStripe3DSAuthenticator$payments_core_releaseFactory;
-	public fun get ()Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;
+public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory;
+	public fun get ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideStripe3DSAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule;ZLjava/util/Map;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;
+	public static fun provideMessageVersionRegistry ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
+}
+
+public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvidePaymentAuthConfigFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvidePaymentAuthConfigFactory;
+	public fun get ()Lcom/stripe/android/PaymentAuthConfig;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentAuthConfig ()Lcom/stripe/android/PaymentAuthConfig;
+}
+
+public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideStripeThreeDs2ServiceFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideStripeThreeDs2ServiceFactory;
+	public fun get ()Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeThreeDs2Service (Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -13,7 +13,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import com.stripe.android.payments.core.injection.AuthenticationComponent
 import com.stripe.android.payments.core.injection.DaggerAuthenticationComponent
 import com.stripe.android.payments.core.injection.Injectable
@@ -91,7 +91,7 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
 
     override fun inject(injectable: Injectable) {
         when (injectable) {
-            is Stripe3ds2TransactionViewModel -> authenticationComponent.inject(injectable)
+            is Stripe3ds2TransactionViewModelFactory -> authenticationComponent.inject(injectable)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
@@ -9,16 +9,22 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.injection.ENABLE_LOGGING
+import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.view.AuthActivityStarterHost
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 
 /**
  * [PaymentAuthenticator] authenticating through Stripe's 3ds2 SDK.
  */
-internal class Stripe3DS2Authenticator(
+@Singleton
+internal class Stripe3DS2Authenticator @Inject constructor(
     private val config: PaymentAuthConfig,
-    private val enableLogging: Boolean,
-    private val threeDs1IntentReturnUrlMap: MutableMap<String, String>
+    @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
+    @InjectorKey private val injectorKey: Int,
 ) : PaymentAuthenticator<StripeIntent> {
 
     /**
@@ -61,12 +67,10 @@ internal class Stripe3DS2Authenticator(
                 config.stripe3ds2Config,
                 authenticatable,
                 authenticatable.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2,
-                threeDs1ReturnUrl = authenticatable.id?.let {
-                    threeDs1IntentReturnUrlMap[it]
-                },
                 requestOptions,
                 enableLogging = enableLogging,
-                host.statusBarColor
+                host.statusBarColor,
+                injectorKey
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
@@ -10,22 +10,28 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.RetryDelaySupplier
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.injection.ENABLE_LOGGING
+import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.stripe3ds2.transaction.ChallengeResult
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 internal interface Stripe3ds2ChallengeResultProcessor {
     suspend fun process(challengeResult: ChallengeResult): PaymentFlowResult.Unvalidated
 }
 
-internal class DefaultStripe3ds2ChallengeResultProcessor constructor(
+@Singleton
+internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
     private val stripeRepository: StripeRepository,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val retryDelaySupplier: RetryDelaySupplier,
-    enableLogging: Boolean,
-    private val workContext: CoroutineContext
+    @Named(ENABLE_LOGGING) enableLogging: Boolean,
+    @IOContext private val workContext: CoroutineContext
 ) : Stripe3ds2ChallengeResultProcessor {
     private val logger = Logger.getInstance(enableLogging)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.Stripe3ds2Fingerprint
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import kotlinx.parcelize.Parcelize
 
@@ -36,10 +37,10 @@ internal class Stripe3ds2TransactionContract :
         val config: PaymentAuthConfig.Stripe3ds2Config,
         val stripeIntent: StripeIntent,
         val nextActionData: StripeIntent.NextActionData.SdkData.Use3DS2,
-        val threeDs1ReturnUrl: String?,
         val requestOptions: ApiRequest.Options,
         val enableLogging: Boolean,
-        val statusBarColor: Int?
+        val statusBarColor: Int?,
+        @InjectorKey val injectorKey: Int
     ) : Parcelable {
         val fingerprint: Stripe3ds2Fingerprint get() = Stripe3ds2Fingerprint(nextActionData)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -67,7 +67,7 @@ internal class Stripe3ds2TransactionViewModel(
     init {
         WeakSetInjectorRegistry.retrieve(args.injectorKey)?.inject(this) ?: run {
             throw IllegalArgumentException(
-                "Failed to retrieve DefaultPaymentAuthenticatorRegistry instance"
+                "Failed to initialize Stripe3ds2TransactionViewModel instance."
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.BindsInstance
 import dagger.Component
@@ -31,6 +32,8 @@ import kotlin.coroutines.CoroutineContext
 )
 internal interface AuthenticationComponent {
     val registry: DefaultPaymentAuthenticatorRegistry
+
+    fun inject(stripe3ds2TransactionViewModel: Stripe3ds2TransactionViewModel)
 
     @Component.Builder
     interface Builder {
@@ -69,6 +72,9 @@ internal interface AuthenticationComponent {
         fun threeDs1IntentReturnUrlMap(
             threeDs1IntentReturnUrlMap: MutableMap<String, String>
         ): Builder
+
+        @BindsInstance
+        fun injectorKey(@InjectorKey id: Int): Builder
 
         fun build(): AuthenticationComponent
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -7,7 +7,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.BindsInstance
 import dagger.Component
@@ -33,7 +33,7 @@ import kotlin.coroutines.CoroutineContext
 internal interface AuthenticationComponent {
     val registry: DefaultPaymentAuthenticatorRegistry
 
-    fun inject(stripe3ds2TransactionViewModel: Stripe3ds2TransactionViewModel)
+    fun inject(stripe3ds2TransactionViewModelFactory: Stripe3ds2TransactionViewModelFactory)
 
     @Component.Builder
     interface Builder {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
@@ -1,33 +1,60 @@
 package com.stripe.android.payments.core.injection
 
+import android.content.Context
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.threeds2.DefaultStripe3ds2ChallengeResultProcessor
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2Authenticator
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2ChallengeResultProcessor
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Provides [PaymentAuthenticator] for [NextActionData.SdkData.Use3DS2].
  * Requires 3ds2 SDK.
  */
 @Module
-internal class Stripe3DSAuthenticatorModule {
+internal abstract class Stripe3DSAuthenticatorModule {
     @IntentAuthenticatorMap
-    @Provides
+    @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS2::class)
-    internal fun provideStripe3DSAuthenticator(
-        @Named(ENABLE_LOGGING) enableLogging: Boolean,
-        threeDs1IntentReturnUrlMap: MutableMap<String, String>
-    ): PaymentAuthenticator<StripeIntent> {
-        return Stripe3DS2Authenticator(
-            PaymentAuthConfig.get(),
-            enableLogging,
-            threeDs1IntentReturnUrlMap
-        )
+    abstract fun bindsStripe3DSAuthenticator(
+        stripe3ds2Authenticator: Stripe3DS2Authenticator
+    ): PaymentAuthenticator<StripeIntent>
+
+    @Binds
+    abstract fun bindsStripe3ds2ChallengeResultProcessor(
+        defaultStripe3ds2ChallengeResultProcessor: DefaultStripe3ds2ChallengeResultProcessor
+    ): Stripe3ds2ChallengeResultProcessor
+
+    companion object {
+        @Provides
+        @Singleton
+        fun providePaymentAuthConfig() = PaymentAuthConfig.get()
+
+        @Provides
+        @Singleton
+        fun provideMessageVersionRegistry() = MessageVersionRegistry()
+
+        @Provides
+        @Singleton
+        fun provideStripeThreeDs2Service(
+            context: Context,
+            @Named(ENABLE_LOGGING) enableLogging: Boolean,
+            @IOContext workContext: CoroutineContext,
+        ): StripeThreeDs2Service {
+            return StripeThreeDs2ServiceImpl(context, enableLogging, workContext)
+        }
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
@@ -28,24 +27,17 @@ class Stripe3DS2AuthenticatorTest {
     private val activity: ComponentActivity = mock()
     private val host = AuthActivityStarterHost.create(activity)
 
-    private var threeDs1IntentReturnUrlMap = mutableMapOf<String, String>()
-
     private val paymentAuthConfig = PaymentAuthConfig.Builder().set3ds2Config(
         PaymentAuthConfig.Stripe3ds2Config.Builder()
             .setTimeout(5)
             .build()
     ).build()
 
-    private lateinit var authenticator: Stripe3DS2Authenticator
-
-    @Before
-    fun setUpAuthenticator() {
-        authenticator = Stripe3DS2Authenticator(
-            paymentAuthConfig,
-            enableLogging = false,
-            threeDs1IntentReturnUrlMap
-        )
-    }
+    private val authenticator = Stripe3DS2Authenticator(
+        paymentAuthConfig,
+        enableLogging = false,
+        injectorKey = 1
+    )
 
     @Test
     fun `authenticate() should invoke startActivityForResult() when stripe3ds2CompletionLauncher is null`() =

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
@@ -16,7 +16,10 @@ import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.stripe3ds2.views.ChallengeProgressFragmentFactory
+import com.stripe.android.utils.TestUtils
+import com.stripe.android.utils.injectableActivityScenario
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -51,7 +54,12 @@ class Stripe3ds2TransactionActivityTest {
 
     @Test
     fun `fragmentFactory should be a ChallengeProgressFragmentFactory`() {
-        ActivityScenario.launch<Stripe3ds2TransactionActivity>(
+        injectableActivityScenario<Stripe3ds2TransactionActivity> {
+            injectActivity {
+                viewModelFactory =
+                    TestUtils.viewModelFactoryFor(mock<Stripe3ds2TransactionViewModel>())
+            }
+        }.launch(
             Intent(
                 ApplicationProvider.getApplicationContext(),
                 Stripe3ds2TransactionActivity::class.java
@@ -86,10 +94,10 @@ class Stripe3ds2TransactionActivityTest {
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
             PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.nextActionData
                 as StripeIntent.NextActionData.SdkData.Use3DS2,
-            threeDs1ReturnUrl = null,
             ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
             enableLogging = false,
-            statusBarColor = null
+            statusBarColor = null,
+            injectorKey = 1
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Share the dagger graph for `Stripe3ds2TransactionViewModel`.
It is done by sharing the `AuthenticationComponent` in the `DefaultPaymentAuthenticatorRegistry` instance with the newly introduced `AuthenticationComponent#inject` method.
Later if any other `Activity` / `ViewModel` requires injection, we can just add the corresponding `#inject` method in `AuthenticationComponent`

For more details, please refer to [this](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BOdU8pXvsZOgq9clyf82RTGdAg-Y8OUkag2eU9iPwUhUaVKU#:h2=Graph-of-fully-daggerized-Andr) internal doc.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Share a single dagger graph for Android SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
