### PR TITLE
Fix form section naming

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/BancontactSpec.kt
@@ -10,11 +10,11 @@ internal val bancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val bancontactNameSection = FormItemSpec.SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
 internal val bancontactEmailSection =
-    FormItemSpec.SectionSpec(IdentifierSpec("email"), SectionFieldSpec.Email)
+    FormItemSpec.SectionSpec(IdentifierSpec("email_section"), SectionFieldSpec.Email)
 internal val bancontactMandate = FormItemSpec.MandateTextSpec(
     IdentifierSpec("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/EpsSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/EpsSpec.kt
@@ -13,12 +13,12 @@ internal val epsParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val epsNameSection = FormItemSpec.SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
 internal val epsBankSection =
     FormItemSpec.SectionSpec(
-        IdentifierSpec("bank section"),
+        IdentifierSpec("bank_section"),
         SectionFieldSpec.BankDropdown(
             IdentifierSpec("bank"),
             R.string.stripe_paymentsheet_eps_bank,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/GiropaySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/GiropaySpec.kt
@@ -6,7 +6,7 @@ internal val giropayParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val giropayNameSection = FormItemSpec.SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/IdealSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/IdealSpec.kt
@@ -18,12 +18,12 @@ internal val idealParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val idealNameSection = SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
-internal val idealEmailSection = SectionSpec(IdentifierSpec("email"), Email)
+internal val idealEmailSection = SectionSpec(IdentifierSpec("email_section"), Email)
 internal val idealBankSection = SectionSpec(
-    IdentifierSpec("bank"),
+    IdentifierSpec("bank_section"),
     SectionFieldSpec.BankDropdown(
         IdentifierSpec("bank"),
         R.string.stripe_paymentsheet_ideal_bank,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/P24Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/P24Spec.kt
@@ -13,16 +13,16 @@ internal val p24ParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val p24NameSection = FormItemSpec.SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
 internal val p24EmailSection = FormItemSpec.SectionSpec(
-    IdentifierSpec("email"),
+    IdentifierSpec("email_section"),
     SectionFieldSpec.Email
 )
 internal val p24BankSection =
     FormItemSpec.SectionSpec(
-        IdentifierSpec("bank section"),
+        IdentifierSpec("bank_section"),
         SectionFieldSpec.BankDropdown(
             IdentifierSpec("bank"),
             R.string.stripe_paymentsheet_p24_bank,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SepaDebitSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SepaDebitSpec.kt
@@ -18,11 +18,11 @@ internal val sepaDebitParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val sepaDebitNameSection = SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
-internal val sepaDebitEmailSection = SectionSpec(IdentifierSpec("email"), Email)
-internal val sepaDebitIbanSection = SectionSpec(IdentifierSpec("iban"), Iban)
+internal val sepaDebitEmailSection = SectionSpec(IdentifierSpec("email_section"), Email)
+internal val sepaDebitIbanSection = SectionSpec(IdentifierSpec("iban_section"), Iban)
 internal val sepaDebitMandate = MandateTextSpec(
     IdentifierSpec("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
@@ -19,12 +19,12 @@ internal val sofortParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val sofortNameSection = SectionSpec(
-    IdentifierSpec("name section"),
+    IdentifierSpec("name_section"),
     SectionFieldSpec.NAME
 )
-internal val sofortEmailSection = SectionSpec(IdentifierSpec("email"), Email)
+internal val sofortEmailSection = SectionSpec(IdentifierSpec("email_section"), Email)
 internal val sofortCountrySection =
-    SectionSpec(IdentifierSpec("country"), Country(setOf("AT", "BE", "DE", "ES", "IT", "NL")))
+    SectionSpec(IdentifierSpec("country_section"), Country(setOf("AT", "BE", "DE", "ES", "IT", "NL")))
 internal val sofortMandate = MandateTextSpec(
     IdentifierSpec("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/specifications/SofortSpec.kt
@@ -24,7 +24,10 @@ internal val sofortNameSection = SectionSpec(
 )
 internal val sofortEmailSection = SectionSpec(IdentifierSpec("email_section"), Email)
 internal val sofortCountrySection =
-    SectionSpec(IdentifierSpec("country_section"), Country(setOf("AT", "BE", "DE", "ES", "IT", "NL")))
+    SectionSpec(
+        IdentifierSpec("country_section"),
+        Country(setOf("AT", "BE", "DE", "ES", "IT", "NL"))
+    )
 internal val sofortMandate = MandateTextSpec(
     IdentifierSpec("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/AddressControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/AddressControllerTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
-class AddresControllerTest {
+class AddressControllerTest {
     private val emailController = TextFieldController(
         EmailConfig()
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -31,9 +31,9 @@ import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
 internal class FormViewModelTest {
-    private val emailSection = FormItemSpec.SectionSpec(IdentifierSpec("emailSection"), Email)
+    private val emailSection = FormItemSpec.SectionSpec(IdentifierSpec("email_section"), Email)
     private val countrySection = FormItemSpec.SectionSpec(
-        IdentifierSpec("countrySection"),
+        IdentifierSpec("country_section"),
         Country()
     )
 
@@ -132,7 +132,7 @@ internal class FormViewModelTest {
 
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertThat(values[1][0]).isEqualTo(IdentifierSpec("emailSection"))
+        assertThat(values[1][0]).isEqualTo(IdentifierSpec("email_section"))
         assertThat(values[1][1]).isEqualTo(IdentifierSpec("email"))
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PopulateFormFromFormFieldValuesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PopulateFormFromFormFieldValuesTest.kt
@@ -18,7 +18,7 @@ class PopulateFormFromFormFieldValuesTest {
         emailController
     )
     private val emailSection = FormElement.SectionElement(
-        identifier = IdentifierSpec("emailSection"),
+        identifier = IdentifierSpec("email_section"),
         emailFieldElement,
         SectionController(emailController.label, listOf(emailController))
     )
@@ -49,7 +49,7 @@ class PopulateFormFromFormFieldValuesTest {
         runBlocking {
             val formFieldValues = FormFieldValues(
                 mapOf(
-                    IdentifierSpec("not in list form elements") to FormFieldEntry(
+                    IdentifierSpec("not_in_list_form_elements") to FormFieldEntry(
                         "valid@email.com",
                         true
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformElementToFormViewValueFlowTest.kt
@@ -19,7 +19,7 @@ class TransformElementToFormViewValueFlowTest {
 
     private val emailController = TextFieldController(EmailConfig())
     private val emailSection = FormElement.SectionElement(
-        identifier = IdentifierSpec("emailSection"),
+        identifier = IdentifierSpec("email_section"),
         SectionFieldElement.Email(
             IdentifierSpec("email"),
             emailController
@@ -29,7 +29,7 @@ class TransformElementToFormViewValueFlowTest {
 
     private val countryController = DropdownFieldController(CountryConfig())
     private val countrySection = FormElement.SectionElement(
-        identifier = IdentifierSpec("countrySection"),
+        identifier = IdentifierSpec("country_section"),
         SectionFieldElement.Country(
             IdentifierSpec("country"),
             countryController

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -32,12 +32,12 @@ import java.io.File
 class TransformSpecToElementTest {
 
     private val nameSection = FormItemSpec.SectionSpec(
-        IdentifierSpec("nameSection"),
+        IdentifierSpec("name_section"),
         SectionFieldSpec.NAME
     )
 
     private val emailSection = FormItemSpec.SectionSpec(
-        IdentifierSpec("emailSection"),
+        IdentifierSpec("email_section"),
         SectionFieldSpec.Email
     )
 
@@ -64,7 +64,7 @@ class TransformSpecToElementTest {
         val formElement = transformSpecToElement.transform(
             listOf(
                 FormItemSpec.SectionSpec(
-                    IdentifierSpec("multifieldSection"),
+                    IdentifierSpec("multifield_section"),
                     listOf(
                         SectionFieldSpec.Country(),
                         IDEAL_BANK_CONFIG
@@ -83,7 +83,7 @@ class TransformSpecToElementTest {
     @Test
     fun `Adding a country section sets up the section and country elements correctly`() {
         val countrySection = FormItemSpec.SectionSpec(
-            IdentifierSpec("countrySection"),
+            IdentifierSpec("country_section"),
             SectionFieldSpec.Country(onlyShowCountryCodes = setOf("AT"))
         )
         val formElement = transformSpecToElement.transform(
@@ -108,7 +108,7 @@ class TransformSpecToElementTest {
     @Test
     fun `Adding a ideal bank section sets up the section and country elements correctly`() {
         val idealSection = FormItemSpec.SectionSpec(
-            IdentifierSpec("idealSection"),
+            IdentifierSpec("ideal_section"),
             IDEAL_BANK_CONFIG
         )
         val formElement = transformSpecToElement.transform(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -100,7 +100,7 @@ class TransformSpecToElementTest {
         // Verify the correct config is setup for the controller
         assertThat(countryElement.controller.label).isEqualTo(CountryConfig().label)
 
-        assertThat(countrySectionElement.identifier.value).isEqualTo("countrySection")
+        assertThat(countrySectionElement.identifier.value).isEqualTo("country_section")
 
         assertThat(countryElement.identifier.value).isEqualTo("country")
     }
@@ -122,7 +122,7 @@ class TransformSpecToElementTest {
         // Verify the correct config is setup for the controller
         assertThat(idealElement.controller.label).isEqualTo(R.string.stripe_paymentsheet_ideal_bank)
 
-        assertThat(idealSectionElement.identifier.value).isEqualTo("idealSection")
+        assertThat(idealSectionElement.identifier.value).isEqualTo("ideal_section")
 
         assertThat(idealElement.identifier.value).isEqualTo("bank")
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Name all form sections as snake case with `section` suffix.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix form section naming