### PR TITLE
Inject `PaymentOptionsViewModel`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4901,6 +4901,16 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCal
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
 }
 
+public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public static fun injectEventReporter (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lcom/stripe/android/paymentsheet/analytics/EventReporter;)V
+	public fun injectMembers (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectPrefsRepositoryFactory (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lkotlin/jvm/functions/Function1;)V
+	public static fun injectWorkContext (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lkotlin/coroutines/CoroutineContext;)V
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet {
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)V
@@ -5111,6 +5121,7 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 public final class com/stripe/android/paymentsheet/injection/DaggerFlowControllerComponent : com/stripe/android/paymentsheet/injection/FlowControllerComponent {
 	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/FlowControllerComponent$Builder;
 	public fun getFlowController ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+	public fun inject (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;)V
 }
 
 public final class com/stripe/android/paymentsheet/injection/DaggerPaymentSheetViewModelComponent : com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.ColorInt
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -34,7 +35,8 @@ internal class PaymentOptionContract :
         val config: PaymentSheet.Configuration?,
         val isGooglePayReady: Boolean,
         val newCard: PaymentSelection.New.Card?,
-        @ColorInt val statusBarColor: Int?
+        @ColorInt val statusBarColor: Int?,
+        @InjectorKey val injectorKey: Int
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
@@ -5,8 +5,10 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.googlepaylauncher.GooglePayLauncherModule
+import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.payments.core.injection.PaymentCommonModule
 import com.stripe.android.paymentsheet.PaymentOptionCallback
+import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
@@ -26,6 +28,8 @@ import javax.inject.Singleton
 )
 internal interface FlowControllerComponent {
     val flowController: DefaultFlowController
+
+    fun inject(paymentOptionsViewModel: PaymentOptionsViewModel.Factory)
 
     @Component.Builder
     interface Builder {
@@ -58,6 +62,9 @@ internal interface FlowControllerComponent {
 
         @BindsInstance
         fun paymentResultCallback(paymentResultCallback: PaymentSheetResultCallback): Builder
+
+        @BindsInstance
+        fun injectorKey(@InjectorKey injectorKey: Int): Builder
 
         fun build(): FlowControllerComponent
     }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -302,7 +302,8 @@ class PaymentOptionsActivityTest {
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
             newCard = null,
-            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
+            injectorKey = 0
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -10,19 +10,43 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.databinding.FragmentPaymentsheetAddPaymentMethodBinding
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.WeakSetInjectorRegistry
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class PaymentOptionsAddPaymentMethodFragmentTest {
     private val eventReporter = mock<EventReporter>()
+
+    private val testInjector: Injector = object : Injector {
+        private var injectorKey: Int? = null
+
+        override fun inject(injectable: Injectable) {
+            val factory = (injectable as PaymentOptionsViewModel.Factory)
+            factory.eventReporter = eventReporter
+            factory.workContext = TestCoroutineDispatcher()
+            factory.prefsRepositoryFactory = { mock() }
+        }
+
+        override fun getInjectorKey() = injectorKey
+
+        override fun setInjectorKey(injectorKey: Int) {
+            this.injectorKey = injectorKey
+        }
+    }
 
     @Before
     fun setup() {
@@ -30,6 +54,12 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
+        WeakSetInjectorRegistry.register(testInjector, MOCK_INJECTOR_KEY)
+    }
+
+    @After
+    fun cleanUp() {
+        WeakSetInjectorRegistry.staticCacheSet.clear()
     }
 
     @Test
@@ -47,7 +77,8 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
             config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
             newCard = null,
-            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
+            injectorKey = MOCK_INJECTOR_KEY
         ),
         fragmentConfig: FragmentConfig? = FragmentConfigFixtures.DEFAULT,
         onReady: (PaymentOptionsAddPaymentMethodFragment, FragmentPaymentsheetAddPaymentMethodBinding) -> Unit
@@ -67,5 +98,9 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
                 )
             )
         }
+    }
+
+    companion object {
+        private const val MOCK_INJECTOR_KEY = 0
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -227,7 +227,8 @@ internal class PaymentOptionsViewModelTest {
             config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             isGooglePayReady = true,
             newCard = null,
-            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
+            statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
+            injectorKey = 0
         )
         private val PAYMENT_METHOD_REPOSITORY_PARAMS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)

--- a/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -264,7 +264,8 @@ internal class DefaultFlowControllerTest {
                     statusBarColor = ContextCompat.getColor(
                         activity,
                         R.color.stripe_toolbar_color_default_dark
-                    )
+                    ),
+                    injectorKey = INJECTOR_KEY
                 )
             }
 
@@ -775,7 +776,9 @@ internal class DefaultFlowControllerTest {
         paymentController,
         { PaymentConfiguration.getInstance(activity) },
         { flowResultProcessor }
-    )
+    ).also {
+        it.setInjectorKey(0)
+    }
 
     private class FakeFlowControllerInitializer(
         var paymentMethods: List<PaymentMethod>,
@@ -843,5 +846,7 @@ internal class DefaultFlowControllerTest {
         )
         private val PAYMENT_METHODS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD) + PaymentMethodFixtures.createCards(5)
+
+        private val INJECTOR_KEY = 0
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Register `DefaultFlowController` as a `Injector` in `WeakMapInjectorRegistry`, retrieve it from `PaymentOptionsViewModel.Factory` and inject it

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`PaymentOptionsViewModel` is started after `DefaultFlowController` is created. This change makes it able to share the object graph created by `DefaultFlowController`.

Please see details in [this section](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BP2CsGCMZVHSCqIfI~Z8Yd4oAg-Y8OUkag2eU9iPwUhUaVKU#:h2=How-about-Activity/ViewModel-?) of the internal doc.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
