### PR TITLE
Add support for setup_future_usage

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -117,7 +117,7 @@ data class PaymentIntent internal constructor(
      */
     override val status: StripeIntent.Status? = null,
 
-    private val setupFutureUsage: StripeIntent.Usage? = null,
+    internal val setupFutureUsage: StripeIntent.Usage? = null,
 
     /**
      * The payment error encountered in the previous [PaymentIntent] confirmation.

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -15,7 +15,9 @@ import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddPaymentMethodBinding
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -160,7 +162,9 @@ internal abstract class BaseAddPaymentMethodFragment(
         addSaveForFutureUseArguments(
             args,
             isCustomer = sheetViewModel.customerConfig != null,
-            isSetupIntent = sheetViewModel.stripeIntent.value is SetupIntent
+            isSetupIntent = (sheetViewModel.stripeIntent.value is SetupIntent
+                || ((sheetViewModel.stripeIntent.value as? PaymentIntent)
+                ?.setupFutureUsage == StripeIntent.Usage.OffSession))
         )
 
         childFragmentManager.commit {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -162,9 +162,13 @@ internal abstract class BaseAddPaymentMethodFragment(
         addSaveForFutureUseArguments(
             args,
             isCustomer = sheetViewModel.customerConfig != null,
-            isSetupIntent = (sheetViewModel.stripeIntent.value is SetupIntent
-                || ((sheetViewModel.stripeIntent.value as? PaymentIntent)
-                ?.setupFutureUsage == StripeIntent.Usage.OffSession))
+            isSetupIntent = (
+                sheetViewModel.stripeIntent.value is SetupIntent ||
+                    (
+                        (sheetViewModel.stripeIntent.value as? PaymentIntent)
+                            ?.setupFutureUsage == StripeIntent.Usage.OffSession
+                        )
+                )
         )
 
         childFragmentManager.commit {

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -713,6 +713,12 @@ internal object PaymentIntentFixtures {
     )
     val PI_WITH_SHIPPING = PARSER.parse(PI_WITH_SHIPPING_JSON)!!
 
+    val PI_OFF_SESSION = PARSER.parse(
+        PI_WITH_SHIPPING_JSON
+    )!!.copy(
+        setupFutureUsage = StripeIntent.Usage.OffSession
+    )
+
     val OXXO_REQUIRES_ACTION_JSON = JSONObject(
         """
         {

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.databinding.PrimaryButtonBinding
 import com.stripe.android.databinding.StripeGooglePayButtonBinding
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentIntentFixtures.PI_OFF_SESSION
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
@@ -348,6 +349,43 @@ class PaymentSheetAddPaymentMethodFragmentTest {
             assertThat(paymentSelection).isNull()
         }
     }
+
+    @Test
+    fun `when payment intent off session fragment parameters set correctly`() {
+        createFragment(stripeIntent = PI_OFF_SESSION) { fragment, viewBinding ->
+            assertThat(
+                fragment.childFragmentManager.findFragmentById(
+                    viewBinding.paymentMethodFragmentContainer.id
+                )
+            ).isInstanceOf(CardDataCollectionFragment::class.java)
+
+            fragment.onPaymentMethodSelected(SupportedPaymentMethod.Bancontact)
+
+            idleLooper()
+
+            val addedFragment = fragment.childFragmentManager.findFragmentById(
+                viewBinding.paymentMethodFragmentContainer.id
+            )
+
+            assertThat(addedFragment).isInstanceOf(ComposeFormDataCollectionFragment::class.java)
+            assertThat(
+                addedFragment?.arguments?.getString(
+                    ComposeFormDataCollectionFragment.EXTRA_PAYMENT_METHOD
+                )
+            ).isEqualTo(SupportedPaymentMethod.Bancontact.name)
+            assertThat(
+                addedFragment?.arguments?.getBoolean(
+                    ComposeFormDataCollectionFragment.EXTRA_SAVE_FOR_FUTURE_USE_VALUE
+                )
+            ).isEqualTo(true)
+            assertThat(
+                addedFragment?.arguments?.getBoolean(
+                    ComposeFormDataCollectionFragment.EXTRA_SAVE_FOR_FUTURE_USE_VISIBILITY
+                )
+            ).isEqualTo(false)
+        }
+    }
+
 
     @Test
     fun `payment method selection has the fields from formFieldValues`() {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/activity/PaymentSheetPlaygroundActivity.kt
@@ -57,6 +57,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
     private val mode: Repository.CheckoutMode
         get() = when (viewBinding.modeRadioGroup.checkedRadioButtonId) {
             R.id.mode_payment_button -> Repository.CheckoutMode.Payment
+            R.id.mode_payment_with_setup_button -> Repository.CheckoutMode.Payment_With_Setup
             else -> Repository.CheckoutMode.Setup
         }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/repository/Repository.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/repository/Repository.kt
@@ -17,7 +17,8 @@ internal interface Repository {
 
     enum class CheckoutMode(val value: String) {
         Setup("setup"),
-        Payment("payment")
+        Payment("payment"),
+        Payment_With_Setup("payment_with_setup")
     }
 
     suspend fun checkout(

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -175,6 +175,13 @@
                 android:checked="true" />
 
             <RadioButton
+                android:id="@+id/mode_payment_with_setup_button"
+                android:text="@string/payment_with_setup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="false" />
+
+            <RadioButton
                 android:id="@+id/mode_setup_button"
                 android:text="@string/setup"
                 android:layout_width="match_parent"

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="on">On</string>
     <string name="off">Off</string>
     <string name="checkout_mode">Checkout Mode</string>
-    <string name="payment">Payment</string>
+    <string name="payment">Pay</string>
+    <string name="payment_with_setup">Pay w/setup</string>
     <string name="setup">Setup</string>
     <string name="reload_paymentsheet">Reload PaymentSheet</string>
     <string name="payment_method">Payment Method</string>


### PR DESCRIPTION
# Summary
When setup_future_usage = off_session is set in the PaymentIntent the save for future use checkbox should behave as if selected, but not be visible.  If it is a returning or new user, once payment is confirmed it should be in the list of saved payment methods.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
