### PR TITLE
Rename all references to optional to hidden as these are fields that …

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -75,7 +75,7 @@ public abstract class com/stripe/android/paymentsheet/specifications/FormItemSpe
 	public static final field $stable I
 }
 
-public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$MandateTextSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/RequiredItemSpec {
 	public static final field $stable I
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
@@ -91,7 +91,7 @@ public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$M
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SaveForFutureUseSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SaveForFutureUseSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/RequiredItemSpec {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -104,7 +104,7 @@ public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$S
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SectionSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+public final class com/stripe/android/paymentsheet/specifications/FormItemSpec$SectionSpec : com/stripe/android/paymentsheet/specifications/FormItemSpec, com/stripe/android/paymentsheet/specifications/RequiredItemSpec {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;Lcom/stripe/android/paymentsheet/specifications/SectionFieldSpec;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -161,7 +161,7 @@ public final class com/stripe/android/paymentsheet/specifications/LayoutSpec {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class com/stripe/android/paymentsheet/specifications/OptionalItemSpec {
+public abstract interface class com/stripe/android/paymentsheet/specifications/RequiredItemSpec {
 	public abstract fun getIdentifier ()Lcom/stripe/android/paymentsheet/specifications/IdentifierSpec;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -21,9 +21,9 @@ internal class FocusRequesterCount {
 }
 
 /**
- * This is used to define which elements can be made optional
+ * This is used to define which elements can be made hidden
  */
-internal interface OptionalElement {
+internal interface HiddenElement {
     val identifier: IdentifierSpec
 }
 
@@ -63,7 +63,7 @@ internal sealed class FormElement {
         val color: Color,
         val merchantName: String?,
         override val controller: InputController? = null,
-    ) : FormElement(), OptionalElement
+    ) : FormElement(), HiddenElement
 
     /**
      * This is an element that will make elements (as specified by identifier) hidden
@@ -79,7 +79,7 @@ internal sealed class FormElement {
         override val identifier: IdentifierSpec,
         val fields: List<SectionFieldElementType>,
         override val controller: SectionController
-    ) : FormElement(), OptionalElement {
+    ) : FormElement(), HiddenElement {
         internal constructor(
             identifier: IdentifierSpec,
             field: SectionFieldElementType,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/Element.kt
@@ -21,13 +21,6 @@ internal class FocusRequesterCount {
 }
 
 /**
- * This is used to define which elements can be made hidden
- */
-internal interface HiddenElement {
-    val identifier: IdentifierSpec
-}
-
-/**
  * This interface is used to define the types of elements allowed in a section
  */
 internal sealed interface SectionFieldElementType {
@@ -63,7 +56,7 @@ internal sealed class FormElement {
         val color: Color,
         val merchantName: String?,
         override val controller: InputController? = null,
-    ) : FormElement(), HiddenElement
+    ) : FormElement()
 
     /**
      * This is an element that will make elements (as specified by identifier) hidden
@@ -79,7 +72,7 @@ internal sealed class FormElement {
         override val identifier: IdentifierSpec,
         val fields: List<SectionFieldElementType>,
         override val controller: SectionController
-    ) : FormElement(), HiddenElement {
+    ) : FormElement() {
         internal constructor(
             identifier: IdentifierSpec,
             field: SectionFieldElementType,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
@@ -18,7 +18,7 @@ internal class SaveForFutureUseController(
     override val error: Flow<FieldError?> = MutableStateFlow(null)
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
 
-    val optionalIdentifiers: Flow<List<IdentifierSpec>> =
+    val hiddenIdentifiers: Flow<List<IdentifierSpec>> =
         saveForFutureUse.map { saveFutureUseInstance ->
             identifiersRequiredForFutureUse.takeUnless { saveFutureUseInstance } ?: emptyList()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/Form.kt
@@ -56,7 +56,7 @@ internal fun Form(
 ) {
     val focusRequesters =
         List(formViewModel.getCountFocusableFields()) { FocusRequester() }
-    val optionalIdentifiers by formViewModel.optionalIdentifiers.asLiveData().observeAsState(
+    val hiddenIdentifiers by formViewModel.hiddenIdentifiers.asLiveData().observeAsState(
         null
     )
     val enabled by formViewModel.enabled.asLiveData().observeAsState(true)
@@ -68,13 +68,13 @@ internal fun Form(
         formViewModel.elements.forEach { element ->
 
             AnimatedVisibility(
-                optionalIdentifiers?.contains(element.identifier) == false,
+                hiddenIdentifiers?.contains(element.identifier) == false,
                 enter = EnterTransition.None,
                 exit = ExitTransition.None
             ) {
                 when (element) {
                     is SectionElement -> {
-                        SectionElementUI(enabled, element, optionalIdentifiers, focusRequesters)
+                        SectionElementUI(enabled, element, hiddenIdentifiers, focusRequesters)
                     }
                     is MandateTextElement -> {
                         MandateElementUI(element)
@@ -94,11 +94,11 @@ internal fun Form(
 internal fun SectionElementUI(
     enabled: Boolean,
     element: SectionElement,
-    optionalIdentifiers: List<IdentifierSpec>?,
+    hiddenIdentifiers: List<IdentifierSpec>?,
     focusRequesters: List<FocusRequester>
 ) {
     AnimatedVisibility(
-        optionalIdentifiers?.contains(element.identifier) == false,
+        hiddenIdentifiers?.contains(element.identifier) == false,
         enter = EnterTransition.None,
         exit = ExitTransition.None
     ) {
@@ -282,34 +282,34 @@ class FormViewModel(
             }
         }
 
-    internal val optionalIdentifiers =
+    internal val hiddenIdentifiers =
         combine(
             saveForFutureUseVisible,
-            saveForFutureUseElement?.controller?.optionalIdentifiers
+            saveForFutureUseElement?.controller?.hiddenIdentifiers
                 ?: MutableStateFlow(emptyList())
-        ) { showFutureUse, optionalIdentifiers ->
+        ) { showFutureUse, hiddenIdentifiers ->
 
-            // For optional *section* identifiers, list of identifiers of elements in the section
+            // For hidden *section* identifiers, list of identifiers of elements in the section
             val identifiers = sectionToFieldIdentifierMap
                 .filter { idControllerPair ->
-                    optionalIdentifiers.contains(idControllerPair.key)
+                    hiddenIdentifiers.contains(idControllerPair.key)
                 }
                 .flatMap { sectionToSectionFieldEntry ->
                     sectionToSectionFieldEntry.value
                 }
 
             if (!showFutureUse && saveForFutureUseElement != null) {
-                optionalIdentifiers
+                hiddenIdentifiers
                     .plus(identifiers)
                     .plus(saveForFutureUseElement.identifier)
             } else {
-                optionalIdentifiers
+                hiddenIdentifiers
                     .plus(identifiers)
             }
         }
 
-    // Mandate is showing if it is an element of the form and it isn't optional
-    internal val showingMandate = optionalIdentifiers.map {
+    // Mandate is showing if it is an element of the form and it isn't hidden
+    internal val showingMandate = hiddenIdentifiers.map {
         elements
             .filterIsInstance<MandateTextElement>()
             .firstOrNull()?.let { mandate ->
@@ -318,7 +318,7 @@ class FormViewModel(
     }
 
     val completeFormValues = TransformElementToFormFieldValueFlow(
-        elements, optionalIdentifiers, showingMandate, saveForFutureUse
+        elements, hiddenIdentifiers, showingMandate, saveForFutureUse
     ).transformFlow()
 
     internal fun populateFormViewValues(formFieldValues: FormFieldValues) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformElementToFormFieldValueFlow.kt
@@ -8,13 +8,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
 /**
- * This class will take a list of form elements and optional identifiers.
+ * This class will take a list of form elements and hidden identifiers.
  * [transformFlow] is the only public method and it will transform
  * the list of form elements into a [FormFieldValues].
  */
 internal class TransformElementToFormFieldValueFlow(
     val elements: List<FormElement>,
-    val optionalIdentifiers: Flow<List<IdentifierSpec>>,
+    private val hiddenIdentifiers: Flow<List<IdentifierSpec>>,
     val showingMandate: Flow<Boolean>,
     val saveForFutureUse: Flow<Boolean>
 ) {
@@ -26,35 +26,35 @@ internal class TransformElementToFormFieldValueFlow(
 
     /**
      * This will return null if any form field values are incomplete, otherwise it is an object
-     * representing all the complete, non-optional fields.
+     * representing all the complete, non-hidden fields.
      */
     fun transformFlow() = combine(
         currentFieldValueMap,
-        optionalIdentifiers,
+        hiddenIdentifiers,
         showingMandate,
         saveForFutureUse
-    ) { idFieldSnapshotMap, optionalIdentifiers, showingMandate, saveForFutureUse ->
-        transform(idFieldSnapshotMap, optionalIdentifiers, showingMandate, saveForFutureUse)
+    ) { idFieldSnapshotMap, hiddenIdentifiers, showingMandate, saveForFutureUse ->
+        transform(idFieldSnapshotMap, hiddenIdentifiers, showingMandate, saveForFutureUse)
     }
 
     private fun transform(
         idFieldSnapshotMap: Map<IdentifierSpec, FormFieldEntry>,
-        optionalIdentifiers: List<IdentifierSpec>,
+        hiddenIdentifiers: List<IdentifierSpec>,
         showingMandate: Boolean,
         saveForFutureUse: Boolean
     ): FormFieldValues? {
         // This will run twice in a row when the save for future use state changes: once for the
-        // saveController changing and once for the the optionalFields changing
-        val optionalFilteredFieldSnapshotMap = idFieldSnapshotMap.filter {
-            !optionalIdentifiers.contains(it.key)
+        // saveController changing and once for the the hidden fields changing
+        val hiddenFilteredFieldSnapshotMap = idFieldSnapshotMap.filter {
+            !hiddenIdentifiers.contains(it.key)
         }
 
         return FormFieldValues(
-            optionalFilteredFieldSnapshotMap,
+            hiddenFilteredFieldSnapshotMap,
             showingMandate,
             saveForFutureUse
         ).takeIf {
-            optionalFilteredFieldSnapshotMap.values.map { it.isComplete }
+            hiddenFilteredFieldSnapshotMap.values.map { it.isComplete }
                 .none { complete -> !complete }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
@@ -25,18 +25,16 @@ data class LayoutSpec(val items: List<FormItemSpec>)
 data class IdentifierSpec(val value: String)
 
 /**
- * Identifies a field that can be made optional.
+ * Identifies a field that can be made hidden.
  */
-interface OptionalItemSpec {
+interface HiddenItemSpec {
     val identifier: IdentifierSpec
 }
 
 /**
  * This is used to define each section in the visual form layout specification
  */
-
 sealed class FormItemSpec {
-
     /**
      * This represents a section in a form that contains other elements
      */
@@ -44,7 +42,7 @@ sealed class FormItemSpec {
         override val identifier: IdentifierSpec,
         val fields: List<SectionFieldSpec>,
         @StringRes val title: Int? = null,
-    ) : FormItemSpec(), OptionalItemSpec {
+    ) : FormItemSpec(), HiddenItemSpec {
         constructor(
             identifier: IdentifierSpec,
             field: SectionFieldSpec,
@@ -59,15 +57,15 @@ sealed class FormItemSpec {
         override val identifier: IdentifierSpec,
         @StringRes val stringResId: Int,
         val color: Color
-    ) : FormItemSpec(), OptionalItemSpec
+    ) : FormItemSpec(), HiddenItemSpec
 
     /**
      * This is an element that will make elements (as specified by identifier hidden
      * when save for future use is unchecked)
      */
     data class SaveForFutureUseSpec(
-        val identifierRequiredForFutureUse: List<OptionalItemSpec>
-    ) : FormItemSpec(), OptionalItemSpec {
+        val identifierRequiredForFutureUse: List<HiddenItemSpec>
+    ) : FormItemSpec(), HiddenItemSpec {
         override val identifier = IdentifierSpec("save_for_future_use")
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/Spec.kt
@@ -27,7 +27,7 @@ data class IdentifierSpec(val value: String)
 /**
  * Identifies a field that can be made hidden.
  */
-interface HiddenItemSpec {
+interface RequiredItemSpec {
     val identifier: IdentifierSpec
 }
 
@@ -42,7 +42,7 @@ sealed class FormItemSpec {
         override val identifier: IdentifierSpec,
         val fields: List<SectionFieldSpec>,
         @StringRes val title: Int? = null,
-    ) : FormItemSpec(), HiddenItemSpec {
+    ) : FormItemSpec(), RequiredItemSpec {
         constructor(
             identifier: IdentifierSpec,
             field: SectionFieldSpec,
@@ -57,15 +57,15 @@ sealed class FormItemSpec {
         override val identifier: IdentifierSpec,
         @StringRes val stringResId: Int,
         val color: Color
-    ) : FormItemSpec(), HiddenItemSpec
+    ) : FormItemSpec(), RequiredItemSpec
 
     /**
      * This is an element that will make elements (as specified by identifier hidden
      * when save for future use is unchecked)
      */
     data class SaveForFutureUseSpec(
-        val identifierRequiredForFutureUse: List<HiddenItemSpec>
-    ) : FormItemSpec(), HiddenItemSpec {
+        val identifierRequiredForFutureUse: List<RequiredItemSpec>
+    ) : FormItemSpec(), RequiredItemSpec {
         override val identifier = IdentifierSpec("save_for_future_use")
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseControllerTest.kt
@@ -9,23 +9,23 @@ import org.junit.Test
 class SaveForFutureUseControllerTest {
     private val mandateIdentifier = IdentifierSpec("mandate")
     private val nameSectionIdentifier = IdentifierSpec("name")
-    private val optionalIdentifiers = listOf(nameSectionIdentifier, mandateIdentifier)
-    private val saveForFutureUseController = SaveForFutureUseController(optionalIdentifiers)
+    private val hiddenIdentifiers = listOf(nameSectionIdentifier, mandateIdentifier)
+    private val saveForFutureUseController = SaveForFutureUseController(hiddenIdentifiers)
 
     @Test
-    fun `Save for future use is initialized as true and no optional items`() =
+    fun `Save for future use is initialized as true and no hidden items`() =
         runBlocking {
             assertThat(saveForFutureUseController.saveForFutureUse.first()).isTrue()
-            assertThat(saveForFutureUseController.optionalIdentifiers.first()).isEmpty()
+            assertThat(saveForFutureUseController.hiddenIdentifiers.first()).isEmpty()
         }
 
     @Test
-    fun `Save for future use when set to false shows the optional items specified`() =
+    fun `Save for future use when set to false shows the hidden items specified`() =
         runBlocking {
             saveForFutureUseController.onValueChange(false)
             assertThat(saveForFutureUseController.saveForFutureUse.first()).isFalse()
-            assertThat(saveForFutureUseController.optionalIdentifiers.first()).isEqualTo(
-                optionalIdentifiers
+            assertThat(saveForFutureUseController.hiddenIdentifiers.first()).isEqualTo(
+                hiddenIdentifiers
             )
         }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -70,7 +70,7 @@ class FormViewModelTest {
         )
 
         val values = mutableListOf<List<IdentifierSpec>>()
-        formViewModel.optionalIdentifiers.asLiveData()
+        formViewModel.hiddenIdentifiers.asLiveData()
             .observeForever {
                 values.add(it)
             }
@@ -84,7 +84,7 @@ class FormViewModelTest {
     }
 
     @Test
-    fun `Verify setting section as optional sets sub-fields as optional as well`() {
+    fun `Verify setting section as hidden sets sub-fields as hidden as well`() {
         val formViewModel = FormViewModel(
             LayoutSpec(
                 listOf(
@@ -99,7 +99,7 @@ class FormViewModelTest {
         )
 
         val values = mutableListOf<List<IdentifierSpec>>()
-        formViewModel.optionalIdentifiers.asLiveData()
+        formViewModel.hiddenIdentifiers.asLiveData()
             .observeForever {
                 values.add(it)
             }
@@ -114,9 +114,9 @@ class FormViewModelTest {
     }
 
     @Test
-    fun `Verify if a field is optional and valid it is not in the formViewValueResult`() =
+    fun `Verify if a field is hidden and valid it is not in the formViewValueResult`() =
         runBlocking {
-            // Here we have one optional and one required field, country will always be in the result,
+            // Here we have one hidden and one required field, country will always be in the result,
             //  and name only if saveForFutureUse is true
             val formViewModel = FormViewModel(
                 LayoutSpec(
@@ -158,9 +158,9 @@ class FormViewModelTest {
         }
 
     @Test
-    fun `Optional invalid fields arent in the formViewValue and has no effect on complete state`() {
+    fun `Hidden invalid fields arent in the formViewValue and has no effect on complete state`() {
         runBlocking {
-            // Here we have one optional and one required field, country will always be in the result,
+            // Here we have one hidden and one required field, country will always be in the result,
             //  and name only if saveForFutureUse is true
             val formViewModel = FormViewModel(
                 LayoutSpec(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
@@ -37,24 +37,24 @@ class TransformElementToFormViewValueFlowTest {
         SectionController(countryController.label, listOf(countryController))
     )
 
-    private val optionalIdentifersFlow = MutableStateFlow<List<IdentifierSpec>>(emptyList())
+    private val hiddenIdentifersFlow = MutableStateFlow<List<IdentifierSpec>>(emptyList())
 
     private val transformElementToFormFieldValueFlow = TransformElementToFormFieldValueFlow(
         listOf(countrySection, emailSection),
-        optionalIdentifersFlow,
+        hiddenIdentifersFlow,
         showingMandate = MutableStateFlow(true),
         saveForFutureUse = MutableStateFlow(false)
     )
 
     @Test
-    fun `With only some complete controllers and no optional values the flow value is null`() {
+    fun `With only some complete controllers and no hidden values the flow value is null`() {
         runBlocking {
             assertThat(transformElementToFormFieldValueFlow.transformFlow().first()).isNull()
         }
     }
 
     @Test
-    fun `If all controllers are complete and no optional values the flow value has all values`() {
+    fun `If all controllers are complete and no hidden values the flow value has all values`() {
         runBlocking {
             emailController.onValueChange("email@valid.com")
 
@@ -69,10 +69,10 @@ class TransformElementToFormViewValueFlowTest {
     }
 
     @Test
-    fun `If an optional field is incomplete field pairs have the non-optional values`() {
+    fun `If an hidden field is incomplete field pairs have the non-hidden values`() {
         runBlocking {
             emailController.onValueChange("email is invalid")
-            optionalIdentifersFlow.value = listOf(IdentifierSpec("email"))
+            hiddenIdentifersFlow.value = listOf(IdentifierSpec("email"))
 
             val formFieldValues = transformElementToFormFieldValueFlow.transformFlow()
 
@@ -86,10 +86,10 @@ class TransformElementToFormViewValueFlowTest {
     }
 
     @Test
-    fun `If an optional field is complete field pairs contain only the non-optional values`() {
+    fun `If an hidden field is complete field pairs contain only the non-hidden values`() {
         runBlocking {
             emailController.onValueChange("email@valid.com")
-            optionalIdentifersFlow.value = listOf(emailSection.fields[0].identifier)
+            hiddenIdentifersFlow.value = listOf(emailSection.fields[0].identifier)
 
             val formFieldValue = transformElementToFormFieldValueFlow.transformFlow().first()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -212,8 +212,8 @@ class TransformSpecToElementTest {
                 R.string.stripe_paymentsheet_sepa_mandate,
                 Color.Gray
             )
-            val optionalIdentifiers = listOf(nameSection, mandate)
-            val saveForFutureUseSpec = FormItemSpec.SaveForFutureUseSpec(optionalIdentifiers)
+            val hiddenIdentifiers = listOf(nameSection, mandate)
+            val saveForFutureUseSpec = FormItemSpec.SaveForFutureUseSpec(hiddenIdentifiers)
             val formElement = listOf(saveForFutureUseSpec).transform(
                 "Example, Inc.",
                 FocusRequesterCount()
@@ -225,12 +225,12 @@ class TransformSpecToElementTest {
             assertThat(saveForFutureUseElement.identifier)
                 .isEqualTo(saveForFutureUseSpec.identifier)
 
-            assertThat(saveForFutureUseController.optionalIdentifiers.first()).isEmpty()
+            assertThat(saveForFutureUseController.hiddenIdentifiers.first()).isEmpty()
 
             saveForFutureUseController.onValueChange(false)
-            assertThat(saveForFutureUseController.optionalIdentifiers.first())
+            assertThat(saveForFutureUseController.hiddenIdentifiers.first())
                 .isEqualTo(
-                    optionalIdentifiers.map { it.identifier }
+                    hiddenIdentifiers.map { it.identifier }
                 )
         }
 }


### PR DESCRIPTION
# Summary
Rename all references to optional to hidden as these are fields that are hidden in the form (not shown with an optional label).

# Motivation
This will support the case of Address where there are fields marked as optional, still shown, but not required for the form to be complete.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
