### PR TITLE
Add support for optional text fields

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownFieldController.kt
@@ -19,6 +19,7 @@ internal class DropdownFieldController(
     override val fieldValue = selectedIndex.map { displayItems[it] }
     override val rawFieldValue = fieldValue.map { config.convertToRaw(it) }
     override val error: Flow<FieldError?> = MutableStateFlow(null)
+    override val showOptionalLabel: Boolean = false // not supported yet
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/InputController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/InputController.kt
@@ -24,6 +24,7 @@ internal sealed interface InputController : Controller {
     val rawFieldValue: Flow<String?>
     val isComplete: Flow<Boolean>
     val error: Flow<FieldError?>
+    val showOptionalLabel: Boolean
 
     fun onRawValueChange(rawValue: String)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
@@ -16,6 +16,7 @@ internal class SaveForFutureUseController(
     override val rawFieldValue: Flow<String?> = fieldValue
 
     override val error: Flow<FieldError?> = MutableStateFlow(null)
+    override val showOptionalLabel: Boolean = false
     override val isComplete: Flow<Boolean> = MutableStateFlow(true)
 
     val hiddenIdentifiers: Flow<List<IdentifierSpec>> =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SimpleTextFieldConfig.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SimpleTextFieldConfig.kt
@@ -21,6 +21,8 @@ internal class SimpleTextFieldConfig(
         override fun getError(): FieldError? = null
 
         override fun isFull(): Boolean = false
+
+        override fun isBlank(): Boolean = input.isBlank()
     }
 
     override fun filter(userTyped: String): String = userTyped

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldController.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.map
  */
 internal class TextFieldController constructor(
     private val textFieldConfig: TextFieldConfig,
-    val showOptionalLabel: Boolean = false
+    override val showOptionalLabel: Boolean = false
 ) : InputController, SectionFieldErrorController {
     val capitalization: KeyboardCapitalization = textFieldConfig.capitalization
     val keyboardType: KeyboardType = textFieldConfig.keyboard
@@ -50,7 +50,9 @@ internal class TextFieldController constructor(
 
     val isFull: Flow<Boolean> = _fieldState.map { it.isFull() }
 
-    override val isComplete: Flow<Boolean> = _fieldState.map { it.isValid() }
+    override val isComplete: Flow<Boolean> = _fieldState.map {
+        it.isValid() || (!it.isValid() && showOptionalLabel && it.isBlank())
+    }
 
     init {
         onValueChange("")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldState.kt
@@ -34,4 +34,10 @@ internal interface TextFieldState {
      * This is needed to know when to advance to the next field.
      */
     fun isFull(): Boolean
+
+    /**
+     * This is used to indicate the field is blank which can be helpful when ignoring optional
+     * fields.
+     */
+    fun isBlank(): Boolean
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldStateConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/TextFieldStateConstants.kt
@@ -8,6 +8,7 @@ internal class TextFieldStateConstants {
         override fun shouldShowError(hasFocus: Boolean): Boolean = false
         override fun isValid(): Boolean = true
         override fun getError(): FieldError? = null
+        override fun isBlank(): Boolean = false
 
         object Full : Valid() {
             override fun isFull(): Boolean = true
@@ -30,6 +31,7 @@ internal class TextFieldStateConstants {
             @StringRes override val errorMessageResId: Int
         ) : Error(errorMessageResId) {
             override fun shouldShowError(hasFocus: Boolean): Boolean = !hasFocus
+            override fun isBlank(): Boolean = false
         }
 
         class Invalid(
@@ -37,10 +39,12 @@ internal class TextFieldStateConstants {
             override val formatArgs: Array<out Any>? = null
         ) : Error(errorMessageResId, formatArgs) {
             override fun shouldShowError(hasFocus: Boolean): Boolean = true
+            override fun isBlank(): Boolean = false
         }
 
         object Blank : Error(R.string.blank_and_required) {
             override fun shouldShowError(hasFocus: Boolean): Boolean = false
+            override fun isBlank(): Boolean = true
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/TextFieldControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/TextFieldControllerTest.kt
@@ -116,6 +116,22 @@ internal class TextFieldControllerTest {
     }
 
     @Test
+    fun `Verify is blank optional fields are considered complete`() {
+        val controller = createControllerWithState(showOptionalLabel = true)
+        controller.onValueChange("invalid")
+
+        var isComplete = true
+        controller.isComplete.asLiveData()
+            .observeForever {
+                isComplete = it
+            }
+
+        assertThat(isComplete).isEqualTo(false)
+        controller.onValueChange("")
+        assertThat(isComplete).isEqualTo(true)
+    }
+
+    @Test
     fun `Verify is visible error is true when onValueChange and shouldShowError returns true`() {
         val controller = createControllerWithState()
         var visibleError = false
@@ -205,7 +221,9 @@ internal class TextFieldControllerTest {
         verify(config).filter("1a2b3c4d")
     }
 
-    private fun createControllerWithState(): TextFieldController {
+    private fun createControllerWithState(
+        showOptionalLabel: Boolean = false
+    ): TextFieldController {
         val config: TextFieldConfig = mock {
             on { determineState("full") } doReturn Full
             on { filter("full") } doReturn "full"
@@ -229,7 +247,7 @@ internal class TextFieldControllerTest {
             on { label } doReturn R.string.address_label_name
         }
 
-        return TextFieldController(config)
+        return TextFieldController(config, showOptionalLabel)
     }
 
     companion object {
@@ -238,6 +256,8 @@ internal class TextFieldControllerTest {
         object ShowWhenNoFocus : TextFieldState {
             override fun isValid(): Boolean = false
             override fun isFull(): Boolean = false
+            override fun isBlank(): Boolean = false
+
             override fun shouldShowError(hasFocus: Boolean): Boolean = !hasFocus
             override fun getError() = fieldError
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -347,6 +347,79 @@ internal class FormViewModelTest {
         }
     }
 
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `Verify params are set when required address fields are complete`() {
+        runBlocking {
+            /**
+             * Using sepa debit as a complex enough example to test the address portion.
+             */
+            val formViewModel = FormViewModel(
+                sepaDebit.layout,
+                saveForFutureUseInitialValue = true,
+                saveForFutureUseInitialVisibility = true,
+                merchantName = "Example, Inc.",
+                resourceRepository = resourceRepository
+            )
+
+            getSectionFieldTextControllerWithLabel(
+                formViewModel,
+                R.string.address_label_name
+            )?.onValueChange("joe")
+            assertThat(
+                formViewModel.completeFormValues.first()?.fieldValuePairs?.get(Email.identifier)
+                    ?.value
+            ).isNull()
+
+            getSectionFieldTextControllerWithLabel(
+                formViewModel,
+                R.string.email
+            )?.onValueChange("joe@gmail.com")
+            assertThat(
+                formViewModel.completeFormValues.first()?.fieldValuePairs?.get(Email.identifier)
+                    ?.value
+            ).isNull()
+
+            getSectionFieldTextControllerWithLabel(
+                formViewModel,
+                R.string.iban
+            )?.onValueChange("DE89370400440532013000")
+            assertThat(
+                formViewModel.completeFormValues.first()?.fieldValuePairs?.get(Email.identifier)
+                    ?.value
+            ).isNull()
+
+            // Fill all address values except line2
+            val addressControllers = AddressControllers.create(formViewModel)
+            val populateAddressControllers = addressControllers.controllers
+                .filter { it.label != R.string.address_label_address_line2 }
+            populateAddressControllers
+                .forEachIndexed { index, textFieldController ->
+                    textFieldController.onValueChange("1234")
+
+                    if (index == populateAddressControllers.size - 1) {
+                        assertThat(
+                            formViewModel
+                                .completeFormValues
+                                .first()
+                                ?.fieldValuePairs
+                                ?.get(Email.identifier)
+                                ?.value
+                        ).isNotNull()
+                    } else {
+                        assertThat(
+                            formViewModel
+                                .completeFormValues
+                                .first()
+                                ?.fieldValuePairs
+                                ?.get(Email.identifier)
+                                ?.value
+                        ).isNull()
+                    }
+                }
+        }
+    }
+
     private fun getSectionFieldTextControllerWithLabel(
         formViewModel: FormViewModel,
         @StringRes label: Int


### PR DESCRIPTION
# Summary
Add support for input controllers having optional fields that do not need to be populated to be considered complete, but if there is text it is required to be complete.

This fixes previous bug where the line2 of the address was required to complete the form.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
