### PR TITLE
[PaymentLauncher] Add a new PaymentResult and pass in publishableKey

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -41,12 +41,16 @@ internal interface PaymentLauncher {
     companion object {
         fun create(
             activity: ComponentActivity,
-            callback: PaymentResultCallback
-        ) = PaymentLauncherFactory(activity, callback).create()
+            callback: PaymentResultCallback,
+            publishableKey: String,
+            stripeAccountId: String? = null
+        ) = PaymentLauncherFactory(activity, callback).create(publishableKey, stripeAccountId)
 
         fun create(
             fragment: Fragment,
-            callback: PaymentResultCallback
-        ) = PaymentLauncherFactory(fragment, callback).create()
+            callback: PaymentResultCallback,
+            publishableKey: String,
+            stripeAccountId: String? = null
+        ) = PaymentLauncherFactory(fragment, callback).create(publishableKey, stripeAccountId)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -41,16 +41,16 @@ internal interface PaymentLauncher {
     companion object {
         fun create(
             activity: ComponentActivity,
-            callback: PaymentResultCallback,
             publishableKey: String,
-            stripeAccountId: String? = null
+            stripeAccountId: String? = null,
+            callback: PaymentResultCallback
         ) = PaymentLauncherFactory(activity, callback).create(publishableKey, stripeAccountId)
 
         fun create(
             fragment: Fragment,
-            callback: PaymentResultCallback,
             publishableKey: String,
-            stripeAccountId: String? = null
+            stripeAccountId: String? = null,
+            callback: PaymentResultCallback
         ) = PaymentLauncherFactory(fragment, callback).create(publishableKey, stripeAccountId)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -18,14 +18,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
 
     private lateinit var launcherArgs: PaymentLauncherContract.Args
 
-    private val viewModel: PaymentLauncherViewModel by viewModels {
-        PaymentLauncherViewModel.Factory(
-            { applicationContext },
-            { AuthActivityStarterHost.create(this) },
-            { launcherArgs }
-        )
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val args = kotlin.runCatching {
@@ -37,7 +29,13 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
 
         launcherArgs = args
 
-        viewModel.registerFromActivity(this)
+        val viewModel: PaymentLauncherViewModel by viewModels {
+            PaymentLauncherViewModel.Factory(
+                { applicationContext },
+                { AuthActivityStarterHost.create(this) },
+                { launcherArgs }
+            )
+        }
 
         viewModel.paymentLauncherResult.observe(this, ::finishWithResult)
 
@@ -54,11 +52,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
                 }
             }
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        viewModel.unregisterFromActivity()
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -30,11 +30,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         launcherArgs = args
 
         val viewModel: PaymentLauncherViewModel by viewModels {
-            PaymentLauncherViewModel.Factory(
-                { applicationContext },
-                { AuthActivityStarterHost.create(this) },
-                { launcherArgs }
-            )
+            PaymentLauncherViewModel.Factory()
         }
 
         viewModel.paymentLauncherResult.observe(this, ::finishWithResult)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.launch
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -16,24 +16,26 @@ import kotlinx.coroutines.launch
  */
 internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
 
-    private lateinit var args: PaymentLauncherContract.Args
+    private lateinit var launcherArgs: PaymentLauncherContract.Args
 
     private val viewModel: PaymentLauncherViewModel by viewModels {
         PaymentLauncherViewModel.Factory(
             { applicationContext },
             { AuthActivityStarterHost.create(this) },
-            { args }
+            { launcherArgs }
         )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        args = kotlin.runCatching {
+        val args = kotlin.runCatching {
             requireNotNull(PaymentLauncherContract.Args.fromIntent(intent))
         }.getOrElse {
             finishWithResult(PaymentResult.Failed(it))
             return
         }
+
+        launcherArgs = args
 
         viewModel.registerFromActivity(this)
 
@@ -42,13 +44,13 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         lifecycleScope.launch {
             when (args) {
                 is PaymentLauncherContract.Args.IntentConfirmationArgs -> {
-                    viewModel.confirmStripeIntent((args as PaymentLauncherContract.Args.IntentConfirmationArgs).confirmStripeIntentParams)
+                    viewModel.confirmStripeIntent(args.confirmStripeIntentParams)
                 }
                 is PaymentLauncherContract.Args.PaymentIntentNextActionArgs -> {
-                    viewModel.handleNextActionForStripeIntent((args as PaymentLauncherContract.Args.PaymentIntentNextActionArgs).paymentIntentClientSecret)
+                    viewModel.handleNextActionForStripeIntent(args.paymentIntentClientSecret)
                 }
                 is PaymentLauncherContract.Args.SetupIntentNextActionArgs -> {
-                    viewModel.handleNextActionForStripeIntent((args as PaymentLauncherContract.Args.SetupIntentNextActionArgs).setupIntentClientSecret)
+                    viewModel.handleNextActionForStripeIntent(args.setupIntentClientSecret)
                 }
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -24,23 +24,32 @@ internal class PaymentLauncherContract :
         return PaymentResult.fromIntent(intent)
     }
 
-    sealed class Args : Parcelable {
+    sealed class Args(
+        open val publishableKey: String,
+        open val stripeAccountId: String? = null
+    ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
         @Parcelize
         data class IntentConfirmationArgs(
+            override val publishableKey: String,
+            override val stripeAccountId: String? = null,
             val confirmStripeIntentParams: ConfirmStripeIntentParams
-        ) : Args()
+        ) : Args(publishableKey, stripeAccountId)
 
         @Parcelize
         data class PaymentIntentNextActionArgs(
+            override val publishableKey: String,
+            override val stripeAccountId: String? = null,
             val paymentIntentClientSecret: String
-        ) : Args()
+        ) : Args(publishableKey, stripeAccountId)
 
         @Parcelize
         data class SetupIntentNextActionArgs(
+            override val publishableKey: String,
+            override val stripeAccountId: String? = null,
             val setupIntentClientSecret: String
-        ) : Args()
+        ) : Args(publishableKey, stripeAccountId)
 
         internal companion object {
             private const val EXTRA_ARGS = "extra_args"

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -13,11 +13,11 @@ internal class PaymentLauncherFactory(
 
     constructor(
         activity: ComponentActivity,
-        callback: PaymentLauncher.PaymentResultCallback
+        callback: PaymentLauncher.PaymentResultCallback,
     ) : this(
         activity.registerForActivityResult(
             PaymentLauncherContract(),
-            callback::onPaymentResult
+            callback::onPaymentResult,
         )
     )
 
@@ -31,5 +31,8 @@ internal class PaymentLauncherFactory(
         )
     )
 
-    fun create(): PaymentLauncher = StripePaymentLauncher(hostActivityLauncher)
+    fun create(
+        publishableKey: String,
+        stripeAccountId: String? = null
+    ): PaymentLauncher = StripePaymentLauncher(hostActivityLauncher, publishableKey, stripeAccountId)
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,30 +1,81 @@
 package com.stripe.android.payments.paymentlauncher
 
+import android.content.Context
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.exception.APIException
 import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.view.AuthActivityStarterHost
 
 /**
  * WIP - view model for PaymentLauncherHostActivity
  */
+
 internal class PaymentLauncherViewModel : ViewModel() {
+    internal lateinit var paymentBrowserAuthLauncher:
+        ActivityResultLauncher<PaymentBrowserAuthContract.Args>
+
+    /**
+     * [PaymentResult] live data to be observed.
+     */
+    internal val paymentLauncherResult = MutableLiveData<PaymentResult>()
+
+    /**
+     * Register for [ActivityResultCaller] when it's available.
+     */
+    internal fun registerFromActivity(activityResultCaller: ActivityResultCaller) {}
+
+    /**
+     * Unregister any [ActivityResultCaller] hosted.
+     */
+    internal fun unregisterFromActivity() {}
 
     /**
      * Confirms a payment intent or setup intent
      */
-    fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {}
+    internal fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {}
 
     /**
-     * Fetches a payment intent and handles its next action.
+     * Fetches a [StripeIntent] and handles its next action.
      */
-    fun handleNextActionForPaymentIntent(clientSecret: String) {}
+    internal fun handleNextActionForStripeIntent(clientSecret: String) {}
 
     /**
-     * Fetches a setup intent and handles its next action.
+     * Parse [StripeIntentResult] into [PaymentResult].
      */
-    fun handleNextActionForSetupIntent(clientSecret: String) {}
+    private fun postResult(stripeIntentResult: StripeIntentResult<StripeIntent>) {
+        when (stripeIntentResult.outcome) {
+            StripeIntentResult.Outcome.SUCCEEDED -> {
+                paymentLauncherResult.postValue(PaymentResult.Completed)
+            }
+            StripeIntentResult.Outcome.FAILED -> {
+                paymentLauncherResult.postValue(
+                    PaymentResult.Failed(
+                        APIException(message = stripeIntentResult.failureMessage)
+                    )
+                )
+            }
+            StripeIntentResult.Outcome.CANCELED -> {
+                paymentLauncherResult.postValue(PaymentResult.Canceled)
+            }
+            StripeIntentResult.Outcome.TIMEDOUT -> {
+                paymentLauncherResult.postValue(PaymentResult.TimedOut)
+            }
+        }
+    }
 
-    internal class Factory : ViewModelProvider.Factory {
+    internal class Factory(
+        private val contextSupplier: () -> Context,
+        private val authHostSupplier: () -> AuthActivityStarterHost,
+        private val argsProvider: () -> PaymentLauncherContract.Args
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return PaymentLauncherViewModel() as T
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -2,12 +2,10 @@ package com.stripe.android.payments.paymentlauncher
 
 import android.content.Context
 import androidx.activity.result.ActivityResultCaller
-import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.StripeIntentResult
-import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.exception.APIException
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.StripeIntent
@@ -18,9 +16,6 @@ import com.stripe.android.view.AuthActivityStarterHost
  */
 
 internal class PaymentLauncherViewModel : ViewModel() {
-    internal lateinit var paymentBrowserAuthLauncher:
-        ActivityResultLauncher<PaymentBrowserAuthContract.Args>
-
     /**
      * [PaymentResult] live data to be observed.
      */

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -65,7 +65,9 @@ internal class PaymentLauncherViewModel : ViewModel() {
                 paymentLauncherResult.postValue(PaymentResult.Canceled)
             }
             StripeIntentResult.Outcome.TIMEDOUT -> {
-                paymentLauncherResult.postValue(PaymentResult.TimedOut)
+                PaymentResult.Failed(
+                    APIException(message = TIMEDOUT_ERROR + stripeIntentResult.failureMessage)
+                )
             }
         }
     }
@@ -79,5 +81,9 @@ internal class PaymentLauncherViewModel : ViewModel() {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return PaymentLauncherViewModel() as T
         }
+    }
+
+    companion object {
+        const val TIMEDOUT_ERROR = "Payment fails due to time out. \n"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.payments.paymentlauncher
 
 import android.content.Context
-import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -20,16 +19,6 @@ internal class PaymentLauncherViewModel : ViewModel() {
      * [PaymentResult] live data to be observed.
      */
     internal val paymentLauncherResult = MutableLiveData<PaymentResult>()
-
-    /**
-     * Register for [ActivityResultCaller] when it's available.
-     */
-    internal fun registerFromActivity(activityResultCaller: ActivityResultCaller) {}
-
-    /**
-     * Unregister any [ActivityResultCaller] hosted.
-     */
-    internal fun unregisterFromActivity() {}
 
     /**
      * Confirms a payment intent or setup intent
@@ -61,7 +50,7 @@ internal class PaymentLauncherViewModel : ViewModel() {
             }
             StripeIntentResult.Outcome.TIMEDOUT -> {
                 PaymentResult.Failed(
-                    APIException(message = TIMEDOUT_ERROR + stripeIntentResult.failureMessage)
+                    APIException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
                 )
             }
         }
@@ -79,6 +68,6 @@ internal class PaymentLauncherViewModel : ViewModel() {
     }
 
     companion object {
-        const val TIMEDOUT_ERROR = "Payment fails due to time out. \n"
+        const val TIMEOUT_ERROR = "Payment fails due to time out. \n"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.payments.paymentlauncher
 
-import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -8,7 +7,6 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIException
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.view.AuthActivityStarterHost
 
 /**
  * WIP - view model for PaymentLauncherHostActivity
@@ -56,11 +54,7 @@ internal class PaymentLauncherViewModel : ViewModel() {
         }
     }
 
-    internal class Factory(
-        private val contextSupplier: () -> Context,
-        private val authHostSupplier: () -> AuthActivityStarterHost,
-        private val argsProvider: () -> PaymentLauncherContract.Args
-    ) : ViewModelProvider.Factory {
+    internal class Factory() : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return PaymentLauncherViewModel() as T

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
@@ -18,9 +18,6 @@ internal sealed class PaymentResult : Parcelable {
     @Parcelize
     object Canceled : PaymentResult()
 
-    @Parcelize
-    object TimedOut : PaymentResult()
-
     @JvmSynthetic
     fun toBundle() = bundleOf(EXTRA to this)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
@@ -18,6 +18,9 @@ internal sealed class PaymentResult : Parcelable {
     @Parcelize
     object Canceled : PaymentResult()
 
+    @Parcelize
+    object TimedOut : PaymentResult()
+
     @JvmSynthetic
     fun toBundle() = bundleOf(EXTRA to this)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -10,46 +10,44 @@ import com.stripe.android.model.ConfirmSetupIntentParams
  */
 internal class StripePaymentLauncher internal constructor(
     private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
+    private val publishableKey: String,
+    private val stripeAccountId: String? = null
 ) : PaymentLauncher {
     override fun confirm(params: ConfirmPaymentIntentParams) {
-        // start a new activity to
-        // confirm the intent with stripeRepository
-        // resolve the nextActionData with authenticatorRegistry
-        // report result to callback
         hostActivityLauncher.launch(
-            PaymentLauncherContract.Args.IntentConfirmationArgs(params)
+            PaymentLauncherContract.Args.IntentConfirmationArgs(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
+                confirmStripeIntentParams = params
+            )
         )
     }
 
     override fun confirm(params: ConfirmSetupIntentParams) {
-        // start a new activity to
-        // confirm the intent with stripeRepository
-        // resolve the nextActionData with authenticatorRegistry
-        // report result to callback
         hostActivityLauncher.launch(
-            PaymentLauncherContract.Args.IntentConfirmationArgs(params)
+            PaymentLauncherContract.Args.IntentConfirmationArgs(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
+                confirmStripeIntentParams = params
+            )
         )
     }
 
     override fun handleNextActionForPaymentIntent(clientSecret: String) {
-        // start a new activity to
-        // fetch the intent with stripeRepository
-        // resolve the nextActionData with authenticatorRegistry
-        // report result to callback
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 paymentIntentClientSecret = clientSecret
             )
         )
     }
 
     override fun handleNextActionForSetupIntent(clientSecret: String) {
-        // start a new activity to
-        // fetch the intent with stripeRepository
-        // resolve the nextActionData with authenticatorRegistry
-        // report result to callback
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 setupIntentClientSecret = clientSecret
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Please see details in [this](https://paper.dropbox.com/doc/2021-05-28-Android-SDK-PaymentLauncher-API--BOKj_IBRZBCk_6VJY3T1PcTQAg-eWPQ4N7Qzb77yvqiO23j2) internal doc.

* Map `PaymentResult.Failed` to [Outcome.TimedOut](https://github.com/stripe/stripe-android/blob/e0367eb48bc63928947095223ee175c92b09c799/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt#L86)
* Added `publishableKey` key and `stripeAccount` to the constructor, like what we did in [Stripe](https://github.com/stripe/stripe-android/blob/c7cb71f922e2bc19e1483dcc1df9400f9ecb0aa2/payments-core/src/main/java/com/stripe/android/Stripe.kt#L67)
* Fully Implemented `PaymentLauncherConfirmationActivity`
* Partially implemented `PaymentLauncherViewModel`, will fully implement it with tests in a follow up


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Modern Stripe API to confirm an `PaymentIntent` / `SetupIntent` and handles their next actions without the need for the client to capture the result in `Activity.onActivityResult`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
