### PR TITLE
[Bug Fix] Added existingPaymentMethodRequired  to GooglePayRepository.kt fix #4155 #4102

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/GooglePayLauncherIntegrationActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayLauncherIntegrationActivity.kt
@@ -53,7 +53,8 @@ class GooglePayLauncherIntegrationActivity : StripeIntentActivity() {
                     isRequired = true,
                     format = GooglePayLauncher.BillingAddressConfig.Format.Full,
                     isPhoneNumberRequired = true
-                )
+                ),
+                existingPaymentMethodRequired = false
             ),
             readyCallback = ::onGooglePayReady,
             resultCallback = ::onGooglePayResult

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,13 @@ android.enableJetifier=false
 
 # Update Stripe.VERSION_NAME when publishing a new release
 VERSION_NAME=17.1.2
+
+
+# Set to example backend deployed to Heroku
+STRIPE_EXAMPLE_BACKEND_URL=https://stripe-testing-yp.herokuapp.com/
+
+# Set to a test publishable key from https://dashboard.stripe.com/test/apikeys
+STRIPE_EXAMPLE_PUBLISHABLE_KEY=pk_test_51JVgBBSCzPyv1Go9PIcd7l8F2lvNdydL9QOK9tpfdoKibi2OyhYPnvrciAzYfYmYhOAQ9qLnwGnVZTxlXroYg2Ew00HxYmTZwT
+
+# Optionally, set to a Connect Account id to test Connect
+##STRIPE_ACCOUNT_ID=

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -65,7 +65,8 @@ class GooglePayLauncher internal constructor(
         googlePayRepositoryFactory = {
             DefaultGooglePayRepository(
                 activity.application,
-                it
+                it,
+                existingPaymentMethodRequired = config.existingPaymentMethodRequired
             )
         },
         AnalyticsRequestFactory(
@@ -104,7 +105,8 @@ class GooglePayLauncher internal constructor(
         googlePayRepositoryFactory = {
             DefaultGooglePayRepository(
                 fragment.requireActivity().application,
-                it
+                it,
+                existingPaymentMethodRequired = config.existingPaymentMethodRequired
             )
         },
         AnalyticsRequestFactory(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -43,12 +43,13 @@ internal class DefaultGooglePayRepository(
     internal constructor(
         context: Context,
         environment: GooglePayEnvironment,
-        logger: Logger = Logger.noop()
+        logger: Logger = Logger.noop(),
+        existingPaymentMethodRequired : Boolean = true
     ) : this(
         context,
         environment,
         billingAddressParameters = null,
-        existingPaymentMethodRequired = true,
+        existingPaymentMethodRequired = existingPaymentMethodRequired,
         logger
     )
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -44,7 +44,7 @@ internal class DefaultGooglePayRepository(
         context: Context,
         environment: GooglePayEnvironment,
         logger: Logger = Logger.noop(),
-        existingPaymentMethodRequired : Boolean = true
+        existingPaymentMethodRequired: Boolean = true
     ) : this(
         context,
         environment,

--- a/payments/build.gradle
+++ b/payments/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    api project(':payments-core')
+    implementation project(':payments-core')
 }
 
 android {


### PR DESCRIPTION
added existingPaymentMethodRequired as a parameter to GooglePayRepository.kt

# Summary
Added `existingPaymentMethodRequired` parameter to `GooglePayRepository.kt`, earlier it is hardcoded to true

# Motivation
There is a bug here, the value of `existingPaymentMethodRequired` is hardcoded in `GooglePayRepository`, because of this some Google Pay Users getting `isReady` = false

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
