### PR TITLE
Update SoftDeleteInputConnection for Android 12

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -236,16 +236,6 @@ class CardMultilineWidget @JvmOverloads constructor(
             )
         }
 
-    private val cvcHelperText: Int
-        @StringRes
-        get() {
-            return if (CardBrand.AmericanExpress == cardBrand) {
-                R.string.cvc_multiline_helper_amex
-            } else {
-                R.string.cvc_multiline_helper
-            }
-        }
-
     @VisibleForTesting
     internal var shouldShowErrorIcon = false
         set(value) {

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -241,8 +241,7 @@ open class StripeEditText @JvmOverloads constructor(
     ) : InputConnectionWrapper(target, mutable) {
         override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
             // This method works on modern versions of Android with soft keyboard delete.
-            val textBeforeCursor = getTextBeforeCursor(1, 0) ?: ""
-            if (textBeforeCursor.isEmpty()) {
+            if (getTextBeforeCursor(1, 0)?.isEmpty() == true) {
                 deleteEmptyListener?.onDeleteEmpty()
             }
             return super.deleteSurroundingText(beforeLength, afterLength)

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -241,7 +241,8 @@ open class StripeEditText @JvmOverloads constructor(
     ) : InputConnectionWrapper(target, mutable) {
         override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
             // This method works on modern versions of Android with soft keyboard delete.
-            if (getTextBeforeCursor(1, 0).isEmpty()) {
+            val textBeforeCursor = getTextBeforeCursor(1, 0) ?: ""
+            if (textBeforeCursor.isEmpty()) {
                 deleteEmptyListener?.onDeleteEmpty()
             }
             return super.deleteSurroundingText(beforeLength, afterLength)


### PR DESCRIPTION


# Summary
`getTextBeforeCursor()` is marked as `@Nullable` in Android 12.
Guard against null return value.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
