### PR TITLE
Support payment method ordering

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParser.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.StripeJsonUtils
+import org.json.JSONObject
+
+internal sealed class PaymentMethodPreferenceJsonParser<out StripeIntentType : StripeIntent> :
+    ModelJsonParser<StripeIntentType> {
+    abstract val stripeIntentFieldName: String
+
+    override fun parse(json: JSONObject): StripeIntentType? {
+        val objectType = StripeJsonUtils.optString(json, FIELD_OBJECT)
+        if (OBJECT_TYPE != objectType) {
+            return null
+        }
+
+        val orderedPaymentMethodTypes = json.optJSONArray(FIELD_ORDERED_PAYMENT_METHOD_TYPES)
+
+        return json.optJSONObject(stripeIntentFieldName)?.let {
+            it.put(FIELD_PAYMENT_METHOD_TYPES, orderedPaymentMethodTypes)
+            parseStripeIntent(it)
+        }
+    }
+
+    abstract fun parseStripeIntent(stripeIntentJson: JSONObject): StripeIntentType?
+
+    protected companion object {
+        private const val OBJECT_TYPE = "payment_method_preference"
+
+        private const val FIELD_OBJECT = "object"
+        private const val FIELD_ORDERED_PAYMENT_METHOD_TYPES = "ordered_payment_method_types"
+        private const val FIELD_PAYMENT_METHOD_TYPES = "payment_method_types"
+    }
+}
+
+internal class PaymentMethodPreferenceForPaymentIntentJsonParser :
+    PaymentMethodPreferenceJsonParser<PaymentIntent>() {
+    override val stripeIntentFieldName = "payment_intent"
+
+    override fun parseStripeIntent(stripeIntentJson: JSONObject) =
+        PaymentIntentJsonParser().parse(stripeIntentJson)
+}
+
+internal class PaymentMethodPreferenceForSetupIntentJsonParser :
+    PaymentMethodPreferenceJsonParser<SetupIntent>() {
+    override val stripeIntentFieldName = "setup_intent"
+
+    override fun parseStripeIntent(stripeIntentJson: JSONObject) =
+        SetupIntentJsonParser().parse(stripeIntentJson)
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -237,7 +237,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret,
         options,
         locale,
-        type = "payment_intent",
         parser = PaymentMethodPreferenceForPaymentIntentJsonParser(),
         analyticsEvent = AnalyticsEvent.PaymentIntentRetrieve
     )
@@ -374,7 +373,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret,
         options,
         locale,
-        type = "setup_intent",
         parser = PaymentMethodPreferenceForSetupIntentJsonParser(),
         analyticsEvent = AnalyticsEvent.SetupIntentRetrieve
     )
@@ -1060,7 +1058,6 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret: String,
         options: ApiRequest.Options,
         locale: Locale,
-        type: String,
         parser: PaymentMethodPreferenceJsonParser<T>,
         analyticsEvent: AnalyticsEvent
     ): T? {
@@ -1068,10 +1065,10 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
 
         val params = createClientSecretParam(
             clientSecret,
-            listOf(type)
+            listOf(parser.stripeIntentFieldName)
         ).plus(
             mapOf(
-                "type" to type,
+                "type" to parser.stripeIntentFieldName,
                 "locale" to locale.toLanguageTag()
             )
         )
@@ -1084,9 +1081,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
             ),
             parser
         ) {
-            fireAnalyticsRequest(
-                analyticsRequestFactory.createRequest(analyticsEvent)
-            )
+            fireAnalyticsRequest(analyticsRequestFactory.createRequest(analyticsEvent))
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -231,7 +231,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     override suspend fun retrievePaymentIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): PaymentIntent? {
         fireFraudDetectionDataRequest()
 
@@ -241,7 +241,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         ).plus(
             mapOf(
                 "type" to "payment_intent",
-                "locale" to locale
+                "locale" to locale.toLanguageTag()
             )
         )
 
@@ -386,7 +386,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     override suspend fun retrieveSetupIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): SetupIntent? {
         fireFraudDetectionDataRequest()
 
@@ -396,7 +396,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         ).plus(
             mapOf(
                 "type" to "setup_intent",
-                "locale" to locale
+                "locale" to locale.toLanguageTag()
             )
         )
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -29,6 +29,7 @@ import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.Locale
 
 /**
  * An interface for data operations on Stripe API objects.
@@ -74,7 +75,7 @@ internal interface StripeRepository {
     suspend fun retrievePaymentIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): PaymentIntent?
 
     @Throws(
@@ -122,7 +123,7 @@ internal interface StripeRepository {
     suspend fun retrieveSetupIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): SetupIntent?
 
     @Throws(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -71,6 +71,18 @@ internal interface StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
+    suspend fun retrievePaymentIntentWithOrderedPaymentMethods(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        locale: String
+    ): PaymentIntent?
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
     suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
@@ -99,6 +111,18 @@ internal interface StripeRepository {
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
+    ): SetupIntent?
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun retrieveSetupIntentWithOrderedPaymentMethods(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        locale: String
     ): SetupIntent?
 
     @Throws(

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import androidx.core.os.LocaleListCompat
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
@@ -29,27 +30,47 @@ internal sealed class StripeIntentRepository {
     class Api(
         private val stripeRepository: StripeRepository,
         private val requestOptions: ApiRequest.Options,
-        private val workContext: CoroutineContext
+        private val workContext: CoroutineContext,
+        private val locale: String? =
+            LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)?.toLanguageTag()
     ) : StripeIntentRepository() {
+        /**
+         * Tries to retrieve the StripeIntent with ordered Payment Methods, falling back to
+         * traditional GET if we don't have a locale or the call fails for any reason.
+         */
         override suspend fun get(clientSecret: ClientSecret) = withContext(workContext) {
             when (clientSecret) {
                 is PaymentIntentClientSecret -> {
-                    val paymentIntent = stripeRepository.retrievePaymentIntent(
-                        clientSecret.value,
-                        requestOptions,
-                        expandFields = listOf("payment_method")
-                    )
-                    requireNotNull(paymentIntent) {
+                    requireNotNull(
+                        locale?.let {
+                            stripeRepository.retrievePaymentIntentWithOrderedPaymentMethods(
+                                clientSecret.value,
+                                requestOptions,
+                                it
+                            )
+                        } ?: stripeRepository.retrievePaymentIntent(
+                            clientSecret.value,
+                            requestOptions,
+                            expandFields = listOf("payment_method")
+                        )
+                    ) {
                         "Could not parse PaymentIntent."
                     }
                 }
                 is SetupIntentClientSecret -> {
-                    val setupIntent = stripeRepository.retrieveSetupIntent(
-                        clientSecret.value,
-                        requestOptions,
-                        expandFields = listOf("payment_method")
-                    )
-                    requireNotNull(setupIntent) {
+                    requireNotNull(
+                        locale?.let {
+                            stripeRepository.retrieveSetupIntentWithOrderedPaymentMethods(
+                                clientSecret.value,
+                                requestOptions,
+                                locale
+                            )
+                        } ?: stripeRepository.retrieveSetupIntent(
+                            clientSecret.value,
+                            requestOptions,
+                            expandFields = listOf("payment_method")
+                        )
+                    ) {
                         "Could not parse SetupIntent."
                     }
                 }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import kotlinx.coroutines.withContext
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 
 internal sealed class StripeIntentRepository {
@@ -31,8 +32,8 @@ internal sealed class StripeIntentRepository {
         private val stripeRepository: StripeRepository,
         private val requestOptions: ApiRequest.Options,
         private val workContext: CoroutineContext,
-        private val locale: String? =
-            LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)?.toLanguageTag()
+        private val locale: Locale? =
+            LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
     ) : StripeIntentRepository() {
         /**
          * Tries to retrieve the StripeIntent with ordered Payment Methods, falling back to

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodPreferenceFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodPreferenceFixtures.kt
@@ -1,0 +1,89 @@
+package com.stripe.android.model
+
+import org.json.JSONObject
+
+internal object PaymentMethodPreferenceFixtures {
+    val EXPANDED_PAYMENT_INTENT_JSON = JSONObject(
+        """
+        {
+          "object": "payment_method_preference",
+          "country_code": "US",
+          "ordered_payment_method_types": [
+            "card",
+            "sepa_debit",
+            "sofort",
+            "ideal",
+            "bancontact"
+          ],
+          "payment_intent": {
+            "id": "pi_1JGB5bIyGgrkZxL74Uk2VygL",
+            "object": "payment_intent",
+            "amount": 973,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "client_secret": "pi_1JGB5bIyGgrkZxL74Uk2VygL_secret_v5JtXY8PPJ9YicEKRyqSVKfHd",
+            "confirmation_method": "automatic",
+            "created": 1626995643,
+            "currency": "eur",
+            "description": null,
+            "last_payment_error": null,
+            "livemode": false,
+            "next_action": null,
+            "payment_method": null,
+            "payment_method_types": [
+              "card",
+              "ideal",
+              "sepa_debit",
+              "bancontact",
+              "sofort"
+            ],
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": null,
+            "source": null,
+            "status": "requires_payment_method"
+          },
+          "type": "payment_intent"
+        }
+        """.trimIndent()
+    )
+
+    val EXPANDED_SETUP_INTENT_JSON = JSONObject(
+        """
+        {
+          "object": "payment_method_preference",
+          "country_code": "US",
+          "ordered_payment_method_types": [
+            "bancontact",
+            "ideal",
+            "sofort",
+            "sepa_debit",
+            "card"
+          ],
+          "setup_intent": {
+            "id": "seti_1JGC8AIyGgrkZxL7QR3c4lWN",
+            "object": "setup_intent",
+            "cancellation_reason": null,
+            "client_secret": "seti_1JGC8AIyGgrkZxL7QR3c4lWN_secret_Ju08uANFNpVJmZdKsfK5COMf921xCzg",
+            "created": 1626999646,
+            "description": null,
+            "last_setup_error": null,
+            "livemode": false,
+            "next_action": null,
+            "payment_method": null,
+            "payment_method_types": [
+              "card",
+              "ideal",
+              "sepa_debit",
+              "bancontact",
+              "sofort"
+            ],
+            "status": "requires_payment_method",
+            "usage": "off_session"
+          },
+          "type": "setup_intent"
+        }
+        """.trimIndent()
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParserTest.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.model.parsers
+
+import com.google.common.truth.Truth
+import com.stripe.android.model.PaymentMethodPreferenceFixtures
+import org.junit.Test
+
+class PaymentMethodPreferenceJsonParserTest {
+    @Test
+    fun parsePaymentIntent_shouldCreateObjectWithOrderedPaymentMethods() {
+        val paymentIntent = PaymentMethodPreferenceForPaymentIntentJsonParser().parse(
+            PaymentMethodPreferenceFixtures.EXPANDED_PAYMENT_INTENT_JSON
+        )
+        val orderedPaymentMethods =
+            ModelJsonParser.jsonArrayToList(
+                PaymentMethodPreferenceFixtures.EXPANDED_PAYMENT_INTENT_JSON
+                    .optJSONArray("ordered_payment_method_types")
+            )
+
+        Truth.assertThat(paymentIntent?.id)
+            .isEqualTo("pi_1JGB5bIyGgrkZxL74Uk2VygL")
+        Truth.assertThat(paymentIntent?.paymentMethodTypes)
+            .containsExactlyElementsIn(orderedPaymentMethods)
+            .inOrder()
+    }
+
+    @Test
+    fun parseSetupIntent_shouldCreateObjectWithOrderedPaymentMethods() {
+        val setupIntent = PaymentMethodPreferenceForSetupIntentJsonParser().parse(
+            PaymentMethodPreferenceFixtures.EXPANDED_SETUP_INTENT_JSON
+        )
+        val orderedPaymentMethods =
+            ModelJsonParser.jsonArrayToList(
+                PaymentMethodPreferenceFixtures.EXPANDED_SETUP_INTENT_JSON
+                    .optJSONArray("ordered_payment_method_types")
+            )
+
+        Truth.assertThat(setupIntent?.id)
+            .isEqualTo("seti_1JGC8AIyGgrkZxL7QR3c4lWN")
+        Truth.assertThat(setupIntent?.paymentMethodTypes)
+            .containsExactlyElementsIn(orderedPaymentMethods)
+            .inOrder()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -52,6 +52,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         return null
     }
 
+    override suspend fun retrievePaymentIntentWithOrderedPaymentMethods(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        locale: String
+    ): PaymentIntent? {
+        return null
+    }
+
     override suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
@@ -72,6 +80,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
+    ): SetupIntent? {
+        return null
+    }
+
+    override suspend fun retrieveSetupIntentWithOrderedPaymentMethods(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        locale: String
     ): SetupIntent? {
         return null
     }

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import org.json.JSONObject
+import java.util.Locale
 
 internal abstract class AbsFakeStripeRepository : StripeRepository {
 
@@ -55,7 +56,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun retrievePaymentIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): PaymentIntent? {
         return null
     }
@@ -87,7 +88,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun retrieveSetupIntentWithOrderedPaymentMethods(
         clientSecret: String,
         options: ApiRequest.Options,
-        locale: String
+        locale: Locale
     ): SetupIntent? {
         return null
     }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodPreferenceFixtures
 import com.stripe.android.model.SourceFixtures
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.Stripe3ds2AuthParams
@@ -1061,6 +1062,66 @@ internal class StripeApiRepositoryTest {
             }
             assertThat(error.message)
                 .isEqualTo("Invalid client secret.")
+        }
+
+    @Test
+    fun `retrievePaymentIntentWithOrderedPaymentMethods() sends all parameters`() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                PaymentMethodPreferenceFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+
+            val clientSecret = "test_locale"
+            val locale = "test_locale"
+            create().retrievePaymentIntentWithOrderedPaymentMethods(
+                clientSecret,
+                DEFAULT_OPTIONS,
+                locale
+            )
+
+            verify(stripeApiRequestExecutor).execute(apiRequestArgumentCaptor.capture())
+            val apiRequest = apiRequestArgumentCaptor.firstValue
+            val paymentMethodDataParams = apiRequest.params?.get("expand") as Collection<*>
+            assertTrue(paymentMethodDataParams.contains("payment_intent"))
+            assertEquals(apiRequest.params?.get("locale"), locale)
+            assertEquals(apiRequest.params?.get("type"), "payment_intent")
+            assertEquals(apiRequest.params?.get("client_secret"), clientSecret)
+
+            verifyFraudDetectionDataAndAnalyticsRequests(AnalyticsEvent.PaymentIntentRetrieve)
+        }
+
+    @Test
+    fun `retrieveSetupIntentWithOrderedPaymentMethods() sends all parameters`() =
+        testDispatcher.runBlockingTest {
+            val stripeResponse = StripeResponse(
+                200,
+                PaymentMethodPreferenceFixtures.EXPANDED_SETUP_INTENT_JSON.toString(),
+                emptyMap()
+            )
+            whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+
+            val clientSecret = "test_locale"
+            val locale = "test_locale"
+            create().retrieveSetupIntentWithOrderedPaymentMethods(
+                clientSecret,
+                DEFAULT_OPTIONS,
+                locale
+            )
+
+            verify(stripeApiRequestExecutor).execute(apiRequestArgumentCaptor.capture())
+            val apiRequest = apiRequestArgumentCaptor.firstValue
+            val paymentMethodDataParams = apiRequest.params?.get("expand") as Collection<*>
+            assertTrue(paymentMethodDataParams.contains("setup_intent"))
+            assertEquals(apiRequest.params?.get("locale"), locale)
+            assertEquals(apiRequest.params?.get("type"), "setup_intent")
+            assertEquals(apiRequest.params?.get("client_secret"), clientSecret)
+
+            verifyFraudDetectionDataAndAnalyticsRequests(AnalyticsEvent.SetupIntentRetrieve)
         }
 
     private fun verifyFraudDetectionDataAndAnalyticsRequests(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1076,7 +1076,7 @@ internal class StripeApiRepositoryTest {
                 .thenReturn(stripeResponse)
 
             val clientSecret = "test_locale"
-            val locale = "test_locale"
+            val locale = Locale.GERMANY
             create().retrievePaymentIntentWithOrderedPaymentMethods(
                 clientSecret,
                 DEFAULT_OPTIONS,
@@ -1087,7 +1087,7 @@ internal class StripeApiRepositoryTest {
             val apiRequest = apiRequestArgumentCaptor.firstValue
             val paymentMethodDataParams = apiRequest.params?.get("expand") as Collection<*>
             assertTrue(paymentMethodDataParams.contains("payment_intent"))
-            assertEquals(apiRequest.params?.get("locale"), locale)
+            assertEquals(apiRequest.params?.get("locale"), locale.toLanguageTag())
             assertEquals(apiRequest.params?.get("type"), "payment_intent")
             assertEquals(apiRequest.params?.get("client_secret"), clientSecret)
 
@@ -1105,8 +1105,8 @@ internal class StripeApiRepositoryTest {
             whenever(stripeApiRequestExecutor.execute(any<ApiRequest>()))
                 .thenReturn(stripeResponse)
 
-            val clientSecret = "test_locale"
-            val locale = "test_locale"
+            val clientSecret = "test_client_secret"
+            val locale = Locale.FRANCE
             create().retrieveSetupIntentWithOrderedPaymentMethods(
                 clientSecret,
                 DEFAULT_OPTIONS,
@@ -1117,7 +1117,7 @@ internal class StripeApiRepositoryTest {
             val apiRequest = apiRequestArgumentCaptor.firstValue
             val paymentMethodDataParams = apiRequest.params?.get("expand") as Collection<*>
             assertTrue(paymentMethodDataParams.contains("setup_intent"))
-            assertEquals(apiRequest.params?.get("locale"), locale)
+            assertEquals(apiRequest.params?.get("locale"), locale.toLanguageTag())
             assertEquals(apiRequest.params?.get("type"), "setup_intent")
             assertEquals(apiRequest.params?.get("client_secret"), clientSecret)
 

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 import kotlin.test.AfterTest
 import kotlin.test.Test
 
@@ -41,11 +42,11 @@ internal class StripeIntentRepositoryTest {
                     .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
             ).thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
 
-            val locale = "test_locale"
+            val locale = Locale.GERMANY
             val paymentIntent =
                 createRepository(locale).get(PaymentIntentClientSecret("client_secret"))
 
-            val localeArgumentCaptor: KArgumentCaptor<String> = argumentCaptor()
+            val localeArgumentCaptor: KArgumentCaptor<Locale> = argumentCaptor()
 
             verify(stripeRepository)
                 .retrievePaymentIntentWithOrderedPaymentMethods(
@@ -68,7 +69,7 @@ internal class StripeIntentRepositoryTest {
                 .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
 
             val paymentIntent =
-                createRepository("test_locale").get(PaymentIntentClientSecret("client_secret"))
+                createRepository(Locale.ITALY).get(PaymentIntentClientSecret("client_secret"))
 
             verify(stripeRepository)
                 .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
@@ -103,7 +104,7 @@ internal class StripeIntentRepositoryTest {
                 testDispatcher
             ).get(PaymentIntentClientSecret("client_secret"))
 
-            val localeArgumentCaptor: KArgumentCaptor<String> = argumentCaptor()
+            val localeArgumentCaptor: KArgumentCaptor<Locale> = argumentCaptor()
 
             verify(stripeRepository)
                 .retrievePaymentIntentWithOrderedPaymentMethods(
@@ -112,11 +113,11 @@ internal class StripeIntentRepositoryTest {
             verify(stripeRepository, never()).retrievePaymentIntent(any(), any(), any())
             assertThat(paymentIntent).isEqualTo(PaymentIntentFixtures.PI_WITH_SHIPPING)
 
-            val defaultLocale = LocaleListCompat.getAdjustedDefault()[0].toLanguageTag()
+            val defaultLocale = LocaleListCompat.getAdjustedDefault()[0]
             assertThat(localeArgumentCaptor.firstValue).isEqualTo(defaultLocale)
         }
 
-    private fun createRepository(locale: String? = null) = StripeIntentRepository.Api(
+    private fun createRepository(locale: Locale? = null) = StripeIntentRepository.Api(
         stripeRepository,
         ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         testDispatcher,

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.paymentsheet.repositories
+
+import androidx.core.os.LocaleListCompat
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+internal class StripeIntentRepositoryTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val stripeRepository = mock<StripeRepository>()
+
+    @AfterTest
+    fun cleanup() {
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `get with locale should retrieve with ordered payment methods`() =
+        testDispatcher.runBlockingTest {
+            whenever(
+                stripeRepository
+                    .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            ).thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            val locale = "test_locale"
+            val paymentIntent =
+                createRepository(locale).get(PaymentIntentClientSecret("client_secret"))
+
+            val localeArgumentCaptor: KArgumentCaptor<String> = argumentCaptor()
+
+            verify(stripeRepository)
+                .retrievePaymentIntentWithOrderedPaymentMethods(
+                    any(), any(), localeArgumentCaptor.capture()
+                )
+            verify(stripeRepository, never()).retrievePaymentIntent(any(), any(), any())
+            assertThat(paymentIntent).isEqualTo(PaymentIntentFixtures.PI_WITH_SHIPPING)
+            assertThat(localeArgumentCaptor.firstValue).isEqualTo(locale)
+        }
+
+    @Test
+    fun `get with locale when ordered payment methods fails should fallback to retrievePaymentIntent()`() =
+        testDispatcher.runBlockingTest {
+            whenever(
+                stripeRepository
+                    .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            ).thenReturn(null)
+
+            whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
+                .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            val paymentIntent =
+                createRepository("test_locale").get(PaymentIntentClientSecret("client_secret"))
+
+            verify(stripeRepository)
+                .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            verify(stripeRepository).retrievePaymentIntent(any(), any(), any())
+            assertThat(paymentIntent).isEqualTo(PaymentIntentFixtures.PI_WITH_SHIPPING)
+        }
+
+    @Test
+    fun `get with null locale should call retrievePaymentIntent()`() =
+        testDispatcher.runBlockingTest {
+            whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
+                .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            createRepository().get(PaymentIntentClientSecret("client_secret"))
+
+            verify(stripeRepository, never())
+                .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            verify(stripeRepository).retrievePaymentIntent(any(), any(), any())
+        }
+
+    @Test
+    fun `get without locale should retrieve ordered payment methods in default locale`() =
+        testDispatcher.runBlockingTest {
+            whenever(
+                stripeRepository
+                    .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            ).thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            val paymentIntent = StripeIntentRepository.Api(
+                stripeRepository,
+                ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+                testDispatcher
+            ).get(PaymentIntentClientSecret("client_secret"))
+
+            val localeArgumentCaptor: KArgumentCaptor<String> = argumentCaptor()
+
+            verify(stripeRepository)
+                .retrievePaymentIntentWithOrderedPaymentMethods(
+                    any(), any(), localeArgumentCaptor.capture()
+                )
+            verify(stripeRepository, never()).retrievePaymentIntent(any(), any(), any())
+            assertThat(paymentIntent).isEqualTo(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            val defaultLocale = LocaleListCompat.getAdjustedDefault()[0].toLanguageTag()
+            assertThat(localeArgumentCaptor.firstValue).isEqualTo(defaultLocale)
+        }
+
+    private fun createRepository(locale: String? = null) = StripeIntentRepository.Api(
+        stripeRepository,
+        ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+        testDispatcher,
+        locale
+    )
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Payment Sheet calls `v1/payment_method_preferences` endpoint to get ordered payment methods when fetching PI/SI, falling back to `/v1/payment_intents/:id` in case of failure or if `null` locale was provided.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support payment method ordering.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified