### PR TITLE
Move DefaultAnalyticsRequestExecutor into its own class

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4606,13 +4606,6 @@ public abstract interface class com/stripe/android/networking/AnalyticsRequestEx
 	public abstract fun executeAsync (Lcom/stripe/android/networking/AnalyticsRequest;)V
 }
 
-public final class com/stripe/android/networking/AnalyticsRequestExecutor$Default : com/stripe/android/networking/AnalyticsRequestExecutor {
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun executeAsync (Lcom/stripe/android/networking/AnalyticsRequest;)V
-}
-
 public final class com/stripe/android/networking/AnalyticsRequestFactory {
 	public final synthetic fun createRequest (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/AnalyticsRequest;
 }

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -26,6 +26,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowFailureMessageFactory
@@ -52,7 +53,7 @@ internal class StripePaymentController internal constructor(
     private val stripeRepository: StripeRepository,
     private val enableLogging: Boolean = false,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor =
-        AnalyticsRequestExecutor.Default(Logger.getInstance(enableLogging)),
+        DefaultAnalyticsRequestExecutor(Logger.getInstance(enableLogging)),
     private val analyticsRequestFactory: AnalyticsRequestFactory =
         AnalyticsRequestFactory(context.applicationContext, publishableKeyProvider),
     private val alipayRepository: AlipayRepository = DefaultAlipayRepository(stripeRepository),

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeApiRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -24,7 +25,7 @@ internal class DefaultCardAccountRangeRepositoryFactory(
 
     constructor(context: Context) : this(
         context,
-        AnalyticsRequestExecutor.Default()
+        DefaultAnalyticsRequestExecutor()
     )
 
     @Throws(IllegalStateException::class)
@@ -64,7 +65,7 @@ internal class DefaultCardAccountRangeRepositoryFactory(
                         publishableKey
                     ),
                     DefaultCardAccountRangeStore(appContext),
-                    AnalyticsRequestExecutor.Default(),
+                    DefaultAnalyticsRequestExecutor(),
                     AnalyticsRequestFactory(appContext, publishableKey)
                 )
             },

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -32,7 +33,7 @@ class GooglePayLauncher internal constructor(
     private val readyCallback: ReadyCallback,
     private val activityResultLauncher: ActivityResultLauncher<GooglePayLauncherContract.Args>,
     analyticsRequestFactory: AnalyticsRequestFactory,
-    analyticsRequestExecutor: AnalyticsRequestExecutor = AnalyticsRequestExecutor.Default()
+    analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor()
 ) {
     private var isReady = false
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -33,7 +34,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
     private val readyCallback: ReadyCallback,
     private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
     analyticsRequestFactory: AnalyticsRequestFactory,
-    analyticsRequestExecutor: AnalyticsRequestExecutor = AnalyticsRequestExecutor.Default()
+    analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor()
 ) {
     private var isReady = false
 

--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestExecutor.kt
@@ -1,14 +1,6 @@
 package com.stripe.android.networking
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
-import com.stripe.android.Logger
-import com.stripe.android.exception.APIConnectionException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import java.io.IOException
-import kotlin.coroutines.CoroutineContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface AnalyticsRequestExecutor {
@@ -16,40 +8,4 @@ fun interface AnalyticsRequestExecutor {
      * Execute the fire-and-forget request asynchronously.
      */
     fun executeAsync(request: AnalyticsRequest)
-
-    class Default(
-        private val logger: Logger = Logger.noop(),
-        private val workContext: CoroutineContext = Dispatchers.IO
-    ) : AnalyticsRequestExecutor {
-        private val connectionFactory = ConnectionFactory.Default()
-
-        /**
-         * Make the request and ignore the response
-         *
-         * @return the response status code. Used for testing purposes.
-         */
-        @VisibleForTesting
-        internal fun execute(request: AnalyticsRequest): Int {
-            connectionFactory.create(request).use {
-                try {
-                    // required to trigger the request
-                    return it.responseCode
-                } catch (e: IOException) {
-                    throw APIConnectionException.create(e, request.baseUrl)
-                }
-            }
-        }
-
-        override fun executeAsync(request: AnalyticsRequest) {
-            logger.info("Event: ${request.params[AnalyticsRequestFactory.FIELD_EVENT]}")
-
-            CoroutineScope(workContext).launch {
-                runCatching {
-                    execute(request)
-                }.onFailure {
-                    logger.error("Exception while making analytics request", it)
-                }
-            }
-        }
-    }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/DefaultAnalyticsRequestExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/DefaultAnalyticsRequestExecutor.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.networking
+
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.Logger
+import com.stripe.android.exception.APIConnectionException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.IOException
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultAnalyticsRequestExecutor(
+    private val logger: Logger = Logger.noop(),
+    private val workContext: CoroutineContext = Dispatchers.IO
+) : AnalyticsRequestExecutor {
+    private val connectionFactory = ConnectionFactory.Default()
+
+    /**
+     * Make the request and ignore the response
+     *
+     * @return the response status code. Used for testing purposes.
+     */
+    @VisibleForTesting
+    internal fun execute(request: AnalyticsRequest): Int {
+        connectionFactory.create(request).use {
+            try {
+                // required to trigger the request
+                return it.responseCode
+            } catch (e: IOException) {
+                throw APIConnectionException.create(e, request.baseUrl)
+            }
+        }
+    }
+
+    override fun executeAsync(request: AnalyticsRequest) {
+        logger.info("Event: ${request.params[AnalyticsRequestFactory.FIELD_EVENT]}")
+
+        CoroutineScope(workContext).launch {
+            runCatching {
+                execute(request)
+            }.onFailure {
+                logger.error("Exception while making analytics request", it)
+            }
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -83,7 +83,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         logger = logger
     ),
     private val analyticsRequestExecutor: AnalyticsRequestExecutor =
-        AnalyticsRequestExecutor.Default(logger, workContext),
+        DefaultAnalyticsRequestExecutor(logger, workContext),
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(context, workContext),
     private val analyticsRequestFactory: AnalyticsRequestFactory =

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import kotlin.properties.Delegates
 
 internal class StripeBrowserLauncherViewModel(
@@ -109,7 +110,7 @@ internal class StripeBrowserLauncherViewModel(
             val browserCapabilitiesSupplier = BrowserCapabilitiesSupplier(application)
 
             return StripeBrowserLauncherViewModel(
-                AnalyticsRequestExecutor.Default(),
+                DefaultAnalyticsRequestExecutor(),
                 AnalyticsRequestFactory(
                     application,
                     config.publishableKey

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -18,6 +18,7 @@ import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.RetryDelaySupplier
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
@@ -300,7 +301,7 @@ internal class Stripe3ds2TransactionViewModelFactory(
     ): T {
         val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
         val stripeRepository = StripeApiRepository(application, { publishableKey })
-        val analyticsRequestExecutor = AnalyticsRequestExecutor.Default(
+        val analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(
             Logger.getInstance(args.enableLogging),
             workContext
         )

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
@@ -26,7 +27,7 @@ internal class DefaultEventReporter internal constructor(
     ) : this(
         mode,
         DefaultDeviceIdRepository(context, workContext),
-        AnalyticsRequestExecutor.Default(),
+        DefaultAnalyticsRequestExecutor(),
         AnalyticsRequestFactory(
             context,
             publishableKeyProvider = { PaymentConfiguration.getInstance(context).publishableKey }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -7,8 +7,8 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.DefaultGooglePayRepository
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
-import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -89,7 +89,7 @@ internal class FlowControllerModule {
         return DefaultEventReporter(
             mode = EventReporter.Mode.Custom,
             DefaultDeviceIdRepository(appContext, Dispatchers.IO),
-            AnalyticsRequestExecutor.Default(),
+            DefaultAnalyticsRequestExecutor(),
             AnalyticsRequestFactory(
                 appContext,
                 { lazyPaymentConfiguration.get().publishableKey }

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -20,6 +20,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -71,7 +72,7 @@ class CardNumberEditText internal constructor(
         workContext,
         DefaultCardAccountRangeRepositoryFactory(context).create(),
         DefaultStaticCardAccountRanges(),
-        AnalyticsRequestExecutor.Default(),
+        DefaultAnalyticsRequestExecutor(),
         AnalyticsRequestFactory(
             context,
             publishableKeyProvider = publishableKeySupplier

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequest
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeClientUserAgentHeaderFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
@@ -121,7 +122,7 @@ internal class PaymentAuthWebViewActivityViewModel(
 
             return PaymentAuthWebViewActivityViewModel(
                 args,
-                AnalyticsRequestExecutor.Default(logger),
+                DefaultAnalyticsRequestExecutor(logger),
                 AnalyticsRequestFactory(
                     application,
                     publishableKey,

--- a/payments-core/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AnalyticsRequestExecutorTest.kt
@@ -20,7 +20,7 @@ class AnalyticsRequestExecutorTest {
     private val logger: Logger = mock()
 
     private val testDispatcher = TestCoroutineDispatcher()
-    private val analyticsRequestExecutor = AnalyticsRequestExecutor.Default(
+    private val analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(
         logger = logger,
         workContext = testDispatcher
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move DefaultAnalyticsRequestExecutor into its own class.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
So it doesn't need to be exposed publicly just because AnalyticsRequestExecutor is public.