### PR TITLE
Always observe `fragmentConfig`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -106,24 +106,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             }
         }
 
-        if (savedInstanceState == null) {
-            // Only fetch initial state if the activity is being created for the first time.
-            // Otherwise the FragmentManager will correctly restore the previous state.
-            fetchConfig(starterArgs)
-        }
-
-        supportFragmentManager.registerFragmentLifecycleCallbacks(
-            object : FragmentManager.FragmentLifecycleCallbacks() {
-                override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
-                    viewBinding.addButton.isVisible = fragment is PaymentOptionsAddPaymentMethodFragment
-                }
-            },
-            false
-        )
-    }
-
-    private fun fetchConfig(starterArgs: PaymentOptionContract.Args) {
-        viewModel.fetchFragmentConfig().observe(this) { config ->
+        viewModel.fragmentConfig.observe(this) { config ->
             if (config != null) {
                 viewModel.transitionTo(
                     // It would be nice to see this condition move into the PaymentOptionsListFragment
@@ -138,6 +121,16 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                 )
             }
         }
+
+        supportFragmentManager.registerFragmentLifecycleCallbacks(
+            object : FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
+                    viewBinding.addButton.isVisible =
+                        fragment is PaymentOptionsAddPaymentMethodFragment
+                }
+            },
+            false
+        )
     }
 
     private fun setupAddButton(addButton: PrimaryButton) {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -147,10 +147,15 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             }
         }
 
-        if (savedInstanceState == null) {
-            // Only fetch initial state if the activity is being created for the first time.
-            // Otherwise the FragmentManager will correctly restore the previous state.
-            fetchConfig()
+        viewModel.fragmentConfig.observe(this) { config ->
+            if (config != null) {
+                val target = if (config.paymentMethods.isEmpty()) {
+                    PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet(config)
+                } else {
+                    PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod(config)
+                }
+                viewModel.transitionTo(target)
+            }
         }
 
         viewModel.startConfirm.observe(this) { event ->
@@ -185,19 +190,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private fun updateErrorMessage(userMessage: BaseSheetViewModel.UserErrorMessage? = null) {
         messageView.isVisible = userMessage != null
         messageView.text = userMessage?.message
-    }
-
-    private fun fetchConfig() {
-        viewModel.fetchFragmentConfig().observe(this) { config ->
-            if (config != null) {
-                val target = if (config.paymentMethods.isEmpty()) {
-                    PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet(config)
-                } else {
-                    PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod(config)
-                }
-                viewModel.transitionTo(target)
-            }
-        }
     }
 
     private fun onTransitionTarget(

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -106,7 +106,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         fetchSavedSelection()
     }
 
-    fun fetchFragmentConfig() = MediatorLiveData<FragmentConfig?>().also { configLiveData ->
+    val fragmentConfig = MediatorLiveData<FragmentConfig?>().also { configLiveData ->
         listOf(
             savedSelection,
             stripeIntent,

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -674,12 +674,12 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `fetchFragmentConfig() when all data is ready should emit value`() {
+    fun `fragmentConfig when all data is ready should emit value`() {
         viewModel.fetchStripeIntent()
         viewModel.fetchIsGooglePayReady()
 
         val configs = mutableListOf<FragmentConfig>()
-        viewModel.fetchFragmentConfig().observeForever { config ->
+        viewModel.fragmentConfig.observeForever { config ->
             if (config != null) {
                 configs.add(config)
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`BaseSheetViewModel.fetchFragmentConfig()` was creating a new `MutableLiveData` every time it was called, so it and was called only on the first `onCreate`.
Make it a `val` so that it's only created once and survives configuration changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix #3878.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified