### PR TITLE
fix 3ds2 callback

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionStarter.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.payments.core.authentication.threeds2
+
+import android.app.Activity
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.StripePaymentController
+import com.stripe.android.view.AuthActivityStarter
+import com.stripe.android.view.AuthActivityStarterHost
+
+/**
+ * A [AuthActivityStarter] to start [Stripe3ds2TransactionActivity]
+ * with legacy [Activity.startActivityForResult] or modern [ActivityResultLauncher.launch].
+ */
+internal interface Stripe3ds2TransactionStarter :
+    AuthActivityStarter<Stripe3ds2TransactionContract.Args> {
+    class Legacy(
+        private val host: AuthActivityStarterHost
+    ) : Stripe3ds2TransactionStarter {
+        override fun start(args: Stripe3ds2TransactionContract.Args) {
+            host.startActivityForResult(
+                Stripe3ds2TransactionActivity::class.java,
+                args.toBundle(),
+                StripePaymentController.getRequestCode(args.stripeIntent)
+            )
+        }
+    }
+
+    class Modern(
+        private val launcher: ActivityResultLauncher<Stripe3ds2TransactionContract.Args>
+    ) : Stripe3ds2TransactionStarter {
+        override fun start(args: Stripe3ds2TransactionContract.Args) {
+            launcher.launch(args)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a `Stripe3ds2TransactionStarter` to for `Stripe3ds2TransactionActivity` 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`PaymentSheet` invokes `StripePaymentController` with the modern `ActivityResultLauncher` API and handles its callback in [onPaymentFlowResult](https://github.com/stripe/stripe-android/blob/98c1fcd215ad281cd48f91cffb86b944179571fe/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt#L442). 
`Stripe3DS2Authenticator` currently just supports the legacy `Activity.startActivityForResult` API. Add a starter to make them compatible.

Fixes https://jira.corp.stripe.com/browse/RUN_MOBILESDK-336

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
