### PR TITLE
Switch the the default focus manager in the forms.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -10,17 +10,6 @@ import com.stripe.android.paymentsheet.elements.TextFieldController
 import com.stripe.android.paymentsheet.specifications.IdentifierSpec
 
 /**
- * This is used to track the number of focus requesters in a form
- */
-internal class FocusRequesterCount {
-    private var value = 0
-
-    fun getAndIncrement() = value++
-
-    fun get() = value
-}
-
-/**
  * This is used to define which elements can be made optional
  */
 internal interface OptionalElement {
@@ -36,7 +25,6 @@ internal sealed interface SectionFieldElementType {
 
     interface TextFieldElement : SectionFieldElementType {
         override val controller: TextFieldController
-        val focusIndexOrder: Int
     }
 
     interface DropdownFieldElement : SectionFieldElementType {
@@ -111,14 +99,12 @@ internal sealed class SectionFieldElement {
 
     data class Name(
         override val identifier: IdentifierSpec,
-        override val controller: TextFieldController,
-        override val focusIndexOrder: Int
+        override val controller: TextFieldController
     ) : SectionFieldElement(), SectionFieldElementType.TextFieldElement
 
     data class Email(
         override val identifier: IdentifierSpec,
-        override val controller: TextFieldController,
-        override val focusIndexOrder: Int
+        override val controller: TextFieldController
     ) : SectionFieldElement(), SectionFieldElementType.TextFieldElement
 
     data class Country(
@@ -133,7 +119,6 @@ internal sealed class SectionFieldElement {
 
     data class SimpleText internal constructor(
         override val identifier: IdentifierSpec,
-        override val controller: TextFieldController,
-        override val focusIndexOrder: Int
+        override val controller: TextFieldController
     ) : SectionFieldElement(), SectionFieldElementType.TextFieldElement
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import com.stripe.android.paymentsheet.FocusRequesterCount
 import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.SectionFieldElement
 import com.stripe.android.paymentsheet.SectionFieldElementType
@@ -22,21 +21,18 @@ import com.stripe.android.paymentsheet.specifications.SectionFieldSpec
  * controller will be a pass through the field controller.
  */
 internal fun List<FormItemSpec>.transform(
-    merchantName: String,
-    focusRequesterCount: FocusRequesterCount
+    merchantName: String
 ): List<FormElement> =
     this.map {
         when (it) {
             is FormItemSpec.SaveForFutureUseSpec -> it.transform(merchantName)
-            is FormItemSpec.SectionSpec -> it.transform(focusRequesterCount)
+            is FormItemSpec.SectionSpec -> it.transform()
             is FormItemSpec.MandateTextSpec -> it.transform(merchantName)
         }
     }
 
-private fun FormItemSpec.SectionSpec.transform(
-    focusRequesterCount: FocusRequesterCount
-): FormElement.SectionElement {
-    val fieldElements = this.fields.transform(focusRequesterCount)
+private fun FormItemSpec.SectionSpec.transform(): FormElement.SectionElement {
+    val fieldElements = this.fields.transform()
 
     // The controller of the section element will be the same as the field element
     // as there is only a single field in a section
@@ -50,20 +46,16 @@ private fun FormItemSpec.SectionSpec.transform(
     )
 }
 
-private fun List<SectionFieldSpec>.transform(
-    focusRequesterCount: FocusRequesterCount
-) = this.map {
+private fun List<SectionFieldSpec>.transform() = this.map {
     when (it) {
-        is SectionFieldSpec.Email -> it.transform(focusRequesterCount)
+        is SectionFieldSpec.Email -> it.transform()
         is SectionFieldSpec.Country -> it.transform()
         is SectionFieldSpec.IdealBank -> it.transform()
-        is SectionFieldSpec.SimpleText -> it.transform(focusRequesterCount)
+        is SectionFieldSpec.SimpleText -> it.transform()
     }
 }
 
-private fun SectionFieldSpec.SimpleText.transform(
-    focusRequesterCount: FocusRequesterCount
-): SectionFieldElementType =
+private fun SectionFieldSpec.SimpleText.transform(): SectionFieldElementType =
     SectionFieldElement.SimpleText(
         this.identifier,
         TextFieldController(
@@ -72,8 +64,7 @@ private fun SectionFieldSpec.SimpleText.transform(
                 capitalization = this.capitalization,
                 keyboard = this.keyboardType
             )
-        ),
-        focusRequesterCount.getAndIncrement()
+        )
     )
 
 private fun FormItemSpec.MandateTextSpec.transform(merchantName: String) =
@@ -86,13 +77,10 @@ private fun FormItemSpec.MandateTextSpec.transform(merchantName: String) =
         merchantName
     )
 
-private fun SectionFieldSpec.Email.transform(
-    focusRequesterCount: FocusRequesterCount
-) =
+private fun SectionFieldSpec.Email.transform() =
     SectionFieldElement.Email(
         this.identifier,
         TextFieldController(EmailConfig()),
-        focusRequesterCount.getAndIncrement()
     )
 
 private fun SectionFieldSpec.Country.transform() =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PopulateFormFromFormFieldValuesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PopulateFormFromFormFieldValuesTest.kt
@@ -15,8 +15,7 @@ class PopulateFormFromFormFieldValuesTest {
     private val emailController = TextFieldController(EmailConfig())
     private val emailFieldElement = SectionFieldElement.Email(
         IdentifierSpec("email"),
-        emailController,
-        0
+        emailController
     )
     private val emailSection = FormElement.SectionElement(
         identifier = IdentifierSpec("emailSection"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
@@ -21,8 +21,7 @@ class TransformElementToFormViewValueFlowTest {
         identifier = IdentifierSpec("emailSection"),
         SectionFieldElement.Email(
             IdentifierSpec("email"),
-            emailController,
-            0
+            emailController
         ),
         SectionController(emailController.label, listOf(emailController))
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -122,10 +122,7 @@ class TransformSpecToElementTest {
                     capitalization = KeyboardCapitalization.Words
                 )
             )
-        ).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        ).transform("Example, Inc.")
 
         val nameElement = (formElement.first() as SectionElement).fields[0]
             as SectionFieldElement.SimpleText

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.FocusRequesterCount
 import com.stripe.android.paymentsheet.FormElement
 import com.stripe.android.paymentsheet.FormElement.MandateTextElement
 import com.stripe.android.paymentsheet.FormElement.SectionElement
@@ -46,10 +45,7 @@ class TransformSpecToElementTest {
                     SectionFieldSpec.IdealBank
                 )
             )
-        ).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        ).transform("Example, Inc.")
 
         val sectionElement = formElement[0] as SectionElement
         assertThat(sectionElement.fields.size).isEqualTo(2)
@@ -63,10 +59,7 @@ class TransformSpecToElementTest {
             IdentifierSpec("countrySection"),
             SectionFieldSpec.Country(onlyShowCountryCodes = setOf("AT"))
         )
-        val formElement = listOf(countrySection).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        val formElement = listOf(countrySection).transform("Example, Inc.")
 
         val countrySectionElement = formElement.first() as SectionElement
         val countryElement = countrySectionElement.fields[0] as Country
@@ -88,10 +81,7 @@ class TransformSpecToElementTest {
             IdentifierSpec("idealSection"),
             SectionFieldSpec.IdealBank
         )
-        val formElement = listOf(idealSection).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        val formElement = listOf(idealSection).transform("Example, Inc.")
 
         val idealSectionElement = formElement.first() as SectionElement
         val idealElement = idealSectionElement.fields[0] as IdealBank
@@ -106,10 +96,7 @@ class TransformSpecToElementTest {
 
     @Test
     fun `Add a name section spec sets up the name element correctly`() {
-        val formElement = listOf(nameSection).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        val formElement = listOf(nameSection).transform("Example, Inc.")
 
         val nameElement =
             (formElement.first() as SectionElement).fields[0] as SectionFieldElement.SimpleText
@@ -124,10 +111,7 @@ class TransformSpecToElementTest {
 
     @Test
     fun `Add a email section spec sets up the email element correctly`() {
-        val formElement = listOf(emailSection).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        val formElement = listOf(emailSection).transform("Example, Inc.")
 
         val emailSectionElement = formElement.first() as SectionElement
         val emailElement = emailSectionElement.fields[0] as Email
@@ -138,36 +122,13 @@ class TransformSpecToElementTest {
     }
 
     @Test
-    fun `Adding to sections that get focus sets up the focus indexes correctly`() {
-        val focusRequesterCount = FocusRequesterCount()
-        val formElement = listOf(nameSection, emailSection).transform(
-            "Example, Inc.",
-            focusRequesterCount
-        )
-
-        val nameSectionElement = formElement[0] as SectionElement
-        val nameElement = nameSectionElement.fields[0] as SectionFieldElement.SimpleText
-        val emailSectionElement = formElement[1] as SectionElement
-        val emailElement = emailSectionElement.fields[0] as Email
-
-        assertThat(nameElement.focusIndexOrder).isEqualTo(0)
-        assertThat(emailElement.focusIndexOrder).isEqualTo(1)
-
-        // It should equal as many text fields as are present
-        assertThat(focusRequesterCount.get()).isEqualTo(2)
-    }
-
-    @Test
     fun `Add a mandate section spec setup of the mandate element correctly`() {
         val mandate = FormItemSpec.MandateTextSpec(
             IdentifierSpec("mandate"),
             R.string.stripe_paymentsheet_sepa_mandate,
             Color.Gray
         )
-        val formElement = listOf(mandate).transform(
-            "Example, Inc.",
-            FocusRequesterCount()
-        )
+        val formElement = listOf(mandate).transform("Example, Inc.")
 
         val mandateElement = formElement.first() as MandateTextElement
 
@@ -187,10 +148,7 @@ class TransformSpecToElementTest {
             )
             val optionalIdentifiers = listOf(nameSection, mandate)
             val saveForFutureUseSpec = FormItemSpec.SaveForFutureUseSpec(optionalIdentifiers)
-            val formElement = listOf(saveForFutureUseSpec).transform(
-                "Example, Inc.",
-                FocusRequesterCount()
-            )
+            val formElement = listOf(saveForFutureUseSpec).transform("Example, Inc.")
 
             val saveForFutureUseElement = formElement.first() as FormElement.SaveForFutureUseElement
             val saveForFutureUseController = saveForFutureUseElement.controller


### PR DESCRIPTION
# Summary
With the upcoming billing fields the order of the fields change based on the country selected.  Rather than refactor the focus requester to dynamically update, it was chosen to use the built in default focus manager.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

