### PR TITLE
Fix browser redirect on firefox browser.

### DIFF
--- a/payments-core/AndroidManifest.xml
+++ b/payments-core/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity
             android:name=".payments.StripeBrowserLauncherActivity"
             android:theme="@style/StripeTransparentTheme"
-            android:launchMode="singleTop"
+            android:launchMode="singleInstance"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/payments-core/AndroidManifest.xml
+++ b/payments-core/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity
             android:name=".payments.StripeBrowserLauncherActivity"
             android:theme="@style/StripeTransparentTheme"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
# Summary
Make the StripeBrowserLauncherActivity a single instance so that it clears the activities up until the StripeBrowserLauncher.  After this change the redirect will now work on the firefox mobile browser.

I found this similar issue: https://stackoverflow.com/questions/55077642/android-deep-link-firefox-like-chrome

For us the concern about the extras is less relevant because in our code base onResult is called which just calls finish (it also then calls onNewIntent).  It does not use the extras.

Attempt to fix #3952

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
