### PR TITLE
Revert "Update PaymentBrowserAuthContract logic"

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -16,6 +16,7 @@ internal interface PaymentBrowserAuthStarter :
     AuthActivityStarter<PaymentBrowserAuthContract.Args> {
     class Legacy(
         private val host: AuthActivityStarterHost,
+        private val hasCompatibleBrowser: Boolean,
         private val defaultReturnUrl: DefaultReturnUrl
     ) : PaymentBrowserAuthStarter {
         override fun start(args: PaymentBrowserAuthContract.Args) {
@@ -23,8 +24,11 @@ internal interface PaymentBrowserAuthStarter :
                 .copy(statusBarColor = host.statusBarColor)
                 .toBundle()
 
+            val shouldUseBrowser =
+                hasCompatibleBrowser && args.hasDefaultReturnUrl(defaultReturnUrl)
+
             host.startActivityForResult(
-                when (args.hasDefaultReturnUrl(defaultReturnUrl)) {
+                when (shouldUseBrowser) {
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -28,6 +28,8 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAlipayRepository
 import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.BrowserCapabilities
+import com.stripe.android.payments.BrowserCapabilitiesSupplier
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowFailureMessageFactory
 import com.stripe.android.payments.PaymentFlowResult
@@ -79,6 +81,10 @@ internal class StripePaymentController internal constructor(
 
     private val defaultReturnUrl = DefaultReturnUrl.create(context)
 
+    private val hasCompatibleBrowser: Boolean by lazy {
+        BrowserCapabilitiesSupplier(context).get() != BrowserCapabilities.Unknown
+    }
+
     /**
      * [paymentRelayLauncher] is mutable and might be updated during
      * through [registerLaunchersWithActivityResultCaller]
@@ -101,6 +107,7 @@ internal class StripePaymentController internal constructor(
             PaymentBrowserAuthStarter.Modern(it)
         } ?: PaymentBrowserAuthStarter.Legacy(
             host,
+            hasCompatibleBrowser,
             defaultReturnUrl
         )
     }
@@ -134,7 +141,7 @@ internal class StripePaymentController internal constructor(
             activityResultCallback
         )
         paymentBrowserAuthLauncher = activityResultCaller.registerForActivityResult(
-            PaymentBrowserAuthContract(),
+            PaymentBrowserAuthContract(defaultReturnUrl),
             activityResultCallback
         )
         authenticatorRegistry.onNewActivityResultCaller(

--- a/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
+import com.stripe.android.payments.BrowserCapabilities
+import com.stripe.android.payments.BrowserCapabilitiesSupplier
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.StripeBrowserLauncherActivity
@@ -17,15 +19,19 @@ import kotlinx.parcelize.Parcelize
  * An [ActivityResultContract] for completing payment authentication in a browser. This will
  * be handled in either [StripeBrowserLauncherActivity] or [PaymentAuthWebViewActivity].
  */
-internal class PaymentBrowserAuthContract :
-    ActivityResultContract<PaymentBrowserAuthContract.Args, PaymentFlowResult.Unvalidated>() {
+internal class PaymentBrowserAuthContract(
+    private val defaultReturnUrl: DefaultReturnUrl,
+    private val hasCompatibleBrowser: (Context) -> Boolean = { context ->
+        BrowserCapabilitiesSupplier(context).get() != BrowserCapabilities.Unknown
+    }
+) : ActivityResultContract<PaymentBrowserAuthContract.Args, PaymentFlowResult.Unvalidated>() {
 
     override fun createIntent(
         context: Context,
         input: Args
     ): Intent {
-        val defaultReturnUrl = DefaultReturnUrl.create(context)
-        val shouldUseBrowser = input.hasDefaultReturnUrl(defaultReturnUrl)
+        val shouldUseBrowser =
+            hasCompatibleBrowser(context) && input.hasDefaultReturnUrl(defaultReturnUrl)
 
         val statusBarColor = when (context) {
             is Activity -> context.window?.statusBarColor

--- a/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilities.kt
@@ -6,5 +6,6 @@ package com.stripe.android.payments
  */
 internal enum class BrowserCapabilities {
     CustomTabs,
+    Chrome,
     Unknown
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/BrowserCapabilitiesSupplier.kt
@@ -17,6 +17,7 @@ internal class BrowserCapabilitiesSupplier(
     fun get(): BrowserCapabilities {
         return when {
             isCustomTabsSupported() -> BrowserCapabilities.CustomTabs
+            isChromeInstalled() -> BrowserCapabilities.Chrome
             else -> BrowserCapabilities.Unknown
         }
     }
@@ -28,6 +29,13 @@ internal class BrowserCapabilitiesSupplier(
                 CHROME_PACKAGE,
                 NoopCustomTabsServiceConnection()
             )
+        }.getOrDefault(false)
+    }
+
+    private fun isChromeInstalled(): Boolean {
+        return runCatching {
+            context.packageManager.getPackageInfo(CHROME_PACKAGE, 0)
+            true
         }.getOrDefault(false)
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivity.kt
@@ -11,6 +11,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.databinding.Stripe3ds2TransactionLayoutBinding
 import com.stripe.android.exception.StripeException
+import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.transaction.ChallengeContract
 import com.stripe.android.stripe3ds2.transaction.ChallengeResult
@@ -92,7 +93,7 @@ internal class Stripe3ds2TransactionActivity : AppCompatActivity() {
         }
 
         val browserLauncher = registerForActivityResult(
-            PaymentBrowserAuthContract()
+            PaymentBrowserAuthContract(DefaultReturnUrl.create(applicationContext))
         ) {
             finishWithResult(it)
         }

--- a/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -34,6 +34,7 @@ class PaymentBrowserAuthStarterTest {
 
     private val legacyStarter = PaymentBrowserAuthStarter.Legacy(
         AuthActivityStarterHost.create(activity),
+        hasCompatibleBrowser = true,
         defaultReturnUrl
     )
 
@@ -78,6 +79,7 @@ class PaymentBrowserAuthStarterTest {
                 activity,
                 statusBarColor = Color.RED
             ),
+            hasCompatibleBrowser = true,
             defaultReturnUrl
         )
         legacyStarter.start(DATA)

--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.Test
 class PaymentBrowserAuthContractTest {
 
     private val defaultReturnUrl = DefaultReturnUrl(
-        "com.stripe.android.test"
+        "com.example.app"
     )
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
@@ -39,7 +39,10 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when has compatible browser and custom return_url should use PaymentAuthWebViewActivity`() {
-        val intent = PaymentBrowserAuthContract().createIntent(
+        val intent = PaymentBrowserAuthContract(
+            defaultReturnUrl,
+            hasCompatibleBrowser = { true }
+        ).createIntent(
             activity,
             ARGS.copy(
                 returnUrl = "myapp://custom"
@@ -52,7 +55,10 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when has compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
-        val intent = PaymentBrowserAuthContract().createIntent(
+        val intent = PaymentBrowserAuthContract(
+            defaultReturnUrl,
+            hasCompatibleBrowser = { true }
+        ).createIntent(
             activity,
             ARGS.copy(
                 returnUrl = defaultReturnUrl.value
@@ -65,7 +71,10 @@ class PaymentBrowserAuthContractTest {
 
     @Test
     fun `createIntent() when no compatible browser and default return_url should use StripeBrowserLauncherActivity`() {
-        val intent = PaymentBrowserAuthContract().createIntent(
+        val intent = PaymentBrowserAuthContract(
+            defaultReturnUrl,
+            hasCompatibleBrowser = { false }
+        ).createIntent(
             activity,
             ARGS.copy(
                 returnUrl = defaultReturnUrl.value
@@ -73,12 +82,15 @@ class PaymentBrowserAuthContractTest {
         )
 
         assertThat(intent.component?.className)
-            .isEqualTo(StripeBrowserLauncherActivity::class.java.name)
+            .isEqualTo(PaymentAuthWebViewActivity::class.java.name)
     }
 
     @Test
     fun `createIntent() should set statusBarColor from activity`() {
-        val intent = PaymentBrowserAuthContract().createIntent(
+        val intent = PaymentBrowserAuthContract(
+            defaultReturnUrl,
+            hasCompatibleBrowser = { false }
+        ).createIntent(
             activity,
             ARGS
         )

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.exception.StripeException
+import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -24,7 +25,10 @@ internal class PaymentAuthWebViewActivityTest {
     val rule = InstantTaskExecutorRule()
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val contract = PaymentBrowserAuthContract()
+    private val contract = PaymentBrowserAuthContract(
+        DefaultReturnUrl.create(context),
+        hasCompatibleBrowser = { true }
+    )
 
     @BeforeTest
     fun before() {


### PR DESCRIPTION
Reverts stripe/stripe-android#3930 and Fix #4087

Note: This issue is reproducible on pixel 5 with Chrome disabled and on an old Android emulator with the Browser app disabled. In both cases, `BrowserCapabilitiesSupplier(context).get() == BrowserCapabilities.Unknown`, if we still route the user to `StripeBrowserLauncherActivity` if there's no browser, then the following will happen

 # Screenshots
| Pixel 5(Android11) | Emulator(Android6) |
| ------------- | ------------- |
|![pixel5](https://user-images.githubusercontent.com/79880926/128579286-a5f09915-7aab-4893-b525-05c504009646.gif)| ![emulator](https://user-images.githubusercontent.com/79880926/128579113-fbbfdafc-07cb-4a73-ad5d-45767381e72c.gif) |

Reverting this change routes the logic to `PaymentAuthWebViewActivity`, which correctly opens the page.
