### PR TITLE
[POC] Split payment controller

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4657,6 +4657,16 @@ public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated$Com
 	public synthetic fun write (Ljava/lang/Object;Landroid/os/Parcel;I)V
 }
 
+public abstract class com/stripe/android/payments/PaymentFlowResultProcessor {
+	public synthetic fun <init> (Landroid/content/Context;Ljavax/inject/Provider;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljavax/inject/Provider;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected abstract fun cancelStripeIntent (Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun createStripeIntentResult (Lcom/stripe/android/model/StripeIntent;ILjava/lang/String;)Lcom/stripe/android/StripeIntentResult;
+	protected final fun getStripeRepository ()Lcom/stripe/android/networking/StripeRepository;
+	public final fun processResult (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun retrieveStripeIntent (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/payments/core/ActivityResultLauncherHost {
 	public abstract fun onLauncherInvalidated ()V
 	public abstract fun onNewActivityResultCaller (Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
@@ -4765,6 +4775,22 @@ public final class com/stripe/android/payments/core/injection/PaymentCommonModul
 	public fun get ()Lcom/stripe/android/payments/PaymentIntentFlowResultProcessor;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun providePaymentIntentFlowResultProcessor (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Landroid/content/Context;Ldagger/Lazy;Lcom/stripe/android/networking/StripeApiRepository;Z)Lcom/stripe/android/payments/PaymentIntentFlowResultProcessor;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentCommonModule_ProvidePaymentSheetApiRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentCommonModule_ProvidePaymentSheetApiRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetApiRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentSheetApiRepository (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Landroid/content/Context;Ldagger/Lazy;)Lcom/stripe/android/paymentsheet/PaymentSheetApiRepository;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentCommonModule_ProvidePaymentSheetPaymentControllerFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentCommonModule_ProvidePaymentSheetPaymentControllerFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetPaymentController;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentSheetPaymentController (Lcom/stripe/android/payments/core/injection/PaymentCommonModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;)Lcom/stripe/android/paymentsheet/PaymentSheetPaymentController;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentCommonModule_ProvideSetupIntentFlowResultProcessorFactory : dagger/internal/Factory {
@@ -4929,6 +4955,13 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 }
 
+public abstract interface class com/stripe/android/paymentsheet/PaymentSheetApiRepository {
+	public abstract fun cancelPaymentIntentSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancelSetupIntentSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun retrievePaymentIntent (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun retrieveSetupIntent (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheetContract : androidx/activity/result/contract/ActivityResultContract {
 	public static final field EXTRA_ARGS Ljava/lang/String;
 	public fun <init> ()V
@@ -4957,6 +4990,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args$Com
 	public static synthetic fun createPaymentIntentArgs$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args$Companion;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
 	public final fun createSetupIntentArgs (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
 	public static synthetic fun createSetupIntentArgs$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args$Companion;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+}
+
+public abstract interface class com/stripe/android/paymentsheet/PaymentSheetPaymentController {
+	public abstract fun onPaymentFlowResultDefaultFlowController (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Lcom/stripe/android/payments/PaymentFlowResultProcessor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onPaymentFlowResultPaymentSheetViewModel (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Lcom/stripe/android/payments/PaymentFlowResultProcessor;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun registerLaunchersWithActivityResultCaller (Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
+	public abstract fun startConfirmAndAuth (Lcom/stripe/android/view/AuthActivityStarterHost;Lcom/stripe/android/model/ConfirmStripeIntentParams;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unregisterLaunchers ()V
 }
 
 public abstract class com/stripe/android/paymentsheet/PaymentSheetResult : android/os/Parcelable {
@@ -4999,7 +5040,54 @@ public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/repositories/PaymentMethodsRepository;Ljavax/inject/Provider;Lcom/stripe/android/googlepaylauncher/GooglePayRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/PaymentController;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/repositories/PaymentMethodsRepository;Ljavax/inject/Provider;Lcom/stripe/android/googlepaylauncher/GooglePayRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/paymentsheet/PaymentSheetPaymentController;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+}
+
+public abstract interface class com/stripe/android/paymentsheet/StartAndConfirmResult {
+}
+
+public final class com/stripe/android/paymentsheet/StartAndConfirmResult$ErrorStripeIntentReady : com/stripe/android/paymentsheet/StartAndConfirmResult {
+	public fun <init> (Lcom/stripe/android/StripeIntentResult;)V
+	public final fun component1 ()Lcom/stripe/android/StripeIntentResult;
+	public final fun copy (Lcom/stripe/android/StripeIntentResult;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$ErrorStripeIntentReady;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/StartAndConfirmResult$ErrorStripeIntentReady;Lcom/stripe/android/StripeIntentResult;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$ErrorStripeIntentReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStripeIntentResult ()Lcom/stripe/android/StripeIntentResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/StartAndConfirmResult$Fatal : com/stripe/android/paymentsheet/StartAndConfirmResult {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Fatal;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Fatal;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Fatal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/StartAndConfirmResult$StripeResultError : com/stripe/android/paymentsheet/StartAndConfirmResult {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$StripeResultError;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/StartAndConfirmResult$StripeResultError;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$StripeResultError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/StartAndConfirmResult$Success : com/stripe/android/paymentsheet/StartAndConfirmResult {
+	public fun <init> (Lcom/stripe/android/StripeIntentResult;)V
+	public final fun component1 ()Lcom/stripe/android/StripeIntentResult;
+	public final fun copy (Lcom/stripe/android/StripeIntentResult;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Success;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Success;Lcom/stripe/android/StripeIntentResult;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/StartAndConfirmResult$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStripeIntentResult ()Lcom/stripe/android/StripeIntentResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory : dagger/internal/Factory {
@@ -5007,7 +5095,7 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/networking/StripeApiRepository;Lcom/stripe/android/PaymentController;Ldagger/Lazy;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/networking/StripeApiRepository;Lcom/stripe/android/paymentsheet/PaymentSheetPaymentController;Ldagger/Lazy;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 }
 
 public final class com/stripe/android/paymentsheet/injection/DaggerFlowControllerComponent : com/stripe/android/paymentsheet/injection/FlowControllerComponent {
@@ -5143,6 +5231,11 @@ public final class com/stripe/android/paymentsheet/model/PaymentOption {
 	public final fun getLabel ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/model/StripeIntentValidator {
+	public fun <init> ()V
+	public final synthetic fun requireValid (Lcom/stripe/android/model/StripeIntent;)Lcom/stripe/android/model/StripeIntent;
 }
 
 public abstract class com/stripe/android/view/ActivityStarter {

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -552,7 +552,6 @@ internal class StripePaymentController internal constructor(
         }
     }
 
-
     override suspend fun onPaymentFlowResultDefaultFlowController(
         paymentFlowResult: PaymentFlowResult.Unvalidated,
         paymentFlowResultProcessor: PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>,
@@ -641,7 +640,6 @@ internal class StripePaymentController internal constructor(
             )
         }
     }
-
 
     internal companion object {
         internal const val PAYMENT_REQUEST_CODE = 50000

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -55,6 +55,7 @@ import com.stripe.android.model.parsers.SourceJsonParser
 import com.stripe.android.model.parsers.Stripe3ds2AuthResultJsonParser
 import com.stripe.android.model.parsers.StripeFileJsonParser
 import com.stripe.android.model.parsers.TokenJsonParser
+import com.stripe.android.paymentsheet.PaymentSheetApiRepository
 import com.stripe.android.utils.StripeUrlUtils
 import kotlinx.coroutines.Dispatchers
 import org.json.JSONException
@@ -89,7 +90,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     betas: Set<StripeApiBeta> = emptySet(),
     apiVersion: String = ApiVersion(betas = betas).code,
     sdkVersion: String = Stripe.VERSION
-) : StripeRepository {
+) : StripeRepository, PaymentSheetApiRepository {
     private val apiRequestFactory = ApiRequest.Factory(
         appInfo = appInfo,
         apiVersion = apiVersion,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -19,7 +19,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Class responsible for processing the result of a [PaymentController] confirm operation.
  */
-internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
+sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
     context: Context,
     private val publishableKeyProvider: Provider<String>,
     protected val stripeRepository: StripeRepository,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentCommonModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentCommonModule.kt
@@ -10,6 +10,8 @@ import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.payments.PaymentFlowResultProcessor
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.paymentsheet.PaymentSheetApiRepository
+import com.stripe.android.paymentsheet.PaymentSheetPaymentController
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
@@ -66,6 +68,30 @@ internal class PaymentCommonModule {
             enableLogging = true
         )
     }
+
+    // TODO: This is kinda incorrectly going to have a different repository from the one below.
+    @Provides
+    @Singleton
+    fun providePaymentSheetApiRepository(
+        appContext: Context,
+        lazyPaymentConfiguration: Lazy<PaymentConfiguration>
+    ) = StripeApiRepository(
+        appContext,
+        { lazyPaymentConfiguration.get().publishableKey }
+    ) as PaymentSheetApiRepository
+
+    @Provides
+    @Singleton
+    fun providePaymentSheetPaymentController(
+        appContext: Context,
+        stripeApiRepository: StripeApiRepository,
+        lazyPaymentConfiguration: Lazy<PaymentConfiguration>
+    ) = StripePaymentController(
+        appContext,
+        { lazyPaymentConfiguration.get().publishableKey },
+        stripeApiRepository,
+        enableLogging = true
+    ) as PaymentSheetPaymentController
 
     @Provides
     @Singleton

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentCommonModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentCommonModule.kt
@@ -69,7 +69,6 @@ internal class PaymentCommonModule {
         )
     }
 
-    // TODO: This is kinda incorrectly going to have a different repository from the one below.
     @Provides
     @Singleton
     fun providePaymentSheetApiRepository(

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetApiRepository.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.exception.APIConnectionException
+import com.stripe.android.exception.APIException
+import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.exception.InvalidRequestException
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.ApiRequest
+
+interface PaymentSheetApiRepository {
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun cancelSetupIntentSource(
+        setupIntentId: String,
+        sourceId: String,
+        options: ApiRequest.Options
+    ): SetupIntent?
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun retrieveSetupIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): SetupIntent?
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun cancelPaymentIntentSource(
+        paymentIntentId: String,
+        sourceId: String,
+        options: ApiRequest.Options
+    ): PaymentIntent?
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun retrievePaymentIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): PaymentIntent?
+
+}

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetApiRepository.kt
@@ -56,5 +56,4 @@ interface PaymentSheetApiRepository {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): PaymentIntent?
-
 }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentController.kt
@@ -1,0 +1,54 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.PaymentFlowResultProcessor
+import com.stripe.android.paymentsheet.model.StripeIntentValidator
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlin.coroutines.CoroutineContext
+
+sealed interface StartAndConfirmResult {
+    data class ErrorStripeIntentReady(val stripeIntentResult: StripeIntentResult<StripeIntent>) :
+        StartAndConfirmResult
+
+    data class StripeResultError(val throwable: Throwable) : StartAndConfirmResult
+    data class Fatal(val throwable: Throwable) : StartAndConfirmResult
+    data class Success(val stripeIntentResult: StripeIntentResult<StripeIntent>) :
+        StartAndConfirmResult
+}
+
+interface PaymentSheetPaymentController {
+
+    /**
+     * Confirm the Stripe Intent and resolve any next actions
+     */
+    suspend fun startConfirmAndAuth(
+        host: AuthActivityStarterHost,
+        confirmStripeIntentParams: ConfirmStripeIntentParams,
+        publishableKey: String,
+        stripeAccountId: String?
+    )
+
+    suspend fun onPaymentFlowResultPaymentSheetViewModel(
+        paymentFlowResult: PaymentFlowResult.Unvalidated,
+        paymentFlowResultProcessor: PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>,
+        workContext: CoroutineContext,
+        stripeIntentValidator: StripeIntentValidator
+    ): StartAndConfirmResult
+
+    suspend fun onPaymentFlowResultDefaultFlowController(
+        paymentFlowResult: PaymentFlowResult.Unvalidated,
+        paymentFlowResultProcessor: PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>,
+    ): PaymentSheetResult
+
+    fun registerLaunchersWithActivityResultCaller(
+        activityResultCaller: ActivityResultCaller,
+        activityResultCallback: ActivityResultCallback<PaymentFlowResult.Unvalidated>
+    )
+
+    fun unregisterLaunchers()
+}

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetPaymentController.kt
@@ -11,12 +11,25 @@ import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * This sealed interface is the result of startAndConfirm it can either be an Error, Fatal, success, or a StripeIntent that is still ready for a new selection
+ */
 sealed interface StartAndConfirmResult {
+    /**
+      *This is an error that can be recovered, the payment intent can be used with a different
+      * payment method.
+      */
     data class ErrorStripeIntentReady(val stripeIntentResult: StripeIntentResult<StripeIntent>) :
         StartAndConfirmResult
 
+    /**
+     * This is an error that cannot be recovered,  new payment intent must be created.
+     */
     data class StripeResultError(val throwable: Throwable) : StartAndConfirmResult
     data class Fatal(val throwable: Throwable) : StartAndConfirmResult
+    /**
+      * The confirm and Auth was successful.
+      */
     data class Success(val stripeIntentResult: StripeIntentResult<StripeIntent>) :
         StartAndConfirmResult
 }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.Logger
-import com.stripe.android.PaymentController
 import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIConnectionException
@@ -469,7 +468,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     }
                 }
                 is StartAndConfirmResult.ErrorStripeIntentReady -> {
-                eventReporter.onPaymentFailure(selection.value)
+                    eventReporter.onPaymentFailure(selection.value)
                     resetViewState(
                         result.stripeIntentResult.intent,
                         result.stripeIntentResult.failureMessage

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -85,7 +85,7 @@ internal class DefaultFlowController @Inject internal constructor(
      *   paymentFlowResultProcessor afterwards.
      */
     private val paymentFlowResultProcessorProvider:
-    Provider<PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>>
+        Provider<PaymentFlowResultProcessor<out StripeIntent, StripeIntentResult<StripeIntent>>>
 ) : PaymentSheet.FlowController {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private var googlePayActivityLauncher: ActivityResultLauncher<StripeGooglePayContract.Args>

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.StripeIntent
 /**
  * Validator for [PaymentIntent] or [SetupIntent] instances used in PaymentSheet.
  */
-internal class StripeIntentValidator {
+class StripeIntentValidator {
     @JvmSynthetic
     fun requireValid(
         stripeIntent: StripeIntent


### PR DESCRIPTION
# Summary
This is currently just a proof of concept to get feedback.

In order to move all the PaymentSheet logic into the PaymentSheet module some of the logic in StripePaymentController and StripeApiRepository need to be exposed.   In order to minimize the amount of data to expose from the StripeApiRepository an interface was created.  I considered making the class public but everything not used by the PaymentSheet internal, but I think an interface makes it more clear on why certain functions are and are not public.

The plan would be to keep the StripePaymentController internal, and only expose the PaymentSheetApiRepository interface and the PaymentSheetPaymentController interface.   With this change only the StripeValidator would also need to be exposed (see note on removing this requirement).

For the StripePaymentController I created a new interface PaymentSheetPaymentController.  This PaymentSheetPaymentController will only expose the functionality needed by PaymentSheet.  In addition, abstracts the return value to a simple success/failure/error.  This keeps that processing closer to the class which is responsible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
