### PR TITLE
Buy button meets accessible requirements

### DIFF
--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -73,12 +73,14 @@
                         android:layout_height="wrap_content"
                         android:layout_margin="@dimen/stripe_paymentsheet_primary_button_margin"
                         android:text="@string/stripe_paymentsheet_pay_button_label"
+                        android:minHeight="48dp"
                         android:visibility="gone" />
 
                     <com.stripe.android.paymentsheet.ui.GooglePayButton
                         android:id="@+id/google_pay_button"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:minHeight="48dp"
                         android:visibility="gone" />
                 </FrameLayout>
             </LinearLayout>


### PR DESCRIPTION
# Summary
Make the buy button minimum height 48dp so that it meets accessibility requirements.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![image](https://user-images.githubusercontent.com/77996191/130889788-84b49b55-3d92-4223-ba34-c33e32a9c11d.png)

