### PR TITLE
Fix crash on `GooglePayLauncher` when confirmation fails

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -190,23 +190,20 @@ internal class GooglePayLauncherViewModel(
     internal suspend fun getResultFromConfirmation(
         requestCode: Int,
         data: Intent
-    ): GooglePayLauncher.Result {
-        return when {
-            paymentController.shouldHandlePaymentResult(requestCode, data) -> {
-                paymentController.getPaymentIntentResult(data)
-                GooglePayLauncher.Result.Completed
+    ): GooglePayLauncher.Result =
+        runCatching {
+            when {
+                paymentController.shouldHandlePaymentResult(requestCode, data) -> {
+                    paymentController.getPaymentIntentResult(data)
+                    GooglePayLauncher.Result.Completed
+                }
+                paymentController.shouldHandleSetupResult(requestCode, data) -> {
+                    paymentController.getSetupIntentResult(data)
+                    GooglePayLauncher.Result.Completed
+                }
+                else -> throw IllegalStateException("Unexpected result: $data")
             }
-            paymentController.shouldHandleSetupResult(requestCode, data) -> {
-                paymentController.getSetupIntentResult(data)
-                GooglePayLauncher.Result.Completed
-            }
-            else -> {
-                GooglePayLauncher.Result.Failed(
-                    IllegalStateException("Unexpected result.")
-                )
-            }
-        }
-    }
+        }.getOrElse { GooglePayLauncher.Result.Failed(it) }
 
     internal class Factory(
         private val application: Application,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -201,7 +201,7 @@ internal class GooglePayLauncherViewModel(
                     paymentController.getSetupIntentResult(data)
                     GooglePayLauncher.Result.Completed
                 }
-                else -> throw IllegalStateException("Unexpected result: $data")
+                else -> throw IllegalStateException("Unexpected confirmation result.")
             }
         }.getOrElse { GooglePayLauncher.Result.Failed(it) }
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -165,7 +165,7 @@ class GooglePayLauncherViewModelTest {
         }
 
     @Test
-    fun `getResultFromConfirmation() with invalid using PaymentIntent should return expected result`() =
+    fun `getResultFromConfirmation() with failed confirmation should return expected result`() =
         testDispatcher.runBlockingTest {
             val exception = StripeException.create(Exception("Failure"))
             val result = viewModel.getResultFromConfirmation(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`GooglePayLauncherViewModel` would crash if `StripeIntent` confirmation resulted in an exception.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix crash on `GooglePayLauncher` when `StripeIntent` confirmation fails (#4104)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified