### PR TITLE
Fix apiDump

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5375,6 +5375,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet {
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Address : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
@@ -5401,6 +5402,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Address : androi
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetails : android/os/Parcelable {
+	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -134,7 +134,6 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion = "$kotlinVersion"
         kotlinCompilerExtensionVersion "$composeVersion"
     }
 }

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -88,7 +88,6 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerVersion = "$kotlinVersion"
         kotlinCompilerExtensionVersion "$composeVersion"
     }
 }

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -56,7 +56,6 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion = "$kotlinVersion"
         kotlinCompilerExtensionVersion "$composeVersion"
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix apiDump.
Remove `ComposeOptions.kotlinCompilerVersion`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
apiDump broken on HEAD.
ComposeOptions.kotlinCompilerVersion is deprecated. Compose now uses the kotlin compiler defined in your buildscript.
