### PR TITLE
Add `isGooglePayAvailable` parameter to `PrefsRepository.getSavedSelection`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5162,11 +5162,11 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewMod
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvidePrefsRepositoryFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvidePrefsRepositoryFactory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvidePrefsRepositoryFactory;
 	public fun get ()Lcom/stripe/android/paymentsheet/PrefsRepository;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun providePrefsRepository (Landroid/content/Context;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/googlepaylauncher/GooglePayRepository;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PrefsRepository;
+	public static fun providePrefsRepository (Landroid/content/Context;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PrefsRepository;
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideStripeIntentRepositoryFactory : dagger/internal/Factory {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -126,7 +126,6 @@ internal class PaymentOptionsViewModel(
                 DefaultPrefsRepository(
                     application,
                     customerId = id,
-                    isGooglePayReady = { starterArgs.isGooglePayReady },
                     workContext = Dispatchers.IO
                 )
             } ?: PrefsRepository.Noop()

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
@@ -4,11 +4,11 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 
 internal interface PrefsRepository {
-    suspend fun getSavedSelection(): SavedSelection
+    suspend fun getSavedSelection(isGooglePayAvailable: Boolean): SavedSelection
     fun savePaymentSelection(paymentSelection: PaymentSelection?)
 
     class Noop : PrefsRepository {
-        override suspend fun getSavedSelection(): SavedSelection = SavedSelection.None
+        override suspend fun getSavedSelection(isGooglePayAvailable: Boolean): SavedSelection = SavedSelection.None
         override fun savePaymentSelection(paymentSelection: PaymentSelection?) {}
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
@@ -8,7 +8,9 @@ internal interface PrefsRepository {
     fun savePaymentSelection(paymentSelection: PaymentSelection?)
 
     class Noop : PrefsRepository {
-        override suspend fun getSavedSelection(isGooglePayAvailable: Boolean): SavedSelection = SavedSelection.None
+        override suspend fun getSavedSelection(isGooglePayAvailable: Boolean): SavedSelection =
+            SavedSelection.None
+
         override fun savePaymentSelection(paymentSelection: PaymentSelection?) {}
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -88,7 +88,7 @@ internal class DefaultFlowControllerInitializer(
                             stripeIntent = stripeIntent,
                             paymentMethodTypes = paymentMethodTypes,
                             paymentMethods = paymentMethods,
-                            savedSelection = prefsRepository.getSavedSelection(),
+                            savedSelection = prefsRepository.getSavedSelection(isGooglePayReady),
                             isGooglePayReady = isGooglePayReady
                         )
                     )
@@ -143,7 +143,7 @@ internal class DefaultFlowControllerInitializer(
         isGooglePayReady: Boolean,
         paymentMethods: List<PaymentMethod>
     ) {
-        if (prefsRepository.getSavedSelection() == SavedSelection.None) {
+        if (prefsRepository.getSavedSelection(isGooglePayReady) == SavedSelection.None) {
             when {
                 paymentMethods.isNotEmpty() -> {
                     PaymentSelection.Saved(paymentMethods.first())

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -5,6 +5,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.ClientSecret
+import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
@@ -33,9 +34,10 @@ internal class DefaultFlowControllerInitializer(
         this@DefaultFlowControllerInitializer.stripeIntentRepository = stripeIntentRepository
         this@DefaultFlowControllerInitializer.paymentMethodsRepository = paymentMethodsRepository
 
-        val isGooglePayReady = paymentSheetConfiguration?.let {
-            isGooglePayReadySupplier(it.googlePay?.environment)
-        } ?: false
+        val isGooglePayReady =
+            clientSecret is PaymentIntentClientSecret && paymentSheetConfiguration?.let {
+                isGooglePayReadySupplier(it.googlePay?.environment)
+            } ?: false
         paymentSheetConfiguration?.customer?.let { customerConfig ->
             createWithCustomer(
                 clientSecret,

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -5,7 +5,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.ClientSecret
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
@@ -16,7 +15,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 internal class DefaultFlowControllerInitializer(
-    private val prefsRepositoryFactory: (String, Boolean) -> PrefsRepository,
+    private val prefsRepositoryFactory: (String) -> PrefsRepository,
     private val isGooglePayReadySupplier: suspend (PaymentSheet.GooglePayConfiguration.Environment?) -> Boolean,
     private val workContext: CoroutineContext
 ) : FlowControllerInitializer {
@@ -34,10 +33,9 @@ internal class DefaultFlowControllerInitializer(
         this@DefaultFlowControllerInitializer.stripeIntentRepository = stripeIntentRepository
         this@DefaultFlowControllerInitializer.paymentMethodsRepository = paymentMethodsRepository
 
-        val isGooglePayReady =
-            clientSecret is PaymentIntentClientSecret && paymentSheetConfiguration?.let {
-                isGooglePayReadySupplier(it.googlePay?.environment)
-            } ?: false
+        val isGooglePayReady = paymentSheetConfiguration?.let {
+            isGooglePayReadySupplier(it.googlePay?.environment)
+        } ?: false
         paymentSheetConfiguration?.customer?.let { customerConfig ->
             createWithCustomer(
                 clientSecret,
@@ -59,8 +57,7 @@ internal class DefaultFlowControllerInitializer(
         isGooglePayReady: Boolean
     ): FlowControllerInitializer.InitResult {
         val prefsRepository = prefsRepositoryFactory(
-            customerConfig.id,
-            isGooglePayReady
+            customerConfig.id
         )
 
         return runCatching {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -57,7 +57,6 @@ internal class FlowControllerModule {
                 DefaultPrefsRepository(
                     appContext,
                     customerId,
-                    { isGooglePayReady },
                     Dispatchers.IO
                 )
             },

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -53,7 +53,7 @@ internal class FlowControllerModule {
     fun provideFlowControllerInitializer(appContext: Context): FlowControllerInitializer {
         return DefaultFlowControllerInitializer(
             prefsRepositoryFactory =
-            { customerId: String, isGooglePayReady: Boolean ->
+            { customerId: String ->
                 DefaultPrefsRepository(
                     appContext,
                     customerId,

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -117,14 +117,12 @@ internal abstract class PaymentSheetViewModelModule {
         fun providePrefsRepository(
             appContext: Context,
             starterArgs: PaymentSheetContract.Args,
-            googlePayRepository: GooglePayRepository,
             @IOContext workContext: CoroutineContext
         ): PrefsRepository {
             return starterArgs.config?.customer?.let { (id) ->
                 DefaultPrefsRepository(
                     appContext,
                     customerId = id,
-                    isGooglePayReady = { googlePayRepository.isReady().first() },
                     workContext = workContext
                 )
             } ?: PrefsRepository.Noop()

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -24,7 +24,6 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -105,7 +105,12 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         get() = customerConfig != null && stripeIntent.value is PaymentIntent
 
     init {
-        fetchSavedSelection()
+        viewModelScope.launch {
+            val savedSelection = withContext(workContext) {
+                prefsRepository.getSavedSelection(isGooglePayReady.asFlow().first())
+            }
+            _savedSelection.value = savedSelection
+        }
     }
 
     val fragmentConfig = MediatorLiveData<FragmentConfig?>().also { configLiveData ->
@@ -176,15 +181,6 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     fun updateSelection(selection: PaymentSelection?) {
         _selection.value = selection
-    }
-
-    private fun fetchSavedSelection() {
-        viewModelScope.launch {
-            val savedSelection = withContext(workContext) {
-                prefsRepository.getSavedSelection(isGooglePayReady.asFlow().first())
-            }
-            _savedSelection.value = savedSelection
-        }
     }
 
     abstract fun onUserCancel()

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
@@ -24,6 +25,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.paymentdatacollection.CardDataCollectionFragment
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.TestOnly
@@ -179,7 +181,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     private fun fetchSavedSelection() {
         viewModelScope.launch {
             val savedSelection = withContext(workContext) {
-                prefsRepository.getSavedSelection()
+                prefsRepository.getSavedSelection(isGooglePayReady.asFlow().first())
             }
             _savedSelection.value = savedSelection
         }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
@@ -22,7 +22,6 @@ internal class DefaultPrefsRepositoryTest {
     private val prefsRepository = DefaultPrefsRepository(
         ApplicationProvider.getApplicationContext(),
         "cus_123",
-        { isGooglePayReady },
         testDispatcher
     )
 
@@ -37,7 +36,7 @@ internal class DefaultPrefsRepositoryTest {
             PaymentSelection.GooglePay
         )
         assertThat(
-            prefsRepository.getSavedSelection()
+            prefsRepository.getSavedSelection(isGooglePayReady)
         ).isEqualTo(
             SavedSelection.GooglePay
         )
@@ -52,7 +51,7 @@ internal class DefaultPrefsRepositoryTest {
                 PaymentSelection.GooglePay
             )
             assertThat(
-                prefsRepository.getSavedSelection()
+                prefsRepository.getSavedSelection(isGooglePayReady)
             ).isEqualTo(
                 SavedSelection.None
             )
@@ -66,7 +65,7 @@ internal class DefaultPrefsRepositoryTest {
             )
         )
         assertThat(
-            prefsRepository.getSavedSelection()
+            prefsRepository.getSavedSelection(isGooglePayReady)
         ).isEqualTo(
             SavedSelection.PaymentMethod(
                 id = "pm_123456789"

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -8,7 +8,8 @@ internal class FakePrefsRepository : PrefsRepository {
 
     private var savedSelection: SavedSelection = SavedSelection.None
 
-    override suspend fun getSavedSelection(): SavedSelection = savedSelection
+    override suspend fun getSavedSelection(isGooglePayAvailable: Boolean): SavedSelection =
+        savedSelection
 
     override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
         paymentSelectionArgs.add(paymentSelection)

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -97,7 +97,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION)
 
-            assertThat(prefsRepository.getSavedSelection())
+            assertThat(prefsRepository.getSavedSelection(true))
                 .isEqualTo(SavedSelection.None)
         }
 

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -383,7 +383,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(prefsRepository.paymentSelectionArgs)
                 .containsExactly(selection)
-            assertThat(prefsRepository.getSavedSelection())
+            assertThat(prefsRepository.getSavedSelection(true))
                 .isEqualTo(
                     SavedSelection.PaymentMethod(selection.paymentMethod.id.orEmpty())
                 )
@@ -435,7 +435,7 @@ internal class PaymentSheetViewModelTest {
                         PAYMENT_INTENT_RESULT_WITH_PM.intent.paymentMethod!!
                     )
                 )
-            assertThat(prefsRepository.getSavedSelection())
+            assertThat(prefsRepository.getSavedSelection(true))
                 .isEqualTo(
                     SavedSelection.PaymentMethod(
                         PAYMENT_INTENT_RESULT_WITH_PM.intent.paymentMethod!!.id!!

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializerTest.kt
@@ -192,11 +192,12 @@ internal class DefaultFlowControllerInitializerTest {
                 )
             )
 
-            assertThat(prefsRepository.getSavedSelection()).isEqualTo(
-                SavedSelection.PaymentMethod(
-                    id = "pm_123456789"
+            assertThat(prefsRepository.getSavedSelection(true))
+                .isEqualTo(
+                    SavedSelection.PaymentMethod(
+                        id = "pm_123456789"
+                    )
                 )
-            )
         }
 
     @Test
@@ -228,7 +229,8 @@ internal class DefaultFlowControllerInitializerTest {
                 )
             )
 
-            assertThat(prefsRepository.getSavedSelection()).isEqualTo(SavedSelection.None)
+            assertThat(prefsRepository.getSavedSelection(true))
+                .isEqualTo(SavedSelection.None)
         }
 
     @Test
@@ -258,7 +260,8 @@ internal class DefaultFlowControllerInitializerTest {
                 )
             )
 
-            assertThat(prefsRepository.getSavedSelection()).isEqualTo(SavedSelection.GooglePay)
+            assertThat(prefsRepository.getSavedSelection(true))
+                .isEqualTo(SavedSelection.GooglePay)
         }
 
     @Test
@@ -347,7 +350,7 @@ internal class DefaultFlowControllerInitializerTest {
         isGooglePayReady: Boolean = true
     ): FlowControllerInitializer {
         return DefaultFlowControllerInitializer(
-            { _, _ -> prefsRepository },
+            { _ -> prefsRepository },
             { isGooglePayReady },
             testDispatcher
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `PrefsRepository` to receive a boolean indicating whether Google Pay is available in `getSavedSelection`, instead of receiving `isGooglePayReady: suspend () -> Boolean` as constructor parameter.
The callers know if Google Pay is available when they call `getSavedSelection` and not during instantiation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Remove dependency on `GooglePayRepository`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified