### PR TITLE
Fix Setup Intent confirmation when using GooglePayLauncher

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -165,7 +165,7 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
         val params = PaymentMethodCreateParams.createFromGooglePay(paymentDataJson)
         val host = AuthActivityStarterHost.create(this)
         lifecycleScope.launch {
-            viewModel.confirmPaymentIntent(host, params)
+            viewModel.confirmStripeIntent(host, params)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.StripePaymentController
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
@@ -151,16 +152,26 @@ internal class GooglePayLauncherViewModel(
         )
     }
 
-    suspend fun confirmPaymentIntent(
+    suspend fun confirmStripeIntent(
         host: AuthActivityStarterHost,
         params: PaymentMethodCreateParams
     ) {
+        val confirmStripeIntentParams = when (args) {
+            is GooglePayLauncherContract.PaymentIntentArgs ->
+                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    paymentMethodCreateParams = params,
+                    clientSecret = args.clientSecret
+                )
+            is GooglePayLauncherContract.SetupIntentArgs ->
+                ConfirmSetupIntentParams.create(
+                    paymentMethodCreateParams = params,
+                    clientSecret = args.clientSecret
+                )
+        }
+
         paymentController.startConfirmAndAuth(
             host,
-            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                paymentMethodCreateParams = params,
-                clientSecret = args.clientSecret
-            ),
+            confirmStripeIntentParams,
             requestOptions
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -176,7 +176,6 @@ class GooglePayLauncherViewModelTest {
                 .isInstanceOf(ConfirmPaymentIntentParams::class.java)
         }
 
-
     @Test
     fun `confirmStripeIntent() using SetupIntent should confirm Setup Intent`() =
         testDispatcher.runBlockingTest {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`GooglePayLauncherViewModel` was always confirming a Payment Intent, when that should depend on the `GooglePayLauncher` initialization arguments.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix Setup Intent confirmation when using GooglePayLauncher

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified