### PR TITLE
Move `ActivityResultLauncher`s into `DefaultPaymentAuthenticatorRegistry`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4838,6 +4838,30 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Stri
 	public static fun injectWorkContext (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lkotlin/coroutines/CoroutineContext;)V
 }
 
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvideDefaultReturnUrlFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvideDefaultReturnUrlFactory;
+	public fun get ()Lcom/stripe/android/payments/DefaultReturnUrl;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideDefaultReturnUrl (Landroid/content/Context;)Lcom/stripe/android/payments/DefaultReturnUrl;
+}
+
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvidePaymentBrowserAuthStarterFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvidePaymentBrowserAuthStarterFactoryFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/jvm/functions/Function1;
+	public static fun providePaymentBrowserAuthStarterFactory (Ldagger/Lazy;Lcom/stripe/android/payments/DefaultReturnUrl;)Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvidePaymentRelayStarterFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvidePaymentRelayStarterFactoryFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/jvm/functions/Function1;
+	public static fun providePaymentRelayStarterFactory (Ldagger/Lazy;)Lkotlin/jvm/functions/Function1;
+}
+
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry;

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -54,14 +54,13 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     lateinit var authenticationComponent: AuthenticationComponent
 
     /**
-     * [paymentRelayLauncher] is mutable and might be updated during
-     * through [onNewActivityResultCaller]
+     * [paymentRelayLauncher] is mutable and might be updated through [onNewActivityResultCaller]
      */
     internal var paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>? = null
 
     /**
-     * [paymentBrowserAuthLauncher] is mutable and might be updated during
-     * through [onNewActivityResultCaller]
+     * [paymentBrowserAuthLauncher] is mutable and might be updated through
+     * [onNewActivityResultCaller]
      */
     internal var paymentBrowserAuthLauncher: ActivityResultLauncher<PaymentBrowserAuthContract.Args>? =
         null

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -4,9 +4,12 @@ import android.app.Activity
 import android.content.Context
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
-import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.PaymentRelayContract
 import com.stripe.android.PaymentRelayStarter
+import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.AnalyticsRequestExecutor
@@ -21,7 +24,6 @@ import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.payments.core.injection.IntentAuthenticatorMap
 import com.stripe.android.payments.core.injection.WeakSetInjectorRegistry
-import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -37,12 +39,30 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
         Map<Class<out StripeIntent.NextActionData>,
             @JvmSuppressWildcards PaymentAuthenticator<StripeIntent>>
 ) : PaymentAuthenticatorRegistry, Injector {
+    @VisibleForTesting
+    internal val allAuthenticators = setOf(
+        listOf(noOpIntentAuthenticator, sourceAuthenticator),
+        paymentAuthenticatorMap.values
+    ).flatten()
 
     /**
      * [AuthenticationComponent] instance is hold to inject into [Activity]s and [ViewModel]s
      * started by the [PaymentAuthenticator]s.
      */
     lateinit var authenticationComponent: AuthenticationComponent
+
+    /**
+     * [paymentRelayLauncher] is mutable and might be updated during
+     * through [onNewActivityResultCaller]
+     */
+    internal var paymentRelayLauncher: ActivityResultLauncher<PaymentRelayStarter.Args>? = null
+
+    /**
+     * [paymentBrowserAuthLauncher] is mutable and might be updated during
+     * through [onNewActivityResultCaller]
+     */
+    internal var paymentBrowserAuthLauncher: ActivityResultLauncher<PaymentBrowserAuthContract.Args>? =
+        null
 
     @InjectorKey
     private var injectorKey: Int? = null
@@ -78,15 +98,27 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
         activityResultCaller: ActivityResultCaller,
         activityResultCallback: ActivityResultCallback<PaymentFlowResult.Unvalidated>
     ) {
-        paymentAuthenticatorMap.values.forEach {
+        allAuthenticators.forEach {
             it.onNewActivityResultCaller(activityResultCaller, activityResultCallback)
         }
+        paymentRelayLauncher = activityResultCaller.registerForActivityResult(
+            PaymentRelayContract(),
+            activityResultCallback
+        )
+        paymentBrowserAuthLauncher = activityResultCaller.registerForActivityResult(
+            PaymentBrowserAuthContract(),
+            activityResultCallback
+        )
     }
 
     override fun onLauncherInvalidated() {
-        paymentAuthenticatorMap.values.forEach {
+        allAuthenticators.forEach {
             it.onLauncherInvalidated()
         }
+        paymentRelayLauncher?.unregister()
+        paymentBrowserAuthLauncher?.unregister()
+        paymentRelayLauncher = null
+        paymentBrowserAuthLauncher = null
     }
 
     override fun inject(injectable: Injectable) {
@@ -102,7 +134,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     }
 
     companion object {
-
         /**
          * Create an instance of [PaymentAuthenticatorRegistry] with dagger and register it in the
          * static cache.
@@ -113,8 +144,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
         fun createInstance(
             context: Context,
             stripeRepository: StripeRepository,
-            paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
-            paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
             analyticsRequestExecutor: AnalyticsRequestExecutor,
             analyticsRequestFactory: AnalyticsRequestFactory,
             enableLogging: Boolean,
@@ -126,8 +155,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
             val component = DaggerAuthenticationComponent.builder()
                 .context(context)
                 .stripeRepository(stripeRepository)
-                .paymentRelayStarterFactory(paymentRelayStarterFactory)
-                .paymentBrowserAuthStarterFactory(paymentBrowserAuthStarterFactory)
                 .analyticsRequestExecutor(analyticsRequestExecutor)
                 .analyticsRequestFactory(analyticsRequestFactory)
                 .enableLogging(enableLogging)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -25,12 +25,14 @@ import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.payments.core.injection.IntentAuthenticatorMap
 import com.stripe.android.payments.core.injection.WeakSetInjectorRegistry
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
  * Default registry to provide look ups for [PaymentAuthenticator].
  * Should be only accessed through [DefaultPaymentAuthenticatorRegistry.createInstance].
  */
+@Singleton
 internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
     private val sourceAuthenticator: SourceAuthenticator,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -7,10 +7,12 @@ import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Need relayLauncher
 /**
  * [PaymentAuthenticator] implementation to perform no-op, just return to client's host.
  */
 @Singleton
+@JvmSuppressWildcards
 internal class NoOpIntentAuthenticator @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
 ) : PaymentAuthenticator<StripeIntent> {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -7,7 +7,6 @@ import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
 
-// Need relayLauncher
 /**
  * [PaymentAuthenticator] implementation to perform no-op, just return to client's host.
  */

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
@@ -18,8 +18,6 @@ import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
-// need relay and browser
-
 /**
  * [PaymentAuthenticator] implementation to authenticate [Source].
  */

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
@@ -18,10 +18,13 @@ import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
+// need relay and browser
+
 /**
  * [PaymentAuthenticator] implementation to authenticate [Source].
  */
 @Singleton
+@JvmSuppressWildcards
 internal class SourceAuthenticator @Inject constructor(
     private val paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -10,11 +10,14 @@ import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// need relay
+
 /**
  * [PaymentAuthenticator] to return if there is no available authenticators. Informs the correct
  * dependency to include for that authenticator.
  */
 @Singleton
+@JvmSuppressWildcards
 internal class UnsupportedAuthenticator @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
 ) : PaymentAuthenticator<StripeIntent> {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -10,8 +10,6 @@ import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
 
-// need relay
-
 /**
  * [PaymentAuthenticator] to return if there is no available authenticators. Informs the correct
  * dependency to include for that authenticator.

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -22,6 +22,7 @@ import kotlin.coroutines.CoroutineContext
  * [PaymentAuthenticator] implementation to redirect to a URL through [PaymentBrowserAuthStarter].
  */
 @Singleton
+@JvmSuppressWildcards
 internal class WebIntentAuthenticator @Inject constructor(
     private val paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -1,14 +1,11 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
-import com.stripe.android.PaymentBrowserAuthStarter
-import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
-import com.stripe.android.view.AuthActivityStarterHost
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -42,16 +39,6 @@ internal interface AuthenticationComponent {
 
         @BindsInstance
         fun stripeRepository(stripeRepository: StripeRepository): Builder
-
-        @BindsInstance
-        fun paymentRelayStarterFactory(
-            paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
-        ): Builder
-
-        @BindsInstance
-        fun paymentBrowserAuthStarterFactory(
-            paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter
-        ): Builder
 
         @BindsInstance
         fun analyticsRequestExecutor(analyticsRequestExecutor: AnalyticsRequestExecutor): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -1,40 +1,83 @@
 package com.stripe.android.payments.core.injection
 
+import android.content.Context
+import com.stripe.android.PaymentBrowserAuthStarter
+import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.authentication.OxxoAuthenticator
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
 import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
+import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Binds
+import dagger.Lazy
 import dagger.Module
+import dagger.Provides
 import dagger.multibindings.IntoMap
+import javax.inject.Singleton
 
 /**
  * Provides mappings between [NextActionData] and [PaymentAuthenticator] provided by payment SDK.
  */
 @Module
-internal interface AuthenticationModule {
+internal abstract class AuthenticationModule {
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS1::class)
-    fun binds3DS1Authenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
+    abstract fun binds3DS1Authenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.RedirectToUrl::class)
-    fun bindsRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
+    abstract fun bindsRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.AlipayRedirect::class)
-    fun bindsAlipayRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
+    abstract fun bindsAlipayRedirectAuthenticator(webIntentAuthenticator: WebIntentAuthenticator): PaymentAuthenticator<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.DisplayOxxoDetails::class)
-    fun bindsOxxoAuthenticator(oxxoAuthenticator: OxxoAuthenticator): PaymentAuthenticator<StripeIntent>
+    abstract fun bindsOxxoAuthenticator(oxxoAuthenticator: OxxoAuthenticator): PaymentAuthenticator<StripeIntent>
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideDefaultReturnUrl(
+            context: Context
+        ) = DefaultReturnUrl.create(context)
+
+        @Provides
+        @Singleton
+        fun providePaymentRelayStarterFactory(
+            lazyRegistry: Lazy<DefaultPaymentAuthenticatorRegistry>,
+        ): (AuthActivityStarterHost) -> PaymentRelayStarter =
+            { host: AuthActivityStarterHost ->
+                lazyRegistry.get().paymentRelayLauncher?.let {
+                    PaymentRelayStarter.Modern(it)
+                } ?: PaymentRelayStarter.Legacy(host)
+            }
+
+        @Provides
+        @Singleton
+        fun providePaymentBrowserAuthStarterFactory(
+            lazyRegistry: Lazy<DefaultPaymentAuthenticatorRegistry>,
+            defaultReturnUrl: DefaultReturnUrl
+        ): (AuthActivityStarterHost) -> PaymentBrowserAuthStarter =
+            { host: AuthActivityStarterHost ->
+                lazyRegistry.get().paymentBrowserAuthLauncher?.let {
+                    PaymentBrowserAuthStarter.Modern(it)
+                } ?: PaymentBrowserAuthStarter.Legacy(
+                    host,
+                    defaultReturnUrl
+                )
+            }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Host the `paymentRelayLauncher` and `paymentBrowserAuthLauncher ` inside `DefaultPaymentAuthenticatorRegistry` so that we don't need to pass them from outside.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This change decouples `DefaultPaymentAuthenticatorRegistry` from the launchers passed from outside, as we already have [ActivityResultLauncherHost#onNewActivityResultCaller](https://github.com/stripe/stripe-android/blob/bd34436c9e64ae60e0ef9a677ae6d0aa0da9cd7a/payments-core/src/main/java/com/stripe/android/payments/core/ActivityResultLauncherHost.kt#L26) to update them correctly.

This change is also a prerequisite for `PaymentLauncher`, which hosts an instance of `PaymentAuthenticatorRegistry`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
