### PR TITLE
[PaymentLauncher] final impl `PaymentLauncherViewModel`

### DIFF
--- a/payments-core/AndroidManifest.xml
+++ b/payments-core/AndroidManifest.xml
@@ -79,7 +79,7 @@
             android:exported="false" />
 
         <activity android:name=".payments.paymentlauncher.PaymentLauncherConfirmationActivity"
-            android:theme="@style/StripeDefaultTheme"
+            android:theme="@style/PayLauncherDefaultTheme"
             android:exported="false"/>
     </application>
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -8,6 +8,7 @@ public abstract interface class com/stripe/android/ApiResultCallback {
 }
 
 public final class com/stripe/android/AppInfo : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/AppInfo$Companion;
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/AppInfo;
@@ -39,6 +40,7 @@ public final class com/stripe/android/BuildConfig {
 }
 
 public final class com/stripe/android/CustomerSession {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/CustomerSession$Companion;
 	public final fun addCustomerSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/CustomerSession$SourceRetrievalListener;)V
 	public final fun attachPaymentMethod (Ljava/lang/String;Lcom/stripe/android/CustomerSession$PaymentMethodRetrievalListener;)V
@@ -91,6 +93,7 @@ public abstract interface class com/stripe/android/CustomerSession$SourceRetriev
 }
 
 public final class com/stripe/android/EphemeralKey : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;JJLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/EphemeralKey;
@@ -113,6 +116,7 @@ public abstract interface class com/stripe/android/EphemeralKeyUpdateListener {
 }
 
 public final class com/stripe/android/GooglePayConfig {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -121,6 +125,7 @@ public final class com/stripe/android/GooglePayConfig {
 }
 
 public final class com/stripe/android/GooglePayJsonFactory {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;Z)V
 	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/GooglePayConfig;Z)V
@@ -138,6 +143,7 @@ public final class com/stripe/android/GooglePayJsonFactory {
 }
 
 public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -161,6 +167,7 @@ public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParamet
 }
 
 public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -175,6 +182,7 @@ public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo : androi
 }
 
 public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParameters : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -191,6 +199,7 @@ public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParame
 }
 
 public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;)V
@@ -224,6 +233,7 @@ public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Total
 }
 
 public final class com/stripe/android/IssuingCardPinService {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/IssuingCardPinService$Companion;
 	public static final fun create (Landroid/content/Context;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
 	public static final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/stripe/android/EphemeralKeyProvider;)Lcom/stripe/android/IssuingCardPinService;
@@ -278,11 +288,13 @@ public final class com/stripe/android/Logger$DefaultImpls {
 }
 
 public final class com/stripe/android/PayWithGoogleUtils {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/PayWithGoogleUtils;
 	public static final fun getPriceString (ILjava/util/Currency;)Ljava/lang/String;
 }
 
 public final class com/stripe/android/PaymentAuthConfig {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/PaymentAuthConfig$Companion;
 	public synthetic fun <init> (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun get ()Lcom/stripe/android/PaymentAuthConfig;
@@ -290,6 +302,7 @@ public final class com/stripe/android/PaymentAuthConfig {
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -302,6 +315,7 @@ public final class com/stripe/android/PaymentAuthConfig$Companion {
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization {
+	public static final field $stable I
 	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/ButtonCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
 	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;Lcom/stripe/android/stripe3ds2/init/ui/ButtonCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
 	public fun equals (Ljava/lang/Object;)Z
@@ -310,6 +324,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomiz
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomization;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -321,6 +336,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ButtonCustomiz
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun copy (ILcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
 	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;ILcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
@@ -332,6 +348,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config : andro
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2Config;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -340,6 +357,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2Config$Builder
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization {
+	public static final field $stable I
 	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/LabelCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
 	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;Lcom/stripe/android/stripe3ds2/init/ui/LabelCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
 	public fun equals (Ljava/lang/Object;)Z
@@ -348,6 +366,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomiza
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomization;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -360,6 +379,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2LabelCustomiza
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization {
+	public static final field $stable I
 	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/TextBoxCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
 	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;Lcom/stripe/android/stripe3ds2/init/ui/TextBoxCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
 	public fun equals (Ljava/lang/Object;)Z
@@ -368,6 +388,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomi
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomization;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -380,6 +401,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2TextBoxCustomi
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization {
+	public static final field $stable I
 	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/ToolbarCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
 	public static synthetic fun copy$default (Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;Lcom/stripe/android/stripe3ds2/init/ui/ToolbarCustomization;ILjava/lang/Object;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
 	public fun equals (Ljava/lang/Object;)Z
@@ -388,6 +410,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomi
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomization;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -401,6 +424,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2ToolbarCustomi
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;
 	public final fun copy (Lcom/stripe/android/stripe3ds2/init/ui/StripeUiCustomization;)Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization;
@@ -414,6 +438,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomizatio
 }
 
 public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomization$Builder$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (Landroid/app/Activity;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -443,6 +468,7 @@ public final class com/stripe/android/PaymentAuthConfig$Stripe3ds2UiCustomizatio
 }
 
 public final class com/stripe/android/PaymentConfiguration : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/PaymentConfiguration$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -469,6 +495,7 @@ public final class com/stripe/android/PaymentConfiguration$Companion {
 }
 
 public final class com/stripe/android/PaymentIntentResult : com/stripe/android/StripeIntentResult {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
 	public final fun component3 ()Ljava/lang/String;
@@ -485,6 +512,7 @@ public final class com/stripe/android/PaymentIntentResult : com/stripe/android/S
 }
 
 public final class com/stripe/android/PaymentSession {
+	public static final field $stable I
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/PaymentSessionConfig;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/PaymentSessionConfig;)V
 	public final fun clearPaymentMethod ()V
@@ -504,6 +532,7 @@ public abstract interface class com/stripe/android/PaymentSession$PaymentSession
 }
 
 public final class com/stripe/android/PaymentSessionConfig : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Ljava/util/List;
@@ -540,6 +569,7 @@ public final class com/stripe/android/PaymentSessionConfig : android/os/Parcelab
 }
 
 public final class com/stripe/android/PaymentSessionConfig$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/PaymentSessionConfig;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -571,6 +601,7 @@ public abstract interface class com/stripe/android/PaymentSessionConfig$Shipping
 }
 
 public final class com/stripe/android/PaymentSessionData : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component3 ()J
 	public final fun component4 ()J
@@ -595,6 +626,7 @@ public final class com/stripe/android/PaymentSessionData : android/os/Parcelable
 }
 
 public final class com/stripe/android/SetupIntentResult : com/stripe/android/StripeIntentResult {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/SetupIntent;
 	public final fun component3 ()Ljava/lang/String;
@@ -611,6 +643,7 @@ public final class com/stripe/android/SetupIntentResult : com/stripe/android/Str
 }
 
 public final class com/stripe/android/Stripe {
+	public static final field $stable I
 	public static final field API_VERSION Ljava/lang/String;
 	public static final field Companion Lcom/stripe/android/Stripe$Companion;
 	public static final field VERSION Ljava/lang/String;
@@ -781,6 +814,7 @@ public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
 }
 
 public final class com/stripe/android/StripeError : com/stripe/android/model/StripeModel, java/io/Serializable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Ljava/lang/String;
@@ -807,6 +841,7 @@ public final class com/stripe/android/StripeError : com/stripe/android/model/Str
 }
 
 public abstract class com/stripe/android/StripeIntentResult : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public abstract fun getFailureMessage ()Ljava/lang/String;
 	public abstract fun getIntent ()Lcom/stripe/android/model/StripeIntent;
 	public final fun getOutcome ()I
@@ -869,21 +904,25 @@ public final class com/stripe/android/StripeKtxKt {
 }
 
 public final class com/stripe/android/exception/APIConnectionException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/exception/APIException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/exception/AuthenticationException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/exception/CardException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCharge ()Ljava/lang/String;
@@ -893,23 +932,27 @@ public final class com/stripe/android/exception/CardException : com/stripe/andro
 }
 
 public final class com/stripe/android/exception/InvalidRequestException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/exception/PermissionException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/exception/RateLimitException : com/stripe/android/exception/StripeException {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract class com/stripe/android/exception/StripeException : java/lang/Exception {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/exception/StripeException$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/StripeError;Ljava/lang/String;ILjava/lang/Throwable;Ljava/lang/String;)V
@@ -934,6 +977,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayEnvironment : j
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher {
+	public static final field $stable I
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;)V
 	public final fun presentForPaymentIntent (Ljava/lang/String;)V
@@ -941,6 +985,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher {
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -964,6 +1009,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Billin
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Config : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;Z)V
@@ -999,9 +1045,11 @@ public abstract interface class com/stripe/android/googlepaylauncher/GooglePayLa
 }
 
 public abstract class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result : android/os/Parcelable {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Canceled : com/stripe/android/googlepaylauncher/GooglePayLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Canceled;
 	public fun describeContents ()I
@@ -1009,6 +1057,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Completed : com/stripe/android/googlepaylauncher/GooglePayLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Completed;
 	public fun describeContents ()I
@@ -1016,6 +1065,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Failed : com/stripe/android/googlepaylauncher/GooglePayLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;)V
 	public final fun component1 ()Ljava/lang/Throwable;
@@ -1034,6 +1084,7 @@ public abstract interface class com/stripe/android/googlepaylauncher/GooglePayLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract : androidx/activity/result/contract/ActivityResultContract {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun createIntent (Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args;)Landroid/content/Intent;
 	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
@@ -1042,9 +1093,11 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 }
 
 public abstract class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args : android/os/Parcelable {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;)V
 	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
@@ -1057,6 +1110,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)V
 	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;
@@ -1069,6 +1123,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherModule {
+	public static final field $stable I
 	public fun <init> ()V
 	public final fun provideGooglePayRepositoryFactory (Landroid/content/Context;Lcom/stripe/android/Logger;)Lkotlin/jvm/functions/Function1;
 }
@@ -1082,6 +1137,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherModule_
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher {
+	public static final field $stable I
 	public static final field DEVELOPER_ERROR I
 	public static final field INTERNAL_ERROR I
 	public static final field NETWORK_ERROR I
@@ -1094,6 +1150,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -1123,6 +1180,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;Z)V
@@ -1161,9 +1219,11 @@ public abstract interface class com/stripe/android/googlepaylauncher/GooglePayPa
 }
 
 public abstract class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result : android/os/Parcelable {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Canceled : com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Canceled;
 	public fun describeContents ()I
@@ -1171,6 +1231,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Completed : com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/PaymentMethod;)V
 	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod;
@@ -1185,6 +1246,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Failed : com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;I)V
 	public final fun component1 ()Ljava/lang/Throwable;
@@ -1205,6 +1267,7 @@ public abstract interface class com/stripe/android/googlepaylauncher/GooglePayPa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract : androidx/activity/result/contract/ActivityResultContract {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun createIntent (Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract$Args;)Landroid/content/Intent;
 	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
@@ -1213,6 +1276,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract$Args : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Ljava/lang/String;I)V
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Ljava/lang/String;ILjava/lang/String;)V
@@ -1247,11 +1311,13 @@ public abstract interface class com/stripe/android/googlepaylauncher/GooglePayRe
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayRepository$Disabled : com/stripe/android/googlepaylauncher/GooglePayRepository {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/googlepaylauncher/GooglePayRepository$Disabled;
 	public fun isReady ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/stripe/android/model/AccountParams : com/stripe/android/model/TokenParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/AccountParams$Companion;
 	public final fun copy (ZLcom/stripe/android/model/AccountParams$BusinessTypeParams;)Lcom/stripe/android/model/AccountParams;
@@ -1277,12 +1343,14 @@ public final class com/stripe/android/model/AccountParams$BusinessType : java/la
 }
 
 public abstract class com/stripe/android/model/AccountParams$BusinessTypeParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun getParamsList ()Ljava/util/List;
 	public fun toParamMap ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company : com/stripe/android/model/AccountParams$BusinessTypeParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)V
@@ -1340,6 +1408,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -1360,6 +1429,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -1376,6 +1446,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)V
@@ -1394,6 +1465,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual : com/stripe/android/model/AccountParams$BusinessTypeParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)V
@@ -1463,6 +1535,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -1487,6 +1560,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -1503,6 +1577,7 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 }
 
 public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
@@ -1532,6 +1607,7 @@ public final class com/stripe/android/model/AccountParams$Companion {
 }
 
 public final class com/stripe/android/model/Address : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/Address$Companion;
 	public fun <init> ()V
@@ -1559,6 +1635,7 @@ public final class com/stripe/android/model/Address : com/stripe/android/model/S
 }
 
 public final class com/stripe/android/model/Address$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/Address;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -1575,6 +1652,7 @@ public final class com/stripe/android/model/Address$Companion {
 }
 
 public final class com/stripe/android/model/AddressJapanParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
@@ -1604,6 +1682,7 @@ public final class com/stripe/android/model/AddressJapanParams : android/os/Parc
 }
 
 public final class com/stripe/android/model/AddressJapanParams$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/AddressJapanParams;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -1617,6 +1696,7 @@ public final class com/stripe/android/model/AddressJapanParams$Builder : com/str
 }
 
 public final class com/stripe/android/model/BankAccount : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Ljava/lang/String;
@@ -1668,6 +1748,7 @@ public final class com/stripe/android/model/BankAccount$Type : java/lang/Enum {
 }
 
 public final class com/stripe/android/model/BankAccountTokenParams : com/stripe/android/model/TokenParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;)V
@@ -1692,11 +1773,13 @@ public final class com/stripe/android/model/BankAccountTokenParams$Type : java/l
 }
 
 public final class com/stripe/android/model/BankAccountTokenParamsFixtures {
+	public static final field $stable I
 	public static final field DEFAULT Lcom/stripe/android/model/BankAccountTokenParams;
 	public static final field INSTANCE Lcom/stripe/android/model/BankAccountTokenParamsFixtures;
 }
 
 public final class com/stripe/android/model/Card : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component10 ()Ljava/lang/String;
@@ -1787,6 +1870,7 @@ public final class com/stripe/android/model/CardFunding : java/lang/Enum {
 }
 
 public final class com/stripe/android/model/CardParams : com/stripe/android/model/TokenParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;II)V
 	public fun <init> (Ljava/lang/String;IILjava/lang/String;)V
@@ -1821,6 +1905,7 @@ public final class com/stripe/android/model/CardParams : com/stripe/android/mode
 }
 
 public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/stripe/android/model/ConfirmStripeIntentParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;
 	public final fun component1 ()Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -1933,6 +2018,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$SetupFutu
 }
 
 public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
@@ -1950,6 +2036,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping 
 }
 
 public final class com/stripe/android/model/ConfirmSetupIntentParams : com/stripe/android/model/ConfirmStripeIntentParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -2008,6 +2095,7 @@ public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion 
 }
 
 public final class com/stripe/android/model/Customer : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
@@ -2040,6 +2128,7 @@ public final class com/stripe/android/model/Customer : com/stripe/android/model/
 }
 
 public final class com/stripe/android/model/CustomerBankAccount : com/stripe/android/model/CustomerPaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/BankAccount;)V
 	public final fun component1 ()Lcom/stripe/android/model/BankAccount;
@@ -2056,6 +2145,7 @@ public final class com/stripe/android/model/CustomerBankAccount : com/stripe/and
 }
 
 public final class com/stripe/android/model/CustomerCard : com/stripe/android/model/CustomerPaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Card;)V
 	public final fun component1 ()Lcom/stripe/android/model/Card;
@@ -2072,11 +2162,13 @@ public final class com/stripe/android/model/CustomerCard : com/stripe/android/mo
 }
 
 public abstract class com/stripe/android/model/CustomerPaymentSource : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getTokenizationMethod ()Lcom/stripe/android/model/TokenizationMethod;
 }
 
 public final class com/stripe/android/model/CustomerSource : com/stripe/android/model/CustomerPaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Source;)V
 	public final fun component1 ()Lcom/stripe/android/model/Source;
@@ -2093,6 +2185,7 @@ public final class com/stripe/android/model/CustomerSource : com/stripe/android/
 }
 
 public final class com/stripe/android/model/CvcTokenParams : com/stripe/android/model/TokenParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/CvcTokenParams;
@@ -2106,6 +2199,7 @@ public final class com/stripe/android/model/CvcTokenParams : com/stripe/android/
 }
 
 public final class com/stripe/android/model/DateOfBirth : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (III)V
 	public final fun component1 ()I
@@ -2125,9 +2219,11 @@ public final class com/stripe/android/model/DateOfBirth : android/os/Parcelable,
 }
 
 public abstract class com/stripe/android/model/ExpirationDate {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/model/ExpirationDate$Validated : com/stripe/android/model/ExpirationDate {
+	public static final field $stable I
 	public fun <init> (II)V
 	public final fun component1 ()I
 	public final fun component2 ()I
@@ -2141,6 +2237,7 @@ public final class com/stripe/android/model/ExpirationDate$Validated : com/strip
 }
 
 public final class com/stripe/android/model/GooglePayResult : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/GooglePayResult$Companion;
 	public fun <init> ()V
@@ -2171,6 +2268,7 @@ public final class com/stripe/android/model/GooglePayResult$Companion {
 }
 
 public final class com/stripe/android/model/IssuingCardPin : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -2185,6 +2283,7 @@ public final class com/stripe/android/model/IssuingCardPin : com/stripe/android/
 }
 
 public final class com/stripe/android/model/KlarnaSourceParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;)V
@@ -2234,6 +2333,7 @@ public final class com/stripe/android/model/KlarnaSourceParams$CustomPaymentMeth
 }
 
 public final class com/stripe/android/model/KlarnaSourceParams$LineItem : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;I)V
 	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;)V
@@ -2264,6 +2364,7 @@ public final class com/stripe/android/model/KlarnaSourceParams$LineItem$Type : j
 }
 
 public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOptions : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;)V
@@ -2300,6 +2401,7 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 }
 
 public final class com/stripe/android/model/MandateDataParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/MandateDataParams$Type;)V
 	public final fun copy (Lcom/stripe/android/model/MandateDataParams$Type;)Lcom/stripe/android/model/MandateDataParams;
@@ -2313,10 +2415,12 @@ public final class com/stripe/android/model/MandateDataParams : android/os/Parce
 }
 
 public abstract class com/stripe/android/model/MandateDataParams$Type : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/model/MandateDataParams$Type$Online : com/stripe/android/model/MandateDataParams$Type {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -2331,6 +2435,7 @@ public final class com/stripe/android/model/MandateDataParams$Type$Online : com/
 }
 
 public final class com/stripe/android/model/PaymentIntent : com/stripe/android/model/StripeIntent {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentIntent$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -2417,6 +2522,7 @@ public final class com/stripe/android/model/PaymentIntent$ConfirmationMethod : j
 }
 
 public final class com/stripe/android/model/PaymentIntent$Error : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -2457,6 +2563,7 @@ public final class com/stripe/android/model/PaymentIntent$Error$Type : java/lang
 }
 
 public final class com/stripe/android/model/PaymentIntent$Shipping : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2480,6 +2587,7 @@ public final class com/stripe/android/model/PaymentIntent$Shipping : com/stripe/
 }
 
 public final class com/stripe/android/model/PaymentMethod : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethod$Companion;
 	public final field auBecsDebit Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
@@ -2525,6 +2633,7 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/m
 }
 
 public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bsbNumber Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
@@ -2543,6 +2652,7 @@ public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stri
 }
 
 public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
@@ -2561,6 +2671,7 @@ public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe
 }
 
 public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field address Lcom/stripe/android/model/Address;
 	public final field email Ljava/lang/String;
@@ -2588,6 +2699,7 @@ public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/s
 }
 
 public final class com/stripe/android/model/PaymentMethod$BillingDetails$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -2598,6 +2710,7 @@ public final class com/stripe/android/model/PaymentMethod$BillingDetails$Builder
 }
 
 public final class com/stripe/android/model/PaymentMethod$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/PaymentMethod;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -2621,6 +2734,7 @@ public final class com/stripe/android/model/PaymentMethod$Builder : com/stripe/a
 }
 
 public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field brand Lcom/stripe/android/model/CardBrand;
 	public final field checks Lcom/stripe/android/model/PaymentMethod$Card$Checks;
@@ -2654,6 +2768,7 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 }
 
 public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field addressLine1Check Ljava/lang/String;
 	public final field addressPostalCodeCheck Ljava/lang/String;
@@ -2671,6 +2786,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stri
 }
 
 public final class com/stripe/android/model/PaymentMethod$Card$Networks : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Set;ZLjava/lang/String;)V
@@ -2691,6 +2807,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$Networks : com/st
 }
 
 public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field isSupported Z
 	public final fun component1 ()Z
@@ -2704,6 +2821,7 @@ public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage
 }
 
 public final class com/stripe/android/model/PaymentMethod$CardPresent : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun copy (Z)Lcom/stripe/android/model/PaymentMethod$CardPresent;
@@ -2721,6 +2839,7 @@ public final class com/stripe/android/model/PaymentMethod$Companion {
 }
 
 public final class com/stripe/android/model/PaymentMethod$Fpx : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field accountHolderType Ljava/lang/String;
 	public final field bank Ljava/lang/String;
@@ -2737,6 +2856,7 @@ public final class com/stripe/android/model/PaymentMethod$Fpx : com/stripe/andro
 }
 
 public final class com/stripe/android/model/PaymentMethod$Ideal : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bank Ljava/lang/String;
 	public final field bankIdentifierCode Ljava/lang/String;
@@ -2753,6 +2873,7 @@ public final class com/stripe/android/model/PaymentMethod$Ideal : com/stripe/and
 }
 
 public final class com/stripe/android/model/PaymentMethod$Netbanking : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bank Ljava/lang/String;
 	public final fun component1 ()Ljava/lang/String;
@@ -2767,6 +2888,7 @@ public final class com/stripe/android/model/PaymentMethod$Netbanking : com/strip
 }
 
 public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bankCode Ljava/lang/String;
 	public final field branchCode Ljava/lang/String;
@@ -2789,6 +2911,7 @@ public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe
 }
 
 public final class com/stripe/android/model/PaymentMethod$Sofort : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field country Ljava/lang/String;
 	public final fun component1 ()Ljava/lang/String;
@@ -2841,10 +2964,12 @@ public final class com/stripe/android/model/PaymentMethod$Type$Companion {
 }
 
 public abstract class com/stripe/android/model/PaymentMethod$TypeData : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public abstract fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
 }
 
 public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field vpa Ljava/lang/String;
 	public final fun component1 ()Ljava/lang/String;
@@ -2859,6 +2984,7 @@ public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/andro
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2934,6 +3060,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -2953,6 +3080,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebi
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -2972,6 +3100,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit 
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Card : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Companion;
 	public fun <init> ()V
@@ -2987,6 +3116,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card : and
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -3076,6 +3206,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3092,6 +3223,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx : andr
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3108,6 +3240,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal : an
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
@@ -3121,6 +3254,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3137,6 +3271,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit 
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
@@ -3150,6 +3285,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : a
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
@@ -3163,12 +3299,14 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : andr
 }
 
 public abstract class com/stripe/android/model/PaymentMethodOptionsParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethod$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
 	public fun toParamMap ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field PARAM_CODE Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
@@ -3185,6 +3323,7 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : co
 }
 
 public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -3205,6 +3344,7 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : co
 }
 
 public final class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field PARAM_APP_ID Ljava/lang/String;
 	public static final field PARAM_CLIENT Ljava/lang/String;
@@ -3222,6 +3362,7 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay
 }
 
 public final class com/stripe/android/model/PersonTokenParams : com/stripe/android/model/TokenParams {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;)V
@@ -3275,6 +3416,7 @@ public final class com/stripe/android/model/PersonTokenParams : com/stripe/andro
 }
 
 public final class com/stripe/android/model/PersonTokenParams$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/PersonTokenParams;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -3300,6 +3442,7 @@ public final class com/stripe/android/model/PersonTokenParams$Builder : com/stri
 }
 
 public final class com/stripe/android/model/PersonTokenParams$Document : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -3320,6 +3463,7 @@ public final class com/stripe/android/model/PersonTokenParams$Document : android
 }
 
 public final class com/stripe/android/model/PersonTokenParams$Relationship : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;)V
@@ -3347,6 +3491,7 @@ public final class com/stripe/android/model/PersonTokenParams$Relationship : and
 }
 
 public final class com/stripe/android/model/PersonTokenParams$Relationship$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/model/PersonTokenParams$Relationship;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -3359,6 +3504,7 @@ public final class com/stripe/android/model/PersonTokenParams$Relationship$Build
 }
 
 public final class com/stripe/android/model/PersonTokenParams$Verification : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;)V
@@ -3379,6 +3525,7 @@ public final class com/stripe/android/model/PersonTokenParams$Verification : and
 }
 
 public final class com/stripe/android/model/RadarSession : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3393,6 +3540,7 @@ public final class com/stripe/android/model/RadarSession : com/stripe/android/mo
 }
 
 public final class com/stripe/android/model/SetupIntent : com/stripe/android/model/StripeIntent {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/SetupIntent$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -3449,6 +3597,7 @@ public final class com/stripe/android/model/SetupIntent$Companion {
 }
 
 public final class com/stripe/android/model/SetupIntent$Error : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -3487,6 +3636,7 @@ public final class com/stripe/android/model/SetupIntent$Error$Type : java/lang/E
 }
 
 public final class com/stripe/android/model/ShippingInformation : com/stripe/android/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ShippingInformation$Companion;
 	public fun <init> ()V
@@ -3512,6 +3662,7 @@ public final class com/stripe/android/model/ShippingInformation$Companion {
 }
 
 public final class com/stripe/android/model/ShippingMethod : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
@@ -3539,6 +3690,7 @@ public final class com/stripe/android/model/ShippingMethod : com/stripe/android/
 }
 
 public final class com/stripe/android/model/Source : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/Source$Companion;
 	public static final fun asSourceType (Ljava/lang/String;)Ljava/lang/String;
@@ -3593,6 +3745,7 @@ public final class com/stripe/android/model/Source : com/stripe/android/model/St
 }
 
 public final class com/stripe/android/model/Source$CodeVerification : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()I
 	public final fun component2 ()Lcom/stripe/android/model/Source$CodeVerification$Status;
@@ -3632,6 +3785,7 @@ public final class com/stripe/android/model/Source$Flow : java/lang/Enum {
 }
 
 public final class com/stripe/android/model/Source$Klarna : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3680,6 +3834,7 @@ public final class com/stripe/android/model/Source$Klarna : com/stripe/android/m
 }
 
 public final class com/stripe/android/model/Source$Owner : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/Address;
 	public final fun component2 ()Ljava/lang/String;
@@ -3707,6 +3862,7 @@ public final class com/stripe/android/model/Source$Owner : com/stripe/android/mo
 }
 
 public final class com/stripe/android/model/Source$Receiver : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
@@ -3726,6 +3882,7 @@ public final class com/stripe/android/model/Source$Receiver : com/stripe/android
 }
 
 public final class com/stripe/android/model/Source$Redirect : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3808,6 +3965,7 @@ public final class com/stripe/android/model/Source$Usage : java/lang/Enum {
 }
 
 public final class com/stripe/android/model/SourceOrder : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Ljava/lang/Integer;
@@ -3830,6 +3988,7 @@ public final class com/stripe/android/model/SourceOrder : com/stripe/android/mod
 }
 
 public final class com/stripe/android/model/SourceOrder$Item : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/SourceOrder$Item$Type;
 	public final fun component2 ()Ljava/lang/Integer;
@@ -3859,6 +4018,7 @@ public final class com/stripe/android/model/SourceOrder$Item$Type : java/lang/En
 }
 
 public final class com/stripe/android/model/SourceOrder$Shipping : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Lcom/stripe/android/model/Address;
@@ -3881,6 +4041,7 @@ public final class com/stripe/android/model/SourceOrder$Shipping : com/stripe/an
 }
 
 public final class com/stripe/android/model/SourceOrderParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;)V
@@ -3901,6 +4062,7 @@ public final class com/stripe/android/model/SourceOrderParams : android/os/Parce
 }
 
 public final class com/stripe/android/model/SourceOrderParams$Item : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
@@ -3936,6 +4098,7 @@ public final class com/stripe/android/model/SourceOrderParams$Item$Type : java/l
 }
 
 public final class com/stripe/android/model/SourceOrderParams$Shipping : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -3960,6 +4123,7 @@ public final class com/stripe/android/model/SourceOrderParams$Shipping : android
 }
 
 public final class com/stripe/android/model/SourceParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/SourceParams$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -4067,6 +4231,7 @@ public final class com/stripe/android/model/SourceParams$Flow : java/lang/Enum {
 }
 
 public final class com/stripe/android/model/SourceParams$OwnerParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;)V
@@ -4085,9 +4250,11 @@ public final class com/stripe/android/model/SourceParams$OwnerParams : android/o
 }
 
 public abstract class com/stripe/android/model/SourceTypeModel : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/model/SourceTypeModel$Card : com/stripe/android/model/SourceTypeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
@@ -4134,6 +4301,7 @@ public final class com/stripe/android/model/SourceTypeModel$Card$ThreeDSecureSta
 }
 
 public final class com/stripe/android/model/SourceTypeModel$SepaDebit : com/stripe/android/model/SourceTypeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -4159,6 +4327,7 @@ public final class com/stripe/android/model/SourceTypeModel$SepaDebit : com/stri
 }
 
 public final class com/stripe/android/model/StripeFile : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public final fun component1 ()Ljava/lang/String;
@@ -4187,6 +4356,7 @@ public final class com/stripe/android/model/StripeFile : com/stripe/android/mode
 }
 
 public final class com/stripe/android/model/StripeFileParams {
+	public static final field $stable I
 	public fun <init> (Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;)V
 	public final fun copy (Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;)Lcom/stripe/android/model/StripeFileParams;
 	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeFileParams;Ljava/io/File;Lcom/stripe/android/model/StripeFilePurpose;ILjava/lang/Object;)Lcom/stripe/android/model/StripeFileParams;
@@ -4196,6 +4366,7 @@ public final class com/stripe/android/model/StripeFileParams {
 }
 
 public final class com/stripe/android/model/StripeFileParams$FileLink : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -4242,9 +4413,11 @@ public abstract interface class com/stripe/android/model/StripeIntent : com/stri
 }
 
 public abstract class com/stripe/android/model/StripeIntent$NextActionData : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/model/StripeIntent$NextActionData$BlikAuthorize;
 	public fun describeContents ()I
@@ -4254,6 +4427,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$BlikAuth
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
@@ -4274,6 +4448,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayO
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Landroid/net/Uri;Ljava/lang/String;)V
 	public final fun component1 ()Landroid/net/Uri;
@@ -4290,9 +4465,11 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$Redirect
 }
 
 public abstract class com/stripe/android/model/StripeIntent$NextActionData$SdkData : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS1 : com/stripe/android/model/StripeIntent$NextActionData$SdkData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -4307,6 +4484,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2 : com/stripe/android/model/StripeIntent$NextActionData$SdkData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -4327,6 +4505,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -4347,6 +4526,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 }
 
 public final class com/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/WeChat;)V
 	public final fun component1 ()Lcom/stripe/android/model/WeChat;
@@ -4415,6 +4595,7 @@ public abstract interface class com/stripe/android/model/StripePaymentSource : a
 }
 
 public final class com/stripe/android/model/Token : com/stripe/android/model/StripeModel, com/stripe/android/model/StripePaymentSource {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/Token$Companion;
 	public final fun component1 ()Ljava/lang/String;
@@ -4457,6 +4638,7 @@ public final class com/stripe/android/model/Token$Type : java/lang/Enum {
 }
 
 public abstract class com/stripe/android/model/TokenParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/model/Token$Type;Ljava/util/Set;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Token$Type;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun getTypeDataParams ()Ljava/util/Map;
@@ -4473,6 +4655,7 @@ public final class com/stripe/android/model/TokenizationMethod : java/lang/Enum 
 }
 
 public final class com/stripe/android/model/WeChat : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4504,6 +4687,7 @@ public final class com/stripe/android/model/WeChat : com/stripe/android/model/St
 }
 
 public final class com/stripe/android/model/WeChatPayNextAction : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
 	public final fun component2 ()Lcom/stripe/android/model/WeChat;
@@ -4519,16 +4703,19 @@ public final class com/stripe/android/model/WeChatPayNextAction : com/stripe/and
 }
 
 public final class com/stripe/android/model/parsers/PaymentIntentJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
 	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/StripeModel;
 }
 
 public abstract class com/stripe/android/model/wallets/Wallet : com/stripe/android/model/StripeModel {
+	public static final field $stable I
 	public synthetic fun <init> (Lcom/stripe/android/model/wallets/Wallet$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
@@ -4542,6 +4729,7 @@ public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWa
 }
 
 public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
@@ -4555,6 +4743,7 @@ public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet : com/
 }
 
 public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com/stripe/android/model/wallets/Wallet, android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
@@ -4568,6 +4757,7 @@ public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com
 }
 
 public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/Address;
 	public final fun component2 ()Ljava/lang/String;
@@ -4587,6 +4777,7 @@ public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet : co
 }
 
 public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
@@ -4600,6 +4791,7 @@ public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet : co
 }
 
 public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet : com/stripe/android/model/wallets/Wallet {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/Address;
 	public final fun component2 ()Ljava/lang/String;
@@ -4621,6 +4813,7 @@ public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet : 
 }
 
 public final class com/stripe/android/networking/AnalyticsRequest : com/stripe/android/networking/StripeRequest {
+	public static final field $stable I
 	public fun <init> (Ljava/util/Map;)V
 	public final fun component1 ()Ljava/util/Map;
 	public final fun copy (Ljava/util/Map;)Lcom/stripe/android/networking/AnalyticsRequest;
@@ -4637,10 +4830,12 @@ public abstract interface class com/stripe/android/networking/AnalyticsRequestEx
 }
 
 public final class com/stripe/android/networking/AnalyticsRequestFactory {
+	public static final field $stable I
 	public final synthetic fun createRequest (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/AnalyticsRequest;
 }
 
 public final class com/stripe/android/networking/ApiRequest : com/stripe/android/networking/StripeRequest {
+	public static final field $stable I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/Map;
 	public final fun copy (Lcom/stripe/android/networking/StripeRequest$Method;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/AppInfo;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/ApiRequest;
@@ -4654,6 +4849,7 @@ public final class com/stripe/android/networking/ApiRequest : com/stripe/android
 }
 
 public final class com/stripe/android/networking/ApiRequest$Factory {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/AppInfo;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/AppInfo;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4665,6 +4861,7 @@ public final class com/stripe/android/networking/ApiRequest$Factory {
 }
 
 public final class com/stripe/android/networking/ApiRequest$Options : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/networking/ApiRequest$Options$Companion;
 	public static final field UNDEFINED_PUBLISHABLE_KEY Ljava/lang/String;
@@ -4699,6 +4896,7 @@ public final class com/stripe/android/networking/RetryDelaySupplier_Factory : da
 }
 
 public abstract class com/stripe/android/networking/StripeRequest {
+	public static final field $stable I
 	public fun <init> ()V
 	public abstract fun getBaseUrl ()Ljava/lang/String;
 	protected fun getBody ()Ljava/lang/String;
@@ -4707,9 +4905,11 @@ public abstract class com/stripe/android/networking/StripeRequest {
 }
 
 public abstract class com/stripe/android/payments/PaymentFlowResult {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated$Companion;
 	public fun <init> ()V
@@ -4868,6 +5068,11 @@ public final class com/stripe/android/payments/core/injection/DaggerAuthenticati
 	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
 }
 
+public final class com/stripe/android/payments/core/injection/DaggerPaymentLauncherComponent : com/stripe/android/payments/core/injection/PaymentLauncherComponent {
+	public static fun builder ()Lcom/stripe/android/payments/core/injection/PaymentLauncherComponent$Builder;
+	public fun inject (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
+}
+
 public abstract interface annotation class com/stripe/android/payments/core/injection/IOContext : java/lang/annotation/Annotation {
 }
 
@@ -4884,6 +5089,8 @@ public abstract interface annotation class com/stripe/android/payments/core/inje
 public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
 	public static final field ENABLE_LOGGING Ljava/lang/String;
 	public static final field PRODUCT_USAGE Ljava/lang/String;
+	public static final field PUBLISHABLE_KEY Ljava/lang/String;
+	public static final field STRIPE_ACCOUNT_ID Ljava/lang/String;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentCommonModule_Companion_ProvideAnalyticsRequestFactoryFactory : dagger/internal/Factory {
@@ -4942,6 +5149,102 @@ public final class com/stripe/android/payments/core/injection/PaymentCommonModul
 	public static fun provideStripePaymentController (Landroid/content/Context;Lcom/stripe/android/networking/StripeApiRepository;Ldagger/Lazy;Z)Lcom/stripe/android/PaymentController;
 }
 
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideAnalyticsRequestFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideAnalyticsRequestFactoryFactory;
+	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideAnalyticsRequestFactory (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Ljava/lang/String;)Lcom/stripe/android/networking/AnalyticsRequestFactory;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideApiRequestOptionsFactory;
+	public fun get ()Lcom/stripe/android/networking/ApiRequest$Options;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideApiRequestOptions (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/ApiRequest$Options;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideDefaultReturnUrlFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideDefaultReturnUrlFactory;
+	public fun get ()Lcom/stripe/android/payments/DefaultReturnUrl;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideDefaultReturnUrl (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;)Lcom/stripe/android/payments/DefaultReturnUrl;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideEnabledLoggingFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideEnabledLoggingFactory;
+	public fun get ()Ljava/lang/Boolean;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideEnabledLogging (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Z
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideIOContextFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideIOContextFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/coroutines/CoroutineContext;
+	public static fun provideIOContext (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideLoggerFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideLoggerFactory;
+	public fun get ()Lcom/stripe/android/Logger;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideLogger (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Z)Lcom/stripe/android/Logger;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentAuthenticatorRegistry (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentIntentFlowResultProcessorFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentIntentFlowResultProcessorFactory;
+	public fun get ()Lcom/stripe/android/payments/PaymentIntentFlowResultProcessor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentIntentFlowResultProcessor (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/PaymentIntentFlowResultProcessor;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideSetupIntentFlowResultProcessorFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideSetupIntentFlowResultProcessorFactory;
+	public fun get ()Lcom/stripe/android/payments/SetupIntentFlowResultProcessor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideSetupIntentFlowResultProcessor (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/SetupIntentFlowResultProcessor;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideStripeApiRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideStripeApiRepositoryFactory;
+	public fun get ()Lcom/stripe/android/networking/StripeRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeApiRepository (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Ljava/lang/String;)Lcom/stripe/android/networking/StripeRepository;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideThreeDs1IntentReturnUrlMapFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideThreeDs1IntentReturnUrlMapFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/util/Map;
+	public static fun provideThreeDs1IntentReturnUrlMap (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Ljava/util/Map;
+}
+
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideUIContextFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideUIContextFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/coroutines/CoroutineContext;
+	public static fun provideUIContext (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Lkotlin/coroutines/CoroutineContext;
+}
+
 public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
 	public fun <init> ()V
 	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory;
@@ -4977,6 +5280,73 @@ public final class com/stripe/android/payments/core/injection/WeChatPayAuthentic
 	public static fun provideWeChatAuthenticator$payments_core_release (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Lcom/stripe/android/payments/core/authentication/UnsupportedAuthenticator;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;
 }
 
+public abstract interface class com/stripe/android/payments/paymentlauncher/PaymentLauncher {
+	public static final field Companion Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;
+	public abstract fun confirm (Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
+	public abstract fun confirm (Lcom/stripe/android/model/ConfirmSetupIntentParams;)V
+	public abstract fun handleNextActionForPaymentIntent (Ljava/lang/String;)V
+	public abstract fun handleNextActionForSetupIntent (Ljava/lang/String;)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion {
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;Landroidx/activity/ComponentActivity;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public final fun createForCompose (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+}
+
+public abstract interface class com/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback {
+	public abstract fun onPaymentResult (Lcom/stripe/android/payments/paymentlauncher/PaymentResult;)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;)V
+	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
+	public static fun injectApiRequestOptions (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/ApiRequest$Options;)V
+	public static fun injectAuthenticatorRegistry (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;)V
+	public static fun injectDefaultReturnUrl (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/payments/DefaultReturnUrl;)V
+	public static fun injectLazyPaymentIntentFlowResultProcessor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ldagger/Lazy;)V
+	public static fun injectLazySetupIntentFlowResultProcessor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ldagger/Lazy;)V
+	public fun injectMembers (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectStripeApiRepository (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/StripeRepository;)V
+	public static fun injectThreeDs1IntentReturnUrlMap (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ljava/util/Map;)V
+	public static fun injectUiContext (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {
+	public static final field $stable I
+	public final synthetic fun toBundle ()Landroid/os/Bundle;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentResult$Canceled : com/stripe/android/payments/paymentlauncher/PaymentResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/payments/paymentlauncher/PaymentResult$Canceled;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentResult$Completed : com/stripe/android/payments/paymentlauncher/PaymentResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/payments/paymentlauncher/PaymentResult$Completed;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentResult$Failed : com/stripe/android/payments/paymentlauncher/PaymentResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Throwable;)V
+	public fun describeContents ()I
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
 }
@@ -4993,6 +5363,7 @@ public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Facto
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet {
+	public static final field $stable I
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)V
 	public final fun presentWithPaymentIntent (Ljava/lang/String;)V
@@ -5004,6 +5375,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet {
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)V
@@ -5032,6 +5404,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -5073,18 +5446,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$D
 }
 
 public abstract class com/stripe/android/paymentsheet/PaymentSheet$FlowController$Result {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$Result$Failure : com/stripe/android/paymentsheet/PaymentSheet$FlowController$Result {
+	public static final field $stable I
 	public fun <init> (Ljava/lang/Throwable;)V
 	public final fun getError ()Ljava/lang/Throwable;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$Result$Success : com/stripe/android/paymentsheet/PaymentSheet$FlowController$Result {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Result$Success;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;)V
@@ -5112,6 +5489,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetContract : androidx/activity/result/contract/ActivityResultContract {
+	public static final field $stable I
 	public static final field EXTRA_ARGS Ljava/lang/String;
 	public fun <init> ()V
 	public fun createIntent (Landroid/content/Context;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;)Landroid/content/Intent;
@@ -5121,6 +5499,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract : androi
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args$Companion;
 	public final fun copy (Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
@@ -5141,9 +5520,11 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args$Com
 }
 
 public abstract class com/stripe/android/paymentsheet/PaymentSheetResult : android/os/Parcelable {
+	public static final field $stable I
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetResult$Canceled : com/stripe/android/paymentsheet/PaymentSheetResult {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/PaymentSheetResult$Canceled;
 	public fun describeContents ()I
@@ -5151,6 +5532,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetResult$Canceled :
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetResult$Completed : com/stripe/android/paymentsheet/PaymentSheetResult {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/PaymentSheetResult$Completed;
 	public fun describeContents ()I
@@ -5158,6 +5540,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetResult$Completed 
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetResult$Failed : com/stripe/android/paymentsheet/PaymentSheetResult {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;)V
 	public final fun component1 ()Ljava/lang/Throwable;
@@ -5331,6 +5714,7 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewMod
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentOption {
+	public static final field $stable I
 	public fun <init> (ILjava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
@@ -5368,6 +5752,7 @@ public final class com/stripe/android/paymentsheet/repositories/StripeIntentRepo
 }
 
 public abstract class com/stripe/android/view/ActivityStarter {
+	public static final field $stable I
 	public final fun startForResult (Lcom/stripe/android/view/ActivityStarter$Args;)V
 }
 
@@ -5387,11 +5772,13 @@ public final class com/stripe/android/view/ActivityStarter$Result$Companion {
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivity : com/stripe/android/view/StripeActivity {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun onActionSave ()V
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Companion;
 	public static final field REQUEST_CODE I
 	public fun <init> (Landroid/app/Activity;)V
@@ -5399,6 +5786,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter : com
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun copy (Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/PaymentConfiguration;ILjava/lang/Integer;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
 	public static synthetic fun copy$default (Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;Lcom/stripe/android/view/BillingAddressFields;ZZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/PaymentConfiguration;ILjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
@@ -5410,6 +5798,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args 
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -5424,12 +5813,14 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Compa
 }
 
 public abstract class com/stripe/android/view/AddPaymentMethodActivityStarter$Result : com/stripe/android/view/ActivityStarter$Result {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Companion;
 	public static final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result;
 	public fun toBundle ()Landroid/os/Bundle;
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Canceled;
 	public fun describeContents ()I
@@ -5441,6 +5832,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/Throwable;
 	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Failure;
@@ -5454,6 +5846,7 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success : com/stripe/android/view/AddPaymentMethodActivityStarter$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod;
 	public final fun copy (Lcom/stripe/android/model/PaymentMethod;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Result$Success;
@@ -5471,15 +5864,18 @@ public abstract interface class com/stripe/android/view/AuthActivityStarter {
 }
 
 public abstract class com/stripe/android/view/AuthActivityStarterHost {
+	public static final field $stable I
 	public abstract fun startActivityForResult (Ljava/lang/Class;Landroid/os/Bundle;I)V
 }
 
 public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextFactory {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public final fun create (Ljava/lang/String;)Ljava/lang/CharSequence;
 }
 
 public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextView : androidx/appcompat/widget/AppCompatTextView {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5489,6 +5885,7 @@ public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextView : 
 }
 
 public final class com/stripe/android/view/BecsDebitWidget : android/widget/FrameLayout {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5512,6 +5909,7 @@ public final class com/stripe/android/view/BillingAddressFields : java/lang/Enum
 }
 
 public final class com/stripe/android/view/CardFormView : android/widget/LinearLayout {
+	public static final field $stable I
 	public static final field CARD_FORM_VIEW Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
@@ -5539,6 +5937,7 @@ public final class com/stripe/android/view/CardInputListener$FocusField : java/l
 }
 
 public final class com/stripe/android/view/CardInputWidget : android/widget/LinearLayout, com/stripe/android/view/CardWidget {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5570,6 +5969,7 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 }
 
 public final class com/stripe/android/view/CardMultilineWidget : android/widget/LinearLayout, com/stripe/android/view/CardWidget {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5605,6 +6005,7 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 }
 
 public final class com/stripe/android/view/CardNumberEditText : com/stripe/android/view/StripeEditText {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5627,6 +6028,7 @@ public final class com/stripe/android/view/CardValidCallback$Fields : java/lang/
 }
 
 public final class com/stripe/android/view/CvcEditText : com/stripe/android/view/StripeEditText {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5634,6 +6036,7 @@ public final class com/stripe/android/view/CvcEditText : com/stripe/android/view
 }
 
 public final class com/stripe/android/view/ExpiryDateEditText : com/stripe/android/view/StripeEditText {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5643,6 +6046,7 @@ public final class com/stripe/android/view/ExpiryDateEditText : com/stripe/andro
 }
 
 public final class com/stripe/android/view/PaymentAuthWebViewActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun onBackPressed ()V
 	public fun onCreateOptionsMenu (Landroid/view/Menu;)Z
@@ -5650,12 +6054,14 @@ public final class com/stripe/android/view/PaymentAuthWebViewActivity : androidx
 }
 
 public final class com/stripe/android/view/PaymentFlowActivity : com/stripe/android/view/StripeActivity {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun onActionSave ()V
 	public fun onBackPressed ()V
 }
 
 public final class com/stripe/android/view/PaymentFlowActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/view/PaymentFlowActivityStarter$Companion;
 	public static final field REQUEST_CODE I
 	public fun <init> (Landroid/app/Activity;Lcom/stripe/android/PaymentSessionConfig;)V
@@ -5663,6 +6069,7 @@ public final class com/stripe/android/view/PaymentFlowActivityStarter : com/stri
 }
 
 public final class com/stripe/android/view/PaymentFlowActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/view/PaymentFlowActivityStarter$Args$Companion;
 	public final fun copy (Lcom/stripe/android/PaymentSessionConfig;Lcom/stripe/android/PaymentSessionData;ZLjava/lang/Integer;)Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
@@ -5676,6 +6083,7 @@ public final class com/stripe/android/view/PaymentFlowActivityStarter$Args : com
 }
 
 public final class com/stripe/android/view/PaymentFlowActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/view/PaymentFlowActivityStarter$Args;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -5693,6 +6101,7 @@ public final class com/stripe/android/view/PaymentFlowActivityStarter$Companion 
 }
 
 public final class com/stripe/android/view/PaymentFlowViewPager : androidx/viewpager/widget/ViewPager {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;Z)V
@@ -5702,12 +6111,14 @@ public final class com/stripe/android/view/PaymentFlowViewPager : androidx/viewp
 }
 
 public final class com/stripe/android/view/PaymentMethodsActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun onBackPressed ()V
 	public fun onSupportNavigateUp ()Z
 }
 
 public final class com/stripe/android/view/PaymentMethodsActivityStarter : com/stripe/android/view/ActivityStarter {
+	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivityStarter$Companion;
 	public static final field REQUEST_CODE I
 	public fun <init> (Landroid/app/Activity;)V
@@ -5715,6 +6126,7 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter : com/s
 }
 
 public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args : com/stripe/android/view/ActivityStarter$Args {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component2 ()I
 	public final fun component3 ()I
@@ -5730,6 +6142,7 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args : 
 }
 
 public final class com/stripe/android/view/PaymentMethodsActivityStarter$Args$Builder : com/stripe/android/ObjectBuilder {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun build ()Lcom/stripe/android/view/PaymentMethodsActivityStarter$Args;
 	public synthetic fun build ()Ljava/lang/Object;
@@ -5749,6 +6162,7 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter$Compani
 }
 
 public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result : com/stripe/android/view/ActivityStarter$Result {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/view/PaymentMethodsActivityStarter$Result$Companion;
 	public final field paymentMethod Lcom/stripe/android/model/PaymentMethod;
@@ -5772,11 +6186,13 @@ public final class com/stripe/android/view/PaymentMethodsActivityStarter$Result$
 }
 
 public final class com/stripe/android/view/PaymentUtils {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/view/PaymentUtils;
 	public static final fun formatPriceStringUsingFree (JLjava/util/Currency;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/stripe/android/view/PostalCodeEditText : com/stripe/android/view/StripeEditText {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5784,6 +6200,7 @@ public final class com/stripe/android/view/PostalCodeEditText : com/stripe/andro
 }
 
 public final class com/stripe/android/view/ShippingInfoWidget : android/widget/LinearLayout {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5810,6 +6227,7 @@ public final class com/stripe/android/view/ShippingInfoWidget$CustomizableShippi
 }
 
 public abstract class com/stripe/android/view/StripeActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field $stable I
 	public fun <init> ()V
 	protected final fun isProgressBarVisible ()Z
 	protected abstract fun onActionSave ()V
@@ -5823,6 +6241,7 @@ public abstract class com/stripe/android/view/StripeActivity : androidx/appcompa
 }
 
 public class com/stripe/android/view/StripeEditText : com/google/android/material/textfield/TextInputEditText {
+	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
@@ -5867,6 +6286,7 @@ public abstract interface class com/stripe/android/view/i18n/ErrorMessageTransla
 }
 
 public final class com/stripe/android/view/i18n/TranslatorManager {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/view/i18n/TranslatorManager;
 	public final fun getErrorMessageTranslator ()Lcom/stripe/android/view/i18n/ErrorMessageTranslator;
 	public final fun setErrorMessageTranslator (Lcom/stripe/android/view/i18n/ErrorMessageTranslator;)V

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
+    implementation "androidx.activity:activity-compose:1.3.1"
+
     javadocDeps libraries.androidx.annotation
     javadocDeps libraries.androidx.appcompat
     javadocDeps "com.google.android.material:material:$materialVersion"
@@ -119,6 +121,7 @@ android {
     }
 
     buildFeatures {
+        compose = true
         viewBinding true
     }
 
@@ -128,6 +131,11 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+
+    composeOptions {
+        kotlinCompilerVersion = "$kotlinVersion"
+        kotlinCompilerExtensionVersion "$composeVersion"
     }
 }
 

--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -40,6 +40,8 @@
 
     <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
+    <style name="PayLauncherDefaultTheme" parent="StripePaymentSheetBaseTheme" />
+
     <style name="StripePaymentSheetAddPaymentMethodTheme">
         <item name="colorOnSurface">@color/stripe_paymentsheet_form</item>
         <item name="colorPrimary">@color/stripe_paymentsheet_form</item>

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
@@ -9,3 +9,13 @@ const val ENABLE_LOGGING = "enableLogging"
  * Name for injected set if strings to represent product usage for analytics.
  */
 const val PRODUCT_USAGE = "productUsage"
+
+/**
+ * Name for user's publishable key
+ */
+const val PUBLISHABLE_KEY = "publishableKey"
+
+/**
+ * Name for user's account id
+ */
+const val STRIPE_ACCOUNT_ID = "stripeAccountId"

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import androidx.annotation.Nullable
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        PaymentLauncherModule::class
+    ]
+)
+internal interface PaymentLauncherComponent {
+    fun inject(factory: PaymentLauncherViewModel.Factory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        @BindsInstance
+        fun publishableKey(@Named(PUBLISHABLE_KEY) publishableKey: String): Builder
+
+        @BindsInstance
+        fun stripeAccountId(@Nullable @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?): Builder
+
+        fun build(): PaymentLauncherComponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -1,0 +1,140 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.BuildConfig
+import com.stripe.android.Logger
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.PaymentIntentFlowResultProcessor
+import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal class PaymentLauncherModule {
+    @Provides
+    @Singleton
+    @Named(ENABLE_LOGGING)
+    fun provideEnabledLogging(): Boolean = BuildConfig.DEBUG
+
+    @Provides
+    @Singleton
+    fun provideApiRequestOptions(
+        @Named(PUBLISHABLE_KEY) publishableKey: String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?,
+    ) = ApiRequest.Options(
+        apiKey = publishableKey,
+        stripeAccount = stripeAccountId
+    )
+
+    @Provides
+    @Singleton
+    fun provideThreeDs1IntentReturnUrlMap() = mutableMapOf<String, String>()
+
+    @Provides
+    @Singleton
+    @IOContext
+    fun provideIOContext(): CoroutineContext = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    @UIContext
+    fun provideUIContext(): CoroutineContext = Dispatchers.Main
+
+    @Provides
+    @Singleton
+    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
+        Logger.getInstance(enableLogging)
+
+    @Provides
+    @Singleton
+    fun provideDefaultReturnUrl(context: Context) = DefaultReturnUrl.create(context)
+
+    @Provides
+    @Singleton
+    fun provideStripeApiRepository(
+        context: Context,
+        @Named(PUBLISHABLE_KEY) publishableKey: String,
+    ): StripeRepository = StripeApiRepository(
+        context,
+        { publishableKey }
+    )
+
+    @Provides
+    @Singleton
+    fun providePaymentIntentFlowResultProcessor(
+        context: Context,
+        stripeApiRepository: StripeRepository,
+        @Named(PUBLISHABLE_KEY) publishableKey: String,
+        @Named(ENABLE_LOGGING) enableLogging: Boolean,
+        @IOContext ioContext: CoroutineContext
+    ): PaymentIntentFlowResultProcessor {
+        return PaymentIntentFlowResultProcessor(
+            context,
+            { publishableKey },
+            stripeApiRepository,
+            enableLogging = enableLogging,
+            ioContext
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideSetupIntentFlowResultProcessor(
+        context: Context,
+        stripeApiRepository: StripeRepository,
+        @Named(PUBLISHABLE_KEY) publishableKey: String,
+        @Named(ENABLE_LOGGING) enableLogging: Boolean,
+        @IOContext ioContext: CoroutineContext
+    ): SetupIntentFlowResultProcessor {
+        return SetupIntentFlowResultProcessor(
+            context,
+            { publishableKey },
+            stripeApiRepository,
+            enableLogging = enableLogging,
+            ioContext
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideAnalyticsRequestFactory(
+        context: Context,
+        @Named(PUBLISHABLE_KEY) publishableKey: String
+    ) = AnalyticsRequestFactory(
+        context,
+        { publishableKey }
+    )
+
+    @Provides
+    @Singleton
+    fun providePaymentAuthenticatorRegistry(
+        context: Context,
+        stripeRepository: StripeRepository,
+        @Named(ENABLE_LOGGING) enableLogging: Boolean,
+        @IOContext workContext: CoroutineContext,
+        @UIContext uiContext: CoroutineContext,
+        threeDs1IntentReturnUrlMap: MutableMap<String, String>,
+        defaultAnalyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
+        analyticsRequestFactory: AnalyticsRequestFactory
+    ): PaymentAuthenticatorRegistry = DefaultPaymentAuthenticatorRegistry.createInstance(
+        context,
+        stripeRepository,
+        defaultAnalyticsRequestExecutor,
+        analyticsRequestFactory,
+        enableLogging,
+        workContext,
+        uiContext,
+        threeDs1IntentReturnUrlMap,
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.paymentlauncher
 
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
@@ -42,6 +43,12 @@ interface PaymentLauncher {
     }
 
     companion object {
+        /**
+         * Create a [PaymentLauncher] instance with [ComponentActivity].
+         *
+         * This API registers an [ActivityResultLauncher] into the [ComponentActivity],  it needs
+         * to be called before the [ComponentActivity] is created.
+         */
         fun create(
             activity: ComponentActivity,
             publishableKey: String,
@@ -49,6 +56,13 @@ interface PaymentLauncher {
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(activity, callback).create(publishableKey, stripeAccountId)
 
+
+        /**
+         * Create a [PaymentLauncher] instance with [Fragment].
+         *
+         * This API registers an [ActivityResultLauncher] into the [Fragment]'s hosting Activity, it
+         * needs to be called before the [Fragment] is created.
+         */
         fun create(
             fragment: Fragment,
             publishableKey: String,
@@ -56,6 +70,13 @@ interface PaymentLauncher {
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(fragment, callback).create(publishableKey, stripeAccountId)
 
+        /**
+         * Create a [PaymentLauncher] used for Jetpack Compose.
+         *
+         * This API uses Compose specific API [rememberLauncherForActivityResult] to register a
+         * [ActivityResultLauncher] into current activity, it should be called as part of Compose
+         * initialization path.
+         */
         @Composable
         fun createForCompose(
             publishableKey: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.payments.paymentlauncher
 
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -52,5 +55,18 @@ interface PaymentLauncher {
             stripeAccountId: String? = null,
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(fragment, callback).create(publishableKey, stripeAccountId)
+
+        @Composable
+        fun createForCompose(
+            publishableKey: String,
+            stripeAccountId: String? = null,
+            callback: PaymentResultCallback
+        ) = PaymentLauncherFactory(
+            LocalContext.current,
+            rememberLauncherForActivityResult(
+                PaymentLauncherContract(),
+                callback::onPaymentResult
+            )
+        ).create(publishableKey, stripeAccountId)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.SetupIntent
 /**
  * API to confirm and handle next actions for [PaymentIntent] and [SetupIntent].
  */
-internal interface PaymentLauncher {
+interface PaymentLauncher {
     /**
      * Confirms and, if necessary, authenticates a [PaymentIntent].
      */

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -56,7 +56,6 @@ interface PaymentLauncher {
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(activity, callback).create(publishableKey, stripeAccountId)
 
-
         /**
          * Create a [PaymentLauncher] instance with [Fragment].
          *

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -71,6 +71,10 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        viewModel.cleanUp()
+    }
     override fun finish() {
         super.finish()
         disableAnimations()

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
 import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.payments.core.injection.InjectorKey
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -25,31 +26,27 @@ internal class PaymentLauncherContract :
     }
 
     sealed class Args(
-        open val publishableKey: String,
-        open val stripeAccountId: String? = null
+        @InjectorKey open val injectorKey: Int,
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
         @Parcelize
         data class IntentConfirmationArgs(
-            override val publishableKey: String,
-            override val stripeAccountId: String? = null,
+            override val injectorKey: Int,
             val confirmStripeIntentParams: ConfirmStripeIntentParams
-        ) : Args(publishableKey, stripeAccountId)
+        ) : Args(injectorKey)
 
         @Parcelize
         data class PaymentIntentNextActionArgs(
-            override val publishableKey: String,
-            override val stripeAccountId: String? = null,
+            override val injectorKey: Int,
             val paymentIntentClientSecret: String
-        ) : Args(publishableKey, stripeAccountId)
+        ) : Args(injectorKey)
 
         @Parcelize
         data class SetupIntentNextActionArgs(
-            override val publishableKey: String,
-            override val stripeAccountId: String? = null,
+            override val injectorKey: Int,
             val setupIntentClientSecret: String
-        ) : Args(publishableKey, stripeAccountId)
+        ) : Args(injectorKey)
 
         internal companion object {
             private const val EXTRA_ARGS = "extra_args"

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -1,13 +1,16 @@
 package com.stripe.android.payments.paymentlauncher
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 
 /**
  * Factory to create a [PaymentLauncher].
  */
 internal class PaymentLauncherFactory(
+    private val context: Context,
     private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>
 ) {
 
@@ -15,6 +18,7 @@ internal class PaymentLauncherFactory(
         activity: ComponentActivity,
         callback: PaymentLauncher.PaymentResultCallback,
     ) : this(
+        activity.applicationContext,
         activity.registerForActivityResult(
             PaymentLauncherContract(),
             callback::onPaymentResult,
@@ -25,6 +29,7 @@ internal class PaymentLauncherFactory(
         fragment: Fragment,
         callback: PaymentLauncher.PaymentResultCallback
     ) : this(
+        fragment.requireActivity().applicationContext,
         fragment.registerForActivityResult(
             PaymentLauncherContract(),
             callback::onPaymentResult
@@ -34,5 +39,17 @@ internal class PaymentLauncherFactory(
     fun create(
         publishableKey: String,
         stripeAccountId: String? = null
-    ): PaymentLauncher = StripePaymentLauncher(hostActivityLauncher, publishableKey, stripeAccountId)
+    ): PaymentLauncher {
+        val injectorKey = WeakMapInjectorRegistry.nextKey()
+        val paymentLauncher =
+            StripePaymentLauncher(
+                hostActivityLauncher,
+                context,
+                publishableKey,
+                stripeAccountId,
+                injectorKey
+            )
+        WeakMapInjectorRegistry.register(paymentLauncher, injectorKey)
+        return paymentLauncher
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.paymentlauncher
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -178,6 +179,18 @@ internal class PaymentLauncherViewModel(
                 }
             )
         }
+    }
+
+    /**
+     * Cleans up the [PaymentAuthenticatorRegistry] by invalidating [ActivityResultLauncher]s
+     * registered within.
+     *
+     * Because the same [PaymentAuthenticatorRegistry] is used for multiple
+     * [PaymentLauncherConfirmationActivity]s. The [ActivityResultLauncher]s registered in the old
+     * [PaymentLauncherConfirmationActivity] needs to be unregistered to prevent leaking.
+     */
+    internal fun cleanUp() {
+        authenticatorRegistry.onLauncherInvalidated()
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,67 +1,292 @@
 package com.stripe.android.payments.paymentlauncher
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIException
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.PaymentIntentFlowResultProcessor
+import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.UIContext
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 /**
- * WIP - view model for PaymentLauncherHostActivity
+ * [ViewModel] for [PaymentLauncherConfirmationActivity].
  */
 
-internal class PaymentLauncherViewModel : ViewModel() {
+internal class PaymentLauncherViewModel(
+    private val stripeApiRepository: StripeRepository,
+    private val authenticatorRegistry: PaymentAuthenticatorRegistry,
+    private val defaultReturnUrl: DefaultReturnUrl,
+    private val apiRequestOptions: ApiRequest.Options,
+    private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
+    private val lazyPaymentIntentFlowResultProcessor: dagger.Lazy<PaymentIntentFlowResultProcessor>,
+    private val lazySetupIntentFlowResultProcessor: dagger.Lazy<SetupIntentFlowResultProcessor>,
+    private val analyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    private val uiContext: CoroutineContext,
+    private val authActivityStarterHost: AuthActivityStarterHost,
+    activityResultCaller: ActivityResultCaller
+) : ViewModel() {
+    init {
+        authenticatorRegistry.onNewActivityResultCaller(
+            activityResultCaller,
+            ::onPaymentFlowResult
+        )
+    }
+
     /**
      * [PaymentResult] live data to be observed.
      */
     internal val paymentLauncherResult = MutableLiveData<PaymentResult>()
 
+    lateinit var stripeIntent: StripeIntent
+
     /**
      * Confirms a payment intent or setup intent
      */
-    internal fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {}
+    internal suspend fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
+        logReturnUrl(confirmStripeIntentParams.returnUrl)
+        val returnUrl = confirmStripeIntentParams.returnUrl.takeUnless { it.isNullOrBlank() }
+            ?: defaultReturnUrl.value
+        runCatching {
+            confirmIntent(confirmStripeIntentParams, returnUrl)
+        }.fold(
+            onSuccess = { intent ->
+                intent.nextActionData?.let {
+                    if (it is StripeIntent.NextActionData.SdkData.Use3DS1) {
+                        intent.id?.let { intentId ->
+                            threeDs1IntentReturnUrlMap[intentId] = returnUrl
+                        }
+                    }
+                }
+                stripeIntent = intent
+                authenticatorRegistry.getAuthenticator(intent).authenticate(
+                    authActivityStarterHost,
+                    intent,
+                    apiRequestOptions
+                )
+            },
+            onFailure = {
+                paymentLauncherResult.postValue(PaymentResult.Failed(it))
+            }
+        )
+    }
+
+    private suspend fun confirmIntent(
+        confirmStripeIntentParams: ConfirmStripeIntentParams,
+        returnUrl: String
+    ): StripeIntent =
+        confirmStripeIntentParams.also {
+            it.returnUrl = returnUrl
+        }.withShouldUseStripeSdk(shouldUseStripeSdk = true).let { decoratedParams ->
+            requireNotNull(
+                when (decoratedParams) {
+                    is ConfirmPaymentIntentParams -> {
+                        stripeApiRepository.confirmPaymentIntent(
+                            decoratedParams,
+                            apiRequestOptions,
+                            expandFields = EXPAND_PAYMENT_METHOD
+                        )
+                    }
+                    is ConfirmSetupIntentParams -> {
+                        stripeApiRepository.confirmSetupIntent(
+                            decoratedParams,
+                            apiRequestOptions,
+                            expandFields = EXPAND_PAYMENT_METHOD
+                        )
+                    }
+                }
+            ) {
+                REQUIRED_ERROR
+            }
+        }
 
     /**
      * Fetches a [StripeIntent] and handles its next action.
      */
-    internal fun handleNextActionForStripeIntent(clientSecret: String) {}
+    internal suspend fun handleNextActionForStripeIntent(clientSecret: String) {
+        runCatching {
+            requireNotNull(
+                stripeApiRepository.retrieveStripeIntent(
+                    clientSecret,
+                    apiRequestOptions
+                )
+            )
+        }.fold(
+            onSuccess = { intent ->
+                stripeIntent = intent
+                authenticatorRegistry.getAuthenticator(intent)
+                    .authenticate(
+                        authActivityStarterHost,
+                        intent,
+                        apiRequestOptions
+                    )
+            },
+            onFailure = {
+                paymentLauncherResult.postValue(PaymentResult.Failed(it))
+            }
+        )
+    }
+
+    @VisibleForTesting
+    internal fun onPaymentFlowResult(paymentFlowResult: PaymentFlowResult.Unvalidated) {
+        viewModelScope.launch {
+            runCatching {
+                when (stripeIntent) {
+                    is PaymentIntent -> {
+                        lazyPaymentIntentFlowResultProcessor.get()
+                    }
+                    is SetupIntent -> {
+                        lazySetupIntentFlowResultProcessor.get()
+                    }
+                }.processResult(paymentFlowResult)
+            }.fold(
+                onSuccess = {
+                    withContext(uiContext) {
+                        postResult(it)
+                    }
+                },
+                onFailure = {
+                    withContext(uiContext) {
+                        paymentLauncherResult.postValue(PaymentResult.Failed(it))
+                    }
+                }
+            )
+        }
+    }
 
     /**
      * Parse [StripeIntentResult] into [PaymentResult].
      */
     private fun postResult(stripeIntentResult: StripeIntentResult<StripeIntent>) {
-        when (stripeIntentResult.outcome) {
-            StripeIntentResult.Outcome.SUCCEEDED -> {
-                paymentLauncherResult.postValue(PaymentResult.Completed)
-            }
-            StripeIntentResult.Outcome.FAILED -> {
-                paymentLauncherResult.postValue(
+        paymentLauncherResult.postValue(
+            when (stripeIntentResult.outcome) {
+                StripeIntentResult.Outcome.SUCCEEDED ->
+                    PaymentResult.Completed
+                StripeIntentResult.Outcome.FAILED ->
                     PaymentResult.Failed(
                         APIException(message = stripeIntentResult.failureMessage)
                     )
-                )
+                StripeIntentResult.Outcome.CANCELED ->
+                    PaymentResult.Canceled
+                StripeIntentResult.Outcome.TIMEDOUT ->
+                    PaymentResult.Failed(
+                        APIException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
+                    )
+                else ->
+                    PaymentResult.Failed(
+                        APIException(message = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
+                    )
             }
-            StripeIntentResult.Outcome.CANCELED -> {
-                paymentLauncherResult.postValue(PaymentResult.Canceled)
+        )
+    }
+
+    private fun logReturnUrl(returnUrl: String?) {
+        when (returnUrl) {
+            defaultReturnUrl.value -> {
+                AnalyticsEvent.ConfirmReturnUrlDefault
             }
-            StripeIntentResult.Outcome.TIMEDOUT -> {
-                PaymentResult.Failed(
-                    APIException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
-                )
+            null -> {
+                AnalyticsEvent.ConfirmReturnUrlNull
             }
+            else -> {
+                AnalyticsEvent.ConfirmReturnUrlCustom
+            }
+        }.let { event ->
+            analyticsRequestExecutor.executeAsync(
+                analyticsRequestFactory.createRequest(event)
+            )
         }
     }
 
-    internal class Factory() : ViewModelProvider.Factory {
+    internal class Factory(
+        @InjectorKey private val injectorKeyProvider: () -> Int,
+        private val authActivityStarterHostProvider: () -> AuthActivityStarterHost,
+        private val activityResultCaller: ActivityResultCaller
+    ) : ViewModelProvider.Factory, Injectable {
+        @Inject
+        lateinit var stripeApiRepository: StripeRepository
+
+        @Inject
+        lateinit var authenticatorRegistry: PaymentAuthenticatorRegistry
+
+        @Inject
+        lateinit var defaultReturnUrl: DefaultReturnUrl
+
+        @Inject
+        lateinit var apiRequestOptions: ApiRequest.Options
+
+        @Inject
+        lateinit var threeDs1IntentReturnUrlMap: MutableMap<String, String>
+
+        @Inject
+        lateinit var lazyPaymentIntentFlowResultProcessor: dagger.Lazy<PaymentIntentFlowResultProcessor>
+
+        @Inject
+        lateinit var lazySetupIntentFlowResultProcessor: dagger.Lazy<SetupIntentFlowResultProcessor>
+
+        @Inject
+        lateinit var analyticsRequestExecutor: DefaultAnalyticsRequestExecutor
+
+        @Inject
+        lateinit var analyticsRequestFactory: AnalyticsRequestFactory
+
+        @Inject
+        @UIContext
+        lateinit var uiContext: CoroutineContext
+
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return PaymentLauncherViewModel() as T
+            WeakMapInjectorRegistry.retrieve(injectorKeyProvider())?.inject(this) ?: run {
+                throw IllegalArgumentException("Failed to initialize PaymentLauncherViewModel.Factory")
+            }
+
+            return PaymentLauncherViewModel(
+                stripeApiRepository,
+                authenticatorRegistry,
+                defaultReturnUrl,
+                apiRequestOptions,
+                threeDs1IntentReturnUrlMap,
+                lazyPaymentIntentFlowResultProcessor,
+                lazySetupIntentFlowResultProcessor,
+                analyticsRequestExecutor,
+                analyticsRequestFactory,
+                uiContext,
+                authActivityStarterHostProvider(),
+                activityResultCaller
+            ) as T
         }
     }
 
-    companion object {
+    internal companion object {
         const val TIMEOUT_ERROR = "Payment fails due to time out. \n"
+        const val UNKNOWN_ERROR = "Payment fails due to unknown error. \n"
+        const val REQUIRED_ERROR = "API request returned an invalid response."
+        val EXPAND_PAYMENT_METHOD = listOf("payment_method")
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentResult.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 /**
  * Result to be passed to the callback of [PaymentLauncher]
  */
-internal sealed class PaymentResult : Parcelable {
+sealed class PaymentResult : Parcelable {
     @Parcelize
     object Completed : PaymentResult()
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -1,23 +1,49 @@
 package com.stripe.android.payments.paymentlauncher
 
+import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.payments.core.injection.DaggerPaymentLauncherComponent
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.PaymentLauncherComponent
 
 /**
- * WIP - implementation of [PaymentLauncher], start an [PaymentLauncherConfirmationActivity] to confirm and
+ * Implementation of [PaymentLauncher], start an [PaymentLauncherConfirmationActivity] to confirm and
  * handle next actions for intents.
  */
 internal class StripePaymentLauncher internal constructor(
     private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
-    private val publishableKey: String,
-    private val stripeAccountId: String? = null
-) : PaymentLauncher {
+    context: Context,
+    publishableKey: String,
+    stripeAccountId: String? = null,
+    @InjectorKey private val injectorKey: Int
+) : PaymentLauncher, Injector {
+
+    private val paymentLauncherComponent: PaymentLauncherComponent =
+        DaggerPaymentLauncherComponent.builder()
+            .context(context)
+            .publishableKey(publishableKey)
+            .stripeAccountId(stripeAccountId)
+            .build()
+
+    override fun inject(injectable: Injectable) {
+        when (injectable) {
+            is PaymentLauncherViewModel.Factory -> {
+                paymentLauncherComponent.inject(injectable)
+            }
+            else -> {
+                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
+            }
+        }
+    }
+
     override fun confirm(params: ConfirmPaymentIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKey,
-                stripeAccountId = stripeAccountId,
+                injectorKey = injectorKey,
                 confirmStripeIntentParams = params
             )
         )
@@ -26,8 +52,7 @@ internal class StripePaymentLauncher internal constructor(
     override fun confirm(params: ConfirmSetupIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKey,
-                stripeAccountId = stripeAccountId,
+                injectorKey = injectorKey,
                 confirmStripeIntentParams = params
             )
         )
@@ -36,8 +61,7 @@ internal class StripePaymentLauncher internal constructor(
     override fun handleNextActionForPaymentIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
-                publishableKey = publishableKey,
-                stripeAccountId = stripeAccountId,
+                injectorKey = injectorKey,
                 paymentIntentClientSecret = clientSecret
             )
         )
@@ -46,8 +70,7 @@ internal class StripePaymentLauncher internal constructor(
     override fun handleNextActionForSetupIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
-                publishableKey = publishableKey,
-                stripeAccountId = stripeAccountId,
+                injectorKey = injectorKey,
                 setupIntentClientSecret = clientSecret
             )
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.payments.paymentlauncher
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.utils.InjectableActivityScenario
+import com.stripe.android.utils.TestUtils
+import com.stripe.android.utils.injectableActivityScenario
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentLauncherConfirmationActivityTest {
+    private val viewModel = mock<PaymentLauncherViewModel>().also {
+        whenever(it.paymentLauncherResult).thenReturn(mock())
+    }
+    private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `start with IntentConfirmationArgs should confirmStripeIntent`() {
+        val confirmStripeIntentParams = mock<ConfirmStripeIntentParams>()
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PaymentLauncherContract.Args.IntentConfirmationArgs(
+                    INJECTOR_KEY,
+                    confirmStripeIntentParams
+                ).toBundle()
+            )
+        ).use {
+            it.onActivity {
+                runBlockingTest {
+                    verify(viewModel).confirmStripeIntent(confirmStripeIntentParams)
+                }
+            }
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `start with PaymentIntentNextActionArgs should handleNextActionForStripeIntent`() {
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
+                    INJECTOR_KEY,
+                    CLIENT_SECRET
+                ).toBundle()
+            )
+        ).use {
+            it.onActivity {
+                runBlockingTest {
+                    verify(viewModel).handleNextActionForStripeIntent(CLIENT_SECRET)
+                }
+            }
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `start with SetupIntentNextActionArgs should handleNextActionForStripeIntent`() {
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PaymentLauncherContract.Args.SetupIntentNextActionArgs(
+                    INJECTOR_KEY,
+                    CLIENT_SECRET
+                ).toBundle()
+            )
+        ).use {
+            it.onActivity {
+                runBlockingTest {
+                    verify(viewModel).handleNextActionForStripeIntent(CLIENT_SECRET)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `start without args should finish with Error result`() {
+        ActivityScenario.launch(
+            PaymentLauncherConfirmationActivity::class.java, Bundle.EMPTY
+        ).use { activityScenario ->
+            Truth.assertThat(activityScenario.state)
+                .isEqualTo(Lifecycle.State.DESTROYED)
+            val result =
+                PaymentResult.fromIntent(activityScenario.result.resultData) as PaymentResult.Failed
+            Truth.assertThat(result.throwable.message)
+                .isEqualTo(
+                    PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR
+                )
+        }
+    }
+
+    private fun mockViewModelActivityScenario():
+        InjectableActivityScenario<PaymentLauncherConfirmationActivity> {
+        return injectableActivityScenario {
+            injectActivity {
+                viewModelFactory = testFactory
+            }
+        }
+    }
+
+    private companion object {
+        const val INJECTOR_KEY = 1
+        const val CLIENT_SECRET = "clientSecret"
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.payments.paymentlauncher
 
 import android.content.Intent
-import android.os.Bundle
 import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -95,13 +93,16 @@ class PaymentLauncherConfirmationActivityTest {
 
     @Test
     fun `start without args should finish with Error result`() {
-        ActivityScenario.launch(
-            PaymentLauncherConfirmationActivity::class.java, Bundle.EMPTY
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            )
         ).use { activityScenario ->
             Truth.assertThat(activityScenario.state)
                 .isEqualTo(Lifecycle.State.DESTROYED)
             val result =
-                PaymentResult.fromIntent(activityScenario.result.resultData) as PaymentResult.Failed
+                PaymentResult.fromIntent(activityScenario.getResult().resultData) as PaymentResult.Failed
             Truth.assertThat(result.throwable.message)
                 .isEqualTo(
                     PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -1,0 +1,368 @@
+package com.stripe.android.payments.paymentlauncher
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentIntentResult
+import com.stripe.android.StripeIntentResult
+import com.stripe.android.StripePaymentController.Companion.EXPAND_PAYMENT_METHOD
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AnalyticsEvent
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.PaymentIntentFlowResultProcessor
+import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PaymentLauncherViewModelTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private val stripeApiRepository = mock<StripeApiRepository>()
+    private val authenticatorRegistry = mock<PaymentAuthenticatorRegistry>()
+    private val defaultReturnUrl =
+        DefaultReturnUrl.create(ApplicationProvider.getApplicationContext())
+    private val apiRequestOptions = mock<ApiRequest.Options>()
+    private val authHost = mock<AuthActivityStarterHost>()
+    private val threeDs1IntentReturnUrlMap = mock<MutableMap<String, String>>()
+    private val paymentIntentFlowResultProcessor = mock<PaymentIntentFlowResultProcessor>()
+    private val setupIntentFlowResultProcessor = mock<SetupIntentFlowResultProcessor>()
+
+    private val analyticsRequestExecutor = mock<DefaultAnalyticsRequestExecutor>()
+    private val analyticsRequestFactory = mock<AnalyticsRequestFactory>()
+    private val uiContext = TestCoroutineDispatcher()
+    private val activityResultCaller = mock<ActivityResultCaller>()
+
+    private val viewModel = PaymentLauncherViewModel(
+        stripeApiRepository,
+        authenticatorRegistry,
+        defaultReturnUrl,
+        apiRequestOptions,
+        threeDs1IntentReturnUrlMap,
+        { paymentIntentFlowResultProcessor },
+        { setupIntentFlowResultProcessor },
+        analyticsRequestExecutor,
+        analyticsRequestFactory,
+        uiContext,
+        authHost,
+        activityResultCaller
+    )
+
+    private val confirmPaymentIntentParams = ConfirmPaymentIntentParams(
+        clientSecret = CLIENT_SECRET,
+        paymentMethodId = PM_ID
+    )
+    private val confirmSetupIntentParams = ConfirmSetupIntentParams(
+        clientSecret = CLIENT_SECRET,
+        paymentMethodId = PM_ID
+    )
+    private val paymentIntent = mock<PaymentIntent>()
+    private val piAuthenticator = mock<PaymentAuthenticator<PaymentIntent>>()
+    private val setupIntent = mock<SetupIntent>()
+    private val siAuthenticator = mock<PaymentAuthenticator<SetupIntent>>()
+    private val stripeIntent = mock<StripeIntent>()
+    private val stripeIntentAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
+    private val succeededPaymentResult =
+        PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.SUCCEEDED)
+    private val failedPaymentResult =
+        PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.FAILED)
+    private val canceledPaymentResult =
+        PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.CANCELED)
+    private val timedOutPaymentResult =
+        PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.TIMEDOUT)
+    private val unknownPaymentResult =
+        PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.UNKNOWN)
+
+    @Before
+    fun setUpMocks() = runBlockingTest {
+        whenever(
+            stripeApiRepository.confirmPaymentIntent(any(), any(), any())
+        ).thenReturn(paymentIntent)
+
+        whenever(
+            stripeApiRepository.confirmSetupIntent(any(), any(), any())
+        ).thenReturn(setupIntent)
+
+        whenever(authenticatorRegistry.getAuthenticator(eq(paymentIntent)))
+            .thenReturn(piAuthenticator)
+
+        whenever(authenticatorRegistry.getAuthenticator(eq(setupIntent)))
+            .thenReturn(siAuthenticator)
+
+        whenever(
+            stripeApiRepository.retrieveStripeIntent(
+                eq(CLIENT_SECRET),
+                eq(apiRequestOptions),
+                any()
+            )
+        )
+            .thenReturn(stripeIntent)
+
+        whenever(authenticatorRegistry.getAuthenticator(eq(stripeIntent)))
+            .thenReturn(stripeIntentAuthenticator)
+    }
+
+    @Test
+    fun `verify confirm PaymentIntent without returnUrl invokes StripeRepository and calls correct authenticator`() =
+        runBlockingTest {
+            viewModel.confirmStripeIntent(confirmPaymentIntentParams)
+
+            verify(analyticsRequestFactory).createRequest(
+                AnalyticsEvent.ConfirmReturnUrlNull
+            )
+            verify(stripeApiRepository).confirmPaymentIntent(
+                argWhere {
+                    it.returnUrl == defaultReturnUrl.value &&
+                        it.paymentMethodId == PM_ID &&
+                        it.clientSecret == CLIENT_SECRET &&
+                        it.shouldUseStripeSdk()
+                },
+                eq(apiRequestOptions),
+                eq(EXPAND_PAYMENT_METHOD)
+            )
+            verify(piAuthenticator).authenticate(
+                eq(authHost),
+                eq(paymentIntent),
+                eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify confirm PaymentIntent with returnUrl invokes StripeRepository and calls correct authenticator`() =
+        runBlockingTest {
+            viewModel.confirmStripeIntent(
+                confirmPaymentIntentParams.also {
+                    it.returnUrl = RETURN_URL
+                }
+            )
+
+            verify(analyticsRequestFactory).createRequest(
+                AnalyticsEvent.ConfirmReturnUrlCustom
+            )
+            verify(stripeApiRepository).confirmPaymentIntent(
+                argWhere {
+                    it.returnUrl == RETURN_URL &&
+                        it.paymentMethodId == PM_ID &&
+                        it.clientSecret == CLIENT_SECRET &&
+                        it.shouldUseStripeSdk()
+                },
+                eq(apiRequestOptions),
+                eq(EXPAND_PAYMENT_METHOD)
+            )
+            verify(piAuthenticator).authenticate(
+                eq(authHost),
+                eq(paymentIntent),
+                eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify confirm SetupIntent without returnUrl invokes StripeRepository and calls correct authenticator`() =
+        runBlockingTest {
+            viewModel.confirmStripeIntent(confirmSetupIntentParams)
+
+            verify(analyticsRequestFactory).createRequest(
+                AnalyticsEvent.ConfirmReturnUrlNull
+            )
+            verify(stripeApiRepository).confirmSetupIntent(
+                argWhere {
+                    it.returnUrl == defaultReturnUrl.value &&
+                        it.paymentMethodId == PM_ID &&
+                        it.clientSecret == CLIENT_SECRET &&
+                        it.shouldUseStripeSdk()
+                },
+                eq(apiRequestOptions),
+                eq(EXPAND_PAYMENT_METHOD)
+            )
+            verify(siAuthenticator).authenticate(
+                eq(authHost),
+                eq(setupIntent),
+                eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify confirm SetupIntent with returnUrl invokes StripeRepository and calls correct authenticator`() =
+        runBlockingTest {
+            viewModel.confirmStripeIntent(
+                confirmSetupIntentParams.also {
+                    it.returnUrl = RETURN_URL
+                }
+            )
+
+            verify(analyticsRequestFactory).createRequest(
+                AnalyticsEvent.ConfirmReturnUrlCustom
+            )
+            verify(stripeApiRepository).confirmSetupIntent(
+                argWhere {
+                    it.returnUrl == RETURN_URL &&
+                        it.paymentMethodId == PM_ID &&
+                        it.clientSecret == CLIENT_SECRET &&
+                        it.shouldUseStripeSdk()
+                },
+                eq(apiRequestOptions),
+                eq(EXPAND_PAYMENT_METHOD)
+            )
+            verify(siAuthenticator).authenticate(
+                eq(authHost),
+                eq(setupIntent),
+                eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify when stripeApiRepository fails then confirmPaymentIntent will post Failed result`() =
+        runBlockingTest {
+            whenever(stripeApiRepository.confirmPaymentIntent(any(), any(), any()))
+                .thenReturn(null)
+
+            viewModel.confirmStripeIntent(confirmPaymentIntentParams)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    @Test
+    fun `verify when stripeApiRepository fails then confirmSetupIntent will post Failed result`() =
+        runBlockingTest {
+            whenever(stripeApiRepository.confirmSetupIntent(any(), any(), any()))
+                .thenReturn(null)
+
+            viewModel.confirmStripeIntent(confirmSetupIntentParams)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    @Test
+    fun `verify next action is handled correctly`() =
+        runBlockingTest {
+            viewModel.handleNextActionForStripeIntent(CLIENT_SECRET)
+
+            verify(stripeIntentAuthenticator).authenticate(
+                eq(authHost),
+                eq(stripeIntent),
+                eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify when stripeApiRepository fails then handleNextAction will post Failed result`() =
+        runBlockingTest {
+            whenever(
+                stripeApiRepository.retrieveStripeIntent(
+                    eq(CLIENT_SECRET),
+                    eq(apiRequestOptions),
+                    any()
+                )
+            ).thenReturn(null)
+
+            viewModel.handleNextActionForStripeIntent(CLIENT_SECRET)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    @Test
+    fun `verify success paymentIntentFlowResult is processed correctly`() =
+        runBlockingTest {
+            viewModel.stripeIntent = paymentIntent
+            val paymentFlowResult = mock<PaymentFlowResult.Unvalidated>()
+            whenever(paymentIntentFlowResultProcessor.processResult(eq(paymentFlowResult)))
+                .thenReturn(succeededPaymentResult)
+
+            viewModel.onPaymentFlowResult(paymentFlowResult)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isEqualTo(PaymentResult.Completed)
+        }
+
+    @Test
+    fun `verify failed paymentIntentFlowResult is processed correctly`() =
+        runBlockingTest {
+            viewModel.stripeIntent = paymentIntent
+            val paymentFlowResult = mock<PaymentFlowResult.Unvalidated>()
+            whenever(paymentIntentFlowResultProcessor.processResult(eq(paymentFlowResult)))
+                .thenReturn(failedPaymentResult)
+
+            viewModel.onPaymentFlowResult(paymentFlowResult)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    @Test
+    fun `verify canceled paymentIntentFlowResult is processed correctly`() =
+        runBlockingTest {
+            viewModel.stripeIntent = paymentIntent
+            val paymentFlowResult = mock<PaymentFlowResult.Unvalidated>()
+            whenever(paymentIntentFlowResultProcessor.processResult(eq(paymentFlowResult)))
+                .thenReturn(canceledPaymentResult)
+
+            viewModel.onPaymentFlowResult(paymentFlowResult)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isEqualTo(PaymentResult.Canceled)
+        }
+
+    @Test
+    fun `verify timedOut paymentIntentFlowResult is processed correctly`() =
+        runBlockingTest {
+            viewModel.stripeIntent = paymentIntent
+            val paymentFlowResult = mock<PaymentFlowResult.Unvalidated>()
+            whenever(paymentIntentFlowResultProcessor.processResult(eq(paymentFlowResult)))
+                .thenReturn(timedOutPaymentResult)
+
+            viewModel.onPaymentFlowResult(paymentFlowResult)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    @Test
+    fun `verify unknown paymentIntentFlowResult is processed correctly`() =
+        runBlockingTest {
+            viewModel.stripeIntent = paymentIntent
+            val paymentFlowResult = mock<PaymentFlowResult.Unvalidated>()
+            whenever(paymentIntentFlowResultProcessor.processResult(eq(paymentFlowResult)))
+                .thenReturn(unknownPaymentResult)
+
+            viewModel.onPaymentFlowResult(paymentFlowResult)
+
+            assertThat(viewModel.paymentLauncherResult.value)
+                .isInstanceOf(PaymentResult.Failed::class.java)
+        }
+
+    companion object {
+        const val CLIENT_SECRET = "clientSecret"
+        const val PM_ID = "12345"
+        const val RETURN_URL = "return://to.me"
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -1,0 +1,86 @@
+package com.stripe.android.payments.paymentlauncher
+
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StripePaymentLauncherTest {
+    private val mockHostActivityLauncher =
+        mock<ActivityResultLauncher<PaymentLauncherContract.Args>>()
+    private val paymentLauncher = StripePaymentLauncher(
+        mockHostActivityLauncher,
+        mock(),
+        PUBLISHABLE_KEY,
+        STRIPE_ACCOUNT_ID,
+        INJECTOR_KEY
+    )
+
+    @Test
+    fun `verify confirm payment creates correct params`() {
+        val params = mock<ConfirmPaymentIntentParams>()
+
+        paymentLauncher.confirm(params)
+
+        verify(mockHostActivityLauncher).launch(
+            argWhere { arg ->
+                arg is PaymentLauncherContract.Args.IntentConfirmationArgs &&
+                    arg.injectorKey == INJECTOR_KEY &&
+                    arg.confirmStripeIntentParams == params
+            }
+        )
+    }
+
+    @Test
+    fun `verify confirm setup creates correct params`() {
+        val params = mock<ConfirmPaymentIntentParams>()
+
+        paymentLauncher.confirm(params)
+
+        verify(mockHostActivityLauncher).launch(
+            argWhere { arg ->
+                arg is PaymentLauncherContract.Args.IntentConfirmationArgs &&
+                    arg.injectorKey == INJECTOR_KEY &&
+                    arg.confirmStripeIntentParams == params
+            }
+        )
+    }
+
+    @Test
+    fun `verify handle next action for payment creates correct params`() {
+        paymentLauncher.handleNextActionForPaymentIntent(CLIENT_SECRET)
+
+        verify(mockHostActivityLauncher).launch(
+            argWhere { arg ->
+                arg is PaymentLauncherContract.Args.PaymentIntentNextActionArgs &&
+                    arg.injectorKey == INJECTOR_KEY &&
+                    arg.paymentIntentClientSecret == CLIENT_SECRET
+            }
+        )
+    }
+
+    @Test
+    fun `verify handle next action for setup creates correct params`() {
+        paymentLauncher.handleNextActionForSetupIntent(CLIENT_SECRET)
+
+        verify(mockHostActivityLauncher).launch(
+            argWhere { arg ->
+                arg is PaymentLauncherContract.Args.SetupIntentNextActionArgs &&
+                    arg.injectorKey == INJECTOR_KEY &&
+                    arg.setupIntentClientSecret == CLIENT_SECRET
+            }
+        )
+    }
+
+    companion object {
+        const val PUBLISHABLE_KEY = "publishableKey"
+        const val STRIPE_ACCOUNT_ID = "stripeAccountId"
+        const val INJECTOR_KEY = 123
+        const val CLIENT_SECRET = "clientSecret"
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Please see details in [this](https://paper.dropbox.com/doc/2021-05-28-Android-SDK-PaymentLauncher-API--BOKj_IBRZBCk_6VJY3T1PcTQAg-eWPQ4N7Qzb77yvqiO23j2) internal doc.

Final implementation of `PayLauncher`.
* Implement `PaymentLauncherViewModel`, route confirmation logic to `PaymentAuthenticatorRegistry`
* Upon confirmation result, post to `PaymentLaunhcerViewModel.paymentLauncherResult`, observed by `PaymentLauncherConfirmationActivity` and notify `PaymentResult` to user
* The logic is mostly duplicated from [StripePaymentController](https://github.com/stripe/stripe-android/blob/f6cf6ffc38451cf20b89ddd10ecc11fc2f3c179f/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt#L49)
* Injection: The entire dependency graph is created only _once_ when `StripePaymentLauncher` is initialized, the same dependencies got injected into  `PaymentLauncherViewModel.Factory` through the [InjectorRegistry](https://github.com/stripe/stripe-android/blob/2008a4767afaa12a408ab0ff6c7498991b78fee2/payments-core/src/main/java/com/stripe/android/payments/core/injection/InjectorRegistry.kt#L14) architecture when a new `PaymentLauncherConfirmationActivity` is started by `PaymentLaunhcer.confirm`/`PaymentLaunhcer.handleNextActionForPaymentIntent`/`PaymentLaunhcer.handleNextActionForSetupIntent`. Please details in [this](https://paper.dropbox.com/doc/Daggerize-Android-SDK--BQuNn2J8LioJhJ0Yi4ZdFAbPAg-Y8OUkag2eU9iPwUhUaVKU#:h2=How-about-Activity/ViewModel-?) internal doc.
* Support for Compose: added a dedicated `PaymentLaunhcer#createForCompose` API that doesn't require activity or fragment, but uses Compose specific APIs internally

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Modern Stripe API to confirm an `PaymentIntent` / `SetupIntent` and handles their next actions without the need for the client to capture the result in `Activity.onActivityResult`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Next steps
* Replace `Stripe` with `PaymentLauncher` from the example app
* Demonstrate the compose API in the example app
* Replace `Stripe` with `PaymentLauncher` from `PaymentSheet` and `FlowController` @skyler-stripe 
