### PR TITLE
Localization download fixes

### DIFF
--- a/payments-core/res/values-FI/strings.xml
+++ b/payments-core/res/values-FI/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kortin numero</string>
-    <string name="acc_label_card_number_node">%s, kortin numero</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Erääntymispäivä</string>
-    <string name="acc_label_expiry_date_node">%s, erääntymispäivä</string>
-    <string name="acc_label_zip">Postinumero</string>
-    <string name="acc_label_zip_short">Postinumero</string>
-    <string name="add_card">Lisää uusi pankki- tai luottokortti, jotta voit tehdä ostoksia tämän sovelluksen kautta.</string>
-    <string name="added">Lisätty %s</string>
-    <string name="address_city_required">Kirjoita paikkakunta</string>
-    <string name="address_country_invalid">Maa ei kelpaa</string>
-    <string name="address_county_required">Kirjoita lääni</string>
-    <string name="address_label_address">Osoite</string>
-    <string name="address_label_address_line1">Osoiterivi 1</string>
-    <string name="address_label_address_line1_optional">Osoiterivi 1 (valinnainen)</string>
-    <string name="address_label_address_line2_optional">Osoiterivi 2 (valinnainen)</string>
-    <string name="address_label_address_optional">Osoite (valinnainen) </string>
-    <string name="address_label_apt">Asunto</string>
-    <string name="address_label_apt_optional">Asunto (valinnainen)</string>
-    <string name="address_label_city">Paikkakunta</string>
-    <string name="address_label_city_optional">Paikkakunta (valinnainen)</string>
-    <string name="address_label_country">Maa</string>
-    <string name="address_label_county">Lääni</string>
-    <string name="address_label_county_optional">Lääni (valinnainen)</string>
-    <string name="address_label_name">Nimi</string>
-    <string name="address_label_phone_number">Puhelinnumero</string>
-    <string name="address_label_phone_number_optional">Puhelinnumero (valinnainen)</string>
-    <string name="address_label_postal_code">Postinumero</string>
-    <string name="address_label_postal_code_optional">Postinumero (valinnainen)</string>
-    <string name="address_label_postcode">Postinumero</string>
-    <string name="address_label_postcode_optional">Postinumero (valinnainen)</string>
-    <string name="address_label_province">Provinssi</string>
-    <string name="address_label_province_optional">Maakunta (valinnainen)</string>
-    <string name="address_label_region_generic">Osavaltio/maakunta/alue</string>
-    <string name="address_label_region_generic_optional">Osavaltio/maakunta/alue (valinnainen)</string>
-    <string name="address_label_state">Osavaltio</string>
-    <string name="address_label_state_optional">Osavaltio (valinnainen)</string>
-    <string name="address_label_zip_code">Postinumero</string>
-    <string name="address_label_zip_code_optional">Postinumero (valinnainen)</string>
-    <string name="address_label_zip_postal_code">Postinumero</string>
-    <string name="address_label_zip_postal_code_optional">Postinumero (valinnainen)</string>
-    <string name="address_name_required">Kirjoita nimesi</string>
-    <string name="address_phone_number_required">Kirjoita puhelinnumerosi</string>
-    <string name="address_postal_code_invalid">Postinumerosi ei kelpaa</string>
-    <string name="address_postcode_invalid">Postinumerosi ei kelpaa</string>
-    <string name="address_province_required">Kirjoita maakunta</string>
-    <string name="address_region_generic_required">Kirjoita osavaltio/maakunta/alue</string>
-    <string name="address_required">Kirjoita osoite</string>
-    <string name="address_shipping_address">Lähetysosoite</string>
-    <string name="address_state_required">Kirjoita osavaltio</string>
-    <string name="address_zip_invalid">Postinumero ei kelpaa.</string>
-    <string name="address_zip_postal_invalid">Postinumero ei kelpaa</string>
-    <string name="becs_mandate_acceptance">
-    Antamalla pankkitilisi tiedot ja vahvistamalla tämän maksun hyväksyt tämän
-    suoraveloituspyynnön ja suoraveloituspyyntöpalvelusopimuksen ja valtuutat
-    Stripe Payments Australia Pty Ltd:n ACN, 160 180 343 suoraveloituksen käyttäjätunnus 507156,
-     veloittamaan tililtäsi BECS:n kautta (\"Kauppias\")
-     kohteen %1$s puolesta kaikista kauppiaan erikseen ilmoittamista summista.
-     Vakuutat, että olet joko tilinomistaja tai valtuutettu allekirjoittaja
-     yllä mainitulla tilillä.
-    </string>
-    <string name="becs_widget_account_number">Tilinumero</string>
-    <string name="becs_widget_account_number_incomplete">Tilinumerosi on puutteellinen.</string>
-    <string name="becs_widget_account_number_required">Tilinumerosi vaaditaan.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Antamasi BSB-numero on puutteellinen.</string>
-    <string name="becs_widget_bsb_invalid">Antamasi BSB-numero on virheellinen.</string>
-    <string name="becs_widget_email">Sähköpostiosoite</string>
-    <string name="becs_widget_email_invalid">Sähköpostiosoitteesi on virheellinen.</string>
-    <string name="becs_widget_email_required">Sähköpostiosoitteesi vaaditaan.</string>
-    <string name="becs_widget_name">Nimi</string>
-    <string name="becs_widget_name_required">Nimesi vaaditaan.</string>
-    <string name="card_ending_in">%1$s päättyy numeroihin %2$s</string>
-    <string name="close">Sulje</string>
-    <string name="delete_payment_method">Poista maksutapa</string>
-    <string name="delete_payment_method_prompt_title">Poista maksutapa?</string>
-    <string name="expiry_date_hint">KK/VV</string>
-    <string name="expiry_label_short">Vanheneminen</string>
-    <string name="fpx_bank_offline">%s - Offline-tilassa</string>
-    <string name="incomplete_expiry_date">Kortin voimassaoloaika on puutteellinen.</string>
-    <string name="invalid_card_number">Kortin numero ei kelpaa.</string>
-    <string name="invalid_cvc">Kortin turvakoodi on virheellinen.</string>
-    <string name="invalid_expiry_month">Kortin erääntymiskuukausi ei kelpaa.</string>
-    <string name="invalid_expiry_year">Kortin voimassaolovuosi ei kelpaa.</string>
-    <string name="invalid_shipping_information">Toimitusosoite ei kelpaa</string>
-    <string name="invalid_zip">Postinumero on puutteellinen.</string>
-    <string name="no_payment_methods">Ei maksumenetelmiä.</string>
-    <string name="payment_method_add_new_card">Lisää uusi kortti...</string>
-    <string name="payment_method_add_new_fpx">Valitse pankkitili (FPX)...</string>
-    <string name="price_free">Maksuton</string>
-    <string name="removed">Poistettu %s</string>
-    <string name="secure_checkout">Turvallinen maksu</string>
-    <string name="stripe_failure_connection_error">Yhteydessä maksun käsittelijään esiintyi ongelmia. Tarkista Internet-yhteys ja yritä uudelleen.</string>
-    <string name="stripe_failure_reason_authentication">Emme pystyneet todentamaan maksutapaasi. Valitse toinen maksutapa ja yritä uudelleen.</string>
-    <string name="stripe_failure_reason_timed_out">Maksutapasi todennus aikakatkaistiin – yritä uudelleen.</string>
-    <string name="stripe_google_pay_error_internal">Sisäinen virhe on tapahtunut.</string>
-    <string name="stripe_paymentsheet_add_button_label">Lisää</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lisää</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kortin tiedot</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Maa tai alue</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Lisää maksutiedot</string>
-    <string name="stripe_paymentsheet_back">Takaisin</string>
-    <string name="stripe_paymentsheet_close">Sulje</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">KK/VV</string>
-    <string name="stripe_paymentsheet_or_pay_using">Tai käytä maksutapaa</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Tai maksa kortilla</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Maksa %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Käsitellään...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Tallenna tämä kortti tulevia maksuja (%s) varten</string>
-    <string name="stripe_paymentsheet_select_payment_method">Valitse maksutapa</string>
-    <string name="stripe_paymentsheet_setup_button_label">Määritä</string>
-    <string name="stripe_paymentsheet_total_amount">Yhteensä: %s</string>
-    <string name="stripe_verify_your_payment">Vahvista maksu</string>
-    <string name="title_add_a_card">Lisää kortti</string>
-    <string name="title_add_an_address">Lisää osoite</string>
-    <string name="title_bank_account">Pankkitili</string>
-    <string name="title_payment_method">Maksutapa</string>
-    <string name="title_select_shipping_method">Valitse lähetysmenetelmä</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kortin numero</string>
+  <string name="acc_label_card_number_node">%s, kortin numero</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Erääntymispäivä</string>
+  <string name="acc_label_expiry_date_node">%s, erääntymispäivä</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Postinumero</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Postinumero</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Lisää uusi pankki- tai luottokortti, jotta voit tehdä ostoksia tämän sovelluksen kautta.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Lisätty %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Kirjoita paikkakunta</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Maa ei kelpaa</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Kirjoita lääni</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Osoite</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Osoiterivi 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Osoiterivi 1 (valinnainen)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Osoiterivi 2 (valinnainen)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Osoite (valinnainen) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Asunto (valinnainen)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Paikkakunta (valinnainen)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Lääni (valinnainen)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Puhelinnumero</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Puhelinnumero (valinnainen)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postinumero (valinnainen)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postinumero</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postinumero (valinnainen)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Maakunta (valinnainen)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Osavaltio/maakunta/alue</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Osavaltio/maakunta/alue (valinnainen)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Osavaltio (valinnainen)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Postinumero (valinnainen)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Postinumero</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Postinumero (valinnainen)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Kirjoita nimesi</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Kirjoita puhelinnumerosi</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Postinumerosi ei kelpaa</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Postinumerosi ei kelpaa</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Kirjoita maakunta</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Kirjoita osavaltio/maakunta/alue</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Kirjoita osoite</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Lähetysosoite</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Kirjoita osavaltio</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Postinumero ei kelpaa.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Postinumero ei kelpaa</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Antamalla pankkitilisi tiedot ja vahvistamalla tämän maksun hyväksyt tämän\n    suoraveloituspyynnön ja suoraveloituspyyntöpalvelusopimuksen ja valtuutat\n    Stripe Payments Australia Pty Ltd:n ACN, 160 180 343 suoraveloituksen käyttäjätunnus 507156,\n     veloittamaan tililtäsi BECS:n kautta (\"Kauppias\")\n     kohteen %1$s puolesta kaikista kauppiaan erikseen ilmoittamista summista.\n     Vakuutat, että olet joko tilinomistaja tai valtuutettu allekirjoittaja\n     yllä mainitulla tilillä.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Tilinumero</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Tilinumerosi on puutteellinen.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Tilinumerosi vaaditaan.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Antamasi BSB-numero on puutteellinen.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Antamasi BSB-numero on virheellinen.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Sähköpostiosoite</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Sähköpostiosoitteesi on virheellinen.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Sähköpostiosoitteesi vaaditaan.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nimi</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Nimesi vaaditaan.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s päättyy numeroihin %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Sulje</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Poista maksutapa</string>
+  <string name="delete_payment_method_prompt_title">Poista maksutapa?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">KK/VV</string>
+  <string name="expiry_label_short">Vanheneminen</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline-tilassa</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kortin voimassaoloaika on puutteellinen.</string>
+  <string name="invalid_card_number">Kortin numero ei kelpaa.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kortin turvakoodi on virheellinen.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kortin erääntymiskuukausi ei kelpaa.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kortin voimassaolovuosi ei kelpaa.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Toimitusosoite ei kelpaa</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Postinumero on puutteellinen.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Ei maksumenetelmiä.</string>
+  <string name="payment_method_add_new_card">Lisää uusi kortti...</string>
+  <string name="payment_method_add_new_fpx">Valitse pankkitili (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Maksuton</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Poistettu %s</string>
+  <string name="secure_checkout">Turvallinen maksu</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Yhteydessä maksun käsittelijään esiintyi ongelmia. Tarkista Internet-yhteys ja yritä uudelleen.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Emme pystyneet todentamaan maksutapaasi. Valitse toinen maksutapa ja yritä uudelleen.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Maksutapasi todennus aikakatkaistiin – yritä uudelleen.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Sisäinen virhe on tapahtunut.</string>
+  <string name="stripe_paymentsheet_add_button_label">Lisää</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lisää</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortin tiedot</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Maa tai alue</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Lisää maksutiedot</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Takaisin</string>
+  <string name="stripe_paymentsheet_close">Sulje</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">KK/VV</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Tai käytä maksutapaa</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Tai maksa kortilla</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Maksa %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Käsitellään...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Tallenna tämä kortti tulevia maksuja (%s) varten</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Valitse maksutapa</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Määritä</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Vahvista maksu</string>
+  <string name="title_add_a_card">Lisää kortti</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Lisää osoite</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Pankkitili</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Maksutapa</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Valitse lähetysmenetelmä</string>
 </resources>

--- a/payments-core/res/values-KO/strings.xml
+++ b/payments-core/res/values-KO/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">카드 번호</string>
-    <string name="acc_label_card_number_node">%s, 카드 번호</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">만료 날짜</string>
-    <string name="acc_label_expiry_date_node">%s, 만료 날짜</string>
-    <string name="acc_label_zip">우편번호</string>
-    <string name="acc_label_zip_short">우편번호</string>
-    <string name="add_card">이 앱에서 구입하려면 새 직불 카드 또는 신용 카드를 추가하십시오.</string>
-    <string name="added">%s 추가됨</string>
-    <string name="address_city_required">도시를 입력하십시오</string>
-    <string name="address_country_invalid">국가가 유효하지 않습니다</string>
-    <string name="address_county_required">국가를 입력하십시오</string>
-    <string name="address_label_address">주소</string>
-    <string name="address_label_address_line1">주소란 1</string>
-    <string name="address_label_address_line1_optional">주소란 1(선택 사항)</string>
-    <string name="address_label_address_line2_optional">주소란 2(선택 사항)</string>
-    <string name="address_label_address_optional">주소(선택 사항)</string>
-    <string name="address_label_apt">아파트</string>
-    <string name="address_label_apt_optional">아파트(선택 사항)</string>
-    <string name="address_label_city">시</string>
-    <string name="address_label_city_optional">도시(선택 사항)</string>
-    <string name="address_label_country">국가</string>
-    <string name="address_label_county">구/군</string>
-    <string name="address_label_county_optional">구/군(선택 사항)</string>
-    <string name="address_label_name">이름</string>
-    <string name="address_label_phone_number">전화번호</string>
-    <string name="address_label_phone_number_optional">전화번호(선택 사항)</string>
-    <string name="address_label_postal_code">우편번호</string>
-    <string name="address_label_postal_code_optional">우편번호(선택 사항)</string>
-    <string name="address_label_postcode">우편번호</string>
-    <string name="address_label_postcode_optional">우편번호(선택 사항)</string>
-    <string name="address_label_province">도</string>
-    <string name="address_label_province_optional">도(선택 사항)</string>
-    <string name="address_label_region_generic">주/도/지역</string>
-    <string name="address_label_region_generic_optional">주 / 도 / 지역(선택 사항)</string>
-    <string name="address_label_state">주</string>
-    <string name="address_label_state_optional">주(선택 사항)</string>
-    <string name="address_label_zip_code">우편번호</string>
-    <string name="address_label_zip_code_optional">우편번호(선택 사항)</string>
-    <string name="address_label_zip_postal_code">우편번호</string>
-    <string name="address_label_zip_postal_code_optional">우편번호(선택 사항)</string>
-    <string name="address_name_required">이름을 입력하십시오</string>
-    <string name="address_phone_number_required">전화번호를 입력하십시오</string>
-    <string name="address_postal_code_invalid">우편번호가 유효하지 않습니다</string>
-    <string name="address_postcode_invalid">우편번호가 유효하지 않습니다</string>
-    <string name="address_province_required">도를 입력하십시오</string>
-    <string name="address_region_generic_required">주/지방/지역을 입력하십시오</string>
-    <string name="address_required">주소를 입력하십시오</string>
-    <string name="address_shipping_address">배송 주소</string>
-    <string name="address_state_required">주를 입력하십시오</string>
-    <string name="address_zip_invalid">우편번호가 유효하지 않습니다.</string>
-    <string name="address_zip_postal_invalid">우편번호가 유효하지 않습니다</string>
-    <string name="becs_mandate_acceptance">
-    은행 계좌 세부 정보를 제공하고 이 결제를 확인하면 다음 자동 이체 요청 및
-    자동 이체 요청 서비스 계약에 동의하는 것이며, 또한
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID 번호 507156
-    (“Stripe”)에서 BECS(Bulk Electronic Clearing System)를
-    통해 %1$s(이하 \"판매자\")의 대리로 
-    판매자가 별도로 귀하에게 전달한 금액에 대해 결제하는 것을 승인하게 됩니다.
-    본인은 위에 나열된 계정의 계정 보유자 또는 승인된 서명자임을 증명합니다.
-    </string>
-    <string name="becs_widget_account_number">계좌 번호</string>
-    <string name="becs_widget_account_number_incomplete">계좌 번호가 불완전합니다.</string>
-    <string name="becs_widget_account_number_required">계좌 번호가 필요합니다.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">입력하신 BSB가 완료되지 않았습니다.</string>
-    <string name="becs_widget_bsb_invalid">입력하신 BSB가 유효하지 않습니다.</string>
-    <string name="becs_widget_email">이메일 주소</string>
-    <string name="becs_widget_email_invalid">이메일 주소가 유효하지 않습니다.</string>
-    <string name="becs_widget_email_required">이메일 주소가 필요합니다.</string>
-    <string name="becs_widget_name">이름</string>
-    <string name="becs_widget_name_required">이름이 필요합니다.</string>
-    <string name="card_ending_in">%2$s(으)로 끝나는 %1$s</string>
-    <string name="close">닫기</string>
-    <string name="delete_payment_method">결제 수단 삭제</string>
-    <string name="delete_payment_method_prompt_title">결제 수단을 삭제하시겠습니까?</string>
-    <string name="expiry_date_hint">MM/YY</string>
-    <string name="expiry_label_short">만료</string>
-    <string name="fpx_bank_offline">%s - 오프라인</string>
-    <string name="incomplete_expiry_date">카드의 만료 날짜가 불완전합니다.</string>
-    <string name="invalid_card_number">카드 번호가 잘못되었습니다.</string>
-    <string name="invalid_cvc">카드의 보안 코드가 유효하지 않습니다.</string>
-    <string name="invalid_expiry_month">카드의 만료 월이 유효하지 않습니다.</string>
-    <string name="invalid_expiry_year">카드의 만료 연도가 유효하지 않습니다.</string>
-    <string name="invalid_shipping_information">잘못된 배송 주소</string>
-    <string name="invalid_zip">우편번호가 불완전합니다.</string>
-    <string name="no_payment_methods">결제 방법이 없습니다.</string>
-    <string name="payment_method_add_new_card">새 카드 추가…</string>
-    <string name="payment_method_add_new_fpx">은행 계좌 선택(FPX)…</string>
-    <string name="price_free">무료</string>
-    <string name="removed">%s 제거됨</string>
-    <string name="secure_checkout">보안 체크 아웃</string>
-    <string name="stripe_failure_connection_error">결제 제공자에게 연결하는 과정에서 문제가 발생했습니다. 인터넷 연결을 확인하시고 다시 시도하십시오.</string>
-    <string name="stripe_failure_reason_authentication">결제 수단을 인증할 수 없습니다. 다른 결제 수단을 선택하고 다시 시도하십시오.</string>
-    <string name="stripe_failure_reason_timed_out">결제 수단 인증 시간이 초과되었습니다. 다시 시도하십시오.</string>
-    <string name="stripe_google_pay_error_internal">내부 오류가 발생했습니다.</string>
-    <string name="stripe_paymentsheet_add_button_label">추가</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ 추가</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">카드 정보</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">국가 또는 지역</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">결제 정보를 추가하세요.</string>
-    <string name="stripe_paymentsheet_back">뒤로</string>
-    <string name="stripe_paymentsheet_close">닫기</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/YY</string>
-    <string name="stripe_paymentsheet_or_pay_using">또는 다음 결제 방식 사용</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">또는 카드 결제</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s 결제</string>
-    <string name="stripe_paymentsheet_pay_button_label">결제</string>
-    <string name="stripe_paymentsheet_primary_button_processing">처리 중...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">이 카드를 향후 %s 결제에 사용하도록 저장</string>
-    <string name="stripe_paymentsheet_select_payment_method">결제 수단을 선택하세요.</string>
-    <string name="stripe_paymentsheet_setup_button_label">설정</string>
-    <string name="stripe_paymentsheet_total_amount">합계 : %s</string>
-    <string name="stripe_verify_your_payment">결제 확인</string>
-    <string name="title_add_a_card">카드 추가</string>
-    <string name="title_add_an_address">주소 설정</string>
-    <string name="title_bank_account">은행 계좌</string>
-    <string name="title_payment_method">결제 수단</string>
-    <string name="title_select_shipping_method">배송 방법 선택</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">카드 번호</string>
+  <string name="acc_label_card_number_node">%s, 카드 번호</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">만료 날짜</string>
+  <string name="acc_label_expiry_date_node">%s, 만료 날짜</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">우편번호</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">우편번호</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">이 앱에서 구입하려면 새 직불 카드 또는 신용 카드를 추가하십시오.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s 추가됨</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">도시를 입력하십시오</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">국가가 유효하지 않습니다</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">국가를 입력하십시오</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">주소</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">주소란 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">주소란 1(선택 사항)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">주소란 2(선택 사항)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">주소(선택 사항)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">아파트(선택 사항)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">도시(선택 사항)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">구/군(선택 사항)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">전화번호</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">전화번호(선택 사항)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">우편번호(선택 사항)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">우편번호</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">우편번호(선택 사항)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">도(선택 사항)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">주/도/지역</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">주 / 도 / 지역(선택 사항)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">주(선택 사항)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">우편번호(선택 사항)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">우편번호</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">우편번호(선택 사항)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">이름을 입력하십시오</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">전화번호를 입력하십시오</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">우편번호가 유효하지 않습니다</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">우편번호가 유효하지 않습니다</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">도를 입력하십시오</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">주/지방/지역을 입력하십시오</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">주소를 입력하십시오</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">배송 주소</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">주를 입력하십시오</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">우편번호가 유효하지 않습니다.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">우편번호가 유효하지 않습니다</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    은행 계좌 세부 정보를 제공하고 이 결제를 확인하면 다음 자동 이체 요청 및\n    자동 이체 요청 서비스 계약에 동의하는 것이며, 또한\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID 번호 507156\n    (“Stripe”)에서 BECS(Bulk Electronic Clearing System)를\n    통해 %1$s(이하 \"판매자\")의 대리로 \n    판매자가 별도로 귀하에게 전달한 금액에 대해 결제하는 것을 승인하게 됩니다.\n    본인은 위에 나열된 계정의 계정 보유자 또는 승인된 서명자임을 증명합니다.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">계좌 번호</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">계좌 번호가 불완전합니다.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">계좌 번호가 필요합니다.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">입력하신 BSB가 완료되지 않았습니다.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">입력하신 BSB가 유효하지 않습니다.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">이메일 주소</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">이메일 주소가 유효하지 않습니다.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">이메일 주소가 필요합니다.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">이름</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">이름이 필요합니다.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%2$s(으)로 끝나는 %1$s</string>
+  <!-- Text for close button -->
+  <string name="close">닫기</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">결제 수단 삭제</string>
+  <string name="delete_payment_method_prompt_title">결제 수단을 삭제하시겠습니까?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/YY</string>
+  <string name="expiry_label_short">만료</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - 오프라인</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">카드의 만료 날짜가 불완전합니다.</string>
+  <string name="invalid_card_number">카드 번호가 잘못되었습니다.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">카드의 보안 코드가 유효하지 않습니다.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">카드의 만료 월이 유효하지 않습니다.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">카드의 만료 연도가 유효하지 않습니다.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">잘못된 배송 주소</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">우편번호가 불완전합니다.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">결제 방법이 없습니다.</string>
+  <string name="payment_method_add_new_card">새 카드 추가…</string>
+  <string name="payment_method_add_new_fpx">은행 계좌 선택(FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">무료</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s 제거됨</string>
+  <string name="secure_checkout">보안 체크 아웃</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">결제 제공자에게 연결하는 과정에서 문제가 발생했습니다. 인터넷 연결을 확인하시고 다시 시도하십시오.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">결제 수단을 인증할 수 없습니다. 다른 결제 수단을 선택하고 다시 시도하십시오.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">결제 수단 인증 시간이 초과되었습니다. 다시 시도하십시오.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">내부 오류가 발생했습니다.</string>
+  <string name="stripe_paymentsheet_add_button_label">추가</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ 추가</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">카드 정보</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">국가 또는 지역</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">결제 정보를 추가하세요.</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">뒤로</string>
+  <string name="stripe_paymentsheet_close">닫기</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/YY</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">또는 다음 결제 방식 사용</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">또는 카드 결제</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s 결제</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">결제</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">처리 중...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">이 카드를 향후 %s 결제에 사용하도록 저장</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">결제 수단을 선택하세요.</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">설정</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">결제 확인</string>
+  <string name="title_add_a_card">카드 추가</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">주소 설정</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">은행 계좌</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">결제 수단</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">배송 방법 선택</string>
 </resources>

--- a/payments-core/res/values-RU/strings.xml
+++ b/payments-core/res/values-RU/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Номер карты</string>
-    <string name="acc_label_card_number_node">%s, номер карты</string>
-    <string name="acc_label_cvc_node">%s, код CVV/CVC</string>
-    <string name="acc_label_expiry_date">Окончание срока действия</string>
-    <string name="acc_label_expiry_date_node">%s, дата истечения срока действия</string>
-    <string name="acc_label_zip">Почтовый индекс</string>
-    <string name="acc_label_zip_short">Почтовый индекс</string>
-    <string name="add_card">Добавьте новую дебетную или кредитную карту, чтобы совершать покупки в этом приложении.</string>
-    <string name="added">Добавлено: %s</string>
-    <string name="address_city_required">Введите город</string>
-    <string name="address_country_invalid">Недопустимое название страны.</string>
-    <string name="address_county_required">Введите страну</string>
-    <string name="address_label_address">Адрес</string>
-    <string name="address_label_address_line1">Адрес (строка 1)</string>
-    <string name="address_label_address_line1_optional">Адрес (строка 1) (необязательно)</string>
-    <string name="address_label_address_line2_optional">Адрес (строка 2) (необязательно)</string>
-    <string name="address_label_address_optional">Адрес (необязательно)</string>
-    <string name="address_label_apt">Кв.</string>
-    <string name="address_label_apt_optional">Кв. (необязательно)</string>
-    <string name="address_label_city">Город</string>
-    <string name="address_label_city_optional">Город (необязательно)</string>
-    <string name="address_label_country">Страна</string>
-    <string name="address_label_county">Графство</string>
-    <string name="address_label_county_optional">Графство (необязательно)</string>
-    <string name="address_label_name">Имя</string>
-    <string name="address_label_phone_number">Номер телефона</string>
-    <string name="address_label_phone_number_optional">Номер телефона (необязательно)</string>
-    <string name="address_label_postal_code">Почтовый индекс</string>
-    <string name="address_label_postal_code_optional">Почтовый индекс (необязательно)</string>
-    <string name="address_label_postcode">Почтовый индекс</string>
-    <string name="address_label_postcode_optional">Почтовый индекс (необязательно)</string>
-    <string name="address_label_province">Провинция</string>
-    <string name="address_label_province_optional">Провинция (необязательно)</string>
-    <string name="address_label_region_generic">Штат / провинция / регион</string>
-    <string name="address_label_region_generic_optional">Штат / провинция / регион (необязательно)</string>
-    <string name="address_label_state">Штат</string>
-    <string name="address_label_state_optional">Штат (необязательно)</string>
-    <string name="address_label_zip_code">Почтовый индекс</string>
-    <string name="address_label_zip_code_optional">Почтовый индекс (необязательно)</string>
-    <string name="address_label_zip_postal_code">Почтовый индекс</string>
-    <string name="address_label_zip_postal_code_optional">Почтовый индекс (необязательно)</string>
-    <string name="address_name_required">Введите свое имя</string>
-    <string name="address_phone_number_required">Введите свой номер телефона</string>
-    <string name="address_postal_code_invalid">Введенный почтовый индекс неверен</string>
-    <string name="address_postcode_invalid">Введенный почтовый индекс неверен</string>
-    <string name="address_province_required">Введите название своей провинции</string>
-    <string name="address_region_generic_required">Введите штат / провинцию / регион</string>
-    <string name="address_required">Введите адрес</string>
-    <string name="address_shipping_address">Адрес доставки</string>
-    <string name="address_state_required">Введите штат</string>
-    <string name="address_zip_invalid">Введенный почтовый индекс неверен.</string>
-    <string name="address_zip_postal_invalid">Введенный почтовый индекс неверен</string>
-    <string name="becs_mandate_acceptance">
-    Предоставляя данные банковского счета и подтверждая платеж, вы принимаете данный запрос прямого списания средств и сервисное
-    соглашение на запрос прямого списания средств, а также уполномочиваете компанию
-    Stripe Payments Australia Pty Ltd, ACN 160 180 343, идентификационный номер пользователя службы прямого списания средств: 507156,
-    (“Stripe”) на списание средств с вашего счета через систему BECS от
-    имени %1$s (\"Продавец\") на суммы, отдельно указанные вам Продавцом.
-    Вы подтверждаете, что являетесь владельцем указанного ниже счета или
-    его уполномоченным представителем
-    </string>
-    <string name="becs_widget_account_number">Номер счета</string>
-    <string name="becs_widget_account_number_incomplete">Номер счета введен не полностью.</string>
-    <string name="becs_widget_account_number_required">Необходимо указать ваш номер счета.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Введенный код BSB неполон.</string>
-    <string name="becs_widget_bsb_invalid">Введенный код BSB неверен.</string>
-    <string name="becs_widget_email">Адрес эл. почты</string>
-    <string name="becs_widget_email_invalid">Неверный адрес эл. почты.</string>
-    <string name="becs_widget_email_required">Необходимо указать ваш адрес эл. почты.</string>
-    <string name="becs_widget_name">Имя</string>
-    <string name="becs_widget_name_required">Необходимо указать ваше имя.</string>
-    <string name="card_ending_in">%1$s, оканч. на %2$s</string>
-    <string name="close">Закрыть</string>
-    <string name="delete_payment_method">Удалить способ оплаты?</string>
-    <string name="delete_payment_method_prompt_title">Удалить метод оплаты?</string>
-    <string name="expiry_date_hint">ММ/ГГ</string>
-    <string name="expiry_label_short">Истечение срока действия</string>
-    <string name="fpx_bank_offline">%s - не в сети</string>
-    <string name="incomplete_expiry_date">Дата истечения срока действия карты введена не полностью.</string>
-    <string name="invalid_card_number">Номер карты недействителен.</string>
-    <string name="invalid_cvc">Код CVV/CVC карты недействителен.</string>
-    <string name="invalid_expiry_month">Недопустимый месяц окончания действия карты.</string>
-    <string name="invalid_expiry_year">Недопустимый год окончания действия карты.</string>
-    <string name="invalid_shipping_information">Ошибочный адрес доставки</string>
-    <string name="invalid_zip">Введенный почтовый индекс неполон.</string>
-    <string name="no_payment_methods">Нет методов оплаты.</string>
-    <string name="payment_method_add_new_card">Добавить новую карту...</string>
-    <string name="payment_method_add_new_fpx">Выберите банковский счет (FPX)…</string>
-    <string name="price_free">Бесплатно</string>
-    <string name="removed">Удалено: %s</string>
-    <string name="secure_checkout">Безопасное оформление и оплата заказа</string>
-    <string name="stripe_failure_connection_error">Возникли проблемы с подключением к системе обработки платежей. Проверьте подключение к Интернету и попробуйте еще раз.</string>
-    <string name="stripe_failure_reason_authentication">Не удалось верифицировать метод оплаты. Выберите другой метод оплаты и повторите попытку.</string>
-    <string name="stripe_failure_reason_timed_out">Лимит времени для аутентификации метода оплаты истек. Попробуйте еще раз</string>
-    <string name="stripe_google_pay_error_internal">Произошла внутренняя ошибка.</string>
-    <string name="stripe_paymentsheet_add_button_label">Добавить</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавить</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Данные платежной карты</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Страна или регион</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Укажите платежные данные</string>
-    <string name="stripe_paymentsheet_back">Назад</string>
-    <string name="stripe_paymentsheet_close">Закрыть</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">ММ / ГГ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Или оплатить с помощью</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Или оплатить картой</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Оплатить %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Оплатить</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Идет обработка...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Сохранить данные этой карты для будущих платежей %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Выберите способ оплаты</string>
-    <string name="stripe_paymentsheet_setup_button_label">Настроить</string>
-    <string name="stripe_paymentsheet_total_amount">Всего: %s</string>
-    <string name="stripe_verify_your_payment">Подтвердите платеж</string>
-    <string name="title_add_a_card">Добавить карту</string>
-    <string name="title_add_an_address">Задать адрес</string>
-    <string name="title_bank_account">Банковский счет</string>
-    <string name="title_payment_method">Метод оплаты</string>
-    <string name="title_select_shipping_method">Выберите метод доставки</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Номер карты</string>
+  <string name="acc_label_card_number_node">%s, номер карты</string>
+  <string name="acc_label_cvc_node">%s, код CVV/CVC</string>
+  <string name="acc_label_expiry_date">Окончание срока действия</string>
+  <string name="acc_label_expiry_date_node">%s, дата истечения срока действия</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Почтовый индекс</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Почтовый индекс</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Добавьте новую дебетную или кредитную карту, чтобы совершать покупки в этом приложении.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Добавлено: %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Введите город</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Недопустимое название страны.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Введите страну</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Адрес</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Адрес (строка 1)</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Адрес (строка 1) (необязательно)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Адрес (строка 2) (необязательно)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Адрес (необязательно)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Кв. (необязательно)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Город (необязательно)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Графство (необязательно)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Номер телефона</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Номер телефона (необязательно)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Почтовый индекс (необязательно)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Почтовый индекс</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Почтовый индекс (необязательно)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Провинция (необязательно)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Штат / провинция / регион</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Штат / провинция / регион (необязательно)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Штат (необязательно)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Почтовый индекс (необязательно)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Почтовый индекс</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Почтовый индекс (необязательно)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Введите свое имя</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Введите свой номер телефона</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Введенный почтовый индекс неверен</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Введенный почтовый индекс неверен</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Введите название своей провинции</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Введите штат / провинцию / регион</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Введите адрес</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Адрес доставки</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Введите штат</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Введенный почтовый индекс неверен.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Введенный почтовый индекс неверен</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Предоставляя данные банковского счета и подтверждая платеж, вы принимаете данный запрос прямого списания средств и сервисное\n    соглашение на запрос прямого списания средств, а также уполномочиваете компанию\n    Stripe Payments Australia Pty Ltd, ACN 160 180 343, идентификационный номер пользователя службы прямого списания средств: 507156,\n    (“Stripe”) на списание средств с вашего счета через систему BECS от\n    имени %1$s (\"Продавец\") на суммы, отдельно указанные вам Продавцом.\n    Вы подтверждаете, что являетесь владельцем указанного ниже счета или\n    его уполномоченным представителем\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Номер счета</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Номер счета введен не полностью.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Необходимо указать ваш номер счета.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Введенный код BSB неполон.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Введенный код BSB неверен.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Адрес эл. почты</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Неверный адрес эл. почты.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Необходимо указать ваш адрес эл. почты.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Имя</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Необходимо указать ваше имя.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, оканч. на %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Закрыть</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Удалить способ оплаты?</string>
+  <string name="delete_payment_method_prompt_title">Удалить метод оплаты?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">ММ/ГГ</string>
+  <string name="expiry_label_short">Истечение срока действия</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - не в сети</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Дата истечения срока действия карты введена не полностью.</string>
+  <string name="invalid_card_number">Номер карты недействителен.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Код CVV/CVC карты недействителен.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Недопустимый месяц окончания действия карты.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Недопустимый год окончания действия карты.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Ошибочный адрес доставки</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Введенный почтовый индекс неполон.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Нет методов оплаты.</string>
+  <string name="payment_method_add_new_card">Добавить новую карту...</string>
+  <string name="payment_method_add_new_fpx">Выберите банковский счет (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Бесплатно</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Удалено: %s</string>
+  <string name="secure_checkout">Безопасное оформление и оплата заказа</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Возникли проблемы с подключением к системе обработки платежей. Проверьте подключение к Интернету и попробуйте еще раз.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Не удалось верифицировать метод оплаты. Выберите другой метод оплаты и повторите попытку.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Лимит времени для аутентификации метода оплаты истек. Попробуйте еще раз</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Произошла внутренняя ошибка.</string>
+  <string name="stripe_paymentsheet_add_button_label">Добавить</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавить</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Данные платежной карты</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Страна или регион</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Укажите платежные данные</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Назад</string>
+  <string name="stripe_paymentsheet_close">Закрыть</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">ММ / ГГ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Или оплатить с помощью</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Или оплатить картой</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Оплатить %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Оплатить</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Идет обработка...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Сохранить данные этой карты для будущих платежей %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Выберите способ оплаты</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Настроить</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Подтвердите платеж</string>
+  <string name="title_add_a_card">Добавить карту</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Задать адрес</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Банковский счет</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Метод оплаты</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Выберите метод доставки</string>
 </resources>

--- a/payments-core/res/values-SV/strings.xml
+++ b/payments-core/res/values-SV/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kortnummer</string>
-    <string name="acc_label_card_number_node">%s, kortnummer</string>
-    <string name="acc_label_cvc_node">%s, CVC-kod</string>
-    <string name="acc_label_expiry_date">Sista giltighetsdag</string>
-    <string name="acc_label_expiry_date_node">%s, sista giltighetsdag</string>
-    <string name="acc_label_zip">Postkod</string>
-    <string name="acc_label_zip_short">Postkod</string>
-    <string name="add_card">Lägg till ett nytt betal- eller kreditkort för att göra köp i den här appen.</string>
-    <string name="added">Tillagt %s</string>
-    <string name="address_city_required">Ange ort</string>
-    <string name="address_country_invalid">Ditt land är felaktigt</string>
-    <string name="address_county_required">Ange land</string>
-    <string name="address_label_address">Adress</string>
-    <string name="address_label_address_line1">Adressrad 1</string>
-    <string name="address_label_address_line1_optional">Adressrad 1 (valfritt)</string>
-    <string name="address_label_address_line2_optional">Adressrad 2 (valfritt)</string>
-    <string name="address_label_address_optional">Adress (valfritt)</string>
-    <string name="address_label_apt">Lgh.</string>
-    <string name="address_label_apt_optional">Lgh. (valfritt)</string>
-    <string name="address_label_city">Ort</string>
-    <string name="address_label_city_optional">Ort (valfritt)</string>
-    <string name="address_label_country">Land</string>
-    <string name="address_label_county">Landskap</string>
-    <string name="address_label_county_optional">Region (valfritt)</string>
-    <string name="address_label_name">Namn</string>
-    <string name="address_label_phone_number">Telefonnummer</string>
-    <string name="address_label_phone_number_optional">Telefonnummer (valfritt)</string>
-    <string name="address_label_postal_code">Postnummer</string>
-    <string name="address_label_postal_code_optional">Postnummer (valfritt)</string>
-    <string name="address_label_postcode">Postnummer</string>
-    <string name="address_label_postcode_optional">Postnummer (valfritt)</string>
-    <string name="address_label_province">Provins</string>
-    <string name="address_label_province_optional">Provins (valfritt)</string>
-    <string name="address_label_region_generic">Delstat/region/provins</string>
-    <string name="address_label_region_generic_optional">Delstat/region/provins (valfritt)</string>
-    <string name="address_label_state">Delstat</string>
-    <string name="address_label_state_optional">Delstat (valfritt)</string>
-    <string name="address_label_zip_code">Postnummer</string>
-    <string name="address_label_zip_code_optional">Postnummer (valfritt)</string>
-    <string name="address_label_zip_postal_code">Postnummer</string>
-    <string name="address_label_zip_postal_code_optional">Postnummer (valfritt)</string>
-    <string name="address_name_required">Ange ditt namn</string>
-    <string name="address_phone_number_required">Ange ditt telefonnummer</string>
-    <string name="address_postal_code_invalid">Postnumret är ogiltigt</string>
-    <string name="address_postcode_invalid">Postnumret är ogiltigt</string>
-    <string name="address_province_required">Ange provins</string>
-    <string name="address_region_generic_required">Ange delstat/region/provins</string>
-    <string name="address_required">Ange adress</string>
-    <string name="address_shipping_address">Leveransadress</string>
-    <string name="address_state_required">Ange delstat</string>
-    <string name="address_zip_invalid">Postnumret är ogiltigt.</string>
-    <string name="address_zip_postal_invalid">Postnumret är ogiltigt</string>
-    <string name="becs_mandate_acceptance">
-    Genom att tillhandahålla dina bankkontouppgifter och bekräfta denna betalning, samtycker du till denna 
-    Direktdebitering och serviceavtal med direktdebitering, och godkänner att
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Användar-ID för direktdebitering 507156
-    (“Stripe”) debiterar ditt konto via Bulk Electronic Clearing System (BECS) på 
-    uppdrag av %1$s (\"säljaren\") för eventuella belopp som separat meddelats till dig
-    av säljaren. Du intygar att du antingen är kontoinnehavare eller auktoriserad
-    undertecknare på det konto som anges ovan.
-    </string>
-    <string name="becs_widget_account_number">Kontonummer</string>
-    <string name="becs_widget_account_number_incomplete">Ditt kontonummer är ofullständigt.</string>
-    <string name="becs_widget_account_number_required">Ditt kontonummer krävs.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Den BSB du angav är inkomplett.</string>
-    <string name="becs_widget_bsb_invalid">Den BSB du angav är fel.</string>
-    <string name="becs_widget_email">E-postadress</string>
-    <string name="becs_widget_email_invalid">Din e-postadress är ogiltig.</string>
-    <string name="becs_widget_email_required">Din e-postadress krävs.</string>
-    <string name="becs_widget_name">Namn</string>
-    <string name="becs_widget_name_required">Ditt namn krävs.</string>
-    <string name="card_ending_in">%1$s slutar med %2$s</string>
-    <string name="close">Stäng</string>
-    <string name="delete_payment_method">Ta bort betalningsmetoden</string>
-    <string name="delete_payment_method_prompt_title">T bort betalningsmetoden?</string>
-    <string name="expiry_date_hint">MM/ÅÅ</string>
-    <string name="expiry_label_short">Giltighetstid</string>
-    <string name="fpx_bank_offline">%s - offline</string>
-    <string name="incomplete_expiry_date">Kortets utgångsdatum är ofullständigt.</string>
-    <string name="invalid_card_number">Kortnumret är ogiltigt.</string>
-    <string name="invalid_cvc">Kortets säkerhetskod är ogiltig.</string>
-    <string name="invalid_expiry_month">Kortets utgångsmånad är ogiltig.</string>
-    <string name="invalid_expiry_year">Kortets utgångsår är ogiltigt.</string>
-    <string name="invalid_shipping_information">Ogiltig leveransadress</string>
-    <string name="invalid_zip">Ditt postnummer är ofullständigt.</string>
-    <string name="no_payment_methods">Inga betalningssätt.</string>
-    <string name="payment_method_add_new_card">Lägg till nytt kort ...</string>
-    <string name="payment_method_add_new_fpx">Välj bankkonto (FPX) ...</string>
-    <string name="price_free">Gratis</string>
-    <string name="removed">Borttaget %s</string>
-    <string name="secure_checkout">Säker betalning</string>
-    <string name="stripe_failure_connection_error">Vi har problem med anslutningen till vår leverantör av betalningstjänster. Kontrollera internetanslutningen och försök igen.</string>
-    <string name="stripe_failure_reason_authentication">Vi kan inte verifiera din betalningsmetod. Välj en annan betalningsmetod och försök igen.</string>
-    <string name="stripe_failure_reason_timed_out">Tidsgränsen passerades vid autentisering av betalningsmetoden – försök igen</string>
-    <string name="stripe_google_pay_error_internal">Ett internt fel uppstod.</string>
-    <string name="stripe_paymentsheet_add_button_label">Lägg till</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lägg till</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformation</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Lägg till betalningsinformation</string>
-    <string name="stripe_paymentsheet_back">Tillbaka</string>
-    <string name="stripe_paymentsheet_close">Stäng</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / ÅÅ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Eller betala genom att använda</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Eller betala med ett kort</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Betala %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Betala</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Bearbetar ...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Spara detta kort för framtiden %s betalningar</string>
-    <string name="stripe_paymentsheet_select_payment_method">Välj din betalningsmetod</string>
-    <string name="stripe_paymentsheet_setup_button_label">Konfigurera</string>
-    <string name="stripe_paymentsheet_total_amount">Totalt: %s</string>
-    <string name="stripe_verify_your_payment">Verifiera din betalning</string>
-    <string name="title_add_a_card">Lägg till kort</string>
-    <string name="title_add_an_address">Lägg till adress</string>
-    <string name="title_bank_account">Bankkonto</string>
-    <string name="title_payment_method">Betalningsmetod</string>
-    <string name="title_select_shipping_method">Välj leveransmetod</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kortnummer</string>
+  <string name="acc_label_card_number_node">%s, kortnummer</string>
+  <string name="acc_label_cvc_node">%s, CVC-kod</string>
+  <string name="acc_label_expiry_date">Sista giltighetsdag</string>
+  <string name="acc_label_expiry_date_node">%s, sista giltighetsdag</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Postkod</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Postkod</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Lägg till ett nytt betal- eller kreditkort för att göra köp i den här appen.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Tillagt %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Ange ort</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Ditt land är felaktigt</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Ange land</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adress</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adressrad 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adressrad 1 (valfritt)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adressrad 2 (valfritt)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adress (valfritt)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Lgh. (valfritt)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ort (valfritt)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Region (valfritt)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonnummer</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonnummer (valfritt)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postnummer (valfritt)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postnummer</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postnummer (valfritt)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provins (valfritt)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Delstat/region/provins</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Delstat/region/provins (valfritt)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Delstat (valfritt)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Postnummer (valfritt)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Postnummer</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Postnummer (valfritt)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Ange ditt namn</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Ange ditt telefonnummer</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Postnumret är ogiltigt</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Postnumret är ogiltigt</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Ange provins</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Ange delstat/region/provins</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Ange adress</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Leveransadress</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Ange delstat</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Postnumret är ogiltigt.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Postnumret är ogiltigt</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Genom att tillhandahålla dina bankkontouppgifter och bekräfta denna betalning, samtycker du till denna \n    Direktdebitering och serviceavtal med direktdebitering, och godkänner att\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Användar-ID för direktdebitering 507156\n    (“Stripe”) debiterar ditt konto via Bulk Electronic Clearing System (BECS) på \n    uppdrag av %1$s (\"säljaren\") för eventuella belopp som separat meddelats till dig\n    av säljaren. Du intygar att du antingen är kontoinnehavare eller auktoriserad\n    undertecknare på det konto som anges ovan.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Kontonummer</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Ditt kontonummer är ofullständigt.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Ditt kontonummer krävs.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Den BSB du angav är inkomplett.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Den BSB du angav är fel.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-postadress</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Din e-postadress är ogiltig.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Din e-postadress krävs.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Namn</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Ditt namn krävs.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s slutar med %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Stäng</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Ta bort betalningsmetoden</string>
+  <string name="delete_payment_method_prompt_title">T bort betalningsmetoden?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/ÅÅ</string>
+  <string name="expiry_label_short">Giltighetstid</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kortets utgångsdatum är ofullständigt.</string>
+  <string name="invalid_card_number">Kortnumret är ogiltigt.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kortets säkerhetskod är ogiltig.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kortets utgångsmånad är ogiltig.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kortets utgångsår är ogiltigt.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Ogiltig leveransadress</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Ditt postnummer är ofullständigt.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Inga betalningssätt.</string>
+  <string name="payment_method_add_new_card">Lägg till nytt kort ...</string>
+  <string name="payment_method_add_new_fpx">Välj bankkonto (FPX) ...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratis</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Borttaget %s</string>
+  <string name="secure_checkout">Säker betalning</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Vi har problem med anslutningen till vår leverantör av betalningstjänster. Kontrollera internetanslutningen och försök igen.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Vi kan inte verifiera din betalningsmetod. Välj en annan betalningsmetod och försök igen.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Tidsgränsen passerades vid autentisering av betalningsmetoden – försök igen</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Ett internt fel uppstod.</string>
+  <string name="stripe_paymentsheet_add_button_label">Lägg till</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lägg till</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformation</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Lägg till betalningsinformation</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Tillbaka</string>
+  <string name="stripe_paymentsheet_close">Stäng</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / ÅÅ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Eller betala genom att använda</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Eller betala med ett kort</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Betala %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Betala</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Bearbetar ...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Spara detta kort för framtiden %s betalningar</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Välj din betalningsmetod</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Konfigurera</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifiera din betalning</string>
+  <string name="title_add_a_card">Lägg till kort</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Lägg till adress</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankkonto</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Betalningsmetod</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Välj leveransmetod</string>
 </resources>

--- a/payments-core/res/values-TR/strings.xml
+++ b/payments-core/res/values-TR/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kart numarası</string>
-    <string name="acc_label_card_number_node">%s, Kart numarası</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Son Kullanma Tarihi</string>
-    <string name="acc_label_expiry_date_node">%s, Son kullanma tarihi</string>
-    <string name="acc_label_zip">Posta Kodu</string>
-    <string name="acc_label_zip_short">Posta Kodu</string>
-    <string name="add_card">Bu uygulama içinden satın alma yapmak için yeni banka kartı veya kredi kartı ekleyin.</string>
-    <string name="added">%s eklendi</string>
-    <string name="address_city_required">Lütfen şehrinizi girin</string>
-    <string name="address_country_invalid">Ülkeniz geçersiz</string>
-    <string name="address_county_required">Lütfen ülkenizi girin</string>
-    <string name="address_label_address">Adres</string>
-    <string name="address_label_address_line1">Adres satırı 1</string>
-    <string name="address_label_address_line1_optional">Adres satırı 1</string>
-    <string name="address_label_address_line2_optional">Adres satırı 2 (isteğe bağlı)</string>
-    <string name="address_label_address_optional">Adres (isteğe bağlı)</string>
-    <string name="address_label_apt">Apt.</string>
-    <string name="address_label_apt_optional">Apt. (isteğe bağlı)</string>
-    <string name="address_label_city">Şehir</string>
-    <string name="address_label_city_optional">Şehir (isteğe bağlı)</string>
-    <string name="address_label_country">Ülke</string>
-    <string name="address_label_county">Ülke</string>
-    <string name="address_label_county_optional">Ülke (isteğe bağlı)</string>
-    <string name="address_label_name">Ad</string>
-    <string name="address_label_phone_number">Telefon numarası</string>
-    <string name="address_label_phone_number_optional">Telefon numarası (isteğe bağlı)</string>
-    <string name="address_label_postal_code">Posta kodu</string>
-    <string name="address_label_postal_code_optional">Posta kodu (isteğe bağlı)</string>
-    <string name="address_label_postcode">Posta kodu</string>
-    <string name="address_label_postcode_optional">Posta kodu (isteğe bağlı)</string>
-    <string name="address_label_province">İlçe</string>
-    <string name="address_label_province_optional">İlçe (isteğe bağlı)</string>
-    <string name="address_label_region_generic">İl /İlçe/Bölge</string>
-    <string name="address_label_region_generic_optional">İl / İlçe / Bölge (isteğe bağlı)</string>
-    <string name="address_label_state">Eyalet</string>
-    <string name="address_label_state_optional">Eyalet (isteğe bağlı)</string>
-    <string name="address_label_zip_code">Posta kodu</string>
-    <string name="address_label_zip_code_optional">Posta kodu (isteğe bağlı)</string>
-    <string name="address_label_zip_postal_code">Posta kodu</string>
-    <string name="address_label_zip_postal_code_optional">Posta kodu (isteğe bağlı)</string>
-    <string name="address_name_required">Lütfen adınızı girin</string>
-    <string name="address_phone_number_required">Lütfen telefon numaranızı girin</string>
-    <string name="address_postal_code_invalid">Posta kodunuz geçersiz</string>
-    <string name="address_postcode_invalid">Posta kodunuz geçersiz</string>
-    <string name="address_province_required">Lütfen ilçenizi girin</string>
-    <string name="address_region_generic_required">Lütfen İl/İlçe/Bölgenizi girin</string>
-    <string name="address_required">Lütfen adresinizi girin</string>
-    <string name="address_shipping_address">Gönderi Adresi</string>
-    <string name="address_state_required">Lütfen eyaletinizi girin</string>
-    <string name="address_zip_invalid">Posta kodunuz geçersiz.</string>
-    <string name="address_zip_postal_invalid">Posta kodunuz geçersiz</string>
-    <string name="becs_mandate_acceptance">
-    Banka hesap bilgilerinizi sağlayarak ve bu ödemeyi onaylayarak, bu Otomatik
-    Ödeme Talebini ve Otomatik Ödeme Talebi hizmet sözleşmesini kabul etmiş
-    olursunuz ve Otomatik Ödeme 507156 Kullanıcı Kimlikli Stripe Payments
-    Australia Pty Ltd ACN 160 180 343 (\"Stripe\")
-    şirketine %1$s (\"Satıcı\") adına, Satıcı tarafından size iletilen herhangi bir tutarı
-    Toplu Elektronik Takas Sistemi (BECS) aracılığıyla hesabınızı borçlandırması için
-    yetki verirsiniz. Yukarıda listelenen hesabın sahibi veya yetkili imza sahibi olduğunuzu onaylarsınız.
-    </string>
-    <string name="becs_widget_account_number">Hesap numarası</string>
-    <string name="becs_widget_account_number_incomplete">Hesap numaranız eksik.</string>
-    <string name="becs_widget_account_number_required">Hesap numaranız gereklidir.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Girdiğiniz BSB eksik.</string>
-    <string name="becs_widget_bsb_invalid">Girdiğiniz BSB geçersiz.</string>
-    <string name="becs_widget_email">E-posta Adresi</string>
-    <string name="becs_widget_email_invalid">E-posta adresiniz geçersiz.</string>
-    <string name="becs_widget_email_required">E-posta adresiniz gereklidir.</string>
-    <string name="becs_widget_name">Ad</string>
-    <string name="becs_widget_name_required">Adınız gereklidir.</string>
-    <string name="card_ending_in">%2$s İle Biten %1$s</string>
-    <string name="close">Kapat</string>
-    <string name="delete_payment_method">Ödeme Metodu Silinsin mi?</string>
-    <string name="delete_payment_method_prompt_title">Ödeme yöntemi silinsin mi?</string>
-    <string name="expiry_date_hint">AA/YY</string>
-    <string name="expiry_label_short">Son kullanma</string>
-    <string name="fpx_bank_offline">%s - Çevrimdışı</string>
-    <string name="incomplete_expiry_date">Kartınızın son kullanma tarihi eksik.</string>
-    <string name="invalid_card_number">Kart numaranız geçersiz.</string>
-    <string name="invalid_cvc">Kartınızın güvenlik kodu geçersiz.</string>
-    <string name="invalid_expiry_month">Kartınızın son kullanma ayı geçersiz.</string>
-    <string name="invalid_expiry_year">Kartınızın son kullanma yılı geçersiz.</string>
-    <string name="invalid_shipping_information">Geçersiz Gönderi Adresi</string>
-    <string name="invalid_zip">Posta kodunuz eksik.</string>
-    <string name="no_payment_methods">Ödeme metodu yok</string>
-    <string name="payment_method_add_new_card">Yeni kart ekle...</string>
-    <string name="payment_method_add_new_fpx">Banka Hesabı Seçin (FPX)...</string>
-    <string name="price_free">Ücretsiz</string>
-    <string name="removed">%s çıkartıldı</string>
-    <string name="secure_checkout">Güvenli Ödeme</string>
-    <string name="stripe_failure_connection_error">Ödeme sağlayıcımıza bağlanmayla ilgili sorun yaşıyoruz. Lütfen internet bağlantınızı kontrol edip tekrar deneyin.</string>
-    <string name="stripe_failure_reason_authentication">Ödeme metodunuzu doğrulayamadık. Lütfen farklı bir ödeme metodu seçin ve tekrar deneyin.</string>
-    <string name="stripe_failure_reason_timed_out">Ödeme metodunuz doğrulanırken zaman aşımına uğradı -- tekrar deneyin</string>
-    <string name="stripe_google_pay_error_internal">Dâhili bir hata oluştu.</string>
-    <string name="stripe_paymentsheet_add_button_label">Ekle</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ekle</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kart bilgileri</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ülke veya bölge</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Ödeme bilgilerinizi ekleyin</string>
-    <string name="stripe_paymentsheet_back">Geri</string>
-    <string name="stripe_paymentsheet_close">Kapat</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">AA / YY</string>
-    <string name="stripe_paymentsheet_or_pay_using">Veya şununla ödeyin:</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ya da kartla ödeyin</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s öde</string>
-    <string name="stripe_paymentsheet_pay_button_label">Öde</string>
-    <string name="stripe_paymentsheet_primary_button_processing">İşleniyor...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Bu kartı gelecekteki %s ödemeleri için kaydedin</string>
-    <string name="stripe_paymentsheet_select_payment_method">Ödeme yönteminizi seçin</string>
-    <string name="stripe_paymentsheet_setup_button_label">Ayarla</string>
-    <string name="stripe_paymentsheet_total_amount">Toplam: %s</string>
-    <string name="stripe_verify_your_payment">Ödemenizi doğrulayın</string>
-    <string name="title_add_a_card">Kart Ekle</string>
-    <string name="title_add_an_address">Adresi Ayarla</string>
-    <string name="title_bank_account">Banka Hesabı</string>
-    <string name="title_payment_method">Ödeme Metodu</string>
-    <string name="title_select_shipping_method">Gönderi Metodunu Seçin</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kart numarası</string>
+  <string name="acc_label_card_number_node">%s, Kart numarası</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Son Kullanma Tarihi</string>
+  <string name="acc_label_expiry_date_node">%s, Son kullanma tarihi</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Posta Kodu</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Posta Kodu</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Bu uygulama içinden satın alma yapmak için yeni banka kartı veya kredi kartı ekleyin.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s eklendi</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Lütfen şehrinizi girin</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Ülkeniz geçersiz</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Lütfen ülkenizi girin</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adres satırı 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adres satırı 1</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adres satırı 2 (isteğe bağlı)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adres (isteğe bağlı)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (isteğe bağlı)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Şehir (isteğe bağlı)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Ülke (isteğe bağlı)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefon numarası</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefon numarası (isteğe bağlı)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Posta kodu (isteğe bağlı)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Posta kodu</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Posta kodu (isteğe bağlı)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">İlçe (isteğe bağlı)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">İl /İlçe/Bölge</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">İl / İlçe / Bölge (isteğe bağlı)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Eyalet (isteğe bağlı)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Posta kodu (isteğe bağlı)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Posta kodu</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Posta kodu (isteğe bağlı)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Lütfen adınızı girin</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Lütfen telefon numaranızı girin</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Posta kodunuz geçersiz</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Posta kodunuz geçersiz</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Lütfen ilçenizi girin</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Lütfen İl/İlçe/Bölgenizi girin</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Lütfen adresinizi girin</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Gönderi Adresi</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Lütfen eyaletinizi girin</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Posta kodunuz geçersiz.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Posta kodunuz geçersiz</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Banka hesap bilgilerinizi sağlayarak ve bu ödemeyi onaylayarak, bu Otomatik\n    Ödeme Talebini ve Otomatik Ödeme Talebi hizmet sözleşmesini kabul etmiş\n    olursunuz ve Otomatik Ödeme 507156 Kullanıcı Kimlikli Stripe Payments\n    Australia Pty Ltd ACN 160 180 343 (\"Stripe\")\n    şirketine %1$s (\"Satıcı\") adına, Satıcı tarafından size iletilen herhangi bir tutarı\n    Toplu Elektronik Takas Sistemi (BECS) aracılığıyla hesabınızı borçlandırması için\n    yetki verirsiniz. Yukarıda listelenen hesabın sahibi veya yetkili imza sahibi olduğunuzu onaylarsınız.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Hesap numarası</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Hesap numaranız eksik.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Hesap numaranız gereklidir.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Girdiğiniz BSB eksik.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Girdiğiniz BSB geçersiz.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-posta Adresi</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">E-posta adresiniz geçersiz.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">E-posta adresiniz gereklidir.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Ad</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Adınız gereklidir.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%2$s İle Biten %1$s</string>
+  <!-- Text for close button -->
+  <string name="close">Kapat</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Ödeme Metodu Silinsin mi?</string>
+  <string name="delete_payment_method_prompt_title">Ödeme yöntemi silinsin mi?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">AA/YY</string>
+  <string name="expiry_label_short">Son kullanma</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Çevrimdışı</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kartınızın son kullanma tarihi eksik.</string>
+  <string name="invalid_card_number">Kart numaranız geçersiz.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kartınızın güvenlik kodu geçersiz.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kartınızın son kullanma ayı geçersiz.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kartınızın son kullanma yılı geçersiz.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Geçersiz Gönderi Adresi</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Posta kodunuz eksik.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Ödeme metodu yok</string>
+  <string name="payment_method_add_new_card">Yeni kart ekle...</string>
+  <string name="payment_method_add_new_fpx">Banka Hesabı Seçin (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Ücretsiz</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s çıkartıldı</string>
+  <string name="secure_checkout">Güvenli Ödeme</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Ödeme sağlayıcımıza bağlanmayla ilgili sorun yaşıyoruz. Lütfen internet bağlantınızı kontrol edip tekrar deneyin.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Ödeme metodunuzu doğrulayamadık. Lütfen farklı bir ödeme metodu seçin ve tekrar deneyin.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Ödeme metodunuz doğrulanırken zaman aşımına uğradı -- tekrar deneyin</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Dâhili bir hata oluştu.</string>
+  <string name="stripe_paymentsheet_add_button_label">Ekle</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ekle</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kart bilgileri</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ülke veya bölge</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Ödeme bilgilerinizi ekleyin</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Geri</string>
+  <string name="stripe_paymentsheet_close">Kapat</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">AA / YY</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Veya şununla ödeyin:</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ya da kartla ödeyin</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s öde</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Öde</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">İşleniyor...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Bu kartı gelecekteki %s ödemeleri için kaydedin</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Ödeme yönteminizi seçin</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Ayarla</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Ödemenizi doğrulayın</string>
+  <string name="title_add_a_card">Kart Ekle</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Adresi Ayarla</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Banka Hesabı</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Ödeme Metodu</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Gönderi Metodunu Seçin</string>
 </resources>

--- a/payments-core/res/values-b+es+419/strings.xml
+++ b/payments-core/res/values-b+es+419/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Número de tarjeta</string>
-    <string name="acc_label_card_number_node">%s, número de tarjeta</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Fecha de vencimiento</string>
-    <string name="acc_label_expiry_date_node">%s, fecha de vencimiento</string>
-    <string name="acc_label_zip">Código ZIP</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Agrega una tarjeta de crédito o de débito nueva para efectuar compras en esta aplicación.</string>
-    <string name="added">Se agregó %s</string>
-    <string name="address_city_required">Ingresa el nombre de tu ciudad.</string>
-    <string name="address_country_invalid">El país no es válido.</string>
-    <string name="address_county_required">Ingresa el nombre de tu condado.</string>
-    <string name="address_label_address">Dirección</string>
-    <string name="address_label_address_line1">Primera línea de la dirección</string>
-    <string name="address_label_address_line1_optional">Primera línea de la dirección (opcional)</string>
-    <string name="address_label_address_line2_optional">Segunda línea de la dirección (opcional)</string>
-    <string name="address_label_address_optional">Dirección (opcional) </string>
-    <string name="address_label_apt">Apto.</string>
-    <string name="address_label_apt_optional">Apto. (opcional)</string>
-    <string name="address_label_city">Ciudad</string>
-    <string name="address_label_city_optional">Ciudad (opcional)</string>
-    <string name="address_label_country">País</string>
-    <string name="address_label_county">Condado</string>
-    <string name="address_label_county_optional">Condado (opcional)</string>
-    <string name="address_label_name">Nombre</string>
-    <string name="address_label_phone_number">Número de teléfono</string>
-    <string name="address_label_phone_number_optional">Número de teléfono (opcional)</string>
-    <string name="address_label_postal_code">Código postal</string>
-    <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_label_postcode">Código postal</string>
-    <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <string name="address_label_province">Provincia</string>
-    <string name="address_label_province_optional">Provincia (opcional)</string>
-    <string name="address_label_region_generic">Estado/provincia/región</string>
-    <string name="address_label_region_generic_optional">Estado/provincia/región (opcional)</string>
-    <string name="address_label_state">Estado</string>
-    <string name="address_label_state_optional">Estado (opcional)</string>
-    <string name="address_label_zip_code">Código postal</string>
-    <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <string name="address_label_zip_postal_code">Código postal</string>
-    <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_name_required">Ingresa tu nombre.</string>
-    <string name="address_phone_number_required">Ingresa tu número de teléfono.</string>
-    <string name="address_postal_code_invalid">El código postal no es válido.</string>
-    <string name="address_postcode_invalid">El código postal no es válido.</string>
-    <string name="address_province_required">Ingresa el nombre de tu provincia.</string>
-    <string name="address_region_generic_required">Ingresa el nombre de tu estado/provincia/región.</string>
-    <string name="address_required">Ingresa tu dirección.</string>
-    <string name="address_shipping_address">Dirección de envío</string>
-    <string name="address_state_required">Ingresa el nombre de tu estado.</string>
-    <string name="address_zip_invalid">El código postal no es válido.</string>
-    <string name="address_zip_postal_invalid">El código postal no es válido.</string>
-    <string name="becs_mandate_acceptance">
-    Al proporcionar los datos de tu cuenta bancaria y confirmar el pago, aceptas esta
-    solicitud de débito directo y el contrato de servicio de solicitud de débito directo, y autorizas a
-    Stripe Payments Australia Pty Ltd, ACN 160 180 343, número de ID de usuario de débito directo 507156
-    (\"Stripe\"), a hacer débitos en tu cuenta mediante el sistema Bulk Electronic Clearing System (BECS) en
-    nombre de %1$s (el \"Comerciante\") por los importes que te comunique por
-    separado el Comerciante. Certificas que eres titular de una cuenta o signatario autorizado
-    de la cuenta especificada arriba.
-    </string>
-    <string name="becs_widget_account_number">Número de cuenta</string>
-    <string name="becs_widget_account_number_incomplete">El número de cuenta está incompleto.</string>
-    <string name="becs_widget_account_number_required">Tu número de cuenta es obligatorio.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">El BSB que ingresaste está incompleto.</string>
-    <string name="becs_widget_bsb_invalid">El BSB que ingresaste no es válido.</string>
-    <string name="becs_widget_email">Dirección de correo electrónico</string>
-    <string name="becs_widget_email_invalid">La dirección de correo electrónico no es válida.</string>
-    <string name="becs_widget_email_required">Tu dirección de correo electrónico es obligatoria.</string>
-    <string name="becs_widget_name">Nombre</string>
-    <string name="becs_widget_name_required">Tu nombre es obligatorio.</string>
-    <string name="card_ending_in">%1$s terminada en %2$s</string>
-    <string name="close">Cerrar</string>
-    <string name="delete_payment_method">Eliminar método de pago</string>
-    <string name="delete_payment_method_prompt_title">¿Deseas eliminar el método de pago?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Vencimiento</string>
-    <string name="fpx_bank_offline">%s - Fuera de línea</string>
-    <string name="incomplete_expiry_date">La fecha de vencimiento de la tarjeta está incompleta.</string>
-    <string name="invalid_card_number">El número de tarjeta no es válido.</string>
-    <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
-    <string name="invalid_expiry_month">El mes de vencimiento de la tarjeta no es válido.</string>
-    <string name="invalid_expiry_year">El año de vencimiento de la tarjeta no es válido.</string>
-    <string name="invalid_shipping_information">Dirección de envío inválida</string>
-    <string name="invalid_zip">El código postal está incompleto.</string>
-    <string name="no_payment_methods">No hay método de pago.</string>
-    <string name="payment_method_add_new_card">Agregar nueva tarjeta…</string>
-    <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
-    <string name="price_free">Gratis</string>
-    <string name="removed">Se eliminó %s</string>
-    <string name="secure_checkout">Proceso de compra seguro</string>
-    <string name="stripe_failure_connection_error">Estamos teniendo problemas para conectar con nuestro proveedor de servicios de pagos. Comprueba si tienes conexión a Internet y vuelve a intentarlo.</string>
-    <string name="stripe_failure_reason_authentication">No pudimos autenticar tu método de pago. Elige otro método y vuelve a intentarlo.</string>
-    <string name="stripe_failure_reason_timed_out">Se agotó el tiempo para autenticar el método de pago. Vuelve a intentarlo.</string>
-    <string name="stripe_google_pay_error_internal">Se produjo un error interno.</string>
-    <string name="stripe_paymentsheet_add_button_label">Agregar</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">Agregar otro</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Agrega la información de pago</string>
-    <string name="stripe_paymentsheet_back">Atrás</string>
-    <string name="stripe_paymentsheet_close">Cerrar</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">O pagar con</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">O pagar con tarjeta</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para futuros pagos de %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Selecciona el método de pago</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verificar tu pago</string>
-    <string name="title_add_a_card">Agrega una tarjeta</string>
-    <string name="title_add_an_address">Establece la dirección</string>
-    <string name="title_bank_account">Cuenta bancaria</string>
-    <string name="title_payment_method">Método de pago</string>
-    <string name="title_select_shipping_method">Selecciona el método de envío</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Número de tarjeta</string>
+  <string name="acc_label_card_number_node">%s, número de tarjeta</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Fecha de vencimiento</string>
+  <string name="acc_label_expiry_date_node">%s, fecha de vencimiento</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Código ZIP</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Agrega una tarjeta de crédito o de débito nueva para efectuar compras en esta aplicación.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Se agregó %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Ingresa el nombre de tu ciudad.</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">El país no es válido.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Ingresa el nombre de tu condado.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Dirección</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Primera línea de la dirección</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Primera línea de la dirección (opcional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Segunda línea de la dirección (opcional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Dirección (opcional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apto. (opcional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ciudad (opcional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Condado (opcional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Número de teléfono</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Número de teléfono (opcional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Código postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincia (opcional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Estado/provincia/región</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Estado/provincia/región (opcional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Estado (opcional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Código postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Ingresa tu nombre.</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Ingresa tu número de teléfono.</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Ingresa el nombre de tu provincia.</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Ingresa el nombre de tu estado/provincia/región.</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Ingresa tu dirección.</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Dirección de envío</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Ingresa el nombre de tu estado.</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">El código postal no es válido.</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Al proporcionar los datos de tu cuenta bancaria y confirmar el pago, aceptas esta\n    solicitud de débito directo y el contrato de servicio de solicitud de débito directo, y autorizas a\n    Stripe Payments Australia Pty Ltd, ACN 160 180 343, número de ID de usuario de débito directo 507156\n    (\"Stripe\"), a hacer débitos en tu cuenta mediante el sistema Bulk Electronic Clearing System (BECS) en\n    nombre de %1$s (el \"Comerciante\") por los importes que te comunique por\n    separado el Comerciante. Certificas que eres titular de una cuenta o signatario autorizado\n    de la cuenta especificada arriba.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Número de cuenta</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">El número de cuenta está incompleto.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Tu número de cuenta es obligatorio.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">El BSB que ingresaste está incompleto.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">El BSB que ingresaste no es válido.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Dirección de correo electrónico</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">La dirección de correo electrónico no es válida.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Tu dirección de correo electrónico es obligatoria.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nombre</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Tu nombre es obligatorio.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s terminada en %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Cerrar</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Eliminar método de pago</string>
+  <string name="delete_payment_method_prompt_title">¿Deseas eliminar el método de pago?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Vencimiento</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Fuera de línea</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La fecha de vencimiento de la tarjeta está incompleta.</string>
+  <string name="invalid_card_number">El número de tarjeta no es válido.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">El mes de vencimiento de la tarjeta no es válido.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">El año de vencimiento de la tarjeta no es válido.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Dirección de envío inválida</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">El código postal está incompleto.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">No hay método de pago.</string>
+  <string name="payment_method_add_new_card">Agregar nueva tarjeta…</string>
+  <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratis</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Se eliminó %s</string>
+  <string name="secure_checkout">Proceso de compra seguro</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Estamos teniendo problemas para conectar con nuestro proveedor de servicios de pagos. Comprueba si tienes conexión a Internet y vuelve a intentarlo.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">No pudimos autenticar tu método de pago. Elige otro método y vuelve a intentarlo.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Se agotó el tiempo para autenticar el método de pago. Vuelve a intentarlo.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Se produjo un error interno.</string>
+  <string name="stripe_paymentsheet_add_button_label">Agregar</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">Agregar otro</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Agrega la información de pago</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Atrás</string>
+  <string name="stripe_paymentsheet_close">Cerrar</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">O pagar con</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">O pagar con tarjeta</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para futuros pagos de %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selecciona el método de pago</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verificar tu pago</string>
+  <string name="title_add_a_card">Agrega una tarjeta</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Establece la dirección</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Cuenta bancaria</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Método de pago</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selecciona el método de envío</string>
 </resources>

--- a/payments-core/res/values-bg-rBG/strings.xml
+++ b/payments-core/res/values-bg-rBG/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Номер на картата</string>
-    <string name="acc_label_card_number_node">%s. Номер на картата</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Дата на валидност</string>
-    <string name="acc_label_expiry_date_node">%s, Дата на валидност</string>
-    <string name="acc_label_zip">Пощенски код</string>
-    <string name="acc_label_zip_short">п.к.</string>
-    <string name="add_card">Добавяне на нова дебитна или кредитна карта за извършване на покупки в това приложение.</string>
-    <string name="added">%s е добавено</string>
-    <string name="address_city_required">Моля, въведете Вашия град</string>
-    <string name="address_country_invalid">Вашият окръг е невалиден</string>
-    <string name="address_county_required">Моля, въведете Вашия окръг</string>
-    <string name="address_label_address">Адрес</string>
-    <string name="address_label_address_line1">Ред 1 на адреса</string>
-    <string name="address_label_address_line1_optional">Ред 1 на адреса (по желание)</string>
-    <string name="address_label_address_line2_optional">Ред 2 на адреса (по желание)</string>
-    <string name="address_label_address_optional">Адрес (по желание)</string>
-    <string name="address_label_apt">Ап.</string>
-    <string name="address_label_apt_optional">Ап. (по желание)</string>
-    <string name="address_label_city">Град</string>
-    <string name="address_label_city_optional">Град (по желание)</string>
-    <string name="address_label_country">Държава</string>
-    <string name="address_label_county">Окръг</string>
-    <string name="address_label_county_optional">Окръг (по желание)</string>
-    <string name="address_label_name">Име</string>
-    <string name="address_label_phone_number">Телефонен номер</string>
-    <string name="address_label_phone_number_optional">Телефонен номер (по желание)</string>
-    <string name="address_label_postal_code">Пощенски код</string>
-    <string name="address_label_postal_code_optional">Пощенски код (по желание)</string>
-    <string name="address_label_postcode">Пощенски код</string>
-    <string name="address_label_postcode_optional">Пощенски код (по желание)</string>
-    <string name="address_label_province">Област</string>
-    <string name="address_label_province_optional">Област (по желание)</string>
-    <string name="address_label_region_generic">Държава/Област/Регион</string>
-    <string name="address_label_region_generic_optional">Щат/Област/Регион (по желание)</string>
-    <string name="address_label_state">Щат</string>
-    <string name="address_label_state_optional">Щат (по желание)</string>
-    <string name="address_label_zip_code">Пощенски код</string>
-    <string name="address_label_zip_code_optional">Пощенски код (по желание)</string>
-    <string name="address_label_zip_postal_code">Пощенски код</string>
-    <string name="address_label_zip_postal_code_optional">Пощенски код (по желание)</string>
-    <string name="address_name_required">Моля, въведете името си</string>
-    <string name="address_phone_number_required">Моля, въведете телефонния си номер</string>
-    <string name="address_postal_code_invalid">Вашият пощенски код е невалиден</string>
-    <string name="address_postcode_invalid">Вашият пощенски код е невалиден</string>
-    <string name="address_province_required">Моля, въведете Вашата област.</string>
-    <string name="address_region_generic_required">Моля, въведете Вашия щат/област/регион</string>
-    <string name="address_required">Моля, въведете адреса си</string>
-    <string name="address_shipping_address">Адрес за доставка</string>
-    <string name="address_state_required">Моля, въведете Вашия щат.</string>
-    <string name="address_zip_invalid">Вашият пощенски код е невалиден.</string>
-    <string name="address_zip_postal_invalid">Вашият пощенски код е невалиден</string>
-    <string name="becs_mandate_acceptance">
-    Предоставяйки данните за банковата си сметка и потвърждавайки това плащане, Вие се съгласявате с това 
-    Искане за директен дебит и със споразумението за обслужване на искане за директен дебит и оправомощавате
-    Stripe Payments Australia Pty Ltd ACN 160 180 343, потребителски ИД номер за директен дебит 507156
-    („Stripe“) да дебитира Вашата сметка чрез системата масов електронен клиринг (BECS) от
-    името на %1$s („Търговеца“) за всички суми, за които Търговецът Ви е съобщил отделно.
-    Удостоверявате, че по отношение на горепосочената сметка сте титуляр на сметката или
-    лице, имащо правото да подписва.
-    </string>
-    <string name="becs_widget_account_number">Номер на сметката</string>
-    <string name="becs_widget_account_number_incomplete">Номерът на Вашата сметка е непълен.</string>
-    <string name="becs_widget_account_number_required">Номерът на Вашата сметка е задължителен.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">BSB, който сте въвели, е непълен.</string>
-    <string name="becs_widget_bsb_invalid">BSB, който сте въвели, е невалиден.</string>
-    <string name="becs_widget_email">Имейл адрес</string>
-    <string name="becs_widget_email_invalid">Вашият имейл е невалиден.</string>
-    <string name="becs_widget_email_required">Вашият имейл адрес е задължителен.</string>
-    <string name="becs_widget_name">Име</string>
-    <string name="becs_widget_name_required">Вашето име е задължително.</string>
-    <string name="card_ending_in">%1$s завършващо на %2$s</string>
-    <string name="close">Затваряне</string>
-    <string name="delete_payment_method">Изтриване на метода на плащане</string>
-    <string name="delete_payment_method_prompt_title">Изтриване на метода на плащане?</string>
-    <string name="expiry_date_hint">ММ/ГГ</string>
-    <string name="expiry_label_short">Валидност</string>
-    <string name="fpx_bank_offline">%s - офлайн</string>
-    <string name="incomplete_expiry_date">Срокът на валидност на Вашата карта е непълен.</string>
-    <string name="invalid_card_number">Номерът на Вашата карта е невалиден.</string>
-    <string name="invalid_cvc">Кодът за сигурност на Вашата карта е невалиден.</string>
-    <string name="invalid_expiry_month">Месецът на валидност на Вашата карта е невалиден.</string>
-    <string name="invalid_expiry_year">Годината на валидност на Вашата карта е невалидна.</string>
-    <string name="invalid_shipping_information">Невалиден адрес за доставка</string>
-    <string name="invalid_zip">Вашият пощенски код е непълен.</string>
-    <string name="no_payment_methods">Няма методи на плащане.</string>
-    <string name="payment_method_add_new_card">Добавяне на нова карта...</string>
-    <string name="payment_method_add_new_fpx">Избор на банкова сметка (FPX)…</string>
-    <string name="price_free">Безплатно</string>
-    <string name="removed">%s е премахнато</string>
-    <string name="secure_checkout">Защитено финализиране</string>
-    <string name="stripe_failure_connection_error">Възникна проблем при свързването с нашия доставчик на платежни услуги. Моля, проверете Вашата интернет връзка и опитайте отново.</string>
-    <string name="stripe_failure_reason_authentication">Не можем да удостоверим Вашия метод на плащане. Моля, изберете различен метод на плащане и опитайте отново.</string>
-    <string name="stripe_failure_reason_timed_out">Времето на изчакване на удостоверяването на Вашия метод на плащане изтече -- опитайте отново</string>
-    <string name="stripe_google_pay_error_internal">Възникна вътрешна грешка.</string>
-    <string name="stripe_paymentsheet_add_button_label">Добавяне</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавяне</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Информация за картата</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Държава или регион</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Добавете своята информация за плащането</string>
-    <string name="stripe_paymentsheet_back">Назад</string>
-    <string name="stripe_paymentsheet_close">Затваряне</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">ММ / ГГ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Или платете чрез</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Или платете с карта</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Плащане %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Плащане</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Обработване...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Запазете тази карта за следващи %s плащания</string>
-    <string name="stripe_paymentsheet_select_payment_method">Изберете метод на плащане</string>
-    <string name="stripe_paymentsheet_setup_button_label">Създаване</string>
-    <string name="stripe_paymentsheet_total_amount">Общо: %s</string>
-    <string name="stripe_verify_your_payment">Потвърдете Вашето плащане</string>
-    <string name="title_add_a_card">Добавяне на карта</string>
-    <string name="title_add_an_address">Задаване на адрес</string>
-    <string name="title_bank_account">Банкова сметка</string>
-    <string name="title_payment_method">Метод на плащане</string>
-    <string name="title_select_shipping_method">Избор на метод на доставка</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Номер на картата</string>
+  <string name="acc_label_card_number_node">%s. Номер на картата</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Дата на валидност</string>
+  <string name="acc_label_expiry_date_node">%s, Дата на валидност</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Пощенски код</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">п.к.</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Добавяне на нова дебитна или кредитна карта за извършване на покупки в това приложение.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s е добавено</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Моля, въведете Вашия град</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Вашият окръг е невалиден</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Моля, въведете Вашия окръг</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Адрес</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Ред 1 на адреса</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Ред 1 на адреса (по желание)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Ред 2 на адреса (по желание)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Адрес (по желание)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Ап. (по желание)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Град (по желание)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Окръг (по желание)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Телефонен номер</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Телефонен номер (по желание)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Пощенски код (по желание)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Пощенски код</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Пощенски код (по желание)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Област (по желание)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Държава/Област/Регион</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Щат/Област/Регион (по желание)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Щат (по желание)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Пощенски код (по желание)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Пощенски код</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Пощенски код (по желание)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Моля, въведете името си</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Моля, въведете телефонния си номер</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Вашият пощенски код е невалиден</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Вашият пощенски код е невалиден</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Моля, въведете Вашата област.</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Моля, въведете Вашия щат/област/регион</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Моля, въведете адреса си</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Адрес за доставка</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Моля, въведете Вашия щат.</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Вашият пощенски код е невалиден.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Вашият пощенски код е невалиден</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Предоставяйки данните за банковата си сметка и потвърждавайки това плащане, Вие се съгласявате с това \n    Искане за директен дебит и със споразумението за обслужване на искане за директен дебит и оправомощавате\n    Stripe Payments Australia Pty Ltd ACN 160 180 343, потребителски ИД номер за директен дебит 507156\n    („Stripe“) да дебитира Вашата сметка чрез системата масов електронен клиринг (BECS) от\n    името на %1$s („Търговеца“) за всички суми, за които Търговецът Ви е съобщил отделно.\n    Удостоверявате, че по отношение на горепосочената сметка сте титуляр на сметката или\n    лице, имащо правото да подписва.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Номер на сметката</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Номерът на Вашата сметка е непълен.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Номерът на Вашата сметка е задължителен.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">BSB, който сте въвели, е непълен.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">BSB, който сте въвели, е невалиден.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Имейл адрес</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Вашият имейл е невалиден.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Вашият имейл адрес е задължителен.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Име</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Вашето име е задължително.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s завършващо на %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Затваряне</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Изтриване на метода на плащане</string>
+  <string name="delete_payment_method_prompt_title">Изтриване на метода на плащане?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">ММ/ГГ</string>
+  <string name="expiry_label_short">Валидност</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - офлайн</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Срокът на валидност на Вашата карта е непълен.</string>
+  <string name="invalid_card_number">Номерът на Вашата карта е невалиден.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Кодът за сигурност на Вашата карта е невалиден.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Месецът на валидност на Вашата карта е невалиден.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Годината на валидност на Вашата карта е невалидна.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Невалиден адрес за доставка</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Вашият пощенски код е непълен.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Няма методи на плащане.</string>
+  <string name="payment_method_add_new_card">Добавяне на нова карта...</string>
+  <string name="payment_method_add_new_fpx">Избор на банкова сметка (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Безплатно</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s е премахнато</string>
+  <string name="secure_checkout">Защитено финализиране</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Възникна проблем при свързването с нашия доставчик на платежни услуги. Моля, проверете Вашата интернет връзка и опитайте отново.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Не можем да удостоверим Вашия метод на плащане. Моля, изберете различен метод на плащане и опитайте отново.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Времето на изчакване на удостоверяването на Вашия метод на плащане изтече -- опитайте отново</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Възникна вътрешна грешка.</string>
+  <string name="stripe_paymentsheet_add_button_label">Добавяне</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавяне</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Информация за картата</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Държава или регион</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Добавете своята информация за плащането</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Назад</string>
+  <string name="stripe_paymentsheet_close">Затваряне</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">ММ / ГГ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Или платете чрез</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Или платете с карта</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Плащане %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Плащане</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Обработване...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Запазете тази карта за следващи %s плащания</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Изберете метод на плащане</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Създаване</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Потвърдете Вашето плащане</string>
+  <string name="title_add_a_card">Добавяне на карта</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Задаване на адрес</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Банкова сметка</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Метод на плащане</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Избор на метод на доставка</string>
 </resources>

--- a/payments-core/res/values-ca-rES/strings.xml
+++ b/payments-core/res/values-ca-rES/strings.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Número de targeta</string>
+  <string name="acc_label_card_number_node">%s, Número de targeta</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Data de caducitat</string>
+  <string name="acc_label_expiry_date_node">%s, Data de caducitat</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Codi ZIP</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Afegir una nova targeta de dèbit o crèdit per fer compres a aquesta aplicació.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Afegit %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Si us plau, introdueix la teva ciutat</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">El teu país no és vàlid</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Si us plau, introdueix el teu país</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adreça</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Línia de l\'adreça 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Línia de l\'adreça 1 (opcional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Línia de l\'adreça 2 (opcional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adreça (opcional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (opcional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ciutat (opcional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">País (opcional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Número de telèfon</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Número de telèfon (opcional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Codi postal (opcional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Codi postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Codi postal (opcional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Província (opcional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">País / Província / Regió</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">País / Província / Regió (opcional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">País (opcional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Codi ZIP (opcional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">ZIP / Codi postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">ZIP / Codi postal (opcional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Si us plau, introdueix el teu nom</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Si us plau, introdueix el teu número de telèfon</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">El teu codi postal no és vàlid</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">El teu codi postal no és vàlid</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Si us plau, introdueix la teva província</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Si us plau, introdueix el teu País/Província/Regió</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Si us plau, introdueix la teva adreça</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Adreça d\'enviament</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Si us plau, introdueix el teu país</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">El teu codi ZIP no és vàlid.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">El teu ZIP / codi postal no és vàlid</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Facilitant-nos les teves dades bancàries i confirmant aquest pagament, estàs d\'acord amb aquesta Sol·licitud de Domiciliació Bancària i amb el Servei de Sol·licitud de Domiciliació Bancària, i autoritzes Stripe Payments Australia Pty Ltd ACN 160 180 343, amb número d\'identificador d\'usuari de domiciliació bancària 507156 («Stripe») a carregar en el teu compte mitjançant el Sistema de Compensació Electrònica a gran escala (BECS per les seves sigles en anglès) en nom de %1$s (el «Venedor») per qualsevol import que se t\'hagi comunicat de manera separada per part del Venedor. Certifiques que ets el titular del compte o un signatari autoritzat del compte indicat anteriorment.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Número de Compte</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">El teu número de compte no està complet.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">El teu número de compte és obligatori.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">El BSB que has introduït és incomplet.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">El BSB que has introduït no és vàlid.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Adreça de correu electrònic</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">La teva adreça no és vàlida.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">La teva adreça electrònica és obligatòria.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nom</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">El teu nom és obligatori.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s que acaba en %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Tancar</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Eliminar mètode de pagament</string>
+  <string name="delete_payment_method_prompt_title">Vols eliminar mètode de pagament?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM / AA</string>
+  <string name="expiry_label_short">Caducitat</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Fora de línia</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La data de caducitat de la teva targeta no està completa.</string>
+  <string name="invalid_card_number">El número de la teva targeta no és vàlid.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">El codi de seguretat de la teva targeta no és vàlid</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">El mes de caducitat de la teva targeta no és vàlid.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">L\'any de caducitat de la teva targeta no és vàlid.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Adreça d\'enviament invàlida</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">El teu codi postal no està complet.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">No hi ha mètodes de pagament.</string>
+  <string name="payment_method_add_new_card">Afegir nova targeta...</string>
+  <string name="payment_method_add_new_fpx">Seleccionar Compte Bancari (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Sense cost</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Eliminat %s</string>
+  <string name="secure_checkout">Compra Segura</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Estem tenint problemes connectant-nos al nostre proveïdor de serveis de pagament. Comprova la teva connexió a internet i torna-ho a provar.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">No podem autenticar el teu mètode de pagament. Si us plau, escull un mètode de pagament diferent.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">S\'ha esgotat el temps d\'autenticació del teu mètode de pagament - intenta-ho un altre cop</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">S\'ha produït un error intern.</string>
+  <string name="stripe_paymentsheet_add_button_label">Afegir</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Afegir</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informació de targeta</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o regió</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Afegir la teva informació de pagament</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Tornar</string>
+  <string name="stripe_paymentsheet_close">Tancar</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">O pagar fent servir</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">O pagar amb una targeta</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Processant...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Desar aquesta tarjeta per futurs %s pagaments</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selecciona el teu mètode de pagament</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configuració</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifica la forma de pagament</string>
+  <string name="title_add_a_card">Afegir una targeta</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Establir adreça</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Compte bancari</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Mètode de pagament</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Seleccionar Mètode d\'Enviament</string>
+</resources>

--- a/payments-core/res/values-cs-rCZ/strings.xml
+++ b/payments-core/res/values-cs-rCZ/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Číslo karty</string>
-    <string name="acc_label_card_number_node">%s, číslo karty</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Datum konce platnosti</string>
-    <string name="acc_label_expiry_date_node">%s, datum konce platnosti</string>
-    <string name="acc_label_zip">PSČ</string>
-    <string name="acc_label_zip_short">PSČ</string>
-    <string name="add_card">Abyste mohli v této aplikaci nakupovat, přidejte novou debetní nebo kreditní kartu.</string>
-    <string name="added">Přidáno %s</string>
-    <string name="address_city_required">Zadejte město</string>
-    <string name="address_country_invalid">Vaše země je neplatná</string>
-    <string name="address_county_required">Zadejte okres</string>
-    <string name="address_label_address">Adresa</string>
-    <string name="address_label_address_line1">1. řádek adresy</string>
-    <string name="address_label_address_line1_optional">1. řádek adresy (volitelně)</string>
-    <string name="address_label_address_line2_optional">2. řádek adresy (volitelně)</string>
-    <string name="address_label_address_optional">Adresa(volitelně) </string>
-    <string name="address_label_apt">Byt</string>
-    <string name="address_label_apt_optional">Byt (volitelně)</string>
-    <string name="address_label_city">Město</string>
-    <string name="address_label_city_optional">Město (volitelně)</string>
-    <string name="address_label_country">Země</string>
-    <string name="address_label_county">Okres</string>
-    <string name="address_label_county_optional">Okres (volitelně)</string>
-    <string name="address_label_name">Jméno</string>
-    <string name="address_label_phone_number">Telefonní číslo</string>
-    <string name="address_label_phone_number_optional">Telefonní číslo (volitelně)</string>
-    <string name="address_label_postal_code">Poštovní směrovací číslo</string>
-    <string name="address_label_postal_code_optional">Poštovní směrovací číslo (volitelně)</string>
-    <string name="address_label_postcode">Poštovní směrovací číslo</string>
-    <string name="address_label_postcode_optional">Poštovní směrovací číslo (volitelně)</string>
-    <string name="address_label_province">Provincie</string>
-    <string name="address_label_province_optional">Provincie (volitelně)</string>
-    <string name="address_label_region_generic">Stát / provincie / region</string>
-    <string name="address_label_region_generic_optional">Stát / provincie / region (volitelně)</string>
-    <string name="address_label_state">Stát</string>
-    <string name="address_label_state_optional">Stát (volitelně)</string>
-    <string name="address_label_zip_code">PSČ</string>
-    <string name="address_label_zip_code_optional">PSČ (volitelně)</string>
-    <string name="address_label_zip_postal_code">PSČ</string>
-    <string name="address_label_zip_postal_code_optional">PSČ (volitelně)</string>
-    <string name="address_name_required">Zadejte své jméno</string>
-    <string name="address_phone_number_required">Zadejte své telefonní číslo</string>
-    <string name="address_postal_code_invalid">Vaše poštovní směrovací číslo je neplatné</string>
-    <string name="address_postcode_invalid">Vaše PSČ je neplatné.</string>
-    <string name="address_province_required">Zadejte provincii</string>
-    <string name="address_region_generic_required">Zadejte stát/provincii/region</string>
-    <string name="address_required">Zadejte svou adresu</string>
-    <string name="address_shipping_address">Dodací adresa</string>
-    <string name="address_state_required">Zadejte stát</string>
-    <string name="address_zip_invalid">Vaše PSČ je neplatné.</string>
-    <string name="address_zip_postal_invalid">Vaše poštovní směrovací číslo je neplatné</string>
-    <string name="becs_mandate_acceptance">
-    Poskytnutím údajů o svém bankovním účtu a potvrzením této platby souhlasíte
-    s tímto požadavkem přímého inkasa a smlouvou o službách inkasa, a autorizujete
-   Stripe Payments Australia Pty Ltd ACN 160 180 343, ID uživatele služby přímého inkasa 507156
-    („Stripe“) k inkasu z vašeho účtu prostřednictvím systému hromadného elektronického zúčtování (BECS) dne
-    jménem %1$s (dále jen „Obchodník“), a to jakýchkoli částek, které vám byly sděleny samostatně
-    obchodníkem. Potvrzujete, že jste buď držitelem účtu nebo autorizovaným
-    signatářem na výše uvedeném účtu.
-    </string>
-    <string name="becs_widget_account_number">Číslo účtu</string>
-    <string name="becs_widget_account_number_incomplete">Vaše číslo účtu je neúplné.</string>
-    <string name="becs_widget_account_number_required">Vašečíslo účtu je povinný údaj.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Zadaný BSB je neúplný.</string>
-    <string name="becs_widget_bsb_invalid">Zadaný BSB je neplatný.</string>
-    <string name="becs_widget_email">E-mailová adresa</string>
-    <string name="becs_widget_email_invalid">Vaše e-mailová adresa není platná.</string>
-    <string name="becs_widget_email_required">Vaše e-mailová adresa je povinný údaj.</string>
-    <string name="becs_widget_name">Jméno</string>
-    <string name="becs_widget_name_required">Vaše jméno je povinný údaj.</string>
-    <string name="card_ending_in">%1$s končící za %2$s</string>
-    <string name="close">Zavřít</string>
-    <string name="delete_payment_method">Odstranit způsob platby</string>
-    <string name="delete_payment_method_prompt_title">Odstranit způsob platby?</string>
-    <string name="expiry_date_hint">MM/RR</string>
-    <string name="expiry_label_short">Konec platnosti</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">Datum konce platnosti vaší karty je neúplné.</string>
-    <string name="invalid_card_number">Číslo vaší karty je neplatné.</string>
-    <string name="invalid_cvc">Bezpečnostní kód vaší karty je neplatný.</string>
-    <string name="invalid_expiry_month">Rok konce platnosti vaší karty je neplatný.</string>
-    <string name="invalid_expiry_year">Rok konce platnosti vaší karty je neplatný.</string>
-    <string name="invalid_shipping_information">Neplatná dodací adresa</string>
-    <string name="invalid_zip">Vaše poštovní směrovací číslo je neúplné.</string>
-    <string name="no_payment_methods">Žádný způsob platby.</string>
-    <string name="payment_method_add_new_card">Přidat novou kartu...</string>
-    <string name="payment_method_add_new_fpx">Vyberte bankovní účet (FPX)</string>
-    <string name="price_free">Zdarma</string>
-    <string name="removed">Odebráno %s</string>
-    <string name="secure_checkout">Bezpečné dokončení platby</string>
-    <string name="stripe_failure_connection_error">Vyskytly se problémy s připojením k našemu poskytovateli plateb. Zkontrolujte prosím připojení k internetu a zkuste to znovu.</string>
-    <string name="stripe_failure_reason_authentication">Nemůžeme ověřit Váš způsob platby. Vyberte si jiný způsob platby a zkuste to znovu.</string>
-    <string name="stripe_failure_reason_timed_out">Časový limit ověření Vašeho způsobu platby uplynul -- zkuste to znovu</string>
-    <string name="stripe_google_pay_error_internal">Došlo k interní chybě.</string>
-    <string name="stripe_paymentsheet_add_button_label">Přidat</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Přidat</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informace o kartě</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Země nebo region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Přidejte své platební údaje</string>
-    <string name="stripe_paymentsheet_back">Zpět</string>
-    <string name="stripe_paymentsheet_close">Zavřít</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
-    <string name="stripe_paymentsheet_or_pay_using">Nebo zaplatit pomocí</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Nebo zaplatit kartou</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Zaplatit %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Zaplatit</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Zpracování...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložit tuto kartu pro budoucí platby %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Vyberte svou platební metodu</string>
-    <string name="stripe_paymentsheet_setup_button_label">Nastavit</string>
-    <string name="stripe_paymentsheet_total_amount">Celkem: %s</string>
-    <string name="stripe_verify_your_payment">Ověřte platbu</string>
-    <string name="title_add_a_card">Přidat kartu</string>
-    <string name="title_add_an_address">Nastavit adresu</string>
-    <string name="title_bank_account">Bankovní účet</string>
-    <string name="title_payment_method">Způsob platby</string>
-    <string name="title_select_shipping_method">Vyberte způsob dopravy</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Číslo karty</string>
+  <string name="acc_label_card_number_node">%s, číslo karty</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Datum konce platnosti</string>
+  <string name="acc_label_expiry_date_node">%s, datum konce platnosti</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">PSČ</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">PSČ</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Abyste mohli v této aplikaci nakupovat, přidejte novou debetní nebo kreditní kartu.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Přidáno %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Zadejte město</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Vaše země je neplatná</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Zadejte okres</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">1. řádek adresy</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">1. řádek adresy (volitelně)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">2. řádek adresy (volitelně)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresa(volitelně) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Byt (volitelně)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Město (volitelně)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Okres (volitelně)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonní číslo</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonní číslo (volitelně)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Poštovní směrovací číslo (volitelně)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Poštovní směrovací číslo</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Poštovní směrovací číslo (volitelně)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincie (volitelně)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Stát / provincie / region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Stát / provincie / region (volitelně)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stát (volitelně)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">PSČ (volitelně)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">PSČ</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">PSČ (volitelně)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Zadejte své jméno</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Zadejte své telefonní číslo</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Vaše poštovní směrovací číslo je neplatné</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Vaše PSČ je neplatné.</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Zadejte provincii</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Zadejte stát/provincii/region</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Zadejte svou adresu</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Dodací adresa</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Zadejte stát</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Vaše PSČ je neplatné.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Vaše poštovní směrovací číslo je neplatné</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Poskytnutím údajů o svém bankovním účtu a potvrzením této platby souhlasíte\n    s tímto požadavkem přímého inkasa a smlouvou o službách inkasa, a autorizujete\n   Stripe Payments Australia Pty Ltd ACN 160 180 343, ID uživatele služby přímého inkasa 507156\n    („Stripe“) k inkasu z vašeho účtu prostřednictvím systému hromadného elektronického zúčtování (BECS) dne\n    jménem %1$s (dále jen „Obchodník“), a to jakýchkoli částek, které vám byly sděleny samostatně\n    obchodníkem. Potvrzujete, že jste buď držitelem účtu nebo autorizovaným\n    signatářem na výše uvedeném účtu.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Číslo účtu</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Vaše číslo účtu je neúplné.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Vašečíslo účtu je povinný údaj.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Zadaný BSB je neúplný.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Zadaný BSB je neplatný.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-mailová adresa</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Vaše e-mailová adresa není platná.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Vaše e-mailová adresa je povinný údaj.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Jméno</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Vaše jméno je povinný údaj.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s končící za %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Zavřít</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Odstranit způsob platby</string>
+  <string name="delete_payment_method_prompt_title">Odstranit způsob platby?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/RR</string>
+  <string name="expiry_label_short">Konec platnosti</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Datum konce platnosti vaší karty je neúplné.</string>
+  <string name="invalid_card_number">Číslo vaší karty je neplatné.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Bezpečnostní kód vaší karty je neplatný.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Rok konce platnosti vaší karty je neplatný.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Rok konce platnosti vaší karty je neplatný.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Neplatná dodací adresa</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Vaše poštovní směrovací číslo je neúplné.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Žádný způsob platby.</string>
+  <string name="payment_method_add_new_card">Přidat novou kartu...</string>
+  <string name="payment_method_add_new_fpx">Vyberte bankovní účet (FPX)</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Zdarma</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Odebráno %s</string>
+  <string name="secure_checkout">Bezpečné dokončení platby</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Vyskytly se problémy s připojením k našemu poskytovateli plateb. Zkontrolujte prosím připojení k internetu a zkuste to znovu.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nemůžeme ověřit Váš způsob platby. Vyberte si jiný způsob platby a zkuste to znovu.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Časový limit ověření Vašeho způsobu platby uplynul -- zkuste to znovu</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Došlo k interní chybě.</string>
+  <string name="stripe_paymentsheet_add_button_label">Přidat</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Přidat</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informace o kartě</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Země nebo region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Přidejte své platební údaje</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Zpět</string>
+  <string name="stripe_paymentsheet_close">Zavřít</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Nebo zaplatit pomocí</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Nebo zaplatit kartou</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Zaplatit %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Zaplatit</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Zpracování...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložit tuto kartu pro budoucí platby %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Vyberte svou platební metodu</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Nastavit</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Ověřte platbu</string>
+  <string name="title_add_a_card">Přidat kartu</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Nastavit adresu</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankovní účet</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Způsob platby</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Vyberte způsob dopravy</string>
 </resources>

--- a/payments-core/res/values-de/strings.xml
+++ b/payments-core/res/values-de/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kartennummer</string>
-    <string name="acc_label_card_number_node">%s, Kartennummer</string>
-    <string name="acc_label_cvc_node">%s, Prüfziffer</string>
-    <string name="acc_label_expiry_date">Ablaufdatum</string>
-    <string name="acc_label_expiry_date_node">%s, Ablaufdatum</string>
-    <string name="acc_label_zip">Postleitzahl</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Fügen Sie eine neue Debit- oder Kreditkarte hinzu, um in dieser App Käufe zu tätigen.</string>
-    <string name="added">%s hinzugefügt</string>
-    <string name="address_city_required">Bitte geben Sie Ihren Ort ein</string>
-    <string name="address_country_invalid">Das Land ist ungültig.</string>
-    <string name="address_county_required">Bitte geben Sie Ihr Land ein</string>
-    <string name="address_label_address">Adresse</string>
-    <string name="address_label_address_line1">Adresszeile 1</string>
-    <string name="address_label_address_line1_optional">Adresszeile 1 (optional)</string>
-    <string name="address_label_address_line2_optional">Adresszeile 2 (optional)</string>
-    <string name="address_label_address_optional">Adresse (optional) </string>
-    <string name="address_label_apt">Wohnung/Gebäude</string>
-    <string name="address_label_apt_optional">Wohnung/Gebäude (optional)</string>
-    <string name="address_label_city">Ort</string>
-    <string name="address_label_city_optional">Ort (optional)</string>
-    <string name="address_label_country">Land</string>
-    <string name="address_label_county">Kreis/Bezirk</string>
-    <string name="address_label_county_optional">Kreis/Bezirk (optional)</string>
-    <string name="address_label_name">Name</string>
-    <string name="address_label_phone_number">Telefonnummer</string>
-    <string name="address_label_phone_number_optional">Telefonnummer (optional)</string>
-    <string name="address_label_postal_code">Postleitzahl</string>
-    <string name="address_label_postal_code_optional">Postleitzahl (optional)</string>
-    <string name="address_label_postcode">Postleitzahl</string>
-    <string name="address_label_postcode_optional">Postleitzahl (optional)</string>
-    <string name="address_label_province">Provinz / Kanton</string>
-    <string name="address_label_province_optional">Kanton (optional)</string>
-    <string name="address_label_region_generic">Bundesland/Kanton/Region</string>
-    <string name="address_label_region_generic_optional">Bundesland / Kanton / Region (optional)</string>
-    <string name="address_label_state">Bundesland</string>
-    <string name="address_label_state_optional">Bundesland (optional)</string>
-    <string name="address_label_zip_code">Postleitzahl</string>
-    <string name="address_label_zip_code_optional">Postleitzahl (optional)</string>
-    <string name="address_label_zip_postal_code">Postleitzahl</string>
-    <string name="address_label_zip_postal_code_optional">Postleitzahl (optional)</string>
-    <string name="address_name_required">Bitte geben Sie Ihren Namen ein</string>
-    <string name="address_phone_number_required">Bitte gehen Sie Ihre Telefonnummer ein</string>
-    <string name="address_postal_code_invalid">Ihre Postleitzahl ist ungültig</string>
-    <string name="address_postcode_invalid">Ihre Postleitzahl ist ungültig</string>
-    <string name="address_province_required">Bitte geben Sie Ihren Kanton ein</string>
-    <string name="address_region_generic_required">Bitte gehen Sie Ihr(e/n) Bundesland / Kanton / Region ein</string>
-    <string name="address_required">Bitte geben Sie Ihre Adresse ein</string>
-    <string name="address_shipping_address">Versandadresse</string>
-    <string name="address_state_required">Bitte geben Sie Ihren Bundesland ein</string>
-    <string name="address_zip_invalid">Ihre Postleitzahl ist ungültig.</string>
-    <string name="address_zip_postal_invalid">Ihre Postleitzahl ist ungültig</string>
-    <string name="becs_mandate_acceptance">
-    Indem Sie Ihre Bankkontodetails angeben und diese Zahlung bestätigen, stimmen Sie dieser
-   Lastschriftanfrage und der Dienstleistungsvereinbarung zu Lastschriftenanfragen zu und autorisieren
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Lastschriftnutzer-ID, Nummer 507156
-    (\"Stripe\"), Ihr Konto über das Bulk Electronic Clearing System (BECS) im
-    Namen von %1$s (der \"Händler\") mit jedem mit dem Händler separat abgesprochenen
-    Betrag zu belasten. Sie bestätigen ferner, dass Sie entweder Kontoinhaber/in oder Zeichnungsberechtigter/Zeichnungsberechtigte
-    des oben angeführten Kontos sind.
-    </string>
-    <string name="becs_widget_account_number">Kontonummer</string>
-    <string name="becs_widget_account_number_incomplete">Die Kontonummer ist unvollständig.</string>
-    <string name="becs_widget_account_number_required">Ihre Kontonummer ist erforderlich.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Die eingegebene BSB-Nummer ist unvollständig.</string>
-    <string name="becs_widget_bsb_invalid">Die eingegebene BSB-Nummer ist ungültig.</string>
-    <string name="becs_widget_email">E-Mail-Adresse</string>
-    <string name="becs_widget_email_invalid">Die E-Mail-Adresse ist ungültig.</string>
-    <string name="becs_widget_email_required">Ihre E-Mail-Adresse ist erforderlich.</string>
-    <string name="becs_widget_name">Name</string>
-    <string name="becs_widget_name_required">Ihr Name ist erforderlich.</string>
-    <string name="card_ending_in">%1$s, endend auf %2$s</string>
-    <string name="close">Schließen</string>
-    <string name="delete_payment_method">Zahlungsmethode löschen</string>
-    <string name="delete_payment_method_prompt_title">Zahlungsmethode löschen?</string>
-    <string name="expiry_date_hint">MM/JJ</string>
-    <string name="expiry_label_short">Ablauf</string>
-    <string name="fpx_bank_offline">%s ─ offline</string>
-    <string name="incomplete_expiry_date">Ablaufdatum der Karte ist unvollständig.</string>
-    <string name="invalid_card_number">Die Kartennummer ist ungültig.</string>
-    <string name="invalid_cvc">Sicherheitscode der Karte ist ungültig.</string>
-    <string name="invalid_expiry_month">Der Ablaufmonat Ihrer Karte ist ungültig.</string>
-    <string name="invalid_expiry_year">Das Ablaufjahr der Karte ist ungültig.</string>
-    <string name="invalid_shipping_information">Ungültige Versandadresse</string>
-    <string name="invalid_zip">Postleitzahl ist unvollständig.</string>
-    <string name="no_payment_methods">Keine Zahlungsmethoden.</string>
-    <string name="payment_method_add_new_card">Neue Karte hinzufügen …</string>
-    <string name="payment_method_add_new_fpx">Bankkonto (FPX) auswählen …</string>
-    <string name="price_free">Kostenlos</string>
-    <string name="removed">%s entfernt</string>
-    <string name="secure_checkout">Sicherer Checkout</string>
-    <string name="stripe_failure_connection_error">Wir haben Schwierigkeiten, eine Verbindung zu unserem Zahlungsanbieter herzustellen. Bitte prüfen Sie Ihre Internetverbindung und versuchen Sie es noch einmal.</string>
-    <string name="stripe_failure_reason_authentication">Wir können Ihre Zahlungsmethode nicht authentifizieren. Bitte wählen Sie eine andere Zahlungsmethode und versuchen Sie es noch einmal.</string>
-    <string name="stripe_failure_reason_timed_out">Zeitüberschreitung bei der Authentifizierung Ihrer Zahlungsmethode – versuchen Sie es noch einmal.</string>
-    <string name="stripe_google_pay_error_internal">Es ist ein interner Fehler aufgetreten.</string>
-    <string name="stripe_paymentsheet_add_button_label">Hinzufügen</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hinzufügen</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kartendaten</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land oder Region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Zahlungsinformationen hinzufügen</string>
-    <string name="stripe_paymentsheet_back">Zurück</string>
-    <string name="stripe_paymentsheet_close">Schließen</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/JJ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Oder zahlen mit</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Oder mit Karte bezahlen</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s zahlen</string>
-    <string name="stripe_paymentsheet_pay_button_label">Zahlen</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Wird verarbeitet …</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Karte für zukünftige Zahlungen von %s speichern</string>
-    <string name="stripe_paymentsheet_select_payment_method">Zahlungsmethode auswählen</string>
-    <string name="stripe_paymentsheet_setup_button_label">Einrichten</string>
-    <string name="stripe_paymentsheet_total_amount">Gesamt: %s</string>
-    <string name="stripe_verify_your_payment">Zahlung verifizieren</string>
-    <string name="title_add_a_card">Karte hinzufügen</string>
-    <string name="title_add_an_address">Adresse hinzufügen</string>
-    <string name="title_bank_account">Bankkonto</string>
-    <string name="title_payment_method">Zahlungsmethode</string>
-    <string name="title_select_shipping_method">Versandmethode auswählen</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kartennummer</string>
+  <string name="acc_label_card_number_node">%s, Kartennummer</string>
+  <string name="acc_label_cvc_node">%s, Prüfziffer</string>
+  <string name="acc_label_expiry_date">Ablaufdatum</string>
+  <string name="acc_label_expiry_date_node">%s, Ablaufdatum</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Postleitzahl</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Fügen Sie eine neue Debit- oder Kreditkarte hinzu, um in dieser App Käufe zu tätigen.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s hinzugefügt</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Bitte geben Sie Ihren Ort ein</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Das Land ist ungültig.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Bitte geben Sie Ihr Land ein</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adresszeile 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adresszeile 1 (optional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adresszeile 2 (optional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresse (optional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Wohnung/Gebäude (optional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ort (optional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Kreis/Bezirk (optional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonnummer</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonnummer (optional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postleitzahl (optional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postleitzahl</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postleitzahl (optional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Kanton (optional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Bundesland/Kanton/Region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Bundesland / Kanton / Region (optional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Bundesland (optional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Postleitzahl (optional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Postleitzahl</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Postleitzahl (optional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Bitte geben Sie Ihren Namen ein</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Bitte gehen Sie Ihre Telefonnummer ein</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Ihre Postleitzahl ist ungültig</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Ihre Postleitzahl ist ungültig</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Bitte geben Sie Ihren Kanton ein</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Bitte gehen Sie Ihr(e/n) Bundesland / Kanton / Region ein</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Bitte geben Sie Ihre Adresse ein</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Versandadresse</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Bitte geben Sie Ihren Bundesland ein</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Ihre Postleitzahl ist ungültig.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Ihre Postleitzahl ist ungültig</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Indem Sie Ihre Bankkontodetails angeben und diese Zahlung bestätigen, stimmen Sie dieser\n   Lastschriftanfrage und der Dienstleistungsvereinbarung zu Lastschriftenanfragen zu und autorisieren\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Lastschriftnutzer-ID, Nummer 507156\n    (\"Stripe\"), Ihr Konto über das Bulk Electronic Clearing System (BECS) im\n    Namen von %1$s (der \"Händler\") mit jedem mit dem Händler separat abgesprochenen\n    Betrag zu belasten. Sie bestätigen ferner, dass Sie entweder Kontoinhaber/in oder Zeichnungsberechtigter/Zeichnungsberechtigte\n    des oben angeführten Kontos sind.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Kontonummer</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Die Kontonummer ist unvollständig.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Ihre Kontonummer ist erforderlich.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Die eingegebene BSB-Nummer ist unvollständig.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Die eingegebene BSB-Nummer ist ungültig.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-Mail-Adresse</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Die E-Mail-Adresse ist ungültig.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Ihre E-Mail-Adresse ist erforderlich.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Name</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Ihr Name ist erforderlich.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, endend auf %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Schließen</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Zahlungsmethode löschen</string>
+  <string name="delete_payment_method_prompt_title">Zahlungsmethode löschen?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/JJ</string>
+  <string name="expiry_label_short">Ablauf</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s ─ offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Ablaufdatum der Karte ist unvollständig.</string>
+  <string name="invalid_card_number">Die Kartennummer ist ungültig.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Sicherheitscode der Karte ist ungültig.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Der Ablaufmonat Ihrer Karte ist ungültig.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Das Ablaufjahr der Karte ist ungültig.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Ungültige Versandadresse</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Postleitzahl ist unvollständig.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Keine Zahlungsmethoden.</string>
+  <string name="payment_method_add_new_card">Neue Karte hinzufügen …</string>
+  <string name="payment_method_add_new_fpx">Bankkonto (FPX) auswählen …</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Kostenlos</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s entfernt</string>
+  <string name="secure_checkout">Sicherer Checkout</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Wir haben Schwierigkeiten, eine Verbindung zu unserem Zahlungsanbieter herzustellen. Bitte prüfen Sie Ihre Internetverbindung und versuchen Sie es noch einmal.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Wir können Ihre Zahlungsmethode nicht authentifizieren. Bitte wählen Sie eine andere Zahlungsmethode und versuchen Sie es noch einmal.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Zeitüberschreitung bei der Authentifizierung Ihrer Zahlungsmethode – versuchen Sie es noch einmal.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Es ist ein interner Fehler aufgetreten.</string>
+  <string name="stripe_paymentsheet_add_button_label">Hinzufügen</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hinzufügen</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartendaten</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land oder Region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Zahlungsinformationen hinzufügen</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Zurück</string>
+  <string name="stripe_paymentsheet_close">Schließen</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/JJ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Oder zahlen mit</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Oder mit Karte bezahlen</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s zahlen</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Zahlen</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Wird verarbeitet …</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Karte für zukünftige Zahlungen von %s speichern</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Zahlungsmethode auswählen</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Einrichten</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Zahlung verifizieren</string>
+  <string name="title_add_a_card">Karte hinzufügen</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Adresse hinzufügen</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankkonto</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Zahlungsmethode</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Versandmethode auswählen</string>
 </resources>

--- a/payments-core/res/values-el-rGR/strings.xml
+++ b/payments-core/res/values-el-rGR/strings.xml
@@ -1,121 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Αριθμός κάρτας</string>
-    <string name="acc_label_card_number_node">%s, Αριθμός κάρτας</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Ημερομηνία λήξης</string>
-    <string name="acc_label_expiry_date_node">%s, Ημερομηνία λήξης</string>
-    <string name="acc_label_zip">Ταχυδρομικός κώδικας</string>
-    <string name="acc_label_zip_short">Τ.Κ.</string>
-    <string name="add_card">Προσθέστε νέα χρεωστική ή πιστωτική κάρτα για να πραγματοποιήσετε αγορές σε αυτήν την εφαρμογή.</string>
-    <string name="added">Προστέθηκε %s</string>
-    <string name="address_city_required">Εισαγάγετε την πόλη σας</string>
-    <string name="address_country_invalid">Η χώρα σας δεν είναι έγκυρη</string>
-    <string name="address_county_required">Εισαγάγετε την κομητεία σας</string>
-    <string name="address_label_address">Διεύθυνση</string>
-    <string name="address_label_address_line1">Γραμμή διεύθυνσης 1</string>
-    <string name="address_label_address_line1_optional">Γραμμή διεύθυνσης 1 (προαιρετικό)</string>
-    <string name="address_label_address_line2_optional">Γραμμή διεύθυνσης 2 (προαιρετικό)</string>
-    <string name="address_label_address_optional">Διεύθυνση (προαιρετικό) </string>
-    <string name="address_label_apt">Διαμ.</string>
-    <string name="address_label_apt_optional">Διαμ. (προαιρετικό)</string>
-    <string name="address_label_city">Πόλη</string>
-    <string name="address_label_city_optional">Πόλη (προαιρετικό)</string>
-    <string name="address_label_country">Χώρα</string>
-    <string name="address_label_county">Κομητεία</string>
-    <string name="address_label_county_optional">Κομητεία (προαιρετικό)</string>
-    <string name="address_label_name">Όνομα</string>
-    <string name="address_label_phone_number">Αριθμός τηλεφώνου</string>
-    <string name="address_label_phone_number_optional">Αριθμός τηλεφώνου (προαιρετικό)</string>
-    <string name="address_label_postal_code">Ταχυδρομικός κώδικας</string>
-    <string name="address_label_postal_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
-    <string name="address_label_postcode">Ταχυδρομικός κώδικας</string>
-    <string name="address_label_postcode_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
-    <string name="address_label_province">Επαρχία</string>
-    <string name="address_label_province_optional">Επαρχία (προαιρετικό)</string>
-    <string name="address_label_region_generic">Πολιτεία / Επαρχία / Περιοχή</string>
-    <string name="address_label_region_generic_optional">Πολιτεία / Επαρχία / Περιοχή (προαιρετικό)</string>
-    <string name="address_label_state">Πολιτεία</string>
-    <string name="address_label_state_optional">Πολιτεία (προαιρετικό)</string>
-    <string name="address_label_zip_code">Ταχυδρομικός κώδικας</string>
-    <string name="address_label_zip_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
-    <string name="address_label_zip_postal_code">Ταχυδρομικός κώδικας</string>
-    <string name="address_label_zip_postal_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
-    <string name="address_name_required">Εισαγάγετε το όνομά σας</string>
-    <string name="address_phone_number_required">Εισαγάγετε τον αριθμό τηλεφώνου σας</string>
-    <string name="address_postal_code_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
-    <string name="address_postcode_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
-    <string name="address_province_required">Εισαγάγετε την επαρχία σας</string>
-    <string name="address_region_generic_required">Εισαγάγετε την πολιτεία/επαρχία/περιοχή σας</string>
-    <string name="address_required">Εισαγάγετε τη διεύθυνσή σας</string>
-    <string name="address_shipping_address">Διεύθυνση αποστολής</string>
-    <string name="address_state_required">Εισαγάγετε την πολιτεία σας</string>
-    <string name="address_zip_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος.</string>
-    <string name="address_zip_postal_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
-    <string name="becs_mandate_acceptance">
-    Παρέχοντας τα στοιχεία του αριθμού λογαριασμού σας και επιβεβαιώνοντας αυτήν την πληρωμή, συμφωνείτε με το παρόν
-    Αίτημα άμεσης χρέωσης και με τη σύμβαση παροχής υπηρεσιών Αιτήματος άμεσης χρέωσης και εξουσιοδοτείτε τη
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 με Αναγνωριστικό αριθμό χρήστη 507156 για την Άμεση χρέωση
-    (η «Stripe»), προκειμένου να χρεώνει τον λογαριασμό σας μέσω του συστήματος Bulk Electronic Clearing System (BECS) για
-    λογαριασμό της %1$s (ο «Έμπορος») για οποιαδήποτε ποσά που αναφέρει ο Έμπορος
-    μόνο σε εσάς. Επιβεβαιώνετε είτε ότι είστε ο δικαιούχος του λογαριασμού είτε εξουσιοδοτημένος
-    υπογράφων για τον προαναφερθέντα λογαριασμό.</string>
-    <string name="becs_widget_account_number">Αριθμός λογαριασμού</string>
-    <string name="becs_widget_account_number_incomplete">Ο αριθμός λογαριασμού σας είναι ελλιπής.</string>
-    <string name="becs_widget_account_number_required">Ο αριθμός λογαριασμού σας απαιτείται.</string>
-    <string name="becs_widget_bsb">Κωδικός BSB</string>
-    <string name="becs_widget_bsb_incomplete">Ο κωδικός BSB που εισάγατε είναι ατελής.</string>
-    <string name="becs_widget_bsb_invalid">Ο κωδικός BSB που εισάγατε δεν είναι έγκυρος.</string>
-    <string name="becs_widget_email">Διεύθυνση ηλεκτρονικού ταχυδρομείου</string>
-    <string name="becs_widget_email_invalid">Η διεύθυνση ηλεκτρονικού ταχυδρομείου σας δεν είναι έγκυρη.</string>
-    <string name="becs_widget_email_required">Η διεύθυνση ηλεκτρονικού ταχυδρομείου σας απαιτείται.</string>
-    <string name="becs_widget_name">Όνομα</string>
-    <string name="becs_widget_name_required">Το όνομά σας απαιτείται.</string>
-    <string name="card_ending_in">%1$s λήγει σε %2$s</string>
-    <string name="close">Κλείσιμο</string>
-    <string name="delete_payment_method">Διαγραφή μεθόδου πληρωμής</string>
-    <string name="delete_payment_method_prompt_title">Να γίνει διαγραφή μεθόδου πληρωμής;</string>
-    <string name="expiry_date_hint">ΜΜ/ΕΕ</string>
-    <string name="expiry_label_short">Λήξη</string>
-    <string name="fpx_bank_offline">%s - Εκτός σύνδεσης</string>
-    <string name="incomplete_expiry_date">Η ημερομηνία λήξης της κάρτας σας είναι ελλιπής.</string>
-    <string name="invalid_card_number">Ο αριθμός της κάρτας σας δεν είναι έγκυρος.</string>
-    <string name="invalid_cvc">Ο κωδικός ασφαλείας της κάρτας σας δεν είναι έγκυρος.</string>
-    <string name="invalid_expiry_month">Ο μήνας λήξης της κάρτας σας δεν είναι έγκυρος.</string>
-    <string name="invalid_expiry_year">Το έτος λήξης της κάρτας σας δεν είναι έγκυρο.</string>
-    <string name="invalid_shipping_information">Μη έγκυρη διεύθυνση αποστολής</string>
-    <string name="invalid_zip">Ο ταχυδρομικός κώδικάς σας είναι ελλιπής.</string>
-    <string name="no_payment_methods">Καμία μέθοδος πληρωμής.</string>
-    <string name="payment_method_add_new_card">Προσθήκη νέας κάρτας…</string>
-    <string name="payment_method_add_new_fpx">Επιλογή τραπεζικού λογαριασμού (FPX)…</string>
-    <string name="price_free">Δωρεάν</string>
-    <string name="removed">Αφαιρέθηκε %s</string>
-    <string name="secure_checkout">Ασφαλές Checkout</string>
-    <string name="stripe_failure_connection_error">Αντιμετωπίζουμε προβλήματα κατά τη σύνδεση με τον πάροχο υπηρεσιών πληρωμής μας. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.</string>
-    <string name="stripe_failure_reason_authentication">Δεν μπορούμε να επαληθεύσουμε τη μέθοδο πληρωμής σας. Επιλέξτε διαφορετική μέθοδο πληρωμής και προσπαθήστε ξανά.</string>
-    <string name="stripe_failure_reason_timed_out">Έληξε το χρονικό όριο επαλήθευσης της μεθόδου πληρωμής σας -- δοκιμάστε ξανά</string>
-    <string name="stripe_google_pay_error_internal">Προέκυψε εσωτερικό σφάλμα.</string>
-    <string name="stripe_paymentsheet_add_button_label">Προσθήκη</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Προσθήκη</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Στοιχεία κάρτας</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Χώρα ή περιοχή</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Προσθέστε τα στοιχεία πληρωμής σας</string>
-    <string name="stripe_paymentsheet_back">Πίσω</string>
-    <string name="stripe_paymentsheet_close">Κλείσιμο</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">ΜΜ / ΕΕ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ή πληρωμή χρησιμοποιώντας</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ή πληρωμή με κάρτα</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Πληρωμή %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Πληρωμή</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Επεξεργασία…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Αποθηκεύστε αυτή την κάρτα για μελλοντικές %s πληρωμές</string>
-    <string name="stripe_paymentsheet_select_payment_method">Επιλέξτε τη μέθοδο πληρωμής σας</string>
-    <string name="stripe_paymentsheet_setup_button_label">Διαμόρφωση</string>
-    <string name="stripe_paymentsheet_total_amount">Σύνολο: %s</string>
-    <string name="stripe_verify_your_payment">Επαληθεύστε την πληρωμή σας</string>
-    <string name="title_add_a_card">Προσθήκη κάρτας</string>
-    <string name="title_add_an_address">Καθορισμός διεύθυνσης</string>
-    <string name="title_bank_account">Τραπεζικός λογαριασμός</string>
-    <string name="title_payment_method">Μέθοδος πληρωμής</string>
-    <string name="title_select_shipping_method">Επιλογή μεθόδου αποστολής</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Αριθμός κάρτας</string>
+  <string name="acc_label_card_number_node">%s, Αριθμός κάρτας</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Ημερομηνία λήξης</string>
+  <string name="acc_label_expiry_date_node">%s, Ημερομηνία λήξης</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Ταχυδρομικός κώδικας</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Τ.Κ.</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Προσθέστε νέα χρεωστική ή πιστωτική κάρτα για να πραγματοποιήσετε αγορές σε αυτήν την εφαρμογή.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Προστέθηκε %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Εισαγάγετε την πόλη σας</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Η χώρα σας δεν είναι έγκυρη</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Εισαγάγετε την κομητεία σας</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Διεύθυνση</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Γραμμή διεύθυνσης 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Γραμμή διεύθυνσης 1 (προαιρετικό)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Γραμμή διεύθυνσης 2 (προαιρετικό)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Διεύθυνση (προαιρετικό) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Διαμ. (προαιρετικό)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Πόλη (προαιρετικό)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Κομητεία (προαιρετικό)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Αριθμός τηλεφώνου</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Αριθμός τηλεφώνου (προαιρετικό)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Ταχυδρομικός κώδικας</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Επαρχία (προαιρετικό)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Πολιτεία / Επαρχία / Περιοχή</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Πολιτεία / Επαρχία / Περιοχή (προαιρετικό)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Πολιτεία (προαιρετικό)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Ταχυδρομικός κώδικας</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Ταχυδρομικός κώδικας (προαιρετικό)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Εισαγάγετε το όνομά σας</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Εισαγάγετε τον αριθμό τηλεφώνου σας</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Εισαγάγετε την επαρχία σας</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Εισαγάγετε την πολιτεία/επαρχία/περιοχή σας</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Εισαγάγετε τη διεύθυνσή σας</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Διεύθυνση αποστολής</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Εισαγάγετε την πολιτεία σας</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Ο ταχυδρομικός κώδικάς σας δεν είναι έγκυρος</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Παρέχοντας τα στοιχεία του αριθμού λογαριασμού σας και επιβεβαιώνοντας αυτήν την πληρωμή, συμφωνείτε με το παρόν\n    Αίτημα άμεσης χρέωσης και με τη σύμβαση παροχής υπηρεσιών Αιτήματος άμεσης χρέωσης και εξουσιοδοτείτε τη\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 με Αναγνωριστικό αριθμό χρήστη 507156 για την Άμεση χρέωση\n    (η «Stripe»), προκειμένου να χρεώνει τον λογαριασμό σας μέσω του συστήματος Bulk Electronic Clearing System (BECS) για\n    λογαριασμό της %1$s (ο «Έμπορος») για οποιαδήποτε ποσά που αναφέρει ο Έμπορος\n    μόνο σε εσάς. Επιβεβαιώνετε είτε ότι είστε ο δικαιούχος του λογαριασμού είτε εξουσιοδοτημένος\n    υπογράφων για τον προαναφερθέντα λογαριασμό.</string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Αριθμός λογαριασμού</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Ο αριθμός λογαριασμού σας είναι ελλιπής.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Ο αριθμός λογαριασμού σας απαιτείται.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">Κωδικός BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Ο κωδικός BSB που εισάγατε είναι ατελής.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Ο κωδικός BSB που εισάγατε δεν είναι έγκυρος.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Διεύθυνση ηλεκτρονικού ταχυδρομείου</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Η διεύθυνση ηλεκτρονικού ταχυδρομείου σας δεν είναι έγκυρη.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Η διεύθυνση ηλεκτρονικού ταχυδρομείου σας απαιτείται.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Όνομα</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Το όνομά σας απαιτείται.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s λήγει σε %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Κλείσιμο</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Διαγραφή μεθόδου πληρωμής</string>
+  <string name="delete_payment_method_prompt_title">Να γίνει διαγραφή μεθόδου πληρωμής;</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">ΜΜ/ΕΕ</string>
+  <string name="expiry_label_short">Λήξη</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Εκτός σύνδεσης</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Η ημερομηνία λήξης της κάρτας σας είναι ελλιπής.</string>
+  <string name="invalid_card_number">Ο αριθμός της κάρτας σας δεν είναι έγκυρος.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Ο κωδικός ασφαλείας της κάρτας σας δεν είναι έγκυρος.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Ο μήνας λήξης της κάρτας σας δεν είναι έγκυρος.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Το έτος λήξης της κάρτας σας δεν είναι έγκυρο.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Μη έγκυρη διεύθυνση αποστολής</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Ο ταχυδρομικός κώδικάς σας είναι ελλιπής.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Καμία μέθοδος πληρωμής.</string>
+  <string name="payment_method_add_new_card">Προσθήκη νέας κάρτας…</string>
+  <string name="payment_method_add_new_fpx">Επιλογή τραπεζικού λογαριασμού (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Δωρεάν</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Αφαιρέθηκε %s</string>
+  <string name="secure_checkout">Ασφαλές Checkout</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Αντιμετωπίζουμε προβλήματα κατά τη σύνδεση με τον πάροχο υπηρεσιών πληρωμής μας. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Δεν μπορούμε να επαληθεύσουμε τη μέθοδο πληρωμής σας. Επιλέξτε διαφορετική μέθοδο πληρωμής και προσπαθήστε ξανά.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Έληξε το χρονικό όριο επαλήθευσης της μεθόδου πληρωμής σας -- δοκιμάστε ξανά</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Προέκυψε εσωτερικό σφάλμα.</string>
+  <string name="stripe_paymentsheet_add_button_label">Προσθήκη</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Προσθήκη</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Στοιχεία κάρτας</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Χώρα ή περιοχή</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Προσθέστε τα στοιχεία πληρωμής σας</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Πίσω</string>
+  <string name="stripe_paymentsheet_close">Κλείσιμο</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">ΜΜ / ΕΕ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ή πληρωμή χρησιμοποιώντας</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ή πληρωμή με κάρτα</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Πληρωμή %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Πληρωμή</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Επεξεργασία…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Αποθηκεύστε αυτή την κάρτα για μελλοντικές %s πληρωμές</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Επιλέξτε τη μέθοδο πληρωμής σας</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Διαμόρφωση</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Επαληθεύστε την πληρωμή σας</string>
+  <string name="title_add_a_card">Προσθήκη κάρτας</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Καθορισμός διεύθυνσης</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Τραπεζικός λογαριασμός</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Μέθοδος πληρωμής</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Επιλογή μεθόδου αποστολής</string>
 </resources>

--- a/payments-core/res/values-en-rGB/strings.xml
+++ b/payments-core/res/values-en-rGB/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Card number</string>
-    <string name="acc_label_card_number_node">%s, Card number</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Expiry date</string>
-    <string name="acc_label_expiry_date_node">%s, Expiry date</string>
-    <string name="acc_label_zip">ZIP Code</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Add a new debit or credit card to make purchases in this app.</string>
-    <string name="added">Added %s</string>
-    <string name="address_city_required">Please enter your city</string>
-    <string name="address_country_invalid">Your country is invalid</string>
-    <string name="address_county_required">Please enter your county</string>
-    <string name="address_label_address">Address</string>
-    <string name="address_label_address_line1">Address line 1</string>
-    <string name="address_label_address_line1_optional">Address line 1 (optional)</string>
-    <string name="address_label_address_line2_optional">Address line 2 (optional)</string>
-    <string name="address_label_address_optional">Address (optional) </string>
-    <string name="address_label_apt">Apt.</string>
-    <string name="address_label_apt_optional">Apt. (optional)</string>
-    <string name="address_label_city">City</string>
-    <string name="address_label_city_optional">City (optional)</string>
-    <string name="address_label_country">Country</string>
-    <string name="address_label_county">County</string>
-    <string name="address_label_county_optional">County (optional)</string>
-    <string name="address_label_name">Name</string>
-    <string name="address_label_phone_number">Phone number</string>
-    <string name="address_label_phone_number_optional">Phone number (optional)</string>
-    <string name="address_label_postal_code">Postcode</string>
-    <string name="address_label_postal_code_optional">Postal code (optional)</string>
-    <string name="address_label_postcode">Postcode</string>
-    <string name="address_label_postcode_optional">Postcode (optional)</string>
-    <string name="address_label_province">Province</string>
-    <string name="address_label_province_optional">Province (optional)</string>
-    <string name="address_label_region_generic">State / Province / Region</string>
-    <string name="address_label_region_generic_optional">State / Province / Region (optional)</string>
-    <string name="address_label_state">State</string>
-    <string name="address_label_state_optional">State (optional)</string>
-    <string name="address_label_zip_code">ZIP code</string>
-    <string name="address_label_zip_code_optional">ZIP code (optional)</string>
-    <string name="address_label_zip_postal_code">ZIP/Postal code</string>
-    <string name="address_label_zip_postal_code_optional">ZIP / Postal code (optional)</string>
-    <string name="address_name_required">Please enter your name</string>
-    <string name="address_phone_number_required">Please enter your phone number</string>
-    <string name="address_postal_code_invalid">Your postal code is invalid</string>
-    <string name="address_postcode_invalid">Your postcode is invalid</string>
-    <string name="address_province_required">Please enter your province</string>
-    <string name="address_region_generic_required">Please enter your State/Province/Region</string>
-    <string name="address_required">Please enter your address</string>
-    <string name="address_shipping_address">Shipping Address</string>
-    <string name="address_state_required">Please enter your state</string>
-    <string name="address_zip_invalid">Your ZIP code is invalid.</string>
-    <string name="address_zip_postal_invalid">Your ZIP/Postal code is invalid</string>
-    <string name="becs_mandate_acceptance">
-    By providing your bank account details and confirming this payment, you agree to this
-    Direct Debit Request and the Direct Debit Request service agreement, and authorise
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156
-    (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on
-    behalf of %1$s (the \"Merchant\") for any amounts separately communicated to you
-    by the Merchant. You certify that you are either an account holder or an authorised
-    signatory on the account listed above.
-    </string>
-    <string name="becs_widget_account_number">Account number</string>
-    <string name="becs_widget_account_number_incomplete">Your account number is incomplete.</string>
-    <string name="becs_widget_account_number_required">Your account number is required.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">The BSB you entered is incomplete.</string>
-    <string name="becs_widget_bsb_invalid">The BSB you entered is invalid.</string>
-    <string name="becs_widget_email">Email Address</string>
-    <string name="becs_widget_email_invalid">Your email address is invalid.</string>
-    <string name="becs_widget_email_required">Your email address is required.</string>
-    <string name="becs_widget_name">Name</string>
-    <string name="becs_widget_name_required">Your name is required.</string>
-    <string name="card_ending_in">%1$s ending in %2$s</string>
-    <string name="close">Close</string>
-    <string name="delete_payment_method">Delete Payment Method?</string>
-    <string name="delete_payment_method_prompt_title">Delete payment method?</string>
-    <string name="expiry_date_hint">MM/YY</string>
-    <string name="expiry_label_short">Expiry</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
-    <string name="invalid_card_number">Your card number is invalid.</string>
-    <string name="invalid_cvc">Your card\'s security code is invalid.</string>
-    <string name="invalid_expiry_month">Your card expiry month is invalid.</string>
-    <string name="invalid_expiry_year">Your card\'s expiry year is invalid.</string>
-    <string name="invalid_shipping_information">Invalid Shipping Address</string>
-    <string name="invalid_zip">Your postcode is incomplete.</string>
-    <string name="no_payment_methods">No payment methods.</string>
-    <string name="payment_method_add_new_card">Add new card…</string>
-    <string name="payment_method_add_new_fpx">Select Bank Account (FPX)…</string>
-    <string name="price_free">Free</string>
-    <string name="removed">Removed %s</string>
-    <string name="secure_checkout">Secure Checkout</string>
-    <string name="stripe_failure_connection_error">We are experiencing issues connecting to our payments provider. Please check your internet connection and try again.</string>
-    <string name="stripe_failure_reason_authentication">We are unable to authenticate your payment method. Please choose a different payment method and try again.</string>
-    <string name="stripe_failure_reason_timed_out">Timed out authenticating your payment method - please try again</string>
-    <string name="stripe_google_pay_error_internal">An internal error occurred.</string>
-    <string name="stripe_paymentsheet_add_button_label">Add</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
-    <string name="stripe_paymentsheet_back">Back</string>
-    <string name="stripe_paymentsheet_close">Close</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / YY</string>
-    <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Pay %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Pay</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Processing...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
-    <string name="stripe_paymentsheet_select_payment_method">Select your payment method</string>
-    <string name="stripe_paymentsheet_setup_button_label">Set up</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verify your payment</string>
-    <string name="title_add_a_card">Add a Card</string>
-    <string name="title_add_an_address">Set Address</string>
-    <string name="title_bank_account">Bank Account</string>
-    <string name="title_payment_method">Payment Method</string>
-    <string name="title_select_shipping_method">Select Shipping Method</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Card number</string>
+  <string name="acc_label_card_number_node">%s, Card number</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Expiry date</string>
+  <string name="acc_label_expiry_date_node">%s, Expiry date</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">ZIP Code</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Add a new debit or credit card to make purchases in this app.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Added %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Please enter your city</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Your country is invalid</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Please enter your county</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Address</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Address line 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Address line 1 (optional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Address line 2 (optional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Address (optional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (optional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">City (optional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">County (optional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Phone number</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Phone number (optional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postal code (optional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postcode</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postcode (optional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Province (optional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">State / Province / Region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">State / Province / Region (optional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">State (optional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">ZIP code (optional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">ZIP/Postal code</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">ZIP / Postal code (optional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Please enter your name</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Please enter your phone number</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Your postal code is invalid</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Your postcode is invalid</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Please enter your province</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Please enter your State/Province/Region</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Please enter your address</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Shipping Address</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Please enter your state</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Your ZIP code is invalid.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Your ZIP/Postal code is invalid</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    By providing your bank account details and confirming this payment, you agree to this\n    Direct Debit Request and the Direct Debit Request service agreement, and authorise\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156\n    (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on\n    behalf of %1$s (the \"Merchant\") for any amounts separately communicated to you\n    by the Merchant. You certify that you are either an account holder or an authorised\n    signatory on the account listed above.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Account number</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Your account number is incomplete.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Your account number is required.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">The BSB you entered is incomplete.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">The BSB you entered is invalid.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Email Address</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Your email address is invalid.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Your email address is required.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Name</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Your name is required.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s ending in %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Close</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Delete Payment Method?</string>
+  <string name="delete_payment_method_prompt_title">Delete payment method?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/YY</string>
+  <string name="expiry_label_short">Expiry</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
+  <string name="invalid_card_number">Your card number is invalid.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Your card\'s security code is invalid.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Your card expiry month is invalid.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Your card\'s expiry year is invalid.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Invalid Shipping Address</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Your postcode is incomplete.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">No payment methods.</string>
+  <string name="payment_method_add_new_card">Add new card…</string>
+  <string name="payment_method_add_new_fpx">Select Bank Account (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Free</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Removed %s</string>
+  <string name="secure_checkout">Secure Checkout</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">We are experiencing issues connecting to our payments provider. Please check your internet connection and try again.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">We are unable to authenticate your payment method. Please choose a different payment method and try again.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Timed out authenticating your payment method - please try again</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">An internal error occurred.</string>
+  <string name="stripe_paymentsheet_add_button_label">Add</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Back</string>
+  <string name="stripe_paymentsheet_close">Close</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / YY</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pay %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pay</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Processing...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Select your payment method</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Set up</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verify your payment</string>
+  <string name="title_add_a_card">Add a Card</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Set Address</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bank Account</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Payment Method</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Select Shipping Method</string>
 </resources>

--- a/payments-core/res/values-en-rGB/strings.xml
+++ b/payments-core/res/values-en-rGB/strings.xml
@@ -171,7 +171,7 @@
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
-  <string name="stripe_paymentsheet_primary_button_processing">Processing...</string>
+  <string name="stripe_paymentsheet_primary_button_processing">Processing…</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/payments-core/res/values-es/strings.xml
+++ b/payments-core/res/values-es/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Número de tarjeta</string>
-    <string name="acc_label_card_number_node">%s, número de tarjeta</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Fecha de caducidad</string>
-    <string name="acc_label_expiry_date_node">%s, fecha de caducidad</string>
-    <string name="acc_label_zip">Código ZIP</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Añade una tarjeta de crédito o de débito nueva para realizar compras en esta aplicación.</string>
-    <string name="added">Se ha añadido %s</string>
-    <string name="address_city_required">Introduce el nombre de tu localidad.</string>
-    <string name="address_country_invalid">El país no es válido.</string>
-    <string name="address_county_required">Introduce el nombre de tu condado.</string>
-    <string name="address_label_address">Dirección</string>
-    <string name="address_label_address_line1">Primera línea de la dirección</string>
-    <string name="address_label_address_line1_optional">Primera línea de la dirección (opcional)</string>
-    <string name="address_label_address_line2_optional">Segunda línea de la dirección (opcional)</string>
-    <string name="address_label_address_optional">Dirección (opcional) </string>
-    <string name="address_label_apt">Piso</string>
-    <string name="address_label_apt_optional">Piso (opcional)</string>
-    <string name="address_label_city">Ciudad</string>
-    <string name="address_label_city_optional">Localidad (opcional)</string>
-    <string name="address_label_country">País</string>
-    <string name="address_label_county">Condado</string>
-    <string name="address_label_county_optional">Condado (opcional)</string>
-    <string name="address_label_name">Nombre</string>
-    <string name="address_label_phone_number">Número de teléfono</string>
-    <string name="address_label_phone_number_optional">Número de teléfono (opcional)</string>
-    <string name="address_label_postal_code">Código postal</string>
-    <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_label_postcode">Código postal</string>
-    <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <string name="address_label_province">Provincia</string>
-    <string name="address_label_province_optional">Provincia (opcional)</string>
-    <string name="address_label_region_generic">Estado/provincia/región</string>
-    <string name="address_label_region_generic_optional">Estado/provincia/región (opcional)</string>
-    <string name="address_label_state">Estado</string>
-    <string name="address_label_state_optional">Estado (opcional)</string>
-    <string name="address_label_zip_code">Código postal</string>
-    <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <string name="address_label_zip_postal_code">Código postal</string>
-    <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_name_required">Introduce tu nombre.</string>
-    <string name="address_phone_number_required">Introduce tu número de teléfono.</string>
-    <string name="address_postal_code_invalid">El código postal no es válido.</string>
-    <string name="address_postcode_invalid">El código postal no es válido.</string>
-    <string name="address_province_required">Introduce el nombre de tu provincia.</string>
-    <string name="address_region_generic_required">Introduce el nombre de tu estado/provincia/región.</string>
-    <string name="address_required">Introduce tu dirección.</string>
-    <string name="address_shipping_address">Dirección de envío</string>
-    <string name="address_state_required">Introduce el nombre de tu estado.</string>
-    <string name="address_zip_invalid">El código postal no es válido.</string>
-    <string name="address_zip_postal_invalid">El código postal no es válido.</string>
-    <string name="becs_mandate_acceptance">
-    Al proporcionar los datos de tu cuenta bancaria y confirmar el pago, aceptas esta
-    solicitud de adeudo directo y el contrato de servicio de solicitud de adeudo directo, y autorizas a
-    Stripe Payments Australia Pty Ltd, ACN 160 180 343, número de ID de usuario de adeudo directo 507156
-    (\"Stripe\"), a efectuar adeudos en tu cuenta mediante el sistema Bulk Electronic Clearing System (BECS) en
-    nombre de %1$s (el \"Comerciante\") por los importes que te comunique por
-    separado el Comerciante. Certificas que eres titular de una cuenta o signatario autorizado
-    de la cuenta especificada arriba.
-    </string>
-    <string name="becs_widget_account_number">Número de cuenta</string>
-    <string name="becs_widget_account_number_incomplete">Tu número de cuenta está incompleto.</string>
-    <string name="becs_widget_account_number_required">El número de cuenta es obligatorio.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">El BSB introducido está incompleto.</string>
-    <string name="becs_widget_bsb_invalid">El BSB introducido no es válido.</string>
-    <string name="becs_widget_email">Dirección de correo electrónico</string>
-    <string name="becs_widget_email_invalid">Tu dirección de correo electrónico no es válida.</string>
-    <string name="becs_widget_email_required">La dirección de correo electrónico es obligatoria.</string>
-    <string name="becs_widget_name">Nombre</string>
-    <string name="becs_widget_name_required">El nombre es obligatorio</string>
-    <string name="card_ending_in">%1$s terminada en %2$s</string>
-    <string name="close">Cerrar</string>
-    <string name="delete_payment_method">Eliminar método de pago</string>
-    <string name="delete_payment_method_prompt_title">¿Deseas eliminar el método de pago?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Caducidad</string>
-    <string name="fpx_bank_offline">%s - Fuera de línea</string>
-    <string name="incomplete_expiry_date">La fecha de caducidad de la tarjeta está incompleta.</string>
-    <string name="invalid_card_number">El número de tarjeta no es válido.</string>
-    <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
-    <string name="invalid_expiry_month">El mes de caducidad de la tarjeta no es válido.</string>
-    <string name="invalid_expiry_year">El año de caducidad de la tarjeta no es válido.</string>
-    <string name="invalid_shipping_information">Dirección de envío no válida</string>
-    <string name="invalid_zip">El código postal está incompleto.</string>
-    <string name="no_payment_methods">Ningún método de pago.</string>
-    <string name="payment_method_add_new_card">Añadir nueva tarjeta…</string>
-    <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
-    <string name="price_free">Gratuito</string>
-    <string name="removed">Se ha eliminado %s</string>
-    <string name="secure_checkout">Proceso de compra seguro</string>
-    <string name="stripe_failure_connection_error">Estamos teniendo problemas de conexión con nuestro proveedor de servicios de pagos. Comprueba tu conexión a Internet y vuelve a intentarlo.</string>
-    <string name="stripe_failure_reason_authentication">No pudimos autenticar el método de pago. Elige otro método y vuelve a intentarlo.</string>
-    <string name="stripe_failure_reason_timed_out">Se agotó el tiempo de espera para autenticar el método de pago. Vuelve a intentarlo.</string>
-    <string name="stripe_google_pay_error_internal">Se ha producido un error interno.</string>
-    <string name="stripe_paymentsheet_add_button_label">Añadir</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Añadir más datos</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Añadir información de pago</string>
-    <string name="stripe_paymentsheet_back">Atrás</string>
-    <string name="stripe_paymentsheet_close">Cerrar</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">O paga con tarjeta</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para realizar compras futuras en %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Selecciona tu método de pago</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verifica tu pago</string>
-    <string name="title_add_a_card">Añade una tarjeta</string>
-    <string name="title_add_an_address">Establece la dirección</string>
-    <string name="title_bank_account">Cuenta bancaria</string>
-    <string name="title_payment_method">Método de pago</string>
-    <string name="title_select_shipping_method">Selecciona el método de envío</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Número de tarjeta</string>
+  <string name="acc_label_card_number_node">%s, número de tarjeta</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Fecha de caducidad</string>
+  <string name="acc_label_expiry_date_node">%s, fecha de caducidad</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Código ZIP</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Añade una tarjeta de crédito o de débito nueva para realizar compras en esta aplicación.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Se ha añadido %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Introduce el nombre de tu localidad.</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">El país no es válido.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Introduce el nombre de tu condado.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Dirección</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Primera línea de la dirección</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Primera línea de la dirección (opcional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Segunda línea de la dirección (opcional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Dirección (opcional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Piso (opcional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Localidad (opcional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Condado (opcional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Número de teléfono</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Número de teléfono (opcional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Código postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincia (opcional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Estado/provincia/región</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Estado/provincia/región (opcional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Estado (opcional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Código postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Introduce tu nombre.</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Introduce tu número de teléfono.</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Introduce el nombre de tu provincia.</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Introduce el nombre de tu estado/provincia/región.</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Introduce tu dirección.</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Dirección de envío</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Introduce el nombre de tu estado.</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">El código postal no es válido.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">El código postal no es válido.</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Al proporcionar los datos de tu cuenta bancaria y confirmar el pago, aceptas esta\n    solicitud de adeudo directo y el contrato de servicio de solicitud de adeudo directo, y autorizas a\n    Stripe Payments Australia Pty Ltd, ACN 160 180 343, número de ID de usuario de adeudo directo 507156\n    (\"Stripe\"), a efectuar adeudos en tu cuenta mediante el sistema Bulk Electronic Clearing System (BECS) en\n    nombre de %1$s (el \"Comerciante\") por los importes que te comunique por\n    separado el Comerciante. Certificas que eres titular de una cuenta o signatario autorizado\n    de la cuenta especificada arriba.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Número de cuenta</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Tu número de cuenta está incompleto.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">El número de cuenta es obligatorio.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">El BSB introducido está incompleto.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">El BSB introducido no es válido.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Dirección de correo electrónico</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Tu dirección de correo electrónico no es válida.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">La dirección de correo electrónico es obligatoria.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nombre</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">El nombre es obligatorio</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s terminada en %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Cerrar</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Eliminar método de pago</string>
+  <string name="delete_payment_method_prompt_title">¿Deseas eliminar el método de pago?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Caducidad</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Fuera de línea</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La fecha de caducidad de la tarjeta está incompleta.</string>
+  <string name="invalid_card_number">El número de tarjeta no es válido.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">El mes de caducidad de la tarjeta no es válido.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">El año de caducidad de la tarjeta no es válido.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Dirección de envío no válida</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">El código postal está incompleto.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Ningún método de pago.</string>
+  <string name="payment_method_add_new_card">Añadir nueva tarjeta…</string>
+  <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratuito</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Se ha eliminado %s</string>
+  <string name="secure_checkout">Proceso de compra seguro</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Estamos teniendo problemas de conexión con nuestro proveedor de servicios de pagos. Comprueba tu conexión a Internet y vuelve a intentarlo.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">No pudimos autenticar el método de pago. Elige otro método y vuelve a intentarlo.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Se agotó el tiempo de espera para autenticar el método de pago. Vuelve a intentarlo.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Se ha producido un error interno.</string>
+  <string name="stripe_paymentsheet_add_button_label">Añadir</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Añadir más datos</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Añadir información de pago</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Atrás</string>
+  <string name="stripe_paymentsheet_close">Cerrar</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">O paga con tarjeta</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para realizar compras futuras en %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selecciona tu método de pago</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifica tu pago</string>
+  <string name="title_add_a_card">Añade una tarjeta</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Establece la dirección</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Cuenta bancaria</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Método de pago</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selecciona el método de envío</string>
 </resources>

--- a/payments-core/res/values-et-rEE/strings.xml
+++ b/payments-core/res/values-et-rEE/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kaardinumber</string>
-    <string name="acc_label_card_number_node">%s, kaardinumber</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Aegumiskuupäev</string>
-    <string name="acc_label_expiry_date_node">%s, aegumiskuupäev</string>
-    <string name="acc_label_zip">Sihtnumber</string>
-    <string name="acc_label_zip_short">Sihtnr</string>
-    <string name="add_card">Selles rakenduses ostude tegemiseks peate lisama uue deebet- või krediitkaardi.</string>
-    <string name="added">Lisati %s</string>
-    <string name="address_city_required">Sisestage linn</string>
-    <string name="address_country_invalid">Riik ei sobi</string>
-    <string name="address_county_required">Sisestage riik</string>
-    <string name="address_label_address">Aadress</string>
-    <string name="address_label_address_line1">Aadressirida 1</string>
-    <string name="address_label_address_line1_optional">Aadressirida 1 (valikuline)</string>
-    <string name="address_label_address_line2_optional">Aadressirida 2 (valikuline)</string>
-    <string name="address_label_address_optional">Aadress (valikuline)</string>
-    <string name="address_label_apt">Korter</string>
-    <string name="address_label_apt_optional">Korter (valikuline)</string>
-    <string name="address_label_city">Linn</string>
-    <string name="address_label_city_optional">Linn (valikuline)</string>
-    <string name="address_label_country">Riik</string>
-    <string name="address_label_county">Maakond</string>
-    <string name="address_label_county_optional">Maakond (valikuline)</string>
-    <string name="address_label_name">Nimi</string>
-    <string name="address_label_phone_number">Telefoninumber</string>
-    <string name="address_label_phone_number_optional">Telefoninumber (valikuline)</string>
-    <string name="address_label_postal_code">Sihtnumber</string>
-    <string name="address_label_postal_code_optional">Sihtnumber (valikuline)</string>
-    <string name="address_label_postcode">Sihtnumber</string>
-    <string name="address_label_postcode_optional">Sihtnumber (valikuline)</string>
-    <string name="address_label_province">Maakond</string>
-    <string name="address_label_province_optional">Maakond (valikuline)</string>
-    <string name="address_label_region_generic">Osariik/maakond/regioon</string>
-    <string name="address_label_region_generic_optional">Osariik/maakond/regioon (valikuline)</string>
-    <string name="address_label_state">Osariik</string>
-    <string name="address_label_state_optional">Osariik (valikuline)</string>
-    <string name="address_label_zip_code">Sihtnumber</string>
-    <string name="address_label_zip_code_optional">Sihtnumber (valikuline)</string>
-    <string name="address_label_zip_postal_code">Sihtnumber</string>
-    <string name="address_label_zip_postal_code_optional">Sihtnumber (valikuline)</string>
-    <string name="address_name_required">Sisestage oma nimi</string>
-    <string name="address_phone_number_required">Sisestage telefoninumber</string>
-    <string name="address_postal_code_invalid">Sihtnumber on kehtetu</string>
-    <string name="address_postcode_invalid">Sihtnumber eon kehtetu</string>
-    <string name="address_province_required">Sisestage maakond</string>
-    <string name="address_region_generic_required">Sisestage osariik/maakond/regioon</string>
-    <string name="address_required">Sisestage aadress</string>
-    <string name="address_shipping_address">Tarneaadress</string>
-    <string name="address_state_required">Sisestage osariik</string>
-    <string name="address_zip_invalid">Sihtnumber on kehtetu.</string>
-    <string name="address_zip_postal_invalid">Sihtnumber on kehtetu.</string>
-    <string name="becs_mandate_acceptance">
-    Esitades oma pangakonto andmed ja kinnitades selle makse, nõustute käesoleva
-    otsekorralduse taotluse ja otsekorralduse taotluse teenuselepinguga ning volitate ettevõtet
-    Stripe Payments Australia Pty Ltd ACN 160 180 343, otsekorralduse kasutaja ID number 507156
-    („Stripe“), sooritama teenuse Bulk Electronic Clearing System (BECS)
-    kaudu %1$s („Kaupleja“) nimel makseid teie kontolt kooskõlas teie ja Kaupleja
-    vahel kokku lepitud summades. Te kinnitate, et olete ülalnimetatud konto
-    omanik või volitatud allkirjaõiguslik isik.
-    </string>
-    <string name="becs_widget_account_number">Kontonumber</string>
-    <string name="becs_widget_account_number_incomplete">Teie kontonumber on puudulik.</string>
-    <string name="becs_widget_account_number_required">Kontonumbri esitamine on kohustuslik.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Sisestatud BSB-number on puudulik.</string>
-    <string name="becs_widget_bsb_invalid">Sisestatud BSB-number ei ole kehtiv.</string>
-    <string name="becs_widget_email">Meiliaadress</string>
-    <string name="becs_widget_email_invalid">Teie meiliaadress on kehtetu.</string>
-    <string name="becs_widget_email_required">Meiliaadressi esitamine kohustuslik.</string>
-    <string name="becs_widget_name">Nimi</string>
-    <string name="becs_widget_name_required">Nime esitamine on kohustuslik.</string>
-    <string name="card_ending_in">%1$s, lõpeb nr-ga %2$s</string>
-    <string name="close">Sulge</string>
-    <string name="delete_payment_method">Kustuta makseviis</string>
-    <string name="delete_payment_method_prompt_title">Kas kustutada makseviis?</string>
-    <string name="expiry_date_hint">KK/AA</string>
-    <string name="expiry_label_short">Aegumine</string>
-    <string name="fpx_bank_offline">%s - võrguühenduseta</string>
-    <string name="incomplete_expiry_date">Kaardi aegumiskuupäev on puudulik.</string>
-    <string name="invalid_card_number">Kaardi number on kehtetu.</string>
-    <string name="invalid_cvc">Kaardi turvakood on kehtetu.</string>
-    <string name="invalid_expiry_month">Kaardi aegumiskuu on kehtetu.</string>
-    <string name="invalid_expiry_year">Kaardi aegumisaasta on kehtetu.</string>
-    <string name="invalid_shipping_information">Kehtetu tarneaadress</string>
-    <string name="invalid_zip">Sihtnumber on puudulik.</string>
-    <string name="no_payment_methods">Makseviisid puuduvad.</string>
-    <string name="payment_method_add_new_card">Lisage uus kaart ...</string>
-    <string name="payment_method_add_new_fpx">Valige pangakonto (FPX) ...</string>
-    <string name="price_free">Tasuta</string>
-    <string name="removed">Eemaldati %s</string>
-    <string name="secure_checkout">Turvaline maksmine</string>
-    <string name="stripe_failure_connection_error">Makseteenuse pakkujaga ei saa ühendust luua. Kontrollige Interneti-ühendust ja proovige uuesti.</string>
-    <string name="stripe_failure_reason_authentication">Makseviisi ei õnnestunud autentida. Palun valige muu makseviis ja proovige uuesti.</string>
-    <string name="stripe_failure_reason_timed_out">Makseviisi autentimise toiming aegus – proovige uuesti</string>
-    <string name="stripe_google_pay_error_internal">Ilmnes sisemine tõrge.</string>
-    <string name="stripe_paymentsheet_add_button_label">Lisa</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ lisa</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kaardi andmed</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Riik või regioon</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Lisage makseteave</string>
-    <string name="stripe_paymentsheet_back">Tagasi</string>
-    <string name="stripe_paymentsheet_close">Sulge</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">KK / AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Või kasuta makseviisi</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Või makske kaardiga</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Maksa %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Töötlemine ...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvestage see kaart tulevasteks makseteks teenuses %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Valige makseviis</string>
-    <string name="stripe_paymentsheet_setup_button_label">Seadista</string>
-    <string name="stripe_paymentsheet_total_amount">Kokku: %s</string>
-    <string name="stripe_verify_your_payment">Kinnitage makse</string>
-    <string name="title_add_a_card">Kaardi lisamine</string>
-    <string name="title_add_an_address">Määrake aadress</string>
-    <string name="title_bank_account">Pangakonto</string>
-    <string name="title_payment_method">Makseviis</string>
-    <string name="title_select_shipping_method">Valige tarneviis</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kaardinumber</string>
+  <string name="acc_label_card_number_node">%s, kaardinumber</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Aegumiskuupäev</string>
+  <string name="acc_label_expiry_date_node">%s, aegumiskuupäev</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Sihtnumber</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Sihtnr</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Selles rakenduses ostude tegemiseks peate lisama uue deebet- või krediitkaardi.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Lisati %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Sisestage linn</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Riik ei sobi</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Sisestage riik</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Aadress</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Aadressirida 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Aadressirida 1 (valikuline)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Aadressirida 2 (valikuline)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Aadress (valikuline)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Korter (valikuline)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Linn (valikuline)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Maakond (valikuline)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefoninumber</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefoninumber (valikuline)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Sihtnumber (valikuline)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Sihtnumber</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Sihtnumber (valikuline)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Maakond (valikuline)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Osariik/maakond/regioon</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Osariik/maakond/regioon (valikuline)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Osariik (valikuline)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Sihtnumber (valikuline)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Sihtnumber</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Sihtnumber (valikuline)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Sisestage oma nimi</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Sisestage telefoninumber</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Sihtnumber on kehtetu</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Sihtnumber eon kehtetu</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Sisestage maakond</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Sisestage osariik/maakond/regioon</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Sisestage aadress</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Tarneaadress</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Sisestage osariik</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Sihtnumber on kehtetu.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Sihtnumber on kehtetu.</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Esitades oma pangakonto andmed ja kinnitades selle makse, nõustute käesoleva\n    otsekorralduse taotluse ja otsekorralduse taotluse teenuselepinguga ning volitate ettevõtet\n    Stripe Payments Australia Pty Ltd ACN 160 180 343, otsekorralduse kasutaja ID number 507156\n    („Stripe“), sooritama teenuse Bulk Electronic Clearing System (BECS)\n    kaudu %1$s („Kaupleja“) nimel makseid teie kontolt kooskõlas teie ja Kaupleja\n    vahel kokku lepitud summades. Te kinnitate, et olete ülalnimetatud konto\n    omanik või volitatud allkirjaõiguslik isik.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Kontonumber</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Teie kontonumber on puudulik.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Kontonumbri esitamine on kohustuslik.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Sisestatud BSB-number on puudulik.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Sisestatud BSB-number ei ole kehtiv.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Meiliaadress</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Teie meiliaadress on kehtetu.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Meiliaadressi esitamine kohustuslik.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nimi</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Nime esitamine on kohustuslik.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, lõpeb nr-ga %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Sulge</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Kustuta makseviis</string>
+  <string name="delete_payment_method_prompt_title">Kas kustutada makseviis?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">KK/AA</string>
+  <string name="expiry_label_short">Aegumine</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - võrguühenduseta</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kaardi aegumiskuupäev on puudulik.</string>
+  <string name="invalid_card_number">Kaardi number on kehtetu.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kaardi turvakood on kehtetu.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kaardi aegumiskuu on kehtetu.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kaardi aegumisaasta on kehtetu.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Kehtetu tarneaadress</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Sihtnumber on puudulik.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Makseviisid puuduvad.</string>
+  <string name="payment_method_add_new_card">Lisage uus kaart ...</string>
+  <string name="payment_method_add_new_fpx">Valige pangakonto (FPX) ...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Tasuta</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Eemaldati %s</string>
+  <string name="secure_checkout">Turvaline maksmine</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Makseteenuse pakkujaga ei saa ühendust luua. Kontrollige Interneti-ühendust ja proovige uuesti.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Makseviisi ei õnnestunud autentida. Palun valige muu makseviis ja proovige uuesti.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Makseviisi autentimise toiming aegus – proovige uuesti</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Ilmnes sisemine tõrge.</string>
+  <string name="stripe_paymentsheet_add_button_label">Lisa</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ lisa</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaardi andmed</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Riik või regioon</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Lisage makseteave</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Tagasi</string>
+  <string name="stripe_paymentsheet_close">Sulge</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">KK / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Või kasuta makseviisi</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Või makske kaardiga</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Maksa %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Töötlemine ...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvestage see kaart tulevasteks makseteks teenuses %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Valige makseviis</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Seadista</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Kinnitage makse</string>
+  <string name="title_add_a_card">Kaardi lisamine</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Määrake aadress</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Pangakonto</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Makseviis</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Valige tarneviis</string>
 </resources>

--- a/payments-core/res/values-fr-rCA/strings.xml
+++ b/payments-core/res/values-fr-rCA/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Numéro de carte</string>
-    <string name="acc_label_card_number_node">%s, numéro de carte</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Date d\'expiration</string>
-    <string name="acc_label_expiry_date_node">%s, date d\'expiration</string>
-    <string name="acc_label_zip">Code postal</string>
-    <string name="acc_label_zip_short">Code postal</string>
-    <string name="add_card">Pour effectuer des achats dans cette appli, ajoutez une carte de débit ou de crédit.</string>
-    <string name="added">%s ajouté</string>
-    <string name="address_city_required">Veuillez entrer votre ville</string>
-    <string name="address_country_invalid">Votre pays n\'est pas valide</string>
-    <string name="address_county_required">Veuillez entrer votre comté</string>
-    <string name="address_label_address">Adresse</string>
-    <string name="address_label_address_line1">Ligne d\'adresse 1</string>
-    <string name="address_label_address_line1_optional">Ligne d\'adresse 1 (facultatif)</string>
-    <string name="address_label_address_line2_optional">Ligne d\'adresse 2 (facultatif)</string>
-    <string name="address_label_address_optional">Adresse (facultatif)</string>
-    <string name="address_label_apt">App.</string>
-    <string name="address_label_apt_optional">App. (facultatif)</string>
-    <string name="address_label_city">Ville</string>
-    <string name="address_label_city_optional">Ville (facultatif)</string>
-    <string name="address_label_country">Pays</string>
-    <string name="address_label_county">Comté</string>
-    <string name="address_label_county_optional">Comté (facultatif)</string>
-    <string name="address_label_name">Nom</string>
-    <string name="address_label_phone_number">Numéro de téléphone</string>
-    <string name="address_label_phone_number_optional">Numéro de téléphone (facultatif)</string>
-    <string name="address_label_postal_code">Code postal</string>
-    <string name="address_label_postal_code_optional">Code postal (facultatif)</string>
-    <string name="address_label_postcode">Code postal</string>
-    <string name="address_label_postcode_optional">Code postal (facultatif)</string>
-    <string name="address_label_province">Province</string>
-    <string name="address_label_province_optional">Province (facultatif)</string>
-    <string name="address_label_region_generic">État/province/région</string>
-    <string name="address_label_region_generic_optional">État/province/région (facultatif)</string>
-    <string name="address_label_state">État</string>
-    <string name="address_label_state_optional">État (facultatif)</string>
-    <string name="address_label_zip_code">Code postal</string>
-    <string name="address_label_zip_code_optional">Code postal (facultatif)</string>
-    <string name="address_label_zip_postal_code">Code postal</string>
-    <string name="address_label_zip_postal_code_optional">Code postal (facultatif)</string>
-    <string name="address_name_required">Veuillez entrer votre nom</string>
-    <string name="address_phone_number_required">Veuillez entrer votre numéro de téléphone</string>
-    <string name="address_postal_code_invalid">Votre code postal n\'est pas valide</string>
-    <string name="address_postcode_invalid">Votre code postal n\'est pas valide</string>
-    <string name="address_province_required">Veuillez entrer votre province</string>
-    <string name="address_region_generic_required">Veuillez entrer votre État/province/région</string>
-    <string name="address_required">Veuillez entrer votre adresse</string>
-    <string name="address_shipping_address">Adresse de livraison</string>
-    <string name="address_state_required">Veuillez entrer votre adresse</string>
-    <string name="address_zip_invalid">Votre code postal n\'est pas valide.</string>
-    <string name="address_zip_postal_invalid">Votre code postal n\'est pas valide</string>
-    <string name="becs_mandate_acceptance">
-    En fournissant les informations sur votre compte bancaire et en confirmant ce paiement, vous acceptez
-    cette demande de prélèvement automatique et les Conditions d\'utilisation du service de demande de prélèvement automatique et autorisez
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 ID utilisateur du prélèvement automatique 507156
-    (« Stripe ») à débiter votre compte par le biais du Bulk Electronic Clearing System (BECS) en
-    faveur de %1$s (le « marchand ») de tout montant qui vous a été communiqué
-    directement par le marchand. Vous attestez que vous êtes titulaire du compte ou un signataire
-    autorisé du compte désigné ci-dessus.
-    </string>
-    <string name="becs_widget_account_number">Numéro de compte</string>
-    <string name="becs_widget_account_number_incomplete">Votre numéro de compte est incomplet.</string>
-    <string name="becs_widget_account_number_required">Votre numéro de compte est obligatoire.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Le numéro BSB que vous avez saisi est incomplet.</string>
-    <string name="becs_widget_bsb_invalid">Le numéro BSB que vous avez saisi n\'est pas valide.</string>
-    <string name="becs_widget_email">Adresse électronique</string>
-    <string name="becs_widget_email_invalid">Votre adresse de courriel n\'est pas valide.</string>
-    <string name="becs_widget_email_required">Votre adresse électronique est obligatoire.</string>
-    <string name="becs_widget_name">Nom</string>
-    <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
-    <string name="card_ending_in">%1$s se terminant par %2$s</string>
-    <string name="close">Fermer</string>
-    <string name="delete_payment_method">Supprimer le moyen de paiement</string>
-    <string name="delete_payment_method_prompt_title">Supprimer le moyen de paiement?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Expiration</string>
-    <string name="fpx_bank_offline">%s ─ hors ligne</string>
-    <string name="incomplete_expiry_date">La date d\'expiration de votre carte est incomplète.</string>
-    <string name="invalid_card_number">Le numéro de votre carte n\'est pas valide.</string>
-    <string name="invalid_cvc">Le code de sécurité de votre carte n\'est pas valide.</string>
-    <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
-    <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
-    <string name="invalid_shipping_information">Adresse de livraison non valide</string>
-    <string name="invalid_zip">Votre code postal est incomplet.</string>
-    <string name="no_payment_methods">Aucun moyen de paiement.</string>
-    <string name="payment_method_add_new_card">Ajouter une nouvelle carte…</string>
-    <string name="payment_method_add_new_fpx">Sélectionner un compte bancaire (FPX)…</string>
-    <string name="price_free">Gratuit</string>
-    <string name="removed">%s supprimé</string>
-    <string name="secure_checkout">Paiement sécurisé</string>
-    <string name="stripe_failure_connection_error">Nous ne parvenons pas à nous connecter à notre prestataire de services de paiement. Veuillez vérifier votre connexion Internet et réessayer.</string>
-    <string name="stripe_failure_reason_authentication">Nous ne sommes pas en mesure d\'identifier votre moyen de paiement. Veuillez sélectionner un autre moyen de paiement et réessayer.</string>
-    <string name="stripe_failure_reason_timed_out">Le délai d\'authentification de votre moyen de paiement est dépassé, veuillez réessayer.</string>
-    <string name="stripe_google_pay_error_internal">Une erreur interne s\'est produite.</string>
-    <string name="stripe_paymentsheet_add_button_label">Ajouter</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informations de la carte</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
-    <string name="stripe_paymentsheet_back">Retour</string>
-    <string name="stripe_paymentsheet_close">Fermer</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Payer %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Payer</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos prochains achats chez %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Sélectionnez votre moyen de paiement</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurer</string>
-    <string name="stripe_paymentsheet_total_amount">Total : %s</string>
-    <string name="stripe_verify_your_payment">Vérifiez votre paiement</string>
-    <string name="title_add_a_card">Ajouter une carte</string>
-    <string name="title_add_an_address">Définir l\'adresse</string>
-    <string name="title_bank_account">Compte bancaire</string>
-    <string name="title_payment_method">Moyen de paiement</string>
-    <string name="title_select_shipping_method">Choisir mode de livraison</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Numéro de carte</string>
+  <string name="acc_label_card_number_node">%s, numéro de carte</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Date d\'expiration</string>
+  <string name="acc_label_expiry_date_node">%s, date d\'expiration</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Code postal</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Code postal</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Pour effectuer des achats dans cette appli, ajoutez une carte de débit ou de crédit.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s ajouté</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Veuillez entrer votre ville</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Votre pays n\'est pas valide</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Veuillez entrer votre comté</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Ligne d\'adresse 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Ligne d\'adresse 1 (facultatif)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Ligne d\'adresse 2 (facultatif)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresse (facultatif)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">App. (facultatif)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ville (facultatif)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Comté (facultatif)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Numéro de téléphone</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Numéro de téléphone (facultatif)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Code postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Province (facultatif)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">État/province/région</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">État/province/région (facultatif)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">État (facultatif)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Code postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Code postal (facultatif)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Veuillez entrer votre nom</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Veuillez entrer votre numéro de téléphone</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Votre code postal n\'est pas valide</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Votre code postal n\'est pas valide</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Veuillez entrer votre province</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Veuillez entrer votre État/province/région</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Veuillez entrer votre adresse</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Adresse de livraison</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Veuillez entrer votre adresse</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Votre code postal n\'est pas valide.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Votre code postal n\'est pas valide</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    En fournissant les informations sur votre compte bancaire et en confirmant ce paiement, vous acceptez\n    cette demande de prélèvement automatique et les Conditions d\'utilisation du service de demande de prélèvement automatique et autorisez\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 ID utilisateur du prélèvement automatique 507156\n    (« Stripe ») à débiter votre compte par le biais du Bulk Electronic Clearing System (BECS) en\n    faveur de %1$s (le « marchand ») de tout montant qui vous a été communiqué\n    directement par le marchand. Vous attestez que vous êtes titulaire du compte ou un signataire\n    autorisé du compte désigné ci-dessus.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Numéro de compte</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Votre numéro de compte est incomplet.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Votre numéro de compte est obligatoire.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Le numéro BSB que vous avez saisi est incomplet.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Le numéro BSB que vous avez saisi n\'est pas valide.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Adresse électronique</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Votre adresse de courriel n\'est pas valide.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Votre adresse électronique est obligatoire.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nom</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s se terminant par %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Fermer</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Supprimer le moyen de paiement</string>
+  <string name="delete_payment_method_prompt_title">Supprimer le moyen de paiement?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Expiration</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s ─ hors ligne</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La date d\'expiration de votre carte est incomplète.</string>
+  <string name="invalid_card_number">Le numéro de votre carte n\'est pas valide.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Le code de sécurité de votre carte n\'est pas valide.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Adresse de livraison non valide</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Votre code postal est incomplet.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Aucun moyen de paiement.</string>
+  <string name="payment_method_add_new_card">Ajouter une nouvelle carte…</string>
+  <string name="payment_method_add_new_fpx">Sélectionner un compte bancaire (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratuit</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s supprimé</string>
+  <string name="secure_checkout">Paiement sécurisé</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Nous ne parvenons pas à nous connecter à notre prestataire de services de paiement. Veuillez vérifier votre connexion Internet et réessayer.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nous ne sommes pas en mesure d\'identifier votre moyen de paiement. Veuillez sélectionner un autre moyen de paiement et réessayer.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Le délai d\'authentification de votre moyen de paiement est dépassé, veuillez réessayer.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Une erreur interne s\'est produite.</string>
+  <string name="stripe_paymentsheet_add_button_label">Ajouter</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations de la carte</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Retour</string>
+  <string name="stripe_paymentsheet_close">Fermer</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Payer %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Payer</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos prochains achats chez %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Sélectionnez votre moyen de paiement</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurer</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Vérifiez votre paiement</string>
+  <string name="title_add_a_card">Ajouter une carte</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Définir l\'adresse</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Compte bancaire</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Moyen de paiement</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Choisir mode de livraison</string>
 </resources>

--- a/payments-core/res/values-fr/strings.xml
+++ b/payments-core/res/values-fr/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Numéro de carte bancaire</string>
-    <string name="acc_label_card_number_node">%s, Numéro de carte bancaire</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Date d\'expiration</string>
-    <string name="acc_label_expiry_date_node">%s, Date d\'expiration</string>
-    <string name="acc_label_zip">Code postal</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Ajoutez une nouvelle carte de débit ou de crédit pour faire des achats à partir de cette application.</string>
-    <string name="added">Le moyen de paiement %s a été ajouté</string>
-    <string name="address_city_required">Indiquez votre ville</string>
-    <string name="address_country_invalid">Votre pays n\'est pas valide</string>
-    <string name="address_county_required">Indiquez votre département</string>
-    <string name="address_label_address">Adresse</string>
-    <string name="address_label_address_line1">Adresse - Ligne 1</string>
-    <string name="address_label_address_line1_optional">Adresse - Ligne 1 (facultatif)</string>
-    <string name="address_label_address_line2_optional">Adresse - Ligne 2 (facultatif)</string>
-    <string name="address_label_address_optional">Adresse (facultatif) </string>
-    <string name="address_label_apt">App.</string>
-    <string name="address_label_apt_optional">Appart. (facultatif)</string>
-    <string name="address_label_city">Ville</string>
-    <string name="address_label_city_optional">Ville (facultatif)</string>
-    <string name="address_label_country">Pays</string>
-    <string name="address_label_county">Département</string>
-    <string name="address_label_county_optional">Département (facultatif)</string>
-    <string name="address_label_name">Nom</string>
-    <string name="address_label_phone_number">Numéro de téléphone</string>
-    <string name="address_label_phone_number_optional">Numéro de téléphone (facultatif)</string>
-    <string name="address_label_postal_code">Code postal</string>
-    <string name="address_label_postal_code_optional">Code postal (facultatif)</string>
-    <string name="address_label_postcode">Code postal</string>
-    <string name="address_label_postcode_optional">Code postal (facultatif)</string>
-    <string name="address_label_province">Province</string>
-    <string name="address_label_province_optional">Province (facultatif)</string>
-    <string name="address_label_region_generic">État/province/région/département</string>
-    <string name="address_label_region_generic_optional">Département / État / Province / Région (facultatif)</string>
-    <string name="address_label_state">État</string>
-    <string name="address_label_state_optional">État (facultatif)</string>
-    <string name="address_label_zip_code">Code postal</string>
-    <string name="address_label_zip_code_optional">Code postal (facultatif)</string>
-    <string name="address_label_zip_postal_code">Code postal</string>
-    <string name="address_label_zip_postal_code_optional">Code postal (facultatif)</string>
-    <string name="address_name_required">Indiquez votre nom</string>
-    <string name="address_phone_number_required">Indiquez votre numéro de téléphone</string>
-    <string name="address_postal_code_invalid">Votre code postal n’est pas valide</string>
-    <string name="address_postcode_invalid">Votre code postal n’est pas valide</string>
-    <string name="address_province_required">Indiquez votre province</string>
-    <string name="address_region_generic_required">Indiquez votre département/État/province/région</string>
-    <string name="address_required">Indiquez votre adresse</string>
-    <string name="address_shipping_address">Adresse de livraison</string>
-    <string name="address_state_required">Indiquez votre département</string>
-    <string name="address_zip_invalid">Votre code postal n’est pas valide.</string>
-    <string name="address_zip_postal_invalid">Votre code postal n’est pas valide</string>
-    <string name="becs_mandate_acceptance">
-    En fournissant vos données bancaires et en confirmant ce paiement, vous acceptez cette
-    demande de prélèvement automatique et les conditions d\'utilisation du service correspondantes, et autorisez
-    Stripe Account Australia Pty Ltd, ACN 160 180 343, ID de compte de prélèvement numéro 507156
-    (\"Stripe\"), à débiter votre compte par le biais du système de prélèvement BECS
-    pour le compte de %1$s (le \"marchand\") pour tout montant vous étant communiqué séparément
-    par ce dernier. Vous certifiez que vous êtes le titulaire ou un signataire autorisé
-    du compte susmentionné.
-    </string>
-    <string name="becs_widget_account_number">Numéro de compte</string>
-    <string name="becs_widget_account_number_incomplete">Votre numéro de compte est incomplet.</string>
-    <string name="becs_widget_account_number_required">Votre numéro de compte est obligatoire.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Le numéro BSB que vous avez saisi est incomplet.</string>
-    <string name="becs_widget_bsb_invalid">Le numéro BSB que vous avez saisi n\'est pas valide.</string>
-    <string name="becs_widget_email">Adresse e-mail</string>
-    <string name="becs_widget_email_invalid">Votre adresse e-mail n\'est pas valide.</string>
-    <string name="becs_widget_email_required">Votre adresse e-mail est obligatoire.</string>
-    <string name="becs_widget_name">Nom</string>
-    <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
-    <string name="card_ending_in">%1$s se terminant par %2$s</string>
-    <string name="close">Fermer</string>
-    <string name="delete_payment_method">Supprimer le moyen de paiement</string>
-    <string name="delete_payment_method_prompt_title">Supprimer le moyen de paiement ?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Expire le</string>
-    <string name="fpx_bank_offline">%s - Hors ligne</string>
-    <string name="incomplete_expiry_date">La date d\'expiration de votre carte bancaire est incomplète.</string>
-    <string name="invalid_card_number">Le numéro de votre carte bancaire n\'est pas valide.</string>
-    <string name="invalid_cvc">Le code de sécurité de votre carte bancaire n\'est pas valide.</string>
-    <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
-    <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
-    <string name="invalid_shipping_information">Adresse de livraison incorrecte</string>
-    <string name="invalid_zip">Votre code postal est incomplet.</string>
-    <string name="no_payment_methods">Aucun moyen de paiement.</string>
-    <string name="payment_method_add_new_card">Ajouter une nouvelle carte bancaire...</string>
-    <string name="payment_method_add_new_fpx">Sélectionner le compte bancaire (FPX)...</string>
-    <string name="price_free">Gratuit</string>
-    <string name="removed">Le moyen de paiement %s a été supprimé</string>
-    <string name="secure_checkout">Paiement sécurisé</string>
-    <string name="stripe_failure_connection_error">Nous ne parvenons pas à nous connecter à notre prestataire de services de paiement. Veuillez vérifier votre connexion Internet et réessayer.</string>
-    <string name="stripe_failure_reason_authentication">Nous ne sommes pas en mesure d\'identifier votre moyen de paiement. Veuillez sélectionner un autre moyen de paiement et réessayer.</string>
-    <string name="stripe_failure_reason_timed_out">La tentative d\'identification de votre moyen de paiement a été interrompue, veuillez réessayer.</string>
-    <string name="stripe_google_pay_error_internal">Une erreur interne s\'est produite.</string>
-    <string name="stripe_paymentsheet_add_button_label">Ajouter</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informations concernant la carte bancaire</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
-    <string name="stripe_paymentsheet_back">Retour</string>
-    <string name="stripe_paymentsheet_close">Fermer</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte bancaire</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Payer %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Payer</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos futurs achats auprès de %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Sélectionnez votre moyen de paiement</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurer</string>
-    <string name="stripe_paymentsheet_total_amount">Total : %s</string>
-    <string name="stripe_verify_your_payment">Vérifier votre paiement</string>
-    <string name="title_add_a_card">Ajouter une carte</string>
-    <string name="title_add_an_address">Ajouter une adresse</string>
-    <string name="title_bank_account">Compte bancaire</string>
-    <string name="title_payment_method">Moyen de paiement</string>
-    <string name="title_select_shipping_method">Sélectionner un mode de livraison</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Numéro de carte bancaire</string>
+  <string name="acc_label_card_number_node">%s, Numéro de carte bancaire</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Date d\'expiration</string>
+  <string name="acc_label_expiry_date_node">%s, Date d\'expiration</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Code postal</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Ajoutez une nouvelle carte de débit ou de crédit pour faire des achats à partir de cette application.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Le moyen de paiement %s a été ajouté</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Indiquez votre ville</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Votre pays n\'est pas valide</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Indiquez votre département</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adresse - Ligne 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adresse - Ligne 1 (facultatif)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adresse - Ligne 2 (facultatif)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresse (facultatif) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Appart. (facultatif)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Ville (facultatif)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Département (facultatif)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Numéro de téléphone</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Numéro de téléphone (facultatif)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Code postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Province (facultatif)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">État/province/région/département</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Département / État / Province / Région (facultatif)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">État (facultatif)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Code postal (facultatif)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Code postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Code postal (facultatif)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Indiquez votre nom</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Indiquez votre numéro de téléphone</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Votre code postal n’est pas valide</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Votre code postal n’est pas valide</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Indiquez votre province</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Indiquez votre département/État/province/région</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Indiquez votre adresse</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Adresse de livraison</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Indiquez votre département</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Votre code postal n’est pas valide.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Votre code postal n’est pas valide</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    En fournissant vos données bancaires et en confirmant ce paiement, vous acceptez cette\n    demande de prélèvement automatique et les conditions d\'utilisation du service correspondantes, et autorisez\n    Stripe Account Australia Pty Ltd, ACN 160 180 343, ID de compte de prélèvement numéro 507156\n    (\"Stripe\"), à débiter votre compte par le biais du système de prélèvement BECS\n    pour le compte de %1$s (le \"marchand\") pour tout montant vous étant communiqué séparément\n    par ce dernier. Vous certifiez que vous êtes le titulaire ou un signataire autorisé\n    du compte susmentionné.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Numéro de compte</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Votre numéro de compte est incomplet.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Votre numéro de compte est obligatoire.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Le numéro BSB que vous avez saisi est incomplet.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Le numéro BSB que vous avez saisi n\'est pas valide.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Adresse e-mail</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Votre adresse e-mail n\'est pas valide.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Votre adresse e-mail est obligatoire.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nom</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s se terminant par %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Fermer</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Supprimer le moyen de paiement</string>
+  <string name="delete_payment_method_prompt_title">Supprimer le moyen de paiement ?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Expire le</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Hors ligne</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La date d\'expiration de votre carte bancaire est incomplète.</string>
+  <string name="invalid_card_number">Le numéro de votre carte bancaire n\'est pas valide.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Le code de sécurité de votre carte bancaire n\'est pas valide.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Adresse de livraison incorrecte</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Votre code postal est incomplet.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Aucun moyen de paiement.</string>
+  <string name="payment_method_add_new_card">Ajouter une nouvelle carte bancaire...</string>
+  <string name="payment_method_add_new_fpx">Sélectionner le compte bancaire (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratuit</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Le moyen de paiement %s a été supprimé</string>
+  <string name="secure_checkout">Paiement sécurisé</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Nous ne parvenons pas à nous connecter à notre prestataire de services de paiement. Veuillez vérifier votre connexion Internet et réessayer.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nous ne sommes pas en mesure d\'identifier votre moyen de paiement. Veuillez sélectionner un autre moyen de paiement et réessayer.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">La tentative d\'identification de votre moyen de paiement a été interrompue, veuillez réessayer.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Une erreur interne s\'est produite.</string>
+  <string name="stripe_paymentsheet_add_button_label">Ajouter</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations concernant la carte bancaire</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Retour</string>
+  <string name="stripe_paymentsheet_close">Fermer</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte bancaire</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Payer %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Payer</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos futurs achats auprès de %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Sélectionnez votre moyen de paiement</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurer</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Vérifier votre paiement</string>
+  <string name="title_add_a_card">Ajouter une carte</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Ajouter une adresse</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Compte bancaire</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Moyen de paiement</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Sélectionner un mode de livraison</string>
 </resources>

--- a/payments-core/res/values-hu/strings.xml
+++ b/payments-core/res/values-hu/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kártyaszám</string>
-    <string name="acc_label_card_number_node">%s, kártyaszám</string>
-    <string name="acc_label_cvc_node">%s, CVC-kód</string>
-    <string name="acc_label_expiry_date">Lejárati dátum</string>
-    <string name="acc_label_expiry_date_node">%s, lejárati dátum</string>
-    <string name="acc_label_zip">Irányítószám</string>
-    <string name="acc_label_zip_short">Irányítószám</string>
-    <string name="add_card">Az alkalmazásban való vásárlásokhoz adjon hozzá egy új hitelkártyát vagy bankkártyát.</string>
-    <string name="added">%s hozzáadva</string>
-    <string name="address_city_required">Írja be a várost.</string>
-    <string name="address_country_invalid">Az országnév érvénytelen.</string>
-    <string name="address_county_required">Írja be az országot.</string>
-    <string name="address_label_address">Cím</string>
-    <string name="address_label_address_line1">Cím 1. sora</string>
-    <string name="address_label_address_line1_optional">1. címsor (nem kötelező)</string>
-    <string name="address_label_address_line2_optional">Cím 2. sora (nem kötelező)</string>
-    <string name="address_label_address_optional">Cím (nem kötelező)</string>
-    <string name="address_label_apt">Házszám</string>
-    <string name="address_label_apt_optional">Házszám (nem kötelező)</string>
-    <string name="address_label_city">Város</string>
-    <string name="address_label_city_optional">Város (nem kötelező)</string>
-    <string name="address_label_country">Ország</string>
-    <string name="address_label_county">Ország</string>
-    <string name="address_label_county_optional">Ország (nem kötelező)</string>
-    <string name="address_label_name">Név</string>
-    <string name="address_label_phone_number">Telefonszám</string>
-    <string name="address_label_phone_number_optional">Telefonszám (nem kötelező)</string>
-    <string name="address_label_postal_code">Irányítószám</string>
-    <string name="address_label_postal_code_optional">Irányítószám (nem kötelező)</string>
-    <string name="address_label_postcode">Irányítószám</string>
-    <string name="address_label_postcode_optional">Irányítószám (nem kötelező)</string>
-    <string name="address_label_province">Tartomány</string>
-    <string name="address_label_province_optional">Tartomány (nem kötelező)</string>
-    <string name="address_label_region_generic">Állam/tartomány/régió</string>
-    <string name="address_label_region_generic_optional">Állam/tartomány/régió (nem kötelező)</string>
-    <string name="address_label_state">Állam</string>
-    <string name="address_label_state_optional">Állam (nem kötelező)</string>
-    <string name="address_label_zip_code">Irányítószám</string>
-    <string name="address_label_zip_code_optional">Irányítószám (nem kötelező)</string>
-    <string name="address_label_zip_postal_code">Irányítószám</string>
-    <string name="address_label_zip_postal_code_optional">Irányítószám (nem kötelező)</string>
-    <string name="address_name_required">Írja be a nevét.</string>
-    <string name="address_phone_number_required">Adja meg a telefonszámát.</string>
-    <string name="address_postal_code_invalid">Irányítószáma érvénytelen.</string>
-    <string name="address_postcode_invalid">Irányítószáma érvénytelen.</string>
-    <string name="address_province_required">Adja meg a tartományt.</string>
-    <string name="address_region_generic_required">Írja be az államot/tartományt/régiót.</string>
-    <string name="address_required">Adja meg címét.</string>
-    <string name="address_shipping_address">Szállítási cím</string>
-    <string name="address_state_required">Írja be az államot.</string>
-    <string name="address_zip_invalid">Irányítószáma érvénytelen.</string>
-    <string name="address_zip_postal_invalid">Irányítószáma érvénytelen.</string>
-    <string name="becs_mandate_acceptance">
-    Bankszámlaadatainak megadásával és a kifizetés jóváhagyásával Ön elfogadja ezt a
-   Beszedési igényt és a Beszedési igény szolgáltatást, és felhatalmazza a 
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 beszedési szolgáltatót, amelynek azonosítója 507156
-    (“Stripe”), hogy megterhelje számláját a Bulk Electronic Clearing System (BECS) rendszeren keresztül 
-    a(z) %1$s (a \"Kereskedő\") nevében minden olyan összeg vonatkozásában, amelyet a 
-    Kereskedő külön közölt Önnel. Ön tanúsítja, hogy vagy számlatulajdonosa vagy egy aláírási meghatalmazottja
-    a fent említett számlának.
-    </string>
-    <string name="becs_widget_account_number">Számlaszám</string>
-    <string name="becs_widget_account_number_incomplete">A számlaszáma hiányos.</string>
-    <string name="becs_widget_account_number_required">Számlaszámának megadása kötelező.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">A beírt BSB-szám hiányos.</string>
-    <string name="becs_widget_bsb_invalid">A beírt BSB-szám érvénytelen.</string>
-    <string name="becs_widget_email">E-mail-cím</string>
-    <string name="becs_widget_email_invalid">Az e-mail-címe érvénytelen.</string>
-    <string name="becs_widget_email_required">E-mail-címének megadása kötelező.</string>
-    <string name="becs_widget_name">Név</string>
-    <string name="becs_widget_name_required">Nevének megadása kötelező.</string>
-    <string name="card_ending_in">%1$s végződése %2$s</string>
-    <string name="close">Bezárás</string>
-    <string name="delete_payment_method">Fizetési mód törlése</string>
-    <string name="delete_payment_method_prompt_title">Törli a fizetési módot?</string>
-    <string name="expiry_date_hint">HH/ÉÉ</string>
-    <string name="expiry_label_short">Lejárat</string>
-    <string name="fpx_bank_offline">%s - offline</string>
-    <string name="incomplete_expiry_date">A kártya lejárati dátuma hiányos.</string>
-    <string name="invalid_card_number">Kártyaszáma érvénytelen.</string>
-    <string name="invalid_cvc">A kártya biztonsági kódja érvénytelen.</string>
-    <string name="invalid_expiry_month">Kártyájának lejárati hónapja érvénytelen.</string>
-    <string name="invalid_expiry_year">Kártyájának lejárati éve érvénytelen.</string>
-    <string name="invalid_shipping_information">Érvénytelen szállítási cím</string>
-    <string name="invalid_zip">Az irányítószám hiányos.</string>
-    <string name="no_payment_methods">Nem található fizetési mód.</string>
-    <string name="payment_method_add_new_card">Új kártya hozzáadása...</string>
-    <string name="payment_method_add_new_fpx">Bankszámlaválasztás (FPX)...</string>
-    <string name="price_free">Ingyenes</string>
-    <string name="removed">%s eltávolítva</string>
-    <string name="secure_checkout">Biztonságos kifizetés</string>
-    <string name="stripe_failure_connection_error">Hibákat tapasztalunk a fizetésszolgáltatónkhoz való kapcsolódáskor. Ellenőrizze az internetkapcsolatát, és próbálja meg újból.</string>
-    <string name="stripe_failure_reason_authentication">Nem tudjuk hitelesíteni a fizetési módját. Kérjük, válasszon másik fizetési módot, és próbálkozzon újból.</string>
-    <string name="stripe_failure_reason_timed_out">Fizetési módjának hitelesítésénél időtúllépés történt, próbálja újra.</string>
-    <string name="stripe_google_pay_error_internal">Belső hiba történt.</string>
-    <string name="stripe_paymentsheet_add_button_label">Hozzáadás</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hozzáadás</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kártyaadatok</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ország vagy régió</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Fizetési adatok megadása</string>
-    <string name="stripe_paymentsheet_back">Vissza</string>
-    <string name="stripe_paymentsheet_close">Bezárás</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">HH / ÉÉ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Vagy fizetés a következővel:</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Vagy fizetés kártyával</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s kifizetése</string>
-    <string name="stripe_paymentsheet_pay_button_label">Fizetés:</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Feldolgozás...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">A kártya mentése a(z) %s részére történő fizetésekhez</string>
-    <string name="stripe_paymentsheet_select_payment_method">Fizetési mód kiválasztása</string>
-    <string name="stripe_paymentsheet_setup_button_label">Beállítás</string>
-    <string name="stripe_paymentsheet_total_amount">Összesen: %s</string>
-    <string name="stripe_verify_your_payment">Igazolja fizetését</string>
-    <string name="title_add_a_card">Kártya hozzáadása</string>
-    <string name="title_add_an_address">Cím beállítása</string>
-    <string name="title_bank_account">Bankszámla</string>
-    <string name="title_payment_method">Fizetési mód</string>
-    <string name="title_select_shipping_method">Szállítási mód választása</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kártyaszám</string>
+  <string name="acc_label_card_number_node">%s, kártyaszám</string>
+  <string name="acc_label_cvc_node">%s, CVC-kód</string>
+  <string name="acc_label_expiry_date">Lejárati dátum</string>
+  <string name="acc_label_expiry_date_node">%s, lejárati dátum</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Irányítószám</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Irányítószám</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Az alkalmazásban való vásárlásokhoz adjon hozzá egy új hitelkártyát vagy bankkártyát.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s hozzáadva</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Írja be a várost.</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Az országnév érvénytelen.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Írja be az országot.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Cím</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Cím 1. sora</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">1. címsor (nem kötelező)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Cím 2. sora (nem kötelező)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Cím (nem kötelező)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Házszám (nem kötelező)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Város (nem kötelező)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Ország (nem kötelező)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonszám</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonszám (nem kötelező)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Irányítószám (nem kötelező)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Irányítószám</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Irányítószám (nem kötelező)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Tartomány (nem kötelező)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Állam/tartomány/régió</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Állam/tartomány/régió (nem kötelező)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Állam (nem kötelező)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Irányítószám (nem kötelező)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Irányítószám</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Irányítószám (nem kötelező)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Írja be a nevét.</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Adja meg a telefonszámát.</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Irányítószáma érvénytelen.</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Irányítószáma érvénytelen.</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Adja meg a tartományt.</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Írja be az államot/tartományt/régiót.</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Adja meg címét.</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Szállítási cím</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Írja be az államot.</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Irányítószáma érvénytelen.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Irányítószáma érvénytelen.</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Bankszámlaadatainak megadásával és a kifizetés jóváhagyásával Ön elfogadja ezt a\n   Beszedési igényt és a Beszedési igény szolgáltatást, és felhatalmazza a \n    Stripe Payments Australia Pty Ltd ACN 160 180 343 beszedési szolgáltatót, amelynek azonosítója 507156\n    (“Stripe”), hogy megterhelje számláját a Bulk Electronic Clearing System (BECS) rendszeren keresztül \n    a(z) %1$s (a \"Kereskedő\") nevében minden olyan összeg vonatkozásában, amelyet a \n    Kereskedő külön közölt Önnel. Ön tanúsítja, hogy vagy számlatulajdonosa vagy egy aláírási meghatalmazottja\n    a fent említett számlának.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Számlaszám</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">A számlaszáma hiányos.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Számlaszámának megadása kötelező.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">A beírt BSB-szám hiányos.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">A beírt BSB-szám érvénytelen.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-mail-cím</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Az e-mail-címe érvénytelen.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">E-mail-címének megadása kötelező.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Név</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Nevének megadása kötelező.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s végződése %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Bezárás</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Fizetési mód törlése</string>
+  <string name="delete_payment_method_prompt_title">Törli a fizetési módot?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">HH/ÉÉ</string>
+  <string name="expiry_label_short">Lejárat</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">A kártya lejárati dátuma hiányos.</string>
+  <string name="invalid_card_number">Kártyaszáma érvénytelen.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">A kártya biztonsági kódja érvénytelen.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kártyájának lejárati hónapja érvénytelen.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kártyájának lejárati éve érvénytelen.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Érvénytelen szállítási cím</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Az irányítószám hiányos.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nem található fizetési mód.</string>
+  <string name="payment_method_add_new_card">Új kártya hozzáadása...</string>
+  <string name="payment_method_add_new_fpx">Bankszámlaválasztás (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Ingyenes</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s eltávolítva</string>
+  <string name="secure_checkout">Biztonságos kifizetés</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Hibákat tapasztalunk a fizetésszolgáltatónkhoz való kapcsolódáskor. Ellenőrizze az internetkapcsolatát, és próbálja meg újból.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nem tudjuk hitelesíteni a fizetési módját. Kérjük, válasszon másik fizetési módot, és próbálkozzon újból.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Fizetési módjának hitelesítésénél időtúllépés történt, próbálja újra.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Belső hiba történt.</string>
+  <string name="stripe_paymentsheet_add_button_label">Hozzáadás</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hozzáadás</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kártyaadatok</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ország vagy régió</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Fizetési adatok megadása</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Vissza</string>
+  <string name="stripe_paymentsheet_close">Bezárás</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">HH / ÉÉ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Vagy fizetés a következővel:</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Vagy fizetés kártyával</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s kifizetése</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Fizetés:</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Feldolgozás...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">A kártya mentése a(z) %s részére történő fizetésekhez</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Fizetési mód kiválasztása</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Beállítás</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Igazolja fizetését</string>
+  <string name="title_add_a_card">Kártya hozzáadása</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Cím beállítása</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankszámla</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Fizetési mód</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Szállítási mód választása</string>
 </resources>

--- a/payments-core/res/values-it/strings.xml
+++ b/payments-core/res/values-it/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Numero carta</string>
-    <string name="acc_label_card_number_node">%s, Numero carta</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Data di scadenza</string>
-    <string name="acc_label_expiry_date_node">%s, Data di scadenza</string>
-    <string name="acc_label_zip">Codice postale</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Aggiungi una nuova carta di credito o di debito per fare acquisti in questa app.</string>
-    <string name="added">Aggiunta di %s</string>
-    <string name="address_city_required">Inserisci la città</string>
-    <string name="address_country_invalid">Paese non valido</string>
-    <string name="address_county_required">Inserisci la contea</string>
-    <string name="address_label_address">Indirizzo</string>
-    <string name="address_label_address_line1">Indirizzo riga 1</string>
-    <string name="address_label_address_line1_optional">Indirizzo riga 1 (facoltativo)</string>
-    <string name="address_label_address_line2_optional">Indirizzo riga 2 (facoltativo)</string>
-    <string name="address_label_address_optional">Indirizzo (facoltativo) </string>
-    <string name="address_label_apt">Interno</string>
-    <string name="address_label_apt_optional">Interno (facoltativo)</string>
-    <string name="address_label_city">Città</string>
-    <string name="address_label_city_optional">Città (facoltativo)</string>
-    <string name="address_label_country">Paese</string>
-    <string name="address_label_county">Contea</string>
-    <string name="address_label_county_optional">Contea (facoltativo)</string>
-    <string name="address_label_name">Nome</string>
-    <string name="address_label_phone_number">Numero di telefono</string>
-    <string name="address_label_phone_number_optional">Numero di telefono (facoltativo)</string>
-    <string name="address_label_postal_code">Codice postale</string>
-    <string name="address_label_postal_code_optional">Codice postale (facoltativo)</string>
-    <string name="address_label_postcode">Codice postale</string>
-    <string name="address_label_postcode_optional">Codice postale (facoltativo)</string>
-    <string name="address_label_province">Provincia</string>
-    <string name="address_label_province_optional">Provincia (facoltativo)</string>
-    <string name="address_label_region_generic">Stato / Provincia / Regione</string>
-    <string name="address_label_region_generic_optional">Stato / Provincia / Regione (facoltativo)</string>
-    <string name="address_label_state">Stato</string>
-    <string name="address_label_state_optional">Stato (facoltativo)</string>
-    <string name="address_label_zip_code">Codice postale</string>
-    <string name="address_label_zip_code_optional">Codice postale (facoltativo)</string>
-    <string name="address_label_zip_postal_code">CAP/Codice postale</string>
-    <string name="address_label_zip_postal_code_optional">CAP/Codice postale (facoltativo)</string>
-    <string name="address_name_required">Inserisci il tuo nome</string>
-    <string name="address_phone_number_required">Inserisci il tuo numero di telefono</string>
-    <string name="address_postal_code_invalid">Il codice postale non è valido</string>
-    <string name="address_postcode_invalid">Il codice postale non è valido</string>
-    <string name="address_province_required">Inserisci la provincia</string>
-    <string name="address_region_generic_required">Inserisci lo Stato/Provincia/Regione</string>
-    <string name="address_required">Inserisci il tuo indirizzo</string>
-    <string name="address_shipping_address">Indirizzo di spedizione</string>
-    <string name="address_state_required">Inserisci lo stato</string>
-    <string name="address_zip_invalid">Il codice postale non è valido.</string>
-    <string name="address_zip_postal_invalid">Il CAP/codice postale non è valido</string>
-    <string name="becs_mandate_acceptance">
-    Fornendo i dati del tuo conto bancario e confermando il pagamento, accetti la presente
-    richiesta di addebito diretto e il contratto di servizio per la richiesta di addebito diretto e autorizzi
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 con numero ID utente per l\'addebito diretto 507156
-    (“Stripe”) ad addebitare sul tuo conto tramite il Bulk Electronic Clearing System (BECS) per
-    conto di %1$s (\"Esercente\") qualsiasi importo che ti viene comunicato separatamente
-    dall\'Esercente. Dichiari di essere un titolare del conto o un firmatario 
-    autorizzato per il conto sopra elencato.
-    </string>
-    <string name="becs_widget_account_number">Numero conto</string>
-    <string name="becs_widget_account_number_incomplete">Numero di conto incompleto.</string>
-    <string name="becs_widget_account_number_required">Il tuo numero di conto è obbligatorio.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Il numero BSB inserito è incompleto</string>
-    <string name="becs_widget_bsb_invalid">Il numero BSB inserito non è valido</string>
-    <string name="becs_widget_email">Indirizzo email</string>
-    <string name="becs_widget_email_invalid">Indirizzo email non valido.</string>
-    <string name="becs_widget_email_required">Il tuo indirizzo email è obbligatorio.</string>
-    <string name="becs_widget_name">Nome</string>
-    <string name="becs_widget_name_required">Il tuo nome è obbligatorio.</string>
-    <string name="card_ending_in">%1$s che termina con %2$s</string>
-    <string name="close">Chiudi</string>
-    <string name="delete_payment_method">Elimina modalità di pagamento</string>
-    <string name="delete_payment_method_prompt_title">Eliminare la modalità di pagamento?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Scadenza</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">La data di scadenza della carta è incompleta.</string>
-    <string name="invalid_card_number">Il numero della carta non è valido.</string>
-    <string name="invalid_cvc">Il codice di sicurezza della carta non è valido.</string>
-    <string name="invalid_expiry_month">Il mese di scadenza della carta non è valido.</string>
-    <string name="invalid_expiry_year">L\'anno di scadenza della carta non è valido.</string>
-    <string name="invalid_shipping_information">Indirizzo di spedizione non valido</string>
-    <string name="invalid_zip">Il codice postale è incompleto.</string>
-    <string name="no_payment_methods">Nessuna modalità di pagamento.</string>
-    <string name="payment_method_add_new_card">Aggiungi nuova carta…</string>
-    <string name="payment_method_add_new_fpx">Seleziona conto bancario (FPX)…</string>
-    <string name="price_free">Gratuita</string>
-    <string name="removed">Rimozione di %s</string>
-    <string name="secure_checkout">Pagamento sicuro</string>
-    <string name="stripe_failure_connection_error">Stiamo riscontrando problemi di connessione con il nostro fornitore di servizi di pagamento. Controlla la connessione a Internet e riprova.</string>
-    <string name="stripe_failure_reason_authentication">Impossibile autenticare la modalità di pagamento. Scegline un\'altra e riprova.</string>
-    <string name="stripe_failure_reason_timed_out">Timeout durante l\'autenticazione della modalità di pagamento. Riprova.</string>
-    <string name="stripe_google_pay_error_internal">Si è verificato un errore interno.</string>
-    <string name="stripe_paymentsheet_add_button_label">Aggiungi</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Aggiungi</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Dati della carta</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Paese o area geografica</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Aggiungi dati di pagamento</string>
-    <string name="stripe_paymentsheet_back">Indietro</string>
-    <string name="stripe_paymentsheet_close">Chiudi</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Oppure paga con carta</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Paga %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Paga</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Elaborazione in corso...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salva la carta per i pagamenti futuri di %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Seleziona la modalità di pagamento</string>
-    <string name="stripe_paymentsheet_setup_button_label">Imposta</string>
-    <string name="stripe_paymentsheet_total_amount">Totale: %s</string>
-    <string name="stripe_verify_your_payment">Verifica il tuo pagamento</string>
-    <string name="title_add_a_card">Aggiungi una carta</string>
-    <string name="title_add_an_address">Aggiungi un indirizzo</string>
-    <string name="title_bank_account">Conto bancario</string>
-    <string name="title_payment_method">Modalità di pagamento</string>
-    <string name="title_select_shipping_method">Scegli metodo spedizione</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Numero carta</string>
+  <string name="acc_label_card_number_node">%s, Numero carta</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Data di scadenza</string>
+  <string name="acc_label_expiry_date_node">%s, Data di scadenza</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Codice postale</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Aggiungi una nuova carta di credito o di debito per fare acquisti in questa app.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Aggiunta di %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Inserisci la città</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Paese non valido</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Inserisci la contea</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Indirizzo</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Indirizzo riga 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Indirizzo riga 1 (facoltativo)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Indirizzo riga 2 (facoltativo)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Indirizzo (facoltativo) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Interno (facoltativo)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Città (facoltativo)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Contea (facoltativo)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Numero di telefono</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Numero di telefono (facoltativo)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Codice postale (facoltativo)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Codice postale</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Codice postale (facoltativo)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincia (facoltativo)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Stato / Provincia / Regione</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Stato / Provincia / Regione (facoltativo)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stato (facoltativo)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Codice postale (facoltativo)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">CAP/Codice postale</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">CAP/Codice postale (facoltativo)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Inserisci il tuo nome</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Inserisci il tuo numero di telefono</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Il codice postale non è valido</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Il codice postale non è valido</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Inserisci la provincia</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Inserisci lo Stato/Provincia/Regione</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Inserisci il tuo indirizzo</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Indirizzo di spedizione</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Inserisci lo stato</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Il codice postale non è valido.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Il CAP/codice postale non è valido</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Fornendo i dati del tuo conto bancario e confermando il pagamento, accetti la presente\n    richiesta di addebito diretto e il contratto di servizio per la richiesta di addebito diretto e autorizzi\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 con numero ID utente per l\'addebito diretto 507156\n    (“Stripe”) ad addebitare sul tuo conto tramite il Bulk Electronic Clearing System (BECS) per\n    conto di %1$s (\"Esercente\") qualsiasi importo che ti viene comunicato separatamente\n    dall\'Esercente. Dichiari di essere un titolare del conto o un firmatario \n    autorizzato per il conto sopra elencato.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Numero conto</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Numero di conto incompleto.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Il tuo numero di conto è obbligatorio.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Il numero BSB inserito è incompleto</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Il numero BSB inserito non è valido</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Indirizzo email</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Indirizzo email non valido.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Il tuo indirizzo email è obbligatorio.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nome</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Il tuo nome è obbligatorio.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s che termina con %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Chiudi</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Elimina modalità di pagamento</string>
+  <string name="delete_payment_method_prompt_title">Eliminare la modalità di pagamento?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Scadenza</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">La data di scadenza della carta è incompleta.</string>
+  <string name="invalid_card_number">Il numero della carta non è valido.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Il codice di sicurezza della carta non è valido.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Il mese di scadenza della carta non è valido.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">L\'anno di scadenza della carta non è valido.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Indirizzo di spedizione non valido</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Il codice postale è incompleto.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nessuna modalità di pagamento.</string>
+  <string name="payment_method_add_new_card">Aggiungi nuova carta…</string>
+  <string name="payment_method_add_new_fpx">Seleziona conto bancario (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratuita</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Rimozione di %s</string>
+  <string name="secure_checkout">Pagamento sicuro</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Stiamo riscontrando problemi di connessione con il nostro fornitore di servizi di pagamento. Controlla la connessione a Internet e riprova.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Impossibile autenticare la modalità di pagamento. Scegline un\'altra e riprova.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Timeout durante l\'autenticazione della modalità di pagamento. Riprova.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Si è verificato un errore interno.</string>
+  <string name="stripe_paymentsheet_add_button_label">Aggiungi</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Aggiungi</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dati della carta</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Paese o area geografica</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Aggiungi dati di pagamento</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Indietro</string>
+  <string name="stripe_paymentsheet_close">Chiudi</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Oppure paga con carta</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Paga %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Paga</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Elaborazione in corso...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salva la carta per i pagamenti futuri di %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Seleziona la modalità di pagamento</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Imposta</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifica il tuo pagamento</string>
+  <string name="title_add_a_card">Aggiungi una carta</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Aggiungi un indirizzo</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Conto bancario</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Modalità di pagamento</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Scegli metodo spedizione</string>
 </resources>

--- a/payments-core/res/values-ja/strings.xml
+++ b/payments-core/res/values-ja/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">カード番号</string>
-    <string name="acc_label_card_number_node">%s、カード番号</string>
-    <string name="acc_label_cvc_node">%s、セキュリティコード</string>
-    <string name="acc_label_expiry_date">有効期限</string>
-    <string name="acc_label_expiry_date_node">%s、有効期限</string>
-    <string name="acc_label_zip">郵便番号</string>
-    <string name="acc_label_zip_short">郵便番号</string>
-    <string name="add_card">このアプリで購入するには、別のデビットカードまたはクレジットカードの登録が必要です。</string>
-    <string name="added">%s が追加されました</string>
-    <string name="address_city_required">市区町村を入力してください</string>
-    <string name="address_country_invalid">国が無効です</string>
-    <string name="address_county_required">国を入力してください</string>
-    <string name="address_label_address">住所</string>
-    <string name="address_label_address_line1">住所 (1 行目)</string>
-    <string name="address_label_address_line1_optional">住所 (1 行目、省略可)</string>
-    <string name="address_label_address_line2_optional">住所 (2 行目、省略可)</string>
-    <string name="address_label_address_optional">住所 (省略可)</string>
-    <string name="address_label_apt">建物名</string>
-    <string name="address_label_apt_optional">アパート / マンション名など (省略可)</string>
-    <string name="address_label_city">市</string>
-    <string name="address_label_city_optional">市区町村 (省略可)</string>
-    <string name="address_label_country">国</string>
-    <string name="address_label_county">群</string>
-    <string name="address_label_county_optional">群 (省略可)</string>
-    <string name="address_label_name">名前</string>
-    <string name="address_label_phone_number">電話番号</string>
-    <string name="address_label_phone_number_optional">電話番号 (省略可)</string>
-    <string name="address_label_postal_code">郵便番号</string>
-    <string name="address_label_postal_code_optional">郵便番号 (省略可)</string>
-    <string name="address_label_postcode">郵便番号</string>
-    <string name="address_label_postcode_optional">郵便番号 (省略可)</string>
-    <string name="address_label_province">都道府県</string>
-    <string name="address_label_province_optional">都道府県 (省略可)</string>
-    <string name="address_label_region_generic">州 / 省 / 地域</string>
-    <string name="address_label_region_generic_optional">都道府県 (省略可)</string>
-    <string name="address_label_state">都道府県</string>
-    <string name="address_label_state_optional">都道府県 (省略可)</string>
-    <string name="address_label_zip_code">郵便番号</string>
-    <string name="address_label_zip_code_optional">郵便番号 (省略可)</string>
-    <string name="address_label_zip_postal_code">郵便番号</string>
-    <string name="address_label_zip_postal_code_optional">郵便番号 (省略可)</string>
-    <string name="address_name_required">名前を入力してください</string>
-    <string name="address_phone_number_required">電話番号を入力してください</string>
-    <string name="address_postal_code_invalid">郵便番号が無効です</string>
-    <string name="address_postcode_invalid">郵便番号が無効です</string>
-    <string name="address_province_required">都道府県を入力してください</string>
-    <string name="address_region_generic_required">都道府県を入力してください</string>
-    <string name="address_required">住所を入力してください</string>
-    <string name="address_shipping_address">配送先住所</string>
-    <string name="address_state_required">都道府県を入力してください</string>
-    <string name="address_zip_invalid">郵便番号が無効です。</string>
-    <string name="address_zip_postal_invalid">郵便番号が無効です</string>
-    <string name="becs_mandate_acceptance">
-    お客様の銀行情報を提供し、この支払いを確認することで、お客様はこの口座引き落とし依頼およびダイレクトデビットリクエスト利用規約 
-    に同意し、
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156
-    (「Stripe」) が、%1$s (「加盟店」) の代理として、加盟店から別途連絡された金額について、Bulk 
-    Electronic Clearing System (BECS 振替) を通して口座引き落としを行うことを承認するものとします。お客様が上
-    記の口座の口座名義人または承認された署名者であることを、
-    お客様は証明するものとします。
-    </string>
-    <string name="becs_widget_account_number">アカウント番号</string>
-    <string name="becs_widget_account_number_incomplete">口座番号に不備があります。</string>
-    <string name="becs_widget_account_number_required">アカウント番号を入力してください。</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">入力した BSB コードに不備があります。</string>
-    <string name="becs_widget_bsb_invalid">入力した BSB コードが無効です。</string>
-    <string name="becs_widget_email">メールアドレス</string>
-    <string name="becs_widget_email_invalid">メールアドレスが無効です。</string>
-    <string name="becs_widget_email_required">メールアドレスを入力してください。</string>
-    <string name="becs_widget_name">名前</string>
-    <string name="becs_widget_name_required">名前を入力してください。</string>
-    <string name="card_ending_in">末尾が %2$s の %1$s</string>
-    <string name="close">閉じる</string>
-    <string name="delete_payment_method">支払い方法を削除する</string>
-    <string name="delete_payment_method_prompt_title">支払い方法を削除しますか？</string>
-    <string name="expiry_date_hint">MM/YY</string>
-    <string name="expiry_label_short">有効期限</string>
-    <string name="fpx_bank_offline">%s - オフライン</string>
-    <string name="incomplete_expiry_date">カードの有効期限の日付に不備があります。</string>
-    <string name="invalid_card_number">カードの番号が無効です。</string>
-    <string name="invalid_cvc">カードのセキュリティコードが無効です。</string>
-    <string name="invalid_expiry_month">カードの有効期限の月が無効です。</string>
-    <string name="invalid_expiry_year">カードの有効期限の年が無効です。</string>
-    <string name="invalid_shipping_information">配送先住所が無効です</string>
-    <string name="invalid_zip">郵便番号の入力に不備があります。</string>
-    <string name="no_payment_methods">支払い方法が指定されていません。</string>
-    <string name="payment_method_add_new_card">新しいカードを追加...</string>
-    <string name="payment_method_add_new_fpx">銀行口座を選択 (FPX)...</string>
-    <string name="price_free">無料</string>
-    <string name="removed">%s が削除されました</string>
-    <string name="secure_checkout">安全なチェックアウト</string>
-    <string name="stripe_failure_connection_error">決済代行会社への接続中に問題が発生しました。インターネット接続をご確認の上、もう一度お試しください。</string>
-    <string name="stripe_failure_reason_authentication">お客様の支払い方法を認証できませんでした。別の支払い方法を選択してもう一度お試しください。</string>
-    <string name="stripe_failure_reason_timed_out">支払い方法の認証がタイムアウトしました。もう一度お試しください</string>
-    <string name="stripe_google_pay_error_internal">内部エラーが発生しました。</string>
-    <string name="stripe_paymentsheet_add_button_label">追加する</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ 追加</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">カード情報</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">国または地域</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">支払い情報を追加</string>
-    <string name="stripe_paymentsheet_back">戻る</string>
-    <string name="stripe_paymentsheet_close">閉じる</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">月 / 年</string>
-    <string name="stripe_paymentsheet_or_pay_using">または別の方法で支払う</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">または、カードで支払う</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s を支払う</string>
-    <string name="stripe_paymentsheet_pay_button_label">支払う: </string>
-    <string name="stripe_paymentsheet_primary_button_processing">処理中...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">今後の %s の支払いのためにこのカードを保存する</string>
-    <string name="stripe_paymentsheet_select_payment_method">支払い方法を選択してください</string>
-    <string name="stripe_paymentsheet_setup_button_label">設定</string>
-    <string name="stripe_paymentsheet_total_amount">合計: %s</string>
-    <string name="stripe_verify_your_payment">支払いの確認</string>
-    <string name="title_add_a_card">カードを追加</string>
-    <string name="title_add_an_address">住所を設定してください</string>
-    <string name="title_bank_account">銀行口座</string>
-    <string name="title_payment_method">お支払い方法</string>
-    <string name="title_select_shipping_method">配送方法を選択してください</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">カード番号</string>
+  <string name="acc_label_card_number_node">%s、カード番号</string>
+  <string name="acc_label_cvc_node">%s、セキュリティコード</string>
+  <string name="acc_label_expiry_date">有効期限</string>
+  <string name="acc_label_expiry_date_node">%s、有効期限</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">郵便番号</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">郵便番号</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">このアプリで購入するには、別のデビットカードまたはクレジットカードの登録が必要です。</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s が追加されました</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">市区町村を入力してください</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">国が無効です</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">国を入力してください</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">住所</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">住所 (1 行目)</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">住所 (1 行目、省略可)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">住所 (2 行目、省略可)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">住所 (省略可)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">アパート / マンション名など (省略可)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">市区町村 (省略可)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">群 (省略可)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">電話番号</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">電話番号 (省略可)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">郵便番号 (省略可)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">郵便番号</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">郵便番号 (省略可)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">都道府県 (省略可)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">州 / 省 / 地域</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">都道府県 (省略可)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">都道府県 (省略可)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">郵便番号 (省略可)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">郵便番号</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">郵便番号 (省略可)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">名前を入力してください</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">電話番号を入力してください</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">郵便番号が無効です</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">郵便番号が無効です</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">都道府県を入力してください</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">都道府県を入力してください</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">住所を入力してください</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">配送先住所</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">都道府県を入力してください</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">郵便番号が無効です。</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">郵便番号が無効です</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    お客様の銀行情報を提供し、この支払いを確認することで、お客様はこの口座引き落とし依頼およびダイレクトデビットリクエスト利用規約 \n    に同意し、\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156\n    (「Stripe」) が、%1$s (「加盟店」) の代理として、加盟店から別途連絡された金額について、Bulk \n    Electronic Clearing System (BECS 振替) を通して口座引き落としを行うことを承認するものとします。お客様が上\n    記の口座の口座名義人または承認された署名者であることを、\n    お客様は証明するものとします。\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">アカウント番号</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">口座番号に不備があります。</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">アカウント番号を入力してください。</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">入力した BSB コードに不備があります。</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">入力した BSB コードが無効です。</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">メールアドレス</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">メールアドレスが無効です。</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">メールアドレスを入力してください。</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">名前</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">名前を入力してください。</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">末尾が %2$s の %1$s</string>
+  <!-- Text for close button -->
+  <string name="close">閉じる</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">支払い方法を削除する</string>
+  <string name="delete_payment_method_prompt_title">支払い方法を削除しますか？</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/YY</string>
+  <string name="expiry_label_short">有効期限</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - オフライン</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">カードの有効期限の日付に不備があります。</string>
+  <string name="invalid_card_number">カードの番号が無効です。</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">カードのセキュリティコードが無効です。</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">カードの有効期限の月が無効です。</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">カードの有効期限の年が無効です。</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">配送先住所が無効です</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">郵便番号の入力に不備があります。</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">支払い方法が指定されていません。</string>
+  <string name="payment_method_add_new_card">新しいカードを追加...</string>
+  <string name="payment_method_add_new_fpx">銀行口座を選択 (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">無料</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s が削除されました</string>
+  <string name="secure_checkout">安全なチェックアウト</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">決済代行会社への接続中に問題が発生しました。インターネット接続をご確認の上、もう一度お試しください。</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">お客様の支払い方法を認証できませんでした。別の支払い方法を選択してもう一度お試しください。</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">支払い方法の認証がタイムアウトしました。もう一度お試しください</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">内部エラーが発生しました。</string>
+  <string name="stripe_paymentsheet_add_button_label">追加する</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ 追加</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">カード情報</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">国または地域</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">支払い情報を追加</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">戻る</string>
+  <string name="stripe_paymentsheet_close">閉じる</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">月 / 年</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">または別の方法で支払う</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">または、カードで支払う</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s を支払う</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">支払う: </string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">処理中...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">今後の %s の支払いのためにこのカードを保存する</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">支払い方法を選択してください</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">設定</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">支払いの確認</string>
+  <string name="title_add_a_card">カードを追加</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">住所を設定してください</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">銀行口座</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">お支払い方法</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">配送方法を選択してください</string>
 </resources>

--- a/payments-core/res/values-lt-rLT/strings.xml
+++ b/payments-core/res/values-lt-rLT/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kortelės numeris</string>
-    <string name="acc_label_card_number_node">%s, kortelės numeris</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Galiojimo pabaigos data</string>
-    <string name="acc_label_expiry_date_node">%s, galiojimo pabaigos data</string>
-    <string name="acc_label_zip">Pašto kodas</string>
-    <string name="acc_label_zip_short">Pašto kodas</string>
-    <string name="add_card">Pridėti naują debeto ar kredito kortelę pirkimams atlikti šioje programėlėje.</string>
-    <string name="added">%s pridėtas</string>
-    <string name="address_city_required">Įveskite savo miestą</string>
-    <string name="address_country_invalid">Jūsų šalis neteisinga</string>
-    <string name="address_county_required">Įveskite savo apygardą</string>
-    <string name="address_label_address">Adresas</string>
-    <string name="address_label_address_line1">1 adreso eilutė</string>
-    <string name="address_label_address_line1_optional">1 adreso eilutė (pasirenkama)</string>
-    <string name="address_label_address_line2_optional">2 adreso eilutė (pasirenkama)</string>
-    <string name="address_label_address_optional">Adresas (pasirenkamas)</string>
-    <string name="address_label_apt">But.</string>
-    <string name="address_label_apt_optional">But. (pasirenkamas)</string>
-    <string name="address_label_city">Miestas</string>
-    <string name="address_label_city_optional">Miestas (pasirenkamas)</string>
-    <string name="address_label_country">Šalis</string>
-    <string name="address_label_county">Apygarda</string>
-    <string name="address_label_county_optional">Apygarda (pasirenkama)</string>
-    <string name="address_label_name">Vardas, pavardė</string>
-    <string name="address_label_phone_number">Telefono numeris</string>
-    <string name="address_label_phone_number_optional">Telefono numeris (pasirenkamas)</string>
-    <string name="address_label_postal_code">Pašto kodas</string>
-    <string name="address_label_postal_code_optional">Pašto kodas (pasirenkamas)</string>
-    <string name="address_label_postcode">Pašto kodas</string>
-    <string name="address_label_postcode_optional">Pašto kodas (pasirenkamas)</string>
-    <string name="address_label_province">Provincija</string>
-    <string name="address_label_province_optional">Provincija (pasirenkama)</string>
-    <string name="address_label_region_generic">Valstija / provincija / regionas</string>
-    <string name="address_label_region_generic_optional">Valstija / provincija / regionas (pasirenkami)</string>
-    <string name="address_label_state">Valstija</string>
-    <string name="address_label_state_optional">Valstija (pasirenkama)</string>
-    <string name="address_label_zip_code">Pašto kodas</string>
-    <string name="address_label_zip_code_optional">Pašto kodas (pasirenkamas)</string>
-    <string name="address_label_zip_postal_code">Pašto kodas</string>
-    <string name="address_label_zip_postal_code_optional">Pašto kodas (pasirenkamas)</string>
-    <string name="address_name_required">Įveskite savo vardą, pavardę</string>
-    <string name="address_phone_number_required">Įveskite savo telefono numerį</string>
-    <string name="address_postal_code_invalid">Jūsų pašto kodas yra netinkamas</string>
-    <string name="address_postcode_invalid">Jūsų pašto kodas yra netinkamas</string>
-    <string name="address_province_required">Įveskite savo provinciją</string>
-    <string name="address_region_generic_required">Įveskite savo valstiją / provinciją / regioną</string>
-    <string name="address_required">Įveskite savo adresą</string>
-    <string name="address_shipping_address">Siuntimo adresas</string>
-    <string name="address_state_required">Įveskite savo valstiją</string>
-    <string name="address_zip_invalid">Jūsų pašto kodas yra netinkamas.</string>
-    <string name="address_zip_postal_invalid">Jūsų pašto kodas yra netinkamas</string>
-    <string name="becs_mandate_acceptance">
-    Pateikdami banko sąskaitos duomenis ir patvirtindami šį mokėjimą, jūs sutinkate su šia
-    tiesioginio debeto užklausa ir tiesioginio debeto užklausos paslaugų sutartimi bei įgaliojate
-    „Stripe Payments Australia Pty Ltd“, ACN 160 180 343, tiesioginio debeto naudotojo ID numeris 507156,
-    (toliau – „Stripe“) nurašyti nuo jūsų sąskaitos per masinę elektroninę tarpuskaitos sistemą (BECS)
-    %1$s vardu (toliau – „Pardavėjas“) bet kokias sumas, atskirai jums nurodytas
-    Pardavėjo. Jūs patvirtinate, kad esate sąskaitos turėtojas arba įgaliotas
-    pasirašyti minėtą sąskaitą asmuo.
-    </string>
-    <string name="becs_widget_account_number">Sąskaitos numeris</string>
-    <string name="becs_widget_account_number_incomplete">Netikslus sąskaitos numeris.</string>
-    <string name="becs_widget_account_number_required">Privaloma nurodyti sąskaitos numerį.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Įvestas neišsamus BSB numeris.</string>
-    <string name="becs_widget_bsb_invalid">Įvestas netinkamas BSB numeris.</string>
-    <string name="becs_widget_email">El. pašto adresas</string>
-    <string name="becs_widget_email_invalid">Jūsų el. pašto adresas yra netinkamas.</string>
-    <string name="becs_widget_email_required">Privaloma nurodyti el. pašto adresą.</string>
-    <string name="becs_widget_name">Vardas, pavardė</string>
-    <string name="becs_widget_name_required">Privaloma nurodyti vardą, pavardę.</string>
-    <string name="card_ending_in">%1$s, kuri baigiasi %2$s</string>
-    <string name="close">Užverti</string>
-    <string name="delete_payment_method">Pašalinti mokėjimo būdą?</string>
-    <string name="delete_payment_method_prompt_title">Pašalinti mokėjimo būdą?</string>
-    <string name="expiry_date_hint">mm / MM</string>
-    <string name="expiry_label_short">Galiojimo pabaigos data</string>
-    <string name="fpx_bank_offline">%s – neprisijungęs</string>
-    <string name="incomplete_expiry_date">Neišsami kortelės galiojimo pabaigos data.</string>
-    <string name="invalid_card_number">Negaliojantis kortelės numeris.</string>
-    <string name="invalid_cvc">Kortelės saugos kodas negalioja.</string>
-    <string name="invalid_expiry_month">Negaliojantis kortelės galiojimo pabaigos mėnuo.</string>
-    <string name="invalid_expiry_year">Kortelės galiojimo pabaigos metai neteisingi.</string>
-    <string name="invalid_shipping_information">Netinkamas siuntimo adresas</string>
-    <string name="invalid_zip">Pašto kodas neišsamus.</string>
-    <string name="no_payment_methods">Nėra mokėjimo būdų.</string>
-    <string name="payment_method_add_new_card">Pridėti naują kortelę...</string>
-    <string name="payment_method_add_new_fpx">Pasirinkti banko sąskaitą (FPX)...</string>
-    <string name="price_free">Nemokamai</string>
-    <string name="removed">%s pašalintas</string>
-    <string name="secure_checkout">Saugus pirkimo užbaigimas</string>
-    <string name="stripe_failure_connection_error">Kilo problemų jungiantis prie mūsų mokėjimo paslaugų teikėjo. Patikrinkite interneto ryšį ir bandykite dar kartą.</string>
-    <string name="stripe_failure_reason_authentication">Nepavyko autentifikuoti mokėjimo būdo. Pasirinkite kitą mokėjimo būdą ir bandykite dar kartą.</string>
-    <string name="stripe_failure_reason_timed_out">Baigėsi mokėjimo būdui autentifikuoti skirtas laikas, bandykite dar kartą</string>
-    <string name="stripe_google_pay_error_internal">Įvyko vidinė klaida.</string>
-    <string name="stripe_paymentsheet_add_button_label">Pridėti</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridėti</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kortelės duomenys</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Šalis arba regionas</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Pridėkite mokėjimo informaciją</string>
-    <string name="stripe_paymentsheet_back">Atgal</string>
-    <string name="stripe_paymentsheet_close">Užverti</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">mm / MM</string>
-    <string name="stripe_paymentsheet_or_pay_using">Arba mokėti naudojant</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Arba mokėti kortele</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Mokėti %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Mokėti</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Apdorojama...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Išsaugoti kortelę vėlesniems %s mokėjimams</string>
-    <string name="stripe_paymentsheet_select_payment_method">Pasirinkite mokėjimo būdą</string>
-    <string name="stripe_paymentsheet_setup_button_label">Nustatyti</string>
-    <string name="stripe_paymentsheet_total_amount">Bendra suma: %s</string>
-    <string name="stripe_verify_your_payment">Patvirtinkite savo mokėjimą.</string>
-    <string name="title_add_a_card">Pridėti kortelę</string>
-    <string name="title_add_an_address">Nustatyti adresą</string>
-    <string name="title_bank_account">Banko sąskaita</string>
-    <string name="title_payment_method">Mokėjimo būdas</string>
-    <string name="title_select_shipping_method">Pasirinkti siuntimo būdą</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kortelės numeris</string>
+  <string name="acc_label_card_number_node">%s, kortelės numeris</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Galiojimo pabaigos data</string>
+  <string name="acc_label_expiry_date_node">%s, galiojimo pabaigos data</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Pašto kodas</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Pašto kodas</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Pridėti naują debeto ar kredito kortelę pirkimams atlikti šioje programėlėje.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s pridėtas</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Įveskite savo miestą</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Jūsų šalis neteisinga</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Įveskite savo apygardą</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresas</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">1 adreso eilutė</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">1 adreso eilutė (pasirenkama)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">2 adreso eilutė (pasirenkama)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresas (pasirenkamas)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">But. (pasirenkamas)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Miestas (pasirenkamas)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Apygarda (pasirenkama)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefono numeris</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefono numeris (pasirenkamas)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Pašto kodas (pasirenkamas)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Pašto kodas</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Pašto kodas (pasirenkamas)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincija (pasirenkama)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Valstija / provincija / regionas</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Valstija / provincija / regionas (pasirenkami)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Valstija (pasirenkama)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Pašto kodas (pasirenkamas)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Pašto kodas</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Pašto kodas (pasirenkamas)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Įveskite savo vardą, pavardę</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Įveskite savo telefono numerį</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Jūsų pašto kodas yra netinkamas</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Jūsų pašto kodas yra netinkamas</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Įveskite savo provinciją</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Įveskite savo valstiją / provinciją / regioną</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Įveskite savo adresą</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Siuntimo adresas</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Įveskite savo valstiją</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Jūsų pašto kodas yra netinkamas.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Jūsų pašto kodas yra netinkamas</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Pateikdami banko sąskaitos duomenis ir patvirtindami šį mokėjimą, jūs sutinkate su šia\n    tiesioginio debeto užklausa ir tiesioginio debeto užklausos paslaugų sutartimi bei įgaliojate\n    „Stripe Payments Australia Pty Ltd“, ACN 160 180 343, tiesioginio debeto naudotojo ID numeris 507156,\n    (toliau – „Stripe“) nurašyti nuo jūsų sąskaitos per masinę elektroninę tarpuskaitos sistemą (BECS)\n    %1$s vardu (toliau – „Pardavėjas“) bet kokias sumas, atskirai jums nurodytas\n    Pardavėjo. Jūs patvirtinate, kad esate sąskaitos turėtojas arba įgaliotas\n    pasirašyti minėtą sąskaitą asmuo.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Sąskaitos numeris</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Netikslus sąskaitos numeris.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Privaloma nurodyti sąskaitos numerį.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Įvestas neišsamus BSB numeris.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Įvestas netinkamas BSB numeris.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">El. pašto adresas</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Jūsų el. pašto adresas yra netinkamas.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Privaloma nurodyti el. pašto adresą.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Vardas, pavardė</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Privaloma nurodyti vardą, pavardę.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, kuri baigiasi %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Užverti</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Pašalinti mokėjimo būdą?</string>
+  <string name="delete_payment_method_prompt_title">Pašalinti mokėjimo būdą?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">mm / MM</string>
+  <string name="expiry_label_short">Galiojimo pabaigos data</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s – neprisijungęs</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Neišsami kortelės galiojimo pabaigos data.</string>
+  <string name="invalid_card_number">Negaliojantis kortelės numeris.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kortelės saugos kodas negalioja.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Negaliojantis kortelės galiojimo pabaigos mėnuo.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kortelės galiojimo pabaigos metai neteisingi.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Netinkamas siuntimo adresas</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Pašto kodas neišsamus.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nėra mokėjimo būdų.</string>
+  <string name="payment_method_add_new_card">Pridėti naują kortelę...</string>
+  <string name="payment_method_add_new_fpx">Pasirinkti banko sąskaitą (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Nemokamai</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s pašalintas</string>
+  <string name="secure_checkout">Saugus pirkimo užbaigimas</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Kilo problemų jungiantis prie mūsų mokėjimo paslaugų teikėjo. Patikrinkite interneto ryšį ir bandykite dar kartą.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nepavyko autentifikuoti mokėjimo būdo. Pasirinkite kitą mokėjimo būdą ir bandykite dar kartą.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Baigėsi mokėjimo būdui autentifikuoti skirtas laikas, bandykite dar kartą</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Įvyko vidinė klaida.</string>
+  <string name="stripe_paymentsheet_add_button_label">Pridėti</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridėti</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortelės duomenys</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Šalis arba regionas</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Pridėkite mokėjimo informaciją</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Atgal</string>
+  <string name="stripe_paymentsheet_close">Užverti</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">mm / MM</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Arba mokėti naudojant</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Arba mokėti kortele</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Mokėti %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Mokėti</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Apdorojama...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Išsaugoti kortelę vėlesniems %s mokėjimams</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Pasirinkite mokėjimo būdą</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Nustatyti</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Patvirtinkite savo mokėjimą.</string>
+  <string name="title_add_a_card">Pridėti kortelę</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Nustatyti adresą</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Banko sąskaita</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Mokėjimo būdas</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Pasirinkti siuntimo būdą</string>
 </resources>

--- a/payments-core/res/values-lv-rLV/strings.xml
+++ b/payments-core/res/values-lv-rLV/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kartes numurs</string>
-    <string name="acc_label_card_number_node">%s, kartes numurs</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Derīguma termiņš</string>
-    <string name="acc_label_expiry_date_node">%s, derīguma termiņš</string>
-    <string name="acc_label_zip">Pasta indekss</string>
-    <string name="acc_label_zip_short">Pasta ind.</string>
-    <string name="add_card">Lai varētu veikt iegādi ar šo lietotni, pievienojiet jaunu debetkarti vai kredītkarti.</string>
-    <string name="added">%s pievienots</string>
-    <string name="address_city_required">Ievadiet pilsētu</string>
-    <string name="address_country_invalid">Ievadītā valsts nav derīga</string>
-    <string name="address_county_required">Ievadiet apriņķi</string>
-    <string name="address_label_address">Adrese</string>
-    <string name="address_label_address_line1">1. adreses rindiņa</string>
-    <string name="address_label_address_line1_optional">1. adreses rindiņa (nav obligāti)</string>
-    <string name="address_label_address_line2_optional">2. adreses rindiņa (nav obligāti)</string>
-    <string name="address_label_address_optional">Adrese (nav obligāti) </string>
-    <string name="address_label_apt">Dzīv.</string>
-    <string name="address_label_apt_optional">Dzīv. (nav obligāti)</string>
-    <string name="address_label_city">Pilsēta</string>
-    <string name="address_label_city_optional">Pilsēta (nav obligāti)</string>
-    <string name="address_label_country">Valsts</string>
-    <string name="address_label_county">Apriņķis</string>
-    <string name="address_label_county_optional">Apriņķis (nav obligāti)</string>
-    <string name="address_label_name">Vārds, uzvārds</string>
-    <string name="address_label_phone_number">Tālruņa numurs</string>
-    <string name="address_label_phone_number_optional">Tālruņa numurs (nav obligāti)</string>
-    <string name="address_label_postal_code">Pasta indekss</string>
-    <string name="address_label_postal_code_optional">Pasta indekss (nav obligāti)</string>
-    <string name="address_label_postcode">Pasta indekss</string>
-    <string name="address_label_postcode_optional">Pasta indekss (nav obligāti)</string>
-    <string name="address_label_province">Province</string>
-    <string name="address_label_province_optional">Province (nav obligāti)</string>
-    <string name="address_label_region_generic">Novads/štats/province/reģions</string>
-    <string name="address_label_region_generic_optional">Novads/štats/province/reģions (nav obligāti)</string>
-    <string name="address_label_state">Novads/štats</string>
-    <string name="address_label_state_optional">Novads/štats (nav obligāti)</string>
-    <string name="address_label_zip_code">Pasta indekss</string>
-    <string name="address_label_zip_code_optional">Pasta indekss (nav obligāti)</string>
-    <string name="address_label_zip_postal_code">Pasta indekss</string>
-    <string name="address_label_zip_postal_code_optional">Pasta indekss (neobligāts)</string>
-    <string name="address_name_required">Ievadiet vārdu un uzvārdu</string>
-    <string name="address_phone_number_required">Ievadiet tālruņa numuru</string>
-    <string name="address_postal_code_invalid">Pasta indekss nav derīgs</string>
-    <string name="address_postcode_invalid">Pasta indekss nav derīgs</string>
-    <string name="address_province_required">Ievadiet provinci</string>
-    <string name="address_region_generic_required">Ievadiet novadu/štatu/provinci/reģionu</string>
-    <string name="address_required">Ievadiet adresi</string>
-    <string name="address_shipping_address">Piegādes adrese</string>
-    <string name="address_state_required">Ievadiet novadu/štatu</string>
-    <string name="address_zip_invalid">Pasta indekss nav derīgs.</string>
-    <string name="address_zip_postal_invalid">Pasta indekss nav derīgs</string>
-    <string name="becs_mandate_acceptance">
-    Sniedzot savu bankas konta informāciju un apstiprinot šo maksājumu, jūs
-    piekrītat šim tiešā debeta pieprasījumam un pakalpojuma līgumam, kā arī pilnvarojat uzņēmumu
-    Stripe Payments Australia Pty Ltd ACN 160 180 343, tiešā debeta lietotāja ID numurs 507156
-    (turpmāk — “Stripe”) izmantot lielapjoma elektronisko klīringa sistēmu (BECS),
-    lai uzņēmuma %1$s (turpmāk — “Tirgotājs”) vārdā debitētu jūsu kontu par jebkādām summām,
-    par kurām Tirgotājs jums ir atsevišķi ziņojis. Jūs apliecināt, ka esat vai nu
-    iepriekš minētā konta īpašnieks, vai tā pilnvarota persona ar paraksta tiesībām.
-    </string>
-    <string name="becs_widget_account_number">Konta numurs</string>
-    <string name="becs_widget_account_number_incomplete">Konta numurs nav pilnīgs.</string>
-    <string name="becs_widget_account_number_required">Jānorāda konta numurs.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Ievadītais BSB ir nepilnīgs.</string>
-    <string name="becs_widget_bsb_invalid">Ievadītais BSB nav derīgs.</string>
-    <string name="becs_widget_email">E-pasta adrese</string>
-    <string name="becs_widget_email_invalid">E-pasta adrese nav derīga.</string>
-    <string name="becs_widget_email_required">Jānorāda e-pasta adrese.</string>
-    <string name="becs_widget_name">Vārds, uzvārds</string>
-    <string name="becs_widget_name_required">Jānorāda vārds/nosaukums.</string>
-    <string name="card_ending_in">%1$s, kuras numura pēdējie cipari ir %2$s</string>
-    <string name="close">Aizvērt</string>
-    <string name="delete_payment_method">Dzēst maksājuma metodi</string>
-    <string name="delete_payment_method_prompt_title">Vai dzēst maksājuma metodi?</string>
-    <string name="expiry_date_hint">MM/GG</string>
-    <string name="expiry_label_short">Derīguma termiņš</string>
-    <string name="fpx_bank_offline">%s — bezsaistē</string>
-    <string name="incomplete_expiry_date">Kartes derīguma termiņa datums nav pilnīgs.</string>
-    <string name="invalid_card_number">Kartes numurs nav derīgs.</string>
-    <string name="invalid_cvc">Kartes drošības kods nav derīgs.</string>
-    <string name="invalid_expiry_month">Kartes derīguma termiņa mēnesis nav derīgs.</string>
-    <string name="invalid_expiry_year">Kartes derīguma termiņa gads nav derīgs.</string>
-    <string name="invalid_shipping_information">Nederīga piegādes adrese</string>
-    <string name="invalid_zip">Pasta indekss nav pilnīgs.</string>
-    <string name="no_payment_methods">Nav maksājuma metožu.</string>
-    <string name="payment_method_add_new_card">Pievienot jaunu karti…</string>
-    <string name="payment_method_add_new_fpx">Atlasīt bankas kontu (FPX)…</string>
-    <string name="price_free">Bezmaksas</string>
-    <string name="removed">%s noņemts</string>
-    <string name="secure_checkout">Droša norēķināšanās</string>
-    <string name="stripe_failure_connection_error">Ir radušās problēmas, veidojot savienojumu ar mūsu maksājumu nodrošinātāju. Lūdzu, pārbaudiet savu interneta savienojumu un mēģiniet vēlreiz.</string>
-    <string name="stripe_failure_reason_authentication">Nevaram autentificēt jūsu maksājuma metodi. Lūdzu, izvēlieties citu maksājuma metodi un mēģiniet vēlreiz.</string>
-    <string name="stripe_failure_reason_timed_out">Autentificējot jūsu maksājuma metodi, iestājās noildze — mēģiniet vēlreiz</string>
-    <string name="stripe_google_pay_error_internal">Radās iekšēja kļūda.</string>
-    <string name="stripe_paymentsheet_add_button_label">Pievienot</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pievienot</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kartes informācija</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Valsts vai reģions</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Pievienot maksājuma informāciju</string>
-    <string name="stripe_paymentsheet_back">Atpakaļ</string>
-    <string name="stripe_paymentsheet_close">Aizvērt</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/GG</string>
-    <string name="stripe_paymentsheet_or_pay_using">Vai maksāt, izmantojot</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Vai maksāt ar karti</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Maksāt %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Maksāt</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Apstrādā…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Saglabāt šo karti %s maksājumiem nākotnē</string>
-    <string name="stripe_paymentsheet_select_payment_method">Izvēlēties savu maksājuma veidu</string>
-    <string name="stripe_paymentsheet_setup_button_label">Iestatīt</string>
-    <string name="stripe_paymentsheet_total_amount">Kopā: %s</string>
-    <string name="stripe_verify_your_payment">Verificējiet savu maksājumu</string>
-    <string name="title_add_a_card">Kartes pievienošana</string>
-    <string name="title_add_an_address">Iestatiet adresi</string>
-    <string name="title_bank_account">Bankas konts</string>
-    <string name="title_payment_method">Maksājuma metode</string>
-    <string name="title_select_shipping_method">Atlasiet piegādes metodi</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kartes numurs</string>
+  <string name="acc_label_card_number_node">%s, kartes numurs</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Derīguma termiņš</string>
+  <string name="acc_label_expiry_date_node">%s, derīguma termiņš</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Pasta indekss</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Pasta ind.</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Lai varētu veikt iegādi ar šo lietotni, pievienojiet jaunu debetkarti vai kredītkarti.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s pievienots</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Ievadiet pilsētu</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Ievadītā valsts nav derīga</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Ievadiet apriņķi</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adrese</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">1. adreses rindiņa</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">1. adreses rindiņa (nav obligāti)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">2. adreses rindiņa (nav obligāti)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adrese (nav obligāti) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Dzīv. (nav obligāti)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Pilsēta (nav obligāti)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Apriņķis (nav obligāti)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Tālruņa numurs</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Tālruņa numurs (nav obligāti)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Pasta indekss (nav obligāti)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Pasta indekss</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Pasta indekss (nav obligāti)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Province (nav obligāti)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Novads/štats/province/reģions</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Novads/štats/province/reģions (nav obligāti)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Novads/štats (nav obligāti)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Pasta indekss (nav obligāti)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Pasta indekss</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Pasta indekss (neobligāts)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Ievadiet vārdu un uzvārdu</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Ievadiet tālruņa numuru</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Pasta indekss nav derīgs</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Pasta indekss nav derīgs</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Ievadiet provinci</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Ievadiet novadu/štatu/provinci/reģionu</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Ievadiet adresi</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Piegādes adrese</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Ievadiet novadu/štatu</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Pasta indekss nav derīgs.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Pasta indekss nav derīgs</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Sniedzot savu bankas konta informāciju un apstiprinot šo maksājumu, jūs\n    piekrītat šim tiešā debeta pieprasījumam un pakalpojuma līgumam, kā arī pilnvarojat uzņēmumu\n    Stripe Payments Australia Pty Ltd ACN 160 180 343, tiešā debeta lietotāja ID numurs 507156\n    (turpmāk — “Stripe”) izmantot lielapjoma elektronisko klīringa sistēmu (BECS),\n    lai uzņēmuma %1$s (turpmāk — “Tirgotājs”) vārdā debitētu jūsu kontu par jebkādām summām,\n    par kurām Tirgotājs jums ir atsevišķi ziņojis. Jūs apliecināt, ka esat vai nu\n    iepriekš minētā konta īpašnieks, vai tā pilnvarota persona ar paraksta tiesībām.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Konta numurs</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Konta numurs nav pilnīgs.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Jānorāda konta numurs.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Ievadītais BSB ir nepilnīgs.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Ievadītais BSB nav derīgs.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-pasta adrese</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">E-pasta adrese nav derīga.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Jānorāda e-pasta adrese.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Vārds, uzvārds</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Jānorāda vārds/nosaukums.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, kuras numura pēdējie cipari ir %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Aizvērt</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Dzēst maksājuma metodi</string>
+  <string name="delete_payment_method_prompt_title">Vai dzēst maksājuma metodi?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/GG</string>
+  <string name="expiry_label_short">Derīguma termiņš</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s — bezsaistē</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kartes derīguma termiņa datums nav pilnīgs.</string>
+  <string name="invalid_card_number">Kartes numurs nav derīgs.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kartes drošības kods nav derīgs.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kartes derīguma termiņa mēnesis nav derīgs.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kartes derīguma termiņa gads nav derīgs.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Nederīga piegādes adrese</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Pasta indekss nav pilnīgs.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nav maksājuma metožu.</string>
+  <string name="payment_method_add_new_card">Pievienot jaunu karti…</string>
+  <string name="payment_method_add_new_fpx">Atlasīt bankas kontu (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Bezmaksas</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s noņemts</string>
+  <string name="secure_checkout">Droša norēķināšanās</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Ir radušās problēmas, veidojot savienojumu ar mūsu maksājumu nodrošinātāju. Lūdzu, pārbaudiet savu interneta savienojumu un mēģiniet vēlreiz.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nevaram autentificēt jūsu maksājuma metodi. Lūdzu, izvēlieties citu maksājuma metodi un mēģiniet vēlreiz.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Autentificējot jūsu maksājuma metodi, iestājās noildze — mēģiniet vēlreiz</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Radās iekšēja kļūda.</string>
+  <string name="stripe_paymentsheet_add_button_label">Pievienot</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pievienot</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartes informācija</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Valsts vai reģions</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Pievienot maksājuma informāciju</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Atpakaļ</string>
+  <string name="stripe_paymentsheet_close">Aizvērt</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/GG</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Vai maksāt, izmantojot</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Vai maksāt ar karti</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Maksāt %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Maksāt</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Apstrādā…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Saglabāt šo karti %s maksājumiem nākotnē</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Izvēlēties savu maksājuma veidu</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Iestatīt</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verificējiet savu maksājumu</string>
+  <string name="title_add_a_card">Kartes pievienošana</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Iestatiet adresi</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankas konts</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Maksājuma metode</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Atlasiet piegādes metodi</string>
 </resources>

--- a/payments-core/res/values-mt/strings.xml
+++ b/payments-core/res/values-mt/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">In-numru tal-kard</string>
-    <string name="acc_label_card_number_node">%s, In-numru tal-kard</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Id-data tal-iskadenza</string>
-    <string name="acc_label_expiry_date_node">%s, Data tal-iskadenza</string>
-    <string name="acc_label_zip">Kodiċi Postali</string>
-    <string name="acc_label_zip_short">Kodiċi Postali</string>
-    <string name="add_card">Żid kard tad-debitu jew kreditu ġdida biex tagħmel ix-xiri f\'din l-app.</string>
-    <string name="added">Miżjud %s</string>
-    <string name="address_city_required">Jekk jogħġbok daħħal il-belt tiegħek</string>
-    <string name="address_country_invalid">Il-pajjiż tiegħek mhux validu</string>
-    <string name="address_county_required">Jekk jogħġbok daħħal il-kontea tiegħek</string>
-    <string name="address_label_address">Indirizz</string>
-    <string name="address_label_address_line1">Indirizz linja 1</string>
-    <string name="address_label_address_line1_optional">Indirizz linja 1 (mhux obbligatorju)</string>
-    <string name="address_label_address_line2_optional">Indirizz linja 2 (mhux obbligatorju)</string>
-    <string name="address_label_address_optional">Indirizz (mhux obbligatorju)</string>
-    <string name="address_label_apt">Appartament</string>
-    <string name="address_label_apt_optional">Appartament (mhux obbligatorju)</string>
-    <string name="address_label_city">Belt</string>
-    <string name="address_label_city_optional">Belt (mhux obbligatorju)</string>
-    <string name="address_label_country">Pajjiż</string>
-    <string name="address_label_county">Kontea</string>
-    <string name="address_label_county_optional">Kontea (mhux obbligatorja)</string>
-    <string name="address_label_name">Isem</string>
-    <string name="address_label_phone_number">In-numru tat-telefon</string>
-    <string name="address_label_phone_number_optional">Numru tat-telefon (mhux obbligatorju)</string>
-    <string name="address_label_postal_code">Kodiċi postali</string>
-    <string name="address_label_postal_code_optional">Kodiċi postali (mhux obbligatorju)</string>
-    <string name="address_label_postcode">Kodiċi postali</string>
-    <string name="address_label_postcode_optional">Kodiċi postali (mhux obbligatorju)</string>
-    <string name="address_label_province">Provinċja</string>
-    <string name="address_label_province_optional">Provinċja (mhux obbligatorja)</string>
-    <string name="address_label_region_generic">Stat / Provinċja / Reġjun</string>
-    <string name="address_label_region_generic_optional">Stat / Provinċja / Reġjun (mhux obbligatorju)</string>
-    <string name="address_label_state">Stat</string>
-    <string name="address_label_state_optional">Stat (mhux obbligatorju)</string>
-    <string name="address_label_zip_code">Kodiċi postali</string>
-    <string name="address_label_zip_code_optional">Kodiċi postali (mhux obbligatorju)</string>
-    <string name="address_label_zip_postal_code">Kodiċi postali</string>
-    <string name="address_label_zip_postal_code_optional">Kodiċi postali (mhux obbligatorju)</string>
-    <string name="address_name_required">Jekk jogħġbok daħħal ismek</string>
-    <string name="address_phone_number_required">Jekk jogħġbok daħħal in-numru tat-telefon tiegħek</string>
-    <string name="address_postal_code_invalid">Il-kodiċi postali tiegħek mhux validu</string>
-    <string name="address_postcode_invalid">Il-kodiċi postali tiegħek mhux validu</string>
-    <string name="address_province_required">Jekk jogħġbok daħħal il-provinċja tiegħek</string>
-    <string name="address_region_generic_required">Jekk jogħġbok daħħal l-Istat/Provinċja/Reġjun tiegħek</string>
-    <string name="address_required">Jekk jogħġbok daħħal l-indirizz tiegħek</string>
-    <string name="address_shipping_address">L-Indirizz tat-Trasport tal-Merkanzija</string>
-    <string name="address_state_required">Jekk jogħġbok daħħal l-istat tiegħek</string>
-    <string name="address_zip_invalid">Il-kodiċi postali tiegħek mhux validu.</string>
-    <string name="address_zip_postal_invalid">Il-Kodiċi postali tiegħek mhux validu</string>
-    <string name="becs_mandate_acceptance">
-    Meta tipprovdi d-dettalji tal-kont bankarju tiegħek u tikkonferma dan il-ħlas, inti
-    taqbel ma\' din it-Talba ta\' Debitu Dirett u l-ftehim ta\' servizz tat-Talba ta\'
-    Debitu Dirett, u tawtorizza lil Stripe Payments Australia Pty Ltd ACN 160 180 343
-    Utent ta\' Debitu Dirett bin-numru tal-ID 507156 (“Stripe”) biex tiddebita l-kont tiegħek
-    permezz tas-Sistema tal-Ikklirjar Elettroniku bl-Ingrossa (BECS) f\'isem %1$s
-    (in-“Negozjant”) għal kwalunkwe ammonti kkomunikati b\'mod separat lilek min-Negozjant.
-    Inti tiċċertifika li inti detentur ta\' kont jew li inti firmatarju awtorizzat fil-kont elenkat hawn fuq.
-    </string>
-    <string name="becs_widget_account_number">In-numru tal-kont</string>
-    <string name="becs_widget_account_number_incomplete">In-numru tal-kont tiegħek mhux komplut.</string>
-    <string name="becs_widget_account_number_required">In-numru tal-kont tiegħek huwa meħtieġ.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Il-BSB li daħħalt mhux komplut.</string>
-    <string name="becs_widget_bsb_invalid">Il-BSB li daħħalt mhux validu.</string>
-    <string name="becs_widget_email">Indirizz Elettroniku</string>
-    <string name="becs_widget_email_invalid">L-indirizz elettroniku tiegħek huwa invalidu.</string>
-    <string name="becs_widget_email_required">L-indirizz elettroniku tiegħek huwa meħtieġ.</string>
-    <string name="becs_widget_name">Isem</string>
-    <string name="becs_widget_name_required">Ismek huwa meħtieġ.</string>
-    <string name="card_ending_in">%1$s li jispiċċa %2$s</string>
-    <string name="close">Agħlaq</string>
-    <string name="delete_payment_method">Ħassar il-Metodu tal-Ħlas</string>
-    <string name="delete_payment_method_prompt_title">Tħassar il-metodu tal-ħlas?</string>
-    <string name="expiry_date_hint">XX/SS</string>
-    <string name="expiry_label_short">Skadenza</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">Id-data tal-iskadenza tal-kard tiegħek mhijiex kompluta.</string>
-    <string name="invalid_card_number">In-numru tal-kard tiegħek mhux validu.</string>
-    <string name="invalid_cvc">Il-kodiċi tas-sigurtà tal-kard tiegħek mhux validu.</string>
-    <string name="invalid_expiry_month">Ix-xahar tal-iskadenza tal-kard tiegħek mhux validu.</string>
-    <string name="invalid_expiry_year">Is-sena tal-iskadenza tal-kard tiegħek mhijiex valida.</string>
-    <string name="invalid_shipping_information">L-Indirizz għat-Trasport tal-Merkanzija Mhux Validu</string>
-    <string name="invalid_zip">Il-kodiċi postali tiegħek mhux komplut.</string>
-    <string name="no_payment_methods">M\'hemmx metodi tal-ħlas.</string>
-    <string name="payment_method_add_new_card">Żid kard ġdida…</string>
-    <string name="payment_method_add_new_fpx">Agħżel Kont Bankarju (FPX)…</string>
-    <string name="price_free">Bla ħlas</string>
-    <string name="removed">Imneħħi %s</string>
-    <string name="secure_checkout">Checkout Sigur</string>
-    <string name="stripe_failure_connection_error">Qed nesperjenzaw problemi fil-konnessjoni mal-fornitur tal-pagamenti tagħna. Jekk jogħġbok iċċekkja l-konnessjoni tal-internet tiegħek u erġa\' pprova.</string>
-    <string name="stripe_failure_reason_authentication">Ma nistgħux nawtentikaw il-metodu tal-ħlas tiegħek. Jekk jogħġbok agħżel metodu tal-ħlas differenti u erġa\' pprova.</string>
-    <string name="stripe_failure_reason_timed_out">Skada l-ħin tal-awtentikazzjoni tal-metodu tal-ħlas tiegħek -- erġa\' pprova</string>
-    <string name="stripe_google_pay_error_internal">Seħħ żball intern.</string>
-    <string name="stripe_paymentsheet_add_button_label">Żid</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Żid</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">L-informazzjoni tal-kard</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pajjiż jew reġjun</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Żid l-informazzjoni dwar il-pagament tiegħek</string>
-    <string name="stripe_paymentsheet_back">Lura</string>
-    <string name="stripe_paymentsheet_close">Agħlaq</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">XX / SS</string>
-    <string name="stripe_paymentsheet_or_pay_using">Jew ħallas bil-</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Jew ħallas bil-kard</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Ħallas %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Ħallas</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Qed jiġi pproċessat...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Erfa\' din il-kard għal pagamenti futuri %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Agħżel il-metodu tal-ħlas tiegħek</string>
-    <string name="stripe_paymentsheet_setup_button_label">Stabilixxi</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Ivverifika l-pagament tiegħek</string>
-    <string name="title_add_a_card">Żid Kard</string>
-    <string name="title_add_an_address">Issettja l-Indirizz</string>
-    <string name="title_bank_account">Kont bankarju</string>
-    <string name="title_payment_method">Metodu tal-Ħlas</string>
-    <string name="title_select_shipping_method">Agħżel il-Mod tat-Trasport tal-Merkanzija</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">In-numru tal-kard</string>
+  <string name="acc_label_card_number_node">%s, In-numru tal-kard</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Id-data tal-iskadenza</string>
+  <string name="acc_label_expiry_date_node">%s, Data tal-iskadenza</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Kodiċi Postali</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Kodiċi Postali</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Żid kard tad-debitu jew kreditu ġdida biex tagħmel ix-xiri f\'din l-app.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Miżjud %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Jekk jogħġbok daħħal il-belt tiegħek</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Il-pajjiż tiegħek mhux validu</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Jekk jogħġbok daħħal il-kontea tiegħek</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Indirizz</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Indirizz linja 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Indirizz linja 1 (mhux obbligatorju)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Indirizz linja 2 (mhux obbligatorju)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Indirizz (mhux obbligatorju)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Appartament (mhux obbligatorju)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Belt (mhux obbligatorju)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Kontea (mhux obbligatorja)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">In-numru tat-telefon</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Numru tat-telefon (mhux obbligatorju)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Kodiċi postali (mhux obbligatorju)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Kodiċi postali</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Kodiċi postali (mhux obbligatorju)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provinċja (mhux obbligatorja)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Stat / Provinċja / Reġjun</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Stat / Provinċja / Reġjun (mhux obbligatorju)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stat (mhux obbligatorju)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Kodiċi postali (mhux obbligatorju)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Kodiċi postali</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Kodiċi postali (mhux obbligatorju)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Jekk jogħġbok daħħal ismek</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Jekk jogħġbok daħħal in-numru tat-telefon tiegħek</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Il-kodiċi postali tiegħek mhux validu</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Il-kodiċi postali tiegħek mhux validu</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Jekk jogħġbok daħħal il-provinċja tiegħek</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Jekk jogħġbok daħħal l-Istat/Provinċja/Reġjun tiegħek</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Jekk jogħġbok daħħal l-indirizz tiegħek</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">L-Indirizz tat-Trasport tal-Merkanzija</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Jekk jogħġbok daħħal l-istat tiegħek</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Il-kodiċi postali tiegħek mhux validu.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Il-Kodiċi postali tiegħek mhux validu</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Meta tipprovdi d-dettalji tal-kont bankarju tiegħek u tikkonferma dan il-ħlas, inti\n    taqbel ma\' din it-Talba ta\' Debitu Dirett u l-ftehim ta\' servizz tat-Talba ta\'\n    Debitu Dirett, u tawtorizza lil Stripe Payments Australia Pty Ltd ACN 160 180 343\n    Utent ta\' Debitu Dirett bin-numru tal-ID 507156 (“Stripe”) biex tiddebita l-kont tiegħek\n    permezz tas-Sistema tal-Ikklirjar Elettroniku bl-Ingrossa (BECS) f\'isem %1$s\n    (in-“Negozjant”) għal kwalunkwe ammonti kkomunikati b\'mod separat lilek min-Negozjant.\n    Inti tiċċertifika li inti detentur ta\' kont jew li inti firmatarju awtorizzat fil-kont elenkat hawn fuq.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">In-numru tal-kont</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">In-numru tal-kont tiegħek mhux komplut.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">In-numru tal-kont tiegħek huwa meħtieġ.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Il-BSB li daħħalt mhux komplut.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Il-BSB li daħħalt mhux validu.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Indirizz Elettroniku</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">L-indirizz elettroniku tiegħek huwa invalidu.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">L-indirizz elettroniku tiegħek huwa meħtieġ.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Isem</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Ismek huwa meħtieġ.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s li jispiċċa %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Agħlaq</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Ħassar il-Metodu tal-Ħlas</string>
+  <string name="delete_payment_method_prompt_title">Tħassar il-metodu tal-ħlas?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">XX/SS</string>
+  <string name="expiry_label_short">Skadenza</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Id-data tal-iskadenza tal-kard tiegħek mhijiex kompluta.</string>
+  <string name="invalid_card_number">In-numru tal-kard tiegħek mhux validu.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Il-kodiċi tas-sigurtà tal-kard tiegħek mhux validu.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Ix-xahar tal-iskadenza tal-kard tiegħek mhux validu.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Is-sena tal-iskadenza tal-kard tiegħek mhijiex valida.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">L-Indirizz għat-Trasport tal-Merkanzija Mhux Validu</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Il-kodiċi postali tiegħek mhux komplut.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">M\'hemmx metodi tal-ħlas.</string>
+  <string name="payment_method_add_new_card">Żid kard ġdida…</string>
+  <string name="payment_method_add_new_fpx">Agħżel Kont Bankarju (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Bla ħlas</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Imneħħi %s</string>
+  <string name="secure_checkout">Checkout Sigur</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Qed nesperjenzaw problemi fil-konnessjoni mal-fornitur tal-pagamenti tagħna. Jekk jogħġbok iċċekkja l-konnessjoni tal-internet tiegħek u erġa\' pprova.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Ma nistgħux nawtentikaw il-metodu tal-ħlas tiegħek. Jekk jogħġbok agħżel metodu tal-ħlas differenti u erġa\' pprova.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Skada l-ħin tal-awtentikazzjoni tal-metodu tal-ħlas tiegħek -- erġa\' pprova</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Seħħ żball intern.</string>
+  <string name="stripe_paymentsheet_add_button_label">Żid</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Żid</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">L-informazzjoni tal-kard</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pajjiż jew reġjun</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Żid l-informazzjoni dwar il-pagament tiegħek</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Lura</string>
+  <string name="stripe_paymentsheet_close">Agħlaq</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">XX / SS</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Jew ħallas bil-</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Jew ħallas bil-kard</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Ħallas %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Ħallas</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Qed jiġi pproċessat...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Erfa\' din il-kard għal pagamenti futuri %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Agħżel il-metodu tal-ħlas tiegħek</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Stabilixxi</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Ivverifika l-pagament tiegħek</string>
+  <string name="title_add_a_card">Żid Kard</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Issettja l-Indirizz</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Kont bankarju</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Metodu tal-Ħlas</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Agħżel il-Mod tat-Trasport tal-Merkanzija</string>
 </resources>

--- a/payments-core/res/values-nb/strings.xml
+++ b/payments-core/res/values-nb/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kortnummer</string>
-    <string name="acc_label_card_number_node">%s, kortnummer</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Utløpsdato</string>
-    <string name="acc_label_expiry_date_node">%s, utløpsdato</string>
-    <string name="acc_label_zip">ZIP-kode</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="add_card">Legg til et nytt debet- eller kredittkort for å gjøre kjøp i denne appen.</string>
-    <string name="added">Lagt til %s</string>
-    <string name="address_city_required">Skriv inn byen din</string>
-    <string name="address_country_invalid">Landet er ugyldig</string>
-    <string name="address_county_required">Skriv inn fylket ditt</string>
-    <string name="address_label_address">Adresse</string>
-    <string name="address_label_address_line1">Adresselinje 1</string>
-    <string name="address_label_address_line1_optional">Adresselinje 1 (valgfritt)</string>
-    <string name="address_label_address_line2_optional">Adresselinje 2 (valgfritt)</string>
-    <string name="address_label_address_optional">Adresse (valgfritt)</string>
-    <string name="address_label_apt">Leil.</string>
-    <string name="address_label_apt_optional">Leil. (valgfritt)</string>
-    <string name="address_label_city">By</string>
-    <string name="address_label_city_optional">By (valgfritt)</string>
-    <string name="address_label_country">Land</string>
-    <string name="address_label_county">Fylke</string>
-    <string name="address_label_county_optional">Fylke (valgfritt)</string>
-    <string name="address_label_name">Navn</string>
-    <string name="address_label_phone_number">Telefonnummer</string>
-    <string name="address_label_phone_number_optional">Telefonnummer (valgfritt)</string>
-    <string name="address_label_postal_code">Postnummer</string>
-    <string name="address_label_postal_code_optional">Postnummer (valgfritt)</string>
-    <string name="address_label_postcode">Postnummer</string>
-    <string name="address_label_postcode_optional">Postnummer (valgfritt)</string>
-    <string name="address_label_province">Provins</string>
-    <string name="address_label_province_optional">Provins (valgfritt)</string>
-    <string name="address_label_region_generic">Stat / provins / region</string>
-    <string name="address_label_region_generic_optional">Stat / provins / region (valgfritt)</string>
-    <string name="address_label_state">Stat</string>
-    <string name="address_label_state_optional">Stat (valgfritt)</string>
-    <string name="address_label_zip_code">Postnummer</string>
-    <string name="address_label_zip_code_optional">Postnummer (valgfritt)</string>
-    <string name="address_label_zip_postal_code">Postnummer</string>
-    <string name="address_label_zip_postal_code_optional">Postnummer (valgfritt)</string>
-    <string name="address_name_required">Skriv inn navnet ditt</string>
-    <string name="address_phone_number_required">Skriv inn telefonnummeret ditt</string>
-    <string name="address_postal_code_invalid">Postnummeret ditt er ugyldig</string>
-    <string name="address_postcode_invalid">Postnummeret ditt er ugyldig</string>
-    <string name="address_province_required">Skriv inn provinsen din</string>
-    <string name="address_region_generic_required">Skriv inn din stat/provins/region</string>
-    <string name="address_required">Skriv inn adressen din</string>
-    <string name="address_shipping_address">Forsendelsesadresse</string>
-    <string name="address_state_required">Skriv inn stat</string>
-    <string name="address_zip_invalid">Postnummeret ditt er ugyldig.</string>
-    <string name="address_zip_postal_invalid">Postnummeret ditt er ugyldig</string>
-    <string name="becs_mandate_acceptance">
-    Ved å angi detaljer for bankkonto og bekrefte betalingen godtar du denne
-    forespørselen om direktedebitering og tjenesteavtalen for forespørsel om direktedebitering, og godkjenner at
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 bruker-ID-nummer for direktedebitering 507156
-    (“Stripe”) debiterer kontoen din gjennom Bulk Electronic Clearing System (BECS) på
-    vegne av %1$s (\"Forhandleren\") for alle beløp separat kommunisert deg
-    av Forhandleren. Du attesterer at du enten er kontoholder eller er autorisert til å
-    signere for kontoen vist ovenfor.
-    </string>
-    <string name="becs_widget_account_number">Kontonummer</string>
-    <string name="becs_widget_account_number_incomplete">Kontonummeret er ufullstendig.</string>
-    <string name="becs_widget_account_number_required">Kontonummer er påkrevd.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Du skrev inn ufullstendig BSB.</string>
-    <string name="becs_widget_bsb_invalid">Du skrev inn ugyldig BSB.</string>
-    <string name="becs_widget_email">E-postadresse</string>
-    <string name="becs_widget_email_invalid">E-postadressen er ugyldig.</string>
-    <string name="becs_widget_email_required">E-postadresse er påkrevd.</string>
-    <string name="becs_widget_name">Navn</string>
-    <string name="becs_widget_name_required">Navn er påkrevd.</string>
-    <string name="card_ending_in">%1$s som slutter på %2$s</string>
-    <string name="close">Lukk</string>
-    <string name="delete_payment_method">Slett betalingsmetode</string>
-    <string name="delete_payment_method_prompt_title">Slette betalingsmåte?</string>
-    <string name="expiry_date_hint">MM/ÅÅ</string>
-    <string name="expiry_label_short">Utløp</string>
-    <string name="fpx_bank_offline">%s – frakoblet</string>
-    <string name="incomplete_expiry_date">Kortets utløpsdato er ufullstendig.</string>
-    <string name="invalid_card_number">Kortnummeret er ugyldig.</string>
-    <string name="invalid_cvc">Kortets sikkerhetskode er ugyldig.</string>
-    <string name="invalid_expiry_month">Kortets utløpsmåned er ugyldig.</string>
-    <string name="invalid_expiry_year">Kortets utløpsår er ugyldig.</string>
-    <string name="invalid_shipping_information">Ugyldig leveringsadresse</string>
-    <string name="invalid_zip">Postnummeret er ufullstendig.</string>
-    <string name="no_payment_methods">Ingen betalingsmetoder.</string>
-    <string name="payment_method_add_new_card">Legg til nytt kort …</string>
-    <string name="payment_method_add_new_fpx">Velg bankkonto (FPX) …</string>
-    <string name="price_free">Gratis</string>
-    <string name="removed">Fjernet %s</string>
-    <string name="secure_checkout">Sikker utsjekking</string>
-    <string name="stripe_failure_connection_error">Det har oppstått et problem under tilkoblingen til betalingstjenesten. Kontroller Internett-forbindelsen og prøv igjen.</string>
-    <string name="stripe_failure_reason_authentication">Vi kan ikke godkjenne betalingsmåten din. Vennligst velg en annen betalingsmetode og prøv igjen.</string>
-    <string name="stripe_failure_reason_timed_out">Tidsavbrudd ved godkjennelse av betalingsmåten din - prøv igjen</string>
-    <string name="stripe_google_pay_error_internal">Det oppstod en intern feil.</string>
-    <string name="stripe_paymentsheet_add_button_label">Legg til</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjon</string>
-    <string name="stripe_paymentsheet_back">Tilbake</string>
-    <string name="stripe_paymentsheet_close">Lukk</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / ÅÅ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Betal %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Betal</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Behandler …</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre kortet til fremtidige betalinger hos %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Velg betalingsmetode</string>
-    <string name="stripe_paymentsheet_setup_button_label">Konfigurer</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verifiser betalingen din</string>
-    <string name="title_add_a_card">Legg til kort</string>
-    <string name="title_add_an_address">Angi adresse</string>
-    <string name="title_bank_account">Bankkonto</string>
-    <string name="title_payment_method">Betalingsmåte</string>
-    <string name="title_select_shipping_method">Velg forsendelsesmetode</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kortnummer</string>
+  <string name="acc_label_card_number_node">%s, kortnummer</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Utløpsdato</string>
+  <string name="acc_label_expiry_date_node">%s, utløpsdato</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">ZIP-kode</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Legg til et nytt debet- eller kredittkort for å gjøre kjøp i denne appen.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Lagt til %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Skriv inn byen din</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Landet er ugyldig</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Skriv inn fylket ditt</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adresselinje 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adresselinje 1 (valgfritt)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adresselinje 2 (valgfritt)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresse (valgfritt)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Leil. (valgfritt)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">By (valgfritt)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Fylke (valgfritt)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonnummer</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonnummer (valgfritt)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postnummer (valgfritt)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postnummer</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postnummer (valgfritt)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provins (valgfritt)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Stat / provins / region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Stat / provins / region (valgfritt)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stat (valgfritt)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Postnummer (valgfritt)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Postnummer</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Postnummer (valgfritt)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Skriv inn navnet ditt</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Skriv inn telefonnummeret ditt</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Postnummeret ditt er ugyldig</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Postnummeret ditt er ugyldig</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Skriv inn provinsen din</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Skriv inn din stat/provins/region</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Skriv inn adressen din</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Forsendelsesadresse</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Skriv inn stat</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Postnummeret ditt er ugyldig.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Postnummeret ditt er ugyldig</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Ved å angi detaljer for bankkonto og bekrefte betalingen godtar du denne\n    forespørselen om direktedebitering og tjenesteavtalen for forespørsel om direktedebitering, og godkjenner at\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 bruker-ID-nummer for direktedebitering 507156\n    (“Stripe”) debiterer kontoen din gjennom Bulk Electronic Clearing System (BECS) på\n    vegne av %1$s (\"Forhandleren\") for alle beløp separat kommunisert deg\n    av Forhandleren. Du attesterer at du enten er kontoholder eller er autorisert til å\n    signere for kontoen vist ovenfor.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Kontonummer</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Kontonummeret er ufullstendig.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Kontonummer er påkrevd.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Du skrev inn ufullstendig BSB.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Du skrev inn ugyldig BSB.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-postadresse</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">E-postadressen er ugyldig.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">E-postadresse er påkrevd.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Navn</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Navn er påkrevd.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s som slutter på %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Lukk</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Slett betalingsmetode</string>
+  <string name="delete_payment_method_prompt_title">Slette betalingsmåte?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/ÅÅ</string>
+  <string name="expiry_label_short">Utløp</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s – frakoblet</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Kortets utløpsdato er ufullstendig.</string>
+  <string name="invalid_card_number">Kortnummeret er ugyldig.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kortets sikkerhetskode er ugyldig.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Kortets utløpsmåned er ugyldig.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Kortets utløpsår er ugyldig.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Ugyldig leveringsadresse</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Postnummeret er ufullstendig.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Ingen betalingsmetoder.</string>
+  <string name="payment_method_add_new_card">Legg til nytt kort …</string>
+  <string name="payment_method_add_new_fpx">Velg bankkonto (FPX) …</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratis</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Fjernet %s</string>
+  <string name="secure_checkout">Sikker utsjekking</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Det har oppstått et problem under tilkoblingen til betalingstjenesten. Kontroller Internett-forbindelsen og prøv igjen.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Vi kan ikke godkjenne betalingsmåten din. Vennligst velg en annen betalingsmetode og prøv igjen.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Tidsavbrudd ved godkjennelse av betalingsmåten din - prøv igjen</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Det oppstod en intern feil.</string>
+  <string name="stripe_paymentsheet_add_button_label">Legg til</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjon</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Tilbake</string>
+  <string name="stripe_paymentsheet_close">Lukk</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / ÅÅ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Betal %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Betal</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Behandler …</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre kortet til fremtidige betalinger hos %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Velg betalingsmetode</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Konfigurer</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifiser betalingen din</string>
+  <string name="title_add_a_card">Legg til kort</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Angi adresse</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankkonto</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Betalingsmåte</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Velg forsendelsesmetode</string>
 </resources>

--- a/payments-core/res/values-nl/strings.xml
+++ b/payments-core/res/values-nl/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Kaartnummer</string>
-    <string name="acc_label_card_number_node">%s, kaartnummer</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Vervaldatum</string>
-    <string name="acc_label_expiry_date_node">%s, vervaldatum</string>
-    <string name="acc_label_zip">Postcode</string>
-    <string name="acc_label_zip_short">Postcode</string>
-    <string name="add_card">Voeg een nieuwe betaalkaart toe om aankopen te doen in deze app.</string>
-    <string name="added">%s toegevoegd</string>
-    <string name="address_city_required">Geef je plaats op</string>
-    <string name="address_country_invalid">Het land is ongeldig</string>
-    <string name="address_county_required">Geef je graafschap op</string>
-    <string name="address_label_address">Adres</string>
-    <string name="address_label_address_line1">Adresregel 1</string>
-    <string name="address_label_address_line1_optional">Adresregel 1 (optioneel)</string>
-    <string name="address_label_address_line2_optional">Adresregel 2 (optioneel)</string>
-    <string name="address_label_address_optional">Adres (optioneel) </string>
-    <string name="address_label_apt">App.</string>
-    <string name="address_label_apt_optional">App. (optioneel)</string>
-    <string name="address_label_city">Plaats</string>
-    <string name="address_label_city_optional">Plaats (optioneel)</string>
-    <string name="address_label_country">Land</string>
-    <string name="address_label_county">Graafschap</string>
-    <string name="address_label_county_optional">Graafschap (optioneel)</string>
-    <string name="address_label_name">Naam</string>
-    <string name="address_label_phone_number">Telefoonnummer</string>
-    <string name="address_label_phone_number_optional">Telefoonnummer (optioneel)</string>
-    <string name="address_label_postal_code">Postcode</string>
-    <string name="address_label_postal_code_optional">Postcode (optioneel)</string>
-    <string name="address_label_postcode">Postcode</string>
-    <string name="address_label_postcode_optional">Postcode (optioneel)</string>
-    <string name="address_label_province">Provincie</string>
-    <string name="address_label_province_optional">Provincie (optioneel)</string>
-    <string name="address_label_region_generic">Staat/provincie/regio</string>
-    <string name="address_label_region_generic_optional">Staat/provincie/regio (optioneel)</string>
-    <string name="address_label_state">Staat</string>
-    <string name="address_label_state_optional">Staat (optioneel)</string>
-    <string name="address_label_zip_code">Postcode</string>
-    <string name="address_label_zip_code_optional">Postcode (optioneel)</string>
-    <string name="address_label_zip_postal_code">Postcode</string>
-    <string name="address_label_zip_postal_code_optional">Postcode (optioneel)</string>
-    <string name="address_name_required">Geef je naam op</string>
-    <string name="address_phone_number_required">Geef je telefoonnummer op</string>
-    <string name="address_postal_code_invalid">Je postcode is ongeldig</string>
-    <string name="address_postcode_invalid">Je postcode is ongeldig</string>
-    <string name="address_province_required">Geef je provincie op</string>
-    <string name="address_region_generic_required">Geef je staat/provincie/regio op</string>
-    <string name="address_required">Geef je adres op</string>
-    <string name="address_shipping_address">Verzendadres</string>
-    <string name="address_state_required">Geef je staat op</string>
-    <string name="address_zip_invalid">Je postcode is ongeldig.</string>
-    <string name="address_zip_postal_invalid">Je postcode is ongeldig</string>
-    <string name="becs_mandate_acceptance">
-    Door je bankrekeninggegevens te verstrekken en deze betaling te bevestigen ga je akkoord met deze
-    aanvraag voor automatische incasso en de Direct Debit Request-serviceovereenkomst, en autoriseer je
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 met gebruikers-ID voor automatische incasso\'s 507156
-    (“Stripe”) om bedragen van je rekening af te schrijven via het BECS-systeem (Bulk Electronic Clearing System)
-    namens %1$s (de \"Handelaar\") voor bedragen die afzonderlijk door de handelaar
-    aan je kenbaar worden gemaakt. Je verklaart dat je de rekeninghouder bent van of bevoegd bent
-    om te tekenen voor de hierboven vermelde rekening.
-    </string>
-    <string name="becs_widget_account_number">Rekeningnummer</string>
-    <string name="becs_widget_account_number_incomplete">Je rekeningnummer is onvolledig.</string>
-    <string name="becs_widget_account_number_required">Je rekeningnummer is vereist.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Het ingevoerde BSB-nummer is onvolledig.</string>
-    <string name="becs_widget_bsb_invalid">Het ingevoerde BSB-nummer is ongeldig.</string>
-    <string name="becs_widget_email">E-mailadres</string>
-    <string name="becs_widget_email_invalid">Je e-mailadres is ongeldig.</string>
-    <string name="becs_widget_email_required">Je e-mailadres is vereist.</string>
-    <string name="becs_widget_name">Naam</string>
-    <string name="becs_widget_name_required">Je naam is vereist.</string>
-    <string name="card_ending_in">%1$s eindigend op %2$s</string>
-    <string name="close">Sluiten</string>
-    <string name="delete_payment_method">Betaalmethode verwijderen</string>
-    <string name="delete_payment_method_prompt_title">Betaalmethode verwijderen?</string>
-    <string name="expiry_date_hint">MM/JJ</string>
-    <string name="expiry_label_short">Vervaldatum</string>
-    <string name="fpx_bank_offline">%s - offline</string>
-    <string name="incomplete_expiry_date">De vervaldatum van je kaart is onvolledig.</string>
-    <string name="invalid_card_number">Het kaartnummer is ongeldig.</string>
-    <string name="invalid_cvc">De beveiligingscode van je kaart is ongeldig.</string>
-    <string name="invalid_expiry_month">De vervalmaand van de kaart is ongeldig.</string>
-    <string name="invalid_expiry_year">Het vervaljaar van de kaart is ongeldig.</string>
-    <string name="invalid_shipping_information">Ongeldig verzendadres</string>
-    <string name="invalid_zip">Je postcode is onvolledig.</string>
-    <string name="no_payment_methods">Geen betalingsmethoden.</string>
-    <string name="payment_method_add_new_card">Nieuwe kaart toevoegen…</string>
-    <string name="payment_method_add_new_fpx">Bankrekening selecteren (FPX)...</string>
-    <string name="price_free">Gratis</string>
-    <string name="removed">%s verwijderd</string>
-    <string name="secure_checkout">Beveiligd afrekenproces</string>
-    <string name="stripe_failure_connection_error">Er zijn momenteel problemen met de verbinding naar onze betalingsprovider. Controleer je internetverbinding en probeer het opnieuw.</string>
-    <string name="stripe_failure_reason_authentication">We kunnen de betaalmethode niet authenticeren. Kies een andere betaalmethode en probeer het nogmaals.</string>
-    <string name="stripe_failure_reason_timed_out">Time-out bij authenticatie van de betaalmethode. Probeer het nogmaals</string>
-    <string name="stripe_google_pay_error_internal">Er is een interne fout opgetreden.</string>
-    <string name="stripe_paymentsheet_add_button_label">Toevoegen</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Toevoegen</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Kaartgegevens</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land of regio</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Je betaalgegevens toevoegen</string>
-    <string name="stripe_paymentsheet_back">Terug</string>
-    <string name="stripe_paymentsheet_close">Sluiten</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / JJ</string>
-    <string name="stripe_paymentsheet_or_pay_using">Of betalen met</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Of met een kaart betalen</string>
-    <string name="stripe_paymentsheet_pay_button_amount">%s betalen</string>
-    <string name="stripe_paymentsheet_pay_button_label">Betaal</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Verwerken...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Deze kaart opslaan voor toekomstige aankopen bij %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Betaalmethode selecteren</string>
-    <string name="stripe_paymentsheet_setup_button_label">Instellen</string>
-    <string name="stripe_paymentsheet_total_amount">Totaal: %s</string>
-    <string name="stripe_verify_your_payment">Je betaling verifiëren</string>
-    <string name="title_add_a_card">Een kaart toevoegen</string>
-    <string name="title_add_an_address">Voeg een adres toe</string>
-    <string name="title_bank_account">Bankrekening</string>
-    <string name="title_payment_method">Betaalmethode</string>
-    <string name="title_select_shipping_method">Selecteer een verzendmethode</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Kaartnummer</string>
+  <string name="acc_label_card_number_node">%s, kaartnummer</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Vervaldatum</string>
+  <string name="acc_label_expiry_date_node">%s, vervaldatum</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Postcode</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Postcode</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Voeg een nieuwe betaalkaart toe om aankopen te doen in deze app.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s toegevoegd</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Geef je plaats op</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Het land is ongeldig</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Geef je graafschap op</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Adresregel 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Adresregel 1 (optioneel)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Adresregel 2 (optioneel)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adres (optioneel) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">App. (optioneel)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Plaats (optioneel)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Graafschap (optioneel)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefoonnummer</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefoonnummer (optioneel)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postcode (optioneel)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postcode</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postcode (optioneel)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincie (optioneel)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Staat/provincie/regio</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Staat/provincie/regio (optioneel)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Staat (optioneel)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Postcode (optioneel)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Postcode</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Postcode (optioneel)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Geef je naam op</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Geef je telefoonnummer op</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Je postcode is ongeldig</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Je postcode is ongeldig</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Geef je provincie op</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Geef je staat/provincie/regio op</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Geef je adres op</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Verzendadres</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Geef je staat op</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Je postcode is ongeldig.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Je postcode is ongeldig</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Door je bankrekeninggegevens te verstrekken en deze betaling te bevestigen ga je akkoord met deze\n    aanvraag voor automatische incasso en de Direct Debit Request-serviceovereenkomst, en autoriseer je\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 met gebruikers-ID voor automatische incasso\'s 507156\n    (“Stripe”) om bedragen van je rekening af te schrijven via het BECS-systeem (Bulk Electronic Clearing System)\n    namens %1$s (de \"Handelaar\") voor bedragen die afzonderlijk door de handelaar\n    aan je kenbaar worden gemaakt. Je verklaart dat je de rekeninghouder bent van of bevoegd bent\n    om te tekenen voor de hierboven vermelde rekening.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Rekeningnummer</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Je rekeningnummer is onvolledig.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Je rekeningnummer is vereist.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Het ingevoerde BSB-nummer is onvolledig.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Het ingevoerde BSB-nummer is ongeldig.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-mailadres</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Je e-mailadres is ongeldig.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Je e-mailadres is vereist.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Naam</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Je naam is vereist.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s eindigend op %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Sluiten</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Betaalmethode verwijderen</string>
+  <string name="delete_payment_method_prompt_title">Betaalmethode verwijderen?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/JJ</string>
+  <string name="expiry_label_short">Vervaldatum</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">De vervaldatum van je kaart is onvolledig.</string>
+  <string name="invalid_card_number">Het kaartnummer is ongeldig.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">De beveiligingscode van je kaart is ongeldig.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">De vervalmaand van de kaart is ongeldig.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Het vervaljaar van de kaart is ongeldig.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Ongeldig verzendadres</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Je postcode is onvolledig.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Geen betalingsmethoden.</string>
+  <string name="payment_method_add_new_card">Nieuwe kaart toevoegen…</string>
+  <string name="payment_method_add_new_fpx">Bankrekening selecteren (FPX)...</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratis</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s verwijderd</string>
+  <string name="secure_checkout">Beveiligd afrekenproces</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Er zijn momenteel problemen met de verbinding naar onze betalingsprovider. Controleer je internetverbinding en probeer het opnieuw.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">We kunnen de betaalmethode niet authenticeren. Kies een andere betaalmethode en probeer het nogmaals.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Time-out bij authenticatie van de betaalmethode. Probeer het nogmaals</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Er is een interne fout opgetreden.</string>
+  <string name="stripe_paymentsheet_add_button_label">Toevoegen</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Toevoegen</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaartgegevens</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land of regio</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Je betaalgegevens toevoegen</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Terug</string>
+  <string name="stripe_paymentsheet_close">Sluiten</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / JJ</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Of betalen met</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Of met een kaart betalen</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">%s betalen</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Betaal</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Verwerken...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Deze kaart opslaan voor toekomstige aankopen bij %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Betaalmethode selecteren</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Instellen</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Je betaling verifiëren</string>
+  <string name="title_add_a_card">Een kaart toevoegen</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Voeg een adres toe</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankrekening</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Betaalmethode</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selecteer een verzendmethode</string>
 </resources>

--- a/payments-core/res/values-nn-rNO/strings.xml
+++ b/payments-core/res/values-nn-rNO/strings.xml
@@ -2,191 +2,191 @@
 <resources>
   <!-- Label for card number entry text field -->
   <string name="acc_label_card_number">Kortnummer</string>
-  <string name="acc_label_card_number_node">%s, Kortnummer</string>
-  <string name="acc_label_cvc_node">%sCVC</string>
-  <string name="acc_label_expiry_date">Udløbsdato</string>
-  <string name="acc_label_expiry_date_node">%sUdløbsdato</string>
+  <string name="acc_label_card_number_node">%s, kortnummer</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Utløpsdato</string>
+  <string name="acc_label_expiry_date_node">%s, utløpsdato</string>
   <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
   <string name="acc_label_zip">Postnummer</string>
   <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
-  <string name="acc_label_zip_short">ZIP</string>
+  <string name="acc_label_zip_short">POSTNR.</string>
   <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
-  <string name="add_card">Tilføj et nyt hævekort eller kreditkort for at foretage køb i denne app.</string>
+  <string name="add_card">Legg til nytt debet- eller kredittkort for gjennomføre kjøp i denne appen.</string>
   <!-- Message displayed when a payment method is removed, stating its name. -->
-  <string name="added">Tilføjet %s</string>
+  <string name="added">Lagt til %s</string>
   <!-- Error text indicating that city is required, used for all locations -->
-  <string name="address_city_required">Indtast din by</string>
+  <string name="address_city_required">Skriv inn staden din</string>
   <!-- Error text indicating country is invalid -->
-  <string name="address_country_invalid">Dit land er ugyldigt</string>
+  <string name="address_country_invalid">Landet ditt er ugyldig</string>
   <!-- Error text indicating that county is required, used for UK addresses -->
-  <string name="address_county_required">Indtast dit county</string>
+  <string name="address_county_required">Skriv inn fylket ditt</string>
   <!-- Caption for Address field on address form -->
   <string name="address_label_address">Adresse</string>
   <!-- Address line 1 placeholder for billing address form. -->
   <string name="address_label_address_line1">Adresselinje 1</string>
   <!-- Label for input requesting the first line of an address where , used for international addresses -->
-  <string name="address_label_address_line1_optional">Adresselinje 1 (valgfrit)</string>
+  <string name="address_label_address_line1_optional">Adresselinje 1 (valfri)</string>
   <!-- Address line 2 placeholder for billing address form. -->
-  <string name="address_label_address_line2_optional">Adresselinje 2 (valgfrit)</string>
+  <string name="address_label_address_line2_optional">Adresselinje 2 (valfritt)</string>
   <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
-  <string name="address_label_address_optional">Adresse (valgfrit) </string>
+  <string name="address_label_address_optional">Adresse (valfri)</string>
   <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
-  <string name="address_label_apt_optional">Lejl. (valgfrit)</string>
+  <string name="address_label_apt_optional">Leilegheit (valfri)</string>
   <!-- Label for input requesting city where input is optional, used for all locations -->
-  <string name="address_label_city_optional">By (valgfrit)</string>
+  <string name="address_label_city_optional">Stad (valfri)</string>
   <!-- Label for input requesting county where input is optional , used for UK based addresses -->
-  <string name="address_label_county_optional">County (valgfrit)</string>
+  <string name="address_label_county_optional">Fylke (valfri)</string>
   <!-- Label for input requesting phone number, used for all locations -->
-  <string name="address_label_phone_number">Telefonnr.</string>
+  <string name="address_label_phone_number">Telefonnummer</string>
   <!-- Label for input requesting phone number where input is optional, used for all locations -->
-  <string name="address_label_phone_number_optional">Telefonnr. (valgfrit)</string>
+  <string name="address_label_phone_number_optional">Telefonnummer (valfri)</string>
   <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
-  <string name="address_label_postal_code_optional">Postnr. (valgfrit)</string>
+  <string name="address_label_postal_code_optional">Postnummer (valfri)</string>
   <!-- Label for input requesting postcode, used for UK based addresses -->
-  <string name="address_label_postcode">Postnr.</string>
+  <string name="address_label_postcode">Postnummer</string>
   <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
-  <string name="address_label_postcode_optional">Postnr. (valgfrit)</string>
+  <string name="address_label_postcode_optional">Postnummer (valfri)</string>
   <!-- Label for input requesting province where province is optional, used for canadian addresses -->
-  <string name="address_label_province_optional">Provins (valgfrit)</string>
+  <string name="address_label_province_optional">Område (valfri)</string>
   <!-- Label for input requesting the region, used for international addresses -->
-  <string name="address_label_region_generic">Stat/provins/region</string>
+  <string name="address_label_region_generic">Stat/område/region</string>
   <!-- Label for input requesting the region where input is optional, used for international addresses -->
-  <string name="address_label_region_generic_optional">Stat/provins/region (valgfrit)</string>
+  <string name="address_label_region_generic_optional">Stat/område/region (valfri)</string>
   <!-- Label for input requesting state where input is optional, used for US based addresses -->
-  <string name="address_label_state_optional">Stat (valgfrit)</string>
+  <string name="address_label_state_optional">Stat (valfri)</string>
   <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
-  <string name="address_label_zip_code_optional">ZIP-kode (valgfrit)</string>
+  <string name="address_label_zip_code_optional">Postnummer (valfri)</string>
   <!-- Label for input requesting postal code, used for international addresses -->
-  <string name="address_label_zip_postal_code">ZIP-kode/Postnr.</string>
+  <string name="address_label_zip_postal_code">Postnummer</string>
   <!-- Label for input requesting postal code where input is optional, used for international addresses -->
-  <string name="address_label_zip_postal_code_optional">ZIP-kode/Postnr. (valgfrit)</string>
+  <string name="address_label_zip_postal_code_optional">Postnummer (valfri)</string>
   <!-- Error text indicating name is required -->
-  <string name="address_name_required">Indtast dit navn</string>
+  <string name="address_name_required">Skriv inn namnet ditt</string>
   <!-- Error text indicating that phone number is required, used for all addresses -->
-  <string name="address_phone_number_required">Indtast dit telefonnr.</string>
+  <string name="address_phone_number_required">Skriv inn telefonnummeret ditt</string>
   <!-- Error text indicating postal code is invalid, used for Canada addresses -->
-  <string name="address_postal_code_invalid">Postnummeret er ugyldigt.</string>
+  <string name="address_postal_code_invalid">Postnummeret ditt er ugyldig</string>
   <!-- Error text indicating postcode is invalid, used for UK addresses -->
-  <string name="address_postcode_invalid">Postnummeret er ugyldigt.</string>
+  <string name="address_postcode_invalid">Postnummeret ditt er ugyldig</string>
   <!-- Error text indicating that province is required, used for Canada addresses -->
-  <string name="address_province_required">Indtast din provins</string>
+  <string name="address_province_required">Skriv inn området ditt</string>
   <!-- Error text indicating that region is required, used for international addresses -->
-  <string name="address_region_generic_required">Indtast din stat/provins/region</string>
+  <string name="address_region_generic_required">Skriv inn stat/område/region</string>
   <!-- Error text indicating that address is required, used for all locations -->
-  <string name="address_required">Indtast din adresse</string>
+  <string name="address_required">Skriv inn adressen din</string>
   <!-- Title for shipping address entry section -->
-  <string name="address_shipping_address">Forsendelsesadresse</string>
+  <string name="address_shipping_address">Sendingsadresse</string>
   <!-- Error text indicating that state is required, used for US addresses -->
-  <string name="address_state_required">Indtast din stat</string>
+  <string name="address_state_required">Skriv inn staten</string>
   <!-- Error text indicating zip code is invalid, used for US addresses -->
-  <string name="address_zip_invalid">ZIP-koden er ugyldig.</string>
+  <string name="address_zip_invalid">Postnummeret ditt er ugyldig.</string>
   <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
-  <string name="address_zip_postal_invalid">ZIP-kode/Postnr. er ugyldigt</string>
+  <string name="address_zip_postal_invalid">Postnummeret ditt er ugyldig</string>
   <!-- BECS Debit Widget - mandate acceptance -->
-  <string name="becs_mandate_acceptance">\n    Ved at angive dine bankoplysninger og bekræfte denne betaling accepterer du denne\n    direkte debiteringsanmodning og debiteringsanmodningens serviceaftale og autoriserer \n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direkte debiterings-bruger-ID 507156\n    (“Stripe”) til at debitere din konto via Bulk Electronic Clearing System (BECS) på \n    vegne af %1$s (“forhandler”) for eventuelle beløb, der separat meddeles dig af\n    forhandleren. Du bekræfter, at du enten er en kontoindehaver eller en\n    autoriseret underskriver på den konto, der er anført ovenfor.\n    </string>
+  <string name="becs_mandate_acceptance">\n    Ved å angje detaljar for bankkonto og stadfeste betalinga, godtek du denne\n    førespurnaden om direktedebitering og tenesteavtalen for førespurnaden om direktedebitering, og gjev\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 brukar-ID-nummer for direktedebitering 507156\n    (“Stripe”) løyve til å debitere kontoen din gjennom Bulk Electronic Clearing System (BECS)\n    på vegner av %1$s (\"forhandlaren\") for eitkvart beløp forhandlaren har\n    kommunisert separat til deg. Du attesterer at du anten er kontoinnehavar\n    eller har signaturrett på den oppgjevne kontoen.\n    </string>
   <!-- Placeholder text for Account number entry field for BECS Debit. -->
   <string name="becs_widget_account_number">Kontonummer</string>
   <!-- BECS Debit Widget - account number field - incomplete error message -->
-  <string name="becs_widget_account_number_incomplete">Dit kontonummer er ikke komplet.</string>
+  <string name="becs_widget_account_number_incomplete">Kontonummeret ditt er ufullstendig.</string>
   <!-- BECS Debit Widget - account number field - required error message -->
-  <string name="becs_widget_account_number_required">Dit kontonummer er påkrævet.</string>
+  <string name="becs_widget_account_number_required">Kontonummer er påkravd.</string>
   <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
-  <string name="becs_widget_bsb">BSB</string>
+  <string name="becs_widget_bsb">BSB-kode</string>
   <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
-  <string name="becs_widget_bsb_incomplete">Den BSB, du angav, er ufuldstændig.</string>
+  <string name="becs_widget_bsb_incomplete">BSB-koden du skreiv inn er ufullstendig.</string>
   <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
-  <string name="becs_widget_bsb_invalid">Den BSB, du angav, er ugyldig.</string>
+  <string name="becs_widget_bsb_invalid">BSB-koden du skreiv inn er ugyldig.</string>
   <!-- BECS Debit Widget - email address field - label -->
-  <string name="becs_widget_email">E-mailadresse.</string>
+  <string name="becs_widget_email">E-postadresse</string>
   <!-- BECS Debit Widget - email address field - invalid error message -->
-  <string name="becs_widget_email_invalid">Din e-mailadresse er ugyldig.</string>
+  <string name="becs_widget_email_invalid">E-postadressen din er ugyldig</string>
   <!-- BECS Debit Widget - email address field - required error message -->
-  <string name="becs_widget_email_required">Din e-mail er påkrævet.</string>
+  <string name="becs_widget_email_required">E-postadresse er påkravd.</string>
   <!-- BECS Debit Widget - name field - label -->
-  <string name="becs_widget_name">Navn</string>
+  <string name="becs_widget_name">Namn</string>
   <!-- BECS Debit Widget - name field - required error message -->
-  <string name="becs_widget_name_required">Dit navn er påkrævet.</string>
+  <string name="becs_widget_name_required">Namn er påkravd.</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
-  <string name="card_ending_in">%1$s slutter på %2$s</string>
+  <string name="card_ending_in">%1$s sluttar på %2$s</string>
   <!-- Text for close button -->
-  <string name="close">Luk</string>
+  <string name="close">Lukk</string>
   <!-- Accessibility action for deleting a payment method -->
-  <string name="delete_payment_method">Slet betalingsmetode</string>
-  <string name="delete_payment_method_prompt_title">Slet betalingsmetode?</string>
+  <string name="delete_payment_method">Slett betalingsmåte</string>
+  <string name="delete_payment_method_prompt_title">Slette betalingsmåte?</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
-  <string name="expiry_label_short">Udløbsdato</string>
+  <string name="expiry_label_short">Utløp</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
-  <string name="fpx_bank_offline">%s -Offline</string>
+  <string name="fpx_bank_offline">%s - fråkopla</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
-  <string name="incomplete_expiry_date">Dit korts udløbsdato er ikke fuldendt.</string>
-  <string name="invalid_card_number">Nummeret på dit kort er ugyldigt.</string>
+  <string name="incomplete_expiry_date">Utløpsdatoen til kortet er ufullstendig.</string>
+  <string name="invalid_card_number">Kortnummeret ditt er ugyldig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
-  <string name="invalid_cvc">Dit korts sikkerhedskode er ugyldig.</string>
+  <string name="invalid_cvc">Sikkerheitskoden til kortet er ugyldig.</string>
   <!-- String to describe an invalid month in expiry date. -->
-  <string name="invalid_expiry_month">Kortets udløbsmåned er ugyldig.</string>
+  <string name="invalid_expiry_month">Utløpsdatoen på kortet ditt er ugyldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
-  <string name="invalid_expiry_year">Dit korts udløbsår er ugyldigt.</string>
+  <string name="invalid_expiry_year">Utløpsåret på kortet ditt er ugyldig.</string>
   <!-- Shipping form error message -->
-  <string name="invalid_shipping_information">Ugyldig forsendelsesadresse</string>
+  <string name="invalid_shipping_information">Ugyldig sendingsadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
-  <string name="invalid_zip">Dit postnummer er ikke fuldendt.</string>
+  <string name="invalid_zip">Postnummeret er ufullstendig.</string>
   <!-- Text informing user there are no existing payment methods in the application -->
-  <string name="no_payment_methods">Ingen betalingsmetoder.</string>
-  <string name="payment_method_add_new_card">Tilføj nyt kort...</string>
-  <string name="payment_method_add_new_fpx">Vælg bankkonto (FPX)...</string>
+  <string name="no_payment_methods">Ingen betalingsmetodar.</string>
+  <string name="payment_method_add_new_card">Legg til nytt kort...</string>
+  <string name="payment_method_add_new_fpx">Vel bankkonto (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
   <!-- Message displayed when a payment method is removed, stating its name. -->
-  <string name="removed">Slettet %s</string>
-  <string name="secure_checkout">Sikker Checkout</string>
+  <string name="removed">Fjerna %s</string>
+  <string name="secure_checkout">Sikker utsjekking</string>
   <!-- Generic error message shown when payment cannot be processed. -->
-  <string name="stripe_failure_connection_error">Vi har problemer med at oprette forbindelse til vores betalingsudbyder. Kontroller din internetforbindelse, og prøv igen.</string>
+  <string name="stripe_failure_connection_error">Vi har problem med å kople til betalingsleverandøren vår. Sjekk tilkoplinga til internett og prøv på nytt.</string>
   <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
-  <string name="stripe_failure_reason_authentication">Vi kunne ikke bekræfte din betalingsmetode. Vælg venligst en anden betalingsmetode, og prøv igen.</string>
+  <string name="stripe_failure_reason_authentication">Vi kan ikkje godkjenne betalingsmåten. Ver vennleg å velje ein annan betalingsmetode og prøv på nytt.</string>
   <!-- Error when 3DS2 authentication timed out. -->
-  <string name="stripe_failure_reason_timed_out">Bekræftelsen af din betalingsmetode udløb -- prøv igen.</string>
+  <string name="stripe_failure_reason_timed_out">Tidsavbrot ved godkjenning av betalingsmåten - prøv på nytt</string>
   <!-- When an internal error is reported when a google pay payment is started. -->
-  <string name="stripe_google_pay_error_internal">Der opstod en intern fejl.</string>
-  <string name="stripe_paymentsheet_add_button_label">Tilføj</string>
+  <string name="stripe_google_pay_error_internal">Ein intern feil oppstod.</string>
+  <string name="stripe_paymentsheet_add_button_label">Legg til</string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
-  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tilføj</string>
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortoplysninger</string>
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
-  <string name="stripe_paymentsheet_add_payment_method_title">Tilføj dine betalingsoplysninger</string>
+  <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjonen din</string>
   <!-- Text for back button -->
-  <string name="stripe_paymentsheet_back">Tilbage</string>
-  <string name="stripe_paymentsheet_close">Luk</string>
+  <string name="stripe_paymentsheet_back">Tilbake</string>
+  <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- label for text field to enter card expiry -->
-  <string name="stripe_paymentsheet_expiration_date_hint">MM/ÅÅ</string>
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / ÅÅ</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
-  <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
+  <string name="stripe_paymentsheet_or_pay_using">Eller betal ved å bruke</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
-  <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
+  <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med eit kort</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_paymentsheet_pay_button_amount">Betal %s</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
-  <string name="stripe_paymentsheet_primary_button_processing">Behandler...</string>
+  <string name="stripe_paymentsheet_primary_button_processing">Behandlar …</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
-  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Gem dette kort til fremtidige %s betalinger</string>
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre dette kortet for framtidige %s betalingar</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
-  <string name="stripe_paymentsheet_select_payment_method">Vælg din betalingsmetode</string>
+  <string name="stripe_paymentsheet_select_payment_method">Vel betalingsmåte</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
-  <string name="stripe_paymentsheet_setup_button_label">Opsætning</string>
+  <string name="stripe_paymentsheet_setup_button_label">Opprett</string>
   <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
-  <string name="stripe_verify_your_payment">Bekræft din betaling</string>
-  <string name="title_add_a_card">Tilføj et kort</string>
+  <string name="stripe_verify_your_payment">Verifiser betalinga di</string>
+  <string name="title_add_a_card">Legg til kort</string>
   <!-- Screen title telling users they should add an address -->
-  <string name="title_add_an_address">Tilføj en adresse</string>
+  <string name="title_add_an_address">Oppgi adresse</string>
   <!-- Label for Bank Account selection or detail entry form -->
   <string name="title_bank_account">Bankkonto</string>
   <!-- Title for Payment Method screen -->
   <string name="title_payment_method">Betalingsmetode</string>
   <!-- Screen title telling users they should select a shipping address -->
-  <string name="title_select_shipping_method">Vælg forsendelsesmetode</string>
+  <string name="title_select_shipping_method">Vel sendingsmåte</string>
 </resources>

--- a/payments-core/res/values-no/strings.xml
+++ b/payments-core/res/values-no/strings.xml
@@ -2,191 +2,191 @@
 <resources>
   <!-- Label for card number entry text field -->
   <string name="acc_label_card_number">Kortnummer</string>
-  <string name="acc_label_card_number_node">%s, Kortnummer</string>
-  <string name="acc_label_cvc_node">%sCVC</string>
-  <string name="acc_label_expiry_date">Udløbsdato</string>
-  <string name="acc_label_expiry_date_node">%sUdløbsdato</string>
+  <string name="acc_label_card_number_node">%s, kortnummer</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Utløpsdato</string>
+  <string name="acc_label_expiry_date_node">%s, utløpsdato</string>
   <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
   <string name="acc_label_zip">Postnummer</string>
   <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
-  <string name="acc_label_zip_short">ZIP</string>
+  <string name="acc_label_zip_short">Pstnr</string>
   <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
-  <string name="add_card">Tilføj et nyt hævekort eller kreditkort for at foretage køb i denne app.</string>
+  <string name="add_card">Legg inn et nytt debet- eller kredittkort for å foreta kjøp i denne appen.</string>
   <!-- Message displayed when a payment method is removed, stating its name. -->
-  <string name="added">Tilføjet %s</string>
+  <string name="added">Lagt til %s</string>
   <!-- Error text indicating that city is required, used for all locations -->
-  <string name="address_city_required">Indtast din by</string>
+  <string name="address_city_required">Skriv inn navnet på byen din</string>
   <!-- Error text indicating country is invalid -->
-  <string name="address_country_invalid">Dit land er ugyldigt</string>
+  <string name="address_country_invalid">Landet ditt er ugyldig</string>
   <!-- Error text indicating that county is required, used for UK addresses -->
-  <string name="address_county_required">Indtast dit county</string>
+  <string name="address_county_required">Skriv inn navnet på fylket ditt</string>
   <!-- Caption for Address field on address form -->
   <string name="address_label_address">Adresse</string>
   <!-- Address line 1 placeholder for billing address form. -->
   <string name="address_label_address_line1">Adresselinje 1</string>
   <!-- Label for input requesting the first line of an address where , used for international addresses -->
-  <string name="address_label_address_line1_optional">Adresselinje 1 (valgfrit)</string>
+  <string name="address_label_address_line1_optional">Adresselinje 1 (valgfritt)</string>
   <!-- Address line 2 placeholder for billing address form. -->
-  <string name="address_label_address_line2_optional">Adresselinje 2 (valgfrit)</string>
+  <string name="address_label_address_line2_optional">Adresselinje 2 (valgfritt)</string>
   <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
-  <string name="address_label_address_optional">Adresse (valgfrit) </string>
+  <string name="address_label_address_optional">Adresse (valgfritt) </string>
   <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
-  <string name="address_label_apt_optional">Lejl. (valgfrit)</string>
+  <string name="address_label_apt_optional">Bolignummer (valgfritt)</string>
   <!-- Label for input requesting city where input is optional, used for all locations -->
-  <string name="address_label_city_optional">By (valgfrit)</string>
+  <string name="address_label_city_optional">By/sted (valgfritt)</string>
   <!-- Label for input requesting county where input is optional , used for UK based addresses -->
-  <string name="address_label_county_optional">County (valgfrit)</string>
+  <string name="address_label_county_optional">Fylke (valgfritt)</string>
   <!-- Label for input requesting phone number, used for all locations -->
-  <string name="address_label_phone_number">Telefonnr.</string>
+  <string name="address_label_phone_number">Telefonnummer</string>
   <!-- Label for input requesting phone number where input is optional, used for all locations -->
-  <string name="address_label_phone_number_optional">Telefonnr. (valgfrit)</string>
+  <string name="address_label_phone_number_optional">Telefonnummer (valgfritt)</string>
   <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
-  <string name="address_label_postal_code_optional">Postnr. (valgfrit)</string>
+  <string name="address_label_postal_code_optional">Postnummer (valgfritt)</string>
   <!-- Label for input requesting postcode, used for UK based addresses -->
-  <string name="address_label_postcode">Postnr.</string>
+  <string name="address_label_postcode">Postnummer</string>
   <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
-  <string name="address_label_postcode_optional">Postnr. (valgfrit)</string>
+  <string name="address_label_postcode_optional">Postnummer (valgfritt)</string>
   <!-- Label for input requesting province where province is optional, used for canadian addresses -->
-  <string name="address_label_province_optional">Provins (valgfrit)</string>
+  <string name="address_label_province_optional">Provins (valgfritt)</string>
   <!-- Label for input requesting the region, used for international addresses -->
-  <string name="address_label_region_generic">Stat/provins/region</string>
+  <string name="address_label_region_generic">Delstat/provins/region</string>
   <!-- Label for input requesting the region where input is optional, used for international addresses -->
-  <string name="address_label_region_generic_optional">Stat/provins/region (valgfrit)</string>
+  <string name="address_label_region_generic_optional">Delstat/provins/region (valgfritt)</string>
   <!-- Label for input requesting state where input is optional, used for US based addresses -->
-  <string name="address_label_state_optional">Stat (valgfrit)</string>
+  <string name="address_label_state_optional">Delstat (valgfritt)</string>
   <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
-  <string name="address_label_zip_code_optional">ZIP-kode (valgfrit)</string>
+  <string name="address_label_zip_code_optional">Postnummer (valgfritt)</string>
   <!-- Label for input requesting postal code, used for international addresses -->
-  <string name="address_label_zip_postal_code">ZIP-kode/Postnr.</string>
+  <string name="address_label_zip_postal_code">Postnummer</string>
   <!-- Label for input requesting postal code where input is optional, used for international addresses -->
-  <string name="address_label_zip_postal_code_optional">ZIP-kode/Postnr. (valgfrit)</string>
+  <string name="address_label_zip_postal_code_optional">Postnummer (valgfritt)</string>
   <!-- Error text indicating name is required -->
-  <string name="address_name_required">Indtast dit navn</string>
+  <string name="address_name_required">Skriv inn navnet ditt</string>
   <!-- Error text indicating that phone number is required, used for all addresses -->
-  <string name="address_phone_number_required">Indtast dit telefonnr.</string>
+  <string name="address_phone_number_required">Skriv inn telefonnummeret ditt</string>
   <!-- Error text indicating postal code is invalid, used for Canada addresses -->
-  <string name="address_postal_code_invalid">Postnummeret er ugyldigt.</string>
+  <string name="address_postal_code_invalid">Postnummeret er ugyldig</string>
   <!-- Error text indicating postcode is invalid, used for UK addresses -->
-  <string name="address_postcode_invalid">Postnummeret er ugyldigt.</string>
+  <string name="address_postcode_invalid">Postnummeret er ugyldig</string>
   <!-- Error text indicating that province is required, used for Canada addresses -->
-  <string name="address_province_required">Indtast din provins</string>
+  <string name="address_province_required">Skriv inn provinsen din</string>
   <!-- Error text indicating that region is required, used for international addresses -->
-  <string name="address_region_generic_required">Indtast din stat/provins/region</string>
+  <string name="address_region_generic_required">Skriv inn delstaten/provinsen/regionen din</string>
   <!-- Error text indicating that address is required, used for all locations -->
-  <string name="address_required">Indtast din adresse</string>
+  <string name="address_required">Skriv inn adressen din</string>
   <!-- Title for shipping address entry section -->
-  <string name="address_shipping_address">Forsendelsesadresse</string>
+  <string name="address_shipping_address">Leveringsadresse</string>
   <!-- Error text indicating that state is required, used for US addresses -->
-  <string name="address_state_required">Indtast din stat</string>
+  <string name="address_state_required">Skriv inn delstaten din</string>
   <!-- Error text indicating zip code is invalid, used for US addresses -->
-  <string name="address_zip_invalid">ZIP-koden er ugyldig.</string>
+  <string name="address_zip_invalid">Postnummeret er ugyldig.</string>
   <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
-  <string name="address_zip_postal_invalid">ZIP-kode/Postnr. er ugyldigt</string>
+  <string name="address_zip_postal_invalid">Postnummeret er ugyldig</string>
   <!-- BECS Debit Widget - mandate acceptance -->
-  <string name="becs_mandate_acceptance">\n    Ved at angive dine bankoplysninger og bekræfte denne betaling accepterer du denne\n    direkte debiteringsanmodning og debiteringsanmodningens serviceaftale og autoriserer \n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direkte debiterings-bruger-ID 507156\n    (“Stripe”) til at debitere din konto via Bulk Electronic Clearing System (BECS) på \n    vegne af %1$s (“forhandler”) for eventuelle beløb, der separat meddeles dig af\n    forhandleren. Du bekræfter, at du enten er en kontoindehaver eller en\n    autoriseret underskriver på den konto, der er anført ovenfor.\n    </string>
+  <string name="becs_mandate_acceptance">\n    Ved å angje detaljar for bankkonto og stadfeste betalinga, godtek du denne\n    førespurnaden om direktedebitering og tenesteavtalen for førespurnaden om direktedebitering, og gjev\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 brukar-ID-nummer for direktedebitering 507156\n    (“Stripe”) løyve til å debitere kontoen din gjennom Bulk Electronic Clearing System (BECS)\n    på vegner av %1$s (\"forhandlaren\") for eitkvart beløp forhandlaren har\n    kommunisert separat til deg. Du attesterer at du anten er kontoinnehavar\n    eller har signaturrett på den oppgjevne kontoen.\n    </string>
   <!-- Placeholder text for Account number entry field for BECS Debit. -->
   <string name="becs_widget_account_number">Kontonummer</string>
   <!-- BECS Debit Widget - account number field - incomplete error message -->
-  <string name="becs_widget_account_number_incomplete">Dit kontonummer er ikke komplet.</string>
+  <string name="becs_widget_account_number_incomplete">Kontonummeret ditt er ufullstendig.</string>
   <!-- BECS Debit Widget - account number field - required error message -->
-  <string name="becs_widget_account_number_required">Dit kontonummer er påkrævet.</string>
+  <string name="becs_widget_account_number_required">Kontonummer er påkravd.</string>
   <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
   <string name="becs_widget_bsb">BSB</string>
   <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
-  <string name="becs_widget_bsb_incomplete">Den BSB, du angav, er ufuldstændig.</string>
+  <string name="becs_widget_bsb_incomplete">Du skreiv inn ein ufullstendig BSB.</string>
   <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
-  <string name="becs_widget_bsb_invalid">Den BSB, du angav, er ugyldig.</string>
+  <string name="becs_widget_bsb_invalid">Du skreiv inn ein ugyldig BSB.</string>
   <!-- BECS Debit Widget - email address field - label -->
-  <string name="becs_widget_email">E-mailadresse.</string>
+  <string name="becs_widget_email">E-postadresse</string>
   <!-- BECS Debit Widget - email address field - invalid error message -->
-  <string name="becs_widget_email_invalid">Din e-mailadresse er ugyldig.</string>
+  <string name="becs_widget_email_invalid">E-postadressen din er ugyldig</string>
   <!-- BECS Debit Widget - email address field - required error message -->
-  <string name="becs_widget_email_required">Din e-mail er påkrævet.</string>
+  <string name="becs_widget_email_required">E-postadresse er påkravd.</string>
   <!-- BECS Debit Widget - name field - label -->
-  <string name="becs_widget_name">Navn</string>
+  <string name="becs_widget_name">Namn</string>
   <!-- BECS Debit Widget - name field - required error message -->
-  <string name="becs_widget_name_required">Dit navn er påkrævet.</string>
+  <string name="becs_widget_name_required">Namn er påkravd.</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
-  <string name="card_ending_in">%1$s slutter på %2$s</string>
+  <string name="card_ending_in">%1$s sluttar på %2$s</string>
   <!-- Text for close button -->
-  <string name="close">Luk</string>
+  <string name="close">Lukk</string>
   <!-- Accessibility action for deleting a payment method -->
-  <string name="delete_payment_method">Slet betalingsmetode</string>
-  <string name="delete_payment_method_prompt_title">Slet betalingsmetode?</string>
+  <string name="delete_payment_method">Slett betalingsmåte</string>
+  <string name="delete_payment_method_prompt_title">Slette betalingsmåte?</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
-  <string name="expiry_label_short">Udløbsdato</string>
+  <string name="expiry_label_short">Utløpsdato</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
-  <string name="fpx_bank_offline">%s -Offline</string>
+  <string name="fpx_bank_offline">%s – Fråkopla</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
-  <string name="incomplete_expiry_date">Dit korts udløbsdato er ikke fuldendt.</string>
-  <string name="invalid_card_number">Nummeret på dit kort er ugyldigt.</string>
+  <string name="incomplete_expiry_date">Utløpsdatoen for kortet ditt er ufullstendig.</string>
+  <string name="invalid_card_number">Kortnummeret ditt er ugyldig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
-  <string name="invalid_cvc">Dit korts sikkerhedskode er ugyldig.</string>
+  <string name="invalid_cvc">Sikkerhetskoden til kortet ditt er ugyldig.</string>
   <!-- String to describe an invalid month in expiry date. -->
-  <string name="invalid_expiry_month">Kortets udløbsmåned er ugyldig.</string>
+  <string name="invalid_expiry_month">Utløpsmåneden for kortet ditt er ugyldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
-  <string name="invalid_expiry_year">Dit korts udløbsår er ugyldigt.</string>
+  <string name="invalid_expiry_year">Utløpsåret for kortet ditt er ugyldig.</string>
   <!-- Shipping form error message -->
-  <string name="invalid_shipping_information">Ugyldig forsendelsesadresse</string>
+  <string name="invalid_shipping_information">Ugyldig leveringsadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
-  <string name="invalid_zip">Dit postnummer er ikke fuldendt.</string>
+  <string name="invalid_zip">Postnummeret ditt er ufullstendig.</string>
   <!-- Text informing user there are no existing payment methods in the application -->
-  <string name="no_payment_methods">Ingen betalingsmetoder.</string>
-  <string name="payment_method_add_new_card">Tilføj nyt kort...</string>
-  <string name="payment_method_add_new_fpx">Vælg bankkonto (FPX)...</string>
+  <string name="no_payment_methods">Ingen betalingsmåter.</string>
+  <string name="payment_method_add_new_card">Legg til nytt kort …</string>
+  <string name="payment_method_add_new_fpx">Vel bankkonto (FPX) ...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
   <!-- Message displayed when a payment method is removed, stating its name. -->
-  <string name="removed">Slettet %s</string>
-  <string name="secure_checkout">Sikker Checkout</string>
+  <string name="removed">Fjerna %s</string>
+  <string name="secure_checkout">Sikker betaling</string>
   <!-- Generic error message shown when payment cannot be processed. -->
-  <string name="stripe_failure_connection_error">Vi har problemer med at oprette forbindelse til vores betalingsudbyder. Kontroller din internetforbindelse, og prøv igen.</string>
+  <string name="stripe_failure_connection_error">Det oppstod et problem med å koble til betalingstilbyderen. Kontroller Internett-tilkoblingen og prøv igjen.</string>
   <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
-  <string name="stripe_failure_reason_authentication">Vi kunne ikke bekræfte din betalingsmetode. Vælg venligst en anden betalingsmetode, og prøv igen.</string>
+  <string name="stripe_failure_reason_authentication">Vi kunne ikkje autentisere betalingsmåten din. Vel ein annan betalingsmåte og prøv igjen.</string>
   <!-- Error when 3DS2 authentication timed out. -->
-  <string name="stripe_failure_reason_timed_out">Bekræftelsen af din betalingsmetode udløb -- prøv igen.</string>
+  <string name="stripe_failure_reason_timed_out">Tidsavbrott for autentisering av betalingsmåten din – prøv igjen</string>
   <!-- When an internal error is reported when a google pay payment is started. -->
-  <string name="stripe_google_pay_error_internal">Der opstod en intern fejl.</string>
-  <string name="stripe_paymentsheet_add_button_label">Tilføj</string>
+  <string name="stripe_google_pay_error_internal">Ein intern feil oppstod.</string>
+  <string name="stripe_paymentsheet_add_button_label">Legg til</string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
-  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tilføj</string>
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortoplysninger</string>
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
-  <string name="stripe_paymentsheet_add_payment_method_title">Tilføj dine betalingsoplysninger</string>
+  <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjon</string>
   <!-- Text for back button -->
-  <string name="stripe_paymentsheet_back">Tilbage</string>
-  <string name="stripe_paymentsheet_close">Luk</string>
+  <string name="stripe_paymentsheet_back">Tilbake</string>
+  <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- label for text field to enter card expiry -->
   <string name="stripe_paymentsheet_expiration_date_hint">MM/ÅÅ</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
-  <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
+  <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med eit kort</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_paymentsheet_pay_button_amount">Betal %s</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
-  <string name="stripe_paymentsheet_primary_button_processing">Behandler...</string>
+  <string name="stripe_paymentsheet_primary_button_processing">Handsamar ...</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
-  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Gem dette kort til fremtidige %s betalinger</string>
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre dette kortet for framtidige %s betalingar</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
-  <string name="stripe_paymentsheet_select_payment_method">Vælg din betalingsmetode</string>
+  <string name="stripe_paymentsheet_select_payment_method">Vel betalingsmåte</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
-  <string name="stripe_paymentsheet_setup_button_label">Opsætning</string>
+  <string name="stripe_paymentsheet_setup_button_label">Konfigurer</string>
   <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
-  <string name="stripe_verify_your_payment">Bekræft din betaling</string>
-  <string name="title_add_a_card">Tilføj et kort</string>
+  <string name="stripe_verify_your_payment">Verifiser betalinga di</string>
+  <string name="title_add_a_card">Legg til eit kort</string>
   <!-- Screen title telling users they should add an address -->
-  <string name="title_add_an_address">Tilføj en adresse</string>
+  <string name="title_add_an_address">Legg inn en adresse</string>
   <!-- Label for Bank Account selection or detail entry form -->
   <string name="title_bank_account">Bankkonto</string>
   <!-- Title for Payment Method screen -->
-  <string name="title_payment_method">Betalingsmetode</string>
+  <string name="title_payment_method">Betalingsmåte</string>
   <!-- Screen title telling users they should select a shipping address -->
-  <string name="title_select_shipping_method">Vælg forsendelsesmetode</string>
+  <string name="title_select_shipping_method">Velg forsendelsesmetode</string>
 </resources>

--- a/payments-core/res/values-pl-rPL/strings.xml
+++ b/payments-core/res/values-pl-rPL/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Nr karty</string>
-    <string name="acc_label_card_number_node">%s, nr karty</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Data ważności</string>
-    <string name="acc_label_expiry_date_node">%s, data ważności</string>
-    <string name="acc_label_zip">Kod pocztowy</string>
-    <string name="acc_label_zip_short">Kod p</string>
-    <string name="add_card">Aby dokonywać zakupów w tej aplikacji, dodaj nową kartę debetową lub kredytową.</string>
-    <string name="added">Dodano: %s</string>
-    <string name="address_city_required">Podaj miejscowość</string>
-    <string name="address_country_invalid">Nieprawidłowy kraj</string>
-    <string name="address_county_required">Podaj kraj</string>
-    <string name="address_label_address">Adres</string>
-    <string name="address_label_address_line1">Linia adresu 1</string>
-    <string name="address_label_address_line1_optional">Linia adresu 1 (opcja)</string>
-    <string name="address_label_address_line2_optional">Linia adresu 2 (opcja)</string>
-    <string name="address_label_address_optional">Adres (opcja)</string>
-    <string name="address_label_apt">Nr lokalu</string>
-    <string name="address_label_apt_optional">Nr lokalu (opcja)</string>
-    <string name="address_label_city">Miejscowość</string>
-    <string name="address_label_city_optional">Miejscowość (opcja)</string>
-    <string name="address_label_country">Kraj</string>
-    <string name="address_label_county">Hrabstwo</string>
-    <string name="address_label_county_optional">Hrabstwo (opcja)</string>
-    <string name="address_label_name">Imię i nazwisko</string>
-    <string name="address_label_phone_number">Nr telefonu</string>
-    <string name="address_label_phone_number_optional">Nr telefonu (opcja)</string>
-    <string name="address_label_postal_code">Kod pocztowy</string>
-    <string name="address_label_postal_code_optional">Kod pocztowy (opcja)</string>
-    <string name="address_label_postcode">Kod pocztowy</string>
-    <string name="address_label_postcode_optional">Kod pocztowy (opcja)</string>
-    <string name="address_label_province">Prowincja</string>
-    <string name="address_label_province_optional">Prowincja (opcja)</string>
-    <string name="address_label_region_generic">Województwo/prowincja/region</string>
-    <string name="address_label_region_generic_optional">Województwo/prowincja/region (opcja)</string>
-    <string name="address_label_state">Stan</string>
-    <string name="address_label_state_optional">Stan (opcja)</string>
-    <string name="address_label_zip_code">Kod pocztowy</string>
-    <string name="address_label_zip_code_optional">Kod pocztowy (opcja)</string>
-    <string name="address_label_zip_postal_code">Kod pocztowy</string>
-    <string name="address_label_zip_postal_code_optional">Kod pocztowy (opcja)</string>
-    <string name="address_name_required">Podaj imię i nazwisko</string>
-    <string name="address_phone_number_required">Podaj nr telefonu</string>
-    <string name="address_postal_code_invalid">Nieprawidłowy kod pocztowy</string>
-    <string name="address_postcode_invalid">Nieprawidłowy kod pocztowy</string>
-    <string name="address_province_required">Podaj prowincję</string>
-    <string name="address_region_generic_required">Podaj województwo/prowincję/region</string>
-    <string name="address_required">Podaj adres</string>
-    <string name="address_shipping_address">Adres dostawy</string>
-    <string name="address_state_required">Podaj stan</string>
-    <string name="address_zip_invalid">Nieprawidłowy kod pocztowy</string>
-    <string name="address_zip_postal_invalid">Nieprawidłowy kod pocztowy</string>
-    <string name="becs_mandate_acceptance">
-    Podając dane konta bankowego i zatwierdzając tę płatność, wyrażasz zgodę na
-    niniejsze żądanie polecenia zapłaty i warunki umowy oraz upoważniasz podmiot
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 o numerze użytkownika Direct Debit 507156
-    („Stripe”) do obciążenia Twojego konta poprzez Bulk Electronic Clearing System (BECS) w
-    imieniu podmiotu %1$s („Partner handlowy”) na dowolną kwotę osobno zakomunikowaną Ci
-    przez Partnera handlowego. Zaświadczasz, że jesteś właścicielem konta lub upoważnioną
-    osobą podpisującą, reprezentującą wyżej wymienione konto.
-    </string>
-    <string name="becs_widget_account_number">Numer konta</string>
-    <string name="becs_widget_account_number_incomplete">Numer konta jest niekompletny.</string>
-    <string name="becs_widget_account_number_required">Wymagany jest numer konta.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Wprowadzony numer BSB jest niepełny.</string>
-    <string name="becs_widget_bsb_invalid">Wprowadzony numer BSB jest nieprawidłowy.</string>
-    <string name="becs_widget_email">Adres e-mail</string>
-    <string name="becs_widget_email_invalid">Twój adres e-mail jest nieprawidłowy.</string>
-    <string name="becs_widget_email_required">Wymagany jest adres e-mail.</string>
-    <string name="becs_widget_name">Imię i nazwisko</string>
-    <string name="becs_widget_name_required">Wymagane jest imię i nazwisko.</string>
-    <string name="card_ending_in">%1$s kończy się %2$s</string>
-    <string name="close">Zamknij</string>
-    <string name="delete_payment_method">Usuń metodę płatności</string>
-    <string name="delete_payment_method_prompt_title">Czy usunąć metodę płatności?</string>
-    <string name="expiry_date_hint">MM/RR</string>
-    <string name="expiry_label_short">Data ważności</string>
-    <string name="fpx_bank_offline">%s – offline</string>
-    <string name="incomplete_expiry_date">Data ważności karty jest niepełna.</string>
-    <string name="invalid_card_number">Nieprawidłowy nr karty.</string>
-    <string name="invalid_cvc">Kod bezpieczeństwa karty jest nieprawidłowy.</string>
-    <string name="invalid_expiry_month">Miesiąc daty ważności karty jest nieprawidłowy.</string>
-    <string name="invalid_expiry_year">Rok daty ważności karty jest nieprawidłowy</string>
-    <string name="invalid_shipping_information">Nieprawidłowy adres dostawy</string>
-    <string name="invalid_zip">Kod pocztowy jest niekompletny.</string>
-    <string name="no_payment_methods">Brak metod płatności</string>
-    <string name="payment_method_add_new_card">Dodaj nową kartę…</string>
-    <string name="payment_method_add_new_fpx">Wybierz konto bankowe (FPX)…</string>
-    <string name="price_free">Bezpłatnie</string>
-    <string name="removed">Usunięto: %s</string>
-    <string name="secure_checkout">Bezpieczna płatność</string>
-    <string name="stripe_failure_connection_error">Wystąpiły trudności z nawiązaniem połączenia z dostawcą usług płatniczych. Sprawdź połączenie z Internetem i spróbuj ponownie.</string>
-    <string name="stripe_failure_reason_authentication">Nie możemy wykonać uwierzytelnienia Twojej metody płatności. Wybierz inną metodę i spróbuj ponownie.</string>
-    <string name="stripe_failure_reason_timed_out">Przekroczono czas uwierzytelnienia metody płatności – spróbuj ponownie</string>
-    <string name="stripe_google_pay_error_internal">Wystąpił wewnętrzny błąd.</string>
-    <string name="stripe_paymentsheet_add_button_label">Dodaj</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Dane karty</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Kraj lub region</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Dodaj informacje o płatności</string>
-    <string name="stripe_paymentsheet_back">Wstecz</string>
-    <string name="stripe_paymentsheet_close">Zamknij</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
-    <string name="stripe_paymentsheet_or_pay_using">Lub zapłać, korzystając z</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Lub zapłać kartą</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Zapłać %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Zapłać</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Przetwarzanie…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Zapisz dane tej karty do przyszłych płatności %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Wybierz metodę płatności</string>
-    <string name="stripe_paymentsheet_setup_button_label">Ustaw</string>
-    <string name="stripe_paymentsheet_total_amount">Razem: %s</string>
-    <string name="stripe_verify_your_payment">Zweryfikuj płatność</string>
-    <string name="title_add_a_card">Dodaj kartę</string>
-    <string name="title_add_an_address">Ustaw adres</string>
-    <string name="title_bank_account">Konto bankowe</string>
-    <string name="title_payment_method">Metoda płatności</string>
-    <string name="title_select_shipping_method">Wybierz metodę przesyłki</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Nr karty</string>
+  <string name="acc_label_card_number_node">%s, nr karty</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Data ważności</string>
+  <string name="acc_label_expiry_date_node">%s, data ważności</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Kod pocztowy</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Kod p</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Aby dokonywać zakupów w tej aplikacji, dodaj nową kartę debetową lub kredytową.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Dodano: %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Podaj miejscowość</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Nieprawidłowy kraj</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Podaj kraj</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Linia adresu 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Linia adresu 1 (opcja)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Linia adresu 2 (opcja)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adres (opcja)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Nr lokalu (opcja)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Miejscowość (opcja)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Hrabstwo (opcja)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Nr telefonu</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Nr telefonu (opcja)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Kod pocztowy (opcja)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Kod pocztowy</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Kod pocztowy (opcja)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Prowincja (opcja)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Województwo/prowincja/region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Województwo/prowincja/region (opcja)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stan (opcja)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Kod pocztowy (opcja)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Kod pocztowy</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Kod pocztowy (opcja)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Podaj imię i nazwisko</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Podaj nr telefonu</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Nieprawidłowy kod pocztowy</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Nieprawidłowy kod pocztowy</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Podaj prowincję</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Podaj województwo/prowincję/region</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Podaj adres</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Adres dostawy</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Podaj stan</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Nieprawidłowy kod pocztowy</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Nieprawidłowy kod pocztowy</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Podając dane konta bankowego i zatwierdzając tę płatność, wyrażasz zgodę na\n    niniejsze żądanie polecenia zapłaty i warunki umowy oraz upoważniasz podmiot\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 o numerze użytkownika Direct Debit 507156\n    („Stripe”) do obciążenia Twojego konta poprzez Bulk Electronic Clearing System (BECS) w\n    imieniu podmiotu %1$s („Partner handlowy”) na dowolną kwotę osobno zakomunikowaną Ci\n    przez Partnera handlowego. Zaświadczasz, że jesteś właścicielem konta lub upoważnioną\n    osobą podpisującą, reprezentującą wyżej wymienione konto.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Numer konta</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Numer konta jest niekompletny.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Wymagany jest numer konta.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Wprowadzony numer BSB jest niepełny.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Wprowadzony numer BSB jest nieprawidłowy.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Adres e-mail</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Twój adres e-mail jest nieprawidłowy.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Wymagany jest adres e-mail.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Imię i nazwisko</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Wymagane jest imię i nazwisko.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s kończy się %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Zamknij</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Usuń metodę płatności</string>
+  <string name="delete_payment_method_prompt_title">Czy usunąć metodę płatności?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/RR</string>
+  <string name="expiry_label_short">Data ważności</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s – offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Data ważności karty jest niepełna.</string>
+  <string name="invalid_card_number">Nieprawidłowy nr karty.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Kod bezpieczeństwa karty jest nieprawidłowy.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Miesiąc daty ważności karty jest nieprawidłowy.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Rok daty ważności karty jest nieprawidłowy</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Nieprawidłowy adres dostawy</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Kod pocztowy jest niekompletny.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Brak metod płatności</string>
+  <string name="payment_method_add_new_card">Dodaj nową kartę…</string>
+  <string name="payment_method_add_new_fpx">Wybierz konto bankowe (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Bezpłatnie</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Usunięto: %s</string>
+  <string name="secure_checkout">Bezpieczna płatność</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Wystąpiły trudności z nawiązaniem połączenia z dostawcą usług płatniczych. Sprawdź połączenie z Internetem i spróbuj ponownie.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nie możemy wykonać uwierzytelnienia Twojej metody płatności. Wybierz inną metodę i spróbuj ponownie.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Przekroczono czas uwierzytelnienia metody płatności – spróbuj ponownie</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Wystąpił wewnętrzny błąd.</string>
+  <string name="stripe_paymentsheet_add_button_label">Dodaj</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dane karty</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Kraj lub region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Dodaj informacje o płatności</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Wstecz</string>
+  <string name="stripe_paymentsheet_close">Zamknij</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Lub zapłać, korzystając z</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Lub zapłać kartą</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Zapłać %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Zapłać</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Przetwarzanie…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Zapisz dane tej karty do przyszłych płatności %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Wybierz metodę płatności</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Ustaw</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Zweryfikuj płatność</string>
+  <string name="title_add_a_card">Dodaj kartę</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Ustaw adres</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Konto bankowe</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Metoda płatności</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Wybierz metodę przesyłki</string>
 </resources>

--- a/payments-core/res/values-pt-rBR/strings.xml
+++ b/payments-core/res/values-pt-rBR/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Número do cartão</string>
-    <string name="acc_label_card_number_node">%s, número do cartão</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Data de validade</string>
-    <string name="acc_label_expiry_date_node">%s, data de validade</string>
-    <string name="acc_label_zip">Código postal</string>
-    <string name="acc_label_zip_short">CEP</string>
-    <string name="add_card">Adicione um novo cartão de débito ou crédito para fazer compras neste aplicativo.</string>
-    <string name="added">Adicionou %s</string>
-    <string name="address_city_required">Informe sua cidade</string>
-    <string name="address_country_invalid">País inválido</string>
-    <string name="address_county_required">Informe seu condado</string>
-    <string name="address_label_address">Endereço</string>
-    <string name="address_label_address_line1">Endereço – Linha 1</string>
-    <string name="address_label_address_line1_optional">Endereço – Linha 1 (opcional)</string>
-    <string name="address_label_address_line2_optional">Endereço – Linha 2 (opcional)</string>
-    <string name="address_label_address_optional">Endereço (opcional)</string>
-    <string name="address_label_apt">Apt.</string>
-    <string name="address_label_apt_optional">Apt. (opcional)</string>
-    <string name="address_label_city">Cidade</string>
-    <string name="address_label_city_optional">Cidade (opcional)</string>
-    <string name="address_label_country">País</string>
-    <string name="address_label_county">Condado</string>
-    <string name="address_label_county_optional">Condado (opcional)</string>
-    <string name="address_label_name">Nome</string>
-    <string name="address_label_phone_number">Telefone</string>
-    <string name="address_label_phone_number_optional">Telefone (opcional)</string>
-    <string name="address_label_postal_code">Código postal</string>
-    <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_label_postcode">Código postal</string>
-    <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <string name="address_label_province">Província</string>
-    <string name="address_label_province_optional">Província (opcional)</string>
-    <string name="address_label_region_generic">Estado/Província/Região</string>
-    <string name="address_label_region_generic_optional">Estado/Província/Região (opcional)</string>
-    <string name="address_label_state">Estado</string>
-    <string name="address_label_state_optional">Estado (opcional)</string>
-    <string name="address_label_zip_code">Código postal</string>
-    <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <string name="address_label_zip_postal_code">Código postal</string>
-    <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_name_required">Informe seu nome</string>
-    <string name="address_phone_number_required">Informe seu telefone</string>
-    <string name="address_postal_code_invalid">Código postal inválido.</string>
-    <string name="address_postcode_invalid">Código postal inválido</string>
-    <string name="address_province_required">Informe sua província</string>
-    <string name="address_region_generic_required">Informe seu estado/província/região</string>
-    <string name="address_required">Informe seu endereço</string>
-    <string name="address_shipping_address">Endereço de envio</string>
-    <string name="address_state_required">Informe seu estado</string>
-    <string name="address_zip_invalid">Código postal inválido.</string>
-    <string name="address_zip_postal_invalid">Código postal inválido.</string>
-    <string name="becs_mandate_acceptance">
-    Ao informar os dados da sua conta bancária e confirmar este pagamento, você aceita esta
-    Solicitação de Débito Direto e o contrato de serviço da Solicitação de Débito Direto, bem como autoriza a
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 com número de Usuário para Débito Direto 507156
-    (a “Stripe”) a debitar de sua conta pelo Bulk Electronic Clearing System (BECS) em
-    nome de %1$s (o \"Comerciante\") quaisquer quantias comunicadas separadamente a você
-    pelo Comerciante. Você confirma que é títular da conta ou signatário
-    autorizado da conta listada acima.
-    </string>
-    <string name="becs_widget_account_number">Número da conta</string>
-    <string name="becs_widget_account_number_incomplete">O número da conta está incompleto.</string>
-    <string name="becs_widget_account_number_required">É obrigatório informar seu número da conta.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">O BSB inserido está incompleto.</string>
-    <string name="becs_widget_bsb_invalid">O BSB inserido é inválido.</string>
-    <string name="becs_widget_email">Endereço de e-mail</string>
-    <string name="becs_widget_email_invalid">Endereço de e-mail inválido.</string>
-    <string name="becs_widget_email_required">É obrigatório informar seu e-mail.</string>
-    <string name="becs_widget_name">Nome</string>
-    <string name="becs_widget_name_required">É obrigatório informar seu nome.</string>
-    <string name="card_ending_in">%1$s com final %2$s</string>
-    <string name="close">Fechar</string>
-    <string name="delete_payment_method">Excluir forma de pagamento</string>
-    <string name="delete_payment_method_prompt_title">Excluir forma de pagamento?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Validade</string>
-    <string name="fpx_bank_offline">%s – Offline</string>
-    <string name="incomplete_expiry_date">Data de validade incompleta.</string>
-    <string name="invalid_card_number">Número do cartão inválido.</string>
-    <string name="invalid_cvc">Código de segurança inválido.</string>
-    <string name="invalid_expiry_month">O mês de validade do cartão é inválido.</string>
-    <string name="invalid_expiry_year">Ano de validade inválido.</string>
-    <string name="invalid_shipping_information">Endereço de envio inválido</string>
-    <string name="invalid_zip">Código postal incompleto.</string>
-    <string name="no_payment_methods">Sem forma de pagamento.</string>
-    <string name="payment_method_add_new_card">Adicionar novo cartão…</string>
-    <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
-    <string name="price_free">Grátis</string>
-    <string name="removed">Removeu %s</string>
-    <string name="secure_checkout">Secure Checkout</string>
-    <string name="stripe_failure_connection_error">Estamos passando por problemas de conexão com nosso provedor de pagamentos. Verifique sua conexão com a Internet e tente novamente.</string>
-    <string name="stripe_failure_reason_authentication">Não é possível autenticar sua forma de pagamento. Escolha outra forma de pagamento e tente de novo.</string>
-    <string name="stripe_failure_reason_timed_out">Tempo limite esgotado para autenticar sua forma de pagamento – tente novamente</string>
-    <string name="stripe_google_pay_error_internal">Ocorreu um erro interno.</string>
-    <string name="stripe_paymentsheet_add_button_label">Adicionar</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Dados do cartão</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Adicione seus dados de pagamento</string>
-    <string name="stripe_paymentsheet_back">Voltar</string>
-    <string name="stripe_paymentsheet_close">Fechar</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ou pague com</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com cartão</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Processando…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvar este cartão para pagamentos futuros a %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Selecione sua forma de pagamento</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verifique seu pagamento</string>
-    <string name="title_add_a_card">Adicionar um cartão</string>
-    <string name="title_add_an_address">Definir endereço</string>
-    <string name="title_bank_account">Conta bancária</string>
-    <string name="title_payment_method">Forma de pagamento</string>
-    <string name="title_select_shipping_method">Selecionar forma de envio</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Número do cartão</string>
+  <string name="acc_label_card_number_node">%s, número do cartão</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Data de validade</string>
+  <string name="acc_label_expiry_date_node">%s, data de validade</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Código postal</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">CEP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Adicione um novo cartão de débito ou crédito para fazer compras neste aplicativo.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Adicionou %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Informe sua cidade</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">País inválido</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Informe seu condado</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Endereço</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Endereço – Linha 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Endereço – Linha 1 (opcional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Endereço – Linha 2 (opcional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Endereço (opcional)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (opcional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Cidade (opcional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Condado (opcional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefone</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefone (opcional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Código postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Província (opcional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Estado/Província/Região</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Estado/Província/Região (opcional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Estado (opcional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Código postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Informe seu nome</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Informe seu telefone</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Código postal inválido.</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Código postal inválido</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Informe sua província</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Informe seu estado/província/região</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Informe seu endereço</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Endereço de envio</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Informe seu estado</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Código postal inválido.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Código postal inválido.</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Ao informar os dados da sua conta bancária e confirmar este pagamento, você aceita esta\n    Solicitação de Débito Direto e o contrato de serviço da Solicitação de Débito Direto, bem como autoriza a\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 com número de Usuário para Débito Direto 507156\n    (a “Stripe”) a debitar de sua conta pelo Bulk Electronic Clearing System (BECS) em\n    nome de %1$s (o \"Comerciante\") quaisquer quantias comunicadas separadamente a você\n    pelo Comerciante. Você confirma que é títular da conta ou signatário\n    autorizado da conta listada acima.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Número da conta</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">O número da conta está incompleto.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">É obrigatório informar seu número da conta.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">O BSB inserido está incompleto.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">O BSB inserido é inválido.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Endereço de e-mail</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Endereço de e-mail inválido.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">É obrigatório informar seu e-mail.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nome</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">É obrigatório informar seu nome.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s com final %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Fechar</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Excluir forma de pagamento</string>
+  <string name="delete_payment_method_prompt_title">Excluir forma de pagamento?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Validade</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s – Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Data de validade incompleta.</string>
+  <string name="invalid_card_number">Número do cartão inválido.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Código de segurança inválido.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">O mês de validade do cartão é inválido.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Ano de validade inválido.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Endereço de envio inválido</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Código postal incompleto.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Sem forma de pagamento.</string>
+  <string name="payment_method_add_new_card">Adicionar novo cartão…</string>
+  <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Grátis</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Removeu %s</string>
+  <string name="secure_checkout">Secure Checkout</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Estamos passando por problemas de conexão com nosso provedor de pagamentos. Verifique sua conexão com a Internet e tente novamente.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Não é possível autenticar sua forma de pagamento. Escolha outra forma de pagamento e tente de novo.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Tempo limite esgotado para autenticar sua forma de pagamento – tente novamente</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Ocorreu um erro interno.</string>
+  <string name="stripe_paymentsheet_add_button_label">Adicionar</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dados do cartão</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Adicione seus dados de pagamento</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Voltar</string>
+  <string name="stripe_paymentsheet_close">Fechar</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ou pague com</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com cartão</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Processando…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvar este cartão para pagamentos futuros a %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selecione sua forma de pagamento</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifique seu pagamento</string>
+  <string name="title_add_a_card">Adicionar um cartão</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Definir endereço</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Conta bancária</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Forma de pagamento</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selecionar forma de envio</string>
 </resources>

--- a/payments-core/res/values-pt-rPT/strings.xml
+++ b/payments-core/res/values-pt-rPT/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Número do cartão</string>
-    <string name="acc_label_card_number_node">%s, número do cartão</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Data de validade</string>
-    <string name="acc_label_expiry_date_node">%s, data de validade</string>
-    <string name="acc_label_zip">C.P.</string>
-    <string name="acc_label_zip_short">C.P.</string>
-    <string name="add_card">Adicione um novo cartão de débito ou de crédito para efetuar compras nesta aplicação.</string>
-    <string name="added">Adicionado %s</string>
-    <string name="address_city_required">Introduza a sua cidade</string>
-    <string name="address_country_invalid">O seu país é inválido</string>
-    <string name="address_county_required">Introduza o seu concelho</string>
-    <string name="address_label_address">Endereço</string>
-    <string name="address_label_address_line1">Linha de endereço 1</string>
-    <string name="address_label_address_line1_optional">Linha de endereço 1 (opcional)</string>
-    <string name="address_label_address_line2_optional">Linha de endereço 2 (opcional)</string>
-    <string name="address_label_address_optional">Endereço (opcional)</string>
-    <string name="address_label_apt">Apt.</string>
-    <string name="address_label_apt_optional">Apt. (opcional)</string>
-    <string name="address_label_city">Cidade</string>
-    <string name="address_label_city_optional">Cidade (opcional)</string>
-    <string name="address_label_country">País</string>
-    <string name="address_label_county">Concelho</string>
-    <string name="address_label_county_optional">Concelho (opcional)</string>
-    <string name="address_label_name">Nome</string>
-    <string name="address_label_phone_number">Número de telefone</string>
-    <string name="address_label_phone_number_optional">Número de telefone (opcional)</string>
-    <string name="address_label_postal_code">Código postal</string>
-    <string name="address_label_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_label_postcode">Código postal</string>
-    <string name="address_label_postcode_optional">Código postal (opcional)</string>
-    <string name="address_label_province">Província</string>
-    <string name="address_label_province_optional">Província (opcional)</string>
-    <string name="address_label_region_generic">Estado/Província/Região</string>
-    <string name="address_label_region_generic_optional">Estado/Província/Região (opcional)</string>
-    <string name="address_label_state">Estado</string>
-    <string name="address_label_state_optional">Estado (opcional)</string>
-    <string name="address_label_zip_code">Código postal</string>
-    <string name="address_label_zip_code_optional">Código postal (opcional)</string>
-    <string name="address_label_zip_postal_code">Código postal</string>
-    <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
-    <string name="address_name_required">Introduza o seu nome</string>
-    <string name="address_phone_number_required">Introduza o seu número de telefone</string>
-    <string name="address_postal_code_invalid">O seu código postal é inválido.</string>
-    <string name="address_postcode_invalid">O seu código postal é inválido</string>
-    <string name="address_province_required">Introduza a sua província</string>
-    <string name="address_region_generic_required">Introduza o seu Estado/Província/Região</string>
-    <string name="address_required">Introduza o seu endereço</string>
-    <string name="address_shipping_address">Endereço de envio</string>
-    <string name="address_state_required">Introduza o seu estado</string>
-    <string name="address_zip_invalid">O seu código postal é inválido.</string>
-    <string name="address_zip_postal_invalid">O seu código postal é inválido</string>
-    <string name="becs_mandate_acceptance">
-    Ao fornecer os seus dados de conta bancária e ao confirmar este pagamento, declara que concorda com este
-    Pedido de Débito Direto e com o contrato de serviços de Pedido de Débito Direto e autoriza a
-    Stripe Payments Australia Pty Ltd ACN 160 180 343, número de ID de Utilizador de Débito Direto 507156
-    (“Stripe”) a debitar a sua conta através do Sistema BECS (Bulk Electronic Clearing System) em
-    nome de %1$s (o \"Comerciante\") em quaisquer montantes comunicados separadamente a si
-    pelo Comerciante. Certifica ainda que é um titular da conta ou um signatário autorizado
-    da conta acima indicada.
-    </string>
-    <string name="becs_widget_account_number">Número de conta</string>
-    <string name="becs_widget_account_number_incomplete">O número da sua conta está incompleto.</string>
-    <string name="becs_widget_account_number_required">O seu número de conta é obrigatório.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">O BSB que introduziu está incompleto.</string>
-    <string name="becs_widget_bsb_invalid">O BSB que introduziu é inválido.</string>
-    <string name="becs_widget_email">Endereço de email</string>
-    <string name="becs_widget_email_invalid">O seu endereço de email é inválido.</string>
-    <string name="becs_widget_email_required">O seu endereço de email é obrigatório.</string>
-    <string name="becs_widget_name">Nome</string>
-    <string name="becs_widget_name_required">O seu nome é obrigatório.</string>
-    <string name="card_ending_in">%1$s a terminar em %2$s</string>
-    <string name="close">Fechar</string>
-    <string name="delete_payment_method">Eliminar método de pagamento</string>
-    <string name="delete_payment_method_prompt_title">Eliminar método de pagamento?</string>
-    <string name="expiry_date_hint">MM/AA</string>
-    <string name="expiry_label_short">Validade</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">A data de validade do seu cartão está incompleta.</string>
-    <string name="invalid_card_number">O número do seu cartão é inválido.</string>
-    <string name="invalid_cvc">O código de segurança do seu cartão é inválido.</string>
-    <string name="invalid_expiry_month">O mês de validade do seu cartão é inválido.</string>
-    <string name="invalid_expiry_year">O ano de validade do seu cartão é inválido.</string>
-    <string name="invalid_shipping_information">Endereço de envio inválido</string>
-    <string name="invalid_zip">O seu código postal está incompleto.</string>
-    <string name="no_payment_methods">Nenhum método de pagamento.</string>
-    <string name="payment_method_add_new_card">Adicionar um novo cartão…</string>
-    <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
-    <string name="price_free">Gratuito</string>
-    <string name="removed">Removido %s</string>
-    <string name="secure_checkout">Finalização de compra segura</string>
-    <string name="stripe_failure_connection_error">Estamos com problemas de ligação relativamente ao nosso prestador de serviços de pagamentos. Verifique a sua ligação à Internet e tente novamente.</string>
-    <string name="stripe_failure_reason_authentication">Não conseguimos autenticar o seu método de pagamento. Selecione outro método de pagamento e tente novamente.</string>
-    <string name="stripe_failure_reason_timed_out">A autenticação do seu método de pagamento atingiu o tempo limite -- tente novamente</string>
-    <string name="stripe_google_pay_error_internal">Ocorreu um erro interno.</string>
-    <string name="stripe_paymentsheet_add_button_label">Adicionar</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informações do cartão</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Adicione as suas informações de pagamento</string>
-    <string name="stripe_paymentsheet_back">Voltar</string>
-    <string name="stripe_paymentsheet_close">Fechar</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ou pagar com</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com um cartão</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
-    <string name="stripe_paymentsheet_primary_button_processing">A processar…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar este cartão para pagamentos futuros %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Selecione o seu método de pagamento</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verifique o seu pagamento</string>
-    <string name="title_add_a_card">Adicionar um cartão</string>
-    <string name="title_add_an_address">Definir endereço</string>
-    <string name="title_bank_account">Conta bancária</string>
-    <string name="title_payment_method">Método de Pagamento</string>
-    <string name="title_select_shipping_method">Selecionar método de envio</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Número do cartão</string>
+  <string name="acc_label_card_number_node">%s, número do cartão</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Data de validade</string>
+  <string name="acc_label_expiry_date_node">%s, data de validade</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">C.P.</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">C.P.</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Adicione um novo cartão de débito ou de crédito para efetuar compras nesta aplicação.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Adicionado %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Introduza a sua cidade</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">O seu país é inválido</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Introduza o seu concelho</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Endereço</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Linha de endereço 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Linha de endereço 1 (opcional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Linha de endereço 2 (opcional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Endereço (opcional)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (opcional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Cidade (opcional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Concelho (opcional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Número de telefone</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Número de telefone (opcional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Código postal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Província (opcional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Estado/Província/Região</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Estado/Província/Região (opcional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Estado (opcional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Código postal (opcional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Código postal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Código postal (opcional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Introduza o seu nome</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Introduza o seu número de telefone</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">O seu código postal é inválido.</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">O seu código postal é inválido</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Introduza a sua província</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Introduza o seu Estado/Província/Região</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Introduza o seu endereço</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Endereço de envio</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Introduza o seu estado</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">O seu código postal é inválido.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">O seu código postal é inválido</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Ao fornecer os seus dados de conta bancária e ao confirmar este pagamento, declara que concorda com este\n    Pedido de Débito Direto e com o contrato de serviços de Pedido de Débito Direto e autoriza a\n    Stripe Payments Australia Pty Ltd ACN 160 180 343, número de ID de Utilizador de Débito Direto 507156\n    (“Stripe”) a debitar a sua conta através do Sistema BECS (Bulk Electronic Clearing System) em\n    nome de %1$s (o \"Comerciante\") em quaisquer montantes comunicados separadamente a si\n    pelo Comerciante. Certifica ainda que é um titular da conta ou um signatário autorizado\n    da conta acima indicada.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Número de conta</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">O número da sua conta está incompleto.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">O seu número de conta é obrigatório.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">O BSB que introduziu está incompleto.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">O BSB que introduziu é inválido.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Endereço de email</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">O seu endereço de email é inválido.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">O seu endereço de email é obrigatório.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nome</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">O seu nome é obrigatório.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s a terminar em %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Fechar</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Eliminar método de pagamento</string>
+  <string name="delete_payment_method_prompt_title">Eliminar método de pagamento?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/AA</string>
+  <string name="expiry_label_short">Validade</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">A data de validade do seu cartão está incompleta.</string>
+  <string name="invalid_card_number">O número do seu cartão é inválido.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">O código de segurança do seu cartão é inválido.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">O mês de validade do seu cartão é inválido.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">O ano de validade do seu cartão é inválido.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Endereço de envio inválido</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">O seu código postal está incompleto.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nenhum método de pagamento.</string>
+  <string name="payment_method_add_new_card">Adicionar um novo cartão…</string>
+  <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Gratuito</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Removido %s</string>
+  <string name="secure_checkout">Finalização de compra segura</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Estamos com problemas de ligação relativamente ao nosso prestador de serviços de pagamentos. Verifique a sua ligação à Internet e tente novamente.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Não conseguimos autenticar o seu método de pagamento. Selecione outro método de pagamento e tente novamente.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">A autenticação do seu método de pagamento atingiu o tempo limite -- tente novamente</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Ocorreu um erro interno.</string>
+  <string name="stripe_paymentsheet_add_button_label">Adicionar</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informações do cartão</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Adicione as suas informações de pagamento</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Voltar</string>
+  <string name="stripe_paymentsheet_close">Fechar</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ou pagar com</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com um cartão</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pagar %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">A processar…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar este cartão para pagamentos futuros %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selecione o seu método de pagamento</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurar</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verifique o seu pagamento</string>
+  <string name="title_add_a_card">Adicionar um cartão</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Definir endereço</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Conta bancária</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Método de Pagamento</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selecionar método de envio</string>
 </resources>

--- a/payments-core/res/values-ro-rRO/strings.xml
+++ b/payments-core/res/values-ro-rRO/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Număr card</string>
-    <string name="acc_label_card_number_node">%s, Număr card</string>
-    <string name="acc_label_cvc_node">%s, Cod CVC</string>
-    <string name="acc_label_expiry_date">Data de expirare</string>
-    <string name="acc_label_expiry_date_node">%s, Data de expirare</string>
-    <string name="acc_label_zip">Cod poștal</string>
-    <string name="acc_label_zip_short">Cod poștal</string>
-    <string name="add_card">Adăugați un nou card de debit sau de credit pentru a face achiziții în această aplicație.</string>
-    <string name="added">%s a fost adăugat</string>
-    <string name="address_city_required">Introduceți orașul în care locuiți</string>
-    <string name="address_country_invalid">Țara dvs. nu este validă</string>
-    <string name="address_county_required">Introduceți județul în care locuiți</string>
-    <string name="address_label_address">Adresa</string>
-    <string name="address_label_address_line1">Rândul 1 pentru adresă</string>
-    <string name="address_label_address_line1_optional">Rândul 1 pentru adresă (opțional)</string>
-    <string name="address_label_address_line2_optional">Rândul 2 pentru adresă (opțional)</string>
-    <string name="address_label_address_optional">Adresă (opțional)</string>
-    <string name="address_label_apt">Ap.</string>
-    <string name="address_label_apt_optional">Apartament (opțional)</string>
-    <string name="address_label_city">Oraș</string>
-    <string name="address_label_city_optional">Oraș (opțional)</string>
-    <string name="address_label_country">Țară</string>
-    <string name="address_label_county">Județ</string>
-    <string name="address_label_county_optional">Județ (opțional)</string>
-    <string name="address_label_name">Nume</string>
-    <string name="address_label_phone_number">Număr de telefon</string>
-    <string name="address_label_phone_number_optional">Număr de telefon (opțional)</string>
-    <string name="address_label_postal_code">Cod poștal</string>
-    <string name="address_label_postal_code_optional">Cod poștal (opțional)</string>
-    <string name="address_label_postcode">Cod poștal</string>
-    <string name="address_label_postcode_optional">Cod poștal (opțional)</string>
-    <string name="address_label_province">Provincie</string>
-    <string name="address_label_province_optional">Provincie (opțional)</string>
-    <string name="address_label_region_generic">Stat/Provincie/Regiune</string>
-    <string name="address_label_region_generic_optional">Stat (opțional)</string>
-    <string name="address_label_state">Stat</string>
-    <string name="address_label_state_optional">Stat (opțional)</string>
-    <string name="address_label_zip_code">Cod poștal</string>
-    <string name="address_label_zip_code_optional">Cod poștal (opțional)</string>
-    <string name="address_label_zip_postal_code">Cod poștal</string>
-    <string name="address_label_zip_postal_code_optional">Cod poștal (opțional)</string>
-    <string name="address_name_required">Introduceți numele dvs.</string>
-    <string name="address_phone_number_required">Introduceți numărul dvs. de telefon</string>
-    <string name="address_postal_code_invalid">Codul dvs. poștal nu este valid</string>
-    <string name="address_postcode_invalid">Codul dvs. poștal nu este valid</string>
-    <string name="address_province_required">Introduceți provincia în care locuiți</string>
-    <string name="address_region_generic_required">Introduceți statul/provincia/regiunea în care locuiți</string>
-    <string name="address_required">Introduceți adresa dvs.</string>
-    <string name="address_shipping_address">Adresa de expediere</string>
-    <string name="address_state_required">Introduceți statul în care locuiți</string>
-    <string name="address_zip_invalid">Codul dvs. poștal nu este valid.</string>
-    <string name="address_zip_postal_invalid">Codul dvs. poștal nu este valid</string>
-    <string name="becs_mandate_acceptance">
-    Prin furnizarea detaliilor contului dvs. bancar și confirmarea acestei plăți, sunteți de acord cu această
-    Solicitare Direct Debit și cu acordul de serviciu privind Solicitarea Direct Debit și autorizați
-    Plățile Stripe Australia Pty Ltd ACN 160 180 343 număr ID utilizator Direct Debit 507156
-    („Stripe”) trebuie să vă debiteze contul prin intermediul Sistemului electronic de compensare colectivă (BECS)
-    în numele %1$s („Comerciantul”) pentru orice sume comunicate separat către dvs.
-    de către Comerciant. Certificați faptul că sunteți fie un titular de cont, fie un semnatar
-    autorizat în contul enumerat mai sus.
-    </string>
-    <string name="becs_widget_account_number">Număr cont</string>
-    <string name="becs_widget_account_number_incomplete">Numărul contului dvs. nu este complet.</string>
-    <string name="becs_widget_account_number_required">Este necesar numărul dvs. de cont.</string>
-    <string name="becs_widget_bsb">Număr BSB</string>
-    <string name="becs_widget_bsb_incomplete">Numărul BSB pe care l-ați introdus nu este complet.</string>
-    <string name="becs_widget_bsb_invalid">Numărul BSB pe care l-ați introdus nu este valid.</string>
-    <string name="becs_widget_email">Adresa de e-mail</string>
-    <string name="becs_widget_email_invalid">Adresa dvs. de e-mail nu este validă.</string>
-    <string name="becs_widget_email_required">Este necesară adresa dvs. de e-mail.</string>
-    <string name="becs_widget_name">Nume</string>
-    <string name="becs_widget_name_required">Este necesar numele dvs.</string>
-    <string name="card_ending_in">%1$s se termină în %2$s</string>
-    <string name="close">Închidere</string>
-    <string name="delete_payment_method">Ștergeți metoda de plată</string>
-    <string name="delete_payment_method_prompt_title">Ștergeți metoda de plată?</string>
-    <string name="expiry_date_hint">LL/AA</string>
-    <string name="expiry_label_short">Data de expirare</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">Data de expirare a cardului dvs. nu este completă.</string>
-    <string name="invalid_card_number">Numărul cardului dvs. nu este valid.</string>
-    <string name="invalid_cvc">Codul de securitate al cardului dvs. nu este valid.</string>
-    <string name="invalid_expiry_month">Luna de expirare a cardului dvs. nu este validă.</string>
-    <string name="invalid_expiry_year">Anul de expirare al cardului dvs. nu este valid.</string>
-    <string name="invalid_shipping_information">Adresa de expediere nu este validă</string>
-    <string name="invalid_zip">Codul dvs. poștal nu este complet.</string>
-    <string name="no_payment_methods">Nu există metode de plată.</string>
-    <string name="payment_method_add_new_card">Adăugare card nou...</string>
-    <string name="payment_method_add_new_fpx">Selectare cont bancar (FPX)…</string>
-    <string name="price_free">Expediere gratuită</string>
-    <string name="removed">%s a fost eliminat</string>
-    <string name="secure_checkout">Validare securizată</string>
-    <string name="stripe_failure_connection_error">Întâmpinăm probleme de conectare cu furnizorul nostru de plăți. Verificați conexiunea la internet și încercați din nou.</string>
-    <string name="stripe_failure_reason_authentication">Nu vă putem autentifica metoda de plată. Alegeți o altă metodă de plată și încercați din nou.</string>
-    <string name="stripe_failure_reason_timed_out">Timpul de autentificare a metodei dvs. de plată a expirat -- încercați din nou</string>
-    <string name="stripe_google_pay_error_internal">A apărut o eroare internă.</string>
-    <string name="stripe_paymentsheet_add_button_label">Adăugare</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adăugare</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informații privind cardul</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Țară sau regiune</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Adăugați informațiile dvs. privind plata</string>
-    <string name="stripe_paymentsheet_back">Înapoi</string>
-    <string name="stripe_paymentsheet_close">Închidere</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">LL/AA</string>
-    <string name="stripe_paymentsheet_or_pay_using">Sau folosiți ca metodă de plată</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Sau folosiți ca metodă de plată un card</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Plătiți %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Plătiți</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Se procesează...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvați acest card pentru plăți viitoare către %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Selectați metoda de plată</string>
-    <string name="stripe_paymentsheet_setup_button_label">Configurare</string>
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_verify_your_payment">Verificați-vă plata</string>
-    <string name="title_add_a_card">Adăugare card</string>
-    <string name="title_add_an_address">Adăugare adresă</string>
-    <string name="title_bank_account">Cont bancar</string>
-    <string name="title_payment_method">Metoda de plată</string>
-    <string name="title_select_shipping_method">Selectare metodă de plată</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Număr card</string>
+  <string name="acc_label_card_number_node">%s, Număr card</string>
+  <string name="acc_label_cvc_node">%s, Cod CVC</string>
+  <string name="acc_label_expiry_date">Data de expirare</string>
+  <string name="acc_label_expiry_date_node">%s, Data de expirare</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Cod poștal</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Cod poștal</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Adăugați un nou card de debit sau de credit pentru a face achiziții în această aplicație.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">%s a fost adăugat</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Introduceți orașul în care locuiți</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Țara dvs. nu este validă</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Introduceți județul în care locuiți</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Rândul 1 pentru adresă</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Rândul 1 pentru adresă (opțional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Rândul 2 pentru adresă (opțional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresă (opțional)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apartament (opțional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Oraș (opțional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Județ (opțional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Număr de telefon</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Număr de telefon (opțional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Cod poștal (opțional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Cod poștal</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Cod poștal (opțional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincie (opțional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Stat/Provincie/Regiune</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Stat (opțional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Stat (opțional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Cod poștal (opțional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Cod poștal</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Cod poștal (opțional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Introduceți numele dvs.</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Introduceți numărul dvs. de telefon</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Codul dvs. poștal nu este valid</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Codul dvs. poștal nu este valid</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Introduceți provincia în care locuiți</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Introduceți statul/provincia/regiunea în care locuiți</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Introduceți adresa dvs.</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Adresa de expediere</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Introduceți statul în care locuiți</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Codul dvs. poștal nu este valid.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Codul dvs. poștal nu este valid</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Prin furnizarea detaliilor contului dvs. bancar și confirmarea acestei plăți, sunteți de acord cu această\n    Solicitare Direct Debit și cu acordul de serviciu privind Solicitarea Direct Debit și autorizați\n    Plățile Stripe Australia Pty Ltd ACN 160 180 343 număr ID utilizator Direct Debit 507156\n    („Stripe”) trebuie să vă debiteze contul prin intermediul Sistemului electronic de compensare colectivă (BECS)\n    în numele %1$s („Comerciantul”) pentru orice sume comunicate separat către dvs.\n    de către Comerciant. Certificați faptul că sunteți fie un titular de cont, fie un semnatar\n    autorizat în contul enumerat mai sus.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Număr cont</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Numărul contului dvs. nu este complet.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Este necesar numărul dvs. de cont.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">Număr BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Numărul BSB pe care l-ați introdus nu este complet.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Numărul BSB pe care l-ați introdus nu este valid.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Adresa de e-mail</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Adresa dvs. de e-mail nu este validă.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Este necesară adresa dvs. de e-mail.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Nume</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Este necesar numele dvs.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s se termină în %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Închidere</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Ștergeți metoda de plată</string>
+  <string name="delete_payment_method_prompt_title">Ștergeți metoda de plată?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">LL/AA</string>
+  <string name="expiry_label_short">Data de expirare</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Data de expirare a cardului dvs. nu este completă.</string>
+  <string name="invalid_card_number">Numărul cardului dvs. nu este valid.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Codul de securitate al cardului dvs. nu este valid.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Luna de expirare a cardului dvs. nu este validă.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Anul de expirare al cardului dvs. nu este valid.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Adresa de expediere nu este validă</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Codul dvs. poștal nu este complet.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Nu există metode de plată.</string>
+  <string name="payment_method_add_new_card">Adăugare card nou...</string>
+  <string name="payment_method_add_new_fpx">Selectare cont bancar (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Expediere gratuită</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">%s a fost eliminat</string>
+  <string name="secure_checkout">Validare securizată</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Întâmpinăm probleme de conectare cu furnizorul nostru de plăți. Verificați conexiunea la internet și încercați din nou.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nu vă putem autentifica metoda de plată. Alegeți o altă metodă de plată și încercați din nou.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Timpul de autentificare a metodei dvs. de plată a expirat -- încercați din nou</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">A apărut o eroare internă.</string>
+  <string name="stripe_paymentsheet_add_button_label">Adăugare</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adăugare</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informații privind cardul</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Țară sau regiune</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Adăugați informațiile dvs. privind plata</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Înapoi</string>
+  <string name="stripe_paymentsheet_close">Închidere</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">LL/AA</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Sau folosiți ca metodă de plată</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Sau folosiți ca metodă de plată un card</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Plătiți %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Plătiți</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Se procesează...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvați acest card pentru plăți viitoare către %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Selectați metoda de plată</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Configurare</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verificați-vă plata</string>
+  <string name="title_add_a_card">Adăugare card</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Adăugare adresă</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Cont bancar</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Metoda de plată</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Selectare metodă de plată</string>
 </resources>

--- a/payments-core/res/values-sk-rSK/strings.xml
+++ b/payments-core/res/values-sk-rSK/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Číslo karty</string>
-    <string name="acc_label_card_number_node">%s, číslo karty</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Dátum ukončenia platnosti</string>
-    <string name="acc_label_expiry_date_node">%s, dátum ukončenia platnosti</string>
-    <string name="acc_label_zip">PSČ</string>
-    <string name="acc_label_zip_short">PSČ</string>
-    <string name="add_card">Pridajte novú debetnú alebo kreditnú kartu, aby ste mohli nakupovať v tejto aplikácii.</string>
-    <string name="added">Spôsob platby %s pridaný</string>
-    <string name="address_city_required">Zadajte vaše mesto</string>
-    <string name="address_country_invalid">Vaša krajina je neplatná.</string>
-    <string name="address_county_required">Zadajte váš kraj</string>
-    <string name="address_label_address">Adresa</string>
-    <string name="address_label_address_line1">Riadok adresy 1</string>
-    <string name="address_label_address_line1_optional">Riadok adresy 1 (voliteľne)</string>
-    <string name="address_label_address_line2_optional">Riadok adresy 2 (voliteľne)</string>
-    <string name="address_label_address_optional">Adresa (voliteľne)</string>
-    <string name="address_label_apt">Byt</string>
-    <string name="address_label_apt_optional">Byt (voliteľne)</string>
-    <string name="address_label_city">Mesto</string>
-    <string name="address_label_city_optional">Mesto (voliteľne)</string>
-    <string name="address_label_country">Krajina</string>
-    <string name="address_label_county">Kraj</string>
-    <string name="address_label_county_optional">Kraj (voliteľne)</string>
-    <string name="address_label_name">Meno</string>
-    <string name="address_label_phone_number">Telefónne číslo</string>
-    <string name="address_label_phone_number_optional">Telefónne číslo (voliteľne)</string>
-    <string name="address_label_postal_code">PSČ</string>
-    <string name="address_label_postal_code_optional">PSČ (voliteľne)</string>
-    <string name="address_label_postcode">PSČ</string>
-    <string name="address_label_postcode_optional">PSČ (voliteľne)</string>
-    <string name="address_label_province">Provincia</string>
-    <string name="address_label_province_optional">Provincia (voliteľne)</string>
-    <string name="address_label_region_generic">Štát/provincia/región</string>
-    <string name="address_label_region_generic_optional">Štát/provincia/región (voliteľne)</string>
-    <string name="address_label_state">Štát</string>
-    <string name="address_label_state_optional">Štát (voliteľne)</string>
-    <string name="address_label_zip_code">PSČ</string>
-    <string name="address_label_zip_code_optional">PSČ (voliteľne)</string>
-    <string name="address_label_zip_postal_code">PSČ</string>
-    <string name="address_label_zip_postal_code_optional">PSČ (voliteľne)</string>
-    <string name="address_name_required">Zadajte svoje meno</string>
-    <string name="address_phone_number_required">Zadajte vaše telefónne číslo</string>
-    <string name="address_postal_code_invalid">Vaše PSČ je neplatné</string>
-    <string name="address_postcode_invalid">Vaše PSČ je neplatné</string>
-    <string name="address_province_required">Zadajte provinciu</string>
-    <string name="address_region_generic_required">Zadajte štát/provinciu/región</string>
-    <string name="address_required">Zadajte vašu adresu</string>
-    <string name="address_shipping_address">Dodacia adresa</string>
-    <string name="address_state_required">Zadajte štát</string>
-    <string name="address_zip_invalid">Vaše PSČ je neplatné.</string>
-    <string name="address_zip_postal_invalid">Vaše PSČ je neplatné</string>
-    <string name="becs_mandate_acceptance">
-    Poskytnutím podrobností o svojom bankovom účte a potvrdením tejto platby súhlasíte s touto
-    požiadavkou na inkaso a zmluvou o službách požiadaviek na inkaso a autorizujete spoločnosť
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 ID používateľa inkasa 507156
-    („Stripe“) na inkaso vášho účtu prostredníctvom systému Bulk Electronic Clearing System (BECS)
-    v mene %1$s (ďalej len „obchodník“) pre všetky sumy, ktoré vám boli oznámené
-    osobitne obchodníkom. Potvrdzujete, že ste buď majiteľom účtu alebo
-    autorizovaným signatárom na vyššie uvedenom účte.
-    </string>
-    <string name="becs_widget_account_number">Číslo účtu</string>
-    <string name="becs_widget_account_number_incomplete">Číslo vášho účtu je neúplné.</string>
-    <string name="becs_widget_account_number_required">Vyžaduje sa vaše číslo účtu.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Zadané BSB je neúplné.</string>
-    <string name="becs_widget_bsb_invalid">Zadané BSB je neplatné.</string>
-    <string name="becs_widget_email">E-mailová adresa</string>
-    <string name="becs_widget_email_invalid">Vaša e-mailová adresa je neplatná.</string>
-    <string name="becs_widget_email_required">Vyžaduje sa vaša e-mailová adresa.</string>
-    <string name="becs_widget_name">Meno</string>
-    <string name="becs_widget_name_required">Vyžaduje sa vaše meno.</string>
-    <string name="card_ending_in">Karta %1$s s poslednými štyrmi číslami %2$s</string>
-    <string name="close">Zatvoriť</string>
-    <string name="delete_payment_method">Odstrániť spôsob platby</string>
-    <string name="delete_payment_method_prompt_title">Vymazať spôsob platby?</string>
-    <string name="expiry_date_hint">MM/RR</string>
-    <string name="expiry_label_short">Ukončenie platnosti</string>
-    <string name="fpx_bank_offline">%s - Offline</string>
-    <string name="incomplete_expiry_date">Dátum vypršania platnosti vašej karty je neúplný.</string>
-    <string name="invalid_card_number">Číslo vašej karty je neplatné.</string>
-    <string name="invalid_cvc">Bezpečnostný kód vašej karty je neplatný.</string>
-    <string name="invalid_expiry_month">Mesiac vypršania platnosti vašej karty je neplatný.</string>
-    <string name="invalid_expiry_year">Rok ukončenia platnosti vašej karty je neplatný.</string>
-    <string name="invalid_shipping_information">Neplatná dodacia adresa</string>
-    <string name="invalid_zip">Vaše poštové smerovacie číslo je neúplné.</string>
-    <string name="no_payment_methods">Žiadne spôsoby platby.</string>
-    <string name="payment_method_add_new_card">Pridať novú kartu…</string>
-    <string name="payment_method_add_new_fpx">Zvoľte bankový účet (FPX)…</string>
-    <string name="price_free">Zdarma</string>
-    <string name="removed">Spôsob platby %s odstránený</string>
-    <string name="secure_checkout">Bezpečná pokladňa</string>
-    <string name="stripe_failure_connection_error">Vyskytli sa problémy s pripojením k nášmu poskytovateľovi platieb. Skontrolujte pripojenie k internetu a skúste to znova.</string>
-    <string name="stripe_failure_reason_authentication">Nemôžeme overiť váš spôsob platby. Vyberte iný spôsob platby a skúste to znova.</string>
-    <string name="stripe_failure_reason_timed_out">Vypršal čas autentifikácie vášho spôsobu platby -- skúste znova</string>
-    <string name="stripe_google_pay_error_internal">Vyskytla sa interná chyba.</string>
-    <string name="stripe_paymentsheet_add_button_label">Pridať</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridať</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Informácie o karte</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Krajina alebo región</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Pridajte svoje informácie o platbe</string>
-    <string name="stripe_paymentsheet_back">Späť</string>
-    <string name="stripe_paymentsheet_close">Zatvoriť</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
-    <string name="stripe_paymentsheet_or_pay_using">Alebo zaplaťte pomocou</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Alebo zaplaťte kartou</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Zaplatiť %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Zaplatiť</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Prebieha spracovanie…</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložiť túto kartu pre budúce platby obchodníkovi %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Vyberte svoj spôsob platby</string>
-    <string name="stripe_paymentsheet_setup_button_label">Nastaviť</string>
-    <string name="stripe_paymentsheet_total_amount">Celkovo: %s</string>
-    <string name="stripe_verify_your_payment">Overenie platby</string>
-    <string name="title_add_a_card">Pridať kartu</string>
-    <string name="title_add_an_address">Zadajte adresu</string>
-    <string name="title_bank_account">Bankový účet</string>
-    <string name="title_payment_method">Spôsob platby</string>
-    <string name="title_select_shipping_method">Zvoľte spôsob dodania</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Číslo karty</string>
+  <string name="acc_label_card_number_node">%s, číslo karty</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Dátum ukončenia platnosti</string>
+  <string name="acc_label_expiry_date_node">%s, dátum ukončenia platnosti</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">PSČ</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">PSČ</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Pridajte novú debetnú alebo kreditnú kartu, aby ste mohli nakupovať v tejto aplikácii.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Spôsob platby %s pridaný</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Zadajte vaše mesto</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Vaša krajina je neplatná.</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Zadajte váš kraj</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Riadok adresy 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Riadok adresy 1 (voliteľne)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Riadok adresy 2 (voliteľne)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Adresa (voliteľne)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Byt (voliteľne)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Mesto (voliteľne)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Kraj (voliteľne)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefónne číslo</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefónne číslo (voliteľne)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">PSČ (voliteľne)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">PSČ</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">PSČ (voliteľne)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provincia (voliteľne)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Štát/provincia/región</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Štát/provincia/región (voliteľne)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Štát (voliteľne)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">PSČ (voliteľne)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">PSČ</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">PSČ (voliteľne)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Zadajte svoje meno</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Zadajte vaše telefónne číslo</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Vaše PSČ je neplatné</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Vaše PSČ je neplatné</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Zadajte provinciu</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Zadajte štát/provinciu/región</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Zadajte vašu adresu</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Dodacia adresa</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Zadajte štát</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Vaše PSČ je neplatné.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Vaše PSČ je neplatné</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Poskytnutím podrobností o svojom bankovom účte a potvrdením tejto platby súhlasíte s touto\n    požiadavkou na inkaso a zmluvou o službách požiadaviek na inkaso a autorizujete spoločnosť\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 ID používateľa inkasa 507156\n    („Stripe“) na inkaso vášho účtu prostredníctvom systému Bulk Electronic Clearing System (BECS)\n    v mene %1$s (ďalej len „obchodník“) pre všetky sumy, ktoré vám boli oznámené\n    osobitne obchodníkom. Potvrdzujete, že ste buď majiteľom účtu alebo\n    autorizovaným signatárom na vyššie uvedenom účte.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Číslo účtu</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Číslo vášho účtu je neúplné.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Vyžaduje sa vaše číslo účtu.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Zadané BSB je neúplné.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Zadané BSB je neplatné.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-mailová adresa</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Vaša e-mailová adresa je neplatná.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Vyžaduje sa vaša e-mailová adresa.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Meno</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Vyžaduje sa vaše meno.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">Karta %1$s s poslednými štyrmi číslami %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Zatvoriť</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Odstrániť spôsob platby</string>
+  <string name="delete_payment_method_prompt_title">Vymazať spôsob platby?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/RR</string>
+  <string name="expiry_label_short">Ukončenie platnosti</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Dátum vypršania platnosti vašej karty je neúplný.</string>
+  <string name="invalid_card_number">Číslo vašej karty je neplatné.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Bezpečnostný kód vašej karty je neplatný.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Mesiac vypršania platnosti vašej karty je neplatný.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Rok ukončenia platnosti vašej karty je neplatný.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Neplatná dodacia adresa</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Vaše poštové smerovacie číslo je neúplné.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Žiadne spôsoby platby.</string>
+  <string name="payment_method_add_new_card">Pridať novú kartu…</string>
+  <string name="payment_method_add_new_fpx">Zvoľte bankový účet (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Zdarma</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Spôsob platby %s odstránený</string>
+  <string name="secure_checkout">Bezpečná pokladňa</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Vyskytli sa problémy s pripojením k nášmu poskytovateľovi platieb. Skontrolujte pripojenie k internetu a skúste to znova.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Nemôžeme overiť váš spôsob platby. Vyberte iný spôsob platby a skúste to znova.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Vypršal čas autentifikácie vášho spôsobu platby -- skúste znova</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Vyskytla sa interná chyba.</string>
+  <string name="stripe_paymentsheet_add_button_label">Pridať</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridať</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informácie o karte</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Krajina alebo región</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Pridajte svoje informácie o platbe</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Späť</string>
+  <string name="stripe_paymentsheet_close">Zatvoriť</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / RR</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Alebo zaplaťte pomocou</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Alebo zaplaťte kartou</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Zaplatiť %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Zaplatiť</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Prebieha spracovanie…</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložiť túto kartu pre budúce platby obchodníkovi %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Vyberte svoj spôsob platby</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Nastaviť</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Overenie platby</string>
+  <string name="title_add_a_card">Pridať kartu</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Zadajte adresu</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bankový účet</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Spôsob platby</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Zvoľte spôsob dodania</string>
 </resources>

--- a/payments-core/res/values-sl-rSI/strings.xml
+++ b/payments-core/res/values-sl-rSI/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">Številka kartice</string>
-    <string name="acc_label_card_number_node">%s, številka kartice</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">Datum poteka</string>
-    <string name="acc_label_expiry_date_node">%s, datum poteka</string>
-    <string name="acc_label_zip">Poštna številka</string>
-    <string name="acc_label_zip_short">Poštna številka</string>
-    <string name="add_card">Dodajte novo bančno plačilno ali kreditno kartico za opravljanje nakupov v tej aplikaciji.</string>
-    <string name="added">Način plačila %s je dodan</string>
-    <string name="address_city_required">Vnesite mesto</string>
-    <string name="address_country_invalid">Vaša država ni veljavna</string>
-    <string name="address_county_required">Vnesite državo</string>
-    <string name="address_label_address">Naslov</string>
-    <string name="address_label_address_line1">Naslov 1</string>
-    <string name="address_label_address_line1_optional">Naslov 1 (izbirno)</string>
-    <string name="address_label_address_line2_optional">Naslov 2 (izbirno)</string>
-    <string name="address_label_address_optional">Naslov (izbirno)</string>
-    <string name="address_label_apt">Stanovanje</string>
-    <string name="address_label_apt_optional">Stanovanje (izbirno)</string>
-    <string name="address_label_city">Mesto</string>
-    <string name="address_label_city_optional">Mesto (izbirno)</string>
-    <string name="address_label_country">Država</string>
-    <string name="address_label_county">Okraj</string>
-    <string name="address_label_county_optional">Država (izbirno)</string>
-    <string name="address_label_name">Ime</string>
-    <string name="address_label_phone_number">Telefonska številka</string>
-    <string name="address_label_phone_number_optional">Telefonska številka (izbirno)</string>
-    <string name="address_label_postal_code">Poštna številka</string>
-    <string name="address_label_postal_code_optional">Poštna številka (izbirno)</string>
-    <string name="address_label_postcode">Poštna številka</string>
-    <string name="address_label_postcode_optional">Poštna številka (izbirno)</string>
-    <string name="address_label_province">Provinca</string>
-    <string name="address_label_province_optional">Provinca (izbirno)</string>
-    <string name="address_label_region_generic">Zvezna država/provinca/regija</string>
-    <string name="address_label_region_generic_optional">Zvezna država/provinca/regija (izbirno)</string>
-    <string name="address_label_state">Zvezna država</string>
-    <string name="address_label_state_optional">Zvezna država (izbirno)</string>
-    <string name="address_label_zip_code">Poštna številka</string>
-    <string name="address_label_zip_code_optional">Poštna številka (izbirno)</string>
-    <string name="address_label_zip_postal_code">Poštna številka</string>
-    <string name="address_label_zip_postal_code_optional">Poštna številka (izbirno)</string>
-    <string name="address_name_required">Vnesite svoje ime</string>
-    <string name="address_phone_number_required">Vnesite svojo telefonsko številko</string>
-    <string name="address_postal_code_invalid">Vaša poštna številka ni veljavna</string>
-    <string name="address_postcode_invalid">Vaša poštna številka ni veljavna</string>
-    <string name="address_province_required">Vnesite provinco</string>
-    <string name="address_region_generic_required">Vnesite zvezno državo/provinco/regijo</string>
-    <string name="address_required">Vnesite svoj naslov</string>
-    <string name="address_shipping_address">Dostavni naslov</string>
-    <string name="address_state_required">Vnesite zvezno državo</string>
-    <string name="address_zip_invalid">Vaša poštna številka ni veljavna.</string>
-    <string name="address_zip_postal_invalid">Vaša poštna številka ni veljavna</string>
-    <string name="becs_mandate_acceptance">
-    Če navedete podatke svojega bančnega računa in potrdite to plačilo, se strinjate s to
-    zahtevo za direktno obremenitev in pogodbo o storitvi za zahtevo za direktno obremenitev ter pooblaščate
-    Stripe Payments Australia Pty Ltd ACN s številko direktne obremenitve 160 180 343 in identifikacijsko številko uporabnika507156
-    (»Stripe«), da obremeni vaš račun prek množičnega elektronskega klirinškega sistema (BECS) v
-    imenu podjetja %1$s (»trgovec«) za katere koli zneske, o katerih vas ločeno
-    obvesti trgovec. Potrjujete, da ste lastnik računa ali pooblaščeni
-    podpisnik za zgoraj navedeni računa.
-    </string>
-    <string name="becs_widget_account_number">Številka računa</string>
-    <string name="becs_widget_account_number_incomplete">Številka vašega računa ni popolna.</string>
-    <string name="becs_widget_account_number_required">Številka vašega računa je obvezna.</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">Vneseni BSB ni popoln.</string>
-    <string name="becs_widget_bsb_invalid">Vneseni BSB ni veljaven.</string>
-    <string name="becs_widget_email">E-poštni naslov</string>
-    <string name="becs_widget_email_invalid">Vaš e-poštni naslov ni veljaven.</string>
-    <string name="becs_widget_email_required">Vaš e-poštni naslov je obvezen.</string>
-    <string name="becs_widget_name">Ime</string>
-    <string name="becs_widget_name_required">Vaše ime je obvezno.</string>
-    <string name="card_ending_in">%1$s, ki se konča s/z %2$s</string>
-    <string name="close">Zapri</string>
-    <string name="delete_payment_method">Izbriši način plačila</string>
-    <string name="delete_payment_method_prompt_title">Ali želite izbrisati načina plačila?</string>
-    <string name="expiry_date_hint">MM/LL</string>
-    <string name="expiry_label_short">Potek</string>
-    <string name="fpx_bank_offline">%s – ni dosegljiva</string>
-    <string name="incomplete_expiry_date">Datum poteka vaše kartice ni popoln.</string>
-    <string name="invalid_card_number">Številka vaše kartice ni veljavna.</string>
-    <string name="invalid_cvc">Varnostna koda vaše kartice ni veljavna.</string>
-    <string name="invalid_expiry_month">Mesec poteka vaše kartice ni veljaven.</string>
-    <string name="invalid_expiry_year">Leto poteka vaše kartice ni veljavno.</string>
-    <string name="invalid_shipping_information">Neveljaven dostavni naslov</string>
-    <string name="invalid_zip">Vaša poštna številka ni popolna.</string>
-    <string name="no_payment_methods">Ni načinov plačila.</string>
-    <string name="payment_method_add_new_card">Dodajte novo kartico ...</string>
-    <string name="payment_method_add_new_fpx">Izberite bančni račun (FPX) …</string>
-    <string name="price_free">Brezplačno</string>
-    <string name="removed">Način plačila %s je odstranjen</string>
-    <string name="secure_checkout">Varen zaključek nakupa</string>
-    <string name="stripe_failure_connection_error">Pri vzpostavljanju povezave z našim ponudnikom plačil prihaja do težav. Preverite povezavo z internetom in poskusite znova.</string>
-    <string name="stripe_failure_reason_authentication">Pristnosti vašega načina plačila ni mogoče preveriti. Izberite drugačen način plačila in poskusite znova.</string>
-    <string name="stripe_failure_reason_timed_out">Pri preverjanju pristnosti vašega načina plačila je potekla časovna omejitev. Poskusite znova.</string>
-    <string name="stripe_google_pay_error_internal">Prišlo je do notranje napake.</string>
-    <string name="stripe_paymentsheet_add_button_label">Dodaj</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Podatki o kartici</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Država ali regija</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Dodajte podatke o plačilu</string>
-    <string name="stripe_paymentsheet_back">Nazaj</string>
-    <string name="stripe_paymentsheet_close">Zapri</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM/LL</string>
-    <string name="stripe_paymentsheet_or_pay_using">Ali pa za plačilo uporabite</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">Ali pa plačajte s kartico</string>
-    <string name="stripe_paymentsheet_pay_button_amount">Plačaj %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">Plačaj</string>
-    <string name="stripe_paymentsheet_primary_button_processing">Obdelovanje ...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Shrani to kartico za prihodnja plačila trgovcu %s</string>
-    <string name="stripe_paymentsheet_select_payment_method">Izberite način plačila</string>
-    <string name="stripe_paymentsheet_setup_button_label">Nastavi</string>
-    <string name="stripe_paymentsheet_total_amount">Skupaj: %s</string>
-    <string name="stripe_verify_your_payment">Preverite svoje plačilo</string>
-    <string name="title_add_a_card">Dodajte kartico</string>
-    <string name="title_add_an_address">Nastavite naslov</string>
-    <string name="title_bank_account">Bančni račun</string>
-    <string name="title_payment_method">Načina plačila</string>
-    <string name="title_select_shipping_method">Izberite način dostave</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Številka kartice</string>
+  <string name="acc_label_card_number_node">%s, številka kartice</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Datum poteka</string>
+  <string name="acc_label_expiry_date_node">%s, datum poteka</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">Poštna številka</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">Poštna številka</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Dodajte novo bančno plačilno ali kreditno kartico za opravljanje nakupov v tej aplikaciji.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Način plačila %s je dodan</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Vnesite mesto</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Vaša država ni veljavna</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Vnesite državo</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Naslov</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Naslov 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Naslov 1 (izbirno)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Naslov 2 (izbirno)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Naslov (izbirno)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Stanovanje (izbirno)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">Mesto (izbirno)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">Država (izbirno)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Telefonska številka</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Telefonska številka (izbirno)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Poštna številka (izbirno)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Poštna številka</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Poštna številka (izbirno)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Provinca (izbirno)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">Zvezna država/provinca/regija</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">Zvezna država/provinca/regija (izbirno)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">Zvezna država (izbirno)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">Poštna številka (izbirno)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">Poštna številka</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">Poštna številka (izbirno)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Vnesite svoje ime</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Vnesite svojo telefonsko številko</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Vaša poštna številka ni veljavna</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Vaša poštna številka ni veljavna</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Vnesite provinco</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Vnesite zvezno državo/provinco/regijo</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Vnesite svoj naslov</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Dostavni naslov</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Vnesite zvezno državo</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Vaša poštna številka ni veljavna.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Vaša poštna številka ni veljavna</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    Če navedete podatke svojega bančnega računa in potrdite to plačilo, se strinjate s to\n    zahtevo za direktno obremenitev in pogodbo o storitvi za zahtevo za direktno obremenitev ter pooblaščate\n    Stripe Payments Australia Pty Ltd ACN s številko direktne obremenitve 160 180 343 in identifikacijsko številko uporabnika507156\n    (»Stripe«), da obremeni vaš račun prek množičnega elektronskega klirinškega sistema (BECS) v\n    imenu podjetja %1$s (»trgovec«) za katere koli zneske, o katerih vas ločeno\n    obvesti trgovec. Potrjujete, da ste lastnik računa ali pooblaščeni\n    podpisnik za zgoraj navedeni računa.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Številka računa</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Številka vašega računa ni popolna.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Številka vašega računa je obvezna.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">Vneseni BSB ni popoln.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">Vneseni BSB ni veljaven.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">E-poštni naslov</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Vaš e-poštni naslov ni veljaven.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Vaš e-poštni naslov je obvezen.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Ime</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Vaše ime je obvezno.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s, ki se konča s/z %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Zapri</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Izbriši način plačila</string>
+  <string name="delete_payment_method_prompt_title">Ali želite izbrisati načina plačila?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/LL</string>
+  <string name="expiry_label_short">Potek</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s – ni dosegljiva</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Datum poteka vaše kartice ni popoln.</string>
+  <string name="invalid_card_number">Številka vaše kartice ni veljavna.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Varnostna koda vaše kartice ni veljavna.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Mesec poteka vaše kartice ni veljaven.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Leto poteka vaše kartice ni veljavno.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Neveljaven dostavni naslov</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Vaša poštna številka ni popolna.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">Ni načinov plačila.</string>
+  <string name="payment_method_add_new_card">Dodajte novo kartico ...</string>
+  <string name="payment_method_add_new_fpx">Izberite bančni račun (FPX) …</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Brezplačno</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Način plačila %s je odstranjen</string>
+  <string name="secure_checkout">Varen zaključek nakupa</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">Pri vzpostavljanju povezave z našim ponudnikom plačil prihaja do težav. Preverite povezavo z internetom in poskusite znova.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">Pristnosti vašega načina plačila ni mogoče preveriti. Izberite drugačen način plačila in poskusite znova.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Pri preverjanju pristnosti vašega načina plačila je potekla časovna omejitev. Poskusite znova.</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">Prišlo je do notranje napake.</string>
+  <string name="stripe_paymentsheet_add_button_label">Dodaj</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Podatki o kartici</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Država ali regija</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Dodajte podatke o plačilu</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Nazaj</string>
+  <string name="stripe_paymentsheet_close">Zapri</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM/LL</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Ali pa za plačilo uporabite</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Ali pa plačajte s kartico</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Plačaj %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Plačaj</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Obdelovanje ...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Shrani to kartico za prihodnja plačila trgovcu %s</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Izberite način plačila</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Nastavi</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Preverite svoje plačilo</string>
+  <string name="title_add_a_card">Dodajte kartico</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Nastavite naslov</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bančni račun</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Načina plačila</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Izberite način dostave</string>
 </resources>

--- a/payments-core/res/values-zh-rHK/strings.xml
+++ b/payments-core/res/values-zh-rHK/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">卡號</string>
-    <string name="acc_label_card_number_node">%s，卡號</string>
-    <string name="acc_label_cvc_node">%s，CVC</string>
-    <string name="acc_label_expiry_date">到期日</string>
-    <string name="acc_label_expiry_date_node">%s，到期日</string>
-    <string name="acc_label_zip">郵區編號</string>
-    <string name="acc_label_zip_short">郵區編號</string>
-    <string name="add_card">添加一個新的扣帳卡或信用卡以便在應用程式內購物。</string>
-    <string name="added">已添加 %s</string>
-    <string name="address_city_required">請輸入您的城市</string>
-    <string name="address_country_invalid">您的國家無效</string>
-    <string name="address_county_required">請輸入您所在的縣</string>
-    <string name="address_label_address">地址</string>
-    <string name="address_label_address_line1">地址行 1</string>
-    <string name="address_label_address_line1_optional">地址行 1（可選）</string>
-    <string name="address_label_address_line2_optional">地址行 2（可選）</string>
-    <string name="address_label_address_optional">地址（可選）</string>
-    <string name="address_label_apt">公寓</string>
-    <string name="address_label_apt_optional">公寓（可選）</string>
-    <string name="address_label_city">城市</string>
-    <string name="address_label_city_optional">城市（可選）</string>
-    <string name="address_label_country">國家</string>
-    <string name="address_label_county">縣</string>
-    <string name="address_label_county_optional">縣（可選）</string>
-    <string name="address_label_name">姓名</string>
-    <string name="address_label_phone_number">電話號碼</string>
-    <string name="address_label_phone_number_optional">電話號碼（可選）</string>
-    <string name="address_label_postal_code">郵區編號</string>
-    <string name="address_label_postal_code_optional">郵區編號（可選）</string>
-    <string name="address_label_postcode">郵區編號</string>
-    <string name="address_label_postcode_optional">郵區編號（可選）</string>
-    <string name="address_label_province">省</string>
-    <string name="address_label_province_optional">省（可選）</string>
-    <string name="address_label_region_generic">州/省/區</string>
-    <string name="address_label_region_generic_optional">州/省/區（可選）</string>
-    <string name="address_label_state">州</string>
-    <string name="address_label_state_optional">州（可選）</string>
-    <string name="address_label_zip_code">郵區編號</string>
-    <string name="address_label_zip_code_optional">郵區編號（可選）</string>
-    <string name="address_label_zip_postal_code">郵區編號</string>
-    <string name="address_label_zip_postal_code_optional">郵區編號（可選）</string>
-    <string name="address_name_required">請輸入您的姓名</string>
-    <string name="address_phone_number_required">請輸入您的電話號碼</string>
-    <string name="address_postal_code_invalid">您的郵區編號無效</string>
-    <string name="address_postcode_invalid">您的郵區編號無效</string>
-    <string name="address_province_required">請輸入您的省份</string>
-    <string name="address_region_generic_required">請輸入您的州/省/區</string>
-    <string name="address_required">請輸入您的地址</string>
-    <string name="address_shipping_address">配送地址</string>
-    <string name="address_state_required">請輸入您所屬的州</string>
-    <string name="address_zip_invalid">您的郵區編號無效。</string>
-    <string name="address_zip_postal_invalid">您的郵區編號無效</string>
-    <string name="becs_mandate_acceptance">
-    透過提供您的銀行帳戶資訊並確認該筆付款，
-    表示您同意本「直接扣帳請求」及其服務條款，
-    並授權 Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID
-    number 507156 (「Stripe」) 透過批量電子清算系統 (BECS)
-    代 %1$s（「商家」）向您的帳戶扣取商家單獨告知您的金額。
-    您確認您是帳戶持有人或上述帳戶的授權簽署人。
-    
-    </string>
-    <string name="becs_widget_account_number">帳號</string>
-    <string name="becs_widget_account_number_incomplete">您的帳號不完整。</string>
-    <string name="becs_widget_account_number_required">您需要填寫帳號。</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">您輸入的 BSB 不完整。</string>
-    <string name="becs_widget_bsb_invalid">您輸入的 BSB 無效。</string>
-    <string name="becs_widget_email">電郵地址</string>
-    <string name="becs_widget_email_invalid">您的電郵地址無效。</string>
-    <string name="becs_widget_email_required">您需要填寫電郵地址。</string>
-    <string name="becs_widget_name">姓名</string>
-    <string name="becs_widget_name_required">您需要填寫姓名。</string>
-    <string name="card_ending_in">%1$s尾號%2$s</string>
-    <string name="close">關閉</string>
-    <string name="delete_payment_method">刪除支付方式</string>
-    <string name="delete_payment_method_prompt_title">刪除支付方式</string>
-    <string name="expiry_date_hint">月月/年年</string>
-    <string name="expiry_label_short">有效期</string>
-    <string name="fpx_bank_offline">%s - 線下</string>
-    <string name="incomplete_expiry_date">您的銀行卡的到期日期不完整。</string>
-    <string name="invalid_card_number">您的卡號無效。</string>
-    <string name="invalid_cvc">您的銀行卡安全碼無效。</string>
-    <string name="invalid_expiry_month">您的銀行卡的到期月份無效。</string>
-    <string name="invalid_expiry_year">您的銀行卡的到期年份無效。</string>
-    <string name="invalid_shipping_information">配送地址無效</string>
-    <string name="invalid_zip">您的郵區編號不完整。</string>
-    <string name="no_payment_methods">沒有支付方式。</string>
-    <string name="payment_method_add_new_card">添加新卡…</string>
-    <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
-    <string name="price_free">免費</string>
-    <string name="removed">已移除 %s</string>
-    <string name="secure_checkout">安全結帳</string>
-    <string name="stripe_failure_connection_error">連接我們的支付提供者時出現了問題。請檢查網路連接，然後重試。</string>
-    <string name="stripe_failure_reason_authentication">我們無法驗證您的付款方式。請選擇另一付款方式並重試。</string>
-    <string name="stripe_failure_reason_timed_out">驗證您的付款方式時超時 -- 請重試</string>
-    <string name="stripe_google_pay_error_internal">發生了內部錯誤。</string>
-    <string name="stripe_paymentsheet_add_button_label">添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">銀行卡資訊</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
-    <string name="stripe_paymentsheet_back">上一步</string>
-    <string name="stripe_paymentsheet_close">關閉</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">月月/年年</string>
-    <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">或用銀行卡支付</string>
-    <string name="stripe_paymentsheet_pay_button_amount">支付%s</string>
-    <string name="stripe_paymentsheet_pay_button_label">支付</string>
-    <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來的 %s 付款</string>
-    <string name="stripe_paymentsheet_select_payment_method">選擇您的支付方式</string>
-    <string name="stripe_paymentsheet_setup_button_label">設置</string>
-    <string name="stripe_paymentsheet_total_amount">總金額：%s</string>
-    <string name="stripe_verify_your_payment">驗證您的付款</string>
-    <string name="title_add_a_card">添加卡片</string>
-    <string name="title_add_an_address">設置地址</string>
-    <string name="title_bank_account">銀行帳戶</string>
-    <string name="title_payment_method">支付方式</string>
-    <string name="title_select_shipping_method">選擇配送方式</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">卡號</string>
+  <string name="acc_label_card_number_node">%s，卡號</string>
+  <string name="acc_label_cvc_node">%s，CVC</string>
+  <string name="acc_label_expiry_date">到期日</string>
+  <string name="acc_label_expiry_date_node">%s，到期日</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">郵區編號</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">郵區編號</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">添加一個新的扣帳卡或信用卡以便在應用程式內購物。</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">已添加 %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">請輸入您的城市</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">您的國家無效</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">請輸入您所在的縣</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">地址行 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">地址行 1（可選）</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">地址行 2（可選）</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">地址（可選）</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">公寓（可選）</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">城市（可選）</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">縣（可選）</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">電話號碼</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">電話號碼（可選）</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">郵區編號（可選）</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">郵區編號</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">郵區編號（可選）</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">省（可選）</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">州/省/區</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">州/省/區（可選）</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">州（可選）</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">郵區編號（可選）</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">郵區編號</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">郵區編號（可選）</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">請輸入您的姓名</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">請輸入您的電話號碼</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">您的郵區編號無效</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">您的郵區編號無效</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">請輸入您的省份</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">請輸入您的州/省/區</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">請輸入您的地址</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">配送地址</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">請輸入您所屬的州</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">您的郵區編號無效。</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">您的郵區編號無效</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    透過提供您的銀行帳戶資訊並確認該筆付款，\n    表示您同意本「直接扣帳請求」及其服務條款，\n    並授權 Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID\n    number 507156 (「Stripe」) 透過批量電子清算系統 (BECS)\n    代 %1$s（「商家」）向您的帳戶扣取商家單獨告知您的金額。\n    您確認您是帳戶持有人或上述帳戶的授權簽署人。\n    \n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">帳號</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">您的帳號不完整。</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">您需要填寫帳號。</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">您輸入的 BSB 不完整。</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">您輸入的 BSB 無效。</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">電郵地址</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">您的電郵地址無效。</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">您需要填寫電郵地址。</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">姓名</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">您需要填寫姓名。</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s尾號%2$s</string>
+  <!-- Text for close button -->
+  <string name="close">關閉</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">刪除支付方式</string>
+  <string name="delete_payment_method_prompt_title">刪除支付方式</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">月月/年年</string>
+  <string name="expiry_label_short">有效期</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - 線下</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">您的銀行卡的到期日期不完整。</string>
+  <string name="invalid_card_number">您的卡號無效。</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">您的銀行卡安全碼無效。</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">您的銀行卡的到期月份無效。</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">您的銀行卡的到期年份無效。</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">配送地址無效</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">您的郵區編號不完整。</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">沒有支付方式。</string>
+  <string name="payment_method_add_new_card">添加新卡…</string>
+  <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">免費</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">已移除 %s</string>
+  <string name="secure_checkout">安全結帳</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">連接我們的支付提供者時出現了問題。請檢查網路連接，然後重試。</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">我們無法驗證您的付款方式。請選擇另一付款方式並重試。</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">驗證您的付款方式時超時 -- 請重試</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">發生了內部錯誤。</string>
+  <string name="stripe_paymentsheet_add_button_label">添加</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">銀行卡資訊</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">上一步</string>
+  <string name="stripe_paymentsheet_close">關閉</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">月月/年年</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">或用銀行卡支付</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">支付%s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來的 %s 付款</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">選擇您的支付方式</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">設置</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">驗證您的付款</string>
+  <string name="title_add_a_card">添加卡片</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">設置地址</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">銀行帳戶</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">支付方式</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">選擇配送方式</string>
 </resources>

--- a/payments-core/res/values-zh-rTW/strings.xml
+++ b/payments-core/res/values-zh-rTW/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">卡號</string>
-    <string name="acc_label_card_number_node">%s，卡號</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <string name="acc_label_expiry_date">到期日</string>
-    <string name="acc_label_expiry_date_node">%s，到期日</string>
-    <string name="acc_label_zip">郵遞區號</string>
-    <string name="acc_label_zip_short">郵遞區號</string>
-    <string name="add_card">添加一個新的簽帳金融卡或信用卡以便在應用程式內購物。</string>
-    <string name="added">已添加 %s</string>
-    <string name="address_city_required">請輸入您的城市</string>
-    <string name="address_country_invalid">您的國家無效</string>
-    <string name="address_county_required">請輸入您所在的縣</string>
-    <string name="address_label_address">地址</string>
-    <string name="address_label_address_line1">地址行 1</string>
-    <string name="address_label_address_line1_optional">地址行 1（可選）</string>
-    <string name="address_label_address_line2_optional">地址行 2（可選）</string>
-    <string name="address_label_address_optional">地址（可選）</string>
-    <string name="address_label_apt">公寓</string>
-    <string name="address_label_apt_optional">公寓（可選）</string>
-    <string name="address_label_city">城市</string>
-    <string name="address_label_city_optional">城市（可選）</string>
-    <string name="address_label_country">國家</string>
-    <string name="address_label_county">縣</string>
-    <string name="address_label_county_optional">縣（可選）</string>
-    <string name="address_label_name">姓名</string>
-    <string name="address_label_phone_number">電話號碼</string>
-    <string name="address_label_phone_number_optional">電話號碼（可選）</string>
-    <string name="address_label_postal_code">郵遞區號</string>
-    <string name="address_label_postal_code_optional">郵遞區號（可選）</string>
-    <string name="address_label_postcode">郵遞區號</string>
-    <string name="address_label_postcode_optional">郵遞區號（可選）</string>
-    <string name="address_label_province">省</string>
-    <string name="address_label_province_optional">省（可選）</string>
-    <string name="address_label_region_generic">州 / 省 / 地區</string>
-    <string name="address_label_region_generic_optional">州 / 省 / 地區（可選）</string>
-    <string name="address_label_state">州</string>
-    <string name="address_label_state_optional">州（可選）</string>
-    <string name="address_label_zip_code">郵遞區號</string>
-    <string name="address_label_zip_code_optional">郵遞區號（可選）</string>
-    <string name="address_label_zip_postal_code">郵遞區號</string>
-    <string name="address_label_zip_postal_code_optional">郵遞區號（可選）</string>
-    <string name="address_name_required">請輸入您的姓名</string>
-    <string name="address_phone_number_required">請輸入您的電話號碼</string>
-    <string name="address_postal_code_invalid">您的郵遞區號無效</string>
-    <string name="address_postcode_invalid">您的郵遞區號無效</string>
-    <string name="address_province_required">請輸入您的省份</string>
-    <string name="address_region_generic_required">請輸入您的州 /省 / 地區</string>
-    <string name="address_required">請輸入您的地址</string>
-    <string name="address_shipping_address">送貨地址</string>
-    <string name="address_state_required">請輸入您所屬的州</string>
-    <string name="address_zip_invalid">您的郵遞區號無效。</string>
-    <string name="address_zip_postal_invalid">您的郵遞區號無效</string>
-    <string name="becs_mandate_acceptance">
-    透過提供您的銀行帳戶資訊並確認該筆付款，
-    表示您同意本「直接簽帳請求」及其服務條款，
-    並授權 Stripe Payments Australia Pty Ltd ACN 160 180 343
-    Direct Debit User ID number 507156 (「Stripe」) 透過過批量電子清算系統 (BECS)
-    代 %1$s（「商家」）向您的帳戶扣取商家單獨告知您的金額。
-    您確認您是帳戶持有人或上述帳戶的授權簽署人。
-    
-    </string>
-    <string name="becs_widget_account_number">帳號</string>
-    <string name="becs_widget_account_number_incomplete">您的帳號不完整。</string>
-    <string name="becs_widget_account_number_required">您需要填寫帳號。</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">您輸入的 BSB 不完整。</string>
-    <string name="becs_widget_bsb_invalid">您輸入的 BSB 無效。</string>
-    <string name="becs_widget_email">電郵地址</string>
-    <string name="becs_widget_email_invalid">您的電郵地址無效。</string>
-    <string name="becs_widget_email_required">您需要填寫電郵地址。</string>
-    <string name="becs_widget_name">姓名</string>
-    <string name="becs_widget_name_required">您需要填寫姓名。</string>
-    <string name="card_ending_in">%1$s 尾號 %2$s</string>
-    <string name="close">關閉</string>
-    <string name="delete_payment_method">刪除付款方式</string>
-    <string name="delete_payment_method_prompt_title">刪除支付方式</string>
-    <string name="expiry_date_hint">月月/年年</string>
-    <string name="expiry_label_short">有效期</string>
-    <string name="fpx_bank_offline">%s - 線下</string>
-    <string name="incomplete_expiry_date">您的卡的到期日期不完整。</string>
-    <string name="invalid_card_number">您的卡號無效。</string>
-    <string name="invalid_cvc">您的金融卡安全碼無效。</string>
-    <string name="invalid_expiry_month">您的金融卡的到期月份無效。</string>
-    <string name="invalid_expiry_year">您的金融卡的到期年份無效。</string>
-    <string name="invalid_shipping_information">送貨地址無效</string>
-    <string name="invalid_zip">您的郵遞區號不完整。</string>
-    <string name="no_payment_methods">沒有付款方式</string>
-    <string name="payment_method_add_new_card">添加新卡...</string>
-    <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
-    <string name="price_free">免費</string>
-    <string name="removed">已移除 %s</string>
-    <string name="secure_checkout">安全結帳</string>
-    <string name="stripe_failure_connection_error">連接我們的支付提供者時出現了問題。請檢查網路連接，然後重試。</string>
-    <string name="stripe_failure_reason_authentication">我們無法驗證您的付款方式。請選擇其他付款方式，然後再試一次。</string>
-    <string name="stripe_failure_reason_timed_out">驗證您的付款方式時逾時 -- 請重試</string>
-    <string name="stripe_google_pay_error_internal">發生了內部錯誤。</string>
-    <string name="stripe_paymentsheet_add_button_label">添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">金融卡資訊</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
-    <string name="stripe_paymentsheet_back">上一步</string>
-    <string name="stripe_paymentsheet_close">關閉</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">年年/月月</string>
-    <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">或用金融卡支付</string>
-    <string name="stripe_paymentsheet_pay_button_amount">支付 %s</string>
-    <string name="stripe_paymentsheet_pay_button_label">支付</string>
-    <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來的 %s 付款。</string>
-    <string name="stripe_paymentsheet_select_payment_method">選擇您的支付方式</string>
-    <string name="stripe_paymentsheet_setup_button_label">設定</string>
-    <string name="stripe_paymentsheet_total_amount">總金額：%s</string>
-    <string name="stripe_verify_your_payment">驗證您的付款</string>
-    <string name="title_add_a_card">新增一張卡</string>
-    <string name="title_add_an_address">設置地址</string>
-    <string name="title_bank_account">銀行帳戶</string>
-    <string name="title_payment_method">付款方式</string>
-    <string name="title_select_shipping_method">選擇送貨方式</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">卡號</string>
+  <string name="acc_label_card_number_node">%s，卡號</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">到期日</string>
+  <string name="acc_label_expiry_date_node">%s，到期日</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">郵遞區號</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">郵遞區號</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">添加一個新的簽帳金融卡或信用卡以便在應用程式內購物。</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">已添加 %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">請輸入您的城市</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">您的國家無效</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">請輸入您所在的縣</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">地址行 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">地址行 1（可選）</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">地址行 2（可選）</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">地址（可選）</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">公寓（可選）</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">城市（可選）</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">縣（可選）</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">電話號碼</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">電話號碼（可選）</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">郵遞區號（可選）</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">郵遞區號</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">郵遞區號（可選）</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">省（可選）</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">州 / 省 / 地區</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">州 / 省 / 地區（可選）</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">州（可選）</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">郵遞區號（可選）</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">郵遞區號</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">郵遞區號（可選）</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">請輸入您的姓名</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">請輸入您的電話號碼</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">您的郵遞區號無效</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">您的郵遞區號無效</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">請輸入您的省份</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">請輸入您的州 /省 / 地區</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">請輸入您的地址</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">送貨地址</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">請輸入您所屬的州</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">您的郵遞區號無效。</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">您的郵遞區號無效</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    透過提供您的銀行帳戶資訊並確認該筆付款，\n    表示您同意本「直接簽帳請求」及其服務條款，\n    並授權 Stripe Payments Australia Pty Ltd ACN 160 180 343\n    Direct Debit User ID number 507156 (「Stripe」) 透過過批量電子清算系統 (BECS)\n    代 %1$s（「商家」）向您的帳戶扣取商家單獨告知您的金額。\n    您確認您是帳戶持有人或上述帳戶的授權簽署人。\n    \n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">帳號</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">您的帳號不完整。</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">您需要填寫帳號。</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">您輸入的 BSB 不完整。</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">您輸入的 BSB 無效。</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">電郵地址</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">您的電郵地址無效。</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">您需要填寫電郵地址。</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">姓名</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">您需要填寫姓名。</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s 尾號 %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">關閉</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">刪除付款方式</string>
+  <string name="delete_payment_method_prompt_title">刪除支付方式</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">月月/年年</string>
+  <string name="expiry_label_short">有效期</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - 線下</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">您的卡的到期日期不完整。</string>
+  <string name="invalid_card_number">您的卡號無效。</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">您的金融卡安全碼無效。</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">您的金融卡的到期月份無效。</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">您的金融卡的到期年份無效。</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">送貨地址無效</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">您的郵遞區號不完整。</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">沒有付款方式</string>
+  <string name="payment_method_add_new_card">添加新卡...</string>
+  <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">免費</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">已移除 %s</string>
+  <string name="secure_checkout">安全結帳</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">連接我們的支付提供者時出現了問題。請檢查網路連接，然後重試。</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">我們無法驗證您的付款方式。請選擇其他付款方式，然後再試一次。</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">驗證您的付款方式時逾時 -- 請重試</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">發生了內部錯誤。</string>
+  <string name="stripe_paymentsheet_add_button_label">添加</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">金融卡資訊</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">上一步</string>
+  <string name="stripe_paymentsheet_close">關閉</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">年年/月月</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">或用金融卡支付</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">支付 %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來的 %s 付款。</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">選擇您的支付方式</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">設定</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">驗證您的付款</string>
+  <string name="title_add_a_card">新增一張卡</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">設置地址</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">銀行帳戶</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">付款方式</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">選擇送貨方式</string>
 </resources>

--- a/payments-core/res/values-zh/strings.xml
+++ b/payments-core/res/values-zh/strings.xml
@@ -1,122 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="acc_label_card_number">卡号</string>
-    <string name="acc_label_card_number_node">%s，卡号</string>
-    <string name="acc_label_cvc_node">%s，CVC</string>
-    <string name="acc_label_expiry_date">到期日</string>
-    <string name="acc_label_expiry_date_node">%s，到期日</string>
-    <string name="acc_label_zip">邮编</string>
-    <string name="acc_label_zip_short">邮编</string>
-    <string name="add_card">添加一张新的借记卡或信用卡以便在此应用中进行购买。</string>
-    <string name="added">已添加 %s</string>
-    <string name="address_city_required">请输入您所在的城市</string>
-    <string name="address_country_invalid">您的国家无效</string>
-    <string name="address_county_required">请输入您所在的县</string>
-    <string name="address_label_address">地址</string>
-    <string name="address_label_address_line1">地址行 1</string>
-    <string name="address_label_address_line1_optional">第 1 行地址 (可选)</string>
-    <string name="address_label_address_line2_optional">地址行 2（可选）</string>
-    <string name="address_label_address_optional">地址 (可选)</string>
-    <string name="address_label_apt">公寓</string>
-    <string name="address_label_apt_optional">公寓号码 (可选)</string>
-    <string name="address_label_city">城市</string>
-    <string name="address_label_city_optional">城市 (可选)</string>
-    <string name="address_label_country">国家</string>
-    <string name="address_label_county">县</string>
-    <string name="address_label_county_optional">县（可选）</string>
-    <string name="address_label_name">姓名</string>
-    <string name="address_label_phone_number">电话号码</string>
-    <string name="address_label_phone_number_optional">电话号码（可选）</string>
-    <string name="address_label_postal_code">邮政编码</string>
-    <string name="address_label_postal_code_optional">邮政编码（可选）</string>
-    <string name="address_label_postcode">邮政编码</string>
-    <string name="address_label_postcode_optional">邮政编码（可选）</string>
-    <string name="address_label_province">省</string>
-    <string name="address_label_province_optional">省 (可选)</string>
-    <string name="address_label_region_generic">州/省/地区</string>
-    <string name="address_label_region_generic_optional">州/省/地区（可选）</string>
-    <string name="address_label_state">州</string>
-    <string name="address_label_state_optional">州 (可选)</string>
-    <string name="address_label_zip_code">邮政编码</string>
-    <string name="address_label_zip_code_optional">邮政编码（可选）</string>
-    <string name="address_label_zip_postal_code">邮政编码</string>
-    <string name="address_label_zip_postal_code_optional">邮政编码（可选）</string>
-    <string name="address_name_required">请输入您的姓名</string>
-    <string name="address_phone_number_required">请输入您的电话号码</string>
-    <string name="address_postal_code_invalid">您的邮政编码无效</string>
-    <string name="address_postcode_invalid">您的邮政编码无效</string>
-    <string name="address_province_required">请输入您所在的省</string>
-    <string name="address_region_generic_required">请输入您所在的州/省/地区</string>
-    <string name="address_required">请输入您的地址</string>
-    <string name="address_shipping_address">送货地址</string>
-    <string name="address_state_required">请输入您所在的州</string>
-    <string name="address_zip_invalid">您的邮政编码无效。</string>
-    <string name="address_zip_postal_invalid">您的邮政编码无效</string>
-    <string name="becs_mandate_acceptance">
-    通过提供您的银行账户信息并确认该笔付款，
-    表示您同意本“直接借记请求”及其服务条款，并授权
-    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID
-    number 507156 (“Stripe”) 通过批量电子清算系统 (BECS)
-    代 %1$s（“商家”）向您的账户扣取商家单独告知您的金额。
-    您确认您是账户持有人或上述账户的授权签署人。
-    
-    </string>
-    <string name="becs_widget_account_number">账号</string>
-    <string name="becs_widget_account_number_incomplete">您的账号不完整。</string>
-    <string name="becs_widget_account_number_required">您需要填写账号。</string>
-    <string name="becs_widget_bsb">BSB</string>
-    <string name="becs_widget_bsb_incomplete">您输入的 BSB 不完整。</string>
-    <string name="becs_widget_bsb_invalid">您输入的 BSB 无效。</string>
-    <string name="becs_widget_email">邮件地址</string>
-    <string name="becs_widget_email_invalid">您的邮件地址无效。</string>
-    <string name="becs_widget_email_required">您需要填写邮件地址。</string>
-    <string name="becs_widget_name">姓名</string>
-    <string name="becs_widget_name_required">您需要填写姓名。</string>
-    <string name="card_ending_in">%1$s 尾号 %2$s</string>
-    <string name="close">关闭</string>
-    <string name="delete_payment_method">删除支付方式</string>
-    <string name="delete_payment_method_prompt_title">删除支付方式？</string>
-    <string name="expiry_date_hint">月月/年年</string>
-    <string name="expiry_label_short">有效期</string>
-    <string name="fpx_bank_offline">%s - 线下</string>
-    <string name="incomplete_expiry_date">您的银行卡的到期日期不完整。</string>
-    <string name="invalid_card_number">您的卡号无效。</string>
-    <string name="invalid_cvc">您的银行卡安全码无效。</string>
-    <string name="invalid_expiry_month">您的银行卡的到期月份无效。</string>
-    <string name="invalid_expiry_year">您的银行卡的到期年份无效。</string>
-    <string name="invalid_shipping_information">无效的送货地址</string>
-    <string name="invalid_zip">您的邮编不完整。</string>
-    <string name="no_payment_methods">没有付款方式。</string>
-    <string name="payment_method_add_new_card">添加新卡...</string>
-    <string name="payment_method_add_new_fpx">选择银行账户 (FPX)…</string>
-    <string name="price_free">免费</string>
-    <string name="removed">已移除 %s</string>
-    <string name="secure_checkout">安全结账</string>
-    <string name="stripe_failure_connection_error">连接我们的支付提供商时出现了问题。请检查网络连接，然后重试。</string>
-    <string name="stripe_failure_reason_authentication">我们未能验证您的支付方式。请选择另一支付方式并重试。</string>
-    <string name="stripe_failure_reason_timed_out">验证您的支付方式时失败——请重试</string>
-    <string name="stripe_google_pay_error_internal">发生了内部错误。</string>
-    <string name="stripe_paymentsheet_add_button_label">添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">银行卡信息</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">国家或地区</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付信息</string>
-    <string name="stripe_paymentsheet_back">返回</string>
-    <string name="stripe_paymentsheet_close">关闭</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">月月/年年</string>
-    <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
-    <string name="stripe_paymentsheet_or_pay_with_card">或用银行卡支付</string>
-    <string name="stripe_paymentsheet_pay_button_amount">支付%s</string>
-    <string name="stripe_paymentsheet_pay_button_label">支付</string>
-    <string name="stripe_paymentsheet_primary_button_processing">正在处理...</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存该卡，用于未来的 %s 付款</string>
-    <string name="stripe_paymentsheet_select_payment_method">选择您的支付方式</string>
-    <string name="stripe_paymentsheet_setup_button_label">设置</string>
-    <string name="stripe_paymentsheet_total_amount">合计：%s</string>
-    <string name="stripe_verify_your_payment">验证您的付款</string>
-    <string name="title_add_a_card">添加一张卡</string>
-    <string name="title_add_an_address">添加一个地址</string>
-    <string name="title_bank_account">银行账户</string>
-    <string name="title_payment_method">支付方式</string>
-    <string name="title_select_shipping_method">选择送货方式</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">卡号</string>
+  <string name="acc_label_card_number_node">%s，卡号</string>
+  <string name="acc_label_cvc_node">%s，CVC</string>
+  <string name="acc_label_expiry_date">到期日</string>
+  <string name="acc_label_expiry_date_node">%s，到期日</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">邮编</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">邮编</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">添加一张新的借记卡或信用卡以便在此应用中进行购买。</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">已添加 %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">请输入您所在的城市</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">您的国家无效</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">请输入您所在的县</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">地址行 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">第 1 行地址 (可选)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">地址行 2（可选）</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">地址 (可选)</string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">公寓号码 (可选)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">城市 (可选)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">县（可选）</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">电话号码</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">电话号码（可选）</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">邮政编码（可选）</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">邮政编码</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">邮政编码（可选）</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">省 (可选)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">州/省/地区</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">州/省/地区（可选）</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">州 (可选)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">邮政编码（可选）</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">邮政编码</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">邮政编码（可选）</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">请输入您的姓名</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">请输入您的电话号码</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">您的邮政编码无效</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">您的邮政编码无效</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">请输入您所在的省</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">请输入您所在的州/省/地区</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">请输入您的地址</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">送货地址</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">请输入您所在的州</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">您的邮政编码无效。</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">您的邮政编码无效</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    通过提供您的银行账户信息并确认该笔付款，\n    表示您同意本“直接借记请求”及其服务条款，并授权\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID\n    number 507156 (“Stripe”) 通过批量电子清算系统 (BECS)\n    代 %1$s（“商家”）向您的账户扣取商家单独告知您的金额。\n    您确认您是账户持有人或上述账户的授权签署人。\n    \n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">账号</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">您的账号不完整。</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">您需要填写账号。</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">您输入的 BSB 不完整。</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">您输入的 BSB 无效。</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">邮件地址</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">您的邮件地址无效。</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">您需要填写邮件地址。</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">姓名</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">您需要填写姓名。</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s 尾号 %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">关闭</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">删除支付方式</string>
+  <string name="delete_payment_method_prompt_title">删除支付方式？</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">月月/年年</string>
+  <string name="expiry_label_short">有效期</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - 线下</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">您的银行卡的到期日期不完整。</string>
+  <string name="invalid_card_number">您的卡号无效。</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">您的银行卡安全码无效。</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">您的银行卡的到期月份无效。</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">您的银行卡的到期年份无效。</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">无效的送货地址</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">您的邮编不完整。</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">没有付款方式。</string>
+  <string name="payment_method_add_new_card">添加新卡...</string>
+  <string name="payment_method_add_new_fpx">选择银行账户 (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">免费</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">已移除 %s</string>
+  <string name="secure_checkout">安全结账</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">连接我们的支付提供商时出现了问题。请检查网络连接，然后重试。</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">我们未能验证您的支付方式。请选择另一支付方式并重试。</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">验证您的支付方式时失败——请重试</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">发生了内部错误。</string>
+  <string name="stripe_paymentsheet_add_button_label">添加</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">银行卡信息</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">国家或地区</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付信息</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">返回</string>
+  <string name="stripe_paymentsheet_close">关闭</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">月月/年年</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">或用银行卡支付</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">支付%s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">正在处理...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存该卡，用于未来的 %s 付款</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">选择您的支付方式</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">设置</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">验证您的付款</string>
+  <string name="title_add_a_card">添加一张卡</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">添加一个地址</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">银行账户</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">支付方式</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">选择送货方式</string>
 </resources>

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -1,203 +1,197 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="acc_label_card_number">Card number</string>
-    <string name="acc_label_expiry_date">Expiration date</string>
-    <string name="acc_label_zip">ZIP Code</string>
-    <string name="acc_label_zip_short">ZIP</string>
-    <string name="acc_label_card_number_node">%s, Card number</string>
-    <string name="acc_label_expiry_date_node">%s, Expiration date</string>
-    <string name="acc_label_cvc_node">%s, CVC</string>
-    <!--Label for input requesting the name of a customer-->
-    <string name="address_label_name">Name</string>
-    <!--Label for input requesting the first line of an address, used for US and Canadian addresses-->
-    <string name="address_label_address">Address</string>
-    <!--Label for input requesting the first line of an address where input is optional, used for US and Canadian addresses-->
-    <string name="address_label_address_optional">Address (optional) </string>
-    <!--Label for input requesting the first line of an address, used for international addresses-->
-    <string name="address_label_address_line1">Address line 1</string>
-    <!--Label for input requesting the first line of an address where , used for international addresses-->
-    <string name="address_label_address_line1_optional">Address line 1 (optional)</string>
-    <!--Label for input requesting apartment number (address line 2) where input is optional, used for US addresses-->
-    <string name="address_label_apt_optional">Apt. (optional)</string>
-    <!-- Label for input requesting address line 2, used for international addresses -->
-    <string name="address_label_address_line2_optional">Address line 2 (optional)</string>
-    <!-- Label for input requesting apartment number (address line 2), used for US and Canada based addresses -->
-    <string name="address_label_apt">Apt.</string>
-    <!--Label for input requesting city, used for all locations-->
-    <string name="address_label_city">City</string>
-    <!--Label for input requesting city where input is optional, used for all locations-->
-    <string name="address_label_city_optional">City (optional)</string>
-    <!--Label for input requesting county, used for UK based addresses-->
-    <string name="address_label_county">County</string>
-    <!--Label for input requesting county where input is optional , used for UK based addresses-->
-    <string name="address_label_county_optional">County (optional)</string>
-    <!--Label for input requesting country, used for all locations-->
-    <string name="address_label_country">Country</string>
-    <!--Label for input requesting phone number, used for all locations-->
-    <string name="address_label_phone_number">Phone number</string>
-    <!--Label for input requesting phone number where input is optional, used for all locations-->
-    <string name="address_label_phone_number_optional">Phone number (optional)</string>
-    <!--Label for input requesting state, used for US addreses-->
-    <string name="address_label_state">State</string>
-    <!--Label for input requesting state where input is optional, used for US addresses-->
-    <string name="address_label_state_optional">State (optional)</string>
-    <!--Label for input requesting zip code, used for US addreses-->
-    <string name="address_label_zip_code">ZIP code</string>
-    <!--Label for input requesting zip code where input is optional, used for US addresses-->
-    <string name="address_label_zip_code_optional">ZIP code (optional)</string>
-    <!--Label for input requesting postal code, used for Canadian addresses-->
-    <string name="address_label_postal_code">Postal code</string>
-    <!--Label for input requesting postal code where input is optional, used for Canadian addresses-->
-    <string name="address_label_postal_code_optional">Postal code (optional)</string>
-    <!--Label for input requesting postcode, used for UK based addresses-->
-    <string name="address_label_postcode">Postcode</string>
-    <!--Label for input requesting postcode where input is optional, used for UK based addresses-->
-    <string name="address_label_postcode_optional">Postcode (optional)</string>
-    <!--Label for input requesting postal code, used for international addresses-->
-    <string name="address_label_zip_postal_code">ZIP/Postal code</string>
-    <!--Label for input requesting postal code where input is optional, used for international addresses-->
-    <string name="address_label_zip_postal_code_optional">ZIP / Postal code (optional)</string>
-    <!-- title of a screen prompting user to enter a shipping address -->
-    <string name="address_shipping_address">Shipping Address</string>
-    <!--Error text indicating zip code is invalid, used for US addresses-->
-    <string name="address_zip_invalid">Your ZIP code is invalid.</string>
-    <!--Error text indicating postcode is invalid, used for UK addresses-->
-    <string name="address_postcode_invalid">Your postcode is invalid</string>
-    <!--Error text indicating postal code is invalid, used for Canadian addresses-->
-    <string name="address_postal_code_invalid">Your postal code is invalid</string>
-    <!--Error text indicating zip/ postal code is invalid, used for international addresses-->
-    <string name="address_zip_postal_invalid">Your ZIP/Postal code is invalid</string>
-    <!--Error text indicating country is invalid-->
-    <string name="address_country_invalid">Your country is invalid</string>
-    <!--Label for input requesting province, used for canadian addresses-->
-    <string name="address_label_province">Province</string>
-    <!--Label for input requesting province where province is optional, used for canadian addresses-->
-    <string name="address_label_province_optional">Province (optional)</string>
-    <!--Label for input requesting the region, used for international addresses-->
-    <string name="address_label_region_generic"> State / Province / Region</string>
-    <!--Label for input requesting the region where input is optional, used for international addresses-->
-    <string name="address_label_region_generic_optional">State / Province / Region (optional)</string>
-    <!--Error text indicating name is required-->
-    <string name="address_name_required">Please enter your name</string>
-    <!--Error text indicating that address is required, used for all locations-->
-    <string name="address_required">Please enter your address</string>
-    <!--Error text indicating that city is required, used for all locations-->
-    <string name="address_city_required">Please enter your city</string>
-    <!--Error text indicating that county is required, used for UK addresses-->
-    <string name="address_county_required">Please enter your county</string>
-    <!--Error text indicating that state is required, used for US addresses-->
-    <string name="address_state_required">Please enter your state</string>
-    <!--Error text indicating that province is required, used for Canadian addresses-->
-    <string name="address_province_required">Please enter your province</string>
-    <!--Error text indicating that region is required, used for international addresses-->
-    <string name="address_region_generic_required">Please enter your State/Province/Region</string>
-    <!--Error text indicating that phone number is required, used for all addresses-->
-    <string name="address_phone_number_required">Please enter your phone number</string>
-    <!--Used to display masked card numbers. %1$s is a card brand, and %2$s is a partial call number, e.g. "Visa ending in 4242"-->
-    <string name="card_ending_in">%1$s ending in %2$s</string>
-    <string name="expiry_date_hint">MM/YY</string>
-    <string name="expiry_label_short">Expiry</string>
-    <string name="invalid_card_number">Your card\'s number is invalid.</string>
-    <string name="invalid_expiry_month">Your card\'s expiration month is invalid.</string>
-    <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
-    <string name="invalid_expiry_year">Your card\'s expiration year is invalid.</string>
-    <string name="invalid_cvc">Your card\'s security code is invalid.</string>
-    <string name="invalid_zip">Your postal code is incomplete.</string>
-    <string name="payment_method_add_new_card">Add new card&#8230;</string>
-    <string name="payment_method_add_new_fpx">Select Bank Account (FPX)&#8230;</string>
-    <!--Human-friendly label for something with $0 price-->
-    <string name="price_free">Free</string>
-    <string name="title_add_a_card">Add a Card</string>
-    <string name="title_bank_account">Bank Account</string>
-    <string name="title_payment_method">Payment Method</string>
-    <!--Screen title telling users they should add an address-->
-    <string name="title_add_an_address">Add an Address</string>
-    <!--Screen title telling users they should select a shipping address-->
-    <string name="title_select_shipping_method">Select Shipping Method</string>
-    <!--Text informing user there are no existing payment methods in the application-->
-    <string name="no_payment_methods">No payment methods.</string>
-    <!--Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application-->
-    <string name="add_card">Add a new debit or credit card to make purchases in this app.</string>
-    <string name="invalid_shipping_information">Invalid Shipping Address</string>
-    <string name="secure_checkout">Secure Checkout</string>
-    <string name="close">Close</string>
+  <!-- Label for card number entry text field -->
+  <string name="acc_label_card_number">Card number</string>
+  <string name="acc_label_card_number_node">%s, Card number</string>
+  <string name="acc_label_cvc_node">%s, CVC</string>
+  <string name="acc_label_expiry_date">Expiration date</string>
+  <string name="acc_label_expiry_date_node">%s, Expiration date</string>
+  <!-- Caption for Zip Code field on address form (only shown when country is United States only) -->
+  <string name="acc_label_zip">ZIP Code</string>
+  <!-- Short string for zip code (United States only) Please keep to 5 characters or less if possible. -->
+  <string name="acc_label_zip_short">ZIP</string>
+  <!-- Text informing user they should add a debit or credit card. Shown when there are no existing payment methods in the application -->
+  <string name="add_card">Add a new debit or credit card to make purchases in this app.</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="added">Added %s</string>
+  <!-- Error text indicating that city is required, used for all locations -->
+  <string name="address_city_required">Please enter your city</string>
+  <!-- Error text indicating country is invalid -->
+  <string name="address_country_invalid">Your country is invalid</string>
+  <!-- Error text indicating that county is required, used for UK addresses -->
+  <string name="address_county_required">Please enter your county</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Address</string>
+  <!-- Address line 1 placeholder for billing address form. -->
+  <string name="address_label_address_line1">Address line 1</string>
+  <!-- Label for input requesting the first line of an address where , used for international addresses -->
+  <string name="address_label_address_line1_optional">Address line 1 (optional)</string>
+  <!-- Address line 2 placeholder for billing address form. -->
+  <string name="address_label_address_line2_optional">Address line 2 (optional)</string>
+  <!-- Label for input requesting the first line of an address where input is optional, used for US and Canada addresses -->
+  <string name="address_label_address_optional">Address (optional) </string>
+  <!-- Label for input requesting apartment number (address line 2) where input is optional, used for US based addresses -->
+  <string name="address_label_apt_optional">Apt. (optional)</string>
+  <!-- Label for input requesting city where input is optional, used for all locations -->
+  <string name="address_label_city_optional">City (optional)</string>
+  <!-- Label for input requesting county where input is optional , used for UK based addresses -->
+  <string name="address_label_county_optional">County (optional)</string>
+  <!-- Label for input requesting phone number, used for all locations -->
+  <string name="address_label_phone_number">Phone number</string>
+  <!-- Label for input requesting phone number where input is optional, used for all locations -->
+  <string name="address_label_phone_number_optional">Phone number (optional)</string>
+  <!-- Label for input requesting postal code where input is optional, used for Canada based addresses -->
+  <string name="address_label_postal_code_optional">Postal code (optional)</string>
+  <!-- Label for input requesting postcode, used for UK based addresses -->
+  <string name="address_label_postcode">Postcode</string>
+  <!-- Label for input requesting postcode where input is optional, used for UK based addresses -->
+  <string name="address_label_postcode_optional">Postcode (optional)</string>
+  <!-- Label for input requesting province where province is optional, used for canadian addresses -->
+  <string name="address_label_province_optional">Province (optional)</string>
+  <!-- Label for input requesting the region, used for international addresses -->
+  <string name="address_label_region_generic">State / Province / Region</string>
+  <!-- Label for input requesting the region where input is optional, used for international addresses -->
+  <string name="address_label_region_generic_optional">State / Province / Region (optional)</string>
+  <!-- Label for input requesting state where input is optional, used for US based addresses -->
+  <string name="address_label_state_optional">State (optional)</string>
+  <!-- Label for input requesting zip code where input is optional, used for US based addresses -->
+  <string name="address_label_zip_code_optional">ZIP code (optional)</string>
+  <!-- Label for input requesting postal code, used for international addresses -->
+  <string name="address_label_zip_postal_code">ZIP/Postal code</string>
+  <!-- Label for input requesting postal code where input is optional, used for international addresses -->
+  <string name="address_label_zip_postal_code_optional">ZIP / Postal code (optional)</string>
+  <!-- Error text indicating name is required -->
+  <string name="address_name_required">Please enter your name</string>
+  <!-- Error text indicating that phone number is required, used for all addresses -->
+  <string name="address_phone_number_required">Please enter your phone number</string>
+  <!-- Error text indicating postal code is invalid, used for Canada addresses -->
+  <string name="address_postal_code_invalid">Your postal code is invalid</string>
+  <!-- Error text indicating postcode is invalid, used for UK addresses -->
+  <string name="address_postcode_invalid">Your postcode is invalid</string>
+  <!-- Error text indicating that province is required, used for Canada addresses -->
+  <string name="address_province_required">Please enter your province</string>
+  <!-- Error text indicating that region is required, used for international addresses -->
+  <string name="address_region_generic_required">Please enter your State/Province/Region</string>
+  <!-- Error text indicating that address is required, used for all locations -->
+  <string name="address_required">Please enter your address</string>
+  <!-- Title for shipping address entry section -->
+  <string name="address_shipping_address">Shipping Address</string>
+  <!-- Error text indicating that state is required, used for US addresses -->
+  <string name="address_state_required">Please enter your state</string>
+  <!-- Error text indicating zip code is invalid, used for US addresses -->
+  <string name="address_zip_invalid">Your ZIP code is invalid.</string>
+  <!-- Error text indicating zip/ postal code is invalid, used for international addresses -->
+  <string name="address_zip_postal_invalid">Your ZIP/Postal code is invalid</string>
+  <!-- BECS Debit Widget - mandate acceptance -->
+  <string name="becs_mandate_acceptance">\n    By providing your bank account details and confirming this payment, you agree to this\n    Direct Debit Request and the Direct Debit Request service agreement, and authorise\n    Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156\n    (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on\n    behalf of %1$s (the \"Merchant\") for any amounts separately communicated to you\n    by the Merchant. You certify that you are either an account holder or an authorised\n    signatory on the account listed above.\n    </string>
+  <!-- Placeholder text for Account number entry field for BECS Debit. -->
+  <string name="becs_widget_account_number">Account number</string>
+  <!-- BECS Debit Widget - account number field - incomplete error message -->
+  <string name="becs_widget_account_number_incomplete">Your account number is incomplete.</string>
+  <!-- BECS Debit Widget - account number field - required error message -->
+  <string name="becs_widget_account_number_required">Your account number is required.</string>
+  <!-- Placeholder text for BSB Number entry field for BECS Debit. -->
+  <string name="becs_widget_bsb">BSB</string>
+  <!-- Error string displayed to user when they have entered an incomplete BSB number. BSB refers to an Australian bank account number -->
+  <string name="becs_widget_bsb_incomplete">The BSB you entered is incomplete.</string>
+  <!-- Error string displayed to user when they enter in an invalid BSB number. &quot;BSB&quot; refers to an Australian bank account. -->
+  <string name="becs_widget_bsb_invalid">The BSB you entered is invalid.</string>
+  <!-- BECS Debit Widget - email address field - label -->
+  <string name="becs_widget_email">Email Address</string>
+  <!-- BECS Debit Widget - email address field - invalid error message -->
+  <string name="becs_widget_email_invalid">Your email address is invalid.</string>
+  <!-- BECS Debit Widget - email address field - required error message -->
+  <string name="becs_widget_email_required">Your email address is required.</string>
+  <!-- BECS Debit Widget - name field - label -->
+  <string name="becs_widget_name">Name</string>
+  <!-- BECS Debit Widget - name field - required error message -->
+  <string name="becs_widget_name_required">Your name is required.</string>
+  <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
+  <string name="card_ending_in">%1$s ending in %2$s</string>
+  <!-- Text for close button -->
+  <string name="close">Close</string>
+  <!-- Accessibility action for deleting a payment method -->
+  <string name="delete_payment_method">Delete Payment Method</string>
+  <string name="delete_payment_method_prompt_title">Delete payment method?</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="expiry_date_hint">MM/YY</string>
+  <string name="expiry_label_short">Expiry</string>
+  <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
+  <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
+  <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
+  <string name="invalid_card_number">Your card\'s number is invalid.</string>
+  <!-- Error message for card entry form when CVC/CVV is invalid -->
+  <string name="invalid_cvc">Your card\'s security code is invalid.</string>
+  <!-- String to describe an invalid month in expiry date. -->
+  <string name="invalid_expiry_month">Your card\'s expiration month is invalid.</string>
+  <!-- String to describe an invalid year in expiry date. -->
+  <string name="invalid_expiry_year">Your card\'s expiration year is invalid.</string>
+  <!-- Shipping form error message -->
+  <string name="invalid_shipping_information">Invalid Shipping Address</string>
+  <!-- Error message for when postal code in form is incomplete -->
+  <string name="invalid_zip">Your postal code is incomplete.</string>
+  <!-- Text informing user there are no existing payment methods in the application -->
+  <string name="no_payment_methods">No payment methods.</string>
+  <string name="payment_method_add_new_card">Add new card…</string>
+  <string name="payment_method_add_new_fpx">Select Bank Account (FPX)…</string>
+  <!-- Label for free shipping method -->
+  <string name="price_free">Free</string>
+  <!-- Message displayed when a payment method is removed, stating its name. -->
+  <string name="removed">Removed %s</string>
+  <string name="secure_checkout">Secure Checkout</string>
+  <!-- Generic error message shown when payment cannot be processed. -->
+  <string name="stripe_failure_connection_error">We are experiencing issues connecting to our payments provider. Please check your internet connection and try again.</string>
+  <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
+  <string name="stripe_failure_reason_authentication">We are unable to authenticate your payment method. Please choose a different payment method and try again.</string>
+  <!-- Error when 3DS2 authentication timed out. -->
+  <string name="stripe_failure_reason_timed_out">Timed out authenticating your payment method -- try again</string>
+  <!-- When an internal error is reported when a google pay payment is started. -->
+  <string name="stripe_google_pay_error_internal">An internal error occurred.</string>
+  <string name="stripe_paymentsheet_add_button_label">Add</string>
+  <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
+  <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
+  <!-- Country selector and postal code entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
+  <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
+  <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
+  <!-- Text for back button -->
+  <string name="stripe_paymentsheet_back">Back</string>
+  <string name="stripe_paymentsheet_close">Close</string>
+  <!-- label for text field to enter card expiry -->
+  <string name="stripe_paymentsheet_expiration_date_hint">MM / YY</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
+  <!-- Label of a button that initiates payment when tapped -->
+  <string name="stripe_paymentsheet_pay_button_amount">Pay %s</string>
+  <!-- Label for a button that starts processing the payment. -->
+  <string name="stripe_paymentsheet_pay_button_label">Pay</string>
+  <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
+  <string name="stripe_paymentsheet_primary_button_processing">Processing...</string>
+  <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
+  <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
+  <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
+  <string name="stripe_paymentsheet_select_payment_method">Select your payment method</string>
+  <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
+  <string name="stripe_paymentsheet_setup_button_label">Set up</string>
+  <!-- Label indicating the total amount that the user is authorizing (e.g. "Total: $25.00") -->
+  <string name="stripe_paymentsheet_total_amount" tools:ignore="MissingTranslation">Total: %s</string>
+  <!-- When there are multiple browsers and web authentication is required, this will show in a window asking which browser they want to use to "Verify your payment" -->
+  <string name="stripe_verify_your_payment">Verify your payment</string>
+  <string name="title_add_a_card">Add a Card</string>
+  <!-- Screen title telling users they should add an address -->
+  <string name="title_add_an_address">Set Address</string>
+  <!-- Label for Bank Account selection or detail entry form -->
+  <string name="title_bank_account">Bank Account</string>
+  <!-- Title for Payment Method screen -->
+  <string name="title_payment_method">Payment Method</string>
+  <!-- Screen title telling users they should select a shipping address -->
+  <string name="title_select_shipping_method">Select Shipping Method</string>
+  <string name="stripe_google_pay_error_resolution_required" tools:ignore="MissingTranslation">Completing the operation requires some form of resolution.</string>
 
-    <string name="added">Added %s</string>
-    <string name="removed">Removed %s</string>
-
-    <string name="delete_payment_method_prompt_title">Delete payment method?</string>
-    <string name="delete_payment_method">Delete payment method</string>
-    <!-- Label that will show that an FPX bank is offline. For example, "AmBank - Offline" -->
-    <string name="fpx_bank_offline">%s - Offline</string>
-
-    <!-- BECS Debit Widget - name field - label -->
-    <string name="becs_widget_name">Name</string>
-    <!-- BECS Debit Widget - email address field - label -->
-    <string name="becs_widget_email">Email Address</string>
-    <!-- BECS Debit Widget - BSB field - label -->
-    <string name="becs_widget_bsb">BSB</string>
-    <!-- BECS Debit Widget - account number field - label -->
-    <string name="becs_widget_account_number">Account number</string>
-    <!-- BECS Debit Widget - BSB field - invalid error message -->
-    <string name="becs_widget_bsb_invalid">The BSB you entered is invalid.</string>
-    <!-- BECS Debit Widget - BSB field - incomplete error message -->
-    <string name="becs_widget_bsb_incomplete">The BSB you entered is incomplete.</string>
-    <!-- BECS Debit Widget - account number field - required error message -->
-    <string name="becs_widget_account_number_required">Your account number is required.</string>
-    <!-- BECS Debit Widget - account number field - incomplete error message -->
-    <string name="becs_widget_account_number_incomplete">Your account number is incomplete.</string>
-    <!-- BECS Debit Widget - name field - required error message -->
-    <string name="becs_widget_name_required">Your name is required.</string>
-    <!-- BECS Debit Widget - email address field - required error message -->
-    <string name="becs_widget_email_required">Your email address is required.</string>
-    <!-- BECS Debit Widget - email address field - invalid error message -->
-    <string name="becs_widget_email_invalid">Your email address is invalid.</string>
-    <!-- BECS Debit Widget - mandate acceptance -->
-    <string name="becs_mandate_acceptance">
-    By providing your bank account details and confirming this payment, you agree to this
-    Direct Debit Request and the
-    &lt;a href="https://stripe.com/au-becs-dd-service-agreement/legal"&gt;Direct Debit Request service agreement&lt;/a&gt;,
-    and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156
-    (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on
-    behalf of %1$s (the "Merchant") for any amounts separately communicated to you
-    by the Merchant. You certify that you are either an account holder or an authorised
-    signatory on the account listed above.
-    </string>
-
-    <!-- Payment Sheet -->
-    <string name="stripe_paymentsheet_back">Back</string>
-    <string name="stripe_paymentsheet_close">Close</string>
-    <string name="stripe_paymentsheet_select_payment_method">Select your payment method</string>
-    <!-- Label indicating the total amount that the user is authorizing (e.g. "Total: $25.00") -->
-    <string name="stripe_paymentsheet_total_amount">Total: %s</string>
-    <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
-    <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
-    <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
-    <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
-    <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
-    <!-- Title of a section containing a card form that will collect the payment information from the user -->
-    <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
-    <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user -->
-    <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
-    <string name="stripe_paymentsheet_expiration_date_hint">MM / YY</string>
-
-    <!-- Label for a button that starts payment processing -->
-    <string name="stripe_paymentsheet_pay_button_label">Pay</string>
-    <!-- Label for a button that starts payment processing for a given amount (e.g. "Pay $25.00") -->
-    <string name="stripe_paymentsheet_pay_button_amount">Pay %s</string>
-    <!-- Label for a button that sets up a payment method for future use -->
-    <string name="stripe_paymentsheet_setup_button_label">Set up</string>
-    <!-- Label shown while the payment is being processed -->
-    <string name="stripe_paymentsheet_primary_button_processing">Processing…</string>
-
-    <string name="stripe_paymentsheet_add_button_label">Add</string>
-
-    <!-- Failure Reason -->
-    <string name="stripe_failure_reason_authentication">We are unable to authenticate your payment method. Please choose a different payment method and try again.</string>
-    <string name="stripe_failure_reason_timed_out">Timed out authenticating your payment method -- try again</string>
-    <string name="stripe_failure_connection_error">We are experiencing issues connecting to our payments provider. Please check your internet connection and try again.</string>
-
-    <string name="stripe_verify_your_payment">Verify your payment</string>
-    <string name="stripe_google_pay_error_internal">An internal error occurred.</string>
-    <string name="stripe_google_pay_error_resolution_required" tools:ignore="MissingTranslation">Completing the operation requires some form of resolution.</string>
 </resources>
+

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -171,7 +171,7 @@
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
-  <string name="stripe_paymentsheet_primary_button_processing">Processing...</string>
+  <string name="stripe_paymentsheet_primary_button_processing">Processing…</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->
@@ -192,6 +192,4 @@
   <!-- Screen title telling users they should select a shipping address -->
   <string name="title_select_shipping_method">Select Shipping Method</string>
   <string name="stripe_google_pay_error_resolution_required" tools:ignore="MissingTranslation">Completing the operation requires some form of resolution.</string>
-
 </resources>
-

--- a/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceFactoryTest.kt
@@ -17,6 +17,6 @@ class BecsDebitMandateAcceptanceFactoryTest {
     fun testCreate() {
         Locale.setDefault(Locale.US)
         assertThat(factory.create("Rocketship Inc.").toString().trim())
-            .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
+            .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
@@ -22,6 +22,5 @@ class BecsDebitMandateAcceptanceTextViewTest {
 
         assertThat(textView.text.toString().trim())
             .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
-
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/BecsDebitMandateAcceptanceTextViewTest.kt
@@ -21,6 +21,7 @@ class BecsDebitMandateAcceptanceTextViewTest {
         textView.companyName = "Rocketship Inc."
 
         assertThat(textView.text.toString().trim())
-            .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
+            .isEqualTo("By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.")
+
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
@@ -159,7 +159,7 @@ internal class BecsDebitWidgetTest {
         assertThat(becsDebitWidget.viewBinding.mandateAcceptanceTextView.text.toString().trim())
             .isEqualTo(
                 """
-                By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the Merchant) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.
+                By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the Direct Debit Request service agreement, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of Rocketship Inc. (the "Merchant") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.
                 """.trimIndent()
             )
     }

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1428,7 +1428,7 @@ internal class CardInputWidgetTest {
     fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() {
         cardInputWidget.usZipCodeRequired = true
         assertThat(cardInputWidget.postalCodeEditText.hint)
-            .isEqualTo("ZIP code")
+            .isEqualTo("ZIP Code")
 
         cardInputWidget.setCardNumber(VISA_WITH_SPACES)
         cardInputWidget.expiryDateEditText.append("12")
@@ -1445,7 +1445,7 @@ internal class CardInputWidgetTest {
     fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() {
         cardInputWidget.usZipCodeRequired = true
         assertThat(cardInputWidget.postalCodeEditText.hint)
-            .isEqualTo("ZIP code")
+            .isEqualTo("ZIP Code")
 
         cardInputWidget.setCardNumber(VISA_WITH_SPACES)
         cardInputWidget.expiryDateEditText.append("12")

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -832,7 +832,7 @@ internal class CardMultilineWidgetTest {
     fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() {
         cardMultilineWidget.usZipCodeRequired = true
         assertThat(cardMultilineWidget.postalInputLayout.hint)
-            .isEqualTo("ZIP code")
+            .isEqualTo("ZIP Code")
 
         cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
@@ -849,7 +849,7 @@ internal class CardMultilineWidgetTest {
     fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() {
         cardMultilineWidget.usZipCodeRequired = true
         assertThat(cardMultilineWidget.postalInputLayout.hint)
-            .isEqualTo("ZIP code")
+            .isEqualTo("ZIP Code")
 
         cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")

--- a/payments-core/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PostalCodeEditTextTest.kt
@@ -62,7 +62,7 @@ class PostalCodeEditTextTest {
 
             postalCodeEditText.config = PostalCodeEditText.Config.US
             assertThat(textInputLayout.hint)
-                .isEqualTo("ZIP code")
+                .isEqualTo("ZIP Code")
         }
     }
 
@@ -77,7 +77,7 @@ class PostalCodeEditTextTest {
             assertThat(textInputLayout.hint)
                 .isNull()
             assertThat(postalCodeEditText.hint)
-                .isEqualTo("ZIP code")
+                .isEqualTo("ZIP Code")
         }
     }
 

--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Tarjeta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Al suministrar tus datos de pago y confirmar el pago, autorizas (A) a %s y a Stripe, nuestro proveedor de servicios de pago, a enviar instrucciones a tu banco para que efectúe débitos en tu cuenta y (B) al banco a que efectúe los débitos en tu cuenta siguiendo esas instrucciones. Como parte de tus prerrogativas, tienes derecho a un rembolso del banco conforme a los términos y condiciones del contrato suscripto con dicha entidad. La solicitud de rembolso deberá efectuarse dentro de las 8 semanas posteriores a la fecha en que se efectuó el débito en tu cuenta. Tus derechos se explican en una declaración que puedes solicitarle a tu banco. Aceptas recibir notificaciones sobre próximos débitos con hasta 2 días de antelación a que estos ocurran.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Dirección</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ciudad</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">País</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Condado</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nombre</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Código postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincia</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Estado</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Código postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">El correo electrónico no es válido.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">El IBAN que ingresaste está incompleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">El IBAN que ingresaste no es válido.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">El IBAN que ingresaste no es válido; \"%s\" no es un código de país admitido.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Tarjeta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Al suministrar tus datos de pago y confirmar el pago, autorizas (A) a %s y a Stripe, nuestro proveedor de servicios de pago, a enviar instrucciones a tu banco para que efectúe débitos en tu cuenta y (B) al banco a que efectúe los débitos en tu cuenta siguiendo esas instrucciones. Como parte de tus prerrogativas, tienes derecho a un rembolso del banco conforme a los términos y condiciones del contrato suscripto con dicha entidad. La solicitud de rembolso deberá efectuarse dentro de las 8 semanas posteriores a la fecha en que se efectuó el débito en tu cuenta. Tus derechos se explican en una declaración que puedes solicitarle a tu banco. Aceptas recibir notificaciones sobre próximos débitos con hasta 2 días de antelación a que estos ocurran.</string>
 </resources>

--- a/paymentsheet/res/values-bg-rBG/strings.xml
+++ b/paymentsheet/res/values-bg-rBG/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Карта</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA дебит</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Запазване за бъдещи плащания</string>
-    <string name="stripe_paymentsheet_sepa_mandate">С предоставянето на информация за плащания и с потвърждаването на това плащане Вие упълномощавате (A) %s и Stripe, нашия доставчик на платежни услуги, да изпращат инструкции до Вашата банка за дебитиране на сметката Ви и (B) Вашата банка да дебитира сметката Ви в съответствие с тези инструкции. Като част от Вашите права имате право на възстановяване на суми от Вашата банка при условията и реда на споразумението с Вашата банка. Възстановяването на сума трябва да бъде поискано в рамките на 8 седмици, считано от датата, на която сметката Ви е била дебитирана. Вашите права са обяснени в извлечение, което можете да получите от Вашата банка. Вие давате своето съгласие да получавате известия за бъдещи дебитирания до 2 дни преди изпълнението им.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Адрес</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Град</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Държава</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Окръг</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Име</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Пощенски код</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Област</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Щат</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Пощенски код</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Вашият имейл е невалиден.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Въведеният IBAN е непълен.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">IBAN, който сте въвели, е невалиден.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Въведеният IBAN е невалиден, „%s“ не е поддържан код на държава.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Вашият IBAN трябва да започва с двубуквен код на държава.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (по желание)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Карта</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA дебит</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Запазване за бъдещи плащания</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">С предоставянето на информация за плащания и с потвърждаването на това плащане Вие упълномощавате (A) %s и Stripe, нашия доставчик на платежни услуги, да изпращат инструкции до Вашата банка за дебитиране на сметката Ви и (B) Вашата банка да дебитира сметката Ви в съответствие с тези инструкции. Като част от Вашите права имате право на възстановяване на суми от Вашата банка при условията и реда на споразумението с Вашата банка. Възстановяването на сума трябва да бъде поискано в рамките на 8 седмици, считано от датата, на която сметката Ви е била дебитирана. Вашите права са обяснени в извлечение, което можете да получите от Вашата банка. Вие давате своето съгласие да получавате известия за бъдещи дебитирания до 2 дни преди изпълнението им.</string>
 </resources>

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Bank iDeal</string>
-    <string name="stripe_paymentsheet_payment_method_card">Targeta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Domiciliació SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Guardar per a futurs pagaments</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Proporcionant la informació de pagament i confirmant aquest pagament, estàs autoritzant (A) %s i Stripe, el nostre proveïdor de serveis de pagament, a enviar ordres al teu banc per tal de carregar des del teu compte i (B) carregar el teu compte en conformitat amb aquestes ordres. Tens dret a un reembolsament per part del teu banc sota els termes i condicions que s\'hagin acordat amb aquest. El reembolsament s\'ha de sol·licitar en un termini de 8 setmanes des de la data en que es va carregar el compte. Els teus drets estan explicats en un extracte que pots demanar al teu banc. Estàs acceptant rebre notificacions per pròxims dèbits fins a dos dies abans de que es portin a terme.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adreça</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ciutat</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">País</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Comtat</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nom</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Codi postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Província</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">País</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Codi ZIP</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">L\'adreça electrònica no és vàlida.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">L\'BAN és incomplet.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">L\'IBAN és incorrecte.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">L\'IBAN no és vàlid, %s no és un codi de país compatible.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">El teu IBAN ha de començar amb un codi de país de dues lletres.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Bank iDeal</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Targeta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Domiciliació SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Guardar per a futurs pagaments</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Proporcionant la informació de pagament i confirmant aquest pagament, estàs autoritzant (A) %s i Stripe, el nostre proveïdor de serveis de pagament, a enviar ordres al teu banc per tal de carregar des del teu compte i (B) carregar el teu compte en conformitat amb aquestes ordres. Tens dret a un reembolsament per part del teu banc sota els termes i condicions que s\'hagin acordat amb aquest. El reembolsament s\'ha de sol·licitar en un termini de 8 setmanes des de la data en que es va carregar el compte. Els teus drets estan explicats en un extracte que pots demanar al teu banc. Estàs acceptant rebre notificacions per pròxims dèbits fins a dos dies abans de que es portin a terme.</string>
 </resources>

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Karta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Debet SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Uložit pro budoucí platby</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Tím, že zadáte informace o platbě a potvrdíte tuto platbu, udělujete společnosti (A) %s a Stripe, našemu poskytovateli platebních služeb, oprávnění zaslat do vaší banky pokyny k zatížení vašeho účtu a (B) vaší bance zatížit váš účet na základě těchto pokynů. V rámci svých práv máte nárok na refundaci od banky na základě smluvních podmínek vaší smlouvy s bankou. Refundaci je nutné nárokovat během 8 týdnů od data, kdy byl váš účet zatížen. Vaše práva jsou vysvětlena v prohlášení, které můžete získat od banky.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Město</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Země</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Okres</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Jméno</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Poštovní směrovací číslo</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincie</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stát</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">PSČ</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Váš e-mail je neplatný.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Číslo IBAN, které jste zadali, je neúplné.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Číslo IBAN, které jste zadali, je neplatné.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Zadané číslo IBAN je neplatné, \"%s\" není podporovaný kód země.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Číslo IBAN by mělo začínat dvěma písmeny kódu země.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (volitelné)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Karta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Debet SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Uložit pro budoucí platby</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Tím, že zadáte informace o platbě a potvrdíte tuto platbu, udělujete společnosti (A) %s a Stripe, našemu poskytovateli platebních služeb, oprávnění zaslat do vaší banky pokyny k zatížení vašeho účtu a (B) vaší bance zatížit váš účet na základě těchto pokynů. V rámci svých práv máte nárok na refundaci od banky na základě smluvních podmínek vaší smlouvy s bankou. Refundaci je nutné nárokovat během 8 týdnů od data, kdy byl váš účet zatížen. Vaše práva jsou vysvětlena v prohlášení, které můžete získat od banky.</string>
 </resources>

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kort</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Gem til fremtidige betalinger</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ved at give dine betalingsoplysninger og bekræfte denne betaling giver du (A) %s og Stripe, vores betalingstjenesteudbyder, tilladelse til at sende instruktioner til din bank om at debitere din konto og (B) din bank til at debitere din konto i overensstemmelse med disse instruktioner. Som en del af dine rettigheder har du ret til en refusion fra din bank under vilkårene og betingelserne i din aftale med din bank. Der skal kræves refusion inden for 8 uger fra den dato, hvor din konto blev debiteret. Dine rettigheder forklares i en erklæring, som du kan få fra din bank. Du accepterer at modtage underretninger om fremtidig debitering op til to dage før de opstår.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">By</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Amt</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Navn</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postnummer</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provins</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">ZIP-kode</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Din e-mail er ugyldig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Det indtastede IBAN-nummer er ufuldstændigt.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Det indtastede IBAN-nummer er ugyldigt.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Den indtastede IBAN er ugyldig, \"%s\" er ikke en gyldig landekode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Dit IBAN-nummer skal starte med en landekode på to bogstaver.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valgfrit)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kort</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Gem til fremtidige betalinger</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ved at give dine betalingsoplysninger og bekræfte denne betaling giver du (A) %s og Stripe, vores betalingstjenesteudbyder, tilladelse til at sende instruktioner til din bank om at debitere din konto og (B) din bank til at debitere din konto i overensstemmelse med disse instruktioner. Som en del af dine rettigheder har du ret til en refusion fra din bank under vilkårene og betingelserne i din aftale med din bank. Der skal kræves refusion inden for 8 uger fra den dato, hvor din konto blev debiteret. Dine rettigheder forklares i en erklæring, som du kan få fra din bank. Du accepterer at modtage underretninger om fremtidig debitering op til to dage før de opstår.</string>
 </resources>

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL-Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Karte</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-Lastschrift</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Für zukünftige Zahlungen speichern</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Durch Angabe der Zahlungsinformationen und Bestätigung der Zahlung ermächtigen Sie (A) %s und Stripe, unseren Zahlungsdienstleister, Zahlungen von Ihrem Konto mittels Lastschrift einzuziehen. Zugleich (B) weisen Sie Ihr Kreditinstitut gemäß diesen Anweisungen an, Ihr Konto entsprechend zu belasten. Sie haben im Rahmen Ihrer Rechte Anspruch auf Erstattung von Ihrem Kreditinstitut gemäß den vereinbarten Bedingungen mit Ihrem Kreditinstitut. Sie können innerhalb von 8 Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen. Es gelten dabei die mit Ihrem Kreditinstitut vereinbarten Bedingungen. Weiterhin erklären Sie sich damit einverstanden, die Vorabankündigung bis spätestens 2 Tage vor Zahlungseinzug zu erhalten.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ort</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Kreis/Bezirk</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Name</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postleitzahl</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provinz / Kanton</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Bundesland</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postleitzahl</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Ihre E-Mail-Adresse ist ungültig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Die eingegebene IBAN ist unvollständig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Die eingegebene IBAN ist ungültig.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Die eingegebene IBAN ist ungültig. „%s“ ist kein unterstützter Ländercode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Ihre IBAN sollte mit einem zweistelligen Ländercode beginnen.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL-Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Karte</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-Lastschrift</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Für zukünftige Zahlungen speichern</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Durch Angabe der Zahlungsinformationen und Bestätigung der Zahlung ermächtigen Sie (A) %s und Stripe, unseren Zahlungsdienstleister, Zahlungen von Ihrem Konto mittels Lastschrift einzuziehen. Zugleich (B) weisen Sie Ihr Kreditinstitut gemäß diesen Anweisungen an, Ihr Konto entsprechend zu belasten. Sie haben im Rahmen Ihrer Rechte Anspruch auf Erstattung von Ihrem Kreditinstitut gemäß den vereinbarten Bedingungen mit Ihrem Kreditinstitut. Sie können innerhalb von 8 Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen. Es gelten dabei die mit Ihrem Kreditinstitut vereinbarten Bedingungen. Weiterhin erklären Sie sich damit einverstanden, die Vorabankündigung bis spätestens 2 Tage vor Zahlungseinzug zu erhalten.</string>
 </resources>

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Κάρτα</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Χρέωση SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Αποθήκευση για μελλοντικές πληρωμές</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Με την παροχή των στοιχείων πληρωμής σας και επιβεβαιώνοντας αυτήν την πληρωμή, εξουσιοδοτείτε (A) την %s και την Stripe, τον πάροχο υπηρεσιών πληρωμών μας, να στείλουν οδηγίες στην τράπεζά σας προκειμένου να χρεώσει τον λογαριασμό σας και (B) την τράπεζά σας προκειμένου να χρεώσει τον λογαριασμό σας, σύμφωνα με τις οδηγίες αυτές. Στο πλαίσιο των δικαιωμάτων σας, δικαιούστε επιστροφή από την τράπεζά σας με βάση τους όρους και τις προϋποθέσεις που διατυπώνονται στη σύμβαση με την τράπεζά σας. Η αξίωση για επιστροφή πρέπει να υποβληθεί εντός 8 εβδομάδων από την ημερομηνία χρέωσης του λογαριασμού σας. Τα δικαιώματά σας επεξηγούνται σε αναλυτική κατάσταση, την οποία μπορείτε να εξασφαλίσετε από την τράπεζά σας. Συμφωνείτε να λαμβάνετε ειδοποιήσεις για μελλοντικές χρεώσεις έως και 2 ημέρες προτού προκύψουν.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Διεύθυνση</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Πόλη</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Χώρα</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Κομητεία</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Όνομα</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Ταχυδρομικός κώδικας</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Επαρχία</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Πολιτεία</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Ταχυδρομικός κώδικας</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Η διεύθυνση email σας δεν είναι έγκυρη.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Ο κωδικός IBAN που εισαγάγατε είναι ελλιπής.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Ο κωδικός IBAN που εισαγάγατε δεν είναι έγκυρος.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Ο κωδικός IBAN που εισάγατε δεν είναι έγκυρος, ο κωδικός «%s» δεν είναι υποστηριζόμενος κωδικός χώρας.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Ο κωδικός IBAN σας πρέπει να αρχίζει με έναν διψήφιο κωδικό χώρας.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (προαιρετικό)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Κάρτα</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Χρέωση SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Αποθήκευση για μελλοντικές πληρωμές</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Με την παροχή των στοιχείων πληρωμής σας και επιβεβαιώνοντας αυτήν την πληρωμή, εξουσιοδοτείτε (A) την %s και την Stripe, τον πάροχο υπηρεσιών πληρωμών μας, να στείλουν οδηγίες στην τράπεζά σας προκειμένου να χρεώσει τον λογαριασμό σας και (B) την τράπεζά σας προκειμένου να χρεώσει τον λογαριασμό σας, σύμφωνα με τις οδηγίες αυτές. Στο πλαίσιο των δικαιωμάτων σας, δικαιούστε επιστροφή από την τράπεζά σας με βάση τους όρους και τις προϋποθέσεις που διατυπώνονται στη σύμβαση με την τράπεζά σας. Η αξίωση για επιστροφή πρέπει να υποβληθεί εντός 8 εβδομάδων από την ημερομηνία χρέωσης του λογαριασμού σας. Τα δικαιώματά σας επεξηγούνται σε αναλυτική κατάσταση, την οποία μπορείτε να εξασφαλίσετε από την τράπεζά σας. Συμφωνείτε να λαμβάνετε ειδοποιήσεις για μελλοντικές χρεώσεις έως και 2 ημέρες προτού προκύψουν.</string>
 </resources>

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Card</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
-    <string name="stripe_paymentsheet_sepa_mandate">By providing your payment information and confirming this payment, you authorise (A) %s and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Address</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">City</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Country</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">County</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Name</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postcode</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Province</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">State</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">ZIP code</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Your email is invalid.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">The IBAN you entered is incomplete.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">The IBAN you entered is invalid.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">The IBAN you entered is invalid; \"%s\" is not a supported country code.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Card</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">By providing your payment information and confirming this payment, you authorise (A) %s and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.</string>
 </resources>

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Tarjeta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Adeudo SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Al facilitarnos la información del pago y al confirmar este pago, autorizas a (A) %s y a Stripe, nuestro proveedor de servicios de pago, a enviar instrucciones a tu banco para adeudar tu cuenta y (B) a tu banco para efectuar los adeudos en tu cuenta siguiendo dichas instrucciones. Como parte de tus derechos, estás legitimado al rembolso por parte de tu banco en los términos y condiciones del contrato suscrito con este. La solicitud del reembolso deberá efectuarse dentro de las ocho semanas posteriores a la fecha de adeudo en cuenta. Tus derechos se explican en una declaración que puedes obtener en tu banco. Aceptas recibir notificaciones sobre próximos adeudos con hasta dos días de antelación a que estos ocurran.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Dirección</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ciudad</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">País</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Condado</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nombre</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Código postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincia</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Estado</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Código postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">El correo electrónico no es válido.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">El IBAN introducido está incompleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">El IBAN introducido no es válido.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">El IBAN que has introducido no es válido: %s no es un código de país admitido.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Tarjeta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Adeudo SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Al facilitarnos la información del pago y al confirmar este pago, autorizas a (A) %s y a Stripe, nuestro proveedor de servicios de pago, a enviar instrucciones a tu banco para adeudar tu cuenta y (B) a tu banco para efectuar los adeudos en tu cuenta siguiendo dichas instrucciones. Como parte de tus derechos, estás legitimado al rembolso por parte de tu banco en los términos y condiciones del contrato suscrito con este. La solicitud del reembolso deberá efectuarse dentro de las ocho semanas posteriores a la fecha de adeudo en cuenta. Tus derechos se explican en una declaración que puedes obtener en tu banco. Aceptas recibir notificaciones sobre próximos adeudos con hasta dos días de antelación a que estos ocurran.</string>
 </resources>

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEALi pank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kaart</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA deebet</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Salvestage tulevasteks makseteks</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Makseteabe esitamise ja käesoleva makse kinnitamisega volitatate (A) ettevõtet %s ja Stripe\'i, meie makseteenuse osutajat, saatma teie panka juhiseid teie konto debiteerimiseks ning (B) oma panka nende juhiste alusel teie kontot debiteerima. Vastavalt teie õigustele, pangaga sõlmitud lepingule ja panga üldtingimustele on teil õigus saada pangalt tagasimakset. Tagasimakse taotlus tuleb esitada 8 nädala jooksul alates teie konto debiteerimise kuupäevast. Teie õigusi selgitatakse avalduses, mille saate oma pangast. Nõustute saama teavitusi tulevaste debiteerimiste kohta kaks päeva enne nende toimumist.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Aadress</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Linn</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Riik</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Maakond</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nimi</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Sihtnumber</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Maakond</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Osariik</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Sihtnumber</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Teie meiliaadress on kehtetu.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Sisestatud IBAN on puudulik.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Sisestatud IBAN on kehtetu.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Sisestatud IBAN on kehtetu, \"%s\" ei ole toetatud riigikood.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Teie IBAN peab algama kahetähelise riigikoodiga.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valikuline)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEALi pank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kaart</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA deebet</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Salvestage tulevasteks makseteks</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Makseteabe esitamise ja käesoleva makse kinnitamisega volitatate (A) ettevõtet %s ja Stripe\'i, meie makseteenuse osutajat, saatma teie panka juhiseid teie konto debiteerimiseks ning (B) oma panka nende juhiste alusel teie kontot debiteerima. Vastavalt teie õigustele, pangaga sõlmitud lepingule ja panga üldtingimustele on teil õigus saada pangalt tagasimakset. Tagasimakse taotlus tuleb esitada 8 nädala jooksul alates teie konto debiteerimise kuupäevast. Teie õigusi selgitatakse avalduses, mille saate oma pangast. Nõustute saama teavitusi tulevaste debiteerimiste kohta kaks päeva enne nende toimumist.</string>
 </resources>

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL-pankki</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kortti</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Tallenna tulevia maksuja varten</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Antamalla maksutiedot ja vahvistamalla tämän maksun, valtuutat (A) %s ja Stripen, maksupalvelun tarjoajamme, lähettämään ohjeita pankillesi tilisi veloittamiseksi ja (B) pankkisi veloittamaan tiliäsi annettujen ohjeiden mukaisesti. Oikeuksiesi mukaisesti olet oikeutettu maksun palautukseen pankiltasi heidän kanssaan tekemäsi sopimuksen mukaisesti. Maksun palautus on lunastettava kahdeksan viikon kuluessa tilisi veloituksesta. Oikeutesi kerrotaan lausunnossa, jonka voit hankkia pankiltasi. Hyväksyt vastaanottamaan ilmoituksia tulevista veloituksista kaksi päivää ennen niiden tapahtumista.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Osoite</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Paikkakunta</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Maa</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Lääni</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nimi</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postinumero</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provinssi</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Osavaltio</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postinumero</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Sähköposti on virheellinen.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">IBAN on puutteellinen.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Antamasi IBAN on virheellinen.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Antamasi IBAN on virheellinen, \"%s\" ei ole tuettu maakoodi.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN-tilinumero alkaa kaksikirjaimisella maakoodilla.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valinnainen)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL-pankki</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kortti</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Tallenna tulevia maksuja varten</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Antamalla maksutiedot ja vahvistamalla tämän maksun, valtuutat (A) %s ja Stripen, maksupalvelun tarjoajamme, lähettämään ohjeita pankillesi tilisi veloittamiseksi ja (B) pankkisi veloittamaan tiliäsi annettujen ohjeiden mukaisesti. Oikeuksiesi mukaisesti olet oikeutettu maksun palautukseen pankiltasi heidän kanssaan tekemäsi sopimuksen mukaisesti. Maksun palautus on lunastettava kahdeksan viikon kuluessa tilisi veloituksesta. Oikeutesi kerrotaan lausunnossa, jonka voit hankkia pankiltasi. Hyväksyt vastaanottamaan ilmoituksia tulevista veloituksista kaksi päivää ennen niiden tapahtumista.</string>
 </resources>

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kard</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">I-save para sa mga pagbabayad sa hinaharap</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Sa pagbibigay ng iyong impormasyon ng pagbabayad at pagkukupirma sa bayad na ito, pinapayagan mo (A) %s at ang Stripe, ang ating payment service provider, na magpadala ng mga tagubilin sa iyong bangko para i-debit ang iyong account at (B) ang iyong bangko na i-debit ang iyong account ayon sa mga naturang tuntunin. Bilang bahagi ng iyong mga karapatan, maaari kang makakuha ng refund mula sa iyong bangko sa ilalim ng mga takda at kundisyon ng iyong kasunduan sa iyong bangko. Ang refund ay dapat hingin sa loob ng 8 linggo mula sa petsa na na-debit ang iyong account. Ang iyong mga karapatan ay naipaliwanag sa isang pahayag na maari mong makuha sa iyong bangko. Pumapayag ka na makatanggap ng mga abiso ukol sa mga debit sa hinaharap ng hanggang 2 na araw bago sila maganap.</string>
-</resources>

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Carte</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Prélèvement SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour les prochains achats</string>
-    <string name="stripe_paymentsheet_sepa_mandate">En fournissant vos informations de paiement et en confirmant ce paiement, vous autorisez (A) %s et Stripe, notre prestataire de services de paiement, à donner à votre institution financière l\'instruction de débiter votre compte, et (B) votre institution financièire à débiter votre compte conformément à ces instructions. Vous bénéficiez d\'un droit de remboursement par votre institution financière selon les conditions décrites dans la convention que vous avez passée avec elle. Toute demande de remboursement doit être présentée dans les 8 semaines suivant la date de débit de votre compte. Vos droits sont précisés dans une déclaration que vous pouvez obtenir auprès de votre institution financière. Vous acceptez de recevoir des notifications concernant les débits futurs jusqu\'à 2 jours avant leur réalisation.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ville</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Pays</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Comté</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nom</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Code postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Province</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">État</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Code postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Votre adresse de courriel n\'est pas valide.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">L\'IBAN que vous avez saisi est incomplet.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">L\'IBAN que vous avez saisi n\'est pas valide.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">L\'IBAN que vous avez saisi n\'est pas valide, « %s » n\'est pas un code pays pris en charge.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (facultatif)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Carte</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Prélèvement SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour les prochains achats</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">En fournissant vos informations de paiement et en confirmant ce paiement, vous autorisez (A) %s et Stripe, notre prestataire de services de paiement, à donner à votre institution financière l\'instruction de débiter votre compte, et (B) votre institution financièire à débiter votre compte conformément à ces instructions. Vous bénéficiez d\'un droit de remboursement par votre institution financière selon les conditions décrites dans la convention que vous avez passée avec elle. Toute demande de remboursement doit être présentée dans les 8 semaines suivant la date de débit de votre compte. Vos droits sont précisés dans une déclaration que vous pouvez obtenir auprès de votre institution financière. Vous acceptez de recevoir des notifications concernant les débits futurs jusqu\'à 2 jours avant leur réalisation.</string>
 </resources>

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Carte</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Prélèvement SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour de futurs achats</string>
-    <string name="stripe_paymentsheet_sepa_mandate">En fournissant vos informations de paiement et en confirmant ce paiement, vous autorisez (A) %s et Stripe, notre prestataire de services de paiement, à donner à votre banque l\'instruction de débiter votre compte, et (B) votre banque à débiter votre compte conformément à ces instructions. Vous bénéficiez d\'un droit à remboursement par votre banque selon les conditions décrites dans la convention que vous avez passée avec elle. Toute demande de remboursement doit être présentée dans les 8 semaines suivant la date de débit de votre compte. Vos droits sont précisés dans une déclaration que vous pouvez obtenir auprès de votre banque. Vous acceptez de recevoir des notifications concernant les débits futurs jusqu\'à 2 jours avant leur réalisation.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ville</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Pays</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Département</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nom</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Code postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Province</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">État</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Code postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Votre adresse e-mail n\'est pas valide.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">L\'IBAN que vous avez saisi est incomplet.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">L\'IBAN que vous avez saisi n\'est pas valide.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">L\'IBAN que vous avez saisi n\'est pas valide, « %s » n\'est pas un code pays pris en charge.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (facultatif)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Carte</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Prélèvement SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour de futurs achats</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">En fournissant vos informations de paiement et en confirmant ce paiement, vous autorisez (A) %s et Stripe, notre prestataire de services de paiement, à donner à votre banque l\'instruction de débiter votre compte, et (B) votre banque à débiter votre compte conformément à ces instructions. Vous bénéficiez d\'un droit à remboursement par votre banque selon les conditions décrites dans la convention que vous avez passée avec elle. Toute demande de remboursement doit être présentée dans les 8 semaines suivant la date de débit de votre compte. Vos droits sont précisés dans une déclaration que vous pouvez obtenir auprès de votre banque. Vous acceptez de recevoir des notifications concernant les débits futurs jusqu\'à 2 jours avant leur réalisation.</string>
 </resources>

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kartica</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Spremi za buduća plaćanja</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Unošenjem vaših podataka o plaćanju, ovlašćujete (A) %s i Stripe, našeg davatelja usluga platnog prometa, da vašoj banci pošalje upute za terećenje vašeg računa, i (B) vašu banku za terećenje vašeg računa u skladu s tim uputama. U sklopu vaših prava, imate pravo na povrat novca od svoje banke prema uvjetima i odredbama ugovora s bankom. Povrat novca mora se zatražiti u roku od 8 tjedana počevši od datuma terećenja vašeg računa. Vaša prava objašnjena su u izjavi koju možete dobiti od svoje banke. Slažete se s primanjem obavijesti o budućim terećenjima do 2 dana prije njihova izvršenja.</string>
-</resources>

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kártya</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA beszedés</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Mentés a későbbi fizetésekhez</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Fizetési adatainak megadásával és a fizetés megerősítésével Ön felhatalmazza (A) a(z) %s céget és a Stripe-ot, fizetési szolgáltatónkat, hogy utasításokat küldjön a bankjának, hogy megterhelje a számláját, és (B) bankját, hogy az utasításoknak megfelelően megterhelje a számláját. A jogai részeként Ön jogosult a bankjától a velük kötött megállapodás feltételei szerinti visszatérítésre. A visszatérítést a számla megterhelésének napjától számított 8 héten belül kell igényelni. Jogait egy, a bankjától beszerezhető nyilatkozat tartalmazza. Beleegyezik abba, hogy a jövőbeni terhelésekről értesítést kap, legfeljebb 2 nappal azok bekövetkezése előtt.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Cím</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Város</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Ország</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Ország</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Név</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Irányítószám</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Tartomány</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Állam</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Irányítószám</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Érvénytelen e-mail-cím.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">A beírt IBAN-szám hiányos.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">A beírt IBAN-szám érvénytelen.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">A beírt IBAN-szám érvénytelen, a(z) „%s” nem támogatott országkód.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Az IBAN-számának egy kétbetűs országkóddal kell kezdődnie.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (nem kötelező)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kártya</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA beszedés</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Mentés a későbbi fizetésekhez</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Fizetési adatainak megadásával és a fizetés megerősítésével Ön felhatalmazza (A) a(z) %s céget és a Stripe-ot, fizetési szolgáltatónkat, hogy utasításokat küldjön a bankjának, hogy megterhelje a számláját, és (B) bankját, hogy az utasításoknak megfelelően megterhelje a számláját. A jogai részeként Ön jogosult a bankjától a velük kötött megállapodás feltételei szerinti visszatérítésre. A visszatérítést a számla megterhelésének napjától számított 8 héten belül kell igényelni. Jogait egy, a bankjától beszerezhető nyilatkozat tartalmazza. Beleegyezik abba, hogy a jövőbeni terhelésekről értesítést kap, legfeljebb 2 nappal azok bekövetkezése előtt.</string>
 </resources>

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kartu</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Simpan untuk pembayaran mendatang</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Dengan memberikan informasi pembayaran dan mengonfirmasi pembayaran ini, berarti Anda mengotorisasi (A) %s dan Stripe, penyedia layanan pembayaran kami, untuk mengirim instruksi kepada bank untuk mendebit rekening Anda dan (B) kepada bank untuk mendebit rekening Anda sesuai instruksi itu. Sebagai bagian dari hak Anda, Anda berhak mendapat pengembalian dana dari bank berdasarkan ketentuan dan persyaratan perjanjian Anda dengan bank. Pengembalian dana harus diklaim dalam waktu 8 minggu sejak tanggal pendebitan rekening Anda. Hak Anda dijelaskan dalam pernyataan yang dapat Anda peroleh dari bank Anda. Anda setuju untuk menerima notifikasi pendebitan di masa mendatang hingga 2 hari sebelum dilakukan.</string>
-</resources>

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banca iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Carta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Addebito SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Salva per i pagamenti futuri</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Fornendo le informazioni di pagamento e confermando questo pagamento, autorizzi (A) %s e Stripe, il nostro fornitore di servizi di pagamento, a inviare istruzioni alla tua banca per l\'addebito sul tuo conto e (B) la tua banca a procedere con tale addebito conformemente alle istruzioni fornite. Tra gli altri diritti, hai anche diritto a un rimborso dalla tua banca in base ai termini e condizioni dell\'accordo sottoscritto con l\'istituto. Un eventuale rimborso va richiesto entro otto settimane a decorrere dalla data di addebito in conto. I tuoi diritti sono consultabili in una dichiarazione che puoi richiedere alla tua banca. Accetti di ricevere una notifica per addebiti futuri fino a 2 giorni prima.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Indirizzo</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Città</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Paese</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Contea</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nome</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Codice postale</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincia</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stato</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Codice postale</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Indirizzo email non valido.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">L\'IBAN inserito è incompleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">L\'IBAN inserito non è valido.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">L\'IBAN inserito non è valido; \"%s\" non è un codice di paese valido.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">L\'IBAN deve iniziare con un codice di paese di due lettere.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (campo facoltativo)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banca iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Carta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Addebito SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Salva per i pagamenti futuri</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Fornendo le informazioni di pagamento e confermando questo pagamento, autorizzi (A) %s e Stripe, il nostro fornitore di servizi di pagamento, a inviare istruzioni alla tua banca per l\'addebito sul tuo conto e (B) la tua banca a procedere con tale addebito conformemente alle istruzioni fornite. Tra gli altri diritti, hai anche diritto a un rimborso dalla tua banca in base ai termini e condizioni dell\'accordo sottoscritto con l\'istituto. Un eventuale rimborso va richiesto entro otto settimane a decorrere dalla data di addebito in conto. I tuoi diritti sono consultabili in una dichiarazione che puoi richiedere alla tua banca. Accetti di ricevere una notifica per addebiti futuri fino a 2 giorni prima.</string>
 </resources>

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL銀行</string>
-    <string name="stripe_paymentsheet_payment_method_card">クレジットカード番号</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA デビット</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">今後の支払いのために保存する</string>
-    <string name="stripe_paymentsheet_sepa_mandate">支払い情報を提供し、この支払いを確定することで、お客様は (A) %s および決済サービスプロバイダーである Stripe がお客様の銀行に口座引き落としの指図を送り、(B) 銀行がこの指図に従ってお客様の口座から引き落としを行うことを承認することになります。お客様の権利の一部として、銀行との契約条件に基づき、お客様は銀行からの返金を受ける権利を有します。返金は口座の引き落とし日から 8 週間以内に請求する必要があります。お客様の権利は、銀行から得られる明細書内で説明されています。お客様は今後の引き落としに関する通知を引き落としの実行日の 2 日前までに受け取ることに同意するものとします。</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">住所</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">市</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">国</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">群</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">名前</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">郵便番号</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">都道府県</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">都道府県</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">郵便番号</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">メールアドレスが無効です。</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">入力した IBAN に不備があります。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">入力した IBAN が無効です。</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">入力した IBAN が無効です。\"%s\" はサポートされている国コードではありません。</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBANコードの先頭には 2 文字の国コードを入力してください。</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (オプション)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL銀行</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">クレジットカード番号</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA デビット</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">今後の支払いのために保存する</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">支払い情報を提供し、この支払いを確定することで、お客様は (A) %s および決済サービスプロバイダーである Stripe がお客様の銀行に口座引き落としの指図を送り、(B) 銀行がこの指図に従ってお客様の口座から引き落としを行うことを承認することになります。お客様の権利の一部として、銀行との契約条件に基づき、お客様は銀行からの返金を受ける権利を有します。返金は口座の引き落とし日から 8 週間以内に請求する必要があります。お客様の権利は、銀行から得られる明細書内で説明されています。お客様は今後の引き落としに関する通知を引き落としの実行日の 2 日前までに受け取ることに同意するものとします。</string>
 </resources>

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL 은행</string>
-    <string name="stripe_paymentsheet_payment_method_card">카드</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">향후 결제에 사용하도록 저장</string>
-    <string name="stripe_paymentsheet_sepa_mandate">결제 정보를 제공하고 이 결제를 확인하면 (A) %s 및 결제 서비스 공급업체 Stripe가 은행에 계좌 출금에 관련한 지침을 전송하고 (B) 은행이 해당 지침에 따라 출금하도록 승인하는 것입니다. 귀하의 권리 중 일부로, 은행에 대한 이용 약관 동의 하에 은행에서 환불을 받을 자격을 부여받게 됩니다. 환불은 계좌에서 출금이 이루어진 날짜로부터 8주 이내에 요청해야 합니다. 귀하의 권리는 은행에서 받으시는 명세서에 설명되어 있습니다. 귀하는 향후 출금 시 최대 2일 전에 알림을 받겠다고 동의하는 것입니다.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">주소</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">시</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">국가</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">구/군</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">이름</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">우편번호</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">도</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">주</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">우편번호</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">이메일이 잘못되었습니다.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">입력한 IBAN이 불완전합니다.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">입력한 IBAN이 잘못되었습니다.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">입력한 IBAN이 잘못되었습니다. \"%s\"은(는) 지원되는 국가 코드가 아닙니다.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN은 두 글자의 국가 코드로 시작해야 합니다.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s(선택 사항)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL 은행</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">카드</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">향후 결제에 사용하도록 저장</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">결제 정보를 제공하고 이 결제를 확인하면 (A) %s 및 결제 서비스 공급업체 Stripe가 은행에 계좌 출금에 관련한 지침을 전송하고 (B) 은행이 해당 지침에 따라 출금하도록 승인하는 것입니다. 귀하의 권리 중 일부로, 은행에 대한 이용 약관 동의 하에 은행에서 환불을 받을 자격을 부여받게 됩니다. 환불은 계좌에서 출금이 이루어진 날짜로부터 8주 이내에 요청해야 합니다. 귀하의 권리는 은행에서 받으시는 명세서에 설명되어 있습니다. 귀하는 향후 출금 시 최대 2일 전에 알림을 받겠다고 동의하는 것입니다.</string>
 </resources>

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL bankas</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kortelė</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA debetas</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Išsaugokite vėlesniems mokėjimams</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Pateikdami mokėjimo duomenis ir patvirtindami šį mokėjimą, leidžiate (A) „%s“ ir „Stripe“ (mūsų mokėjimo paslaugų teikėjui) jūsų bankui siųsti nurodymus nurašyti pinigus iš jūsų sąskaitos ir (B) leidžiate savo bankui, gavus tokius nurodymus, nurašyti pinigus iš jūsų sąskaitos. Pagal jūsų su banku sudarytos sutarties sąlygas turite teisę iš banko reikalauti pinigų grąžinimo. Prašymą grąžinti pinigus turite pateikti per 8 savaites nuo pinigų iš jūsų sąskaitos nurašymo dienos. Jūsų teisės paaiškintos pareiškime, kurį galite gauti iš savo banko. Sutinkate gauti pranešimus apie būsimus nurašymus likus iki 2 dienų iki jų įvykdymo momento.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresas</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Miestas</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Šalis</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Apygarda</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Vardas, pavardė</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Pašto kodas</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincija</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Valstija</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Pašto kodas</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Jūsų el. paštas yra neteisingas.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Įvedėte ne visą IBAN.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Įvedėte neteisingą IBAN.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Įvedėte neteisingą IBAN kodą, \"%s\" nėra palaikomas šalies kodas.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Jūsų IBAN turėtų prasidėti šalies kodu iš dviejų raidžių.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (pasirenkamas)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL bankas</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kortelė</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA debetas</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Išsaugokite vėlesniems mokėjimams</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Pateikdami mokėjimo duomenis ir patvirtindami šį mokėjimą, leidžiate (A) „%s“ ir „Stripe“ (mūsų mokėjimo paslaugų teikėjui) jūsų bankui siųsti nurodymus nurašyti pinigus iš jūsų sąskaitos ir (B) leidžiate savo bankui, gavus tokius nurodymus, nurašyti pinigus iš jūsų sąskaitos. Pagal jūsų su banku sudarytos sutarties sąlygas turite teisę iš banko reikalauti pinigų grąžinimo. Prašymą grąžinti pinigus turite pateikti per 8 savaites nuo pinigų iš jūsų sąskaitos nurašymo dienos. Jūsų teisės paaiškintos pareiškime, kurį galite gauti iš savo banko. Sutinkate gauti pranešimus apie būsimus nurašymus likus iki 2 dienų iki jų įvykdymo momento.</string>
 </resources>

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
-    <string name="stripe_paymentsheet_payment_method_card">Karte</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA debets</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Saglabāt nākotnes maksājumiem</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Norādot savu maksājuma informāciju un apstiprinot šo maksājumu, jūs pilnvarojat A) %s un Stripe (mūsu maksājumu pakalpojumu sniedzēju) nosūtīt rīkojumu jūsu bankai debetēt jūsu kontu un B) jūsu banku debetēt jūsu kontu saskaņā ar šo rīkojumu. Jums ir tiesības pieprasīt naudas līdzekļu atmaksu no jūsu bankas saskaņā ar jūsu bankas konta apkalpošanas līguma noteikumiem un nosacījumiem. Naudas līdzekļu atmaksa jāpieprasa astoņu nedēļu laikā, sākot no jūsu konta debetēšanas datuma. Jūsu tiesības ir paskaidrotas paziņojumā, kuru varat saņemt savā bankā. Jūs piekrītat saņemt paziņojumus par turpmākajiem debeta darījumiem vismaz divas dienas pirms to veikšanas.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adrese</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Pilsēta</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Valsts</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Apriņķis</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Vārds, uzvārds</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Pasta indekss</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Province</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Novads/štats</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Pasta indekss</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-pasta adrese nav derīga.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Ievadītais IBAN nav pilnīgs.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Ievadītais IBAN nav derīgs.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Ievadītais IBAN nav derīgs, \"%s\" nav atbalstīts valsts kods.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN sākumā jābūt divu burtu valsts kodam.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (nav obligāti)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Karte</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA debets</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Saglabāt nākotnes maksājumiem</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Norādot savu maksājuma informāciju un apstiprinot šo maksājumu, jūs pilnvarojat A) %s un Stripe (mūsu maksājumu pakalpojumu sniedzēju) nosūtīt rīkojumu jūsu bankai debetēt jūsu kontu un B) jūsu banku debetēt jūsu kontu saskaņā ar šo rīkojumu. Jums ir tiesības pieprasīt naudas līdzekļu atmaksu no jūsu bankas saskaņā ar jūsu bankas konta apkalpošanas līguma noteikumiem un nosacījumiem. Naudas līdzekļu atmaksa jāpieprasa astoņu nedēļu laikā, sākot no jūsu konta debetēšanas datuma. Jūsu tiesības ir paskaidrotas paziņojumā, kuru varat saņemt savā bankā. Jūs piekrītat saņemt paziņojumus par turpmākajiem debeta darījumiem vismaz divas dienas pirms to veikšanas.</string>
 </resources>

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">Bank iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kad</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Debit SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Simpan untuk pembayaran masa hadapan</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Dengan memberikan maklumat pembayaran anda dan mengesahkan pembayaran ini, anda mengizinkan (A) %s dan Stripe, iaitu penyedia perkhidmatan pembayaran kami, untuk menghantar arahan kepada bank untuk mendebitkan akaun anda dan (B) bank anda untuk mendebitkan akaun anda menurut arahan tersebut. Sebagai sebahagian daripada hak anda, anda layak mendapat bayaran balik daripada bank menurut terma dan syarat perjanjian dengan bank anda. Bayaran balik mesti dituntut dalam tempoh 8 minggu mulai tarikh akaun anda didebitkan. Hak anda dijelaskan dalam pernyataan yang boleh anda dapatkan daripada bank anda. Anda bersetuju untuk menerima pemberitahuan bagi debit masa hadapan sehingga 2 hari sebelum debit tersebut dibuat.</string>
-</resources>

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Il-Bank iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kard</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Debitu SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Erfa\' għall-pagamenti fil-ġejjieni</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Meta tagħti l-informazzjoni tal-pagament tiegħek u tikkonferma dan il-pagament, tkun qed tawtorizza lil (A) %s u lil Stripe, l-operatur tas-servizz tal-pagamenti tagħna, biex jibagħtu struzzjonijiet lill-bank tiegħek biex jieħu l-fondi mill-kont tiegħek u (B) lill-bank tiegħek biex jieħu l-fondi mill-kont tiegħek skont dawn l-istruzzjonijiet. Bħala parti mid-drittijiet tiegħek, inti għandek dritt għall-ħlas lura mill-bank tiegħek skont it-termini u l-kundizzjonijiet tal-ftehim tiegħek mal-bank tiegħek. Ħlas lura għandu jintalab fi żmien 8 ġimgħat, li jibdew jgħoddu mid-data li fiha l-fondi jittieħdu mill-kont tiegħek. Id-drittijiet tiegħek huma spjegati f\'dikjarazzjoni li tista\' tikseb mingħand il-bank tiegħek. Inti taqbel li, sa jumejn qabel, tirċievi notifika kull darba li l-fondi jkunu se jittieħdu mill-kont tiegħek.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Indirizz</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Belt</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Pajjiż</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Kontea</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Isem</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Kodiċi postali</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provinċja</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Kodiċi postali</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">L-indirizz tal-email li daħħalt mhux tajjeb.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">L-IBAN li daħħalt mhux komplut.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">L-IBAN li daħħalt mhux tajjeb.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">L-IBAN li daħħalt mhux tajjeb, \"%s\" mhux pajjiż li jista\' jintuża.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">L-IBAN tiegħek għandu jibda b\'kodiċi tal-pajjiż magħmul minn żewġ ittri.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (mhux obbligatorja)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Il-Bank iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kard</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Debitu SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Erfa\' għall-pagamenti fil-ġejjieni</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Meta tagħti l-informazzjoni tal-pagament tiegħek u tikkonferma dan il-pagament, tkun qed tawtorizza lil (A) %s u lil Stripe, l-operatur tas-servizz tal-pagamenti tagħna, biex jibagħtu struzzjonijiet lill-bank tiegħek biex jieħu l-fondi mill-kont tiegħek u (B) lill-bank tiegħek biex jieħu l-fondi mill-kont tiegħek skont dawn l-istruzzjonijiet. Bħala parti mid-drittijiet tiegħek, inti għandek dritt għall-ħlas lura mill-bank tiegħek skont it-termini u l-kundizzjonijiet tal-ftehim tiegħek mal-bank tiegħek. Ħlas lura għandu jintalab fi żmien 8 ġimgħat, li jibdew jgħoddu mid-data li fiha l-fondi jittieħdu mill-kont tiegħek. Id-drittijiet tiegħek huma spjegati f\'dikjarazzjoni li tista\' tikseb mingħand il-bank tiegħek. Inti taqbel li, sa jumejn qabel, tirċievi notifika kull darba li l-fondi jkunu se jittieħdu mill-kont tiegħek.</string>
 </resources>

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kort</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Lagre til fremtidige betalinger</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgi betalingsinformasjonen din og bekrefte denne betalingen gir du tillatelse til at (A) %s og Stripe, vår leverandør for betalingstjenesten, sende anmodning til banken din om å belaste kontoen din og (B) banken din belaster kontoen din i samsvar med anmodningen. Som del av dine rettigheter kan du kreve å få beløpet tilbakeført i henhold til avtalen du har med banken. Tilbakeføringskrav må fremsettes innen 8 uker etter at kontoen ble belastet. Rettighetene dine blir forklart i en erklæring som du kan få fra banken. Du godtar å motta varsler om fremtidige belastninger opptil to dager før de skjer.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">By</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Fylke</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Navn</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postnummer</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provins</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postnummer</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-posten din er ugyldig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">IBAN-nummeret du la inn er ufullstendig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">IBAN-nummeret du la inn er ugyldig.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">IBAN-nummeret du la inn er ugyldig, «%s» er ikke en gyldig landskode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN-nummeret skal starte med en tosifret landskode.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valgfritt)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kort</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Lagre til fremtidige betalinger</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgi betalingsinformasjonen din og bekrefte denne betalingen gir du tillatelse til at (A) %s og Stripe, vår leverandør for betalingstjenesten, sende anmodning til banken din om å belaste kontoen din og (B) banken din belaster kontoen din i samsvar med anmodningen. Som del av dine rettigheter kan du kreve å få beløpet tilbakeført i henhold til avtalen du har med banken. Tilbakeføringskrav må fremsettes innen 8 uker etter at kontoen ble belastet. Rettighetene dine blir forklart i en erklæring som du kan få fra banken. Du godtar å motta varsler om fremtidige belastninger opptil to dager før de skjer.</string>
 </resources>

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL-bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kaart</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-incasso</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Opslaan voor toekomstige betalingen</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Door je betaalgegevens op te geven en deze betaling te bevestigen geef je toestemming aan (A) %s en Stripe, onze betaaldienstverlener, een opdracht te sturen aan je bank om je rekening te debiteren en aan (B) je bank om je rekening te debiteren conform deze opdracht. Je hebt het recht op terugbetaling door je bank conform de met je bank overeengekomen voorwaarden. Een verzoek tot terugbetaling moet worden ingediend binnen 8 weken vanaf de datum waarop je rekening is gedebiteerd. Je rechten worden uitgelegd in een verklaring die je kunt opvragen bij je bank. Je stemt ermee in dat je minstens 2 dagen voor de uitvoering van toekomstige debiteringen hierover op de hoogte wordt gesteld.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Plaats</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Graafschap</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Naam</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postcode</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincie</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Staat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postcode</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Je e-mailadres is ongeldig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Het opgegeven IBAN-nummer is onvolledig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Het opgegeven IBAN-nummer is ongeldig.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Het opgegeven IBAN-nummer is ongeldig: \"%s\" is geen ondersteunde landcode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Het IBAN-nummer moet beginnen met een landcode van twee letters.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (optioneel)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL-bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kaart</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-incasso</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Opslaan voor toekomstige betalingen</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Door je betaalgegevens op te geven en deze betaling te bevestigen geef je toestemming aan (A) %s en Stripe, onze betaaldienstverlener, een opdracht te sturen aan je bank om je rekening te debiteren en aan (B) je bank om je rekening te debiteren conform deze opdracht. Je hebt het recht op terugbetaling door je bank conform de met je bank overeengekomen voorwaarden. Een verzoek tot terugbetaling moet worden ingediend binnen 8 weken vanaf de datum waarop je rekening is gedebiteerd. Je rechten worden uitgelegd in een verklaring die je kunt opvragen bij je bank. Je stemt ermee in dat je minstens 2 dagen voor de uitvoering van toekomstige debiteringen hierover op de hoogte wordt gesteld.</string>
 </resources>

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kort</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-betaling</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgje betalingsopplysningane dine og bekrefte denne betalinga, autoriserer du (A) %s og Stripe, betalingstenesteleverandøren vår, til å sende instruksjonar til banken din om å debitere kontoen din og (B) banken din om å debitere kontoen din i medhald av dei instruksjonane. Som ein del av rettane dine, har du krav på ein refusjon frå banken din under vilkåra i avtalen din med banken. Ein refusjon må hevdast innan 8 veker frå datoen da kontoen din vart debitert. Rettane dine vert forklart i ei erklæring som du kan få frå banken. Du godtek å take imot varsel for framtidige debetar opptil 2 dagar før dei oppstår.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Stad</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Fylke</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Namn</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postnummer</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Område</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Fylke</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postnummer</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-postadressa di er ugyldig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Du skreiv inn eit ufullstendig IBAN-nummer.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Du skreiv inn eit ugyldig IBAN-nummer.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Du skreiv inn eit ugyldig IBAN-nummer, \"%s\" er ikkje ei støtta landskode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN-nummeret bør starte med ei landskode med to bokstavar.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kort</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA-betaling</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgje betalingsopplysningane dine og bekrefte denne betalinga, autoriserer du (A) %s og Stripe, betalingstenesteleverandøren vår, til å sende instruksjonar til banken din om å debitere kontoen din og (B) banken din om å debitere kontoen din i medhald av dei instruksjonane. Som ein del av rettane dine, har du krav på ein refusjon frå banken din under vilkåra i avtalen din med banken. Ein refusjon må hevdast innan 8 veker frå datoen da kontoen din vart debitert. Rettane dine vert forklart i ei erklæring som du kan få frå banken. Du godtek å take imot varsel for framtidige debetar opptil 2 dagar før dei oppstår.</string>
 </resources>

--- a/paymentsheet/res/values-no/strings.xml
+++ b/paymentsheet/res/values-no/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kort</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgje betalingsopplysningane dine og bekrefte denne betalinga, autoriserer du (A) %s og Stripe, betalingstenesteleverandøren vår, til å sende instruksjonar til banken din om å debitere kontoen din og (B) banken din om å debitere kontoen din i medhald av dei instruksjonane. Som ein del av rettane dine, har du krav på ein refusjon frå banken din under vilkåra i avtalen din med banken. Ein refusjon må hevdast innan 8 veker frå datoen da kontoen din vart debitert. Rettane dine vert forklart i ei erklæring som du kan få frå banken. Du godtek å take imot varsel for framtidige debetar opptil 2 dagar før dei oppstår.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresse</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Sted</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Fylke</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Namn</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postnummer</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provins</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postnummer</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-postadressa di er ugyldig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Du skreiv inn eit ufullstendig IBAN-nummer.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Du skreiv inn eit ugyldig IBAN-nummer.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Du skreiv inn eit ugyldig IBAN-nummer, \"%s\" er ikkje ei støtta landskode.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN-nummeret bør starte med ei landskode med to bokstavar.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kort</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ved å oppgje betalingsopplysningane dine og bekrefte denne betalinga, autoriserer du (A) %s og Stripe, betalingstenesteleverandøren vår, til å sende instruksjonar til banken din om å debitere kontoen din og (B) banken din om å debitere kontoen din i medhald av dei instruksjonane. Som ein del av rettane dine, har du krav på ein refusjon frå banken din under vilkåra i avtalen din med banken. Ein refusjon må hevdast innan 8 veker frå datoen da kontoen din vart debitert. Rettane dine vert forklart i ei erklæring som du kan få frå banken. Du godtek å take imot varsel for framtidige debetar opptil 2 dagar før dei oppstår.</string>
 </resources>

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Karta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Polecenie zapłaty SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Zapisz do przyszłych płatności</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Podając dane płatności i potwierdzając tę płatność, upoważniasz (A) %s i Stripe, naszego dostawcę usług płatności, do wysłania instrukcji do Twojego banku w celu obciążenia Twojego konta oraz (B) Twój bank do obciążenia Twojego konta zgodnie z tymi instrukcjami. W ramach swoich praw jesteś uprawniony(-a) do otrzymania zwrotu od Twojego banku zgodnie z zasadami i warunkami umowy z bankiem. Zwrot należy odebrać w ciągu 8 tygodni, licząc od daty obciążenia konta. Twoje prawa są wyjaśnione w oświadczeniu, które możesz otrzymać z banku. Wyrażasz zgodę na otrzymywanie powiadomień w przypadku przyszłych obciążeń do 2 dni przed ich wystąpieniem.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Miejscowość</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Kraj</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Hrabstwo</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Imię i nazwisko</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Kod pocztowy</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Prowincja</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stan</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Kod pocztowy</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Adres e-mail jest nieprawidłowy.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Podany IBAN jest niepełny.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Podany IBAN jest nieprawidłowy.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Podany IBAN jest nieprawidłowy. „%s” nie jest prawidłowym kodem kraju.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN powinien się zaczynać od dwuliterowego kodu kraju.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcjonalnie)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Karta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Polecenie zapłaty SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Zapisz do przyszłych płatności</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Podając dane płatności i potwierdzając tę płatność, upoważniasz (A) %s i Stripe, naszego dostawcę usług płatności, do wysłania instrukcji do Twojego banku w celu obciążenia Twojego konta oraz (B) Twój bank do obciążenia Twojego konta zgodnie z tymi instrukcjami. W ramach swoich praw jesteś uprawniony(-a) do otrzymania zwrotu od Twojego banku zgodnie z zasadami i warunkami umowy z bankiem. Zwrot należy odebrać w ciągu 8 tygodni, licząc od daty obciążenia konta. Twoje prawa są wyjaśnione w oświadczeniu, które możesz otrzymać z banku. Wyrażasz zgodę na otrzymywanie powiadomień w przypadku przyszłych obciążeń do 2 dni przed ich wystąpieniem.</string>
 </resources>

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Cartão</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Salvar para pagamentos futuros</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ao fornecer seus dados de pagamento e confirmar este pagamento, você autoriza (A) %s e a Stripe, o nosso provedor de serviços de pagamento, a enviar instruções ao seu banco para debitar sua conta e (B) seu banco a debitar sua conta, de acordo com as referidas instruções. Os seus direitos incluem a possibilidade de exigir do banco o reembolso do valor debitado, nos termos e condições acordados com a instituição. O reembolso deve ser solicitado dentro de um prazo de 8 semanas a partir da data do débito na conta. Você concorda em receber notificações de débitos futuros em até 2 dias antes do débito.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Endereço</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Cidade</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">País</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Condado</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nome</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Código postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Província</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Estado</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Código postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Seu e-mail é inválido.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">O IBAN inserido está incompleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">O IBAN inserido é inválido.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">O IBAN inserido é inválido, \"%s\" não foi reconhecido como código de país.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Seu IBAN deve começar com um código de país de duas letras.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Cartão</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Salvar para pagamentos futuros</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ao fornecer seus dados de pagamento e confirmar este pagamento, você autoriza (A) %s e a Stripe, o nosso provedor de serviços de pagamento, a enviar instruções ao seu banco para debitar sua conta e (B) seu banco a debitar sua conta, de acordo com as referidas instruções. Os seus direitos incluem a possibilidade de exigir do banco o reembolso do valor debitado, nos termos e condições acordados com a instituição. O reembolso deve ser solicitado dentro de um prazo de 8 semanas a partir da data do débito na conta. Você concorda em receber notificações de débitos futuros em até 2 dias antes do débito.</string>
 </resources>

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Cartão</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Guardar para pagamentos futuros</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Quando fornecer os seus dados de pagamento e confirmar este pagamento, autoriza (A) %s e a Stripe, o nosso provedor de serviços de pagamentos, a enviar instruções ao seu banco para debitar a sua conta e (B) o seu banco a debitar a sua conta de acordo com essas instruções. Como parte dos seus direitos, tem direito a um reembolso do seu banco de acordo com os termos e condições do seu acordo com o banco. Um reembolso deve ser solicitado até 8 semanas a partir da data na qual a sua conta foi debitada. Os seus direitos são explicados numa declaração que pode obter do seu banco. Aceita receber notificações de futuros débitos até 2 dias antes de serem efetuados.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Endereço</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Cidade</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">País</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Concelho</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nome</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Código postal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Província</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Estado</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Código postal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">O seu email é inválido.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">O IBAN que introduziu está incompleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">O IBAN que introduziu é inválido.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">O IBAN que introduziu é inválido, \"%s\" não é um código de país suportado.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">O seu IBAN deve começar por um código de duas letras correspondente ao país.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Cartão</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Débito SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Guardar para pagamentos futuros</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Quando fornecer os seus dados de pagamento e confirmar este pagamento, autoriza (A) %s e a Stripe, o nosso provedor de serviços de pagamentos, a enviar instruções ao seu banco para debitar a sua conta e (B) o seu banco a debitar a sua conta de acordo com essas instruções. Como parte dos seus direitos, tem direito a um reembolso do seu banco de acordo com os termos e condições do seu acordo com o banco. Um reembolso deve ser solicitado até 8 semanas a partir da data na qual a sua conta foi debitada. Os seus direitos são explicados numa declaração que pode obter do seu banco. Aceita receber notificações de futuros débitos até 2 dias antes de serem efetuados.</string>
 </resources>

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Număr card</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Salvați pentru plăți viitoare</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Prin furnizarea informațiilor dvs. privind plata și confirmarea acestei plăți, autorizați (A) %s și Stripe, furnizorul nostru de servicii de plată, să trimită instrucțiuni băncii dvs. pentru a vă debita contul și pentru ca (B) banca dvs. să facă acest lucru în conformitate cu instrucțiunile respective. Conform drepturilor dvs., aveți dreptul la o rambursare din partea băncii dvs. în conformitate cu termenii și condițiile acordului dvs. cu aceasta. O rambursare trebuie revendicată în termen de opt săptămâni de la data debitării contului. Drepturile dvs. sunt explicate într-o declarație pe care o puteți obține de la bancă. Sunteți de acord să primiți notificări pentru debitări viitoare cu până la două zile înainte de efectuarea acestora.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Oraș</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Țară</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Județ</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Nume</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Cod poștal</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincie</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Stat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Cod poștal</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-mailul dvs. nu este valid.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Codul IBAN pe care l-ați introdus nu este complet.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Codul IBAN pe care l-ați introdus nu este valid.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Codul IBAN pe care l-ați introdus nu este valid, \"%s\" nu este un cod de țară acceptat.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Codul dvs. IBAN trebuie să înceapă cu un cod de țară format din două litere.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (opțional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Număr card</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Salvați pentru plăți viitoare</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Prin furnizarea informațiilor dvs. privind plata și confirmarea acestei plăți, autorizați (A) %s și Stripe, furnizorul nostru de servicii de plată, să trimită instrucțiuni băncii dvs. pentru a vă debita contul și pentru ca (B) banca dvs. să facă acest lucru în conformitate cu instrucțiunile respective. Conform drepturilor dvs., aveți dreptul la o rambursare din partea băncii dvs. în conformitate cu termenii și condițiile acordului dvs. cu aceasta. O rambursare trebuie revendicată în termen de opt săptămâni de la data debitării contului. Drepturile dvs. sunt explicate într-o declarație pe care o puteți obține de la bancă. Sunteți de acord să primiți notificări pentru debitări viitoare cu până la două zile înainte de efectuarea acestora.</string>
 </resources>

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Банк в системе iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Карта</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Списание средств SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Сохранить данные для будущих платежей</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Указав свои платежные данные и подтвердив платеж, вы уполномочиваете (A) %s и Stripe, нашего поставщика платежных услуг, на отправку вашему банку инструкций на списание средств с вашего счета и (B) ваш банк на списание средств с вашего счета согласно данным инструкциям. Вы имеете право на возврат средств от вашего банка согласно положениям и условиям Вашего соглашения с банком. Подать заявку на возврат средств следует в течение 8 недель с даты списания средств с вашего счета. Ваши права объясняются в выписке, которую вы можете получить в своем банке. Вы даете согласие на получение уведомлений о будущих дебетованиях в срок до 2 дней до их поступления.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Адрес</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Город</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Страна</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Графство</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Имя</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Почтовый индекс</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Провинция</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Штат</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Почтовый индекс</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Недействительный адрес эл. почты.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Введенный код IBAN неполон.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Введенный код IBAN содержит ошибку.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Введенный код IBAN ошибочен, \"%s\" – неверный код страны.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Код IBAN должен начинаться с двухбуквенного кода страны.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (необязательно)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Банк в системе iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Карта</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Списание средств SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Сохранить данные для будущих платежей</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Указав свои платежные данные и подтвердив платеж, вы уполномочиваете (A) %s и Stripe, нашего поставщика платежных услуг, на отправку вашему банку инструкций на списание средств с вашего счета и (B) ваш банк на списание средств с вашего счета согласно данным инструкциям. Вы имеете право на возврат средств от вашего банка согласно положениям и условиям Вашего соглашения с банком. Подать заявку на возврат средств следует в течение 8 недель с даты списания средств с вашего счета. Ваши права объясняются в выписке, которую вы можете получить в своем банке. Вы даете согласие на получение уведомлений о будущих дебетованиях в срок до 2 дней до их поступления.</string>
 </resources>

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
-    <string name="stripe_paymentsheet_payment_method_card">Karta</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA inkaso</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Uložiť pre budúce platby</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Poskytnutím informácií o platbe a potvrdením tejto platby splnomocňujete (A) spoločnosti %s a Stripe, nášho poskytovateľa platobných služieb, na posielanie platobných príkazov do vašej banky na odpísanie finančných prostriedkov z vášho účtu a (B) vašu banku na odpísanie finančných prostriedkov z vášho účtu v súlade s pokynmi. V rámci vašich práv máte právo na refundáciu od vašej banky podľa zmluvných podmienok uvedených v zmluve s vašou bankou. Refundáciu si musíte vyžiadať do 8 týždňov odo dňa, kedy boli finančné prostriedky odpísané z vášho účtu. Vaše práva sú vysvetlené vo vyhlásení, ktoré môžete získať od svojej banky. Súhlasíte s tým, že budete dostávať oznámenia o budúcich debetných platbách až 2 dni pred ich uskutočnením.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adresa</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Mesto</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Krajina</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Kraj</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Meno</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">PSČ</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provincia</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Štát</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">PSČ</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Váš e-mail je neplatný.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Zadaný IBAN je neúplný.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Zadaný IBAN je neplatný.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Zadaný IBAN je neplatný, „%s“ nie je podporovaný kód krajiny.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Váš IBAN by mal začínať dvojpísmenovým kódom krajiny.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (voliteľné)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Karta</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA inkaso</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Uložiť pre budúce platby</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Poskytnutím informácií o platbe a potvrdením tejto platby splnomocňujete (A) spoločnosti %s a Stripe, nášho poskytovateľa platobných služieb, na posielanie platobných príkazov do vašej banky na odpísanie finančných prostriedkov z vášho účtu a (B) vašu banku na odpísanie finančných prostriedkov z vášho účtu v súlade s pokynmi. V rámci vašich práv máte právo na refundáciu od vašej banky podľa zmluvných podmienok uvedených v zmluve s vašou bankou. Refundáciu si musíte vyžiadať do 8 týždňov odo dňa, kedy boli finančné prostriedky odpísané z vášho účtu. Vaše práva sú vysvetlené vo vyhlásení, ktoré môžete získať od svojej banky. Súhlasíte s tým, že budete dostávať oznámenia o budúcich debetných platbách až 2 dni pred ich uskutočnením.</string>
 </resources>

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kartica</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Obremenitev SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Shrani za prihodnja plačila</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Z navedbo podatkov o plačilu in potrditvijo tega plačila pooblaščate (A) podjetje %s in družbo Stripe, našega ponudnika plačilnih storitev, da posreduje navodila vaši banki za bremenitev vašega računa, in (B) vašo banko, da bremeni vaš račun v skladu s temi navodili. Vaše pravice vključujejo tudi pravico do povračila denarnih sredstev s strani vaše banke v skladu s pogoji in določili vaše pogodbe z banko. Povračilo denarnih sredstev morate zahtevati v 8 tednih od dneva bremenitve vašega računa. Vaše pravice so podrobno opisane na izpisku, ki ga lahko pridobite v banki. Strinjate se s prejemom obvestil za prihodnje bremenitve največ 2 dni pred njihovo izvedbo.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Naslov</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Mesto</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Država</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Okraj</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Ime</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Poštna številka</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provinca</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Zvezna država</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Poštna številka</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Vaš e-poštni naslov ni veljaven.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Vnesena koda IBAN ni popolna.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Vnesena koda IBAN ni veljavna.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Vnesena koda IBAN ni veljavna. \"%s\" ni podprta koda države.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Vaša koda IBAN se mora začeti z dvomestno kodo države.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (izbirno)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kartica</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">Obremenitev SEPA</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Shrani za prihodnja plačila</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Z navedbo podatkov o plačilu in potrditvijo tega plačila pooblaščate (A) podjetje %s in družbo Stripe, našega ponudnika plačilnih storitev, da posreduje navodila vaši banki za bremenitev vašega računa, in (B) vašo banko, da bremeni vaš račun v skladu s temi navodili. Vaše pravice vključujejo tudi pravico do povračila denarnih sredstev s strani vaše banke v skladu s pogoji in določili vaše pogodbe z banko. Povračilo denarnih sredstev morate zahtevati v 8 tednih od dneva bremenitve vašega računa. Vaše pravice so podrobno opisane na izpisku, ki ga lahko pridobite v banki. Strinjate se s prejemom obvestil za prihodnje bremenitve največ 2 dni pred njihovo izvedbo.</string>
 </resources>

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kort</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Spara för framtida betalningar</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Genom att tillhandahålla din betalningsinformation och bekräfta denna betalning godkänner du (A) %s och Stripe, vår betaltjänstleverantör, att skicka instruktioner till din bank att debitera ditt konto och (B) din bank att debitera ditt konto i enlighet med dessa instruktioner. Som en del av dina rättigheter har du rätt till återbetalning från din bank enligt villkoren för ditt avtal med din bank. Återbetalning måste krävas inom åtta veckor från det datum då ditt konto debiterades. Dina rättigheter förklaras i ett utdrag som du kan få från din bank. Du godkänner att få aviseringar för framtida debiteringar upp till två dagar innan de inträffar.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adress</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Ort</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Land</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Landskap</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Namn</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postnummer</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Provins</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Delstat</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Postnummer</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Din e-postadress är ogiltig.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Angivet IBAN är ofullständigt.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Angivet IBAN är ogiltigt.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Angivet IBAN är ogiltigt, \"%s\" är inte en giltig landskod.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Ditt IBAN ska börja med en landskod (två bokstäver).</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kort</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Spara för framtida betalningar</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Genom att tillhandahålla din betalningsinformation och bekräfta denna betalning godkänner du (A) %s och Stripe, vår betaltjänstleverantör, att skicka instruktioner till din bank att debitera ditt konto och (B) din bank att debitera ditt konto i enlighet med dessa instruktioner. Som en del av dina rättigheter har du rätt till återbetalning från din bank enligt villkoren för ditt avtal med din bank. Återbetalning måste krävas inom åtta veckor från det datum då ditt konto debiterades. Dina rättigheter förklaras i ett utdrag som du kan få från din bank. Du godkänner att få aviseringar för framtida debiteringar upp till två dagar innan de inträffar.</string>
 </resources>

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">ธนาคารที่รองรับ iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">บัตร</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">การหักบัญชีอัตโนมัติแบบ SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">บันทึกไว้เพื่อชำระเงินในอนาคต</string>
-    <string name="stripe_paymentsheet_sepa_mandate">เมื่อให้ข้อมูลการชำระเงินและยืนยันการชำระเงินนี้ หมายความว่าคุณ (ก) อนุญาตให้ %s และ Stripe ซึ่งเป็นผู้ให้บริการชำระเงินส่งคำสั่งให้ธนาคารหักเงินจากบัญชีของคุณ และ (ข) อนุญาตให้ธนาคารหักเงินจากบัญชีตามคำสั่งดังกล่าว คุณมีสิทธิ์รับเงินคืนจากธนาคารภายใต้เงื่อนไขและข้อกำหนดซึ่งระบุไว้ในข้อตกลงที่คุณทำไว้กับธนาคาร โดยจะต้องทำการขอเงินคืนภายใน 8 สัปดาห์นับจากวันที่มีการหักเงินจากบัญชี คุณสามารถดูสิทธิ์ของตัวเองได้ในใบแจ้งยอดบัญชีที่ขอได้จากธนาคาร คุณตกลงที่จะรับการแจ้งเตือนเกี่ยวกับการหักเงินในบัญชีในอนาคตสูงสุดไม่เกิน 2 วันก่อนที่จะถึงวันหักจริง</string>
-</resources>

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-    <string name="stripe_paymentsheet_payment_method_card">Kart</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Bankamatik</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Gelecekteki ödemeler için kaydedilsin</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Ödeme bilgilerinizi sağlayarak ve bu ödemeyi onaylayarak, (A) %s ve ödeme hizmeti sağlayıcımız Stripe\'a hesabınızdan ödeme tahsilatı yapması için bankanıza talimatlar göndermesi ve (B) bankanıza bu talimatlara uygun olarak hesabınızdan ödeme tahsilatı yapması için yetki verirsiniz. Haklarınızın bir parçası olarak, bankanızla yaptığınız sözleşmenin hüküm ve koşulları uyarınca bankanızdan geri ödeme alma hakkına sahipsiniz. Geri ödeme, hesabınızdan ödeme tahsilatı yapıldığı tarihten itibaren 8 hafta içinde talep edilmelidir. Haklarınız, bankanızdan alabileceğiniz bir hesap özetinde açıklanmaktadır. Tahakkuk etmeden 2 gün öncesine kadar gelecekteki ödeme tahsilatları için bildirim almayı da kabul edersiniz.</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Adres</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">Şehir</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Ülke</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">Ülke</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Ad</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Posta kodu</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">İlçe</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">Eyalet</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">Posta kodu</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">E-postanız geçersiz.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">Girdiğiniz IBAN eksik.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">Girdiğiniz IBAN geçersiz.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">Girdiğiniz IBAN geçersiz. \"%s\" desteklenen bir ülke kodu değil.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">IBAN numaranız iki harfli bir ülke koduyla başlamalıdır.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (isteğe bağlı)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Kart</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Bankamatik</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Gelecekteki ödemeler için kaydedilsin</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">Ödeme bilgilerinizi sağlayarak ve bu ödemeyi onaylayarak, (A) %s ve ödeme hizmeti sağlayıcımız Stripe\'a hesabınızdan ödeme tahsilatı yapması için bankanıza talimatlar göndermesi ve (B) bankanıza bu talimatlara uygun olarak hesabınızdan ödeme tahsilatı yapması için yetki verirsiniz. Haklarınızın bir parçası olarak, bankanızla yaptığınız sözleşmenin hüküm ve koşulları uyarınca bankanızdan geri ödeme alma hakkına sahipsiniz. Geri ödeme, hesabınızdan ödeme tahsilatı yapıldığı tarihten itibaren 8 hafta içinde talep edilmelidir. Haklarınız, bankanızdan alabileceğiniz bir hesap özetinde açıklanmaktadır. Tahakkuk etmeden 2 gün öncesine kadar gelecekteki ödeme tahsilatları için bildirim almayı da kabul edersiniz.</string>
 </resources>

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="stripe_paymentsheet_ideal_bank">Ngân hàng iDEAL</string>
-    <string name="stripe_paymentsheet_payment_method_card">Thẻ</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">Ghi nợ SEPA</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">Tiết kiệm cho các khoản thanh toán trong tương lai</string>
-    <string name="stripe_paymentsheet_sepa_mandate">Bằng việc cung cấp thông tin thanh toán của quý vị và xác nhận khoản thanh toán này, quý vị đã ủy quyền cho (A) %s và Stripe, nhà cung cấp dịch vụ thanh toán của chúng tôi, gửi hướng dẫn đến ngân hàng của quý vị để ghi nợ tài khoản của quý vị và (B) ngân hàng ghi nợ tài khoản của quý vị theo những hướng dẫn đó. Trong các quyền của mình, quý vị được hoàn tiền từ ngân hàng của mình theo các điều khoản và điều kiện trong thỏa thuận của quý vị với ngân hàng của quý vị. Khoản tiền hoàn phải được yêu cầu trong vòng 8 tuần kể từ ngày tài khoản của quý vị bị ghi nợ. Các quyền của quý vị được giải thích trong bản tuyên bố mà quý vị có thể nhận được từ ngân hàng của mình. Quý vị đồng ý nhận thông báo cho các khoản ghi nợ trong tương lai tối đa 2 ngày trước khi chúng xảy ra.</string>
-</resources>

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
-    <string name="stripe_paymentsheet_payment_method_card">卡</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
-    <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式並確認該付款即表示您授權 (A) %s 與我們的支付服務者 Stripe 向您的銀行發送對您的帳戶進行借記的指令以及 (B) 您的銀行按照這些指令對您的帳戶進行借記。根據您與您的銀行協議的條款和條件，您有權從您的銀行得到退款。退款必須在 8 周內提出，從您的帳戶被扣款之日起算。您的權利在結單上有解釋，可從您的銀行獲取。您同意提前 2 天接收後續借記的通知。</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">城市</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">國家</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">縣</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">姓名</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">郵區編號</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">省</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">州</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">郵區編號</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">您的電郵地址無效。</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">您輸入的 IBAN 不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">您輸入的 IBAN 無效。</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">您輸入的 IBAN 無效，\"%s\" 是不支持的國家代碼。</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">您的 IBAN 應以一個兩字母的國家代碼開頭。</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s（可選）</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">卡</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式並確認該付款即表示您授權 (A) %s 與我們的支付服務者 Stripe 向您的銀行發送對您的帳戶進行借記的指令以及 (B) 您的銀行按照這些指令對您的帳戶進行借記。根據您與您的銀行協議的條款和條件，您有權從您的銀行得到退款。退款必須在 8 周內提出，從您的帳戶被扣款之日起算。您的權利在結單上有解釋，可從您的銀行獲取。您同意提前 2 天接收後續借記的通知。</string>
 </resources>

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
-    <string name="stripe_paymentsheet_payment_method_card">卡</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
-    <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式並確認該付款即表示您授權 (A) %s 與我們的支付服務商 Stripe 向您的銀行發送對您的帳戶進行借記的指令以及 (B) 您的銀行按照這些指令對您的帳戶進行借記。根據您與您的銀行協議的條款和條件，您有權從您的銀行得到退款。退款必須在 8 周內提出，從您的帳戶被扣款之日起算。您的權利在結單上有解釋，可從您的銀行獲取。您同意提前 2 天接收後續借記的通知。</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">城市</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">國家</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">縣</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">姓名</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">郵遞區號</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">省</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">州</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">郵遞區號</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">您的電郵地址無效。</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">您輸入的 IBAN 不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">您輸入的 IBAN 無效。</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">您輸入的 IBAN 無效，\"%s\" 是不支援的國家代碼。</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">您的 IBAN 應以一個兩字母國家代碼開頭。</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s（可選）</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">卡</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式並確認該付款即表示您授權 (A) %s 與我們的支付服務商 Stripe 向您的銀行發送對您的帳戶進行借記的指令以及 (B) 您的銀行按照這些指令對您的帳戶進行借記。根據您與您的銀行協議的條款和條件，您有權從您的銀行得到退款。退款必須在 8 周內提出，從您的帳戶被扣款之日起算。您的權利在結單上有解釋，可從您的銀行獲取。您同意提前 2 天接收後續借記的通知。</string>
 </resources>

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -1,8 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL 银行</string>
-    <string name="stripe_paymentsheet_payment_method_card">银行卡</string>
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA 借记</string>
-    <string name="stripe_paymentsheet_save_for_future_payments">保存以用于未来的付款</string>
-    <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式并确认该付款即表示您授权 (A) %s 与我们的支付服务商 Stripe 向您的银行发送对您的账户进行借记的指令以及 (B) 您的银行按照这些指令对您的账户进行借记。根据您与您的银行协议的条款和条件，您有权从您的银行得到退款。退款必须在 8 周内提出，从您的帐户被扣款之日起算。您的权利在对账单上有解释，可从您的银行获取。您同意提前 2 天接收后续借记的通知。</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">地址</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">城市</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">国家</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">县</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">姓名</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">邮政编码</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">省</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">州</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">邮政编码</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">您的邮件地址无效。</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">您输入的 IBAN 不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">您输入的 IBAN 无效。</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">您输入的 IBAN 无效，\"%s\" 是不支持的国家代码。</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">您的 IBAN 应以一个两字母国家代码开头。</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s（可选）</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL 银行</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">银行卡</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA 借记</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">保存以用于未来的付款</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">提供您的支付方式并确认该付款即表示您授权 (A) %s 与我们的支付服务商 Stripe 向您的银行发送对您的账户进行借记的指令以及 (B) 您的银行按照这些指令对您的账户进行借记。根据您与您的银行协议的条款和条件，您有权从您的银行得到退款。退款必须在 8 周内提出，从您的帐户被扣款之日起算。您的权利在对账单上有解释，可从您的银行获取。您同意提前 2 天接收后续借记的通知。</string>
 </resources>

--- a/paymentsheet/res/values/donttranslate.xml
+++ b/paymentsheet/res/values/donttranslate.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stripe_paymentsheet_payment_method_sofort" translatable="false">Sofort</string>
+    <string name="stripe_paymentsheet_payment_method_ideal" translatable="false">iDEAL</string>
+    <string name="stripe_paymentsheet_payment_method_bancontact" translatable="false">Bancontact</string>
+    <string name="stripe_paymentsheet_iban" translatable="false">IBAN</string>
+</resources>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -1,38 +1,91 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Use when a required field has not been filled in -->
-    <string name="incomplete" tools:ignore="MissingTranslation">%s is incomplete.</string>
-    <!-- Use when a required field is not valid and cannot be corrected. -->
-    <string name="malformed" tools:ignore="MissingTranslation">%s is malformed.</string>
-    <!-- Use when a required field is blank and submit is clicked. -->
-    <string name="blank_and_required" tools:ignore="MissingTranslation">%s cannot be blank.</string>
-    <!-- Use when is not valid, but the exact problem is unknown. -->
-    <string name="invalid" tools:ignore="MissingTranslation">%s is invalid.</string>
-    <string name="email" tools:ignore="MissingTranslation">Email</string>
-    <string name="address_label_name" tools:ignore="MissingTranslation">Name</string>
-    <string name="address_label_country" tools:ignore="MissingTranslation">Country</string>
-
-    <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
-    <string name="stripe_paymentsheet_sepa_mandate">By providing your payment information and confirming this payment, you authorise (A) %s and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.</string>
-    <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-
-    <string name="stripe_paymentsheet_iban" translatable="false">IBAN</string>
-    <!-- An error message displayed when the customer's IBAN is invalid. -->
-    <string name="stripe_paymentsheet_iban_invalid" tools:ignore="MissingTranslation">The IBAN you entered is invalid.</string>
-    <!-- An error message displayed when the IBAN country code is not supported. -->
-    <string name="stripe_paymentsheet_iban_invalid_country" tools:ignore="MissingTranslation">The IBAN you entered is invalid, \"%s\" is not a supported country code.</string>
-    <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
-    <string name="stripe_paymentsheet_iban_invalid_start" tools:ignore="MissingTranslation">Your IBAN should start with a two-letter country code.</string>
-
-    <!-- Title for card payment method -->
-    <string name="stripe_paymentsheet_payment_method_card">Card</string>
-    <!-- Title for Bancontact payment method -->
-    <string name="stripe_paymentsheet_payment_method_bancontact" translatable="false">Bancontact</string>
-    <!-- Title for iDEAL payment method -->
-    <string name="stripe_paymentsheet_payment_method_ideal" translatable="false">iDEAL</string>
-    <!-- Title for Sepa Debit payment method -->
-    <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
-    <!-- Title for Sofort payment method -->
-    <string name="stripe_paymentsheet_payment_method_sofort" translatable="false">Sofort</string>
-    <string name="stripe_paymentsheet_form_label_optional" tools:ignore="MissingTranslation">%s (optional)</string>
+  <!-- Use when a required field has not been filled in -->
+  <string name="incomplete" tools:ignore="MissingTranslation">%s is incomplete.</string>
+  <!-- Use when a required field is not valid and cannot be corrected. -->
+  <string name="malformed" tools:ignore="MissingTranslation">%s is malformed.</string>
+  <!-- Use when a required field is blank and submit is clicked. -->
+  <string name="blank_and_required" tools:ignore="MissingTranslation">%s cannot be blank.</string>
+  <!-- Use when is not valid, but the exact problem is unknown. -->
+  <string name="invalid" tools:ignore="MissingTranslation">%s is invalid.</string>
+  <string name="email" tools:ignore="MissingTranslation">Email</string>
+  <!-- Caption for Address field on address form -->
+  <string name="address_label_address">Address</string>
+  <!-- Label for input requesting address line 2, used for international addresses -->
+  <string name="address_label_address_line2" tools:ignore="MissingTranslation">Address line 2</string>
+  <!-- Used to describe address in United Arab Emirates -->
+  <string name="address_label_ae_emirate" tools:ignore="MissingTranslation">Emirate</string>
+  <!-- Used to describe an address field in Australia -->
+  <string name="address_label_au_suburb_or_city" tools:ignore="MissingTranslation">Suburb or City</string>
+  <!-- Used to describe a field of an addres in Jamaica and Barbados -->
+  <string name="address_label_bb_jm_parish" tools:ignore="MissingTranslation">Parish</string>
+  <!-- Used to describe a field of an address -->
+  <string name="address_label_cedex" tools:ignore="MissingTranslation">Cedex</string>
+  <!-- Caption for City field on address form -->
+  <string name="address_label_city">City</string>
+  <!-- Caption for Country field on address form -->
+  <string name="address_label_country">Country</string>
+  <!-- Caption for County field on address form (only countries that use county, like United Kingdom) -->
+  <string name="address_label_county">County</string>
+  <!-- Used to describe a field of an address -->
+  <string name="address_label_department" tools:ignore="MissingTranslation">Department</string>
+  <!-- Used to describe a field of an address -->
+  <string name="address_label_district" tools:ignore="MissingTranslation">District</string>
+  <!-- Used to describe an address field in HK -->
+  <string name="address_label_hk_area" tools:ignore="MissingTranslation">Area</string>
+  <!-- Used to decribe a field in an address in Ireland -->
+  <string name="address_label_ie_eircode" tools:ignore="MissingTranslation">Eircode</string>
+  <!-- Used to describe an address field in Ireland -->
+  <string name="address_label_ie_townland" tools:ignore="MissingTranslation">Townland</string>
+  <!-- Used to describe postal code in India -->
+  <string name="address_label_in_pin" tools:ignore="MissingTranslation">Pin</string>
+  <!-- Used to describe a field in an address. -->
+  <string name="address_label_island" tools:ignore="MissingTranslation">Island</string>
+  <!-- Used to describe a field of an address in Japan -->
+  <string name="address_label_jp_prefecture" tools:ignore="MissingTranslation">Prefecture</string>
+  <!-- Used to describe a field of an address in South Korea -->
+  <string name="address_label_kr_do_si" tools:ignore="MissingTranslation">Do si</string>
+  <!-- Caption for Name field on address form -->
+  <string name="address_label_name">Name</string>
+  <!-- Used to describe a field of an address -->
+  <string name="address_label_neighborhood" tools:ignore="MissingTranslation">Neighborhood</string>
+  <!-- Used to describe a field of an address. -->
+  <string name="address_label_oblast" tools:ignore="MissingTranslation">Oblast</string>
+  <!-- Used to describe a field of an address -->
+  <string name="address_label_post_town" tools:ignore="MissingTranslation">Post or Town</string>
+  <!-- Short string for postal code (text used in non-US countries) -->
+  <string name="address_label_postal_code">Postal code</string>
+  <!-- Caption for Province field on address form (only countries that use province, like Canada) -->
+  <string name="address_label_province">Province</string>
+  <!-- Caption for State field on address form (only countries that use state , like United States) -->
+  <string name="address_label_state">State</string>
+  <!-- Used to describe a field of an address. -->
+  <string name="address_label_suburb" tools:ignore="MissingTranslation">Suburb</string>
+  <!-- Used to describe an address field. -->
+  <string name="address_label_village_township" tools:ignore="MissingTranslation">Village or Township</string>
+  <!-- Label for input requesting zip code, used for US based addreses -->
+  <string name="address_label_zip_code">ZIP Code</string>
+  <!-- Error message when email is invalid -->
+  <string name="email_is_invalid">Your email is invalid.</string>
+  <!-- An error message displayed when the customer's IBAN is incomplete. -->
+  <string name="iban_incomplete">The IBAN you entered is incomplete.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="iban_invalid">The IBAN you entered is invalid.</string>
+  <!-- An error message displayed when the IBAN country code is not supported. -->
+  <string name="iban_invalid_country">The IBAN you entered is invalid, \"%s\" is not a supported country code.</string>
+  <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
+  <string name="iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
+  <!-- The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) -->
+  <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
+  <!-- iDEAL bank section title for iDEAL form entry. -->
+  <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Title for credit card number entry field -->
+  <string name="stripe_paymentsheet_payment_method_card">Card</string>
+  <!-- Payment method brand name -->
+  <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
+  <!-- The label of a switch indicating whether to save the payment method for future payments. -->
+  <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
+  <!-- SEPA mandate text -->
+  <string name="stripe_paymentsheet_sepa_mandate">By providing your payment information and confirming this payment, you authorise (A) %s and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.</string>
 </resources>
+

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -88,4 +88,3 @@
   <!-- SEPA mandate text -->
   <string name="stripe_paymentsheet_sepa_mandate">By providing your payment information and confirming this payment, you authorise (A) %s and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.</string>
 </resources>
-

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanConfig.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanConfig.kt
@@ -57,7 +57,7 @@ internal class IbanConfig : TextFieldConfig {
         // First 2 characters represent the country code. Any number means it's invalid
         if (countryCode.any { it.isDigit() }) {
             return TextFieldStateConstants.Error.Invalid(
-                R.string.stripe_paymentsheet_iban_invalid_start
+                R.string.iban_invalid_start
             )
         }
 
@@ -68,7 +68,7 @@ internal class IbanConfig : TextFieldConfig {
 
         if (!Locale.getISOCountries().contains(countryCode)) {
             return TextFieldStateConstants.Error.Invalid(
-                R.string.stripe_paymentsheet_iban_invalid_country
+                R.string.iban_invalid_country
             )
         }
 
@@ -84,7 +84,7 @@ internal class IbanConfig : TextFieldConfig {
             }
         } else {
             TextFieldStateConstants.Error.Invalid(
-                R.string.stripe_paymentsheet_iban_invalid
+                R.string.iban_invalid
             )
         }
     }

--- a/scripts/localization_vars.sh
+++ b/scripts/localization_vars.sh
@@ -5,6 +5,12 @@ MODULES=(
   "payments-core"
 )
 
+#
+# Take great caution here, there are languages that are and are not finalized that may or may
+# not contain all the required translated strings.
+# In review (see: RUN-184): fil,hr,id,ms-MY,tr,vi
+LANGUAGES="bg_BG,ca-ES,zh-Hans,zh-HK,zh-Hant,cs-CZ,da,nl,en-GB,en,et-EE,fi,fr-CA,fr,de,el-GR,hu,it,ja,ko,lt-LT,lv-LV,mt,nb,no,nn-NO,pl-PL,pt-BR,pt-PT,ro-RO,ru,sk-SK,sl-SI,es-419,es,sv,tr"
+
 # API token should be retrieved from: https://app.lokalise.com/profile#apitokens
-API_TOKEN=ce811e6ad9fb1e9008ede8d4247c1070159b77f3
+API_TOKEN=
 PROJECT_ID=747824695e51bc2f4aa912.89576472

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -32,18 +32,38 @@ FINAL_STATUS_ID=587
 
 rm -rf android/*
 
-#strings.xml -- are android strings not assigned to a file.
-#          --filter-langs $LANGUAGES \
+echo "AVAILABLE LANGUAGES: "
+lokalise2 --token $API_TOKEN --project-id $PROJECT_ID language list | grep iso
+
+echo "DOWNLOADING LANGUAGES: ${LANGUAGES}"
 
 for MODULE in "paymentsheet" "payments-core"
 do
-    echo "Downloading strings in $MODULE module: $MODULE/strings.xml"
+    echo ""
+    echo ""
+    echo "----------------------------------------------------------"
+    echo "DOWNLOADING STRINGS in $MODULE MODULE: $MODULE/strings.xml"
+    echo "----------------------------------------------------------"
+    lokalise2 --token $API_TOKEN \
+          --project-id $PROJECT_ID \
+          file download \
+          --format xml \
+          --filter-langs $LANGUAGES \
+          --filter-filenames $MODULE/strings.xml \
+          --custom-translation-status-ids $FINAL_STATUS_ID \
+          --export-sort "a_z" \
+          --directory-prefix . \
+          --original-filenames=false \
+          --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
+
+    # Need to download english separately because their strings are not marked final (this is what we uploaded)
+    # This must be done after the first one.
     lokalise2 --token $API_TOKEN \
           --project-id $PROJECT_ID \
           file download \
           --format xml \
           --filter-filenames $MODULE/strings.xml \
-          --custom-translation-status-ids $FINAL_STATUS_ID \
+          --filter-langs "en" \
           --export-sort "a_z" \
           --directory-prefix . \
           --original-filenames=false \
@@ -53,24 +73,19 @@ do
     mv android/$MODULE/values-es-r419 android/$MODULE/values-b+es+419
     mv android/$MODULE/values-zh-rHant android/$MODULE/values-zh-rTW
     mv android/$MODULE/values-zh-rHans android/$MODULE/values-zh
-    mv android/$MODULE/values-id android/$MODULE/values-in
-
-    #Don't replace the english one
-    rm android/$MODULE/values/strings.xml 
 
     # This is used by the untranslated_project_keys.sh script
     cp android/$MODULE/values-en-rGB/strings.xml android/$MODULE-lokalize-strings.xml
 
-    # Remove the existing strings files with the exception of the default one in case there are changes there we need to save
-    find ../$MODULE -type f \( -name "*values-*/strings.xml" ! -name "*values/strings.xml" \) | xargs rm
+    # Remove the existing strings files
+    find ../$MODULE/res -type f -name strings.xml | xargs rm
 
     # Copy in the new strings files
     cp -R  android/$MODULE/* ../$MODULE/res/
 
     echo ""
-    echo "Translated strings (country codes): " 
-    echo "--------------------"
-    ls -1 android/$MODULE/ | paste -sd "," - | sed 's/values-//g'
-    
+    echo "TRANSLATED STRINGS (country codes): "
+    echo "----------------------------------------------------------"
+    ls -1 android/$MODULE/ | paste -sd "," - | sed 's/[,]*values[-]*//g'
 done
 


### PR DESCRIPTION
# Summary
- Restricted the download script to specific languages.
- Now we will download the default, english version and copy it over, this might mean merging prior to checking in for cases where strings have not yet been translated.
- Prior to committing, the string should be entered in lokalize, even if not translated.

# Motivation
This will make running localize.sh produce consistent results every time the script is running.  In the future it could be added to CI.  It is probably not a bad idea to add it to git push

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
