### PR TITLE
Rename input controller used in forms.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.graphics.Color
-import com.stripe.android.paymentsheet.elements.Controller
+import com.stripe.android.paymentsheet.elements.InputController
 import com.stripe.android.paymentsheet.elements.DropdownFieldController
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseController
 import com.stripe.android.paymentsheet.elements.TextFieldController
@@ -31,7 +31,7 @@ internal interface OptionalElement {
  */
 internal sealed interface SectionFieldElementType {
     val identifier: IdentifierSpec
-    val controller: Controller
+    val controller: InputController
 
     interface TextFieldElement : SectionFieldElementType {
         override val controller: TextFieldController
@@ -48,7 +48,7 @@ internal sealed interface SectionFieldElementType {
  * Each item in the layout has an identifier and a controller associated with it.
  */
 internal sealed class FormElement {
-    abstract val controller: Controller?
+    abstract val controller: InputController?
     abstract val identifier: IdentifierSpec
 
     /**
@@ -61,7 +61,7 @@ internal sealed class FormElement {
         val stringResId: Int,
         val color: Color,
         val merchantName: String?,
-        override val controller: Controller? = null,
+        override val controller: InputController? = null,
     ) : FormElement(), OptionalElement
 
     /**
@@ -77,12 +77,12 @@ internal sealed class FormElement {
     data class SectionElement(
         override val identifier: IdentifierSpec,
         val field: SectionFieldElementType,
-        override val controller: Controller
+        override val controller: InputController
     ) : FormElement(), OptionalElement
 }
 
 /**
- * This class defines the type associated with the element or value.   See [FormFieldValues] and [Controller]
+ * This class defines the type associated with the element or value.   See [FormFieldValues] and [InputController]
  */
 enum class ElementType {
     Name,
@@ -98,7 +98,7 @@ enum class ElementType {
  */
 internal sealed class SectionFieldElement {
     abstract val identifier: IdentifierSpec
-    abstract val controller: Controller
+    abstract val controller: InputController
 
     data class Name(
         override val identifier: IdentifierSpec,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
@@ -6,13 +6,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 
 /**
- * This class controls the dropdown view and implements the [Controller] interface.
+ * This class controls the dropdown view and implements the [InputController] interface.
  * Because it can never be in error the `errorMessage` is always null.  It is also
  * designed to always have a value selected, so isComplete is always true.
  */
 internal class DropdownFieldController(
     private val config: DropdownConfig,
-) : Controller {
+) : InputController {
     val displayItems: List<String> = config.getDisplayItems()
     private val _selectedIndex = MutableStateFlow(0)
     val selectedIndex: Flow<Int> = _selectedIndex

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/InputController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/InputController.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * This class provides the logic behind the fields.
  */
-internal sealed interface Controller {
+internal sealed interface InputController {
     val label: Int
     val fieldValue: Flow<String>
     val rawFieldValue: Flow<String?>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.map
 
 internal class SaveForFutureUseController(
     identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList()
-) : Controller {
+) : InputController {
     override val label: Int = R.string.save_for_future_use
     private val _saveForFutureUse = MutableStateFlow(true)
     val saveForFutureUse: Flow<Boolean> = _saveForFutureUse

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.map
 internal class TextFieldController @VisibleForTesting constructor(
     private val textFieldConfig: TextFieldConfig,
     override val elementType: ElementType
-) : Controller {
+) : InputController {
 
     constructor(
         textFieldConfig: TextFieldConfig

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.stripe.android.paymentsheet.FormElement
-import com.stripe.android.paymentsheet.elements.Controller
+import com.stripe.android.paymentsheet.elements.InputController
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -64,14 +64,14 @@ internal class TransformElementToFormFieldValueFlow(
         }
     }
 
-    private fun getCurrentFieldValuePairs(idControllerMap: Map<IdentifierSpec, Controller>) =
+    private fun getCurrentFieldValuePairs(idControllerMap: Map<IdentifierSpec, InputController>) =
         idControllerMap.map { fieldControllerEntry ->
             getCurrentFieldValuePair(fieldControllerEntry.key, fieldControllerEntry.value)
         }
 
     private fun getCurrentFieldValuePair(
         field: IdentifierSpec,
-        controller: Controller
+        controller: InputController
     ) = combine(controller.rawFieldValue, controller.isComplete) { rawFieldValue, isComplete ->
         Pair(
             field,


### PR DESCRIPTION
# Summary
Rename in the input controller used for forms.  This distinction will be helpful when we add a `SectionController` that will be used to control the UI, not for collecting input.

