### PR TITLE
Make the form error an object instead of a string

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/Controller.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/Controller.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.elements
 
+import androidx.annotation.StringRes
 import com.stripe.android.paymentsheet.ElementType
 import kotlinx.coroutines.flow.Flow
 
@@ -11,8 +12,13 @@ internal sealed interface Controller {
     val fieldValue: Flow<String>
     val rawFieldValue: Flow<String?>
     val isComplete: Flow<Boolean>
-    val errorMessage: Flow<Int?>
+    val error: Flow<FieldError?>
     val elementType: ElementType
 
     fun onRawValueChange(rawValue: String)
 }
+
+internal data class FieldError(
+    @StringRes val errorFieldLabel: Int,
+    @StringRes val errorMessage: Int
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
@@ -19,7 +19,7 @@ internal class DropdownFieldController(
     override val label: Int = config.label
     override val fieldValue = selectedIndex.map { displayItems[it] }
     override val rawFieldValue = fieldValue.map { config.convertToRaw(it) }
-    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
+    override val error: Flow<FieldError?> = MutableStateFlow(null)
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
     override val elementType: ElementType = config.elementType
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
@@ -16,7 +16,7 @@ internal class SaveForFutureUseController(
     override val fieldValue: Flow<String> = saveForFutureUse.map { it.toString() }
     override val rawFieldValue: Flow<String?> = fieldValue
 
-    override val errorMessage: Flow<Int?> = MutableStateFlow(null)
+    override val error: Flow<FieldError?> = MutableStateFlow(null)
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
     override val elementType: ElementType = ElementType.SaveForFutureUse
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
@@ -48,8 +48,10 @@ internal class TextFieldController @VisibleForTesting constructor(
     val visibleError: Flow<Boolean> = combine(_fieldState, _hasFocus) { fieldState, hasFocus ->
         fieldState.shouldShowError(hasFocus)
     }
-    override val errorMessage: Flow<Int?> = visibleError.map { visibleError ->
-        _fieldState.value.getErrorMessageResId()?.takeIf { visibleError }
+    override val error: Flow<FieldError?> = visibleError.map { visibleError ->
+        _fieldState.value.getErrorMessageResId()?.let {
+            FieldError(label, it)
+        }?.takeIf { visibleError }
     }
 
     val isFull: Flow<Boolean> = _fieldState.map { it.isFull() }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentsheet.elements.TextFieldStateConstants.Error
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 
 /**
@@ -48,11 +49,13 @@ internal class TextFieldController @VisibleForTesting constructor(
     val visibleError: Flow<Boolean> = combine(_fieldState, _hasFocus) { fieldState, hasFocus ->
         fieldState.shouldShowError(hasFocus)
     }
-    override val error: Flow<FieldError?> = visibleError.map { visibleError ->
-        _fieldState.value.getErrorMessageResId()?.let {
-            FieldError(label, it)
-        }?.takeIf { visibleError }
-    }
+    override val error: Flow<FieldError?> = visibleError
+        .filter { it }
+        .map {
+            _fieldState.value.getErrorMessageResId()?.let {
+                FieldError(label, it)
+            }
+        }
 
     val isFull: Flow<Boolean> = _fieldState.map { it.isFull() }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -74,13 +74,13 @@ internal fun Form(
                         ) {
                             val controller = element.controller
 
-                            val error by controller.errorMessage.asLiveData()
+                            val error by controller.error.asLiveData()
                                 .observeAsState(null)
                             val sectionErrorString =
                                 error?.let {
                                     stringResource(
-                                        it,
-                                        stringResource(controller.label)
+                                        it.errorMessage,
+                                        stringResource(it.errorFieldLabel)
                                     )
                                 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/TextFieldControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/TextFieldControllerTest.kt
@@ -45,15 +45,16 @@ internal class TextFieldControllerTest {
     fun `verify the error message is set when should be visible`() {
         val controller = createControllerWithState()
 
-        var errorMessageResId: Int? = 5
-        controller.errorMessage.asLiveData()
+        var fieldError: FieldError? = FieldError(5, 5)
+        controller.error.asLiveData()
             .observeForever {
-                errorMessageResId = it
+                fieldError = it
             }
 
         controller.onValueChange("showWhenNoFocus")
         shadowOf(getMainLooper()).idle()
-        assertThat(errorMessageResId).isEqualTo(R.string.incomplete)
+        assertThat(fieldError?.errorMessage).isEqualTo(R.string.incomplete)
+        assertThat(fieldError?.errorFieldLabel).isEqualTo(R.string.address_label_name)
     }
 
     @Test
@@ -206,6 +207,8 @@ internal class TextFieldControllerTest {
             // These are for the initial call to onValueChange("")
             on { determineState("") } doReturn Blank
             on { filter("") } doReturn ""
+
+            on { label } doReturn R.string.address_label_name
         }
 
         return TextFieldController(config, ElementType.Email)


### PR DESCRIPTION
# Summary
Change error from just a message to a message and the field value in error.  This will allow us to correctly print the error message when there is more than one field in a section.
