### PR TITLE
Require credit postal for only US, CA, and GB

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -16,6 +16,10 @@ object CountryUtils {
         "TV", "TZ", "UG", "VU", "YE", "ZA", "ZW"
     )
 
+    internal val CARD_POSTAL_CODE_COUNTRIES = setOf(
+        "US", "GB", "CA"
+    )
+
     private fun localizedCountries(currentLocale: Locale) =
         Locale.getISOCountries().map { code ->
             Country(
@@ -63,11 +67,11 @@ object CountryUtils {
     )
     @JvmSynthetic
     internal fun doesCountryUsePostalCode(countryCode: String): Boolean {
-        return !NO_POSTAL_CODE_COUNTRIES.contains(countryCode.uppercase())
+        return CARD_POSTAL_CODE_COUNTRIES.contains(countryCode.uppercase())
     }
 
     @JvmSynthetic
     fun doesCountryUsePostalCode(countryCode: CountryCode): Boolean {
-        return !NO_POSTAL_CODE_COUNTRIES.contains(countryCode.value)
+        return CARD_POSTAL_CODE_COUNTRIES.contains(countryCode.value)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -7,15 +7,6 @@ import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet -- this still auto-completes
 object CountryUtils {
-
-    internal val NO_POSTAL_CODE_COUNTRIES = setOf(
-        "AE", "AG", "AN", "AO", "AW", "BF", "BI", "BJ", "BO", "BS", "BW", "BZ", "CD", "CF", "CG",
-        "CI", "CK", "CM", "DJ", "DM", "ER", "FJ", "GD", "GH", "GM", "GN", "GQ", "GY", "HK", "IE",
-        "JM", "KE", "KI", "KM", "KN", "KP", "LC", "ML", "MO", "MR", "MS", "MU", "MW", "NR", "NU",
-        "PA", "QA", "RW", "SB", "SC", "SL", "SO", "SR", "ST", "SY", "TF", "TK", "TL", "TO", "TT",
-        "TV", "TZ", "UG", "VU", "YE", "ZA", "ZW"
-    )
-
     internal val CARD_POSTAL_CODE_COUNTRIES = setOf(
         "US", "GB", "CA"
     )

--- a/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
@@ -21,7 +21,7 @@ class CountryUtilsTest {
     fun `doesCountryUsePostalCode() should return expected result`() {
         assertThat(CountryUtils.doesCountryUsePostalCode(CountryCode.create("US")))
             .isTrue()
-        assertThat(CountryUtils.doesCountryUsePostalCode(CountryCode.create("UK")))
+        assertThat(CountryUtils.doesCountryUsePostalCode(CountryCode.create("GB")))
             .isTrue()
         assertThat(CountryUtils.doesCountryUsePostalCode(CountryCode.create("CA")))
             .isTrue()

--- a/payments-core/src/test/java/com/stripe/android/view/PostalCodeValidatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PostalCodeValidatorTest.kt
@@ -57,8 +57,8 @@ class PostalCodeValidatorTest {
 
     @Test
     fun testCountryWithoutPostalCode() {
-        assertTrue(isValid("", CountryUtils.NO_POSTAL_CODE_COUNTRIES.first()))
-        assertTrue(isValid("ABC123", CountryUtils.NO_POSTAL_CODE_COUNTRIES.first()))
+        assertTrue(isValid("", "DE"))
+        assertTrue(isValid("ABC123", "DE"))
     }
 
     private fun isValid(postalCode: String, countryCode: String): Boolean {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -73,7 +73,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `changing selectedCountry to France should show postal code view`() {
-        setupPostalCode(FRANCE)
+        setupPostalCode(CountryCode.CA)
         assertThat(billingAddressView.postalCodeLayout.isVisible)
             .isTrue()
     }
@@ -200,7 +200,7 @@ class BillingAddressViewTest {
 
     @Test
     fun `address with unvalidated postal code country and null postal code should return null`() {
-        setupPostalCode(MEXICO, "    ")
+        setupPostalCode(CountryCode.GB)
         assertThat(billingAddressView.address.value)
             .isNull()
     }


### PR DESCRIPTION
# Summary
Change the credit card postal code so it is only required for: US, CA, and GB to match other Stripe UIs.

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-341

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
