### PR TITLE
Remove unnecessary builder method for `PaymentLauncherModule`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
@@ -45,8 +45,6 @@ internal interface PaymentLauncherComponent {
         @BindsInstance
         fun stripeAccountIdProvider(@Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?): Builder
 
-        fun paymentLauncherModule(paymentLauncherModule: PaymentLauncherModule): Builder
-
         fun build(): PaymentLauncherComponent
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This method is not needed. Dagger will create an instance automatically.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
